### PR TITLE
Emit disallowed_names lint for functions

### DIFF
--- a/clippy_lints/src/disallowed_names.rs
+++ b/clippy_lints/src/disallowed_names.rs
@@ -2,10 +2,11 @@ use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint;
 use clippy_utils::is_in_test;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_hir::{Pat, PatKind};
+use rustc_hir::intravisit::FnKind;
+use rustc_hir::{HirId, Pat, PatKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
-use rustc_span::Symbol;
+use rustc_span::{Ident, Symbol};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -36,22 +37,45 @@ impl DisallowedNames {
             disallow: conf.disallowed_names.iter().map(|x| Symbol::intern(x)).collect(),
         }
     }
-}
 
-impl_lint_pass!(DisallowedNames => [DISALLOWED_NAMES]);
-
-impl<'tcx> LateLintPass<'tcx> for DisallowedNames {
-    fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>) {
-        if let PatKind::Binding(.., ident, _) = pat.kind
-            && self.disallow.contains(&ident.name)
-            && !is_in_test(cx.tcx, pat.hir_id)
-        {
+    fn check(&mut self, cx: &LateContext<'_>, ident: Ident, hir_id: HirId) {
+        if self.disallow.contains(&ident.name) && !is_in_test(cx.tcx, hir_id) {
             span_lint(
                 cx,
                 DISALLOWED_NAMES,
                 ident.span,
                 format!("use of a disallowed/placeholder name `{}`", ident.name),
             );
+        }
+    }
+}
+
+impl_lint_pass!(DisallowedNames => [DISALLOWED_NAMES]);
+
+impl<'tcx> LateLintPass<'tcx> for DisallowedNames {
+    fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>) {
+        if let PatKind::Binding(.., ident, _) = pat.kind {
+            self.check(cx, ident, pat.hir_id);
+        }
+    }
+
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        kind: FnKind<'tcx>,
+        _: &'tcx rustc_hir::FnDecl<'tcx>,
+        _: &'tcx rustc_hir::Body<'tcx>,
+        _: rustc_span::Span,
+        _: rustc_span::def_id::LocalDefId,
+    ) {
+        match kind {
+            FnKind::ItemFn(ident, ..) => {
+                self.check(cx, ident, cx.last_node_with_lint_attrs);
+            },
+            FnKind::Method(ident, _) => {
+                self.check(cx, ident, cx.last_node_with_lint_attrs);
+            },
+            _ => {},
         }
     }
 }

--- a/clippy_lints/src/disallowed_names.rs
+++ b/clippy_lints/src/disallowed_names.rs
@@ -69,13 +69,10 @@ impl<'tcx> LateLintPass<'tcx> for DisallowedNames {
         _: rustc_span::def_id::LocalDefId,
     ) {
         match kind {
-            FnKind::ItemFn(ident, ..) => {
+            FnKind::ItemFn(ident, ..) | FnKind::Method(ident, _) => {
                 self.check(cx, ident, cx.last_node_with_lint_attrs);
             },
-            FnKind::Method(ident, _) => {
-                self.check(cx, ident, cx.last_node_with_lint_attrs);
-            },
-            _ => {},
+            FnKind::Closure => {},
         }
     }
 }

--- a/tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs
+++ b/tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::await_holding_invalid_type)]
+#![allow(clippy::disallowed_names)]
 use std::net::Ipv4Addr;
 
 async fn bad() -> u32 {

--- a/tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.stderr
+++ b/tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.stderr
@@ -1,5 +1,5 @@
 error: holding a disallowed type across an await point `std::string::String`
-  --> tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs:5:9
+  --> tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs:6:9
    |
 LL |     let _x = String::from("hello");
    |         ^^
@@ -9,13 +9,13 @@ LL |     let _x = String::from("hello");
    = help: to override `-D warnings` add `#[allow(clippy::await_holding_invalid_type)]`
 
 error: holding a disallowed type across an await point `std::net::Ipv4Addr`
-  --> tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs:11:9
+  --> tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs:12:9
    |
 LL |     let x = Ipv4Addr::new(127, 0, 0, 1);
    |         ^
 
 error: holding a disallowed type across an await point `std::string::String`
-  --> tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs:35:13
+  --> tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs:36:13
    |
 LL |         let _x = String::from("hi!");
    |             ^^

--- a/tests/ui-toml/dbg_macro/dbg_macro.fixed
+++ b/tests/ui-toml/dbg_macro/dbg_macro.fixed
@@ -1,6 +1,6 @@
 //@compile-flags: --test
 #![warn(clippy::dbg_macro)]
-#![allow(clippy::unnecessary_operation, clippy::no_effect)]
+#![allow(clippy::unnecessary_operation, clippy::no_effect, clippy::disallowed_names)]
 
 fn foo(n: u32) -> u32 {
     if let Some(n) = n.checked_sub(4) { n } else { n }

--- a/tests/ui-toml/dbg_macro/dbg_macro.rs
+++ b/tests/ui-toml/dbg_macro/dbg_macro.rs
@@ -1,6 +1,6 @@
 //@compile-flags: --test
 #![warn(clippy::dbg_macro)]
-#![allow(clippy::unnecessary_operation, clippy::no_effect)]
+#![allow(clippy::unnecessary_operation, clippy::no_effect, clippy::disallowed_names)]
 
 fn foo(n: u32) -> u32 {
     if let Some(n) = dbg!(n.checked_sub(4)) { n } else { n }

--- a/tests/ui-toml/item_name_repetitions/allow_exact_repetitions/item_name_repetitions.rs
+++ b/tests/ui-toml/item_name_repetitions/allow_exact_repetitions/item_name_repetitions.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::module_name_repetitions)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 
 pub mod foo {
     // this line should produce a warning:

--- a/tests/ui-toml/print_macro/print_macro.rs
+++ b/tests/ui-toml/print_macro/print_macro.rs
@@ -1,6 +1,7 @@
 //@compile-flags: --test
 #![warn(clippy::print_stdout)]
 #![warn(clippy::print_stderr)]
+#![allow(clippy::disallowed_names)]
 
 fn foo(n: u32) {
     print!("{n}");

--- a/tests/ui-toml/print_macro/print_macro.stderr
+++ b/tests/ui-toml/print_macro/print_macro.stderr
@@ -1,5 +1,5 @@
 error: use of `print!`
-  --> tests/ui-toml/print_macro/print_macro.rs:6:5
+  --> tests/ui-toml/print_macro/print_macro.rs:7:5
    |
 LL |     print!("{n}");
    |     ^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     print!("{n}");
    = help: to override `-D warnings` add `#[allow(clippy::print_stdout)]`
 
 error: use of `eprint!`
-  --> tests/ui-toml/print_macro/print_macro.rs:8:5
+  --> tests/ui-toml/print_macro/print_macro.rs:9:5
    |
 LL |     eprint!("{n}");
    |     ^^^^^^^^^^^^^^

--- a/tests/ui-toml/renamed_function_params/renamed_function_params.rs
+++ b/tests/ui-toml/renamed_function_params/renamed_function_params.rs
@@ -3,7 +3,7 @@
 //@[default] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/renamed_function_params/default
 //@[extend] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/renamed_function_params/extend
 #![warn(clippy::renamed_function_params)]
-#![allow(clippy::partialeq_ne_impl, clippy::to_string_trait_impl)]
+#![allow(clippy::disallowed_names, clippy::partialeq_ne_impl, clippy::to_string_trait_impl)]
 #![allow(unused)]
 
 use std::hash::{Hash, Hasher};

--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.default.stderr
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.default.stderr
@@ -1,5 +1,5 @@
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:270:19
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:271:19
    |
 LL |     /* Safety: */ unsafe {}
    |                   ^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     /* Safety: */ unsafe {}
    = help: to override `-D warnings` add `#[allow(clippy::undocumented_unsafe_blocks)]`
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:275:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:276:5
    |
 LL |     unsafe {}
    |     ^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     unsafe {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:280:14
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:281:14
    |
 LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    |              ^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:280:29
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:281:29
    |
 LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    |                             ^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:280:48
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:281:48
    |
 LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    |                                                ^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:287:18
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:288:18
    |
 LL |     let _ = (42, unsafe {}, "test", unsafe {});
    |                  ^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     let _ = (42, unsafe {}, "test", unsafe {});
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:287:37
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:288:37
    |
 LL |     let _ = (42, unsafe {}, "test", unsafe {});
    |                                     ^^^^^^^^^
@@ -57,7 +57,7 @@ LL |     let _ = (42, unsafe {}, "test", unsafe {});
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:293:14
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:294:14
    |
 LL |     let _ = *unsafe { &42 };
    |              ^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     let _ = *unsafe { &42 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:299:19
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:300:19
    |
 LL |     let _ = match unsafe {} {
    |                   ^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     let _ = match unsafe {} {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:306:14
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:307:14
    |
 LL |     let _ = &unsafe {};
    |              ^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     let _ = &unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:311:14
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:312:14
    |
 LL |     let _ = [unsafe {}; 5];
    |              ^^^^^^^^^
@@ -89,7 +89,7 @@ LL |     let _ = [unsafe {}; 5];
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:316:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:317:13
    |
 LL |     let _ = unsafe {};
    |             ^^^^^^^^^
@@ -97,7 +97,7 @@ LL |     let _ = unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:327:8
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:328:8
    |
 LL |     t!(unsafe {});
    |        ^^^^^^^^^
@@ -105,7 +105,7 @@ LL |     t!(unsafe {});
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:334:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:335:13
    |
 LL |             unsafe {}
    |             ^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     t!();
    = note: this error originates in the macro `t` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:343:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:344:5
    |
 LL |     unsafe {} // SAFETY:
    |     ^^^^^^^^^
@@ -125,7 +125,7 @@ LL |     unsafe {} // SAFETY:
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:349:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:350:5
    |
 LL |     unsafe {
    |     ^^^^^^^^
@@ -133,7 +133,7 @@ LL |     unsafe {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:360:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:361:5
    |
 LL |     unsafe {};
    |     ^^^^^^^^^
@@ -141,7 +141,7 @@ LL |     unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:365:20
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:366:20
    |
 LL |     println!("{}", unsafe { String::from_utf8_unchecked(vec![]) });
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     println!("{}", unsafe { String::from_utf8_unchecked(vec![]) });
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:373:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:374:5
    |
 LL |     unsafe impl A for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL |     unsafe impl A for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:381:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:382:9
    |
 LL |         unsafe impl B for (u32) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,7 +165,7 @@ LL |         unsafe impl B for (u32) {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:403:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:404:13
    |
 LL |             unsafe impl T for $t {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL |     no_safety_comment!(());
    = note: this error originates in the macro `no_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:429:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:430:13
    |
 LL |             unsafe impl T for $t {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ LL |     no_safety_comment!(());
    = note: this error originates in the macro `no_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:439:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:440:5
    |
 LL |     unsafe impl T for (i32) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ LL |     unsafe impl T for (i32) {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:429:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:430:13
    |
 LL |             unsafe impl T for $t {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -209,7 +209,7 @@ LL |     no_safety_comment!(u32);
    = note: this error originates in the macro `no_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:446:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:447:5
    |
 LL |     unsafe impl T for (bool) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +217,7 @@ LL |     unsafe impl T for (bool) {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:493:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:494:5
    |
 LL |     unsafe impl NoComment for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -225,7 +225,7 @@ LL |     unsafe impl NoComment for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:498:19
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:499:19
    |
 LL |     /* SAFETY: */ unsafe impl InlineComment for () {}
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -233,7 +233,7 @@ LL |     /* SAFETY: */ unsafe impl InlineComment for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:503:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:504:5
    |
 LL |     unsafe impl TrailingComment for () {} // SAFETY:
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,13 +241,13 @@ LL |     unsafe impl TrailingComment for () {} // SAFETY:
    = help: consider adding a safety comment on the preceding line
 
 error: constant item has unnecessary safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:508:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:509:5
    |
 LL |     const BIG_NUMBER: i32 = 1000000;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider removing the safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:507:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:508:5
    |
 LL |     // SAFETY:
    |     ^^^^^^^^^^
@@ -255,7 +255,7 @@ LL |     // SAFETY:
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_safety_comment)]`
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:510:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:511:5
    |
 LL |     unsafe impl Interference for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +263,7 @@ LL |     unsafe impl Interference for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:518:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:519:5
    |
 LL |     unsafe impl ImplInFn for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,7 +271,7 @@ LL |     unsafe impl ImplInFn for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:528:1
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:529:1
    |
 LL | unsafe impl CrateRoot for () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +279,7 @@ LL | unsafe impl CrateRoot for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: statement has unnecessary safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:543:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:544:5
    |
 LL | /     let _ = {
 LL | |
@@ -289,13 +289,13 @@ LL | |     };
    | |______^
    |
 help: consider removing the safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:542:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:543:5
    |
 LL |     // SAFETY: this is more than one level away, so it should warn
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:545:12
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:546:12
    |
 LL |         if unsafe { true } {
    |            ^^^^^^^^^^^^^^^
@@ -303,7 +303,7 @@ LL |         if unsafe { true } {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:549:23
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:550:23
    |
 LL |             let bar = unsafe {};
    |                       ^^^^^^^^^
@@ -311,7 +311,7 @@ LL |             let bar = unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:638:52
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:639:52
    |
 LL |         const NO_SAFETY_IN_TRAIT_BUT_IN_IMPL: u8 = unsafe { 0 };
    |                                                    ^^^^^^^^^^^^
@@ -319,7 +319,7 @@ LL |         const NO_SAFETY_IN_TRAIT_BUT_IN_IMPL: u8 = unsafe { 0 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:647:41
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:648:41
    |
 LL |         const NO_SAFETY_IN_TRAIT: i32 = unsafe { 1 };
    |                                         ^^^^^^^^^^^^
@@ -327,7 +327,7 @@ LL |         const NO_SAFETY_IN_TRAIT: i32 = unsafe { 1 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:657:42
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:658:42
    |
 LL |         const HAS_SAFETY_IN_TRAIT: i32 = unsafe { 3 };
    |                                          ^^^^^^^^^^^^
@@ -335,7 +335,7 @@ LL |         const HAS_SAFETY_IN_TRAIT: i32 = unsafe { 3 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:662:40
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:663:40
    |
 LL |         const NO_SAFETY_IN_IMPL: i32 = unsafe { 1 };
    |                                        ^^^^^^^^^^^^
@@ -343,13 +343,13 @@ LL |         const NO_SAFETY_IN_IMPL: i32 = unsafe { 1 };
    = help: consider adding a safety comment on the preceding line
 
 error: statement has unnecessary safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:719:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:720:5
    |
 LL |     _ = bar();
    |     ^^^^^^^^^^
    |
 help: consider removing the safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:718:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:719:5
    |
 LL |     // SAFETY: unnecessary_safety_comment triggers here
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.disabled.stderr
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.disabled.stderr
@@ -1,5 +1,5 @@
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:270:19
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:271:19
    |
 LL |     /* Safety: */ unsafe {}
    |                   ^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     /* Safety: */ unsafe {}
    = help: to override `-D warnings` add `#[allow(clippy::undocumented_unsafe_blocks)]`
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:275:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:276:5
    |
 LL |     unsafe {}
    |     ^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     unsafe {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:280:14
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:281:14
    |
 LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    |              ^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:280:29
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:281:29
    |
 LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    |                             ^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:280:48
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:281:48
    |
 LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    |                                                ^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:287:18
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:288:18
    |
 LL |     let _ = (42, unsafe {}, "test", unsafe {});
    |                  ^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     let _ = (42, unsafe {}, "test", unsafe {});
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:287:37
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:288:37
    |
 LL |     let _ = (42, unsafe {}, "test", unsafe {});
    |                                     ^^^^^^^^^
@@ -57,7 +57,7 @@ LL |     let _ = (42, unsafe {}, "test", unsafe {});
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:293:14
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:294:14
    |
 LL |     let _ = *unsafe { &42 };
    |              ^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     let _ = *unsafe { &42 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:299:19
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:300:19
    |
 LL |     let _ = match unsafe {} {
    |                   ^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     let _ = match unsafe {} {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:306:14
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:307:14
    |
 LL |     let _ = &unsafe {};
    |              ^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     let _ = &unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:311:14
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:312:14
    |
 LL |     let _ = [unsafe {}; 5];
    |              ^^^^^^^^^
@@ -89,7 +89,7 @@ LL |     let _ = [unsafe {}; 5];
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:316:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:317:13
    |
 LL |     let _ = unsafe {};
    |             ^^^^^^^^^
@@ -97,7 +97,7 @@ LL |     let _ = unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:327:8
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:328:8
    |
 LL |     t!(unsafe {});
    |        ^^^^^^^^^
@@ -105,7 +105,7 @@ LL |     t!(unsafe {});
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:334:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:335:13
    |
 LL |             unsafe {}
    |             ^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     t!();
    = note: this error originates in the macro `t` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:343:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:344:5
    |
 LL |     unsafe {} // SAFETY:
    |     ^^^^^^^^^
@@ -125,7 +125,7 @@ LL |     unsafe {} // SAFETY:
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:349:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:350:5
    |
 LL |     unsafe {
    |     ^^^^^^^^
@@ -133,7 +133,7 @@ LL |     unsafe {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:360:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:361:5
    |
 LL |     unsafe {};
    |     ^^^^^^^^^
@@ -141,7 +141,7 @@ LL |     unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:365:20
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:366:20
    |
 LL |     println!("{}", unsafe { String::from_utf8_unchecked(vec![]) });
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     println!("{}", unsafe { String::from_utf8_unchecked(vec![]) });
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:373:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:374:5
    |
 LL |     unsafe impl A for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL |     unsafe impl A for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:381:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:382:9
    |
 LL |         unsafe impl B for (u32) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,7 +165,7 @@ LL |         unsafe impl B for (u32) {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:403:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:404:13
    |
 LL |             unsafe impl T for $t {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL |     no_safety_comment!(());
    = note: this error originates in the macro `no_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:429:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:430:13
    |
 LL |             unsafe impl T for $t {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ LL |     no_safety_comment!(());
    = note: this error originates in the macro `no_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:439:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:440:5
    |
 LL |     unsafe impl T for (i32) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ LL |     unsafe impl T for (i32) {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:429:13
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:430:13
    |
 LL |             unsafe impl T for $t {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -209,7 +209,7 @@ LL |     no_safety_comment!(u32);
    = note: this error originates in the macro `no_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:446:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:447:5
    |
 LL |     unsafe impl T for (bool) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +217,7 @@ LL |     unsafe impl T for (bool) {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:493:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:494:5
    |
 LL |     unsafe impl NoComment for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -225,7 +225,7 @@ LL |     unsafe impl NoComment for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:498:19
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:499:19
    |
 LL |     /* SAFETY: */ unsafe impl InlineComment for () {}
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -233,7 +233,7 @@ LL |     /* SAFETY: */ unsafe impl InlineComment for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:503:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:504:5
    |
 LL |     unsafe impl TrailingComment for () {} // SAFETY:
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,13 +241,13 @@ LL |     unsafe impl TrailingComment for () {} // SAFETY:
    = help: consider adding a safety comment on the preceding line
 
 error: constant item has unnecessary safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:508:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:509:5
    |
 LL |     const BIG_NUMBER: i32 = 1000000;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider removing the safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:507:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:508:5
    |
 LL |     // SAFETY:
    |     ^^^^^^^^^^
@@ -255,7 +255,7 @@ LL |     // SAFETY:
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_safety_comment)]`
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:510:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:511:5
    |
 LL |     unsafe impl Interference for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +263,7 @@ LL |     unsafe impl Interference for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:518:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:519:5
    |
 LL |     unsafe impl ImplInFn for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,7 +271,7 @@ LL |     unsafe impl ImplInFn for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:528:1
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:529:1
    |
 LL | unsafe impl CrateRoot for () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +279,7 @@ LL | unsafe impl CrateRoot for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:539:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:540:9
    |
 LL |         unsafe {};
    |         ^^^^^^^^^
@@ -287,7 +287,7 @@ LL |         unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: statement has unnecessary safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:543:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:544:5
    |
 LL | /     let _ = {
 LL | |
@@ -297,13 +297,13 @@ LL | |     };
    | |______^
    |
 help: consider removing the safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:542:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:543:5
    |
 LL |     // SAFETY: this is more than one level away, so it should warn
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:545:12
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:546:12
    |
 LL |         if unsafe { true } {
    |            ^^^^^^^^^^^^^^^
@@ -311,7 +311,7 @@ LL |         if unsafe { true } {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:549:23
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:550:23
    |
 LL |             let bar = unsafe {};
    |                       ^^^^^^^^^
@@ -319,7 +319,7 @@ LL |             let bar = unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:568:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:569:9
    |
 LL |         unsafe { a_function_with_a_very_long_name_to_break_the_line() };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -327,7 +327,7 @@ LL |         unsafe { a_function_with_a_very_long_name_to_break_the_line() };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:573:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:574:9
    |
 LL |         unsafe { a_const_function_with_a_very_long_name_to_break_the_line() };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -335,7 +335,7 @@ LL |         unsafe { a_const_function_with_a_very_long_name_to_break_the_line()
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:578:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:579:9
    |
 LL |         unsafe { a_const_function_with_a_very_long_name_to_break_the_line() };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -343,7 +343,7 @@ LL |         unsafe { a_const_function_with_a_very_long_name_to_break_the_line()
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:585:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:586:5
    |
 LL |     unsafe {}
    |     ^^^^^^^^^
@@ -351,7 +351,7 @@ LL |     unsafe {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:590:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:591:5
    |
 LL |     unsafe {
    |     ^^^^^^^^
@@ -359,7 +359,7 @@ LL |     unsafe {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:598:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:599:9
    |
 LL |         unsafe { a_function_with_a_very_long_name_to_break_the_line() };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -367,7 +367,7 @@ LL |         unsafe { a_function_with_a_very_long_name_to_break_the_line() };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:604:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:605:9
    |
 LL |         unsafe { a_const_function_with_a_very_long_name_to_break_the_line() };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -375,7 +375,7 @@ LL |         unsafe { a_const_function_with_a_very_long_name_to_break_the_line()
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:611:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:612:9
    |
 LL |         unsafe { a_const_function_with_a_very_long_name_to_break_the_line() };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -383,7 +383,7 @@ LL |         unsafe { a_const_function_with_a_very_long_name_to_break_the_line()
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:617:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:618:5
    |
 LL |     unsafe {}
    |     ^^^^^^^^^
@@ -391,7 +391,7 @@ LL |     unsafe {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:638:52
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:639:52
    |
 LL |         const NO_SAFETY_IN_TRAIT_BUT_IN_IMPL: u8 = unsafe { 0 };
    |                                                    ^^^^^^^^^^^^
@@ -399,7 +399,7 @@ LL |         const NO_SAFETY_IN_TRAIT_BUT_IN_IMPL: u8 = unsafe { 0 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:647:41
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:648:41
    |
 LL |         const NO_SAFETY_IN_TRAIT: i32 = unsafe { 1 };
    |                                         ^^^^^^^^^^^^
@@ -407,7 +407,7 @@ LL |         const NO_SAFETY_IN_TRAIT: i32 = unsafe { 1 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:657:42
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:658:42
    |
 LL |         const HAS_SAFETY_IN_TRAIT: i32 = unsafe { 3 };
    |                                          ^^^^^^^^^^^^
@@ -415,7 +415,7 @@ LL |         const HAS_SAFETY_IN_TRAIT: i32 = unsafe { 3 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:662:40
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:663:40
    |
 LL |         const NO_SAFETY_IN_IMPL: i32 = unsafe { 1 };
    |                                        ^^^^^^^^^^^^
@@ -423,7 +423,7 @@ LL |         const NO_SAFETY_IN_IMPL: i32 = unsafe { 1 };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:673:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:674:9
    |
 LL |         unsafe { here_is_another_variable_with_long_name };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -431,7 +431,7 @@ LL |         unsafe { here_is_another_variable_with_long_name };
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:702:9
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:703:9
    |
 LL |         unsafe { Date::__from_ordinal_date_unchecked(1970, 1) }.into_julian_day_just_make_this_line_longer();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -439,13 +439,13 @@ LL |         unsafe { Date::__from_ordinal_date_unchecked(1970, 1) }.into_julian
    = help: consider adding a safety comment on the preceding line
 
 error: statement has unnecessary safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:719:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:720:5
    |
 LL |     _ = bar();
    |     ^^^^^^^^^^
    |
 help: consider removing the safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:718:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:719:5
    |
 LL |     // SAFETY: unnecessary_safety_comment triggers here
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs
@@ -7,6 +7,7 @@
 #![allow(
     deref_nullptr,
     non_local_definitions,
+    clippy::disallowed_names,
     clippy::let_unit_value,
     clippy::missing_safety_doc
 )]

--- a/tests/ui-toml/useless_vec/useless_vec.fixed
+++ b/tests/ui-toml/useless_vec/useless_vec.fixed
@@ -1,6 +1,6 @@
 //@compile-flags: --test
 #![warn(clippy::useless_vec)]
-#![allow(clippy::unnecessary_operation, clippy::no_effect)]
+#![allow(clippy::unnecessary_operation, clippy::no_effect, clippy::disallowed_names)]
 
 fn foo(_: &[u32]) {}
 

--- a/tests/ui-toml/useless_vec/useless_vec.rs
+++ b/tests/ui-toml/useless_vec/useless_vec.rs
@@ -1,6 +1,6 @@
 //@compile-flags: --test
 #![warn(clippy::useless_vec)]
-#![allow(clippy::unnecessary_operation, clippy::no_effect)]
+#![allow(clippy::unnecessary_operation, clippy::no_effect, clippy::disallowed_names)]
 
 fn foo(_: &[u32]) {}
 

--- a/tests/ui/absurd-extreme-comparisons.rs
+++ b/tests/ui/absurd-extreme-comparisons.rs
@@ -4,7 +4,8 @@
     clippy::eq_op,
     clippy::no_effect,
     clippy::unnecessary_operation,
-    clippy::needless_pass_by_value
+    clippy::needless_pass_by_value,
+    clippy::disallowed_names
 )]
 
 #[rustfmt::skip]

--- a/tests/ui/absurd-extreme-comparisons.stderr
+++ b/tests/ui/absurd-extreme-comparisons.stderr
@@ -1,5 +1,5 @@
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:14:5
+  --> tests/ui/absurd-extreme-comparisons.rs:15:5
    |
 LL |     u <= 0;
    |     ^^^^^^
@@ -9,7 +9,7 @@ LL |     u <= 0;
    = help: to override `-D warnings` add `#[allow(clippy::absurd_extreme_comparisons)]`
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:17:5
+  --> tests/ui/absurd-extreme-comparisons.rs:18:5
    |
 LL |     u <= Z;
    |     ^^^^^^
@@ -17,7 +17,7 @@ LL |     u <= Z;
    = help: because `Z` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `u == Z` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:20:5
+  --> tests/ui/absurd-extreme-comparisons.rs:21:5
    |
 LL |     u < Z;
    |     ^^^^^
@@ -25,7 +25,7 @@ LL |     u < Z;
    = help: because `Z` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:23:5
+  --> tests/ui/absurd-extreme-comparisons.rs:24:5
    |
 LL |     Z >= u;
    |     ^^^^^^
@@ -33,7 +33,7 @@ LL |     Z >= u;
    = help: because `Z` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `Z == u` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:26:5
+  --> tests/ui/absurd-extreme-comparisons.rs:27:5
    |
 LL |     Z > u;
    |     ^^^^^
@@ -41,7 +41,7 @@ LL |     Z > u;
    = help: because `Z` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:29:5
+  --> tests/ui/absurd-extreme-comparisons.rs:30:5
    |
 LL |     u > u32::MAX;
    |     ^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     u > u32::MAX;
    = help: because `u32::MAX` is the maximum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:32:5
+  --> tests/ui/absurd-extreme-comparisons.rs:33:5
    |
 LL |     u >= u32::MAX;
    |     ^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL |     u >= u32::MAX;
    = help: because `u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u == u32::MAX` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:35:5
+  --> tests/ui/absurd-extreme-comparisons.rs:36:5
    |
 LL |     u32::MAX < u;
    |     ^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     u32::MAX < u;
    = help: because `u32::MAX` is the maximum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:38:5
+  --> tests/ui/absurd-extreme-comparisons.rs:39:5
    |
 LL |     u32::MAX <= u;
    |     ^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     u32::MAX <= u;
    = help: because `u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u32::MAX == u` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:41:5
+  --> tests/ui/absurd-extreme-comparisons.rs:42:5
    |
 LL |     1-1 > u;
    |     ^^^^^^^
@@ -81,7 +81,7 @@ LL |     1-1 > u;
    = help: because `1-1` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:44:5
+  --> tests/ui/absurd-extreme-comparisons.rs:45:5
    |
 LL |     u >= !0;
    |     ^^^^^^^
@@ -89,7 +89,7 @@ LL |     u >= !0;
    = help: because `!0` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u == !0` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:47:5
+  --> tests/ui/absurd-extreme-comparisons.rs:48:5
    |
 LL |     u <= 12 - 2*6;
    |     ^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL |     u <= 12 - 2*6;
    = help: because `12 - 2*6` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `u == 12 - 2*6` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:51:5
+  --> tests/ui/absurd-extreme-comparisons.rs:52:5
    |
 LL |     i < -127 - 1;
    |     ^^^^^^^^^^^^
@@ -105,7 +105,7 @@ LL |     i < -127 - 1;
    = help: because `-127 - 1` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:54:5
+  --> tests/ui/absurd-extreme-comparisons.rs:55:5
    |
 LL |     i8::MAX >= i;
    |     ^^^^^^^^^^^^
@@ -113,7 +113,7 @@ LL |     i8::MAX >= i;
    = help: because `i8::MAX` is the maximum value for this type, this comparison is always true
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:57:5
+  --> tests/ui/absurd-extreme-comparisons.rs:58:5
    |
 LL |     3-7 < i32::MIN;
    |     ^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     3-7 < i32::MIN;
    = help: because `i32::MIN` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:61:5
+  --> tests/ui/absurd-extreme-comparisons.rs:62:5
    |
 LL |     b >= true;
    |     ^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     b >= true;
    = help: because `true` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `b == true` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:64:5
+  --> tests/ui/absurd-extreme-comparisons.rs:65:5
    |
 LL |     false > b;
    |     ^^^^^^^^^
@@ -137,7 +137,7 @@ LL |     false > b;
    = help: because `false` is the minimum value for this type, this comparison is always false
 
 error: <-comparison of unit values detected. This will always be false
-  --> tests/ui/absurd-extreme-comparisons.rs:69:5
+  --> tests/ui/absurd-extreme-comparisons.rs:70:5
    |
 LL |     () < {};
    |     ^^^^^^^

--- a/tests/ui/arc_with_non_send_sync.rs
+++ b/tests/ui/arc_with_non_send_sync.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::arc_with_non_send_sync)]
-#![allow(unused_variables)]
+#![allow(unused_variables, clippy::disallowed_names)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -4,6 +4,7 @@
 #![feature(f16)]
 #![allow(
     clippy::assign_op_pattern,
+    clippy::disallowed_names,
     clippy::erasing_op,
     clippy::identity_op,
     clippy::no_effect,

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -1,5 +1,5 @@
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:166:13
+  --> tests/ui/arithmetic_side_effects.rs:167:13
    |
 LL |     let _ = 1f16 + 1f16;
    |             ^^^^^^^^^^^
@@ -8,763 +8,763 @@ LL |     let _ = 1f16 + 1f16;
    = help: to override `-D warnings` add `#[allow(clippy::arithmetic_side_effects)]`
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:170:13
+  --> tests/ui/arithmetic_side_effects.rs:171:13
    |
 LL |     let _ = 1f128 + 1f128;
    |             ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:175:13
+  --> tests/ui/arithmetic_side_effects.rs:176:13
    |
 LL |     let _ = String::new() + &String::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:311:5
+  --> tests/ui/arithmetic_side_effects.rs:312:5
    |
 LL |     _n += 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:313:5
+  --> tests/ui/arithmetic_side_effects.rs:314:5
    |
 LL |     _n += &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:315:5
+  --> tests/ui/arithmetic_side_effects.rs:316:5
    |
 LL |     _n -= 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:317:5
+  --> tests/ui/arithmetic_side_effects.rs:318:5
    |
 LL |     _n -= &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:319:5
+  --> tests/ui/arithmetic_side_effects.rs:320:5
    |
 LL |     _n /= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:321:5
+  --> tests/ui/arithmetic_side_effects.rs:322:5
    |
 LL |     _n /= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:323:5
+  --> tests/ui/arithmetic_side_effects.rs:324:5
    |
 LL |     _n %= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:325:5
+  --> tests/ui/arithmetic_side_effects.rs:326:5
    |
 LL |     _n %= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:327:5
+  --> tests/ui/arithmetic_side_effects.rs:328:5
    |
 LL |     _n *= 2;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:329:5
+  --> tests/ui/arithmetic_side_effects.rs:330:5
    |
 LL |     _n *= &2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:331:5
+  --> tests/ui/arithmetic_side_effects.rs:332:5
    |
 LL |     _n += -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:333:5
+  --> tests/ui/arithmetic_side_effects.rs:334:5
    |
 LL |     _n += &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:335:5
+  --> tests/ui/arithmetic_side_effects.rs:336:5
    |
 LL |     _n -= -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:337:5
+  --> tests/ui/arithmetic_side_effects.rs:338:5
    |
 LL |     _n -= &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:339:5
+  --> tests/ui/arithmetic_side_effects.rs:340:5
    |
 LL |     _n /= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:341:5
+  --> tests/ui/arithmetic_side_effects.rs:342:5
    |
 LL |     _n /= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:343:5
+  --> tests/ui/arithmetic_side_effects.rs:344:5
    |
 LL |     _n %= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:345:5
+  --> tests/ui/arithmetic_side_effects.rs:346:5
    |
 LL |     _n %= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:347:5
+  --> tests/ui/arithmetic_side_effects.rs:348:5
    |
 LL |     _n *= -2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:349:5
+  --> tests/ui/arithmetic_side_effects.rs:350:5
    |
 LL |     _n *= &-2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:351:5
+  --> tests/ui/arithmetic_side_effects.rs:352:5
    |
 LL |     _custom += Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:353:5
+  --> tests/ui/arithmetic_side_effects.rs:354:5
    |
 LL |     _custom += &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:355:5
+  --> tests/ui/arithmetic_side_effects.rs:356:5
    |
 LL |     _custom -= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:357:5
+  --> tests/ui/arithmetic_side_effects.rs:358:5
    |
 LL |     _custom -= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:359:5
+  --> tests/ui/arithmetic_side_effects.rs:360:5
    |
 LL |     _custom /= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:361:5
+  --> tests/ui/arithmetic_side_effects.rs:362:5
    |
 LL |     _custom /= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:363:5
+  --> tests/ui/arithmetic_side_effects.rs:364:5
    |
 LL |     _custom %= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:365:5
+  --> tests/ui/arithmetic_side_effects.rs:366:5
    |
 LL |     _custom %= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:367:5
+  --> tests/ui/arithmetic_side_effects.rs:368:5
    |
 LL |     _custom *= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:369:5
+  --> tests/ui/arithmetic_side_effects.rs:370:5
    |
 LL |     _custom *= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:371:5
+  --> tests/ui/arithmetic_side_effects.rs:372:5
    |
 LL |     _custom >>= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:373:5
+  --> tests/ui/arithmetic_side_effects.rs:374:5
    |
 LL |     _custom >>= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:375:5
+  --> tests/ui/arithmetic_side_effects.rs:376:5
    |
 LL |     _custom <<= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:377:5
+  --> tests/ui/arithmetic_side_effects.rs:378:5
    |
 LL |     _custom <<= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:379:5
+  --> tests/ui/arithmetic_side_effects.rs:380:5
    |
 LL |     _custom += -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:381:5
+  --> tests/ui/arithmetic_side_effects.rs:382:5
    |
 LL |     _custom += &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:383:5
+  --> tests/ui/arithmetic_side_effects.rs:384:5
    |
 LL |     _custom -= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:385:5
+  --> tests/ui/arithmetic_side_effects.rs:386:5
    |
 LL |     _custom -= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:387:5
+  --> tests/ui/arithmetic_side_effects.rs:388:5
    |
 LL |     _custom /= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:389:5
+  --> tests/ui/arithmetic_side_effects.rs:390:5
    |
 LL |     _custom /= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:391:5
+  --> tests/ui/arithmetic_side_effects.rs:392:5
    |
 LL |     _custom %= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:393:5
+  --> tests/ui/arithmetic_side_effects.rs:394:5
    |
 LL |     _custom %= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:395:5
+  --> tests/ui/arithmetic_side_effects.rs:396:5
    |
 LL |     _custom *= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:397:5
+  --> tests/ui/arithmetic_side_effects.rs:398:5
    |
 LL |     _custom *= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:399:5
+  --> tests/ui/arithmetic_side_effects.rs:400:5
    |
 LL |     _custom >>= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:401:5
+  --> tests/ui/arithmetic_side_effects.rs:402:5
    |
 LL |     _custom >>= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:403:5
+  --> tests/ui/arithmetic_side_effects.rs:404:5
    |
 LL |     _custom <<= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:405:5
+  --> tests/ui/arithmetic_side_effects.rs:406:5
    |
 LL |     _custom <<= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:409:10
+  --> tests/ui/arithmetic_side_effects.rs:410:10
    |
 LL |     _n = _n + 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:411:10
+  --> tests/ui/arithmetic_side_effects.rs:412:10
    |
 LL |     _n = _n + &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:413:10
+  --> tests/ui/arithmetic_side_effects.rs:414:10
    |
 LL |     _n = 1 + _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:415:10
+  --> tests/ui/arithmetic_side_effects.rs:416:10
    |
 LL |     _n = &1 + _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:417:10
+  --> tests/ui/arithmetic_side_effects.rs:418:10
    |
 LL |     _n = _n - 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:419:10
+  --> tests/ui/arithmetic_side_effects.rs:420:10
    |
 LL |     _n = _n - &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:421:10
+  --> tests/ui/arithmetic_side_effects.rs:422:10
    |
 LL |     _n = 1 - _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:423:10
+  --> tests/ui/arithmetic_side_effects.rs:424:10
    |
 LL |     _n = &1 - _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:425:10
+  --> tests/ui/arithmetic_side_effects.rs:426:10
    |
 LL |     _n = _n / 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:427:10
+  --> tests/ui/arithmetic_side_effects.rs:428:10
    |
 LL |     _n = _n / &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:429:10
+  --> tests/ui/arithmetic_side_effects.rs:430:10
    |
 LL |     _n = _n % 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:431:10
+  --> tests/ui/arithmetic_side_effects.rs:432:10
    |
 LL |     _n = _n % &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:433:10
+  --> tests/ui/arithmetic_side_effects.rs:434:10
    |
 LL |     _n = _n * 2;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:435:10
+  --> tests/ui/arithmetic_side_effects.rs:436:10
    |
 LL |     _n = _n * &2;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:437:10
+  --> tests/ui/arithmetic_side_effects.rs:438:10
    |
 LL |     _n = 2 * _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:439:10
+  --> tests/ui/arithmetic_side_effects.rs:440:10
    |
 LL |     _n = &2 * _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:441:10
+  --> tests/ui/arithmetic_side_effects.rs:442:10
    |
 LL |     _n = 23 + &85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:443:10
+  --> tests/ui/arithmetic_side_effects.rs:444:10
    |
 LL |     _n = &23 + 85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:445:10
+  --> tests/ui/arithmetic_side_effects.rs:446:10
    |
 LL |     _n = &23 + &85;
    |          ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:447:15
+  --> tests/ui/arithmetic_side_effects.rs:448:15
    |
 LL |     _custom = _custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:449:15
+  --> tests/ui/arithmetic_side_effects.rs:450:15
    |
 LL |     _custom = _custom + &_custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:451:15
+  --> tests/ui/arithmetic_side_effects.rs:452:15
    |
 LL |     _custom = Custom + _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:453:15
+  --> tests/ui/arithmetic_side_effects.rs:454:15
    |
 LL |     _custom = &Custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:455:15
+  --> tests/ui/arithmetic_side_effects.rs:456:15
    |
 LL |     _custom = _custom - Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:457:15
+  --> tests/ui/arithmetic_side_effects.rs:458:15
    |
 LL |     _custom = _custom - &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:459:15
+  --> tests/ui/arithmetic_side_effects.rs:460:15
    |
 LL |     _custom = Custom - _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:461:15
+  --> tests/ui/arithmetic_side_effects.rs:462:15
    |
 LL |     _custom = &Custom - _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:463:15
+  --> tests/ui/arithmetic_side_effects.rs:464:15
    |
 LL |     _custom = _custom / Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:465:15
+  --> tests/ui/arithmetic_side_effects.rs:466:15
    |
 LL |     _custom = _custom / &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:467:15
+  --> tests/ui/arithmetic_side_effects.rs:468:15
    |
 LL |     _custom = _custom % Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:469:15
+  --> tests/ui/arithmetic_side_effects.rs:470:15
    |
 LL |     _custom = _custom % &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:471:15
+  --> tests/ui/arithmetic_side_effects.rs:472:15
    |
 LL |     _custom = _custom * Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:473:15
+  --> tests/ui/arithmetic_side_effects.rs:474:15
    |
 LL |     _custom = _custom * &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:475:15
+  --> tests/ui/arithmetic_side_effects.rs:476:15
    |
 LL |     _custom = Custom * _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:477:15
+  --> tests/ui/arithmetic_side_effects.rs:478:15
    |
 LL |     _custom = &Custom * _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:479:15
+  --> tests/ui/arithmetic_side_effects.rs:480:15
    |
 LL |     _custom = Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:481:15
+  --> tests/ui/arithmetic_side_effects.rs:482:15
    |
 LL |     _custom = &Custom + Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:483:15
+  --> tests/ui/arithmetic_side_effects.rs:484:15
    |
 LL |     _custom = &Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:485:15
+  --> tests/ui/arithmetic_side_effects.rs:486:15
    |
 LL |     _custom = _custom >> _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:487:15
+  --> tests/ui/arithmetic_side_effects.rs:488:15
    |
 LL |     _custom = _custom >> &_custom;
    |               ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:489:15
+  --> tests/ui/arithmetic_side_effects.rs:490:15
    |
 LL |     _custom = Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:491:15
+  --> tests/ui/arithmetic_side_effects.rs:492:15
    |
 LL |     _custom = &Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:495:23
+  --> tests/ui/arithmetic_side_effects.rs:496:23
    |
 LL |     _n.saturating_div(0);
    |                       ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:497:21
+  --> tests/ui/arithmetic_side_effects.rs:498:21
    |
 LL |     _n.wrapping_div(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:499:21
+  --> tests/ui/arithmetic_side_effects.rs:500:21
    |
 LL |     _n.wrapping_rem(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:501:28
+  --> tests/ui/arithmetic_side_effects.rs:502:28
    |
 LL |     _n.wrapping_rem_euclid(0);
    |                            ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:504:23
+  --> tests/ui/arithmetic_side_effects.rs:505:23
    |
 LL |     _n.saturating_div(_n);
    |                       ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:506:21
+  --> tests/ui/arithmetic_side_effects.rs:507:21
    |
 LL |     _n.wrapping_div(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:508:21
+  --> tests/ui/arithmetic_side_effects.rs:509:21
    |
 LL |     _n.wrapping_rem(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:510:28
+  --> tests/ui/arithmetic_side_effects.rs:511:28
    |
 LL |     _n.wrapping_rem_euclid(_n);
    |                            ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:513:23
+  --> tests/ui/arithmetic_side_effects.rs:514:23
    |
 LL |     _n.saturating_div(*Box::new(_n));
    |                       ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:517:10
+  --> tests/ui/arithmetic_side_effects.rs:518:10
    |
 LL |     _n = -_n;
    |          ^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:519:10
+  --> tests/ui/arithmetic_side_effects.rs:520:10
    |
 LL |     _n = -&_n;
    |          ^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:521:15
+  --> tests/ui/arithmetic_side_effects.rs:522:15
    |
 LL |     _custom = -_custom;
    |               ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:523:15
+  --> tests/ui/arithmetic_side_effects.rs:524:15
    |
 LL |     _custom = -&_custom;
    |               ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:525:9
+  --> tests/ui/arithmetic_side_effects.rs:526:9
    |
 LL |     _ = -*Box::new(_n);
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:535:5
+  --> tests/ui/arithmetic_side_effects.rs:536:5
    |
 LL |     1 + i;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:537:5
+  --> tests/ui/arithmetic_side_effects.rs:538:5
    |
 LL |     i * 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:539:5
+  --> tests/ui/arithmetic_side_effects.rs:540:5
    |
 LL |     1 % i / 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:541:5
+  --> tests/ui/arithmetic_side_effects.rs:542:5
    |
 LL |     i - 2 + 2 - i;
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:543:5
+  --> tests/ui/arithmetic_side_effects.rs:544:5
    |
 LL |     -i;
    |     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:555:5
+  --> tests/ui/arithmetic_side_effects.rs:556:5
    |
 LL |     i += 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:557:5
+  --> tests/ui/arithmetic_side_effects.rs:558:5
    |
 LL |     i -= 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:559:5
+  --> tests/ui/arithmetic_side_effects.rs:560:5
    |
 LL |     i *= 2;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:562:5
+  --> tests/ui/arithmetic_side_effects.rs:563:5
    |
 LL |     i /= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:565:5
+  --> tests/ui/arithmetic_side_effects.rs:566:5
    |
 LL |     i /= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:567:5
+  --> tests/ui/arithmetic_side_effects.rs:568:5
    |
 LL |     i /= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:570:5
+  --> tests/ui/arithmetic_side_effects.rs:571:5
    |
 LL |     i %= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:573:5
+  --> tests/ui/arithmetic_side_effects.rs:574:5
    |
 LL |     i %= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:575:5
+  --> tests/ui/arithmetic_side_effects.rs:576:5
    |
 LL |     i %= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:586:5
+  --> tests/ui/arithmetic_side_effects.rs:587:5
    |
 LL |     10 / a
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:641:9
+  --> tests/ui/arithmetic_side_effects.rs:642:9
    |
 LL |         x / maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:646:9
+  --> tests/ui/arithmetic_side_effects.rs:647:9
    |
 LL |         x % maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:658:5
+  --> tests/ui/arithmetic_side_effects.rs:659:5
    |
 LL |     one.add_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:663:5
+  --> tests/ui/arithmetic_side_effects.rs:664:5
    |
 LL |     one.sub_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:670:5
+  --> tests/ui/arithmetic_side_effects.rs:671:5
    |
 LL |     one.add(&one);
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:672:5
+  --> tests/ui/arithmetic_side_effects.rs:673:5
    |
 LL |     Box::new(one).add(one);
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/as_underscore.fixed
+++ b/tests/ui/as_underscore.fixed
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_names)]
 #![warn(clippy::as_underscore)]
 
 fn foo(_n: usize) {}

--- a/tests/ui/as_underscore.rs
+++ b/tests/ui/as_underscore.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_names)]
 #![warn(clippy::as_underscore)]
 
 fn foo(_n: usize) {}

--- a/tests/ui/as_underscore.stderr
+++ b/tests/ui/as_underscore.stderr
@@ -1,5 +1,5 @@
 error: using `as _` conversion
-  --> tests/ui/as_underscore.rs:7:9
+  --> tests/ui/as_underscore.rs:8:9
    |
 LL |     foo(n as _);
    |         ^^^^^-
@@ -10,7 +10,7 @@ LL |     foo(n as _);
    = help: to override `-D warnings` add `#[allow(clippy::as_underscore)]`
 
 error: using `as _` conversion
-  --> tests/ui/as_underscore.rs:11:18
+  --> tests/ui/as_underscore.rs:12:18
    |
 LL |     let _n: u8 = n as _;
    |                  ^^^^^-

--- a/tests/ui/await_holding_lock.rs
+++ b/tests/ui/await_holding_lock.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::await_holding_lock)]
-#![allow(clippy::readonly_write_lock)]
+#![allow(clippy::readonly_write_lock, clippy::disallowed_names)]
 
 // When adding or modifying a test, please do the same for parking_lot::Mutex.
 mod std_mutex {

--- a/tests/ui/await_holding_refcell_ref.rs
+++ b/tests/ui/await_holding_refcell_ref.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_names)]
 #![warn(clippy::await_holding_refcell_ref)]
 
 use std::cell::RefCell;

--- a/tests/ui/await_holding_refcell_ref.stderr
+++ b/tests/ui/await_holding_refcell_ref.stderr
@@ -1,12 +1,12 @@
 error: this `RefCell` reference is held across an await point
-  --> tests/ui/await_holding_refcell_ref.rs:6:9
+  --> tests/ui/await_holding_refcell_ref.rs:7:9
    |
 LL |     let b = x.borrow();
    |         ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the await points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:9:11
+  --> tests/ui/await_holding_refcell_ref.rs:10:11
    |
 LL |     baz().await
    |           ^^^^^
@@ -14,27 +14,27 @@ LL |     baz().await
    = help: to override `-D warnings` add `#[allow(clippy::await_holding_refcell_ref)]`
 
 error: this `RefCell` reference is held across an await point
-  --> tests/ui/await_holding_refcell_ref.rs:13:9
+  --> tests/ui/await_holding_refcell_ref.rs:14:9
    |
 LL |     let b = x.borrow_mut();
    |         ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the await points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:16:11
+  --> tests/ui/await_holding_refcell_ref.rs:17:11
    |
 LL |     baz().await
    |           ^^^^^
 
 error: this `RefCell` reference is held across an await point
-  --> tests/ui/await_holding_refcell_ref.rs:36:9
+  --> tests/ui/await_holding_refcell_ref.rs:37:9
    |
 LL |     let b = x.borrow_mut();
    |         ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the await points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:39:24
+  --> tests/ui/await_holding_refcell_ref.rs:40:24
    |
 LL |     let second = baz().await;
    |                        ^^^^^
@@ -43,40 +43,40 @@ LL |     let third = baz().await;
    |                       ^^^^^
 
 error: this `RefCell` reference is held across an await point
-  --> tests/ui/await_holding_refcell_ref.rs:49:9
+  --> tests/ui/await_holding_refcell_ref.rs:50:9
    |
 LL |     let b = x.borrow_mut();
    |         ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the await points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:52:24
+  --> tests/ui/await_holding_refcell_ref.rs:53:24
    |
 LL |     let second = baz().await;
    |                        ^^^^^
 
 error: this `RefCell` reference is held across an await point
-  --> tests/ui/await_holding_refcell_ref.rs:65:13
+  --> tests/ui/await_holding_refcell_ref.rs:66:13
    |
 LL |         let b = x.borrow_mut();
    |             ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the await points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:68:15
+  --> tests/ui/await_holding_refcell_ref.rs:69:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `RefCell` reference is held across an await point
-  --> tests/ui/await_holding_refcell_ref.rs:79:13
+  --> tests/ui/await_holding_refcell_ref.rs:80:13
    |
 LL |         let b = x.borrow_mut();
    |             ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the await points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:82:15
+  --> tests/ui/await_holding_refcell_ref.rs:83:15
    |
 LL |         baz().await
    |               ^^^^^

--- a/tests/ui/bind_instead_of_map.fixed
+++ b/tests/ui/bind_instead_of_map.fixed
@@ -1,5 +1,5 @@
 #![deny(clippy::bind_instead_of_map)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::disallowed_names)]
 
 // need a main anyway, use it get rid of unused warnings too
 pub fn main() {

--- a/tests/ui/bind_instead_of_map.rs
+++ b/tests/ui/bind_instead_of_map.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::bind_instead_of_map)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::disallowed_names)]
 
 // need a main anyway, use it get rid of unused warnings too
 pub fn main() {

--- a/tests/ui/bind_instead_of_map_multipart.fixed
+++ b/tests/ui/bind_instead_of_map_multipart.fixed
@@ -1,5 +1,5 @@
 #![deny(clippy::bind_instead_of_map)]
-#![allow(clippy::blocks_in_conditions)]
+#![allow(clippy::blocks_in_conditions, clippy::disallowed_names)]
 
 pub fn main() {
     let _ = Some("42").map(|s| if s.len() < 42 { 0 } else { s.len() });

--- a/tests/ui/bind_instead_of_map_multipart.rs
+++ b/tests/ui/bind_instead_of_map_multipart.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::bind_instead_of_map)]
-#![allow(clippy::blocks_in_conditions)]
+#![allow(clippy::blocks_in_conditions, clippy::disallowed_names)]
 
 pub fn main() {
     let _ = Some("42").and_then(|s| if s.len() < 42 { Some(0) } else { Some(s.len()) });

--- a/tests/ui/borrow_deref_ref.fixed
+++ b/tests/ui/borrow_deref_ref.fixed
@@ -1,6 +1,6 @@
 //@aux-build: proc_macros.rs
 
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code, unused_variables, clippy::disallowed_names)]
 
 extern crate proc_macros;
 use proc_macros::with_span;

--- a/tests/ui/borrow_deref_ref.rs
+++ b/tests/ui/borrow_deref_ref.rs
@@ -1,6 +1,6 @@
 //@aux-build: proc_macros.rs
 
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code, unused_variables, clippy::disallowed_names)]
 
 extern crate proc_macros;
 use proc_macros::with_span;

--- a/tests/ui/box_default.fixed
+++ b/tests/ui/box_default.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::box_default)]
-#![allow(clippy::boxed_local, clippy::default_constructed_unit_structs)]
+#![allow(
+    clippy::boxed_local,
+    clippy::default_constructed_unit_structs,
+    clippy::disallowed_names
+)]
 
 #[derive(Default)]
 struct ImplementsDefault;

--- a/tests/ui/box_default.rs
+++ b/tests/ui/box_default.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::box_default)]
-#![allow(clippy::boxed_local, clippy::default_constructed_unit_structs)]
+#![allow(
+    clippy::boxed_local,
+    clippy::default_constructed_unit_structs,
+    clippy::disallowed_names
+)]
 
 #[derive(Default)]
 struct ImplementsDefault;

--- a/tests/ui/box_default.stderr
+++ b/tests/ui/box_default.stderr
@@ -1,5 +1,5 @@
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:34:32
+  --> tests/ui/box_default.rs:38:32
    |
 LL |     let string1: Box<String> = Box::new(Default::default());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
@@ -8,55 +8,55 @@ LL |     let string1: Box<String> = Box::new(Default::default());
    = help: to override `-D warnings` add `#[allow(clippy::box_default)]`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:36:32
+  --> tests/ui/box_default.rs:40:32
    |
 LL |     let string2: Box<String> = Box::new(String::new());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:38:41
+  --> tests/ui/box_default.rs:42:41
    |
 LL |     let impl1: Box<ImplementsDefault> = Box::new(Default::default());
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:40:29
+  --> tests/ui/box_default.rs:44:29
    |
 LL |     let vec: Box<Vec<u8>> = Box::new(Vec::new());
    |                             ^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:42:25
+  --> tests/ui/box_default.rs:46:25
    |
 LL |     let byte: Box<u8> = Box::new(u8::default());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:44:45
+  --> tests/ui/box_default.rs:48:45
    |
 LL |     let vec2: Box<Vec<ImplementsDefault>> = Box::new(vec![]);
    |                                             ^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:46:32
+  --> tests/ui/box_default.rs:50:32
    |
 LL |     let vec3: Box<Vec<bool>> = Box::new(Vec::from([]));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:49:25
+  --> tests/ui/box_default.rs:53:25
    |
 LL |     let plain_default = Box::new(Default::default());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:67:16
+  --> tests/ui/box_default.rs:71:16
    |
 LL |     call_ty_fn(Box::new(u8::default()));
    |                ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:95:17
+  --> tests/ui/box_default.rs:99:17
    |
 LL |         Self::x(Box::new(T::default()));
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`

--- a/tests/ui/boxed_local.rs
+++ b/tests/ui/boxed_local.rs
@@ -1,5 +1,6 @@
 #![allow(
     clippy::borrowed_box,
+    clippy::disallowed_names,
     clippy::needless_pass_by_value,
     clippy::unused_unit,
     clippy::redundant_clone,

--- a/tests/ui/boxed_local.stderr
+++ b/tests/ui/boxed_local.stderr
@@ -1,5 +1,5 @@
 error: local variable doesn't need to be boxed here
-  --> tests/ui/boxed_local.rs:40:13
+  --> tests/ui/boxed_local.rs:41:13
    |
 LL | fn warn_arg(x: Box<A>) {
    |             ^
@@ -8,19 +8,19 @@ LL | fn warn_arg(x: Box<A>) {
    = help: to override `-D warnings` add `#[allow(clippy::boxed_local)]`
 
 error: local variable doesn't need to be boxed here
-  --> tests/ui/boxed_local.rs:123:12
+  --> tests/ui/boxed_local.rs:124:12
    |
 LL | pub fn new(_needs_name: Box<PeekableSeekable<&()>>) -> () {}
    |            ^^^^^^^^^^^
 
 error: local variable doesn't need to be boxed here
-  --> tests/ui/boxed_local.rs:189:44
+  --> tests/ui/boxed_local.rs:190:44
    |
 LL |         fn default_impl_x(self: Box<Self>, x: Box<u32>) -> u32 {
    |                                            ^
 
 error: local variable doesn't need to be boxed here
-  --> tests/ui/boxed_local.rs:198:16
+  --> tests/ui/boxed_local.rs:199:16
    |
 LL |         fn foo(x: Box<u32>) {}
    |                ^

--- a/tests/ui/branches_sharing_code/false_positives.rs
+++ b/tests/ui/branches_sharing_code/false_positives.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 #![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
 
 use std::sync::Mutex;

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -8,6 +8,7 @@
 )]
 #![allow(
     clippy::cast_abs_to_unsigned,
+    clippy::disallowed_names,
     clippy::no_effect,
     clippy::unnecessary_min_or_max,
     clippy::unnecessary_operation,

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -1,5 +1,5 @@
 error: casting `i32` to `f32` causes a loss of precision (`i32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:26:5
+  --> tests/ui/cast.rs:24:5
    |
 LL |     x0 as f32;
    |     ^^^^^^^^^
@@ -8,37 +8,37 @@ LL |     x0 as f32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_precision_loss)]`
 
 error: casting `i64` to `f32` causes a loss of precision (`i64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:30:5
+  --> tests/ui/cast.rs:28:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
 error: casting `i64` to `f64` causes a loss of precision (`i64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> tests/ui/cast.rs:33:5
+  --> tests/ui/cast.rs:31:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
 error: casting `u32` to `f32` causes a loss of precision (`u32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:37:5
+  --> tests/ui/cast.rs:35:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f32` causes a loss of precision (`u64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:41:5
+  --> tests/ui/cast.rs:39:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> tests/ui/cast.rs:44:5
+  --> tests/ui/cast.rs:42:5
    |
 LL |     x3 as f64;
    |     ^^^^^^^^^
 
 error: casting `f32` to `i32` may truncate the value
-  --> tests/ui/cast.rs:48:5
+  --> tests/ui/cast.rs:46:5
    |
 LL |     1f32 as i32;
    |     ^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     1f32 as i32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_truncation)]`
 
 error: casting `f32` to `u32` may truncate the value
-  --> tests/ui/cast.rs:51:5
+  --> tests/ui/cast.rs:49:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     1f32 as u32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:51:5
+  --> tests/ui/cast.rs:49:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     1f32 as u32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_sign_loss)]`
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:55:5
+  --> tests/ui/cast.rs:53:5
    |
 LL |     1f64 as f32;
    |     ^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     1f64 as f32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `i32` to `i8` may truncate the value
-  --> tests/ui/cast.rs:58:5
+  --> tests/ui/cast.rs:56:5
    |
 LL |     1i32 as i8;
    |     ^^^^^^^^^^
@@ -86,7 +86,7 @@ LL +     i8::try_from(1i32);
    |
 
 error: casting `i32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:61:5
+  --> tests/ui/cast.rs:59:5
    |
 LL |     1i32 as u8;
    |     ^^^^^^^^^^
@@ -99,7 +99,7 @@ LL +     u8::try_from(1i32);
    |
 
 error: casting `f64` to `isize` may truncate the value
-  --> tests/ui/cast.rs:64:5
+  --> tests/ui/cast.rs:62:5
    |
 LL |     1f64 as isize;
    |     ^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     1f64 as isize;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `usize` may truncate the value
-  --> tests/ui/cast.rs:67:5
+  --> tests/ui/cast.rs:65:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
@@ -115,13 +115,13 @@ LL |     1f64 as usize;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:67:5
+  --> tests/ui/cast.rs:65:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u32` to `u16` may truncate the value
-  --> tests/ui/cast.rs:71:5
+  --> tests/ui/cast.rs:69:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^^^^^^^^
@@ -134,7 +134,7 @@ LL +     u16::try_from(1f32 as u32);
    |
 
 error: casting `f32` to `u32` may truncate the value
-  --> tests/ui/cast.rs:71:5
+  --> tests/ui/cast.rs:69:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
@@ -142,13 +142,13 @@ LL |     1f32 as u32 as u16;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:71:5
+  --> tests/ui/cast.rs:69:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
 
 error: casting `i32` to `i8` may truncate the value
-  --> tests/ui/cast.rs:77:22
+  --> tests/ui/cast.rs:75:22
    |
 LL |         let _x: i8 = 1i32 as _;
    |                      ^^^^^^^^^
@@ -161,7 +161,7 @@ LL +         let _x: i8 = 1i32.try_into();
    |
 
 error: casting `f32` to `i32` may truncate the value
-  --> tests/ui/cast.rs:80:9
+  --> tests/ui/cast.rs:78:9
    |
 LL |         1f32 as i32;
    |         ^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL |         1f32 as i32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `i32` may truncate the value
-  --> tests/ui/cast.rs:83:9
+  --> tests/ui/cast.rs:81:9
    |
 LL |         1f64 as i32;
    |         ^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL |         1f64 as i32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:86:9
+  --> tests/ui/cast.rs:84:9
    |
 LL |         1f32 as u8;
    |         ^^^^^^^^^^
@@ -185,13 +185,13 @@ LL |         1f32 as u8;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u8` may lose the sign of the value
-  --> tests/ui/cast.rs:86:9
+  --> tests/ui/cast.rs:84:9
    |
 LL |         1f32 as u8;
    |         ^^^^^^^^^^
 
 error: casting `u8` to `i8` may wrap around the value
-  --> tests/ui/cast.rs:91:5
+  --> tests/ui/cast.rs:89:5
    |
 LL |     1u8 as i8;
    |     ^^^^^^^^^
@@ -200,31 +200,31 @@ LL |     1u8 as i8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_wrap)]`
 
 error: casting `u16` to `i16` may wrap around the value
-  --> tests/ui/cast.rs:94:5
+  --> tests/ui/cast.rs:92:5
    |
 LL |     1u16 as i16;
    |     ^^^^^^^^^^^
 
 error: casting `u32` to `i32` may wrap around the value
-  --> tests/ui/cast.rs:97:5
+  --> tests/ui/cast.rs:95:5
    |
 LL |     1u32 as i32;
    |     ^^^^^^^^^^^
 
 error: casting `u64` to `i64` may wrap around the value
-  --> tests/ui/cast.rs:100:5
+  --> tests/ui/cast.rs:98:5
    |
 LL |     1u64 as i64;
    |     ^^^^^^^^^^^
 
 error: casting `usize` to `isize` may wrap around the value
-  --> tests/ui/cast.rs:103:5
+  --> tests/ui/cast.rs:101:5
    |
 LL |     1usize as isize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `usize` to `i8` may truncate the value
-  --> tests/ui/cast.rs:107:5
+  --> tests/ui/cast.rs:105:5
    |
 LL |     1usize as i8;
    |     ^^^^^^^^^^^^
@@ -237,7 +237,7 @@ LL +     i8::try_from(1usize);
    |
 
 error: casting `usize` to `i16` may truncate the value
-  --> tests/ui/cast.rs:111:5
+  --> tests/ui/cast.rs:109:5
    |
 LL |     1usize as i16;
    |     ^^^^^^^^^^^^^
@@ -250,7 +250,7 @@ LL +     i16::try_from(1usize);
    |
 
 error: casting `usize` to `i16` may wrap around the value on targets with 16-bit wide pointers
-  --> tests/ui/cast.rs:111:5
+  --> tests/ui/cast.rs:109:5
    |
 LL |     1usize as i16;
    |     ^^^^^^^^^^^^^
@@ -259,7 +259,7 @@ LL |     1usize as i16;
    = note: for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
 
 error: casting `usize` to `i32` may truncate the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:116:5
+  --> tests/ui/cast.rs:114:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
@@ -272,19 +272,19 @@ LL +     i32::try_from(1usize);
    |
 
 error: casting `usize` to `i32` may wrap around the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:116:5
+  --> tests/ui/cast.rs:114:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting `usize` to `i64` may wrap around the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:121:5
+  --> tests/ui/cast.rs:119:5
    |
 LL |     1usize as i64;
    |     ^^^^^^^^^^^^^
 
 error: casting `u16` to `isize` may wrap around the value on targets with 16-bit wide pointers
-  --> tests/ui/cast.rs:127:5
+  --> tests/ui/cast.rs:125:5
    |
 LL |     1u16 as isize;
    |     ^^^^^^^^^^^^^
@@ -293,13 +293,13 @@ LL |     1u16 as isize;
    = note: for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
 
 error: casting `u32` to `isize` may wrap around the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:131:5
+  --> tests/ui/cast.rs:129:5
    |
 LL |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u64` to `isize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:135:5
+  --> tests/ui/cast.rs:133:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
@@ -312,55 +312,55 @@ LL +     isize::try_from(1u64);
    |
 
 error: casting `u64` to `isize` may wrap around the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:135:5
+  --> tests/ui/cast.rs:133:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:141:5
+  --> tests/ui/cast.rs:139:5
    |
 LL |     -1i32 as u32;
    |     ^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:145:5
+  --> tests/ui/cast.rs:143:5
    |
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
 error: casting `i8` to `u8` may lose the sign of the value
-  --> tests/ui/cast.rs:157:5
+  --> tests/ui/cast.rs:155:5
    |
 LL |     (i8::MIN).abs() as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:162:5
+  --> tests/ui/cast.rs:160:5
    |
 LL |     (-1i64).abs() as u64;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:164:5
+  --> tests/ui/cast.rs:162:5
    |
 LL |     (-1isize).abs() as usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:172:5
+  --> tests/ui/cast.rs:170:5
    |
 LL |     (unsafe { (-1i64).checked_abs().unwrap_unchecked() }) as u64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:188:5
+  --> tests/ui/cast.rs:186:5
    |
 LL |     (unsafe { (-1i64).checked_isqrt().unwrap_unchecked() }) as u64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `i8` may truncate the value
-  --> tests/ui/cast.rs:240:5
+  --> tests/ui/cast.rs:238:5
    |
 LL |     (-99999999999i64).min(1) as i8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -373,7 +373,7 @@ LL +     i8::try_from((-99999999999i64).min(1));
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:254:5
+  --> tests/ui/cast.rs:252:5
    |
 LL |     999999u64.clamp(0, 256) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -386,7 +386,7 @@ LL +     u8::try_from(999999u64.clamp(0, 256));
    |
 
 error: casting `main::E2` to `u8` may truncate the value
-  --> tests/ui/cast.rs:277:21
+  --> tests/ui/cast.rs:275:21
    |
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
@@ -399,7 +399,7 @@ LL +             let _ = u8::try_from(self);
    |
 
 error: casting `main::E2::B` to `u8` will truncate the value
-  --> tests/ui/cast.rs:280:21
+  --> tests/ui/cast.rs:278:21
    |
 LL |             let _ = Self::B as u8;
    |                     ^^^^^^^^^^^^^
@@ -408,7 +408,7 @@ LL |             let _ = Self::B as u8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_enum_truncation)]`
 
 error: casting `main::E5` to `i8` may truncate the value
-  --> tests/ui/cast.rs:322:21
+  --> tests/ui/cast.rs:320:21
    |
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
@@ -421,13 +421,13 @@ LL +             let _ = i8::try_from(self);
    |
 
 error: casting `main::E5::A` to `i8` will truncate the value
-  --> tests/ui/cast.rs:325:21
+  --> tests/ui/cast.rs:323:21
    |
 LL |             let _ = Self::A as i8;
    |                     ^^^^^^^^^^^^^
 
 error: casting `main::E6` to `i16` may truncate the value
-  --> tests/ui/cast.rs:343:21
+  --> tests/ui/cast.rs:341:21
    |
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
@@ -440,7 +440,7 @@ LL +             let _ = i16::try_from(self);
    |
 
 error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:363:21
+  --> tests/ui/cast.rs:361:21
    |
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
@@ -453,7 +453,7 @@ LL +             let _ = usize::try_from(self);
    |
 
 error: casting `main::E10` to `u16` may truncate the value
-  --> tests/ui/cast.rs:411:21
+  --> tests/ui/cast.rs:409:21
    |
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
@@ -466,7 +466,7 @@ LL +             let _ = u16::try_from(self);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:423:13
+  --> tests/ui/cast.rs:421:13
    |
 LL |     let c = (q >> 16) as u8;
    |             ^^^^^^^^^^^^^^^
@@ -479,7 +479,7 @@ LL +     let c = u8::try_from(q >> 16);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:428:13
+  --> tests/ui/cast.rs:426:13
    |
 LL |     let c = (q / 1000) as u8;
    |             ^^^^^^^^^^^^^^^^
@@ -492,85 +492,85 @@ LL +     let c = u8::try_from(q / 1000);
    |
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:441:9
+  --> tests/ui/cast.rs:439:9
    |
 LL |         (x * x) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:447:32
+  --> tests/ui/cast.rs:445:32
    |
 LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
    |                                ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:450:5
+  --> tests/ui/cast.rs:448:5
    |
 LL |     (2_i32).checked_pow(3).unwrap() as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:452:5
+  --> tests/ui/cast.rs:450:5
    |
 LL |     (-2_i32).pow(3) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:457:5
+  --> tests/ui/cast.rs:455:5
    |
 LL |     (-5_i32 % 2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:460:5
+  --> tests/ui/cast.rs:458:5
    |
 LL |     (-5_i32 % -2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:464:5
+  --> tests/ui/cast.rs:462:5
    |
 LL |     (-2_i32 >> 1) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:468:5
+  --> tests/ui/cast.rs:466:5
    |
 LL |     (x * x) as u32;
    |     ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:470:5
+  --> tests/ui/cast.rs:468:5
    |
 LL |     (x * x * x) as u32;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:474:5
+  --> tests/ui/cast.rs:472:5
    |
 LL |     (y * y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:477:5
+  --> tests/ui/cast.rs:475:5
    |
 LL |     (y * y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:479:5
+  --> tests/ui/cast.rs:477:5
    |
 LL |     (y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:482:5
+  --> tests/ui/cast.rs:480:5
    |
 LL |     (y / y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `/`
-  --> tests/ui/cast.rs:482:6
+  --> tests/ui/cast.rs:480:6
    |
 LL |     (y / y * y * -2) as u16;
    |      ^^^^^
@@ -578,97 +578,97 @@ LL |     (y / y * y * -2) as u16;
    = note: `#[deny(clippy::eq_op)]` on by default
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:486:5
+  --> tests/ui/cast.rs:484:5
    |
 LL |     (y + y + y + -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:489:5
+  --> tests/ui/cast.rs:487:5
    |
 LL |     (y + y + y + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:493:5
+  --> tests/ui/cast.rs:491:5
    |
 LL |     (z + -2) as u16;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:496:5
+  --> tests/ui/cast.rs:494:5
    |
 LL |     (z + z + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:500:9
+  --> tests/ui/cast.rs:498:9
    |
 LL |         (a * a * b * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:502:9
+  --> tests/ui/cast.rs:500:9
    |
 LL |         (a * b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:505:9
+  --> tests/ui/cast.rs:503:9
    |
 LL |         (a * -b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:508:9
+  --> tests/ui/cast.rs:506:9
    |
 LL |         (a * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:510:9
+  --> tests/ui/cast.rs:508:9
    |
 LL |         (a * -2) as u32;
    |         ^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:513:9
+  --> tests/ui/cast.rs:511:9
    |
 LL |         (a * b * c * -2) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:516:9
+  --> tests/ui/cast.rs:514:9
    |
 LL |         (a / b) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:518:9
+  --> tests/ui/cast.rs:516:9
    |
 LL |         (a / b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:521:9
+  --> tests/ui/cast.rs:519:9
    |
 LL |         (a / b + b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:524:9
+  --> tests/ui/cast.rs:522:9
    |
 LL |         a.saturating_pow(3) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:527:9
+  --> tests/ui/cast.rs:525:9
    |
 LL |         (a.abs() * b.pow(2) / c.abs()) as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:535:21
+  --> tests/ui/cast.rs:533:21
    |
 LL |             let _ = i32::MIN as u32; // cast_sign_loss
    |                     ^^^^^^^^^^^^^^^
@@ -679,7 +679,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:538:21
+  --> tests/ui/cast.rs:536:21
    |
 LL |             let _ = u32::MAX as u8; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^
@@ -696,7 +696,7 @@ LL +             let _ = u8::try_from(u32::MAX); // cast_possible_truncation
    |
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:541:21
+  --> tests/ui/cast.rs:539:21
    |
 LL |             let _ = std::f64::consts::PI as f32; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -708,7 +708,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `i64` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:552:5
+  --> tests/ui/cast.rs:550:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -721,13 +721,13 @@ LL +     usize::try_from(bar.unwrap().unwrap())
    |
 
 error: casting `i64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:552:5
+  --> tests/ui/cast.rs:550:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:569:5
+  --> tests/ui/cast.rs:567:5
    |
 LL |     (256 & 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -740,7 +740,7 @@ LL +     u8::try_from(256 & 999999u64);
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:572:5
+  --> tests/ui/cast.rs:570:5
    |
 LL |     (255 % 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -1,5 +1,5 @@
 error: casting `i32` to `f32` causes a loss of precision (`i32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:23:5
+  --> tests/ui/cast.rs:26:5
    |
 LL |     x0 as f32;
    |     ^^^^^^^^^
@@ -8,37 +8,37 @@ LL |     x0 as f32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_precision_loss)]`
 
 error: casting `i64` to `f32` causes a loss of precision (`i64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:27:5
+  --> tests/ui/cast.rs:30:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
 error: casting `i64` to `f64` causes a loss of precision (`i64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> tests/ui/cast.rs:30:5
+  --> tests/ui/cast.rs:33:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
 error: casting `u32` to `f32` causes a loss of precision (`u32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:34:5
+  --> tests/ui/cast.rs:37:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f32` causes a loss of precision (`u64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:38:5
+  --> tests/ui/cast.rs:41:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> tests/ui/cast.rs:41:5
+  --> tests/ui/cast.rs:44:5
    |
 LL |     x3 as f64;
    |     ^^^^^^^^^
 
 error: casting `f32` to `i32` may truncate the value
-  --> tests/ui/cast.rs:45:5
+  --> tests/ui/cast.rs:48:5
    |
 LL |     1f32 as i32;
    |     ^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     1f32 as i32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_truncation)]`
 
 error: casting `f32` to `u32` may truncate the value
-  --> tests/ui/cast.rs:48:5
+  --> tests/ui/cast.rs:51:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     1f32 as u32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:48:5
+  --> tests/ui/cast.rs:51:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     1f32 as u32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_sign_loss)]`
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:52:5
+  --> tests/ui/cast.rs:55:5
    |
 LL |     1f64 as f32;
    |     ^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     1f64 as f32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `i32` to `i8` may truncate the value
-  --> tests/ui/cast.rs:55:5
+  --> tests/ui/cast.rs:58:5
    |
 LL |     1i32 as i8;
    |     ^^^^^^^^^^
@@ -86,7 +86,7 @@ LL +     i8::try_from(1i32);
    |
 
 error: casting `i32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:58:5
+  --> tests/ui/cast.rs:61:5
    |
 LL |     1i32 as u8;
    |     ^^^^^^^^^^
@@ -99,7 +99,7 @@ LL +     u8::try_from(1i32);
    |
 
 error: casting `f64` to `isize` may truncate the value
-  --> tests/ui/cast.rs:61:5
+  --> tests/ui/cast.rs:64:5
    |
 LL |     1f64 as isize;
    |     ^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     1f64 as isize;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `usize` may truncate the value
-  --> tests/ui/cast.rs:64:5
+  --> tests/ui/cast.rs:67:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
@@ -115,13 +115,13 @@ LL |     1f64 as usize;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:64:5
+  --> tests/ui/cast.rs:67:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u32` to `u16` may truncate the value
-  --> tests/ui/cast.rs:68:5
+  --> tests/ui/cast.rs:71:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^^^^^^^^
@@ -134,7 +134,7 @@ LL +     u16::try_from(1f32 as u32);
    |
 
 error: casting `f32` to `u32` may truncate the value
-  --> tests/ui/cast.rs:68:5
+  --> tests/ui/cast.rs:71:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
@@ -142,13 +142,13 @@ LL |     1f32 as u32 as u16;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:68:5
+  --> tests/ui/cast.rs:71:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
 
 error: casting `i32` to `i8` may truncate the value
-  --> tests/ui/cast.rs:74:22
+  --> tests/ui/cast.rs:77:22
    |
 LL |         let _x: i8 = 1i32 as _;
    |                      ^^^^^^^^^
@@ -161,7 +161,7 @@ LL +         let _x: i8 = 1i32.try_into();
    |
 
 error: casting `f32` to `i32` may truncate the value
-  --> tests/ui/cast.rs:77:9
+  --> tests/ui/cast.rs:80:9
    |
 LL |         1f32 as i32;
    |         ^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL |         1f32 as i32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `i32` may truncate the value
-  --> tests/ui/cast.rs:80:9
+  --> tests/ui/cast.rs:83:9
    |
 LL |         1f64 as i32;
    |         ^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL |         1f64 as i32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:83:9
+  --> tests/ui/cast.rs:86:9
    |
 LL |         1f32 as u8;
    |         ^^^^^^^^^^
@@ -185,13 +185,13 @@ LL |         1f32 as u8;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u8` may lose the sign of the value
-  --> tests/ui/cast.rs:83:9
+  --> tests/ui/cast.rs:86:9
    |
 LL |         1f32 as u8;
    |         ^^^^^^^^^^
 
 error: casting `u8` to `i8` may wrap around the value
-  --> tests/ui/cast.rs:88:5
+  --> tests/ui/cast.rs:91:5
    |
 LL |     1u8 as i8;
    |     ^^^^^^^^^
@@ -200,31 +200,31 @@ LL |     1u8 as i8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_wrap)]`
 
 error: casting `u16` to `i16` may wrap around the value
-  --> tests/ui/cast.rs:91:5
+  --> tests/ui/cast.rs:94:5
    |
 LL |     1u16 as i16;
    |     ^^^^^^^^^^^
 
 error: casting `u32` to `i32` may wrap around the value
-  --> tests/ui/cast.rs:94:5
+  --> tests/ui/cast.rs:97:5
    |
 LL |     1u32 as i32;
    |     ^^^^^^^^^^^
 
 error: casting `u64` to `i64` may wrap around the value
-  --> tests/ui/cast.rs:97:5
+  --> tests/ui/cast.rs:100:5
    |
 LL |     1u64 as i64;
    |     ^^^^^^^^^^^
 
 error: casting `usize` to `isize` may wrap around the value
-  --> tests/ui/cast.rs:100:5
+  --> tests/ui/cast.rs:103:5
    |
 LL |     1usize as isize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `usize` to `i8` may truncate the value
-  --> tests/ui/cast.rs:104:5
+  --> tests/ui/cast.rs:107:5
    |
 LL |     1usize as i8;
    |     ^^^^^^^^^^^^
@@ -237,7 +237,7 @@ LL +     i8::try_from(1usize);
    |
 
 error: casting `usize` to `i16` may truncate the value
-  --> tests/ui/cast.rs:108:5
+  --> tests/ui/cast.rs:111:5
    |
 LL |     1usize as i16;
    |     ^^^^^^^^^^^^^
@@ -250,7 +250,7 @@ LL +     i16::try_from(1usize);
    |
 
 error: casting `usize` to `i16` may wrap around the value on targets with 16-bit wide pointers
-  --> tests/ui/cast.rs:108:5
+  --> tests/ui/cast.rs:111:5
    |
 LL |     1usize as i16;
    |     ^^^^^^^^^^^^^
@@ -259,7 +259,7 @@ LL |     1usize as i16;
    = note: for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
 
 error: casting `usize` to `i32` may truncate the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:113:5
+  --> tests/ui/cast.rs:116:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
@@ -272,19 +272,19 @@ LL +     i32::try_from(1usize);
    |
 
 error: casting `usize` to `i32` may wrap around the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:113:5
+  --> tests/ui/cast.rs:116:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting `usize` to `i64` may wrap around the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:118:5
+  --> tests/ui/cast.rs:121:5
    |
 LL |     1usize as i64;
    |     ^^^^^^^^^^^^^
 
 error: casting `u16` to `isize` may wrap around the value on targets with 16-bit wide pointers
-  --> tests/ui/cast.rs:124:5
+  --> tests/ui/cast.rs:127:5
    |
 LL |     1u16 as isize;
    |     ^^^^^^^^^^^^^
@@ -293,13 +293,13 @@ LL |     1u16 as isize;
    = note: for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
 
 error: casting `u32` to `isize` may wrap around the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:128:5
+  --> tests/ui/cast.rs:131:5
    |
 LL |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u64` to `isize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:132:5
+  --> tests/ui/cast.rs:135:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
@@ -312,55 +312,55 @@ LL +     isize::try_from(1u64);
    |
 
 error: casting `u64` to `isize` may wrap around the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:132:5
+  --> tests/ui/cast.rs:135:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:138:5
+  --> tests/ui/cast.rs:141:5
    |
 LL |     -1i32 as u32;
    |     ^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:142:5
+  --> tests/ui/cast.rs:145:5
    |
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
 error: casting `i8` to `u8` may lose the sign of the value
-  --> tests/ui/cast.rs:154:5
+  --> tests/ui/cast.rs:157:5
    |
 LL |     (i8::MIN).abs() as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:159:5
+  --> tests/ui/cast.rs:162:5
    |
 LL |     (-1i64).abs() as u64;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:161:5
+  --> tests/ui/cast.rs:164:5
    |
 LL |     (-1isize).abs() as usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:169:5
+  --> tests/ui/cast.rs:172:5
    |
 LL |     (unsafe { (-1i64).checked_abs().unwrap_unchecked() }) as u64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:185:5
+  --> tests/ui/cast.rs:188:5
    |
 LL |     (unsafe { (-1i64).checked_isqrt().unwrap_unchecked() }) as u64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `i8` may truncate the value
-  --> tests/ui/cast.rs:237:5
+  --> tests/ui/cast.rs:240:5
    |
 LL |     (-99999999999i64).min(1) as i8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -373,7 +373,7 @@ LL +     i8::try_from((-99999999999i64).min(1));
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:251:5
+  --> tests/ui/cast.rs:254:5
    |
 LL |     999999u64.clamp(0, 256) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -386,7 +386,7 @@ LL +     u8::try_from(999999u64.clamp(0, 256));
    |
 
 error: casting `main::E2` to `u8` may truncate the value
-  --> tests/ui/cast.rs:274:21
+  --> tests/ui/cast.rs:277:21
    |
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
@@ -399,7 +399,7 @@ LL +             let _ = u8::try_from(self);
    |
 
 error: casting `main::E2::B` to `u8` will truncate the value
-  --> tests/ui/cast.rs:277:21
+  --> tests/ui/cast.rs:280:21
    |
 LL |             let _ = Self::B as u8;
    |                     ^^^^^^^^^^^^^
@@ -408,7 +408,7 @@ LL |             let _ = Self::B as u8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_enum_truncation)]`
 
 error: casting `main::E5` to `i8` may truncate the value
-  --> tests/ui/cast.rs:319:21
+  --> tests/ui/cast.rs:322:21
    |
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
@@ -421,13 +421,13 @@ LL +             let _ = i8::try_from(self);
    |
 
 error: casting `main::E5::A` to `i8` will truncate the value
-  --> tests/ui/cast.rs:322:21
+  --> tests/ui/cast.rs:325:21
    |
 LL |             let _ = Self::A as i8;
    |                     ^^^^^^^^^^^^^
 
 error: casting `main::E6` to `i16` may truncate the value
-  --> tests/ui/cast.rs:340:21
+  --> tests/ui/cast.rs:343:21
    |
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
@@ -440,7 +440,7 @@ LL +             let _ = i16::try_from(self);
    |
 
 error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:360:21
+  --> tests/ui/cast.rs:363:21
    |
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
@@ -453,7 +453,7 @@ LL +             let _ = usize::try_from(self);
    |
 
 error: casting `main::E10` to `u16` may truncate the value
-  --> tests/ui/cast.rs:408:21
+  --> tests/ui/cast.rs:411:21
    |
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
@@ -466,7 +466,7 @@ LL +             let _ = u16::try_from(self);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:420:13
+  --> tests/ui/cast.rs:423:13
    |
 LL |     let c = (q >> 16) as u8;
    |             ^^^^^^^^^^^^^^^
@@ -479,7 +479,7 @@ LL +     let c = u8::try_from(q >> 16);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:425:13
+  --> tests/ui/cast.rs:428:13
    |
 LL |     let c = (q / 1000) as u8;
    |             ^^^^^^^^^^^^^^^^
@@ -492,85 +492,85 @@ LL +     let c = u8::try_from(q / 1000);
    |
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:438:9
+  --> tests/ui/cast.rs:441:9
    |
 LL |         (x * x) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:444:32
+  --> tests/ui/cast.rs:447:32
    |
 LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
    |                                ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:447:5
+  --> tests/ui/cast.rs:450:5
    |
 LL |     (2_i32).checked_pow(3).unwrap() as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:449:5
+  --> tests/ui/cast.rs:452:5
    |
 LL |     (-2_i32).pow(3) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:454:5
+  --> tests/ui/cast.rs:457:5
    |
 LL |     (-5_i32 % 2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:457:5
+  --> tests/ui/cast.rs:460:5
    |
 LL |     (-5_i32 % -2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:461:5
+  --> tests/ui/cast.rs:464:5
    |
 LL |     (-2_i32 >> 1) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:465:5
+  --> tests/ui/cast.rs:468:5
    |
 LL |     (x * x) as u32;
    |     ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:467:5
+  --> tests/ui/cast.rs:470:5
    |
 LL |     (x * x * x) as u32;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:471:5
+  --> tests/ui/cast.rs:474:5
    |
 LL |     (y * y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:474:5
+  --> tests/ui/cast.rs:477:5
    |
 LL |     (y * y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:476:5
+  --> tests/ui/cast.rs:479:5
    |
 LL |     (y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:479:5
+  --> tests/ui/cast.rs:482:5
    |
 LL |     (y / y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `/`
-  --> tests/ui/cast.rs:479:6
+  --> tests/ui/cast.rs:482:6
    |
 LL |     (y / y * y * -2) as u16;
    |      ^^^^^
@@ -578,97 +578,97 @@ LL |     (y / y * y * -2) as u16;
    = note: `#[deny(clippy::eq_op)]` on by default
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:483:5
+  --> tests/ui/cast.rs:486:5
    |
 LL |     (y + y + y + -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:486:5
+  --> tests/ui/cast.rs:489:5
    |
 LL |     (y + y + y + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:490:5
+  --> tests/ui/cast.rs:493:5
    |
 LL |     (z + -2) as u16;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:493:5
+  --> tests/ui/cast.rs:496:5
    |
 LL |     (z + z + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:497:9
+  --> tests/ui/cast.rs:500:9
    |
 LL |         (a * a * b * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:499:9
+  --> tests/ui/cast.rs:502:9
    |
 LL |         (a * b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:502:9
+  --> tests/ui/cast.rs:505:9
    |
 LL |         (a * -b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:505:9
+  --> tests/ui/cast.rs:508:9
    |
 LL |         (a * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:507:9
+  --> tests/ui/cast.rs:510:9
    |
 LL |         (a * -2) as u32;
    |         ^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:510:9
+  --> tests/ui/cast.rs:513:9
    |
 LL |         (a * b * c * -2) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:513:9
+  --> tests/ui/cast.rs:516:9
    |
 LL |         (a / b) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:515:9
+  --> tests/ui/cast.rs:518:9
    |
 LL |         (a / b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:518:9
+  --> tests/ui/cast.rs:521:9
    |
 LL |         (a / b + b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:521:9
+  --> tests/ui/cast.rs:524:9
    |
 LL |         a.saturating_pow(3) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:524:9
+  --> tests/ui/cast.rs:527:9
    |
 LL |         (a.abs() * b.pow(2) / c.abs()) as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:532:21
+  --> tests/ui/cast.rs:535:21
    |
 LL |             let _ = i32::MIN as u32; // cast_sign_loss
    |                     ^^^^^^^^^^^^^^^
@@ -679,7 +679,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:535:21
+  --> tests/ui/cast.rs:538:21
    |
 LL |             let _ = u32::MAX as u8; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^
@@ -696,7 +696,7 @@ LL +             let _ = u8::try_from(u32::MAX); // cast_possible_truncation
    |
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:538:21
+  --> tests/ui/cast.rs:541:21
    |
 LL |             let _ = std::f64::consts::PI as f32; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -708,7 +708,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `i64` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:549:5
+  --> tests/ui/cast.rs:552:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -721,13 +721,13 @@ LL +     usize::try_from(bar.unwrap().unwrap())
    |
 
 error: casting `i64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:549:5
+  --> tests/ui/cast.rs:552:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:566:5
+  --> tests/ui/cast.rs:569:5
    |
 LL |     (256 & 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -740,7 +740,7 @@ LL +     u8::try_from(256 & 999999u64);
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:569:5
+  --> tests/ui/cast.rs:572:5
    |
 LL |     (255 % 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cast_slice_different_sizes.rs
+++ b/tests/ui/cast_slice_different_sizes.rs
@@ -1,5 +1,5 @@
 //@no-rustfix: overlapping suggestions
-#![allow(clippy::let_unit_value, clippy::unnecessary_cast)]
+#![allow(clippy::let_unit_value, clippy::unnecessary_cast, clippy::disallowed_names)]
 
 fn main() {
     let x: [i32; 3] = [1_i32, 2, 3];

--- a/tests/ui/cfg_not_test.rs
+++ b/tests/ui/cfg_not_test.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::cfg_not_test)]
 
 fn important_check() {}

--- a/tests/ui/cognitive_complexity.rs
+++ b/tests/ui/cognitive_complexity.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::cognitive_complexity)]
 #![allow(
+    clippy::disallowed_names,
     clippy::eq_op,
     clippy::needless_borrows_for_generic_args,
     clippy::needless_return,

--- a/tests/ui/cognitive_complexity.stderr
+++ b/tests/ui/cognitive_complexity.stderr
@@ -1,5 +1,5 @@
 error: the function has a cognitive complexity of (28/25)
-  --> tests/ui/cognitive_complexity.rs:11:4
+  --> tests/ui/cognitive_complexity.rs:12:4
    |
 LL | fn main() {
    |    ^^^^
@@ -9,7 +9,7 @@ LL | fn main() {
    = help: to override `-D warnings` add `#[allow(clippy::cognitive_complexity)]`
 
 error: the function has a cognitive complexity of (7/1)
-  --> tests/ui/cognitive_complexity.rs:98:4
+  --> tests/ui/cognitive_complexity.rs:99:4
    |
 LL | fn kaboom() {
    |    ^^^^^^
@@ -17,7 +17,7 @@ LL | fn kaboom() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:158:4
+  --> tests/ui/cognitive_complexity.rs:159:4
    |
 LL | fn baa() {
    |    ^^^
@@ -25,7 +25,7 @@ LL | fn baa() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:161:13
+  --> tests/ui/cognitive_complexity.rs:162:13
    |
 LL |     let x = || match 99 {
    |             ^^
@@ -33,7 +33,7 @@ LL |     let x = || match 99 {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:179:4
+  --> tests/ui/cognitive_complexity.rs:180:4
    |
 LL | fn bar() {
    |    ^^^
@@ -41,7 +41,7 @@ LL | fn bar() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:192:4
+  --> tests/ui/cognitive_complexity.rs:193:4
    |
 LL | fn dont_warn_on_tests() {
    |    ^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL | fn dont_warn_on_tests() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:202:4
+  --> tests/ui/cognitive_complexity.rs:203:4
    |
 LL | fn barr() {
    |    ^^^^
@@ -57,7 +57,7 @@ LL | fn barr() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (3/1)
-  --> tests/ui/cognitive_complexity.rs:214:4
+  --> tests/ui/cognitive_complexity.rs:215:4
    |
 LL | fn barr2() {
    |    ^^^^^
@@ -65,7 +65,7 @@ LL | fn barr2() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:232:4
+  --> tests/ui/cognitive_complexity.rs:233:4
    |
 LL | fn barrr() {
    |    ^^^^^
@@ -73,7 +73,7 @@ LL | fn barrr() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (3/1)
-  --> tests/ui/cognitive_complexity.rs:244:4
+  --> tests/ui/cognitive_complexity.rs:245:4
    |
 LL | fn barrr2() {
    |    ^^^^^^
@@ -81,7 +81,7 @@ LL | fn barrr2() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:262:4
+  --> tests/ui/cognitive_complexity.rs:263:4
    |
 LL | fn barrrr() {
    |    ^^^^^^
@@ -89,7 +89,7 @@ LL | fn barrrr() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (3/1)
-  --> tests/ui/cognitive_complexity.rs:274:4
+  --> tests/ui/cognitive_complexity.rs:275:4
    |
 LL | fn barrrr2() {
    |    ^^^^^^^
@@ -97,7 +97,7 @@ LL | fn barrrr2() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:292:4
+  --> tests/ui/cognitive_complexity.rs:293:4
    |
 LL | fn cake() {
    |    ^^^^
@@ -105,7 +105,7 @@ LL | fn cake() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (4/1)
-  --> tests/ui/cognitive_complexity.rs:304:8
+  --> tests/ui/cognitive_complexity.rs:305:8
    |
 LL | pub fn read_file(input_path: &str) -> String {
    |        ^^^^^^^^^
@@ -113,7 +113,7 @@ LL | pub fn read_file(input_path: &str) -> String {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:337:4
+  --> tests/ui/cognitive_complexity.rs:338:4
    |
 LL | fn void(void: Void) {
    |    ^^^^
@@ -121,7 +121,7 @@ LL | fn void(void: Void) {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (8/1)
-  --> tests/ui/cognitive_complexity.rs:390:4
+  --> tests/ui/cognitive_complexity.rs:391:4
    |
 LL | fn early_ret() -> i32 {
    |    ^^^^^^^^^
@@ -129,7 +129,7 @@ LL | fn early_ret() -> i32 {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:413:13
+  --> tests/ui/cognitive_complexity.rs:414:13
    |
 LL |     let x = |a: i32, b: i32| -> i32 {
    |             ^^^^^^^^^^^^^^^^
@@ -137,7 +137,7 @@ LL |     let x = |a: i32, b: i32| -> i32 {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:428:8
+  --> tests/ui/cognitive_complexity.rs:429:8
    |
 LL |     fn moo(&self) {
    |        ^^^
@@ -145,7 +145,7 @@ LL |     fn moo(&self) {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:439:14
+  --> tests/ui/cognitive_complexity.rs:440:14
    |
 LL |     async fn a() {
    |              ^
@@ -153,7 +153,7 @@ LL |     async fn a() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:448:22
+  --> tests/ui/cognitive_complexity.rs:449:22
    |
 LL |         pub async fn async_method() {
    |                      ^^^^^^^^^^^^
@@ -161,7 +161,7 @@ LL |         pub async fn async_method() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:459:8
+  --> tests/ui/cognitive_complexity.rs:460:8
    |
 LL |     fn foo() {
    |        ^^^
@@ -169,7 +169,7 @@ LL |     fn foo() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:466:8
+  --> tests/ui/cognitive_complexity.rs:467:8
    |
 LL |     fn bar() {
    |        ^^^

--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::collapsible_match)]
 #![allow(
     clippy::collapsible_if,
+    clippy::disallowed_names,
     clippy::equatable_if_let,
     clippy::needless_return,
     clippy::no_effect,

--- a/tests/ui/collapsible_match.stderr
+++ b/tests/ui/collapsible_match.stderr
@@ -1,5 +1,5 @@
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:15:20
+  --> tests/ui/collapsible_match.rs:16:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -10,7 +10,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:15:12
+  --> tests/ui/collapsible_match.rs:16:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -21,7 +21,7 @@ LL |             Some(n) => foo(n),
    = help: to override `-D warnings` add `#[allow(clippy::collapsible_match)]`
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:25:20
+  --> tests/ui/collapsible_match.rs:26:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -32,7 +32,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:25:12
+  --> tests/ui/collapsible_match.rs:26:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -41,7 +41,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:35:9
+  --> tests/ui/collapsible_match.rs:36:9
    |
 LL | /         if let Some(n) = val {
 LL | |
@@ -51,7 +51,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:34:15
+  --> tests/ui/collapsible_match.rs:35:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -59,7 +59,7 @@ LL |         if let Some(n) = val {
    |                ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:44:9
+  --> tests/ui/collapsible_match.rs:45:9
    |
 LL | /         if let Some(n) = val {
 LL | |
@@ -71,7 +71,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:43:15
+  --> tests/ui/collapsible_match.rs:44:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -79,7 +79,7 @@ LL |         if let Some(n) = val {
    |                ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:57:9
+  --> tests/ui/collapsible_match.rs:58:9
    |
 LL | /         match val {
 LL | |
@@ -89,7 +89,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:56:15
+  --> tests/ui/collapsible_match.rs:57:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -98,7 +98,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:67:13
+  --> tests/ui/collapsible_match.rs:68:13
    |
 LL | /             if let Some(n) = val {
 LL | |
@@ -108,7 +108,7 @@ LL | |             }
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:66:12
+  --> tests/ui/collapsible_match.rs:67:12
    |
 LL |         Ok(val) => {
    |            ^^^ replace this binding
@@ -116,7 +116,7 @@ LL |             if let Some(n) = val {
    |                    ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:78:9
+  --> tests/ui/collapsible_match.rs:79:9
    |
 LL | /         match val {
 LL | |
@@ -126,7 +126,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:77:15
+  --> tests/ui/collapsible_match.rs:78:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -135,7 +135,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:90:13
+  --> tests/ui/collapsible_match.rs:91:13
    |
 LL | /             if let Some(n) = val {
 LL | |
@@ -147,7 +147,7 @@ LL | |             }
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:89:12
+  --> tests/ui/collapsible_match.rs:90:12
    |
 LL |         Ok(val) => {
    |            ^^^ replace this binding
@@ -155,7 +155,7 @@ LL |             if let Some(n) = val {
    |                    ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:103:20
+  --> tests/ui/collapsible_match.rs:104:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -166,7 +166,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:103:12
+  --> tests/ui/collapsible_match.rs:104:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -175,7 +175,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:113:22
+  --> tests/ui/collapsible_match.rs:114:22
    |
 LL |           Some(val) => match val {
    |  ______________________^
@@ -186,7 +186,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:113:14
+  --> tests/ui/collapsible_match.rs:114:14
    |
 LL |         Some(val) => match val {
    |              ^^^ replace this binding
@@ -195,7 +195,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:257:22
+  --> tests/ui/collapsible_match.rs:258:22
    |
 LL |           Some(val) => match val {
    |  ______________________^
@@ -206,7 +206,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:257:14
+  --> tests/ui/collapsible_match.rs:258:14
    |
 LL |         Some(val) => match val {
    |              ^^^ replace this binding
@@ -215,7 +215,7 @@ LL |             E::A(val) | E::B(val) => foo(val),
    |             ^^^^^^^^^^^^^^^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:289:9
+  --> tests/ui/collapsible_match.rs:290:9
    |
 LL | /         if let Some(u) = a {
 LL | |
@@ -225,7 +225,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:288:27
+  --> tests/ui/collapsible_match.rs:289:27
    |
 LL |     if let Issue9647::A { a, .. } = x {
    |                           ^ replace this binding
@@ -233,7 +233,7 @@ LL |         if let Some(u) = a {
    |                ^^^^^^^ with this pattern, prefixed by `a`:
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:299:9
+  --> tests/ui/collapsible_match.rs:300:9
    |
 LL | /         if let Some(u) = a {
 LL | |
@@ -243,7 +243,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:298:35
+  --> tests/ui/collapsible_match.rs:299:35
    |
 LL |     if let Issue9647::A { a: Some(a), .. } = x {
    |                                   ^ replace this binding

--- a/tests/ui/collapsible_match2.rs
+++ b/tests/ui/collapsible_match2.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::collapsible_match)]
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_return,
     clippy::no_effect,
     clippy::single_match,

--- a/tests/ui/collapsible_match2.stderr
+++ b/tests/ui/collapsible_match2.stderr
@@ -1,5 +1,5 @@
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match2.rs:13:34
+  --> tests/ui/collapsible_match2.rs:14:34
    |
 LL |               Ok(val) if make() => match val {
    |  __________________________________^
@@ -10,7 +10,7 @@ LL | |             },
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match2.rs:13:16
+  --> tests/ui/collapsible_match2.rs:14:16
    |
 LL |             Ok(val) if make() => match val {
    |                ^^^ replace this binding
@@ -21,7 +21,7 @@ LL |                 Some(n) => foo(n),
    = help: to override `-D warnings` add `#[allow(clippy::collapsible_match)]`
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match2.rs:21:24
+  --> tests/ui/collapsible_match2.rs:22:24
    |
 LL |               Ok(val) => match val {
    |  ________________________^
@@ -32,7 +32,7 @@ LL | |             },
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match2.rs:21:16
+  --> tests/ui/collapsible_match2.rs:22:16
    |
 LL |             Ok(val) => match val {
    |                ^^^ replace this binding
@@ -41,7 +41,7 @@ LL |                 Some(n) => foo(n),
    |                 ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match2.rs:36:29
+  --> tests/ui/collapsible_match2.rs:37:29
    |
 LL |                       $pat => match $e {
    |  _____________________________^
@@ -55,7 +55,7 @@ LL |           mac!(res_opt => Ok(val), val => Some(n), foo(n));
    |           ------------------------------------------------ in this macro invocation
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match2.rs:49:28
+  --> tests/ui/collapsible_match2.rs:50:28
    |
 LL |         mac!(res_opt => Ok(val), val => Some(n), foo(n));
    |                            ^^^          ^^^^^^^ with this pattern
@@ -64,7 +64,7 @@ LL |         mac!(res_opt => Ok(val), val => Some(n), foo(n));
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match2.rs:54:20
+  --> tests/ui/collapsible_match2.rs:55:20
    |
 LL |           Some(s) => match *s {
    |  ____________________^
@@ -75,7 +75,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match2.rs:54:14
+  --> tests/ui/collapsible_match2.rs:55:14
    |
 LL |         Some(s) => match *s {
    |              ^ replace this binding
@@ -84,7 +84,7 @@ LL |             [n] => foo(n),
    |             ^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match2.rs:64:24
+  --> tests/ui/collapsible_match2.rs:65:24
    |
 LL |           Some(ref s) => match s {
    |  ________________________^
@@ -95,7 +95,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match2.rs:64:14
+  --> tests/ui/collapsible_match2.rs:65:14
    |
 LL |         Some(ref s) => match s {
    |              ^^^^^ replace this binding

--- a/tests/ui/collection_is_never_read.rs
+++ b/tests/ui/collection_is_never_read.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::useless_vec)]
+#![allow(unused, clippy::disallowed_names, clippy::useless_vec)]
 #![warn(clippy::collection_is_never_read)]
 
 use std::collections::{HashMap, HashSet};

--- a/tests/ui/comparison_chain.rs
+++ b/tests/ui/comparison_chain.rs
@@ -1,5 +1,5 @@
 //@no-rustfix: has placeholders
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 #![warn(clippy::comparison_chain)]
 
 fn a() {}

--- a/tests/ui/crashes/auxiliary/ice-8681-aux.rs
+++ b/tests/ui/crashes/auxiliary/ice-8681-aux.rs
@@ -1,4 +1,4 @@
-pub fn foo(x: &u32) -> u32 {
+pub fn some_meaningful_name(x: &u32) -> u32 {
     /* Safety:
      * This is totally ok.
      */

--- a/tests/ui/crashes/cc_seme.rs
+++ b/tests/ui/crashes/cc_seme.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 // Test for https://github.com/rust-lang/rust-clippy/issues/478
 
+#![allow(clippy::disallowed_names)]
+
 enum Baz {
     One,
     Two,

--- a/tests/ui/crashes/elidable_lifetime_names_impl_trait.fixed
+++ b/tests/ui/crashes/elidable_lifetime_names_impl_trait.fixed
@@ -1,5 +1,5 @@
 #![deny(clippy::elidable_lifetime_names)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 
 trait Foo {}
 

--- a/tests/ui/crashes/elidable_lifetime_names_impl_trait.rs
+++ b/tests/ui/crashes/elidable_lifetime_names_impl_trait.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::elidable_lifetime_names)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 
 trait Foo {}
 

--- a/tests/ui/crashes/ice-11422.fixed
+++ b/tests/ui/crashes/ice-11422.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::implied_bounds_in_impls)]
+#![allow(clippy::disallowed_names)]
 
 use std::fmt::Debug;
 use std::ops::*;

--- a/tests/ui/crashes/ice-11422.rs
+++ b/tests/ui/crashes/ice-11422.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::implied_bounds_in_impls)]
+#![allow(clippy::disallowed_names)]
 
 use std::fmt::Debug;
 use std::ops::*;

--- a/tests/ui/crashes/ice-11422.stderr
+++ b/tests/ui/crashes/ice-11422.stderr
@@ -1,5 +1,5 @@
 error: this bound is already specified as the supertrait of `PartialOrd`
-  --> tests/ui/crashes/ice-11422.rs:6:33
+  --> tests/ui/crashes/ice-11422.rs:7:33
    |
 LL | fn r#gen() -> impl PartialOrd + PartialEq + Debug {}
    |                                 ^^^^^^^^^

--- a/tests/ui/crashes/ice-13544-original.rs
+++ b/tests/ui/crashes/ice-13544-original.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 #![warn(clippy::significant_drop_tightening)]
+#![allow(clippy::disallowed_names)]
 
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};

--- a/tests/ui/crashes/ice-14325.rs
+++ b/tests/ui/crashes/ice-14325.rs
@@ -1,6 +1,6 @@
 //@check-pass
 
-#![allow(clippy::redundant_pattern_matching)]
+#![allow(clippy::redundant_pattern_matching, clippy::disallowed_names)]
 
 struct S<'a> {
     s: &'a str,

--- a/tests/ui/crashes/ice-6139.rs
+++ b/tests/ui/crashes/ice-6139.rs
@@ -2,8 +2,8 @@
 
 trait T<'a> {}
 
-fn foo(_: Vec<Box<dyn T<'_>>>) {}
+fn bar(_: Vec<Box<dyn T<'_>>>) {}
 
 fn main() {
-    foo(vec![]);
+    bar(vec![]);
 }

--- a/tests/ui/crashes/ice-6153.rs
+++ b/tests/ui/crashes/ice-6153.rs
@@ -5,7 +5,7 @@ pub struct S<'a, 'e>(&'a str, &'e str);
 pub type T<'a, 'e> = std::collections::HashMap<S<'a, 'e>, ()>;
 
 impl<'e, 'a: 'e> S<'a, 'e> {
-    pub fn foo(_a: &str, _b: &str, _map: &T) {}
+    pub fn bar(_a: &str, _b: &str, _map: &T) {}
 }
 
 fn main() {}

--- a/tests/ui/crashes/ice-8681.rs
+++ b/tests/ui/crashes/ice-8681.rs
@@ -7,5 +7,5 @@
 mod ice_8681_aux;
 
 fn main() {
-    let _ = ice_8681_aux::foo(&0u32);
+    let _ = ice_8681_aux::some_meaningful_name(&0u32);
 }

--- a/tests/ui/crashes/if_same_then_else.rs
+++ b/tests/ui/crashes/if_same_then_else.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 
 #![deny(clippy::if_same_then_else)]
+#![allow(clippy::disallowed_names)]
 
 // Test for https://github.com/rust-lang/rust-clippy/issues/2426
 

--- a/tests/ui/crashes/inherent_impl.rs
+++ b/tests/ui/crashes/inherent_impl.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 
 #![deny(clippy::multiple_inherent_impl)]
+#![allow(clippy::disallowed_names)]
 
 // Test for https://github.com/rust-lang/rust-clippy/issues/4578
 

--- a/tests/ui/crashes/missing_const_for_fn_14774.fixed
+++ b/tests/ui/crashes/missing_const_for_fn_14774.fixed
@@ -1,5 +1,6 @@
 //@compile-flags: -Z validate-mir
 #![warn(clippy::missing_const_for_fn)]
+#![allow(clippy::disallowed_names)]
 
 static BLOCK_FN_DEF: fn(usize) -> usize = {
     //~v missing_const_for_fn

--- a/tests/ui/crashes/missing_const_for_fn_14774.rs
+++ b/tests/ui/crashes/missing_const_for_fn_14774.rs
@@ -1,5 +1,6 @@
 //@compile-flags: -Z validate-mir
 #![warn(clippy::missing_const_for_fn)]
+#![allow(clippy::disallowed_names)]
 
 static BLOCK_FN_DEF: fn(usize) -> usize = {
     //~v missing_const_for_fn

--- a/tests/ui/crashes/missing_const_for_fn_14774.stderr
+++ b/tests/ui/crashes/missing_const_for_fn_14774.stderr
@@ -1,5 +1,5 @@
 error: this could be a `const fn`
-  --> tests/ui/crashes/missing_const_for_fn_14774.rs:6:5
+  --> tests/ui/crashes/missing_const_for_fn_14774.rs:7:5
    |
 LL | /     fn foo(a: usize) -> usize {
 LL | |         a + 10

--- a/tests/ui/dbg_macro/dbg_macro.fixed
+++ b/tests/ui/dbg_macro/dbg_macro.fixed
@@ -2,7 +2,8 @@
     clippy::no_effect,
     clippy::uninlined_format_args,
     clippy::unit_arg,
-    clippy::unnecessary_operation
+    clippy::unnecessary_operation,
+    clippy::disallowed_names
 )]
 #![warn(clippy::dbg_macro)]
 

--- a/tests/ui/dbg_macro/dbg_macro.rs
+++ b/tests/ui/dbg_macro/dbg_macro.rs
@@ -2,7 +2,8 @@
     clippy::no_effect,
     clippy::uninlined_format_args,
     clippy::unit_arg,
-    clippy::unnecessary_operation
+    clippy::unnecessary_operation,
+    clippy::disallowed_names
 )]
 #![warn(clippy::dbg_macro)]
 

--- a/tests/ui/dbg_macro/dbg_macro.stderr
+++ b/tests/ui/dbg_macro/dbg_macro.stderr
@@ -231,7 +231,7 @@ LL +         print!("{}", s);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:138:36
+  --> tests/ui/dbg_macro/dbg_macro.rs:139:36
    |
 LL |         takes_async_fn(async |val| dbg!(val));
    |                                    ^^^^^^^^^

--- a/tests/ui/dbg_macro/dbg_macro.stderr
+++ b/tests/ui/dbg_macro/dbg_macro.stderr
@@ -1,5 +1,5 @@
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:10:22
+  --> tests/ui/dbg_macro/dbg_macro.rs:11:22
    |
 LL |     if let Some(n) = dbg!(n.checked_sub(4)) { n } else { n }
    |                      ^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     if let Some(n) = n.checked_sub(4) { n } else { n }
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:16:8
+  --> tests/ui/dbg_macro/dbg_macro.rs:17:8
    |
 LL |     if dbg!(n <= 1) {
    |        ^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     if n <= 1 {
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:19:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:20:9
    |
 LL |         dbg!(1)
    |         ^^^^^^^
@@ -37,7 +37,7 @@ LL +         1
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:22:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:23:9
    |
 LL |         dbg!(n * factorial(n - 1))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +         n * factorial(n - 1)
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:28:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:29:5
    |
 LL |     dbg!(42);
    |     ^^^^^^^^
@@ -61,7 +61,7 @@ LL +     42;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:31:14
+  --> tests/ui/dbg_macro/dbg_macro.rs:32:14
    |
 LL |     foo(3) + dbg!(factorial(4));
    |              ^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +     foo(3) + factorial(4);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:34:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:35:5
    |
 LL |     dbg!(1, 2, 3, 4, 5);
    |     ^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +     (1, 2, 3, 4, 5);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:56:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:57:5
    |
 LL |     dbg!();
    |     ^^^^^^
@@ -96,7 +96,7 @@ LL -     dbg!();
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:60:13
+  --> tests/ui/dbg_macro/dbg_macro.rs:61:13
    |
 LL |     let _ = dbg!();
    |             ^^^^^^
@@ -108,7 +108,7 @@ LL +     let _ = ();
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:63:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:64:9
    |
 LL |     bar(dbg!());
    |         ^^^^^^
@@ -120,7 +120,7 @@ LL +     bar(());
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:66:10
+  --> tests/ui/dbg_macro/dbg_macro.rs:67:10
    |
 LL |     foo!(dbg!());
    |          ^^^^^^
@@ -132,7 +132,7 @@ LL +     foo!(());
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:69:16
+  --> tests/ui/dbg_macro/dbg_macro.rs:70:16
    |
 LL |     foo2!(foo!(dbg!()));
    |                ^^^^^^
@@ -144,7 +144,7 @@ LL +     foo2!(foo!(()));
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:51:13
+  --> tests/ui/dbg_macro/dbg_macro.rs:52:13
    |
 LL |             dbg!();
    |             ^^^^^^
@@ -159,7 +159,7 @@ LL -             dbg!();
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:92:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:93:9
    |
 LL |         dbg!(2);
    |         ^^^^^^^
@@ -171,7 +171,7 @@ LL +         2;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:99:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:100:5
    |
 LL |     dbg!(1);
    |     ^^^^^^^
@@ -183,7 +183,7 @@ LL +     1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:105:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:106:5
    |
 LL |     dbg!(1);
    |     ^^^^^^^
@@ -195,7 +195,7 @@ LL +     1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:112:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:113:9
    |
 LL |         dbg!(1);
    |         ^^^^^^^
@@ -207,7 +207,7 @@ LL +         1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:119:31
+  --> tests/ui/dbg_macro/dbg_macro.rs:120:31
    |
 LL |         println!("dbg: {:?}", dbg!(s));
    |                               ^^^^^^^
@@ -219,7 +219,7 @@ LL +         println!("dbg: {:?}", s);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:122:22
+  --> tests/ui/dbg_macro/dbg_macro.rs:123:22
    |
 LL |         print!("{}", dbg!(s));
    |                      ^^^^^^^

--- a/tests/ui/default_constructed_unit_structs.fixed
+++ b/tests/ui/default_constructed_unit_structs.fixed
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::default_constructed_unit_structs)]
 use std::marker::PhantomData;
 

--- a/tests/ui/default_constructed_unit_structs.rs
+++ b/tests/ui/default_constructed_unit_structs.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::default_constructed_unit_structs)]
 use std::marker::PhantomData;
 

--- a/tests/ui/disallowed_names.rs
+++ b/tests/ui/disallowed_names.rs
@@ -83,3 +83,25 @@ mod tests {
 fn test_with_disallowed_name() {
     let foo = 0;
 }
+
+mod functions_test {
+    fn foo() {}
+    //~^ disallowed_names
+
+    pub fn quux(_some_meaningful_arg: i32) {}
+    //~^ disallowed_names
+
+    pub async fn baz(_more_meaningful_arg: bool) {}
+    //~^ disallowed_names
+
+    fn do_not_lint_foo() {}
+
+    struct SomeMeaningfulStruct {}
+    impl SomeMeaningfulStruct {
+        fn foo(&self) {}
+        //~^ disallowed_names
+
+        const fn baz(&self) {}
+        //~^ disallowed_names
+    }
+}

--- a/tests/ui/disallowed_names.stderr
+++ b/tests/ui/disallowed_names.stderr
@@ -85,5 +85,35 @@ error: use of a disallowed/placeholder name `quux`
 LL |     if let Some(ref mut quux) = Some(42) {}
    |                         ^^^^
 
-error: aborting due to 14 previous errors
+error: use of a disallowed/placeholder name `foo`
+  --> tests/ui/disallowed_names.rs:88:8
+   |
+LL |     fn foo() {}
+   |        ^^^
+
+error: use of a disallowed/placeholder name `quux`
+  --> tests/ui/disallowed_names.rs:91:12
+   |
+LL |     pub fn quux(_some_meaningful_arg: i32) {}
+   |            ^^^^
+
+error: use of a disallowed/placeholder name `baz`
+  --> tests/ui/disallowed_names.rs:94:18
+   |
+LL |     pub async fn baz(_more_meaningful_arg: bool) {}
+   |                  ^^^
+
+error: use of a disallowed/placeholder name `foo`
+  --> tests/ui/disallowed_names.rs:101:12
+   |
+LL |         fn foo(&self) {}
+   |            ^^^
+
+error: use of a disallowed/placeholder name `baz`
+  --> tests/ui/disallowed_names.rs:104:18
+   |
+LL |         const fn baz(&self) {}
+   |                  ^^^
+
+error: aborting due to 19 previous errors
 

--- a/tests/ui/diverging_sub_expression.rs
+++ b/tests/ui/diverging_sub_expression.rs
@@ -1,7 +1,11 @@
 #![warn(clippy::diverging_sub_expression)]
-#![allow(clippy::match_same_arms, clippy::overly_complex_bool_expr)]
-#![allow(clippy::nonminimal_bool)]
-#[allow(clippy::empty_loop)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::empty_loop,
+    clippy::match_same_arms,
+    clippy::nonminimal_bool,
+    clippy::overly_complex_bool_expr
+)]
 fn diverge() -> ! {
     loop {}
 }

--- a/tests/ui/diverging_sub_expression.stderr
+++ b/tests/ui/diverging_sub_expression.stderr
@@ -1,5 +1,5 @@
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:20:10
+  --> tests/ui/diverging_sub_expression.rs:24:10
    |
 LL |     b || diverge();
    |          ^^^^^^^^^
@@ -8,61 +8,61 @@ LL |     b || diverge();
    = help: to override `-D warnings` add `#[allow(clippy::diverging_sub_expression)]`
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:23:10
+  --> tests/ui/diverging_sub_expression.rs:27:10
    |
 LL |     b || A.foo();
    |          ^^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:34:26
+  --> tests/ui/diverging_sub_expression.rs:38:26
    |
 LL |             6 => true || return,
    |                          ^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:37:26
+  --> tests/ui/diverging_sub_expression.rs:41:26
    |
 LL |             7 => true || continue,
    |                          ^^^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:42:26
+  --> tests/ui/diverging_sub_expression.rs:46:26
    |
 LL |             3 => true || diverge(),
    |                          ^^^^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:47:30
+  --> tests/ui/diverging_sub_expression.rs:51:30
    |
 LL |                 _ => true || panic!("boo"),
    |                              ^^^^^^^^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:52:29
+  --> tests/ui/diverging_sub_expression.rs:56:29
    |
 LL |             15 => true || { return; },
    |                             ^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:55:30
+  --> tests/ui/diverging_sub_expression.rs:59:30
    |
 LL |             16 => false || { return; },
    |                              ^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:59:29
+  --> tests/ui/diverging_sub_expression.rs:63:29
    |
 LL |             17 => true || { return },
    |                             ^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:62:30
+  --> tests/ui/diverging_sub_expression.rs:66:30
    |
 LL |             18 => false || { return },
    |                              ^^^^^^
 
 error: sub-expression diverges
-  --> tests/ui/diverging_sub_expression.rs:73:26
+  --> tests/ui/diverging_sub_expression.rs:77:26
    |
 LL |             _ => true || break,
    |                          ^^^^^

--- a/tests/ui/doc/doc_overindented_list_items.fixed
+++ b/tests/ui/doc/doc_overindented_list_items.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::doc_overindented_list_items)]
+#![allow(clippy::disallowed_names)]
 
 #[rustfmt::skip]
 /// - first list item

--- a/tests/ui/doc/doc_overindented_list_items.rs
+++ b/tests/ui/doc/doc_overindented_list_items.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::doc_overindented_list_items)]
+#![allow(clippy::disallowed_names)]
 
 #[rustfmt::skip]
 /// - first list item

--- a/tests/ui/doc/doc_overindented_list_items.stderr
+++ b/tests/ui/doc/doc_overindented_list_items.stderr
@@ -1,5 +1,5 @@
 error: doc list item overindented
-  --> tests/ui/doc/doc_overindented_list_items.rs:5:5
+  --> tests/ui/doc/doc_overindented_list_items.rs:6:5
    |
 LL | ///        overindented line
    |     ^^^^^^^ help: try using `  ` (2 spaces)
@@ -8,31 +8,31 @@ LL | ///        overindented line
    = help: to override `-D warnings` add `#[allow(clippy::doc_overindented_list_items)]`
 
 error: doc list item overindented
-  --> tests/ui/doc/doc_overindented_list_items.rs:7:5
+  --> tests/ui/doc/doc_overindented_list_items.rs:8:5
    |
 LL | ///      this is overindented line too
    |     ^^^^^ help: try using `  ` (2 spaces)
 
 error: doc list item overindented
-  --> tests/ui/doc/doc_overindented_list_items.rs:14:7
+  --> tests/ui/doc/doc_overindented_list_items.rs:15:7
    |
 LL | ///        overindented line
    |       ^^^^^ help: try using `  ` (2 spaces)
 
 error: doc list item overindented
-  --> tests/ui/doc/doc_overindented_list_items.rs:16:7
+  --> tests/ui/doc/doc_overindented_list_items.rs:17:7
    |
 LL | ///      this is overindented line too
    |       ^^^ help: try using `  ` (2 spaces)
 
 error: doc list item overindented
-  --> tests/ui/doc/doc_overindented_list_items.rs:23:5
+  --> tests/ui/doc/doc_overindented_list_items.rs:24:5
    |
 LL | ///        overindented line
    |     ^^^^^^^ help: try using `  ` (2 spaces)
 
 error: doc list item overindented
-  --> tests/ui/doc/doc_overindented_list_items.rs:25:5
+  --> tests/ui/doc/doc_overindented_list_items.rs:26:5
    |
 LL | ///      this is overindented line too
    |     ^^^^^ help: try using `  ` (2 spaces)

--- a/tests/ui/doc/needless_doctest_main.rs
+++ b/tests/ui/doc/needless_doctest_main.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 
 #![warn(clippy::needless_doctest_main)]
+#![allow(clippy::disallowed_names)]
 //! issue 10491:
 //! ```rust,no_test
 //! use std::collections::HashMap;

--- a/tests/ui/doc_link_with_quotes.rs
+++ b/tests/ui/doc_link_with_quotes.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::doc_link_with_quotes)]
+#![allow(clippy::disallowed_names)]
 
 fn main() {
     foo()

--- a/tests/ui/doc_link_with_quotes.stderr
+++ b/tests/ui/doc_link_with_quotes.stderr
@@ -1,5 +1,5 @@
 error: possible intra-doc link using quotes instead of backticks
-  --> tests/ui/doc_link_with_quotes.rs:7:12
+  --> tests/ui/doc_link_with_quotes.rs:8:12
    |
 LL | /// Calls ['bar'] uselessly
    |            ^^^^^
@@ -8,7 +8,7 @@ LL | /// Calls ['bar'] uselessly
    = help: to override `-D warnings` add `#[allow(clippy::doc_link_with_quotes)]`
 
 error: possible intra-doc link using quotes instead of backticks
-  --> tests/ui/doc_link_with_quotes.rs:13:12
+  --> tests/ui/doc_link_with_quotes.rs:14:12
    |
 LL | /// Calls ["bar"] uselessly
    |            ^^^^^

--- a/tests/ui/duplicated_attributes.rs
+++ b/tests/ui/duplicated_attributes.rs
@@ -2,7 +2,7 @@
 #![feature(rustc_attrs)]
 #![warn(clippy::duplicated_attributes)]
 #![cfg(any(unix, windows))]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 #![allow(dead_code)] //~ ERROR: duplicated attribute
 #![cfg(any(unix, windows))] // Should not warn!
 

--- a/tests/ui/duplicated_attributes.stderr
+++ b/tests/ui/duplicated_attributes.stderr
@@ -7,7 +7,7 @@ LL | #![allow(dead_code)]
 note: first defined here
   --> tests/ui/duplicated_attributes.rs:5:10
    |
-LL | #![allow(dead_code)]
+LL | #![allow(dead_code, clippy::disallowed_names)]
    |          ^^^^^^^^^
 help: remove this attribute
   --> tests/ui/duplicated_attributes.rs:6:10

--- a/tests/ui/elidable_lifetime_names.fixed
+++ b/tests/ui/elidable_lifetime_names.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::needless_lifetimes, clippy::elidable_lifetime_names)]
+#![allow(clippy::disallowed_names)]
 
 type Ref<'r> = &'r u8;
 

--- a/tests/ui/elidable_lifetime_names.rs
+++ b/tests/ui/elidable_lifetime_names.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::needless_lifetimes, clippy::elidable_lifetime_names)]
+#![allow(clippy::disallowed_names)]
 
 type Ref<'r> = &'r u8;
 

--- a/tests/ui/elidable_lifetime_names.stderr
+++ b/tests/ui/elidable_lifetime_names.stderr
@@ -1,5 +1,5 @@
 error: the following explicit lifetimes could be elided: 'a, 'b
-  --> tests/ui/elidable_lifetime_names.rs:9:21
+  --> tests/ui/elidable_lifetime_names.rs:10:21
    |
 LL | fn lifetime_param_2<'a, 'b>(_x: Ref<'a>, _y: &'b u8) {}
    |                     ^^  ^^          ^^        ^^
@@ -13,7 +13,7 @@ LL + fn lifetime_param_2(_x: Ref<'_>, _y: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/elidable_lifetime_names.rs:34:15
+  --> tests/ui/elidable_lifetime_names.rs:35:15
    |
 LL | fn fn_bound_2<'a, F, I>(_m: Lt<'a, I>, _f: F) -> Lt<'a, I>
    |               ^^               ^^                   ^^
@@ -25,7 +25,7 @@ LL + fn fn_bound_2<F, I>(_m: Lt<'_, I>, _f: F) -> Lt<'_, I>
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/elidable_lifetime_names.rs:44:19
+  --> tests/ui/elidable_lifetime_names.rs:45:19
    |
 LL | fn struct_with_lt<'a>(_foo: Foo<'a>) -> &'a str {
    |                   ^^            ^^       ^^
@@ -37,7 +37,7 @@ LL + fn struct_with_lt(_foo: Foo<'_>) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/elidable_lifetime_names.rs:59:25
+  --> tests/ui/elidable_lifetime_names.rs:60:25
    |
 LL | fn struct_with_lt4a<'a, 'b>(_foo: &'a Foo<'b>) -> &'a str {
    |                         ^^                ^^
@@ -49,7 +49,7 @@ LL + fn struct_with_lt4a<'a>(_foo: &'a Foo<'_>) -> &'a str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/elidable_lifetime_names.rs:66:18
+  --> tests/ui/elidable_lifetime_names.rs:67:18
    |
 LL | fn alias_with_lt<'a>(_foo: FooAlias<'a>) -> &'a str {
    |                  ^^                 ^^       ^^
@@ -61,7 +61,7 @@ LL + fn alias_with_lt(_foo: FooAlias<'_>) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/elidable_lifetime_names.rs:81:24
+  --> tests/ui/elidable_lifetime_names.rs:82:24
    |
 LL | fn alias_with_lt4a<'a, 'b>(_foo: &'a FooAlias<'b>) -> &'a str {
    |                        ^^                     ^^
@@ -73,7 +73,7 @@ LL + fn alias_with_lt4a<'a>(_foo: &'a FooAlias<'_>) -> &'a str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/elidable_lifetime_names.rs:91:24
+  --> tests/ui/elidable_lifetime_names.rs:92:24
    |
 LL | fn out_return_type_lts<'a>(e: &'a str) -> Cow<'a> {
    |                        ^^      ^^             ^^
@@ -85,7 +85,7 @@ LL + fn out_return_type_lts(e: &str) -> Cow<'_> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/elidable_lifetime_names.rs:103:10
+  --> tests/ui/elidable_lifetime_names.rs:104:10
    |
 LL |     impl<'a> Foo for Baz<'a> {}
    |          ^^              ^^
@@ -97,7 +97,7 @@ LL +     impl Foo for Baz<'_> {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/elidable_lifetime_names.rs:106:16
+  --> tests/ui/elidable_lifetime_names.rs:107:16
    |
 LL |         fn baz<'a>(&'a self) -> impl Foo + 'a {
    |                ^^   ^^                     ^^
@@ -109,7 +109,7 @@ LL +         fn baz(&self) -> impl Foo + '_ {
    |
 
 error: the following explicit lifetimes could be elided: 'py
-  --> tests/ui/elidable_lifetime_names.rs:139:14
+  --> tests/ui/elidable_lifetime_names.rs:140:14
    |
 LL |     impl<'t, 'py> ContentString<'t> {
    |              ^^^
@@ -125,7 +125,7 @@ LL ~         fn map_content2(&self, f: impl FnOnce(&'t str) -> &'t str) -> Conte
    |
 
 error: the following explicit lifetimes could be elided: 'py
-  --> tests/ui/elidable_lifetime_names.rs:150:14
+  --> tests/ui/elidable_lifetime_names.rs:151:14
    |
 LL |     impl<'t, 'py> ContentString<'t> {
    |              ^^^
@@ -141,7 +141,7 @@ LL ~         fn map_content3(&'_ self, f: impl FnOnce(&'t str) -> &'t str) -> Co
    |
 
 error: the following explicit lifetimes could be elided: 'py
-  --> tests/ui/elidable_lifetime_names.rs:171:14
+  --> tests/ui/elidable_lifetime_names.rs:172:14
    |
 LL |     impl<'t, 'py> ContentString<'t> {
    |              ^^^

--- a/tests/ui/empty_line_after/outer_attribute.1.fixed
+++ b/tests/ui/empty_line_after/outer_attribute.1.fixed
@@ -1,5 +1,6 @@
 //@aux-build:../auxiliary/proc_macro_attr.rs
 #![warn(clippy::empty_line_after_outer_attr, clippy::empty_line_after_doc_comments)]
+#![allow(clippy::disallowed_names)]
 
 //~v empty_line_after_outer_attr
 #[crate_type = "lib"]

--- a/tests/ui/empty_line_after/outer_attribute.2.fixed
+++ b/tests/ui/empty_line_after/outer_attribute.2.fixed
@@ -1,5 +1,6 @@
 //@aux-build:../auxiliary/proc_macro_attr.rs
 #![warn(clippy::empty_line_after_outer_attr, clippy::empty_line_after_doc_comments)]
+#![allow(clippy::disallowed_names)]
 
 //~v empty_line_after_outer_attr
 #![crate_type = "lib"]

--- a/tests/ui/empty_line_after/outer_attribute.rs
+++ b/tests/ui/empty_line_after/outer_attribute.rs
@@ -1,5 +1,6 @@
 //@aux-build:../auxiliary/proc_macro_attr.rs
 #![warn(clippy::empty_line_after_outer_attr, clippy::empty_line_after_doc_comments)]
+#![allow(clippy::disallowed_names)]
 
 //~v empty_line_after_outer_attr
 #[crate_type = "lib"]

--- a/tests/ui/empty_line_after/outer_attribute.stderr
+++ b/tests/ui/empty_line_after/outer_attribute.stderr
@@ -1,5 +1,5 @@
 error: empty line after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:5:1
+  --> tests/ui/empty_line_after/outer_attribute.rs:6:1
    |
 LL | / #[crate_type = "lib"]
 LL | |
@@ -16,7 +16,7 @@ LL | #![crate_type = "lib"]
    |  +
 
 error: empty line after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:13:1
+  --> tests/ui/empty_line_after/outer_attribute.rs:14:1
    |
 LL | / #[inline]
 LL | |
@@ -28,7 +28,7 @@ LL |   fn with_one_newline_and_comment() {}
    = help: if the empty line is unintentional, remove it
 
 error: empty line after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:23:1
+  --> tests/ui/empty_line_after/outer_attribute.rs:24:1
    |
 LL | / #[inline]
 LL | |
@@ -39,7 +39,7 @@ LL |   fn with_one_newline() {}
    = help: if the empty line is unintentional, remove it
 
 error: empty lines after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:30:5
+  --> tests/ui/empty_line_after/outer_attribute.rs:31:5
    |
 LL | /     #[crate_type = "lib"]
 LL | |
@@ -55,7 +55,7 @@ LL |     #![crate_type = "lib"]
    |      +
 
 error: empty line after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:37:1
+  --> tests/ui/empty_line_after/outer_attribute.rs:38:1
    |
 LL | / #[doc = "doc attributes should be considered attributes"]
 LL | |
@@ -66,7 +66,7 @@ LL |   enum Baz {
    = help: if the empty line is unintentional, remove it
 
 error: empty line after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:45:1
+  --> tests/ui/empty_line_after/outer_attribute.rs:46:1
    |
 LL | / #[repr(C)]
 LL | |
@@ -77,7 +77,7 @@ LL |   struct Foo {
    = help: if the empty line is unintentional, remove it
 
 error: empty line after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:53:1
+  --> tests/ui/empty_line_after/outer_attribute.rs:54:1
    |
 LL | / #[allow(dead_code)]
 LL | |
@@ -88,7 +88,7 @@ LL |   mod foo {}
    = help: if the empty line is unintentional, remove it
 
 error: empty line after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:58:1
+  --> tests/ui/empty_line_after/outer_attribute.rs:59:1
    |
 LL | / #[inline]
 LL | | // Still lint cases where the empty line does not immediately follow the attribute
@@ -100,7 +100,7 @@ LL |   fn comment_before_empty_line() {}
    = help: if the empty line is unintentional, remove it
 
 error: empty lines after outer attribute
-  --> tests/ui/empty_line_after/outer_attribute.rs:64:1
+  --> tests/ui/empty_line_after/outer_attribute.rs:65:1
    |
 LL | / #[allow(unused)]
 ...  |

--- a/tests/ui/entry.fixed
+++ b/tests/ui/entry.fixed
@@ -1,6 +1,11 @@
 //@needs-asm-support
 
-#![allow(unused, clippy::needless_pass_by_value, clippy::collapsible_if)]
+#![allow(
+    unused,
+    clippy::needless_pass_by_value,
+    clippy::collapsible_if,
+    clippy::disallowed_names
+)]
 #![warn(clippy::map_entry)]
 
 use std::arch::asm;

--- a/tests/ui/entry.rs
+++ b/tests/ui/entry.rs
@@ -1,6 +1,11 @@
 //@needs-asm-support
 
-#![allow(unused, clippy::needless_pass_by_value, clippy::collapsible_if)]
+#![allow(
+    unused,
+    clippy::needless_pass_by_value,
+    clippy::collapsible_if,
+    clippy::disallowed_names
+)]
 #![warn(clippy::map_entry)]
 
 use std::arch::asm;

--- a/tests/ui/entry.stderr
+++ b/tests/ui/entry.stderr
@@ -1,5 +1,5 @@
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:24:5
+  --> tests/ui/entry.rs:29:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -11,7 +11,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::map_entry)]`
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:30:5
+  --> tests/ui/entry.rs:35:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -34,7 +34,7 @@ LL +     });
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:40:5
+  --> tests/ui/entry.rs:45:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -58,7 +58,7 @@ LL +     });
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:50:5
+  --> tests/ui/entry.rs:55:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -82,7 +82,7 @@ LL +     }
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:61:5
+  --> tests/ui/entry.rs:66:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -101,7 +101,7 @@ LL +     });
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:68:5
+  --> tests/ui/entry.rs:73:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -128,7 +128,7 @@ LL +     });
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:81:5
+  --> tests/ui/entry.rs:86:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -153,7 +153,7 @@ LL +     }
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:92:5
+  --> tests/ui/entry.rs:97:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -194,7 +194,7 @@ LL +     });
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:127:5
+  --> tests/ui/entry.rs:132:5
    |
 LL | /     if !m.contains_key(&m!(k)) {
 LL | |
@@ -203,7 +203,7 @@ LL | |     }
    | |_____^ help: try: `m.entry(m!(k)).or_insert_with(|| m!(v));`
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:160:5
+  --> tests/ui/entry.rs:165:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -224,7 +224,7 @@ LL +     });
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry.rs:194:5
+  --> tests/ui/entry.rs:199:5
    |
 LL | /     if !map.contains_key(&1) {
 LL | |

--- a/tests/ui/entry_btree.fixed
+++ b/tests/ui/entry_btree.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::map_entry)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 
 use std::collections::BTreeMap;
 

--- a/tests/ui/entry_btree.rs
+++ b/tests/ui/entry_btree.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::map_entry)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 
 use std::collections::BTreeMap;
 

--- a/tests/ui/entry_with_else.fixed
+++ b/tests/ui/entry_with_else.fixed
@@ -1,4 +1,9 @@
-#![allow(unused, clippy::needless_pass_by_value, clippy::collapsible_if)]
+#![allow(
+    unused,
+    clippy::needless_pass_by_value,
+    clippy::collapsible_if,
+    clippy::disallowed_names
+)]
 #![warn(clippy::map_entry)]
 
 use std::collections::{BTreeMap, HashMap};

--- a/tests/ui/entry_with_else.rs
+++ b/tests/ui/entry_with_else.rs
@@ -1,4 +1,9 @@
-#![allow(unused, clippy::needless_pass_by_value, clippy::collapsible_if)]
+#![allow(
+    unused,
+    clippy::needless_pass_by_value,
+    clippy::collapsible_if,
+    clippy::disallowed_names
+)]
 #![warn(clippy::map_entry)]
 
 use std::collections::{BTreeMap, HashMap};

--- a/tests/ui/entry_with_else.stderr
+++ b/tests/ui/entry_with_else.stderr
@@ -1,5 +1,5 @@
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_with_else.rs:14:5
+  --> tests/ui/entry_with_else.rs:19:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -25,7 +25,7 @@ LL +     }
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_with_else.rs:21:5
+  --> tests/ui/entry_with_else.rs:26:5
    |
 LL | /     if m.contains_key(&k) {
 LL | |
@@ -49,7 +49,7 @@ LL +     }
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_with_else.rs:28:5
+  --> tests/ui/entry_with_else.rs:33:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -70,7 +70,7 @@ LL +     }
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_with_else.rs:35:5
+  --> tests/ui/entry_with_else.rs:40:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -91,7 +91,7 @@ LL +     }
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_with_else.rs:42:5
+  --> tests/ui/entry_with_else.rs:47:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |
@@ -115,7 +115,7 @@ LL +     }
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_with_else.rs:49:5
+  --> tests/ui/entry_with_else.rs:54:5
    |
 LL | /     if m.contains_key(&k) {
 LL | |
@@ -140,7 +140,7 @@ LL ~     };
    |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_with_else.rs:56:5
+  --> tests/ui/entry_with_else.rs:61:5
    |
 LL | /     if m.contains_key(&k) {
 LL | |

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -1,6 +1,7 @@
 #![warn(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
 #![allow(unused)]
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_borrow,
     clippy::needless_option_as_deref,
     clippy::needless_pass_by_value,

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
 #![allow(unused)]
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_borrow,
     clippy::needless_option_as_deref,
     clippy::needless_pass_by_value,

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -1,5 +1,5 @@
 error: redundant closure
-  --> tests/ui/eta.rs:31:27
+  --> tests/ui/eta.rs:32:27
    |
 LL |     let a = Some(1u8).map(|a| foo(a));
    |                           ^^^^^^^^^^ help: replace the closure with the function itself: `foo`
@@ -8,31 +8,31 @@ LL |     let a = Some(1u8).map(|a| foo(a));
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure)]`
 
 error: redundant closure
-  --> tests/ui/eta.rs:36:40
+  --> tests/ui/eta.rs:37:40
    |
 LL |     let _: Option<Vec<u8>> = true.then(|| vec![]); // special case vec!
    |                                        ^^^^^^^^^ help: replace the closure with `Vec::new`: `std::vec::Vec::new`
 
 error: redundant closure
-  --> tests/ui/eta.rs:39:35
+  --> tests/ui/eta.rs:40:35
    |
 LL |     let d = Some(1u8).map(|a| foo((|b| foo2(b))(a))); //is adjusted?
    |                                   ^^^^^^^^^^^^^ help: replace the closure with the function itself: `foo2`
 
 error: redundant closure
-  --> tests/ui/eta.rs:42:26
+  --> tests/ui/eta.rs:43:26
    |
 LL |     all(&[1, 2, 3], &&2, |x, y| below(x, y)); //is adjusted
    |                          ^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `below`
 
 error: redundant closure
-  --> tests/ui/eta.rs:51:27
+  --> tests/ui/eta.rs:52:27
    |
 LL |     let e = Some(1u8).map(|a| generic(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `generic`
 
 error: redundant closure
-  --> tests/ui/eta.rs:104:51
+  --> tests/ui/eta.rs:105:51
    |
 LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.foo());
    |                                                   ^^^^^^^^^^^ help: replace the closure with the method itself: `TestStruct::foo`
@@ -41,175 +41,175 @@ LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.foo());
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_for_method_calls)]`
 
 error: redundant closure
-  --> tests/ui/eta.rs:106:51
+  --> tests/ui/eta.rs:107:51
    |
 LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.trait_foo());
    |                                                   ^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `TestTrait::trait_foo`
 
 error: redundant closure
-  --> tests/ui/eta.rs:109:42
+  --> tests/ui/eta.rs:110:42
    |
 LL |     let e = Some(&mut vec![1, 2, 3]).map(|v| v.clear());
    |                                          ^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::vec::Vec::clear`
 
 error: redundant closure
-  --> tests/ui/eta.rs:114:29
+  --> tests/ui/eta.rs:115:29
    |
 LL |     let e = Some("str").map(|s| s.to_string());
    |                             ^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::string::ToString::to_string`
 
 error: redundant closure
-  --> tests/ui/eta.rs:116:27
+  --> tests/ui/eta.rs:117:27
    |
 LL |     let e = Some('a').map(|s| s.to_uppercase());
    |                           ^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `char::to_uppercase`
 
 error: redundant closure
-  --> tests/ui/eta.rs:119:65
+  --> tests/ui/eta.rs:120:65
    |
 LL |     let e: std::vec::Vec<char> = vec!['a', 'b', 'c'].iter().map(|c| c.to_ascii_uppercase()).collect();
    |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `char::to_ascii_uppercase`
 
 error: redundant closure
-  --> tests/ui/eta.rs:136:23
+  --> tests/ui/eta.rs:137:23
    |
 LL |         let _ = x.map(|x| x.parse::<i16>());
    |                       ^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `str::parse::<i16>`
 
 error: redundant closure
-  --> tests/ui/eta.rs:189:22
+  --> tests/ui/eta.rs:190:22
    |
 LL |     requires_fn_once(|| x());
    |                      ^^^^^^ help: replace the closure with the function itself: `x`
 
 error: redundant closure
-  --> tests/ui/eta.rs:197:27
+  --> tests/ui/eta.rs:198:27
    |
 LL |     let a = Some(1u8).map(|a| foo_ptr(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `foo_ptr`
 
 error: redundant closure
-  --> tests/ui/eta.rs:203:27
+  --> tests/ui/eta.rs:204:27
    |
 LL |     let a = Some(1u8).map(|a| closure(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `closure`
 
 error: redundant closure
-  --> tests/ui/eta.rs:236:28
+  --> tests/ui/eta.rs:237:28
    |
 LL |     x.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut add_to_res`
 
 error: redundant closure
-  --> tests/ui/eta.rs:238:28
+  --> tests/ui/eta.rs:239:28
    |
 LL |     y.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut add_to_res`
 
 error: redundant closure
-  --> tests/ui/eta.rs:240:28
+  --> tests/ui/eta.rs:241:28
    |
 LL |     z.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `add_to_res`
 
 error: redundant closure
-  --> tests/ui/eta.rs:248:21
+  --> tests/ui/eta.rs:249:21
    |
 LL |         Some(1).map(|n| closure(n));
    |                     ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut closure`
 
 error: redundant closure
-  --> tests/ui/eta.rs:253:21
+  --> tests/ui/eta.rs:254:21
    |
 LL |         Some(1).map(|n| in_loop(n));
    |                     ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `in_loop`
 
 error: redundant closure
-  --> tests/ui/eta.rs:347:18
+  --> tests/ui/eta.rs:348:18
    |
 LL |     takes_fn_mut(|| f());
    |                  ^^^^^^ help: replace the closure with the function itself: `&mut f`
 
 error: redundant closure
-  --> tests/ui/eta.rs:351:19
+  --> tests/ui/eta.rs:352:19
    |
 LL |     takes_fn_once(|| f());
    |                   ^^^^^^ help: replace the closure with the function itself: `&mut f`
 
 error: redundant closure
-  --> tests/ui/eta.rs:356:26
+  --> tests/ui/eta.rs:357:26
    |
 LL |     move || takes_fn_mut(|| f_used_once())
    |                          ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut f_used_once`
 
 error: redundant closure
-  --> tests/ui/eta.rs:369:19
+  --> tests/ui/eta.rs:370:19
    |
 LL |     array_opt.map(|a| a.as_slice());
    |                   ^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<[u8; 3]>::as_slice`
 
 error: redundant closure
-  --> tests/ui/eta.rs:373:19
+  --> tests/ui/eta.rs:374:19
    |
 LL |     slice_opt.map(|s| s.len());
    |                   ^^^^^^^^^^^ help: replace the closure with the method itself: `<[u8]>::len`
 
 error: redundant closure
-  --> tests/ui/eta.rs:377:17
+  --> tests/ui/eta.rs:378:17
    |
 LL |     ptr_opt.map(|p| p.is_null());
    |                 ^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<*const usize>::is_null`
 
 error: redundant closure
-  --> tests/ui/eta.rs:382:17
+  --> tests/ui/eta.rs:383:17
    |
 LL |     dyn_opt.map(|d| d.method_on_dyn());
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<dyn TestTrait>::method_on_dyn`
 
 error: redundant closure
-  --> tests/ui/eta.rs:443:19
+  --> tests/ui/eta.rs:444:19
    |
 LL |     let _ = f(&0, |x, y| f2(x, y));
    |                   ^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `f2`
 
 error: redundant closure
-  --> tests/ui/eta.rs:472:22
+  --> tests/ui/eta.rs:473:22
    |
 LL |             test.map(|t| t.method())
    |                      ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `Test::method`
 
 error: redundant closure
-  --> tests/ui/eta.rs:477:22
+  --> tests/ui/eta.rs:478:22
    |
 LL |             test.map(|t| t.method())
    |                      ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `super::Outer::method`
 
 error: redundant closure
-  --> tests/ui/eta.rs:491:18
+  --> tests/ui/eta.rs:492:18
    |
 LL |         test.map(|t| t.method())
    |                  ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `test_mod::Test::method`
 
 error: redundant closure
-  --> tests/ui/eta.rs:499:30
+  --> tests/ui/eta.rs:500:30
    |
 LL |                     test.map(|t| t.method())
    |                              ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `crate::issue_10854::d::Test::method`
 
 error: redundant closure
-  --> tests/ui/eta.rs:519:38
+  --> tests/ui/eta.rs:520:38
    |
 LL |         let x = Box::new(|| None.map(|x| f(x)));
    |                                      ^^^^^^^^ help: replace the closure with the function itself: `&f`
 
 error: redundant closure
-  --> tests/ui/eta.rs:524:38
+  --> tests/ui/eta.rs:525:38
    |
 LL |         let x = Box::new(|| None.map(|x| f(x)));
    |                                      ^^^^^^^^ help: replace the closure with the function itself: `f`
 
 error: redundant closure
-  --> tests/ui/eta.rs:542:35
+  --> tests/ui/eta.rs:543:35
    |
 LL |         let _field = bind.or_else(|| get_default()).unwrap();
    |                                   ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `get_default`

--- a/tests/ui/expect_tool_lint_rfc_2383.rs
+++ b/tests/ui/expect_tool_lint_rfc_2383.rs
@@ -10,7 +10,7 @@
 //! This test can't cover every lint from Clippy, rustdoc and potentially other
 //! tools that will be developed. This therefore only tests a small subset of lints
 #![expect(rustdoc::missing_crate_level_docs)]
-#![allow(clippy::needless_if)]
+#![allow(clippy::disallowed_names, clippy::needless_if)]
 
 mod rustc_ok {
     //! See <https://doc.rust-lang.org/rustc/lints/index.html>

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -4,6 +4,7 @@
     dead_code,
     unused_braces,
     clippy::borrowed_box,
+    clippy::disallowed_names,
     clippy::needless_borrow,
     clippy::needless_return,
     clippy::ptr_arg,

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -4,6 +4,7 @@
     dead_code,
     unused_braces,
     clippy::borrowed_box,
+    clippy::disallowed_names,
     clippy::needless_borrow,
     clippy::needless_return,
     clippy::ptr_arg,

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -1,5 +1,5 @@
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:69:19
+  --> tests/ui/explicit_auto_deref.rs:70:19
    |
 LL |     let _: &str = &*s;
    |                   ^^^ help: try: `&s`
@@ -8,271 +8,271 @@ LL |     let _: &str = &*s;
    = help: to override `-D warnings` add `#[allow(clippy::explicit_auto_deref)]`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:71:19
+  --> tests/ui/explicit_auto_deref.rs:72:19
    |
 LL |     let _: &str = &*{ String::new() };
    |                   ^^^^^^^^^^^^^^^^^^^ help: try: `&{ String::new() }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:73:19
+  --> tests/ui/explicit_auto_deref.rs:74:19
    |
 LL |     let _: &str = &mut *{ String::new() };
    |                   ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut { String::new() }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:78:11
+  --> tests/ui/explicit_auto_deref.rs:79:11
    |
 LL |     f_str(&*s);
    |           ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:83:13
+  --> tests/ui/explicit_auto_deref.rs:84:13
    |
 LL |     f_str_t(&*s, &*s); // Don't lint second param.
    |             ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:88:24
+  --> tests/ui/explicit_auto_deref.rs:89:24
    |
 LL |     let _: &Box<i32> = &**b;
    |                        ^^^^ help: try: `&b`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:95:7
+  --> tests/ui/explicit_auto_deref.rs:96:7
    |
 LL |     c(&*s);
    |       ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:102:9
+  --> tests/ui/explicit_auto_deref.rs:103:9
    |
 LL |         &**x
    |         ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:107:11
+  --> tests/ui/explicit_auto_deref.rs:108:11
    |
 LL |         { &**x }
    |           ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:112:9
+  --> tests/ui/explicit_auto_deref.rs:113:9
    |
 LL |         &**{ x }
    |         ^^^^^^^^ help: try: `{ x }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:117:9
+  --> tests/ui/explicit_auto_deref.rs:118:9
    |
 LL |         &***x
    |         ^^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:135:12
+  --> tests/ui/explicit_auto_deref.rs:136:12
    |
 LL |         f1(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:137:12
+  --> tests/ui/explicit_auto_deref.rs:138:12
    |
 LL |         f2(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:139:12
+  --> tests/ui/explicit_auto_deref.rs:140:12
    |
 LL |         f3(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:141:27
+  --> tests/ui/explicit_auto_deref.rs:142:27
    |
 LL |         f4.callable_str()(&*x);
    |                           ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:143:12
+  --> tests/ui/explicit_auto_deref.rs:144:12
    |
 LL |         f5(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:145:12
+  --> tests/ui/explicit_auto_deref.rs:146:12
    |
 LL |         f6(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:147:27
+  --> tests/ui/explicit_auto_deref.rs:148:27
    |
 LL |         f7.callable_str()(&*x);
    |                           ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:149:25
+  --> tests/ui/explicit_auto_deref.rs:150:25
    |
 LL |         f8.callable_t()(&*x);
    |                         ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:151:12
+  --> tests/ui/explicit_auto_deref.rs:152:12
    |
 LL |         f9(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:153:13
+  --> tests/ui/explicit_auto_deref.rs:154:13
    |
 LL |         f10(&*x);
    |             ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:155:26
+  --> tests/ui/explicit_auto_deref.rs:156:26
    |
 LL |         f11.callable_t()(&*x);
    |                          ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:160:16
+  --> tests/ui/explicit_auto_deref.rs:161:16
    |
 LL |     let _ = S1(&*s);
    |                ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:166:21
+  --> tests/ui/explicit_auto_deref.rs:167:21
    |
 LL |     let _ = S2 { s: &*s };
    |                     ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:183:30
+  --> tests/ui/explicit_auto_deref.rs:184:30
    |
 LL |             let _ = Self::S1(&**s);
    |                              ^^^^ help: try: `s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:185:35
+  --> tests/ui/explicit_auto_deref.rs:186:35
    |
 LL |             let _ = Self::S2 { s: &**s };
    |                                   ^^^^ help: try: `s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:189:20
+  --> tests/ui/explicit_auto_deref.rs:190:20
    |
 LL |     let _ = E1::S1(&*s);
    |                    ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:191:25
+  --> tests/ui/explicit_auto_deref.rs:192:25
    |
 LL |     let _ = E1::S2 { s: &*s };
    |                         ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:210:13
+  --> tests/ui/explicit_auto_deref.rs:211:13
    |
 LL |     let _ = (*b).foo;
    |             ^^^^ help: try: `b`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:212:13
+  --> tests/ui/explicit_auto_deref.rs:213:13
    |
 LL |     let _ = (**b).foo;
    |             ^^^^^ help: try: `b`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:228:19
+  --> tests/ui/explicit_auto_deref.rs:229:19
    |
 LL |     let _ = f_str(*ref_str);
    |                   ^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:231:19
+  --> tests/ui/explicit_auto_deref.rs:232:19
    |
 LL |     let _ = f_str(**ref_ref_str);
    |                   ^^^^^^^^^^^^^ help: try: `ref_ref_str`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:242:12
+  --> tests/ui/explicit_auto_deref.rs:243:12
    |
 LL |     f_str(&&*ref_str); // `needless_borrow` will suggest removing both references
    |            ^^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:245:12
+  --> tests/ui/explicit_auto_deref.rs:246:12
    |
 LL |     f_str(&&**ref_str); // `needless_borrow` will suggest removing only one reference
    |            ^^^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:256:41
+  --> tests/ui/explicit_auto_deref.rs:257:41
    |
 LL |     let _ = || -> &'static str { return *s };
    |                                         ^^ help: try: `s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:276:9
+  --> tests/ui/explicit_auto_deref.rs:277:9
    |
 LL |         &**x
    |         ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:300:8
+  --> tests/ui/explicit_auto_deref.rs:301:8
    |
 LL |     c1(*x);
    |        ^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:304:20
+  --> tests/ui/explicit_auto_deref.rs:305:20
    |
 LL |             return *x;
    |                    ^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:307:9
+  --> tests/ui/explicit_auto_deref.rs:308:9
    |
 LL |         *x
    |         ^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:342:20
+  --> tests/ui/explicit_auto_deref.rs:343:20
    |
 LL |         Some(x) => &mut *x,
    |                    ^^^^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:376:22
+  --> tests/ui/explicit_auto_deref.rs:377:22
    |
 LL |         let _ = &mut (*{ x.u }).x;
    |                      ^^^^^^^^^^ help: try: `{ x.u }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:383:22
+  --> tests/ui/explicit_auto_deref.rs:384:22
    |
 LL |         let _ = &mut (**x.u).x;
    |                      ^^^^^^^ help: try: `(*x.u)`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:385:22
+  --> tests/ui/explicit_auto_deref.rs:386:22
    |
 LL |         let _ = &mut (**{ x.u }).x;
    |                      ^^^^^^^^^^^ help: try: `{ x.u }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:390:22
+  --> tests/ui/explicit_auto_deref.rs:391:22
    |
 LL |         let _ = &mut (*x.u).x;
    |                      ^^^^^^ help: try: `x.u`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:392:22
+  --> tests/ui/explicit_auto_deref.rs:393:22
    |
 LL |         let _ = &mut (*{ x.u }).x;
    |                      ^^^^^^^^^^ help: try: `{ x.u }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:416:13
+  --> tests/ui/explicit_auto_deref.rs:417:13
    |
 LL |         foo(&*wrapped_bar);
    |             ^^^^^^^^^^^^^ help: try: `&wrapped_bar`

--- a/tests/ui/fn_to_numeric_cast.64bit.stderr
+++ b/tests/ui/fn_to_numeric_cast.64bit.stderr
@@ -1,5 +1,5 @@
 error: casting function pointer `foo` to `i8`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:12:13
+  --> tests/ui/fn_to_numeric_cast.rs:13:13
    |
 LL |     let _ = foo as i8;
    |             ^^^^^^^^^ help: try: `foo as usize`
@@ -8,19 +8,19 @@ LL |     let _ = foo as i8;
    = help: to override `-D warnings` add `#[allow(clippy::fn_to_numeric_cast_with_truncation)]`
 
 error: casting function pointer `foo` to `i16`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:14:13
+  --> tests/ui/fn_to_numeric_cast.rs:15:13
    |
 LL |     let _ = foo as i16;
    |             ^^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `foo` to `i32`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:16:13
+  --> tests/ui/fn_to_numeric_cast.rs:17:13
    |
 LL |     let _ = foo as i32;
    |             ^^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `foo` to `i64`
-  --> tests/ui/fn_to_numeric_cast.rs:19:13
+  --> tests/ui/fn_to_numeric_cast.rs:20:13
    |
 LL |     let _ = foo as i64;
    |             ^^^^^^^^^^ help: try: `foo as usize`
@@ -29,115 +29,115 @@ LL |     let _ = foo as i64;
    = help: to override `-D warnings` add `#[allow(clippy::fn_to_numeric_cast)]`
 
 error: casting function pointer `foo` to `i128`
-  --> tests/ui/fn_to_numeric_cast.rs:21:13
+  --> tests/ui/fn_to_numeric_cast.rs:22:13
    |
 LL |     let _ = foo as i128;
    |             ^^^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `foo` to `isize`
-  --> tests/ui/fn_to_numeric_cast.rs:23:13
+  --> tests/ui/fn_to_numeric_cast.rs:24:13
    |
 LL |     let _ = foo as isize;
    |             ^^^^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `foo` to `u8`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:26:13
+  --> tests/ui/fn_to_numeric_cast.rs:27:13
    |
 LL |     let _ = foo as u8;
    |             ^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `foo` to `u16`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:28:13
+  --> tests/ui/fn_to_numeric_cast.rs:29:13
    |
 LL |     let _ = foo as u16;
    |             ^^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `foo` to `u32`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:30:13
+  --> tests/ui/fn_to_numeric_cast.rs:31:13
    |
 LL |     let _ = foo as u32;
    |             ^^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `foo` to `u64`
-  --> tests/ui/fn_to_numeric_cast.rs:33:13
+  --> tests/ui/fn_to_numeric_cast.rs:34:13
    |
 LL |     let _ = foo as u64;
    |             ^^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `foo` to `u128`
-  --> tests/ui/fn_to_numeric_cast.rs:35:13
+  --> tests/ui/fn_to_numeric_cast.rs:36:13
    |
 LL |     let _ = foo as u128;
    |             ^^^^^^^^^^^ help: try: `foo as usize`
 
 error: casting function pointer `abc` to `i8`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:49:13
+  --> tests/ui/fn_to_numeric_cast.rs:50:13
    |
 LL |     let _ = abc as i8;
    |             ^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `i16`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:51:13
+  --> tests/ui/fn_to_numeric_cast.rs:52:13
    |
 LL |     let _ = abc as i16;
    |             ^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `i32`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:53:13
+  --> tests/ui/fn_to_numeric_cast.rs:54:13
    |
 LL |     let _ = abc as i32;
    |             ^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `i64`
-  --> tests/ui/fn_to_numeric_cast.rs:56:13
+  --> tests/ui/fn_to_numeric_cast.rs:57:13
    |
 LL |     let _ = abc as i64;
    |             ^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `i128`
-  --> tests/ui/fn_to_numeric_cast.rs:58:13
+  --> tests/ui/fn_to_numeric_cast.rs:59:13
    |
 LL |     let _ = abc as i128;
    |             ^^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `isize`
-  --> tests/ui/fn_to_numeric_cast.rs:60:13
+  --> tests/ui/fn_to_numeric_cast.rs:61:13
    |
 LL |     let _ = abc as isize;
    |             ^^^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `u8`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:63:13
+  --> tests/ui/fn_to_numeric_cast.rs:64:13
    |
 LL |     let _ = abc as u8;
    |             ^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `u16`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:65:13
+  --> tests/ui/fn_to_numeric_cast.rs:66:13
    |
 LL |     let _ = abc as u16;
    |             ^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `u32`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:67:13
+  --> tests/ui/fn_to_numeric_cast.rs:68:13
    |
 LL |     let _ = abc as u32;
    |             ^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `u64`
-  --> tests/ui/fn_to_numeric_cast.rs:70:13
+  --> tests/ui/fn_to_numeric_cast.rs:71:13
    |
 LL |     let _ = abc as u64;
    |             ^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `abc` to `u128`
-  --> tests/ui/fn_to_numeric_cast.rs:72:13
+  --> tests/ui/fn_to_numeric_cast.rs:73:13
    |
 LL |     let _ = abc as u128;
    |             ^^^^^^^^^^^ help: try: `abc as usize`
 
 error: casting function pointer `f` to `i32`, which truncates the value
-  --> tests/ui/fn_to_numeric_cast.rs:80:5
+  --> tests/ui/fn_to_numeric_cast.rs:81:5
    |
 LL |     f as i32
    |     ^^^^^^^^ help: try: `f as usize`

--- a/tests/ui/fn_to_numeric_cast.rs
+++ b/tests/ui/fn_to_numeric_cast.rs
@@ -3,6 +3,7 @@
 //@[64bit]ignore-bitwidth: 32
 //@no-rustfix
 #![warn(clippy::fn_to_numeric_cast, clippy::fn_to_numeric_cast_with_truncation)]
+#![allow(clippy::disallowed_names)]
 
 fn foo() -> String {
     String::new()

--- a/tests/ui/fn_to_numeric_cast_any.rs
+++ b/tests/ui/fn_to_numeric_cast_any.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::fn_to_numeric_cast_any)]
-#![allow(clippy::fn_to_numeric_cast, clippy::fn_to_numeric_cast_with_truncation)]
+#![allow(
+    clippy::fn_to_numeric_cast,
+    clippy::fn_to_numeric_cast_with_truncation,
+    clippy::disallowed_names
+)]
 //@no-rustfix
 fn foo() -> u8 {
     0

--- a/tests/ui/fn_to_numeric_cast_any.stderr
+++ b/tests/ui/fn_to_numeric_cast_any.stderr
@@ -1,5 +1,5 @@
 error: casting function pointer `foo` to `i8`
-  --> tests/ui/fn_to_numeric_cast_any.rs:23:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:27:13
    |
 LL |     let _ = foo as i8;
    |             ^^^^^^^^^
@@ -12,7 +12,7 @@ LL |     let _ = foo() as i8;
    |                ++
 
 error: casting function pointer `foo` to `i16`
-  --> tests/ui/fn_to_numeric_cast_any.rs:26:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:30:13
    |
 LL |     let _ = foo as i16;
    |             ^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     let _ = foo() as i16;
    |                ++
 
 error: casting function pointer `foo` to `i32`
-  --> tests/ui/fn_to_numeric_cast_any.rs:29:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:33:13
    |
 LL |     let _ = foo as i32;
    |             ^^^^^^^^^^
@@ -34,7 +34,7 @@ LL |     let _ = foo() as i32;
    |                ++
 
 error: casting function pointer `foo` to `i64`
-  --> tests/ui/fn_to_numeric_cast_any.rs:32:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:36:13
    |
 LL |     let _ = foo as i64;
    |             ^^^^^^^^^^
@@ -45,7 +45,7 @@ LL |     let _ = foo() as i64;
    |                ++
 
 error: casting function pointer `foo` to `i128`
-  --> tests/ui/fn_to_numeric_cast_any.rs:35:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:39:13
    |
 LL |     let _ = foo as i128;
    |             ^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     let _ = foo() as i128;
    |                ++
 
 error: casting function pointer `foo` to `isize`
-  --> tests/ui/fn_to_numeric_cast_any.rs:38:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:42:13
    |
 LL |     let _ = foo as isize;
    |             ^^^^^^^^^^^^
@@ -67,7 +67,7 @@ LL |     let _ = foo() as isize;
    |                ++
 
 error: casting function pointer `foo` to `u8`
-  --> tests/ui/fn_to_numeric_cast_any.rs:41:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:45:13
    |
 LL |     let _ = foo as u8;
    |             ^^^^^^^^^
@@ -78,7 +78,7 @@ LL |     let _ = foo() as u8;
    |                ++
 
 error: casting function pointer `foo` to `u16`
-  --> tests/ui/fn_to_numeric_cast_any.rs:44:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:48:13
    |
 LL |     let _ = foo as u16;
    |             ^^^^^^^^^^
@@ -89,7 +89,7 @@ LL |     let _ = foo() as u16;
    |                ++
 
 error: casting function pointer `foo` to `u32`
-  --> tests/ui/fn_to_numeric_cast_any.rs:47:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:51:13
    |
 LL |     let _ = foo as u32;
    |             ^^^^^^^^^^
@@ -100,7 +100,7 @@ LL |     let _ = foo() as u32;
    |                ++
 
 error: casting function pointer `foo` to `u64`
-  --> tests/ui/fn_to_numeric_cast_any.rs:50:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:54:13
    |
 LL |     let _ = foo as u64;
    |             ^^^^^^^^^^
@@ -111,7 +111,7 @@ LL |     let _ = foo() as u64;
    |                ++
 
 error: casting function pointer `foo` to `u128`
-  --> tests/ui/fn_to_numeric_cast_any.rs:53:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:57:13
    |
 LL |     let _ = foo as u128;
    |             ^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL |     let _ = foo() as u128;
    |                ++
 
 error: casting function pointer `foo` to `usize`
-  --> tests/ui/fn_to_numeric_cast_any.rs:56:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:60:13
    |
 LL |     let _ = foo as usize;
    |             ^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL |     let _ = foo() as usize;
    |                ++
 
 error: casting function pointer `Struct::static_method` to `usize`
-  --> tests/ui/fn_to_numeric_cast_any.rs:61:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:65:13
    |
 LL |     let _ = Struct::static_method as usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL |     let _ = Struct::static_method() as usize;
    |                                  ++
 
 error: casting function pointer `f` to `usize`
-  --> tests/ui/fn_to_numeric_cast_any.rs:66:5
+  --> tests/ui/fn_to_numeric_cast_any.rs:70:5
    |
 LL |     f as usize
    |     ^^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     f() as usize
    |      ++
 
 error: casting function pointer `T::static_method` to `usize`
-  --> tests/ui/fn_to_numeric_cast_any.rs:71:5
+  --> tests/ui/fn_to_numeric_cast_any.rs:75:5
    |
 LL |     T::static_method as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +166,7 @@ LL |     T::static_method() as usize
    |                     ++
 
 error: casting function pointer `(clos as fn(u32) -> u32)` to `usize`
-  --> tests/ui/fn_to_numeric_cast_any.rs:78:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:82:13
    |
 LL |     let _ = (clos as fn(u32) -> u32) as usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL |     let _ = (clos as fn(u32) -> u32)() as usize;
    |                                     ++
 
 error: casting function pointer `foo` to `*const ()`
-  --> tests/ui/fn_to_numeric_cast_any.rs:83:13
+  --> tests/ui/fn_to_numeric_cast_any.rs:87:13
    |
 LL |     let _ = foo as *const ();
    |             ^^^^^^^^^^^^^^^^

--- a/tests/ui/formatting.rs
+++ b/tests/ui/formatting.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::deref_addrof)]
 #![allow(clippy::nonminimal_bool)]
+#![allow(clippy::disallowed_names)]
 
 fn foo() -> bool {
     true

--- a/tests/ui/formatting.stderr
+++ b/tests/ui/formatting.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are trying to use `.. -= ..`, but you really are doing `.. = (- ..)`
-  --> tests/ui/formatting.rs:13:6
+  --> tests/ui/formatting.rs:14:6
    |
 LL |     a =- 35;
    |      ^^^^
@@ -9,7 +9,7 @@ LL |     a =- 35;
    = help: to override `-D warnings` add `#[allow(clippy::suspicious_assignment_formatting)]`
 
 error: this looks like you are trying to use `.. *= ..`, but you really are doing `.. = (* ..)`
-  --> tests/ui/formatting.rs:17:6
+  --> tests/ui/formatting.rs:18:6
    |
 LL |     a =* &191;
    |      ^^^^
@@ -17,7 +17,7 @@ LL |     a =* &191;
    = note: to remove this lint, use either `*=` or `= *`
 
 error: this looks like you are trying to use `.. != ..`, but you really are doing `.. = (! ..)`
-  --> tests/ui/formatting.rs:23:6
+  --> tests/ui/formatting.rs:24:6
    |
 LL |     b =! false;
    |      ^^^^
@@ -25,7 +25,7 @@ LL |     b =! false;
    = note: to remove this lint, use either `!=` or `= !`
 
 error: possibly missing a comma here
-  --> tests/ui/formatting.rs:35:19
+  --> tests/ui/formatting.rs:36:19
    |
 LL |         -1, -2, -3 // <= no comma here
    |                   ^
@@ -34,7 +34,7 @@ LL |         -1, -2, -3 // <= no comma here
    = note: `#[deny(clippy::possible_missing_comma)]` on by default
 
 error: possibly missing a comma here
-  --> tests/ui/formatting.rs:42:19
+  --> tests/ui/formatting.rs:43:19
    |
 LL |         -1, -2, -3 // <= no comma here
    |                   ^
@@ -42,7 +42,7 @@ LL |         -1, -2, -3 // <= no comma here
    = note: to remove this lint, add a comma or write the expr in a single line
 
 error: possibly missing a comma here
-  --> tests/ui/formatting.rs:82:11
+  --> tests/ui/formatting.rs:83:11
    |
 LL |         -1
    |           ^

--- a/tests/ui/from_str_radix_10.fixed
+++ b/tests/ui/from_str_radix_10.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::from_str_radix_10)]
+#![allow(clippy::disallowed_names)]
 
 mod some_mod {
     // fake function that shouldn't trigger the lint

--- a/tests/ui/from_str_radix_10.rs
+++ b/tests/ui/from_str_radix_10.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::from_str_radix_10)]
+#![allow(clippy::disallowed_names)]
 
 mod some_mod {
     // fake function that shouldn't trigger the lint

--- a/tests/ui/from_str_radix_10.stderr
+++ b/tests/ui/from_str_radix_10.stderr
@@ -1,5 +1,5 @@
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:28:5
+  --> tests/ui/from_str_radix_10.rs:29:5
    |
 LL |     u32::from_str_radix("30", 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"30".parse::<u32>()`
@@ -8,43 +8,43 @@ LL |     u32::from_str_radix("30", 10)?;
    = help: to override `-D warnings` add `#[allow(clippy::from_str_radix_10)]`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:31:5
+  --> tests/ui/from_str_radix_10.rs:32:5
    |
 LL |     i64::from_str_radix("24", 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"24".parse::<i64>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:34:5
+  --> tests/ui/from_str_radix_10.rs:35:5
    |
 LL |     isize::from_str_radix("100", 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"100".parse::<isize>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:37:5
+  --> tests/ui/from_str_radix_10.rs:38:5
    |
 LL |     u8::from_str_radix("7", 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"7".parse::<u8>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:40:5
+  --> tests/ui/from_str_radix_10.rs:41:5
    |
 LL |     u16::from_str_radix(&("10".to_owned() + "5"), 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `("10".to_owned() + "5").parse::<u16>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:43:5
+  --> tests/ui/from_str_radix_10.rs:44:5
    |
 LL |     i128::from_str_radix(Test + Test, 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(Test + Test).parse::<i128>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:47:5
+  --> tests/ui/from_str_radix_10.rs:48:5
    |
 LL |     i32::from_str_radix(string, 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.parse::<i32>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:51:5
+  --> tests/ui/from_str_radix_10.rs:52:5
    |
 LL |     i32::from_str_radix(&stringier, 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `stringier.parse::<i32>()`

--- a/tests/ui/if_not_else.fixed
+++ b/tests/ui/if_not_else.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::if_not_else)]
+#![allow(clippy::disallowed_names)]
 
 fn foo() -> bool {
     unimplemented!()

--- a/tests/ui/if_not_else.rs
+++ b/tests/ui/if_not_else.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::if_not_else)]
+#![allow(clippy::disallowed_names)]
 
 fn foo() -> bool {
     unimplemented!()

--- a/tests/ui/if_not_else.stderr
+++ b/tests/ui/if_not_else.stderr
@@ -1,5 +1,5 @@
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:13:5
+  --> tests/ui/if_not_else.rs:12:5
    |
 LL | /     if !bla() {
 LL | |
@@ -24,7 +24,7 @@ LL +     }
    |
 
 error: unnecessary `!=` operation
-  --> tests/ui/if_not_else.rs:20:5
+  --> tests/ui/if_not_else.rs:19:5
    |
 LL | /     if 4 != 5 {
 LL | |
@@ -47,7 +47,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:35:5
+  --> tests/ui/if_not_else.rs:34:5
    |
 LL | /     if !(foo() && bla()) {
 LL | |
@@ -79,7 +79,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:54:5
+  --> tests/ui/if_not_else.rs:53:5
    |
 LL | /     if !foo() {
 LL | |
@@ -102,7 +102,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:62:5
+  --> tests/ui/if_not_else.rs:61:5
    |
 LL | /     if !bla() {
 LL | |
@@ -125,7 +125,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:73:5
+  --> tests/ui/if_not_else.rs:72:5
    |
 LL | /     if !foo() {
 LL | |

--- a/tests/ui/if_not_else.stderr
+++ b/tests/ui/if_not_else.stderr
@@ -1,5 +1,5 @@
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:11:5
+  --> tests/ui/if_not_else.rs:13:5
    |
 LL | /     if !bla() {
 LL | |
@@ -24,7 +24,7 @@ LL +     }
    |
 
 error: unnecessary `!=` operation
-  --> tests/ui/if_not_else.rs:18:5
+  --> tests/ui/if_not_else.rs:20:5
    |
 LL | /     if 4 != 5 {
 LL | |
@@ -47,7 +47,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:33:5
+  --> tests/ui/if_not_else.rs:35:5
    |
 LL | /     if !(foo() && bla()) {
 LL | |
@@ -79,7 +79,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:52:5
+  --> tests/ui/if_not_else.rs:54:5
    |
 LL | /     if !foo() {
 LL | |
@@ -102,7 +102,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:60:5
+  --> tests/ui/if_not_else.rs:62:5
    |
 LL | /     if !bla() {
 LL | |
@@ -125,7 +125,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:71:5
+  --> tests/ui/if_not_else.rs:73:5
    |
 LL | /     if !foo() {
 LL | |

--- a/tests/ui/if_then_some_else_none.fixed
+++ b/tests/ui/if_then_some_else_none.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::if_then_some_else_none)]
-#![allow(clippy::redundant_pattern_matching, clippy::unnecessary_lazy_evaluations)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::redundant_pattern_matching,
+    clippy::unnecessary_lazy_evaluations
+)]
 
 fn main() {
     // Should issue an error.

--- a/tests/ui/if_then_some_else_none.rs
+++ b/tests/ui/if_then_some_else_none.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::if_then_some_else_none)]
-#![allow(clippy::redundant_pattern_matching, clippy::unnecessary_lazy_evaluations)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::redundant_pattern_matching,
+    clippy::unnecessary_lazy_evaluations
+)]
 
 fn main() {
     // Should issue an error.

--- a/tests/ui/if_then_some_else_none.stderr
+++ b/tests/ui/if_then_some_else_none.stderr
@@ -1,5 +1,5 @@
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:6:13
+  --> tests/ui/if_then_some_else_none.rs:10:13
    |
 LL |       let _ = if foo() {
    |  _____________^
@@ -15,7 +15,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::if_then_some_else_none)]`
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:16:13
+  --> tests/ui/if_then_some_else_none.rs:20:13
    |
 LL |       let _ = if matches!(true, true) {
    |  _____________^
@@ -28,19 +28,19 @@ LL | |     };
    | |_____^ help: try: `matches!(true, true).then(||  { println!("true!"); matches!(true, false) })`
 
 error: this could be simplified with `bool::then_some`
-  --> tests/ui/if_then_some_else_none.rs:27:28
+  --> tests/ui/if_then_some_else_none.rs:31:28
    |
 LL |     let _ = x.and_then(|o| if o < 32 { Some(o) } else { None });
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(o < 32).then_some(o)`
 
 error: this could be simplified with `bool::then_some`
-  --> tests/ui/if_then_some_else_none.rs:32:13
+  --> tests/ui/if_then_some_else_none.rs:36:13
    |
 LL |     let _ = if !x { Some(0) } else { None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(!x).then_some(0)`
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:88:13
+  --> tests/ui/if_then_some_else_none.rs:92:13
    |
 LL |       let _ = if foo() {
    |  _____________^
@@ -53,7 +53,7 @@ LL | |     };
    | |_____^ help: try: `foo().then(||  { println!("true!"); 150 })`
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:138:5
+  --> tests/ui/if_then_some_else_none.rs:142:5
    |
 LL |     if s == "1" { Some(true) } else { None }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(s == "1").then(|| true)`

--- a/tests/ui/ignored_unit_patterns.fixed
+++ b/tests/ui/ignored_unit_patterns.fixed
@@ -1,6 +1,7 @@
 //@aux-build:proc_macro_derive.rs
 #![warn(clippy::ignored_unit_patterns)]
 #![allow(
+    clippy::disallowed_names,
     clippy::let_unit_value,
     clippy::redundant_pattern_matching,
     clippy::single_match,

--- a/tests/ui/ignored_unit_patterns.rs
+++ b/tests/ui/ignored_unit_patterns.rs
@@ -1,6 +1,7 @@
 //@aux-build:proc_macro_derive.rs
 #![warn(clippy::ignored_unit_patterns)]
 #![allow(
+    clippy::disallowed_names,
     clippy::let_unit_value,
     clippy::redundant_pattern_matching,
     clippy::single_match,

--- a/tests/ui/ignored_unit_patterns.stderr
+++ b/tests/ui/ignored_unit_patterns.stderr
@@ -1,5 +1,5 @@
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:16:12
+  --> tests/ui/ignored_unit_patterns.rs:17:12
    |
 LL |         Ok(_) => {},
    |            ^ help: use `()` instead of `_`: `()`
@@ -8,49 +8,49 @@ LL |         Ok(_) => {},
    = help: to override `-D warnings` add `#[allow(clippy::ignored_unit_patterns)]`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:17:13
+  --> tests/ui/ignored_unit_patterns.rs:18:13
    |
 LL |         Err(_) => {},
    |             ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:19:15
+  --> tests/ui/ignored_unit_patterns.rs:20:15
    |
 LL |     if let Ok(_) = foo() {}
    |               ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:21:28
+  --> tests/ui/ignored_unit_patterns.rs:22:28
    |
 LL |     let _ = foo().map_err(|_| todo!());
    |                            ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:27:16
+  --> tests/ui/ignored_unit_patterns.rs:28:16
    |
 LL |             Ok(_) => {},
    |                ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:29:17
+  --> tests/ui/ignored_unit_patterns.rs:30:17
    |
 LL |             Err(_) => {},
    |                 ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:41:9
+  --> tests/ui/ignored_unit_patterns.rs:42:9
    |
 LL |     let _ = foo().unwrap();
    |         ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:50:13
+  --> tests/ui/ignored_unit_patterns.rs:51:13
    |
 LL |         (1, _) => unimplemented!(),
    |             ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:57:13
+  --> tests/ui/ignored_unit_patterns.rs:58:13
    |
 LL |     for (x, _) in v {
    |             ^ help: use `()` instead of `_`: `()`

--- a/tests/ui/implicit_return.fixed
+++ b/tests/ui/implicit_return.fixed
@@ -1,7 +1,13 @@
 //@aux-build: proc_macros.rs
 
 #![warn(clippy::implicit_return)]
-#![allow(clippy::needless_return, clippy::needless_bool, unused, clippy::never_loop)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::needless_return,
+    clippy::needless_bool,
+    unused,
+    clippy::never_loop
+)]
 
 extern crate proc_macros;
 use proc_macros::with_span;

--- a/tests/ui/implicit_return.rs
+++ b/tests/ui/implicit_return.rs
@@ -1,7 +1,13 @@
 //@aux-build: proc_macros.rs
 
 #![warn(clippy::implicit_return)]
-#![allow(clippy::needless_return, clippy::needless_bool, unused, clippy::never_loop)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::needless_return,
+    clippy::needless_bool,
+    unused,
+    clippy::never_loop
+)]
 
 extern crate proc_macros;
 use proc_macros::with_span;

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -1,5 +1,5 @@
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:15:5
+  --> tests/ui/implicit_return.rs:21:5
    |
 LL |     true
    |     ^^^^
@@ -12,7 +12,7 @@ LL |     return true
    |     ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:20:15
+  --> tests/ui/implicit_return.rs:26:15
    |
 LL |     if true { true } else { false }
    |               ^^^^
@@ -23,7 +23,7 @@ LL |     if true { return true } else { false }
    |               ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:20:29
+  --> tests/ui/implicit_return.rs:26:29
    |
 LL |     if true { true } else { false }
    |                             ^^^^^
@@ -34,7 +34,7 @@ LL |     if true { true } else { return false }
    |                             ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:28:17
+  --> tests/ui/implicit_return.rs:34:17
    |
 LL |         true => false,
    |                 ^^^^^
@@ -45,7 +45,7 @@ LL |         true => return false,
    |                 ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:30:20
+  --> tests/ui/implicit_return.rs:36:20
    |
 LL |         false => { true },
    |                    ^^^^
@@ -56,7 +56,7 @@ LL |         false => { return true },
    |                    ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:44:9
+  --> tests/ui/implicit_return.rs:50:9
    |
 LL |         break true;
    |         ^^^^^^^^^^
@@ -68,7 +68,7 @@ LL +         return true;
    |
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:52:13
+  --> tests/ui/implicit_return.rs:58:13
    |
 LL |             break true;
    |             ^^^^^^^^^^
@@ -80,7 +80,7 @@ LL +             return true;
    |
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:61:13
+  --> tests/ui/implicit_return.rs:67:13
    |
 LL |             break true;
    |             ^^^^^^^^^^
@@ -92,7 +92,7 @@ LL +             return true;
    |
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:80:18
+  --> tests/ui/implicit_return.rs:86:18
    |
 LL |     let _ = || { true };
    |                  ^^^^
@@ -103,7 +103,7 @@ LL |     let _ = || { return true };
    |                  ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:82:16
+  --> tests/ui/implicit_return.rs:88:16
    |
 LL |     let _ = || true;
    |                ^^^^
@@ -114,7 +114,7 @@ LL |     let _ = || return true;
    |                ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:91:5
+  --> tests/ui/implicit_return.rs:97:5
    |
 LL |     format!("test {}", "test")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,7 +125,7 @@ LL |     return format!("test {}", "test")
    |     ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:101:5
+  --> tests/ui/implicit_return.rs:107:5
    |
 LL |     m!(true, false)
    |     ^^^^^^^^^^^^^^^
@@ -136,7 +136,7 @@ LL |     return m!(true, false)
    |     ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:108:13
+  --> tests/ui/implicit_return.rs:114:13
    |
 LL |             break true;
    |             ^^^^^^^^^^
@@ -148,7 +148,7 @@ LL +             return true;
    |
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:114:17
+  --> tests/ui/implicit_return.rs:120:17
    |
 LL |                 break 'outer false;
    |                 ^^^^^^^^^^^^^^^^^^
@@ -160,7 +160,7 @@ LL +                 return false;
    |
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:130:5
+  --> tests/ui/implicit_return.rs:136:5
    |
 LL | /     loop {
 LL | |         m!(true);
@@ -173,7 +173,7 @@ LL |     return loop {
    |     ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:145:5
+  --> tests/ui/implicit_return.rs:151:5
    |
 LL |     true
    |     ^^^^

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -184,7 +184,7 @@ LL |     return true
    |     ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:170:22
+  --> tests/ui/implicit_return.rs:176:22
    |
 LL |     let _ = async || 0;
    |                      ^
@@ -195,7 +195,7 @@ LL |     let _ = async || return 0;
    |                      ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:173:31
+  --> tests/ui/implicit_return.rs:179:31
    |
 LL |     let _ = async || -> i32 { 0 };
    |                               ^
@@ -206,7 +206,7 @@ LL |     let _ = async || -> i32 { return 0 };
    |                               ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:175:28
+  --> tests/ui/implicit_return.rs:181:28
    |
 LL |     let _ = async |a: i32| a;
    |                            ^
@@ -217,7 +217,7 @@ LL |     let _ = async |a: i32| return a;
    |                            ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:178:30
+  --> tests/ui/implicit_return.rs:184:30
    |
 LL |     let _ = async |a: i32| { a };
    |                              ^
@@ -228,7 +228,7 @@ LL |     let _ = async |a: i32| { return a };
    |                              ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:187:22
+  --> tests/ui/implicit_return.rs:193:22
    |
 LL |     let _ = async || foo().await;
    |                      ^^^^^
@@ -239,7 +239,7 @@ LL |     let _ = async || return foo().await;
    |                      ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:191:9
+  --> tests/ui/implicit_return.rs:197:9
    |
 LL |         foo().await
    |         ^^^^^
@@ -250,7 +250,7 @@ LL |         return foo().await
    |         ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:195:24
+  --> tests/ui/implicit_return.rs:201:24
    |
 LL |     let _ = async || { foo().await };
    |                        ^^^^^
@@ -261,7 +261,7 @@ LL |     let _ = async || { return foo().await };
    |                        ++++++
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:197:32
+  --> tests/ui/implicit_return.rs:203:32
    |
 LL |     let _ = async || -> bool { foo().await };
    |                                ^^^^^

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::incompatible_msrv)]
+#![allow(clippy::disallowed_names)]
 #![feature(custom_inner_attributes)]
 #![feature(panic_internals)]
 #![clippy::msrv = "1.3.0"]

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -1,5 +1,5 @@
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.10.0`
-  --> tests/ui/incompatible_msrv.rs:14:39
+  --> tests/ui/incompatible_msrv.rs:15:39
    |
 LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    |                                       ^^^^^
@@ -8,25 +8,25 @@ LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.12.0`
-  --> tests/ui/incompatible_msrv.rs:18:11
+  --> tests/ui/incompatible_msrv.rs:19:11
    |
 LL |         v.into_key();
    |           ^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.4.0`
-  --> tests/ui/incompatible_msrv.rs:22:5
+  --> tests/ui/incompatible_msrv.rs:23:5
    |
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:46:9
+  --> tests/ui/incompatible_msrv.rs:47:9
    |
 LL |         core::panicking::panic("foo");
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:53:13
+  --> tests/ui/incompatible_msrv.rs:54:13
    |
 LL |             core::panicking::panic($msg)
    |             ^^^^^^^^^^^^^^^^^^^^^^
@@ -37,13 +37,13 @@ LL |     my_panic!("foo");
    = note: this error originates in the macro `my_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:59:13
+  --> tests/ui/incompatible_msrv.rs:60:13
    |
 LL |     assert!(core::panicking::panic("out of luck"));
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.80.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:72:13
+  --> tests/ui/incompatible_msrv.rs:73:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/infinite_loops.rs
+++ b/tests/ui/infinite_loops.rs
@@ -1,7 +1,7 @@
 //@no-rustfix: multiple suggestions add `-> !` to the same fn
 //@aux-build:proc_macros.rs
 
-#![allow(clippy::never_loop)]
+#![allow(clippy::never_loop, clippy::disallowed_names)]
 #![warn(clippy::infinite_loop)]
 
 extern crate proc_macros;

--- a/tests/ui/items_after_statement.rs
+++ b/tests/ui/items_after_statement.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::items_after_statements)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::disallowed_names, clippy::uninlined_format_args)]
 
 fn ok() {
     fn foo() {

--- a/tests/ui/iter_cloned_collect.fixed
+++ b/tests/ui/iter_cloned_collect.fixed
@@ -1,5 +1,5 @@
 #![allow(unused)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::disallowed_names, clippy::useless_vec)]
 
 use std::collections::{HashSet, VecDeque};
 

--- a/tests/ui/iter_cloned_collect.rs
+++ b/tests/ui/iter_cloned_collect.rs
@@ -1,5 +1,5 @@
 #![allow(unused)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::disallowed_names, clippy::useless_vec)]
 
 use std::collections::{HashSet, VecDeque};
 

--- a/tests/ui/large_futures.fixed
+++ b/tests/ui/large_futures.fixed
@@ -1,4 +1,5 @@
 #![allow(
+    clippy::disallowed_names,
     clippy::future_not_send,
     clippy::manual_async_fn,
     clippy::never_loop,

--- a/tests/ui/large_futures.rs
+++ b/tests/ui/large_futures.rs
@@ -1,4 +1,5 @@
 #![allow(
+    clippy::disallowed_names,
     clippy::future_not_send,
     clippy::manual_async_fn,
     clippy::never_loop,

--- a/tests/ui/large_futures.stderr
+++ b/tests/ui/large_futures.stderr
@@ -1,5 +1,5 @@
 error: large future with a size of 16385 bytes
-  --> tests/ui/large_futures.rs:13:9
+  --> tests/ui/large_futures.rs:14:9
    |
 LL |         big_fut([0u8; 1024 * 16]).await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(big_fut([0u8; 1024 * 16]))`
@@ -8,37 +8,37 @@ LL |         big_fut([0u8; 1024 * 16]).await;
    = help: to override `-D warnings` add `#[allow(clippy::large_futures)]`
 
 error: large future with a size of 16386 bytes
-  --> tests/ui/large_futures.rs:16:5
+  --> tests/ui/large_futures.rs:17:5
    |
 LL |     f.await
    |     ^ help: consider `Box::pin` on it: `Box::pin(f)`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:21:9
+  --> tests/ui/large_futures.rs:22:9
    |
 LL |         wait().await;
    |         ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:27:13
+  --> tests/ui/large_futures.rs:28:13
    |
 LL |             wait().await;
    |             ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:35:5
+  --> tests/ui/large_futures.rs:36:5
    |
 LL |     foo().await;
    |     ^^^^^ help: consider `Box::pin` on it: `Box::pin(foo())`
 
 error: large future with a size of 49159 bytes
-  --> tests/ui/large_futures.rs:38:5
+  --> tests/ui/large_futures.rs:39:5
    |
 LL |     calls_fut(fut).await;
    |     ^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(calls_fut(fut))`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:51:5
+  --> tests/ui/large_futures.rs:52:5
    |
 LL | /     async {
 LL | |
@@ -61,7 +61,7 @@ LL +     })
    |
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:64:13
+  --> tests/ui/large_futures.rs:65:13
    |
 LL | /             async {
 LL | |

--- a/tests/ui/large_types_passed_by_value.rs
+++ b/tests/ui/large_types_passed_by_value.rs
@@ -2,6 +2,7 @@
 //@normalize-stderr-test: "\(limit: \d+ byte\)" -> "(limit: N byte)"
 //@no-rustfix
 #![warn(clippy::large_types_passed_by_value)]
+#![allow(clippy::disallowed_names)]
 
 pub struct Large([u8; 2048]);
 

--- a/tests/ui/large_types_passed_by_value.stderr
+++ b/tests/ui/large_types_passed_by_value.stderr
@@ -1,5 +1,5 @@
 error: this argument (N byte) is passed by value, but might be more efficient if passed by reference (limit: N byte)
-  --> tests/ui/large_types_passed_by_value.rs:20:11
+  --> tests/ui/large_types_passed_by_value.rs:21:11
    |
 LL | fn bad(a: LargeAndCopy) {}
    |           ^^^^^^^^^^^^ help: consider passing by reference instead: `&LargeAndCopy`
@@ -8,43 +8,43 @@ LL | fn bad(a: LargeAndCopy) {}
    = help: to override `-D warnings` add `#[allow(clippy::large_types_passed_by_value)]`
 
 error: this argument (N byte) is passed by value, but might be more efficient if passed by reference (limit: N byte)
-  --> tests/ui/large_types_passed_by_value.rs:26:37
+  --> tests/ui/large_types_passed_by_value.rs:27:37
    |
 LL |     fn other_is_not_ok(self, other: LargeAndCopy) {}
    |                                     ^^^^^^^^^^^^ help: consider passing by reference instead: `&LargeAndCopy`
 
 error: this argument (N byte) is passed by value, but might be more efficient if passed by reference (limit: N byte)
-  --> tests/ui/large_types_passed_by_value.rs:33:36
+  --> tests/ui/large_types_passed_by_value.rs:34:36
    |
 LL |     fn devoure_array(&self, array: [u8; 6666]);
    |                                    ^^^^^^^^^^ help: consider passing by reference instead: `&[u8; 6666]`
 
 error: this argument (N byte) is passed by value, but might be more efficient if passed by reference (limit: N byte)
-  --> tests/ui/large_types_passed_by_value.rs:35:34
+  --> tests/ui/large_types_passed_by_value.rs:36:34
    |
 LL |     fn devoure_tuple(&self, tup: (LargeAndCopy, LargeAndCopy));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider passing by reference instead: `&(LargeAndCopy, LargeAndCopy)`
 
 error: this argument (N byte) is passed by value, but might be more efficient if passed by reference (limit: N byte)
-  --> tests/ui/large_types_passed_by_value.rs:37:50
+  --> tests/ui/large_types_passed_by_value.rs:38:50
    |
 LL |     fn devoure_array_and_tuple_wow(&self, array: [u8; 6666], tup: (LargeAndCopy, LargeAndCopy));
    |                                                  ^^^^^^^^^^ help: consider passing by reference instead: `&[u8; 6666]`
 
 error: this argument (N byte) is passed by value, but might be more efficient if passed by reference (limit: N byte)
-  --> tests/ui/large_types_passed_by_value.rs:37:67
+  --> tests/ui/large_types_passed_by_value.rs:38:67
    |
 LL |     fn devoure_array_and_tuple_wow(&self, array: [u8; 6666], tup: (LargeAndCopy, LargeAndCopy));
    |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider passing by reference instead: `&(LargeAndCopy, LargeAndCopy)`
 
 error: this argument (N byte) is passed by value, but might be more efficient if passed by reference (limit: N byte)
-  --> tests/ui/large_types_passed_by_value.rs:64:17
+  --> tests/ui/large_types_passed_by_value.rs:65:17
    |
 LL | fn foo_never(x: LargeAndCopy) {
    |                 ^^^^^^^^^^^^ help: consider passing by reference instead: `&LargeAndCopy`
 
 error: this argument (N byte) is passed by value, but might be more efficient if passed by reference (limit: N byte)
-  --> tests/ui/large_types_passed_by_value.rs:69:11
+  --> tests/ui/large_types_passed_by_value.rs:70:11
    |
 LL | fn foo(x: LargeAndCopy) {
    |           ^^^^^^^^^^^^ help: consider passing by reference instead: `&LargeAndCopy`

--- a/tests/ui/let_and_return.edition2021.fixed
+++ b/tests/ui/let_and_return.edition2021.fixed
@@ -2,7 +2,7 @@
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
 
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::let_and_return)]
 
 use std::cell::RefCell;

--- a/tests/ui/let_and_return.edition2024.fixed
+++ b/tests/ui/let_and_return.edition2024.fixed
@@ -2,7 +2,7 @@
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
 
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::let_and_return)]
 
 use std::cell::RefCell;

--- a/tests/ui/let_and_return.fixed
+++ b/tests/ui/let_and_return.fixed
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::let_and_return)]
 
 use std::cell::RefCell;

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -2,7 +2,7 @@
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
 
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::let_and_return)]
 
 use std::cell::RefCell;

--- a/tests/ui/linkedlist.rs
+++ b/tests/ui/linkedlist.rs
@@ -1,6 +1,6 @@
 #![feature(associated_type_defaults)]
 #![warn(clippy::linkedlist)]
-#![allow(unused, dead_code, clippy::needless_pass_by_value)]
+#![allow(unused, dead_code, clippy::disallowed_names, clippy::needless_pass_by_value)]
 
 extern crate alloc;
 use alloc::collections::linked_list::LinkedList;

--- a/tests/ui/manual_async_fn.fixed
+++ b/tests/ui/manual_async_fn.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_async_fn)]
-#![allow(clippy::needless_pub_self, unused)]
+#![allow(clippy::disallowed_names, clippy::needless_pub_self, unused)]
 
 use std::future::Future;
 

--- a/tests/ui/manual_async_fn.rs
+++ b/tests/ui/manual_async_fn.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_async_fn)]
-#![allow(clippy::needless_pub_self, unused)]
+#![allow(clippy::disallowed_names, clippy::needless_pub_self, unused)]
 
 use std::future::Future;
 

--- a/tests/ui/manual_contains.fixed
+++ b/tests/ui/manual_contains.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_contains)]
-#![allow(clippy::eq_op, clippy::useless_vec)]
+#![allow(clippy::disallowed_names, clippy::eq_op, clippy::useless_vec)]
 
 fn should_lint() {
     let vec: Vec<u8> = vec![1, 2, 3, 4, 5, 6];

--- a/tests/ui/manual_contains.rs
+++ b/tests/ui/manual_contains.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_contains)]
-#![allow(clippy::eq_op, clippy::useless_vec)]
+#![allow(clippy::disallowed_names, clippy::eq_op, clippy::useless_vec)]
 
 fn should_lint() {
     let vec: Vec<u8> = vec![1, 2, 3, 4, 5, 6];

--- a/tests/ui/manual_dangling_ptr.fixed
+++ b/tests/ui/manual_dangling_ptr.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::manual_dangling_ptr)]
+#![allow(clippy::disallowed_names)]
 use std::mem;
 
 pub fn foo(_const: *const f32, _mut: *mut i32) {}

--- a/tests/ui/manual_dangling_ptr.rs
+++ b/tests/ui/manual_dangling_ptr.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::manual_dangling_ptr)]
+#![allow(clippy::disallowed_names)]
 use std::mem;
 
 pub fn foo(_const: *const f32, _mut: *mut i32) {}

--- a/tests/ui/manual_dangling_ptr.stderr
+++ b/tests/ui/manual_dangling_ptr.stderr
@@ -1,5 +1,5 @@
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:7:24
+  --> tests/ui/manual_dangling_ptr.rs:8:24
    |
 LL |     let _: *const u8 = 1 as *const _;
    |                        ^^^^^^^^^^^^^ help: use: `std::ptr::dangling()`
@@ -8,55 +8,55 @@ LL |     let _: *const u8 = 1 as *const _;
    = help: to override `-D warnings` add `#[allow(clippy::manual_dangling_ptr)]`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:9:13
+  --> tests/ui/manual_dangling_ptr.rs:10:13
    |
 LL |     let _ = 2 as *const u32;
    |             ^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling::<u32>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:11:13
+  --> tests/ui/manual_dangling_ptr.rs:12:13
    |
 LL |     let _ = 4 as *mut f32;
    |             ^^^^^^^^^^^^^ help: use: `std::ptr::dangling_mut::<f32>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:14:13
+  --> tests/ui/manual_dangling_ptr.rs:15:13
    |
 LL |     let _ = mem::align_of::<u8>() as *const u8;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling::<u8>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:16:13
+  --> tests/ui/manual_dangling_ptr.rs:17:13
    |
 LL |     let _ = mem::align_of::<u32>() as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling::<u32>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:18:13
+  --> tests/ui/manual_dangling_ptr.rs:19:13
    |
 LL |     let _ = mem::align_of::<usize>() as *const usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling::<usize>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:21:9
+  --> tests/ui/manual_dangling_ptr.rs:22:9
    |
 LL |     foo(4 as *const _, 4 as *mut _);
    |         ^^^^^^^^^^^^^ help: use: `std::ptr::dangling()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:21:24
+  --> tests/ui/manual_dangling_ptr.rs:22:24
    |
 LL |     foo(4 as *const _, 4 as *mut _);
    |                        ^^^^^^^^^^^ help: use: `std::ptr::dangling_mut()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:41:9
+  --> tests/ui/manual_dangling_ptr.rs:42:9
    |
 LL |     foo(4 as *const _, 4 as *mut _);
    |         ^^^^^^^^^^^^^ help: use: `std::ptr::dangling()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:41:24
+  --> tests/ui/manual_dangling_ptr.rs:42:24
    |
 LL |     foo(4 as *const _, 4 as *mut _);
    |                        ^^^^^^^^^^^ help: use: `std::ptr::dangling_mut()`

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -1,5 +1,6 @@
 //@aux-build:option_helpers.rs
 #![warn(clippy::manual_is_variant_and)]
+#![allow(clippy::disallowed_names)]
 
 #[macro_use]
 extern crate option_helpers;

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -1,5 +1,6 @@
 //@aux-build:option_helpers.rs
 #![warn(clippy::manual_is_variant_and)]
+#![allow(clippy::disallowed_names)]
 
 #[macro_use]
 extern crate option_helpers;

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -1,5 +1,5 @@
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:51:17
+  --> tests/ui/manual_is_variant_and.rs:52:17
    |
 LL |       let _ = opt.map(|x| x > 1)
    |  _________________^
@@ -11,7 +11,7 @@ LL | |         .unwrap_or_default();
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:56:17
+  --> tests/ui/manual_is_variant_and.rs:57:17
    |
 LL |       let _ = opt.map(|x| {
    |  _________________^
@@ -30,13 +30,13 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:61:17
+  --> tests/ui/manual_is_variant_and.rs:62:17
    |
 LL |     let _ = opt.map(|x| x > 1).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:64:10
+  --> tests/ui/manual_is_variant_and.rs:65:10
    |
 LL |           .map(|x| x > 1)
    |  __________^
@@ -45,37 +45,37 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:68:13
+  --> tests/ui/manual_is_variant_and.rs:69:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:70:13
+  --> tests/ui/manual_is_variant_and.rs:71:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:72:13
+  --> tests/ui/manual_is_variant_and.rs:73:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == some_true!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:74:13
+  --> tests/ui/manual_is_variant_and.rs:75:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != some_false!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:81:18
+  --> tests/ui/manual_is_variant_and.rs:82:18
    |
 LL |     let _ = opt2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(char::is_alphanumeric)`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:99:17
+  --> tests/ui/manual_is_variant_and.rs:100:17
    |
 LL |       let _ = res.map(|x| {
    |  _________________^
@@ -94,7 +94,7 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:104:17
+  --> tests/ui/manual_is_variant_and.rs:105:17
    |
 LL |       let _ = res.map(|x| x > 1)
    |  _________________^
@@ -103,25 +103,25 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_ok_and(|x| x > 1)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:108:13
+  --> tests/ui/manual_is_variant_and.rs:109:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x % 2 == 0) == Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Ok::<usize, ()>(2).is_ok_and(|x| x % 2 == 0)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:110:13
+  --> tests/ui/manual_is_variant_and.rs:111:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x % 2 == 0) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x % 2 == 0)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:112:13
+  --> tests/ui/manual_is_variant_and.rs:113:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x % 2 == 0) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x % 2 == 0)`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:119:18
+  --> tests/ui/manual_is_variant_and.rs:120:18
    |
 LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`

--- a/tests/ui/manual_let_else.rs
+++ b/tests/ui/manual_let_else.rs
@@ -2,6 +2,7 @@
 #![allow(unused_braces, unused_variables, dead_code)]
 #![allow(
     clippy::collapsible_else_if,
+    clippy::disallowed_names,
     clippy::unused_unit,
     clippy::let_unit_value,
     clippy::match_single_binding,

--- a/tests/ui/manual_let_else.stderr
+++ b/tests/ui/manual_let_else.stderr
@@ -530,7 +530,7 @@ LL +             };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:520:9
+  --> tests/ui/manual_let_else.rs:521:9
    |
 LL | /         let value = match foo() {
 LL | |
@@ -540,7 +540,7 @@ LL | |         };
    | |__________^ help: consider writing: `let Ok(value) = foo() else { return Err("abc") };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:527:9
+  --> tests/ui/manual_let_else.rs:528:9
    |
 LL | /         let v = match w {
 LL | |

--- a/tests/ui/manual_let_else.stderr
+++ b/tests/ui/manual_let_else.stderr
@@ -1,5 +1,5 @@
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:29:5
+  --> tests/ui/manual_let_else.rs:30:5
    |
 LL |     let v = if let Some(v_some) = g() { v_some } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { return };`
@@ -8,7 +8,7 @@ LL |     let v = if let Some(v_some) = g() { v_some } else { return };
    = help: to override `-D warnings` add `#[allow(clippy::manual_let_else)]`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:32:5
+  --> tests/ui/manual_let_else.rs:33:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -27,7 +27,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:40:5
+  --> tests/ui/manual_let_else.rs:41:5
    |
 LL | /     let v = if let Some(v) = g() {
 ...  |
@@ -45,25 +45,25 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:53:9
+  --> tests/ui/manual_let_else.rs:54:9
    |
 LL |         let v = if let Some(v_some) = g() { v_some } else { continue };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { continue };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:56:9
+  --> tests/ui/manual_let_else.rs:57:9
    |
 LL |         let v = if let Some(v_some) = g() { v_some } else { break };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { break };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:61:5
+  --> tests/ui/manual_let_else.rs:62:5
    |
 LL |     let v = if let Some(v_some) = g() { v_some } else { panic!() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { panic!() };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:65:5
+  --> tests/ui/manual_let_else.rs:66:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -82,7 +82,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:74:5
+  --> tests/ui/manual_let_else.rs:75:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -101,7 +101,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:83:5
+  --> tests/ui/manual_let_else.rs:84:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -121,7 +121,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:93:5
+  --> tests/ui/manual_let_else.rs:94:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -141,7 +141,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:103:5
+  --> tests/ui/manual_let_else.rs:104:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -167,7 +167,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:120:5
+  --> tests/ui/manual_let_else.rs:121:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -188,7 +188,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:132:5
+  --> tests/ui/manual_let_else.rs:133:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -214,7 +214,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:149:5
+  --> tests/ui/manual_let_else.rs:150:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -236,7 +236,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:161:5
+  --> tests/ui/manual_let_else.rs:162:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -255,7 +255,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:170:5
+  --> tests/ui/manual_let_else.rs:171:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -276,7 +276,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:181:5
+  --> tests/ui/manual_let_else.rs:182:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -297,7 +297,7 @@ LL +     } };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:192:5
+  --> tests/ui/manual_let_else.rs:193:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -325,7 +325,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:211:5
+  --> tests/ui/manual_let_else.rs:212:5
    |
 LL | /     let (v, w) = if let Some(v_some) = g().map(|v| (v, 42)) {
 LL | |
@@ -344,7 +344,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:220:5
+  --> tests/ui/manual_let_else.rs:221:5
    |
 LL | /     let (w, S { v }) = if let (Some(v_some), w_some) = (g().map(|_| S { v: 0 }), 0) {
 LL | |
@@ -363,7 +363,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:231:13
+  --> tests/ui/manual_let_else.rs:232:13
    |
 LL |             let $n = if let Some(v) = $e { v } else { return };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some($n) = g() else { return };`
@@ -374,19 +374,19 @@ LL |     create_binding_if_some!(w, g());
    = note: this error originates in the macro `create_binding_if_some` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:241:5
+  --> tests/ui/manual_let_else.rs:242:5
    |
 LL |     let v = if let Variant::A(a, 0) = e() { a } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Variant::A(v, 0) = e() else { return };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:245:5
+  --> tests/ui/manual_let_else.rs:246:5
    |
 LL |     let mut v = if let Variant::B(b) = e() { b } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Variant::B(mut v) = e() else { return };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:250:5
+  --> tests/ui/manual_let_else.rs:251:5
    |
 LL | /     let v = if let Ok(Some(Variant::B(b))) | Err(Some(Variant::A(b, _))) = nested {
 LL | |
@@ -405,19 +405,19 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:258:5
+  --> tests/ui/manual_let_else.rs:259:5
    |
 LL |     let v = if let Variant::A(.., a) = e() { a } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Variant::A(.., v) = e() else { return };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:262:5
+  --> tests/ui/manual_let_else.rs:263:5
    |
 LL |     let w = if let (Some(v), ()) = (g(), ()) { v } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let (Some(w), ()) = (g(), ()) else { return };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:266:5
+  --> tests/ui/manual_let_else.rs:267:5
    |
 LL | /     let w = if let Some(S { v: x }) = Some(S { v: 0 }) {
 LL | |
@@ -436,7 +436,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:275:5
+  --> tests/ui/manual_let_else.rs:276:5
    |
 LL | /     let v = if let Some(S { v: x }) = Some(S { v: 0 }) {
 LL | |
@@ -455,7 +455,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:284:5
+  --> tests/ui/manual_let_else.rs:285:5
    |
 LL | /     let (x, S { v }, w) = if let Some(U { v, w, x }) = None::<U<S<()>>> {
 LL | |
@@ -474,7 +474,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:402:5
+  --> tests/ui/manual_let_else.rs:403:5
    |
 LL | /     let _ = match ff {
 LL | |
@@ -484,13 +484,13 @@ LL | |     };
    | |______^ help: consider writing: `let Some(_) = ff else { macro_call!() };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:479:9
+  --> tests/ui/manual_let_else.rs:480:9
    |
 LL |         let v = if let Some(v_some) = g() { v_some } else { return };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { return };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:491:9
+  --> tests/ui/manual_let_else.rs:492:9
    |
 LL | /         let signature = match value {
 LL | |
@@ -510,7 +510,7 @@ LL +             };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else.rs:507:9
+  --> tests/ui/manual_let_else.rs:508:9
    |
 LL | /         let signature = match value {
 LL | |

--- a/tests/ui/manual_let_else_question_mark.fixed
+++ b/tests/ui/manual_let_else_question_mark.fixed
@@ -1,6 +1,7 @@
 #![allow(unused_braces, unused_variables, dead_code)]
 #![allow(
     clippy::collapsible_else_if,
+    clippy::disallowed_names,
     clippy::unused_unit,
     clippy::let_unit_value,
     clippy::match_single_binding,

--- a/tests/ui/manual_let_else_question_mark.rs
+++ b/tests/ui/manual_let_else_question_mark.rs
@@ -1,6 +1,7 @@
 #![allow(unused_braces, unused_variables, dead_code)]
 #![allow(
     clippy::collapsible_else_if,
+    clippy::disallowed_names,
     clippy::unused_unit,
     clippy::let_unit_value,
     clippy::match_single_binding,

--- a/tests/ui/manual_let_else_question_mark.stderr
+++ b/tests/ui/manual_let_else_question_mark.stderr
@@ -1,5 +1,5 @@
 error: this `let...else` may be rewritten with the `?` operator
-  --> tests/ui/manual_let_else_question_mark.rs:29:5
+  --> tests/ui/manual_let_else_question_mark.rs:30:5
    |
 LL |     let Some(v) = g() else { return None };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `let v = g()?;`
@@ -8,19 +8,19 @@ LL |     let Some(v) = g() else { return None };
    = help: to override `-D warnings` add `#[allow(clippy::question_mark)]`
 
 error: this `let...else` may be rewritten with the `?` operator
-  --> tests/ui/manual_let_else_question_mark.rs:36:5
+  --> tests/ui/manual_let_else_question_mark.rs:37:5
    |
 LL |     let Some((v, w)) = g() else { return None };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `let (v, w) = g()?;`
 
 error: this block may be rewritten with the `?` operator
-  --> tests/ui/manual_let_else_question_mark.rs:40:13
+  --> tests/ui/manual_let_else_question_mark.rs:41:13
    |
 LL |     let v = if let Some(v_some) = g() { v_some } else { return None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `g()?`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else_question_mark.rs:45:5
+  --> tests/ui/manual_let_else_question_mark.rs:46:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |
@@ -40,7 +40,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else_question_mark.rs:57:9
+  --> tests/ui/manual_let_else_question_mark.rs:58:9
    |
 LL | /         let v = match g() {
 LL | |
@@ -50,13 +50,13 @@ LL | |         };
    | |__________^ help: consider writing: `let Some(v) = g() else { return None };`
 
 error: this could be rewritten as `let...else`
-  --> tests/ui/manual_let_else_question_mark.rs:68:9
+  --> tests/ui/manual_let_else_question_mark.rs:69:9
    |
 LL |         let v = if let Some(v_some) = g() { v_some } else { return None };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { return None };`
 
 error: this `let...else` may be rewritten with the `?` operator
-  --> tests/ui/manual_let_else_question_mark.rs:77:5
+  --> tests/ui/manual_let_else_question_mark.rs:78:5
    |
 LL | /     let Some(x) = y else {
 LL | |         return None;

--- a/tests/ui/manual_map_option_2.fixed
+++ b/tests/ui/manual_map_option_2.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_map)]
-#![allow(clippy::toplevel_ref_arg)]
+#![allow(clippy::disallowed_names, clippy::toplevel_ref_arg)]
 
 fn main() {
     // Lint. `y` is declared within the arm, so it isn't captured by the map closure

--- a/tests/ui/manual_map_option_2.rs
+++ b/tests/ui/manual_map_option_2.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_map)]
-#![allow(clippy::toplevel_ref_arg)]
+#![allow(clippy::disallowed_names, clippy::toplevel_ref_arg)]
 
 fn main() {
     // Lint. `y` is declared within the arm, so it isn't captured by the map closure

--- a/tests/ui/manual_non_exhaustive_enum.rs
+++ b/tests/ui/manual_non_exhaustive_enum.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_non_exhaustive)]
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 //@no-rustfix
 pub enum E {
     //~^ manual_non_exhaustive

--- a/tests/ui/manual_repeat_n.fixed
+++ b/tests/ui/manual_repeat_n.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::manual_repeat_n)]
+#![allow(clippy::disallowed_names)]
 
 use std::iter::repeat;
 

--- a/tests/ui/manual_repeat_n.rs
+++ b/tests/ui/manual_repeat_n.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::manual_repeat_n)]
+#![allow(clippy::disallowed_names)]
 
 use std::iter::repeat;
 

--- a/tests/ui/manual_repeat_n.stderr
+++ b/tests/ui/manual_repeat_n.stderr
@@ -1,5 +1,5 @@
 error: this `repeat().take()` can be written more concisely
-  --> tests/ui/manual_repeat_n.rs:6:13
+  --> tests/ui/manual_repeat_n.rs:7:13
    |
 LL |     let _ = repeat(10).take(3);
    |             ^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(10, 3)`
@@ -8,25 +8,25 @@ LL |     let _ = repeat(10).take(3);
    = help: to override `-D warnings` add `#[allow(clippy::manual_repeat_n)]`
 
 error: this `repeat().take()` can be written more concisely
-  --> tests/ui/manual_repeat_n.rs:9:13
+  --> tests/ui/manual_repeat_n.rs:10:13
    |
 LL |     let _ = repeat(String::from("foo")).take(4);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(String::from("foo"), 4)`
 
 error: this `repeat().take()` can be written more concisely
-  --> tests/ui/manual_repeat_n.rs:12:18
+  --> tests/ui/manual_repeat_n.rs:13:18
    |
 LL |     for value in std::iter::repeat(5).take(3) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(5, 3)`
 
 error: this `repeat().take()` can be written more concisely
-  --> tests/ui/manual_repeat_n.rs:15:21
+  --> tests/ui/manual_repeat_n.rs:16:21
    |
 LL |     let _: Vec<_> = std::iter::repeat(String::from("bar")).take(10).collect();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(String::from("bar"), 10)`
 
 error: this `repeat().take()` can be written more concisely
-  --> tests/ui/manual_repeat_n.rs:18:13
+  --> tests/ui/manual_repeat_n.rs:19:13
    |
 LL |     let _ = repeat(vec![1, 2]).take(2);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(vec![1, 2], 2)`

--- a/tests/ui/match_expr_like_matches_macro.fixed
+++ b/tests/ui/match_expr_like_matches_macro.fixed
@@ -2,6 +2,7 @@
 #![allow(
     unreachable_patterns,
     dead_code,
+    clippy::disallowed_names,
     clippy::equatable_if_let,
     clippy::needless_borrowed_reference,
     clippy::redundant_guards

--- a/tests/ui/match_expr_like_matches_macro.rs
+++ b/tests/ui/match_expr_like_matches_macro.rs
@@ -2,6 +2,7 @@
 #![allow(
     unreachable_patterns,
     dead_code,
+    clippy::disallowed_names,
     clippy::equatable_if_let,
     clippy::needless_borrowed_reference,
     clippy::redundant_guards

--- a/tests/ui/match_expr_like_matches_macro.stderr
+++ b/tests/ui/match_expr_like_matches_macro.stderr
@@ -1,5 +1,5 @@
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:14:14
+  --> tests/ui/match_expr_like_matches_macro.rs:15:14
    |
 LL |       let _y = match x {
    |  ______________^
@@ -12,7 +12,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::match_like_matches_macro)]`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/match_expr_like_matches_macro.rs:21:14
+  --> tests/ui/match_expr_like_matches_macro.rs:22:14
    |
 LL |       let _w = match x {
    |  ______________^
@@ -25,7 +25,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/match_expr_like_matches_macro.rs:28:14
+  --> tests/ui/match_expr_like_matches_macro.rs:29:14
    |
 LL |       let _z = match x {
    |  ______________^
@@ -35,7 +35,7 @@ LL | |     };
    | |_____^ help: try: `x.is_none()`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:35:15
+  --> tests/ui/match_expr_like_matches_macro.rs:36:15
    |
 LL |       let _zz = match x {
    |  _______________^
@@ -45,13 +45,13 @@ LL | |     };
    | |_____^ help: try: `!matches!(x, Some(r) if r == 0)`
 
 error: if let .. else expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:42:16
+  --> tests/ui/match_expr_like_matches_macro.rs:43:16
    |
 LL |     let _zzz = if let Some(5) = x { true } else { false };
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(x, Some(5))`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:67:20
+  --> tests/ui/match_expr_like_matches_macro.rs:68:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -62,7 +62,7 @@ LL | |         };
    | |_________^ help: try: `matches!(x, E::A(_) | E::B(_))`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:78:20
+  --> tests/ui/match_expr_like_matches_macro.rs:79:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -74,7 +74,7 @@ LL | |         };
    | |_________^ help: try: `matches!(x, E::A(_) | E::B(_))`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:89:20
+  --> tests/ui/match_expr_like_matches_macro.rs:90:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -85,7 +85,7 @@ LL | |         };
    | |_________^ help: try: `!matches!(x, E::B(_) | E::C)`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:150:18
+  --> tests/ui/match_expr_like_matches_macro.rs:151:18
    |
 LL |           let _z = match &z {
    |  __________________^
@@ -95,7 +95,7 @@ LL | |         };
    | |_________^ help: try: `matches!(z, Some(3))`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:160:18
+  --> tests/ui/match_expr_like_matches_macro.rs:161:18
    |
 LL |           let _z = match &z {
    |  __________________^
@@ -105,7 +105,7 @@ LL | |         };
    | |_________^ help: try: `matches!(&z, Some(3))`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:178:21
+  --> tests/ui/match_expr_like_matches_macro.rs:179:21
    |
 LL |               let _ = match &z {
    |  _____________________^
@@ -115,7 +115,7 @@ LL | |             };
    | |_____________^ help: try: `matches!(&z, AnEnum::X)`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:193:20
+  --> tests/ui/match_expr_like_matches_macro.rs:194:20
    |
 LL |           let _res = match &val {
    |  ____________________^
@@ -125,7 +125,7 @@ LL | |         };
    | |_________^ help: try: `matches!(&val, &Some(ref _a))`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:206:20
+  --> tests/ui/match_expr_like_matches_macro.rs:207:20
    |
 LL |           let _res = match &val {
    |  ____________________^
@@ -135,7 +135,7 @@ LL | |         };
    | |_________^ help: try: `matches!(&val, &Some(ref _a))`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_expr_like_matches_macro.rs:265:14
+  --> tests/ui/match_expr_like_matches_macro.rs:266:14
    |
 LL |       let _y = match Some(5) {
    |  ______________^

--- a/tests/ui/missing_assert_message.rs
+++ b/tests/ui/missing_assert_message.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::missing_assert_message)]
 
 macro_rules! bar {

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -6,6 +6,7 @@
 //@aux-build:helper.rs
 //@aux-build:../auxiliary/proc_macros.rs
 
+#![allow(clippy::disallowed_names)]
 #![warn(clippy::missing_const_for_fn)]
 #![feature(type_alias_impl_trait)]
 

--- a/tests/ui/missing_doc.rs
+++ b/tests/ui/missing_doc.rs
@@ -5,7 +5,7 @@
 #![warn(clippy::missing_docs_in_private_items)]
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 //! Some garbage docs for the crate here
 #![doc = "More garbage"]
 

--- a/tests/ui/missing_doc_impl.rs
+++ b/tests/ui/missing_doc_impl.rs
@@ -1,7 +1,7 @@
 //@aux-build: proc_macros.rs
 
 #![warn(clippy::missing_docs_in_private_items)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 #![feature(associated_type_defaults)]
 
 //! Some garbage docs for the crate here

--- a/tests/ui/missing_inline.rs
+++ b/tests/ui/missing_inline.rs
@@ -2,7 +2,7 @@
 #![crate_type = "dylib"]
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
-#![allow(dead_code, non_snake_case)]
+#![allow(dead_code, non_snake_case, clippy::disallowed_names)]
 
 type Typedef = String;
 pub type PubTypedef = String;

--- a/tests/ui/missing_inline_executable.rs
+++ b/tests/ui/missing_inline_executable.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 
 #![warn(clippy::missing_inline_in_public_items)]
+#![allow(clippy::disallowed_names)]
 
 pub fn foo() {}
 

--- a/tests/ui/module_name_repetitions.rs
+++ b/tests/ui/module_name_repetitions.rs
@@ -1,7 +1,7 @@
 //@compile-flags: --test
 
 #![warn(clippy::module_name_repetitions)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::disallowed_names)]
 
 pub mod foo {
     pub fn foo() {}

--- a/tests/ui/multiple_bound_locations.rs
+++ b/tests/ui/multiple_bound_locations.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::multiple_bound_locations)]
+#![allow(clippy::disallowed_names)]
 
 fn ty<F: std::fmt::Debug>(a: F)
 //~^ multiple_bound_locations

--- a/tests/ui/multiple_bound_locations.stderr
+++ b/tests/ui/multiple_bound_locations.stderr
@@ -1,5 +1,5 @@
 error: bound is defined in more than one place
-  --> tests/ui/multiple_bound_locations.rs:3:7
+  --> tests/ui/multiple_bound_locations.rs:4:7
    |
 LL | fn ty<F: std::fmt::Debug>(a: F)
    |       ^
@@ -11,7 +11,7 @@ LL |     F: Sized,
    = help: to override `-D warnings` add `#[allow(clippy::multiple_bound_locations)]`
 
 error: bound is defined in more than one place
-  --> tests/ui/multiple_bound_locations.rs:10:17
+  --> tests/ui/multiple_bound_locations.rs:11:17
    |
 LL | fn lifetime<'a, 'b: 'a, 'c>(a: &'b str, b: &'a str, c: &'c str)
    |                 ^^
@@ -20,7 +20,7 @@ LL |     'b: 'c,
    |     ^^
 
 error: bound is defined in more than one place
-  --> tests/ui/multiple_bound_locations.rs:17:12
+  --> tests/ui/multiple_bound_locations.rs:18:12
    |
 LL | fn ty_pred<F: Sized>()
    |            ^
@@ -29,7 +29,7 @@ LL |     for<'a> F: Send + 'a,
    |             ^
 
 error: bound is defined in more than one place
-  --> tests/ui/multiple_bound_locations.rs:27:11
+  --> tests/ui/multiple_bound_locations.rs:28:11
    |
 LL |     fn ty<F: std::fmt::Debug>(a: F)
    |           ^
@@ -38,7 +38,7 @@ LL |         F: Sized,
    |         ^
 
 error: bound is defined in more than one place
-  --> tests/ui/multiple_bound_locations.rs:34:21
+  --> tests/ui/multiple_bound_locations.rs:35:21
    |
 LL |     fn lifetime<'a, 'b: 'a, 'c>(a: &'b str, b: &'a str, c: &'c str)
    |                     ^^
@@ -47,7 +47,7 @@ LL |         'b: 'c,
    |         ^^
 
 error: bound is defined in more than one place
-  --> tests/ui/multiple_bound_locations.rs:41:16
+  --> tests/ui/multiple_bound_locations.rs:42:16
    |
 LL |     fn ty_pred<F: Sized>()
    |                ^

--- a/tests/ui/must_use_unit.fixed
+++ b/tests/ui/must_use_unit.fixed
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::must_use_unit)]
-#![allow(clippy::unused_unit)]
+#![allow(clippy::unused_unit, clippy::disallowed_names)]
 
 extern crate proc_macros;
 use proc_macros::external;

--- a/tests/ui/must_use_unit.rs
+++ b/tests/ui/must_use_unit.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::must_use_unit)]
-#![allow(clippy::unused_unit)]
+#![allow(clippy::unused_unit, clippy::disallowed_names)]
 
 extern crate proc_macros;
 use proc_macros::external;

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::mut_mut)]
 #![allow(unused)]
 #![allow(
+    clippy::disallowed_names,
     clippy::no_effect,
     clippy::uninlined_format_args,
     clippy::unnecessary_operation,

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -1,5 +1,5 @@
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:15:11
+  --> tests/ui/mut_mut.rs:16:11
    |
 LL | fn fun(x: &mut &mut u32) -> bool {
    |           ^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL | fn fun(x: &mut &mut u32) -> bool {
    = help: to override `-D warnings` add `#[allow(clippy::mut_mut)]`
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:33:17
+  --> tests/ui/mut_mut.rs:34:17
    |
 LL |     let mut x = &mut &mut 1u32;
    |                 ^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:55:25
+  --> tests/ui/mut_mut.rs:56:25
    |
 LL |     let mut z = inline!(&mut $(&mut 3u32));
    |                         ^
@@ -22,37 +22,37 @@ LL |     let mut z = inline!(&mut $(&mut 3u32));
    = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this expression mutably borrows a mutable reference. Consider reborrowing
-  --> tests/ui/mut_mut.rs:36:21
+  --> tests/ui/mut_mut.rs:37:21
    |
 LL |         let mut y = &mut x;
    |                     ^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:41:32
+  --> tests/ui/mut_mut.rs:42:32
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                                ^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:41:16
+  --> tests/ui/mut_mut.rs:42:16
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                ^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:48:37
+  --> tests/ui/mut_mut.rs:49:37
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                                     ^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:48:16
+  --> tests/ui/mut_mut.rs:49:16
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                ^^^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:48:21
+  --> tests/ui/mut_mut.rs:49:21
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                     ^^^^^^^^^^^^^

--- a/tests/ui/needless_bool/fixable.fixed
+++ b/tests/ui/needless_bool/fixable.fixed
@@ -8,7 +8,8 @@
     clippy::needless_if,
     clippy::needless_return,
     clippy::self_named_constructors,
-    clippy::struct_field_names
+    clippy::struct_field_names,
+    clippy::disallowed_names
 )]
 
 use std::cell::Cell;

--- a/tests/ui/needless_bool/fixable.rs
+++ b/tests/ui/needless_bool/fixable.rs
@@ -8,7 +8,8 @@
     clippy::needless_if,
     clippy::needless_return,
     clippy::self_named_constructors,
-    clippy::struct_field_names
+    clippy::struct_field_names,
+    clippy::disallowed_names
 )]
 
 use std::cell::Cell;

--- a/tests/ui/needless_bool/fixable.stderr
+++ b/tests/ui/needless_bool/fixable.stderr
@@ -1,5 +1,5 @@
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:41:5
+  --> tests/ui/needless_bool/fixable.rs:42:5
    |
 LL | /     if x {
 LL | |         true
@@ -12,7 +12,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::needless_bool)]`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:47:5
+  --> tests/ui/needless_bool/fixable.rs:48:5
    |
 LL | /     if x {
 LL | |         false
@@ -22,7 +22,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `!x`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:53:5
+  --> tests/ui/needless_bool/fixable.rs:54:5
    |
 LL | /     if x && y {
 LL | |         false
@@ -32,7 +32,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `!(x && y)`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:62:5
+  --> tests/ui/needless_bool/fixable.rs:63:5
    |
 LL | /     if a == b {
 LL | |         false
@@ -42,7 +42,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a != b`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:68:5
+  --> tests/ui/needless_bool/fixable.rs:69:5
    |
 LL | /     if a != b {
 LL | |         false
@@ -52,7 +52,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a == b`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:74:5
+  --> tests/ui/needless_bool/fixable.rs:75:5
    |
 LL | /     if a < b {
 LL | |         false
@@ -62,7 +62,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a >= b`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:80:5
+  --> tests/ui/needless_bool/fixable.rs:81:5
    |
 LL | /     if a <= b {
 LL | |         false
@@ -72,7 +72,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a > b`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:86:5
+  --> tests/ui/needless_bool/fixable.rs:87:5
    |
 LL | /     if a > b {
 LL | |         false
@@ -82,7 +82,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a <= b`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:92:5
+  --> tests/ui/needless_bool/fixable.rs:93:5
    |
 LL | /     if a >= b {
 LL | |         false
@@ -92,7 +92,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a < b`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:121:5
+  --> tests/ui/needless_bool/fixable.rs:122:5
    |
 LL | /     if x {
 LL | |         return true;
@@ -102,7 +102,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return x`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:130:5
+  --> tests/ui/needless_bool/fixable.rs:131:5
    |
 LL | /     if x {
 LL | |         return false;
@@ -112,7 +112,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return !x`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:139:5
+  --> tests/ui/needless_bool/fixable.rs:140:5
    |
 LL | /     if x && y {
 LL | |         return true;
@@ -122,7 +122,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return x && y`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:148:5
+  --> tests/ui/needless_bool/fixable.rs:149:5
    |
 LL | /     if x && y {
 LL | |         return false;
@@ -132,7 +132,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return !(x && y)`
 
 error: equality checks against true are unnecessary
-  --> tests/ui/needless_bool/fixable.rs:157:8
+  --> tests/ui/needless_bool/fixable.rs:158:8
    |
 LL |     if x == true {};
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
@@ -141,25 +141,25 @@ LL |     if x == true {};
    = help: to override `-D warnings` add `#[allow(clippy::bool_comparison)]`
 
 error: equality checks against false can be replaced by a negation
-  --> tests/ui/needless_bool/fixable.rs:162:8
+  --> tests/ui/needless_bool/fixable.rs:163:8
    |
 LL |     if x == false {};
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: equality checks against true are unnecessary
-  --> tests/ui/needless_bool/fixable.rs:173:8
+  --> tests/ui/needless_bool/fixable.rs:174:8
    |
 LL |     if x == true {};
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
 
 error: equality checks against false can be replaced by a negation
-  --> tests/ui/needless_bool/fixable.rs:175:8
+  --> tests/ui/needless_bool/fixable.rs:176:8
    |
 LL |     if x == false {};
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:185:12
+  --> tests/ui/needless_bool/fixable.rs:186:12
    |
 LL |       } else if returns_bool() {
    |  ____________^
@@ -170,7 +170,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `{ !returns_bool() }`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:199:5
+  --> tests/ui/needless_bool/fixable.rs:200:5
    |
 LL | /     if unsafe { no(4) } & 1 != 0 {
 LL | |         true
@@ -180,31 +180,31 @@ LL | |     };
    | |_____^ help: you can reduce it to: `(unsafe { no(4) } & 1 != 0)`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:205:30
+  --> tests/ui/needless_bool/fixable.rs:206:30
    |
 LL |     let _brackets_unneeded = if unsafe { no(4) } & 1 != 0 { true } else { false };
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `unsafe { no(4) } & 1 != 0`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:209:9
+  --> tests/ui/needless_bool/fixable.rs:210:9
    |
 LL |         if unsafe { no(4) } & 1 != 0 { true } else { false }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `(unsafe { no(4) } & 1 != 0)`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:221:14
+  --> tests/ui/needless_bool/fixable.rs:222:14
    |
 LL |     let _x = if a && b { true } else { false }.then(|| todo!());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `(a && b)`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:223:14
+  --> tests/ui/needless_bool/fixable.rs:224:14
    |
 LL |     let _x = if a && b { true } else { false } as u8;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `(a && b)`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:227:14
+  --> tests/ui/needless_bool/fixable.rs:228:14
    |
 LL |     let _x = if a { true } else { false }.then(|| todo!());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `a`

--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -1,6 +1,7 @@
 #![allow(
     unused,
     non_local_definitions,
+    clippy::disallowed_names,
     clippy::uninlined_format_args,
     clippy::unnecessary_mut_passed,
     clippy::unnecessary_to_owned,

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -1,6 +1,7 @@
 #![allow(
     unused,
     non_local_definitions,
+    clippy::disallowed_names,
     clippy::uninlined_format_args,
     clippy::unnecessary_mut_passed,
     clippy::unnecessary_to_owned,

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -1,5 +1,5 @@
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:16:15
+  --> tests/ui/needless_borrow.rs:17:15
    |
 LL |     let _ = x(&&a); // warn
    |               ^^^ help: change this to: `&a`
@@ -8,166 +8,166 @@ LL |     let _ = x(&&a); // warn
    = help: to override `-D warnings` add `#[allow(clippy::needless_borrow)]`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:22:13
+  --> tests/ui/needless_borrow.rs:23:13
    |
 LL |     mut_ref(&mut &mut b); // warn
    |             ^^^^^^^^^^^ help: change this to: `&mut b`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:36:13
+  --> tests/ui/needless_borrow.rs:37:13
    |
 LL |             &&a
    |             ^^^ help: change this to: `&a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:39:15
+  --> tests/ui/needless_borrow.rs:40:15
    |
 LL |         46 => &&a,
    |               ^^^ help: change this to: `&a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:46:27
+  --> tests/ui/needless_borrow.rs:47:27
    |
 LL |                     break &ref_a;
    |                           ^^^^^^ help: change this to: `ref_a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:54:15
+  --> tests/ui/needless_borrow.rs:55:15
    |
 LL |     let _ = x(&&&a);
    |               ^^^^ help: change this to: `&a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:56:15
+  --> tests/ui/needless_borrow.rs:57:15
    |
 LL |     let _ = x(&mut &&a);
    |               ^^^^^^^^ help: change this to: `&a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:58:15
+  --> tests/ui/needless_borrow.rs:59:15
    |
 LL |     let _ = x(&&&mut b);
    |               ^^^^^^^^ help: change this to: `&mut b`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:60:15
+  --> tests/ui/needless_borrow.rs:61:15
    |
 LL |     let _ = x(&&ref_a);
    |               ^^^^^^^ help: change this to: `ref_a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:64:11
+  --> tests/ui/needless_borrow.rs:65:11
    |
 LL |         x(&b);
    |           ^^ help: change this to: `b`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:72:13
+  --> tests/ui/needless_borrow.rs:73:13
    |
 LL |     mut_ref(&mut x);
    |             ^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:74:13
+  --> tests/ui/needless_borrow.rs:75:13
    |
 LL |     mut_ref(&mut &mut x);
    |             ^^^^^^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:76:23
+  --> tests/ui/needless_borrow.rs:77:23
    |
 LL |     let y: &mut i32 = &mut x;
    |                       ^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:78:23
+  --> tests/ui/needless_borrow.rs:79:23
    |
 LL |     let y: &mut i32 = &mut &mut x;
    |                       ^^^^^^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:88:14
+  --> tests/ui/needless_borrow.rs:89:14
    |
 LL |         0 => &mut x,
    |              ^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:95:14
+  --> tests/ui/needless_borrow.rs:96:14
    |
 LL |         0 => &mut x,
    |              ^^^^^^ help: change this to: `x`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:108:13
+  --> tests/ui/needless_borrow.rs:109:13
    |
 LL |     let _ = (&x).0;
    |             ^^^^ help: change this to: `x`
 
+error: this expression borrows a value the compiler would automatically borrow
+  --> tests/ui/needless_borrow.rs:112:22
+   |
+LL |     let _ = unsafe { (&*x).0 };
+   |                      ^^^^^ help: change this to: `(*x)`
+
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:119:5
+  --> tests/ui/needless_borrow.rs:123:5
    |
 LL |     (&&()).foo();
    |     ^^^^^^ help: change this to: `(&())`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:129:5
+  --> tests/ui/needless_borrow.rs:133:5
    |
 LL |     (&&5).foo();
    |     ^^^^^ help: change this to: `(&5)`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:156:23
+  --> tests/ui/needless_borrow.rs:160:23
    |
 LL |     let x: (&str,) = (&"",);
    |                       ^^^ help: change this to: `""`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:199:13
+  --> tests/ui/needless_borrow.rs:203:13
    |
 LL |             (&self.f)()
    |             ^^^^^^^^^ help: change this to: `(self.f)`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:209:13
+  --> tests/ui/needless_borrow.rs:213:13
    |
 LL |             (&mut self.f)()
    |             ^^^^^^^^^^^^^ help: change this to: `(self.f)`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:247:22
+  --> tests/ui/needless_borrow.rs:251:22
    |
 LL |         let _ = &mut (&mut { x.u }).x;
    |                      ^^^^^^^^^^^^^^ help: change this to: `{ x.u }`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:255:22
+  --> tests/ui/needless_borrow.rs:259:22
    |
 LL |         let _ = &mut (&mut { x.u }).x;
    |                      ^^^^^^^^^^^^^^ help: change this to: `{ x.u }`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:260:22
+  --> tests/ui/needless_borrow.rs:264:22
    |
 LL |         let _ = &mut (&mut x.u).x;
    |                      ^^^^^^^^^^ help: change this to: `x.u`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:262:22
+  --> tests/ui/needless_borrow.rs:266:22
    |
 LL |         let _ = &mut (&mut { x.u }).x;
    |                      ^^^^^^^^^^^^^^ help: change this to: `{ x.u }`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:284:23
+  --> tests/ui/needless_borrow.rs:288:23
    |
 LL |     option.unwrap_or((&x.0,));
    |                       ^^^^ help: change this to: `x.0`
-
-error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:291:13
-   |
-LL |     let _ = (&slice).len();
-   |             ^^^^^^^^ help: change this to: `slice`
 
 error: aborting due to 28 previous errors
 

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -103,71 +103,71 @@ error: this expression borrows a value the compiler would automatically borrow
 LL |     let _ = (&x).0;
    |             ^^^^ help: change this to: `x`
 
-error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:112:22
-   |
-LL |     let _ = unsafe { (&*x).0 };
-   |                      ^^^^^ help: change this to: `(*x)`
-
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:123:5
+  --> tests/ui/needless_borrow.rs:120:5
    |
 LL |     (&&()).foo();
    |     ^^^^^^ help: change this to: `(&())`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:133:5
+  --> tests/ui/needless_borrow.rs:130:5
    |
 LL |     (&&5).foo();
    |     ^^^^^ help: change this to: `(&5)`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:160:23
+  --> tests/ui/needless_borrow.rs:157:23
    |
 LL |     let x: (&str,) = (&"",);
    |                       ^^^ help: change this to: `""`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:203:13
+  --> tests/ui/needless_borrow.rs:200:13
    |
 LL |             (&self.f)()
    |             ^^^^^^^^^ help: change this to: `(self.f)`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:213:13
+  --> tests/ui/needless_borrow.rs:210:13
    |
 LL |             (&mut self.f)()
    |             ^^^^^^^^^^^^^ help: change this to: `(self.f)`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:251:22
+  --> tests/ui/needless_borrow.rs:248:22
    |
 LL |         let _ = &mut (&mut { x.u }).x;
    |                      ^^^^^^^^^^^^^^ help: change this to: `{ x.u }`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:259:22
+  --> tests/ui/needless_borrow.rs:256:22
    |
 LL |         let _ = &mut (&mut { x.u }).x;
    |                      ^^^^^^^^^^^^^^ help: change this to: `{ x.u }`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:264:22
+  --> tests/ui/needless_borrow.rs:261:22
    |
 LL |         let _ = &mut (&mut x.u).x;
    |                      ^^^^^^^^^^ help: change this to: `x.u`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> tests/ui/needless_borrow.rs:266:22
+  --> tests/ui/needless_borrow.rs:263:22
    |
 LL |         let _ = &mut (&mut { x.u }).x;
    |                      ^^^^^^^^^^^^^^ help: change this to: `{ x.u }`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:288:23
+  --> tests/ui/needless_borrow.rs:285:23
    |
 LL |     option.unwrap_or((&x.0,));
    |                       ^^^^ help: change this to: `x.0`
+
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> tests/ui/needless_borrow.rs:292:13
+   |
+LL |     let _ = (&slice).len();
+   |             ^^^^^^^^ help: change this to: `slice`
 
 error: aborting due to 28 previous errors
 

--- a/tests/ui/needless_borrowed_ref.fixed
+++ b/tests/ui/needless_borrowed_ref.fixed
@@ -3,6 +3,7 @@
     unused,
     irrefutable_let_patterns,
     non_shorthand_field_patterns,
+    clippy::disallowed_names,
     clippy::needless_borrow,
     clippy::needless_if
 )]

--- a/tests/ui/needless_borrowed_ref.rs
+++ b/tests/ui/needless_borrowed_ref.rs
@@ -3,6 +3,7 @@
     unused,
     irrefutable_let_patterns,
     non_shorthand_field_patterns,
+    clippy::disallowed_names,
     clippy::needless_borrow,
     clippy::needless_if
 )]

--- a/tests/ui/needless_borrowed_ref.stderr
+++ b/tests/ui/needless_borrowed_ref.stderr
@@ -1,5 +1,5 @@
 error: this pattern takes a reference on something that is being dereferenced
-  --> tests/ui/needless_borrowed_ref.rs:30:34
+  --> tests/ui/needless_borrowed_ref.rs:31:34
    |
 LL |     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
    |                                  ^^^^^^
@@ -13,7 +13,7 @@ LL +     let _ = v.iter_mut().filter(|a| a.is_empty());
    |
 
 error: this pattern takes a reference on something that is being dereferenced
-  --> tests/ui/needless_borrowed_ref.rs:35:17
+  --> tests/ui/needless_borrowed_ref.rs:36:17
    |
 LL |     if let Some(&ref v) = thingy {}
    |                 ^^^^^^
@@ -25,7 +25,7 @@ LL +     if let Some(v) = thingy {}
    |
 
 error: this pattern takes a reference on something that is being dereferenced
-  --> tests/ui/needless_borrowed_ref.rs:38:14
+  --> tests/ui/needless_borrowed_ref.rs:39:14
    |
 LL |     if let &[&ref a, ref b] = slice_of_refs {}
    |              ^^^^^^
@@ -37,7 +37,7 @@ LL +     if let &[a, ref b] = slice_of_refs {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:41:9
+  --> tests/ui/needless_borrowed_ref.rs:42:9
    |
 LL |     let &[ref a, ..] = &array;
    |         ^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +     let [a, ..] = &array;
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:43:9
+  --> tests/ui/needless_borrowed_ref.rs:44:9
    |
 LL |     let &[ref a, ref b, ..] = &array;
    |         ^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL +     let [a, b, ..] = &array;
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:46:12
+  --> tests/ui/needless_borrowed_ref.rs:47:12
    |
 LL |     if let &[ref a, ref b] = slice {}
    |            ^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +     if let [a, b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:48:12
+  --> tests/ui/needless_borrowed_ref.rs:49:12
    |
 LL |     if let &[ref a, ref b] = &vec[..] {}
    |            ^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +     if let [a, b] = &vec[..] {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:51:12
+  --> tests/ui/needless_borrowed_ref.rs:52:12
    |
 LL |     if let &[ref a, ref b, ..] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL +     if let [a, b, ..] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:53:12
+  --> tests/ui/needless_borrowed_ref.rs:54:12
    |
 LL |     if let &[ref a, .., ref b] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL +     if let [a, .., b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:55:12
+  --> tests/ui/needless_borrowed_ref.rs:56:12
    |
 LL |     if let &[.., ref a, ref b] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL +     if let [.., a, b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:58:12
+  --> tests/ui/needless_borrowed_ref.rs:59:12
    |
 LL |     if let &[ref a, _] = slice {}
    |            ^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL +     if let [a, _] = slice {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:61:12
+  --> tests/ui/needless_borrowed_ref.rs:62:12
    |
 LL |     if let &(ref a, ref b, ref c) = &tuple {}
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL +     if let (a, b, c) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:63:12
+  --> tests/ui/needless_borrowed_ref.rs:64:12
    |
 LL |     if let &(ref a, _, ref c) = &tuple {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     if let (a, _, c) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:65:12
+  --> tests/ui/needless_borrowed_ref.rs:66:12
    |
 LL |     if let &(ref a, ..) = &tuple {}
    |            ^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL +     if let (a, ..) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:68:12
+  --> tests/ui/needless_borrowed_ref.rs:69:12
    |
 LL |     if let &TupleStruct(ref a, ..) = &tuple_struct {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     if let TupleStruct(a, ..) = &tuple_struct {}
    |
 
 error: dereferencing a struct pattern where every field's pattern takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:71:12
+  --> tests/ui/needless_borrowed_ref.rs:72:12
    |
 LL |       if let &Struct {
    |  ____________^
@@ -202,7 +202,7 @@ LL ~         c: renamed,
    |
 
 error: dereferencing a struct pattern where every field's pattern takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:79:12
+  --> tests/ui/needless_borrowed_ref.rs:80:12
    |
 LL |     if let &Struct { ref a, b: _, .. } = &s {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/needless_borrows_for_generic_args.fixed
+++ b/tests/ui/needless_borrows_for_generic_args.fixed
@@ -2,7 +2,8 @@
 #![allow(
     clippy::unnecessary_to_owned,
     clippy::unnecessary_literal_unwrap,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::disallowed_names
 )]
 
 use core::ops::Deref;

--- a/tests/ui/needless_borrows_for_generic_args.rs
+++ b/tests/ui/needless_borrows_for_generic_args.rs
@@ -2,7 +2,8 @@
 #![allow(
     clippy::unnecessary_to_owned,
     clippy::unnecessary_literal_unwrap,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::disallowed_names
 )]
 
 use core::ops::Deref;

--- a/tests/ui/needless_borrows_for_generic_args.stderr
+++ b/tests/ui/needless_borrows_for_generic_args.stderr
@@ -1,5 +1,5 @@
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:16:37
+  --> tests/ui/needless_borrows_for_generic_args.rs:17:37
    |
 LL |     let _ = Command::new("ls").args(&["-a", "-l"]).status().unwrap();
    |                                     ^^^^^^^^^^^^^ help: change this to: `["-a", "-l"]`
@@ -8,61 +8,61 @@ LL |     let _ = Command::new("ls").args(&["-a", "-l"]).status().unwrap();
    = help: to override `-D warnings` add `#[allow(clippy::needless_borrows_for_generic_args)]`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:18:33
+  --> tests/ui/needless_borrows_for_generic_args.rs:19:33
    |
 LL |     let _ = Path::new(".").join(&&".");
    |                                 ^^^^^ help: change this to: `"."`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:23:33
+  --> tests/ui/needless_borrows_for_generic_args.rs:24:33
    |
 LL |     let _ = std::fs::write("x", &"".to_string());
    |                                 ^^^^^^^^^^^^^^^ help: change this to: `"".to_string()`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:39:27
+  --> tests/ui/needless_borrows_for_generic_args.rs:40:27
    |
 LL |         deref_target_is_x(&X);
    |                           ^^ help: change this to: `X`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:53:30
+  --> tests/ui/needless_borrows_for_generic_args.rs:54:30
    |
 LL |         multiple_constraints(&[[""]]);
    |                              ^^^^^^^ help: change this to: `[[""]]`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:74:49
+  --> tests/ui/needless_borrows_for_generic_args.rs:75:49
    |
 LL |         multiple_constraints_normalizes_to_same(&X, X);
    |                                                 ^^ help: change this to: `X`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:133:24
+  --> tests/ui/needless_borrows_for_generic_args.rs:134:24
    |
 LL |             takes_iter(&mut x)
    |                        ^^^^^^ help: change this to: `x`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:143:41
+  --> tests/ui/needless_borrows_for_generic_args.rs:144:41
    |
 LL |         let _ = Command::new("ls").args(&["-a", "-l"]).status().unwrap();
    |                                         ^^^^^^^^^^^^^ help: change this to: `["-a", "-l"]`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:255:13
+  --> tests/ui/needless_borrows_for_generic_args.rs:256:13
    |
 LL |         foo(&a);
    |             ^^ help: change this to: `a`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:340:11
+  --> tests/ui/needless_borrows_for_generic_args.rs:341:11
    |
 LL |         f(&String::new()); // Lint, makes no difference
    |           ^^^^^^^^^^^^^^ help: change this to: `String::new()`
 
 error: the borrowed expression implements the required traits
-  --> tests/ui/needless_borrows_for_generic_args.rs:345:11
+  --> tests/ui/needless_borrows_for_generic_args.rs:346:11
    |
 LL |         f(&"".to_owned()); // Lint
    |           ^^^^^^^^^^^^^^ help: change this to: `"".to_owned()`

--- a/tests/ui/needless_collect.fixed
+++ b/tests/ui/needless_collect.fixed
@@ -1,5 +1,6 @@
 #![allow(
     unused,
+    clippy::disallowed_names,
     clippy::needless_if,
     clippy::suspicious_map,
     clippy::iter_count,

--- a/tests/ui/needless_collect.rs
+++ b/tests/ui/needless_collect.rs
@@ -1,5 +1,6 @@
 #![allow(
     unused,
+    clippy::disallowed_names,
     clippy::needless_if,
     clippy::suspicious_map,
     clippy::iter_count,

--- a/tests/ui/needless_collect.stderr
+++ b/tests/ui/needless_collect.stderr
@@ -1,5 +1,5 @@
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:15:29
+  --> tests/ui/needless_collect.rs:16:29
    |
 LL |     let len = sample.iter().collect::<Vec<_>>().len();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `count()`
@@ -8,109 +8,109 @@ LL |     let len = sample.iter().collect::<Vec<_>>().len();
    = help: to override `-D warnings` add `#[allow(clippy::needless_collect)]`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:17:22
+  --> tests/ui/needless_collect.rs:18:22
    |
 LL |     if sample.iter().collect::<Vec<_>>().is_empty() {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:21:28
+  --> tests/ui/needless_collect.rs:22:28
    |
 LL |     sample.iter().cloned().collect::<Vec<_>>().contains(&1);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == 1)`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:27:35
+  --> tests/ui/needless_collect.rs:28:35
    |
 LL |     sample.iter().map(|x| (x, x)).collect::<HashMap<_, _>>().is_empty();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:29:35
+  --> tests/ui/needless_collect.rs:30:35
    |
 LL |     sample.iter().map(|x| (x, x)).collect::<BTreeMap<_, _>>().is_empty();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:37:19
+  --> tests/ui/needless_collect.rs:38:19
    |
 LL |     sample.iter().collect::<LinkedList<_>>().len();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `count()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:39:19
+  --> tests/ui/needless_collect.rs:40:19
    |
 LL |     sample.iter().collect::<LinkedList<_>>().is_empty();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:41:28
+  --> tests/ui/needless_collect.rs:42:28
    |
 LL |     sample.iter().cloned().collect::<LinkedList<_>>().contains(&1);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == 1)`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:43:19
+  --> tests/ui/needless_collect.rs:44:19
    |
 LL |     sample.iter().collect::<LinkedList<_>>().contains(&&1);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == &1)`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:47:19
+  --> tests/ui/needless_collect.rs:48:19
    |
 LL |     sample.iter().collect::<BinaryHeap<_>>().len();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `count()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:49:19
+  --> tests/ui/needless_collect.rs:50:19
    |
 LL |     sample.iter().collect::<BinaryHeap<_>>().is_empty();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:55:27
+  --> tests/ui/needless_collect.rs:56:27
    |
 LL |     let _ = sample.iter().collect::<HashSet<_>>().is_empty();
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:57:27
+  --> tests/ui/needless_collect.rs:58:27
    |
 LL |     let _ = sample.iter().collect::<HashSet<_>>().contains(&&0);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == &0)`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:80:27
+  --> tests/ui/needless_collect.rs:81:27
    |
 LL |     let _ = sample.iter().collect::<VecWrapper<_>>().is_empty();
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:82:27
+  --> tests/ui/needless_collect.rs:83:27
    |
 LL |     let _ = sample.iter().collect::<VecWrapper<_>>().contains(&&0);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == &0)`
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:87:40
+  --> tests/ui/needless_collect.rs:88:40
    |
 LL |         Vec::<u8>::new().extend((0..10).collect::<Vec<_>>());
    |                                        ^^^^^^^^^^^^^^^^^^^^ help: remove this call
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:89:20
+  --> tests/ui/needless_collect.rs:90:20
    |
 LL |         foo((0..10).collect::<Vec<_>>());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: remove this call
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:91:49
+  --> tests/ui/needless_collect.rs:92:49
    |
 LL |         bar((0..10).collect::<Vec<_>>(), (0..10).collect::<Vec<_>>());
    |                                                 ^^^^^^^^^^^^^^^^^^^^ help: remove this call
 
 error: avoid using `collect()` when not needed
-  --> tests/ui/needless_collect.rs:93:37
+  --> tests/ui/needless_collect.rs:94:37
    |
 LL |         baz((0..10), (), ('a'..='z').collect::<Vec<_>>())
    |                                     ^^^^^^^^^^^^^^^^^^^^ help: remove this call

--- a/tests/ui/needless_continue.rs
+++ b/tests/ui/needless_continue.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::needless_continue)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::disallowed_names, clippy::uninlined_format_args)]
 
 macro_rules! zero {
     ($x:expr) => {

--- a/tests/ui/needless_lifetimes.fixed
+++ b/tests/ui/needless_lifetimes.fixed
@@ -4,6 +4,7 @@
 #![allow(
     unused,
     clippy::boxed_local,
+    clippy::disallowed_names,
     clippy::extra_unused_type_parameters,
     clippy::needless_pass_by_value,
     clippy::redundant_allocation,

--- a/tests/ui/needless_lifetimes.rs
+++ b/tests/ui/needless_lifetimes.rs
@@ -4,6 +4,7 @@
 #![allow(
     unused,
     clippy::boxed_local,
+    clippy::disallowed_names,
     clippy::extra_unused_type_parameters,
     clippy::needless_pass_by_value,
     clippy::redundant_allocation,

--- a/tests/ui/needless_lifetimes.stderr
+++ b/tests/ui/needless_lifetimes.stderr
@@ -1,5 +1,5 @@
 error: the following explicit lifetimes could be elided: 'a, 'b
-  --> tests/ui/needless_lifetimes.rs:19:23
+  --> tests/ui/needless_lifetimes.rs:20:23
    |
 LL | fn distinct_lifetimes<'a, 'b>(_x: &'a u8, _y: &'b u8, _z: u8) {}
    |                       ^^  ^^       ^^          ^^
@@ -13,7 +13,7 @@ LL + fn distinct_lifetimes(_x: &u8, _y: &u8, _z: u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a, 'b
-  --> tests/ui/needless_lifetimes.rs:22:24
+  --> tests/ui/needless_lifetimes.rs:23:24
    |
 LL | fn distinct_and_static<'a, 'b>(_x: &'a u8, _y: &'b u8, _z: &'static u8) {}
    |                        ^^  ^^       ^^          ^^
@@ -25,7 +25,7 @@ LL + fn distinct_and_static(_x: &u8, _y: &u8, _z: &'static u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:33:15
+  --> tests/ui/needless_lifetimes.rs:34:15
    |
 LL | fn in_and_out<'a>(x: &'a u8, _y: u8) -> &'a u8 {
    |               ^^      ^^                 ^^
@@ -37,7 +37,7 @@ LL + fn in_and_out(x: &u8, _y: u8) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/needless_lifetimes.rs:46:31
+  --> tests/ui/needless_lifetimes.rs:47:31
    |
 LL | fn multiple_in_and_out_2a<'a, 'b>(x: &'a u8, _y: &'b u8) -> &'a u8 {
    |                               ^^                  ^^
@@ -49,7 +49,7 @@ LL + fn multiple_in_and_out_2a<'a>(x: &'a u8, _y: &u8) -> &'a u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:54:27
+  --> tests/ui/needless_lifetimes.rs:55:27
    |
 LL | fn multiple_in_and_out_2b<'a, 'b>(_x: &'a u8, y: &'b u8) -> &'b u8 {
    |                           ^^           ^^
@@ -61,7 +61,7 @@ LL + fn multiple_in_and_out_2b<'b>(_x: &u8, y: &'b u8) -> &'b u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/needless_lifetimes.rs:72:26
+  --> tests/ui/needless_lifetimes.rs:73:26
    |
 LL | fn deep_reference_1a<'a, 'b>(x: &'a u8, _y: &'b u8) -> Result<&'a u8, ()> {
    |                          ^^                  ^^
@@ -73,7 +73,7 @@ LL + fn deep_reference_1a<'a>(x: &'a u8, _y: &u8) -> Result<&'a u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:80:22
+  --> tests/ui/needless_lifetimes.rs:81:22
    |
 LL | fn deep_reference_1b<'a, 'b>(_x: &'a u8, y: &'b u8) -> Result<&'b u8, ()> {
    |                      ^^           ^^
@@ -85,7 +85,7 @@ LL + fn deep_reference_1b<'b>(_x: &u8, y: &'b u8) -> Result<&'b u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:90:21
+  --> tests/ui/needless_lifetimes.rs:91:21
    |
 LL | fn deep_reference_3<'a>(x: &'a u8, _y: u8) -> Result<&'a u8, ()> {
    |                     ^^      ^^                        ^^
@@ -97,7 +97,7 @@ LL + fn deep_reference_3(x: &u8, _y: u8) -> Result<&u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:96:28
+  --> tests/ui/needless_lifetimes.rs:97:28
    |
 LL | fn where_clause_without_lt<'a, T>(x: &'a u8, _y: u8) -> Result<&'a u8, ()>
    |                            ^^         ^^                        ^^
@@ -109,7 +109,7 @@ LL + fn where_clause_without_lt<T>(x: &u8, _y: u8) -> Result<&u8, ()>
    |
 
 error: the following explicit lifetimes could be elided: 's
-  --> tests/ui/needless_lifetimes.rs:127:21
+  --> tests/ui/needless_lifetimes.rs:128:21
    |
 LL |     fn self_and_out<'s>(&'s self) -> &'s u8 {
    |                     ^^   ^^           ^^
@@ -121,7 +121,7 @@ LL +     fn self_and_out(&self) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 't
-  --> tests/ui/needless_lifetimes.rs:135:30
+  --> tests/ui/needless_lifetimes.rs:136:30
    |
 LL |     fn self_and_in_out_1<'s, 't>(&'s self, _x: &'t u8) -> &'s u8 {
    |                              ^^                 ^^
@@ -133,7 +133,7 @@ LL +     fn self_and_in_out_1<'s>(&'s self, _x: &u8) -> &'s u8 {
    |
 
 error: the following explicit lifetimes could be elided: 's
-  --> tests/ui/needless_lifetimes.rs:143:26
+  --> tests/ui/needless_lifetimes.rs:144:26
    |
 LL |     fn self_and_in_out_2<'s, 't>(&'s self, x: &'t u8) -> &'t u8 {
    |                          ^^       ^^
@@ -145,7 +145,7 @@ LL +     fn self_and_in_out_2<'t>(&self, x: &'t u8) -> &'t u8 {
    |
 
 error: the following explicit lifetimes could be elided: 's, 't
-  --> tests/ui/needless_lifetimes.rs:148:29
+  --> tests/ui/needless_lifetimes.rs:149:29
    |
 LL |     fn distinct_self_and_in<'s, 't>(&'s self, _x: &'t u8) {}
    |                             ^^  ^^   ^^            ^^
@@ -157,7 +157,7 @@ LL +     fn distinct_self_and_in(&self, _x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:172:21
+  --> tests/ui/needless_lifetimes.rs:173:21
    |
 LL | fn struct_with_lt4b<'a, 'b>(_foo: &'a Foo<'b>) -> &'b str {
    |                     ^^             ^^
@@ -169,7 +169,7 @@ LL + fn struct_with_lt4b<'b>(_foo: &Foo<'b>) -> &'b str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:188:22
+  --> tests/ui/needless_lifetimes.rs:189:22
    |
 LL | fn trait_obj_elided2<'a>(_arg: &'a dyn Drop) -> &'a str {
    |                      ^^         ^^               ^^
@@ -181,7 +181,7 @@ LL + fn trait_obj_elided2(_arg: &dyn Drop) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:199:20
+  --> tests/ui/needless_lifetimes.rs:200:20
    |
 LL | fn alias_with_lt4b<'a, 'b>(_foo: &'a FooAlias<'b>) -> &'b str {
    |                    ^^             ^^
@@ -193,7 +193,7 @@ LL + fn alias_with_lt4b<'b>(_foo: &FooAlias<'b>) -> &'b str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:204:30
+  --> tests/ui/needless_lifetimes.rs:205:30
    |
 LL | fn named_input_elided_output<'a>(_arg: &'a str) -> &str {
    |                              ^^         ^^          ^
@@ -205,7 +205,7 @@ LL + fn named_input_elided_output(_arg: &str) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:213:19
+  --> tests/ui/needless_lifetimes.rs:214:19
    |
 LL | fn trait_bound_ok<'a, T: WithLifetime<'static>>(_: &'a u8, _: T) {
    |                   ^^                                ^^
@@ -217,7 +217,7 @@ LL + fn trait_bound_ok<T: WithLifetime<'static>>(_: &u8, _: T) {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:249:24
+  --> tests/ui/needless_lifetimes.rs:250:24
    |
 LL |         fn needless_lt<'a>(x: &'a u8) {}
    |                        ^^      ^^
@@ -229,7 +229,7 @@ LL +         fn needless_lt(x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:254:24
+  --> tests/ui/needless_lifetimes.rs:255:24
    |
 LL |         fn needless_lt<'a>(_x: &'a u8) {}
    |                        ^^       ^^
@@ -241,7 +241,7 @@ LL +         fn needless_lt(_x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:285:55
+  --> tests/ui/needless_lifetimes.rs:286:55
    |
 LL |     fn impl_trait_elidable_nested_anonymous_lifetimes<'a>(i: &'a i32, f: impl Fn(&i32) -> &i32) -> &'a i32 {
    |                                                       ^^      ^^                                    ^^
@@ -253,7 +253,7 @@ LL +     fn impl_trait_elidable_nested_anonymous_lifetimes(i: &i32, f: impl Fn(&
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:295:26
+  --> tests/ui/needless_lifetimes.rs:296:26
    |
 LL |     fn generics_elidable<'a, T: Fn(&i32) -> &i32>(i: &'a i32, f: T) -> &'a i32 {
    |                          ^^                           ^^                ^^
@@ -265,7 +265,7 @@ LL +     fn generics_elidable<T: Fn(&i32) -> &i32>(i: &i32, f: T) -> &i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:308:30
+  --> tests/ui/needless_lifetimes.rs:309:30
    |
 LL |     fn where_clause_elidable<'a, T>(i: &'a i32, f: T) -> &'a i32
    |                              ^^         ^^                ^^
@@ -277,7 +277,7 @@ LL +     fn where_clause_elidable<T>(i: &i32, f: T) -> &i32
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:324:28
+  --> tests/ui/needless_lifetimes.rs:325:28
    |
 LL |     fn pointer_fn_elidable<'a>(i: &'a i32, f: fn(&i32) -> &i32) -> &'a i32 {
    |                            ^^      ^^                               ^^
@@ -289,7 +289,7 @@ LL +     fn pointer_fn_elidable(i: &i32, f: fn(&i32) -> &i32) -> &i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:338:28
+  --> tests/ui/needless_lifetimes.rs:339:28
    |
 LL |     fn nested_fn_pointer_3<'a>(_: &'a i32) -> fn(fn(&i32) -> &i32) -> i32 {
    |                            ^^      ^^
@@ -301,7 +301,7 @@ LL +     fn nested_fn_pointer_3(_: &i32) -> fn(fn(&i32) -> &i32) -> i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:342:28
+  --> tests/ui/needless_lifetimes.rs:343:28
    |
 LL |     fn nested_fn_pointer_4<'a>(_: &'a i32) -> impl Fn(fn(&i32)) {
    |                            ^^      ^^
@@ -313,7 +313,7 @@ LL +     fn nested_fn_pointer_4(_: &i32) -> impl Fn(fn(&i32)) {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:365:21
+  --> tests/ui/needless_lifetimes.rs:366:21
    |
 LL |         fn implicit<'a>(&'a self) -> &'a () {
    |                     ^^   ^^           ^^
@@ -325,7 +325,7 @@ LL +         fn implicit(&self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:369:25
+  --> tests/ui/needless_lifetimes.rs:370:25
    |
 LL |         fn implicit_mut<'a>(&'a mut self) -> &'a () {
    |                         ^^   ^^               ^^
@@ -337,7 +337,7 @@ LL +         fn implicit_mut(&mut self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:374:21
+  --> tests/ui/needless_lifetimes.rs:375:21
    |
 LL |         fn explicit<'a>(self: &'a Arc<Self>) -> &'a () {
    |                     ^^         ^^                ^^
@@ -349,7 +349,7 @@ LL +         fn explicit(self: &Arc<Self>) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:379:25
+  --> tests/ui/needless_lifetimes.rs:380:25
    |
 LL |         fn explicit_mut<'a>(self: &'a mut Rc<Self>) -> &'a () {
    |                         ^^         ^^                   ^^
@@ -361,7 +361,7 @@ LL +         fn explicit_mut(self: &mut Rc<Self>) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:392:31
+  --> tests/ui/needless_lifetimes.rs:393:31
    |
 LL |         fn lifetime_elsewhere<'a>(self: Box<Self>, here: &'a ()) -> &'a () {
    |                               ^^                          ^^         ^^
@@ -373,7 +373,7 @@ LL +         fn lifetime_elsewhere(self: Box<Self>, here: &()) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:399:21
+  --> tests/ui/needless_lifetimes.rs:400:21
    |
 LL |         fn implicit<'a>(&'a self) -> &'a ();
    |                     ^^   ^^           ^^
@@ -385,7 +385,7 @@ LL +         fn implicit(&self) -> &();
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:401:30
+  --> tests/ui/needless_lifetimes.rs:402:30
    |
 LL |         fn implicit_provided<'a>(&'a self) -> &'a () {
    |                              ^^   ^^           ^^
@@ -397,7 +397,7 @@ LL +         fn implicit_provided(&self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:407:21
+  --> tests/ui/needless_lifetimes.rs:408:21
    |
 LL |         fn explicit<'a>(self: &'a Arc<Self>) -> &'a ();
    |                     ^^         ^^                ^^
@@ -409,7 +409,7 @@ LL +         fn explicit(self: &Arc<Self>) -> &();
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:410:30
+  --> tests/ui/needless_lifetimes.rs:411:30
    |
 LL |         fn explicit_provided<'a>(self: &'a Arc<Self>) -> &'a () {
    |                              ^^         ^^                ^^
@@ -421,7 +421,7 @@ LL +         fn explicit_provided(self: &Arc<Self>) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:421:31
+  --> tests/ui/needless_lifetimes.rs:422:31
    |
 LL |         fn lifetime_elsewhere<'a>(self: Box<Self>, here: &'a ()) -> &'a ();
    |                               ^^                          ^^         ^^
@@ -433,7 +433,7 @@ LL +         fn lifetime_elsewhere(self: Box<Self>, here: &()) -> &();
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:423:40
+  --> tests/ui/needless_lifetimes.rs:424:40
    |
 LL |         fn lifetime_elsewhere_provided<'a>(self: Box<Self>, here: &'a ()) -> &'a () {
    |                                        ^^                          ^^         ^^
@@ -445,7 +445,7 @@ LL +         fn lifetime_elsewhere_provided(self: Box<Self>, here: &()) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:433:12
+  --> tests/ui/needless_lifetimes.rs:434:12
    |
 LL |     fn foo<'a>(x: &'a u8, y: &'_ u8) {}
    |            ^^      ^^
@@ -457,7 +457,7 @@ LL +     fn foo(x: &u8, y: &'_ u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:436:12
+  --> tests/ui/needless_lifetimes.rs:437:12
    |
 LL |     fn bar<'a>(x: &'a u8, y: &'_ u8, z: &'_ u8) {}
    |            ^^      ^^
@@ -469,7 +469,7 @@ LL +     fn bar(x: &u8, y: &'_ u8, z: &'_ u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:444:18
+  --> tests/ui/needless_lifetimes.rs:445:18
    |
 LL |     fn one_input<'a>(x: &'a u8) -> &'a u8 {
    |                  ^^      ^^         ^^
@@ -481,7 +481,7 @@ LL +     fn one_input(x: &u8) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:450:42
+  --> tests/ui/needless_lifetimes.rs:451:42
    |
 LL |     fn multiple_inputs_output_not_elided<'a, 'b>(x: &'a u8, y: &'b u8, z: &'b u8) -> &'b u8 {
    |                                          ^^          ^^
@@ -493,7 +493,7 @@ LL +     fn multiple_inputs_output_not_elided<'b>(x: &u8, y: &'b u8, z: &'b u8) 
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:467:22
+  --> tests/ui/needless_lifetimes.rs:468:22
    |
 LL |         fn one_input<'a>(x: &'a u8) -> &'a u8 {
    |                      ^^      ^^         ^^

--- a/tests/ui/needless_pass_by_ref_mut.rs
+++ b/tests/ui/needless_pass_by_ref_mut.rs
@@ -1,4 +1,5 @@
 #![allow(
+    clippy::disallowed_names,
     clippy::if_same_then_else,
     clippy::no_effect,
     clippy::ptr_arg,

--- a/tests/ui/needless_pass_by_ref_mut.stderr
+++ b/tests/ui/needless_pass_by_ref_mut.stderr
@@ -1,5 +1,5 @@
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:12:11
+  --> tests/ui/needless_pass_by_ref_mut.rs:13:11
    |
 LL | fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
    |           ^^^^^^^^^^^^^ help: consider changing to: `&Vec<u32>`
@@ -8,79 +8,79 @@ LL | fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
    = help: to override `-D warnings` add `#[allow(clippy::needless_pass_by_ref_mut)]`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:38:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:39:12
    |
 LL | fn foo6(s: &mut Vec<u32>) {
    |            ^^^^^^^^^^^^^ help: consider changing to: `&Vec<u32>`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:49:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:50:12
    |
 LL |     fn bar(&mut self) {}
    |            ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:52:29
+  --> tests/ui/needless_pass_by_ref_mut.rs:53:29
    |
 LL |     fn mushroom(&self, vec: &mut Vec<i32>) -> usize {
    |                             ^^^^^^^^^^^^^ help: consider changing to: `&Vec<i32>`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:130:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:131:16
    |
 LL | async fn a1(x: &mut i32) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:135:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:136:16
    |
 LL | async fn a2(x: &mut i32, y: String) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:140:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:141:16
    |
 LL | async fn a3(x: &mut i32, y: String, z: String) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:145:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:146:16
    |
 LL | async fn a4(x: &mut i32, y: i32) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:150:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:151:24
    |
 LL | async fn a5(x: i32, y: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:155:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:156:24
    |
 LL | async fn a6(x: i32, y: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:160:32
+  --> tests/ui/needless_pass_by_ref_mut.rs:161:32
    |
 LL | async fn a7(x: i32, y: i32, z: &mut i32) {
    |                                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:165:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:166:24
    |
 LL | async fn a8(x: i32, a: &mut i32, y: i32, z: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:165:45
+  --> tests/ui/needless_pass_by_ref_mut.rs:166:45
    |
 LL | async fn a8(x: i32, a: &mut i32, y: i32, z: &mut i32) {
    |                                             ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:201:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:202:16
    |
 LL | fn cfg_warn(s: &mut u32) {}
    |                ^^^^^^^^ help: consider changing to: `&u32`
@@ -88,7 +88,7 @@ LL | fn cfg_warn(s: &mut u32) {}
    = note: this is cfg-gated and may require further changes
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:206:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:207:20
    |
 LL |     fn cfg_warn(s: &mut u32) {}
    |                    ^^^^^^^^ help: consider changing to: `&u32`
@@ -96,115 +96,115 @@ LL |     fn cfg_warn(s: &mut u32) {}
    = note: this is cfg-gated and may require further changes
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:219:39
+  --> tests/ui/needless_pass_by_ref_mut.rs:220:39
    |
 LL | async fn inner_async2(x: &mut i32, y: &mut u32) {
    |                                       ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:228:26
+  --> tests/ui/needless_pass_by_ref_mut.rs:229:26
    |
 LL | async fn inner_async3(x: &mut i32, y: &mut u32) {
    |                          ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:248:30
+  --> tests/ui/needless_pass_by_ref_mut.rs:249:30
    |
 LL | async fn call_in_closure1(n: &mut str) {
    |                              ^^^^^^^^ help: consider changing to: `&str`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:268:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:269:16
    |
 LL | fn closure2(n: &mut usize) -> impl '_ + FnMut() -> usize {
    |                ^^^^^^^^^^ help: consider changing to: `&usize`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:280:22
+  --> tests/ui/needless_pass_by_ref_mut.rs:281:22
    |
 LL | async fn closure4(n: &mut usize) {
    |                      ^^^^^^^^^^ help: consider changing to: `&usize`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:335:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:336:12
    |
 LL |     fn bar(&mut self) {}
    |            ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:338:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:339:18
    |
 LL |     async fn foo(&mut self, u: &mut i32, v: &mut u32) {
    |                  ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:338:45
+  --> tests/ui/needless_pass_by_ref_mut.rs:339:45
    |
 LL |     async fn foo(&mut self, u: &mut i32, v: &mut u32) {
    |                                             ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:347:46
+  --> tests/ui/needless_pass_by_ref_mut.rs:348:46
    |
 LL |     async fn foo2(&mut self, u: &mut i32, v: &mut u32) {
    |                                              ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:364:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:365:18
    |
 LL | fn _empty_tup(x: &mut (())) {}
    |                  ^^^^^^^^^ help: consider changing to: `&()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:366:19
+  --> tests/ui/needless_pass_by_ref_mut.rs:367:19
    |
 LL | fn _single_tup(x: &mut ((i32,))) {}
    |                   ^^^^^^^^^^^^^ help: consider changing to: `&(i32,)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:368:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:369:18
    |
 LL | fn _multi_tup(x: &mut ((i32, u32))) {}
    |                  ^^^^^^^^^^^^^^^^^ help: consider changing to: `&(i32, u32)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:370:11
+  --> tests/ui/needless_pass_by_ref_mut.rs:371:11
    |
 LL | fn _fn(x: &mut (fn())) {}
    |           ^^^^^^^^^^^ help: consider changing to: `&fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:373:23
+  --> tests/ui/needless_pass_by_ref_mut.rs:374:23
    |
 LL | fn _extern_rust_fn(x: &mut extern "Rust" fn()) {}
    |                       ^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&extern "Rust" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:375:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:376:20
    |
 LL | fn _extern_c_fn(x: &mut extern "C" fn()) {}
    |                    ^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&extern "C" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:377:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:378:18
    |
 LL | fn _unsafe_fn(x: &mut unsafe fn()) {}
    |                  ^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:379:25
+  --> tests/ui/needless_pass_by_ref_mut.rs:380:25
    |
 LL | fn _unsafe_extern_fn(x: &mut unsafe extern "C" fn()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:381:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:382:20
    |
 LL | fn _fn_with_arg(x: &mut unsafe extern "C" fn(i32)) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn(i32)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:383:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:384:20
    |
 LL | fn _fn_with_ret(x: &mut unsafe extern "C" fn() -> (i32)) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn() -> (i32)`

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::needless_pass_by_value)]
 #![allow(dead_code)]
 #![allow(
+    clippy::disallowed_names,
     clippy::option_option,
     clippy::redundant_clone,
     clippy::redundant_pattern_matching,

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -1,5 +1,5 @@
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:19:23
+  --> tests/ui/needless_pass_by_value.rs:20:23
    |
 LL | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T> {
    |                       ^^^^^^ help: consider changing the type to: `&[T]`
@@ -8,13 +8,13 @@ LL | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T
    = help: to override `-D warnings` add `#[allow(clippy::needless_pass_by_value)]`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:35:11
+  --> tests/ui/needless_pass_by_value.rs:36:11
    |
 LL | fn bar(x: String, y: Wrapper) {
    |           ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:35:22
+  --> tests/ui/needless_pass_by_value.rs:36:22
    |
 LL | fn bar(x: String, y: Wrapper) {
    |                      ^^^^^^^
@@ -25,7 +25,7 @@ LL | fn bar(x: String, y: &Wrapper) {
    |                      +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:44:71
+  --> tests/ui/needless_pass_by_value.rs:45:71
    |
 LL | fn test_borrow_trait<T: Borrow<str>, U: AsRef<str>, V>(t: T, u: U, v: V) {
    |                                                                       ^
@@ -36,7 +36,7 @@ LL | fn test_borrow_trait<T: Borrow<str>, U: AsRef<str>, V>(t: T, u: U, v: &V) {
    |                                                                       +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:58:18
+  --> tests/ui/needless_pass_by_value.rs:59:18
    |
 LL | fn test_match(x: Option<Option<String>>, y: Option<Option<String>>) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL | fn test_match(x: Option<Option<&String>>, y: Option<Option<String>>) {
    |                                +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:73:24
+  --> tests/ui/needless_pass_by_value.rs:74:24
    |
 LL | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                        ^^^^^^^
@@ -58,7 +58,7 @@ LL | fn test_destructure(x: &Wrapper, y: Wrapper, z: Wrapper) {
    |                        +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:73:36
+  --> tests/ui/needless_pass_by_value.rs:74:36
    |
 LL | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                                    ^^^^^^^
@@ -69,7 +69,7 @@ LL | fn test_destructure(x: Wrapper, y: &Wrapper, z: Wrapper) {
    |                                    +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:92:49
+  --> tests/ui/needless_pass_by_value.rs:93:49
    |
 LL | fn test_blanket_ref<T: Foo, S: Serialize>(vals: T, serializable: S) {}
    |                                                 ^
@@ -80,7 +80,7 @@ LL | fn test_blanket_ref<T: Foo, S: Serialize>(vals: &T, serializable: S) {}
    |                                                 +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:95:18
+  --> tests/ui/needless_pass_by_value.rs:96:18
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                  ^^^^^^
@@ -91,7 +91,7 @@ LL | fn issue_2114(s: &String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                  +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:95:29
+  --> tests/ui/needless_pass_by_value.rs:96:29
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                             ^^^^^^
@@ -108,7 +108,7 @@ LL +     let _ = t.to_string();
    |
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:95:40
+  --> tests/ui/needless_pass_by_value.rs:96:40
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                                        ^^^^^^^^
@@ -119,7 +119,7 @@ LL | fn issue_2114(s: String, t: String, u: &Vec<i32>, v: Vec<i32>) {
    |                                        +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:95:53
+  --> tests/ui/needless_pass_by_value.rs:96:53
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                                                     ^^^^^^^^
@@ -136,13 +136,13 @@ LL +     let _ = v.to_owned();
    |
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:113:12
+  --> tests/ui/needless_pass_by_value.rs:114:12
    |
 LL |         s: String,
    |            ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:115:12
+  --> tests/ui/needless_pass_by_value.rs:116:12
    |
 LL |         t: String,
    |            ^^^^^^
@@ -153,7 +153,7 @@ LL |         t: &String,
    |            +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:125:23
+  --> tests/ui/needless_pass_by_value.rs:126:23
    |
 LL |     fn baz(&self, uu: U, ss: Self) {}
    |                       ^
@@ -164,7 +164,7 @@ LL |     fn baz(&self, uu: &U, ss: Self) {}
    |                       +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:125:30
+  --> tests/ui/needless_pass_by_value.rs:126:30
    |
 LL |     fn baz(&self, uu: U, ss: Self) {}
    |                              ^^^^
@@ -175,13 +175,13 @@ LL |     fn baz(&self, uu: U, ss: &Self) {}
    |                              +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:149:24
+  --> tests/ui/needless_pass_by_value.rs:150:24
    |
 LL | fn bar_copy(x: u32, y: CopyWrapper) {
    |                        ^^^^^^^^^^^
    |
 help: or consider marking this type as `Copy`
-  --> tests/ui/needless_pass_by_value.rs:147:1
+  --> tests/ui/needless_pass_by_value.rs:148:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^
@@ -191,13 +191,13 @@ LL | fn bar_copy(x: u32, y: &CopyWrapper) {
    |                        +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:157:29
+  --> tests/ui/needless_pass_by_value.rs:158:29
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                             ^^^^^^^^^^^
    |
 help: or consider marking this type as `Copy`
-  --> tests/ui/needless_pass_by_value.rs:147:1
+  --> tests/ui/needless_pass_by_value.rs:148:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^
@@ -207,13 +207,13 @@ LL | fn test_destructure_copy(x: &CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                             +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:157:45
+  --> tests/ui/needless_pass_by_value.rs:158:45
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                             ^^^^^^^^^^^
    |
 help: or consider marking this type as `Copy`
-  --> tests/ui/needless_pass_by_value.rs:147:1
+  --> tests/ui/needless_pass_by_value.rs:148:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^
@@ -223,13 +223,13 @@ LL | fn test_destructure_copy(x: CopyWrapper, y: &CopyWrapper, z: CopyWrapper) {
    |                                             +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:157:61
+  --> tests/ui/needless_pass_by_value.rs:158:61
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                                             ^^^^^^^^^^^
    |
 help: or consider marking this type as `Copy`
-  --> tests/ui/needless_pass_by_value.rs:147:1
+  --> tests/ui/needless_pass_by_value.rs:148:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^
@@ -239,7 +239,7 @@ LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: &CopyWrapper) {
    |                                                             +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:173:40
+  --> tests/ui/needless_pass_by_value.rs:174:40
    |
 LL | fn some_fun<'b, S: Bar<'b, ()>>(items: S) {}
    |                                        ^
@@ -250,7 +250,7 @@ LL | fn some_fun<'b, S: Bar<'b, ()>>(items: &S) {}
    |                                        +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:179:20
+  --> tests/ui/needless_pass_by_value.rs:180:20
    |
 LL | fn more_fun(items: impl Club<'static, i32>) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ LL | fn more_fun(items: &impl Club<'static, i32>) {}
    |                    +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:194:24
+  --> tests/ui/needless_pass_by_value.rs:195:24
    |
 LL | fn option_inner_ref(x: Option<String>) {
    |                        ^^^^^^^^^^^^^^
@@ -272,7 +272,7 @@ LL | fn option_inner_ref(x: Option<&String>) {
    |                               +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:204:27
+  --> tests/ui/needless_pass_by_value.rs:205:27
    |
 LL | fn non_standard_option(x: non_standard::Option<String>) {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -283,7 +283,7 @@ LL | fn non_standard_option(x: &non_standard::Option<String>) {
    |                           +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:209:22
+  --> tests/ui/needless_pass_by_value.rs:210:22
    |
 LL | fn option_by_name(x: Option<std::option::Option<core::option::Option<non_standard::Option<String>>>>) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -294,7 +294,7 @@ LL | fn option_by_name(x: Option<std::option::Option<core::option::Option<&non_s
    |                                                                      +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:216:18
+  --> tests/ui/needless_pass_by_value.rs:217:18
    |
 LL | fn non_option(x: OptStr) {
    |                  ^^^^^^
@@ -305,7 +305,7 @@ LL | fn non_option(x: &OptStr) {
    |                  +
 
 error: this argument is passed by value, but not consumed in the function body
-  --> tests/ui/needless_pass_by_value.rs:223:25
+  --> tests/ui/needless_pass_by_value.rs:224:25
    |
 LL | fn non_option_either(x: Opt<String>) {
    |                         ^^^^^^^^^^^

--- a/tests/ui/needless_pass_by_value_proc_macro.rs
+++ b/tests/ui/needless_pass_by_value_proc_macro.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 
 #![warn(clippy::needless_pass_by_value)]
+#![allow(clippy::disallowed_names)]
 
 extern crate proc_macro;
 

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -2,6 +2,7 @@
 #![feature(yeet_expr)]
 #![allow(unused)]
 #![allow(
+    clippy::disallowed_names,
     clippy::if_same_then_else,
     clippy::single_match,
     clippy::needless_bool,

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -2,6 +2,7 @@
 #![feature(yeet_expr)]
 #![allow(unused)]
 #![allow(
+    clippy::disallowed_names,
     clippy::if_same_then_else,
     clippy::single_match,
     clippy::needless_bool,

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -1,5 +1,5 @@
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:30:5
+  --> tests/ui/needless_return.rs:31:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:35:5
+  --> tests/ui/needless_return.rs:36:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:41:5
+  --> tests/ui/needless_return.rs:42:5
    |
 LL |     return true;;;
    |     ^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL +     true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:47:5
+  --> tests/ui/needless_return.rs:48:5
    |
 LL |     return true;; ; ;
    |     ^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +     true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:53:9
+  --> tests/ui/needless_return.rs:54:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL +         true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:56:9
+  --> tests/ui/needless_return.rs:57:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +         false
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:63:17
+  --> tests/ui/needless_return.rs:64:17
    |
 LL |         true => return false,
    |                 ^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +         true => false,
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:66:13
+  --> tests/ui/needless_return.rs:67:13
    |
 LL |             return true;
    |             ^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL +             true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:74:9
+  --> tests/ui/needless_return.rs:75:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL +         true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:77:16
+  --> tests/ui/needless_return.rs:78:16
    |
 LL |     let _ = || return true;
    |                ^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL +     let _ = || true;
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:82:5
+  --> tests/ui/needless_return.rs:83:5
    |
 LL |     return the_answer!();
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -133,10 +133,12 @@ LL +     the_answer!()
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:87:5
+  --> tests/ui/needless_return.rs:87:21
    |
-LL |     return;
-   |     ^^^^^^
+LL |   fn test_void_fun() {
+   |  _____________________^
+LL | |     return;
+   | |__________^
    |
 help: remove `return`
    |
@@ -146,10 +148,12 @@ LL + fn test_void_fun() {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:93:9
+  --> tests/ui/needless_return.rs:93:11
    |
-LL |         return;
-   |         ^^^^^^
+LL |       if b {
+   |  ___________^
+LL | |         return;
+   | |______________^
    |
 help: remove `return`
    |
@@ -159,10 +163,12 @@ LL +     if b {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:96:9
+  --> tests/ui/needless_return.rs:96:13
    |
-LL |         return;
-   |         ^^^^^^
+LL |       } else {
+   |  _____________^
+LL | |         return;
+   | |______________^
    |
 help: remove `return`
    |
@@ -172,7 +178,7 @@ LL +     } else {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:104:14
+  --> tests/ui/needless_return.rs:105:14
    |
 LL |         _ => return,
    |              ^^^^^^
@@ -184,10 +190,12 @@ LL +         _ => (),
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:114:13
+  --> tests/ui/needless_return.rs:114:24
    |
-LL |             return;
-   |             ^^^^^^
+LL |               let _ = 42;
+   |  ________________________^
+LL | |             return;
+   | |__________________^
    |
 help: remove `return`
    |
@@ -197,7 +205,7 @@ LL +             let _ = 42;
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:117:14
+  --> tests/ui/needless_return.rs:118:14
    |
 LL |         _ => return,
    |              ^^^^^^
@@ -209,7 +217,7 @@ LL +         _ => (),
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:131:9
+  --> tests/ui/needless_return.rs:132:9
    |
 LL |         return String::from("test");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +229,7 @@ LL +         String::from("test")
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:134:9
+  --> tests/ui/needless_return.rs:135:9
    |
 LL |         return String::new();
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -233,7 +241,7 @@ LL +         String::new()
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:157:32
+  --> tests/ui/needless_return.rs:158:32
    |
 LL |         bar.unwrap_or_else(|_| return)
    |                                ^^^^^^
@@ -245,10 +253,12 @@ LL +         bar.unwrap_or_else(|_| {})
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:163:13
+  --> tests/ui/needless_return.rs:163:21
    |
-LL |             return;
-   |             ^^^^^^
+LL |           let _ = || {
+   |  _____________________^
+LL | |             return;
+   | |__________________^
    |
 help: remove `return`
    |
@@ -258,7 +268,7 @@ LL +         let _ = || {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:166:20
+  --> tests/ui/needless_return.rs:167:20
    |
 LL |         let _ = || return;
    |                    ^^^^^^
@@ -270,7 +280,7 @@ LL +         let _ = || {};
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:173:32
+  --> tests/ui/needless_return.rs:174:32
    |
 LL |         res.unwrap_or_else(|_| return Foo)
    |                                ^^^^^^^^^^
@@ -282,7 +292,7 @@ LL +         res.unwrap_or_else(|_| Foo)
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:183:5
+  --> tests/ui/needless_return.rs:184:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^
@@ -294,7 +304,7 @@ LL +     true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:188:5
+  --> tests/ui/needless_return.rs:189:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^
@@ -306,7 +316,7 @@ LL +     true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:194:9
+  --> tests/ui/needless_return.rs:195:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -318,7 +328,7 @@ LL +         true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:197:9
+  --> tests/ui/needless_return.rs:198:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
@@ -330,7 +340,7 @@ LL +         false
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:204:17
+  --> tests/ui/needless_return.rs:205:17
    |
 LL |         true => return false,
    |                 ^^^^^^^^^^^^
@@ -342,7 +352,7 @@ LL +         true => false,
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:207:13
+  --> tests/ui/needless_return.rs:208:13
    |
 LL |             return true;
    |             ^^^^^^^^^^^
@@ -354,7 +364,7 @@ LL +             true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:215:9
+  --> tests/ui/needless_return.rs:216:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -366,7 +376,7 @@ LL +         true
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:218:16
+  --> tests/ui/needless_return.rs:219:16
    |
 LL |     let _ = || return true;
    |                ^^^^^^^^^^^
@@ -378,7 +388,7 @@ LL +     let _ = || true;
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:223:5
+  --> tests/ui/needless_return.rs:224:5
    |
 LL |     return the_answer!();
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -390,10 +400,12 @@ LL +     the_answer!()
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:228:5
+  --> tests/ui/needless_return.rs:228:33
    |
-LL |     return;
-   |     ^^^^^^
+LL |   async fn async_test_void_fun() {
+   |  _________________________________^
+LL | |     return;
+   | |__________^
    |
 help: remove `return`
    |
@@ -403,10 +415,12 @@ LL + async fn async_test_void_fun() {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:234:9
+  --> tests/ui/needless_return.rs:234:11
    |
-LL |         return;
-   |         ^^^^^^
+LL |       if b {
+   |  ___________^
+LL | |         return;
+   | |______________^
    |
 help: remove `return`
    |
@@ -416,10 +430,12 @@ LL +     if b {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:237:9
+  --> tests/ui/needless_return.rs:237:13
    |
-LL |         return;
-   |         ^^^^^^
+LL |       } else {
+   |  _____________^
+LL | |         return;
+   | |______________^
    |
 help: remove `return`
    |
@@ -429,7 +445,7 @@ LL +     } else {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:245:14
+  --> tests/ui/needless_return.rs:246:14
    |
 LL |         _ => return,
    |              ^^^^^^
@@ -441,7 +457,7 @@ LL +         _ => (),
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:259:9
+  --> tests/ui/needless_return.rs:260:9
    |
 LL |         return String::from("test");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -453,7 +469,7 @@ LL +         String::from("test")
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:262:9
+  --> tests/ui/needless_return.rs:263:9
    |
 LL |         return String::new();
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -465,7 +481,7 @@ LL +         String::new()
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:279:5
+  --> tests/ui/needless_return.rs:280:5
    |
 LL |     return format!("Hello {}", "world!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -477,7 +493,7 @@ LL +     format!("Hello {}", "world!")
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:321:9
+  --> tests/ui/needless_return.rs:322:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -492,7 +508,7 @@ LL ~     }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:324:9
+  --> tests/ui/needless_return.rs:325:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
@@ -505,7 +521,7 @@ LL ~     }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:332:13
+  --> tests/ui/needless_return.rs:333:13
    |
 LL |             return 10;
    |             ^^^^^^^^^
@@ -520,7 +536,7 @@ LL ~     }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:336:13
+  --> tests/ui/needless_return.rs:337:13
    |
 LL |             return 100;
    |             ^^^^^^^^^^
@@ -534,7 +550,7 @@ LL ~     }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:345:9
+  --> tests/ui/needless_return.rs:346:9
    |
 LL |         return 0;
    |         ^^^^^^^^
@@ -547,7 +563,7 @@ LL ~     }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:353:13
+  --> tests/ui/needless_return.rs:354:13
    |
 LL |             return *(x as *const isize);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -563,7 +579,7 @@ LL ~     }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:356:13
+  --> tests/ui/needless_return.rs:357:13
    |
 LL |             return !*(x as *const isize);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -577,10 +593,12 @@ LL ~     }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:365:9
+  --> tests/ui/needless_return.rs:365:20
    |
-LL |         return;
-   |         ^^^^^^
+LL |           let _ = 42;
+   |  ____________________^
+LL | |         return;
+   | |______________^
    |
 help: remove `return`
    |
@@ -590,10 +608,10 @@ LL +         let _ = 42;
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:371:21
+  --> tests/ui/needless_return.rs:372:20
    |
 LL |         let _ = 42; return;
-   |                     ^^^^^^
+   |                    ^^^^^^^
    |
 help: remove `return`
    |
@@ -602,7 +620,7 @@ LL +         let _ = 42;
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:384:9
+  --> tests/ui/needless_return.rs:385:9
    |
 LL |         return Ok(format!("ok!"));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -614,7 +632,7 @@ LL +         Ok(format!("ok!"))
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:387:9
+  --> tests/ui/needless_return.rs:388:9
    |
 LL |         return Err(format!("err!"));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -626,7 +644,7 @@ LL +         Err(format!("err!"))
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:394:9
+  --> tests/ui/needless_return.rs:395:9
    |
 LL |         return if true { 1 } else { 2 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -638,7 +656,7 @@ LL +         if true { 1 } else { 2 }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:399:9
+  --> tests/ui/needless_return.rs:400:9
    |
 LL |         return if b1 { 0 } else { 1 } | if b2 { 2 } else { 3 } | if b3 { 4 } else { 5 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -650,7 +668,7 @@ LL +         (if b1 { 0 } else { 1 } | if b2 { 2 } else { 3 } | if b3 { 4 } else
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:421:5
+  --> tests/ui/needless_return.rs:422:5
    |
 LL |     return { "a".to_string() } + "b" + { "c" };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -662,7 +680,7 @@ LL +     ({ "a".to_string() } + "b" + { "c" })
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:426:5
+  --> tests/ui/needless_return.rs:427:5
    |
 LL |     return "".split("").next().unwrap().to_string();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -674,7 +692,7 @@ LL +     "".split("").next().unwrap().to_string()
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:461:5
+  --> tests/ui/needless_return.rs:462:5
    |
 LL |     return unsafe { todo() } as *const i32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -685,101 +703,5 @@ LL -     return unsafe { todo() } as *const i32;
 LL +     (unsafe { todo() } as *const i32)
    |
 
-error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:468:13
-   |
-LL |             return 1;
-   |             ^^^^^^^^
-   |
-help: remove `return`
-   |
-LL -             return 1;
-LL +             1
-   |
-
-error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:471:13
-   |
-LL |             return 2;
-   |             ^^^^^^^^
-   |
-help: remove `return`
-   |
-LL -             return 2;
-LL +             2
-   |
-
-error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:474:13
-   |
-LL |             return 3;
-   |             ^^^^^^^^
-   |
-help: remove `return`
-   |
-LL -             return 3;
-LL +             3
-   |
-
-error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:481:13
-   |
-LL |             return 1;
-   |             ^^^^^^^^
-   |
-help: remove `return`
-   |
-LL -             return 1;
-LL +             1
-   |
-
-error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:486:13
-   |
-LL |             return 3;
-   |             ^^^^^^^^
-   |
-help: remove `return`
-   |
-LL -             return 3;
-LL +             3
-   |
-
-error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:493:13
-   |
-LL |             return 1;
-   |             ^^^^^^^^
-   |
-help: remove `return`
-   |
-LL -             return 1;
-LL +             1
-   |
-
-error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:498:13
-   |
-LL |             return 3;
-   |             ^^^^^^^^
-   |
-help: remove `return`
-   |
-LL -             return 3;
-LL +             3
-   |
-
-error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:506:13
-   |
-LL |             return 1;
-   |             ^^^^^^^^
-   |
-help: remove `return`
-   |
-LL -             return 1;
-LL +             1
-   |
-
-error: aborting due to 63 previous errors
+error: aborting due to 55 previous errors
 

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -133,12 +133,10 @@ LL +     the_answer!()
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:87:21
+  --> tests/ui/needless_return.rs:88:5
    |
-LL |   fn test_void_fun() {
-   |  _____________________^
-LL | |     return;
-   | |__________^
+LL |     return;
+   |     ^^^^^^
    |
 help: remove `return`
    |
@@ -148,12 +146,10 @@ LL + fn test_void_fun() {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:93:11
+  --> tests/ui/needless_return.rs:94:9
    |
-LL |       if b {
-   |  ___________^
-LL | |         return;
-   | |______________^
+LL |         return;
+   |         ^^^^^^
    |
 help: remove `return`
    |
@@ -163,12 +159,10 @@ LL +     if b {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:96:13
+  --> tests/ui/needless_return.rs:97:9
    |
-LL |       } else {
-   |  _____________^
-LL | |         return;
-   | |______________^
+LL |         return;
+   |         ^^^^^^
    |
 help: remove `return`
    |
@@ -190,12 +184,10 @@ LL +         _ => (),
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:114:24
+  --> tests/ui/needless_return.rs:115:13
    |
-LL |               let _ = 42;
-   |  ________________________^
-LL | |             return;
-   | |__________________^
+LL |             return;
+   |             ^^^^^^
    |
 help: remove `return`
    |
@@ -253,12 +245,10 @@ LL +         bar.unwrap_or_else(|_| {})
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:163:21
+  --> tests/ui/needless_return.rs:164:13
    |
-LL |           let _ = || {
-   |  _____________________^
-LL | |             return;
-   | |__________________^
+LL |             return;
+   |             ^^^^^^
    |
 help: remove `return`
    |
@@ -400,12 +390,10 @@ LL +     the_answer!()
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:228:33
+  --> tests/ui/needless_return.rs:229:5
    |
-LL |   async fn async_test_void_fun() {
-   |  _________________________________^
-LL | |     return;
-   | |__________^
+LL |     return;
+   |     ^^^^^^
    |
 help: remove `return`
    |
@@ -415,12 +403,10 @@ LL + async fn async_test_void_fun() {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:234:11
+  --> tests/ui/needless_return.rs:235:9
    |
-LL |       if b {
-   |  ___________^
-LL | |         return;
-   | |______________^
+LL |         return;
+   |         ^^^^^^
    |
 help: remove `return`
    |
@@ -430,12 +416,10 @@ LL +     if b {
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:237:13
+  --> tests/ui/needless_return.rs:238:9
    |
-LL |       } else {
-   |  _____________^
-LL | |         return;
-   | |______________^
+LL |         return;
+   |         ^^^^^^
    |
 help: remove `return`
    |
@@ -593,12 +577,10 @@ LL ~     }
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:365:20
+  --> tests/ui/needless_return.rs:366:9
    |
-LL |           let _ = 42;
-   |  ____________________^
-LL | |         return;
-   | |______________^
+LL |         return;
+   |         ^^^^^^
    |
 help: remove `return`
    |
@@ -608,10 +590,10 @@ LL +         let _ = 42;
    |
 
 error: unneeded `return` statement
-  --> tests/ui/needless_return.rs:372:20
+  --> tests/ui/needless_return.rs:372:21
    |
 LL |         let _ = 42; return;
-   |                    ^^^^^^^
+   |                     ^^^^^^
    |
 help: remove `return`
    |
@@ -703,5 +685,101 @@ LL -     return unsafe { todo() } as *const i32;
 LL +     (unsafe { todo() } as *const i32)
    |
 
-error: aborting due to 55 previous errors
+error: unneeded `return` statement
+  --> tests/ui/needless_return.rs:469:13
+   |
+LL |             return 1;
+   |             ^^^^^^^^
+   |
+help: remove `return`
+   |
+LL -             return 1;
+LL +             1
+   |
+
+error: unneeded `return` statement
+  --> tests/ui/needless_return.rs:472:13
+   |
+LL |             return 2;
+   |             ^^^^^^^^
+   |
+help: remove `return`
+   |
+LL -             return 2;
+LL +             2
+   |
+
+error: unneeded `return` statement
+  --> tests/ui/needless_return.rs:475:13
+   |
+LL |             return 3;
+   |             ^^^^^^^^
+   |
+help: remove `return`
+   |
+LL -             return 3;
+LL +             3
+   |
+
+error: unneeded `return` statement
+  --> tests/ui/needless_return.rs:482:13
+   |
+LL |             return 1;
+   |             ^^^^^^^^
+   |
+help: remove `return`
+   |
+LL -             return 1;
+LL +             1
+   |
+
+error: unneeded `return` statement
+  --> tests/ui/needless_return.rs:487:13
+   |
+LL |             return 3;
+   |             ^^^^^^^^
+   |
+help: remove `return`
+   |
+LL -             return 3;
+LL +             3
+   |
+
+error: unneeded `return` statement
+  --> tests/ui/needless_return.rs:494:13
+   |
+LL |             return 1;
+   |             ^^^^^^^^
+   |
+help: remove `return`
+   |
+LL -             return 1;
+LL +             1
+   |
+
+error: unneeded `return` statement
+  --> tests/ui/needless_return.rs:499:13
+   |
+LL |             return 3;
+   |             ^^^^^^^^
+   |
+help: remove `return`
+   |
+LL -             return 3;
+LL +             3
+   |
+
+error: unneeded `return` statement
+  --> tests/ui/needless_return.rs:507:13
+   |
+LL |             return 1;
+   |             ^^^^^^^^
+   |
+help: remove `return`
+   |
+LL -             return 1;
+LL +             1
+   |
+
+error: aborting due to 63 previous errors
 

--- a/tests/ui/needless_return_with_question_mark.fixed
+++ b/tests/ui/needless_return_with_question_mark.fixed
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_return,
     clippy::no_effect,
     clippy::unit_arg,

--- a/tests/ui/needless_return_with_question_mark.rs
+++ b/tests/ui/needless_return_with_question_mark.rs
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_return,
     clippy::no_effect,
     clippy::unit_arg,

--- a/tests/ui/needless_return_with_question_mark.stderr
+++ b/tests/ui/needless_return_with_question_mark.stderr
@@ -1,5 +1,5 @@
 error: unneeded `return` statement with `?` operator
-  --> tests/ui/needless_return_with_question_mark.rs:29:5
+  --> tests/ui/needless_return_with_question_mark.rs:30:5
    |
 LL |     return Err(())?;
    |     ^^^^^^^ help: remove it
@@ -8,7 +8,7 @@ LL |     return Err(())?;
    = help: to override `-D warnings` add `#[allow(clippy::needless_return_with_question_mark)]`
 
 error: unneeded `return` statement with `?` operator
-  --> tests/ui/needless_return_with_question_mark.rs:70:9
+  --> tests/ui/needless_return_with_question_mark.rs:71:9
    |
 LL |         return Err(())?;
    |         ^^^^^^^ help: remove it

--- a/tests/ui/no_effect_async_fn.rs
+++ b/tests/ui/no_effect_async_fn.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::no_effect_underscore_binding)]
+#![allow(clippy::disallowed_names)]
 #![no_main]
 
 trait AsyncTrait {

--- a/tests/ui/no_effect_async_fn.stderr
+++ b/tests/ui/no_effect_async_fn.stderr
@@ -1,5 +1,5 @@
 error: binding to `_` prefixed variable with no side-effect
-  --> tests/ui/no_effect_async_fn.rs:20:17
+  --> tests/ui/no_effect_async_fn.rs:21:17
    |
 LL |             let _c = 0;
    |                 ^^
@@ -8,19 +8,19 @@ LL |             let _c = 0;
    = help: to override `-D warnings` add `#[allow(clippy::no_effect_underscore_binding)]`
 
 error: binding to `_` prefixed variable with no side-effect
-  --> tests/ui/no_effect_async_fn.rs:13:13
+  --> tests/ui/no_effect_async_fn.rs:14:13
    |
 LL |         let _a = 0;
    |             ^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> tests/ui/no_effect_async_fn.rs:39:13
+  --> tests/ui/no_effect_async_fn.rs:40:13
    |
 LL |         let _c = 0;
    |             ^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> tests/ui/no_effect_async_fn.rs:32:9
+  --> tests/ui/no_effect_async_fn.rs:33:9
    |
 LL |     let _a = 0;
    |         ^^

--- a/tests/ui/only_used_in_recursion2.rs
+++ b/tests/ui/only_used_in_recursion2.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::only_used_in_recursion)]
+#![allow(clippy::disallowed_names)]
 //@no-rustfix
 fn _with_inner(flag: u32, a: u32, b: u32) -> usize {
     //~^ only_used_in_recursion

--- a/tests/ui/only_used_in_recursion2.stderr
+++ b/tests/ui/only_used_in_recursion2.stderr
@@ -1,11 +1,11 @@
 error: parameter is only used in recursion
-  --> tests/ui/only_used_in_recursion2.rs:3:35
+  --> tests/ui/only_used_in_recursion2.rs:4:35
    |
 LL | fn _with_inner(flag: u32, a: u32, b: u32) -> usize {
    |                                   ^ help: if this is intentional, prefix it with an underscore: `_b`
    |
 note: parameter used here
-  --> tests/ui/only_used_in_recursion2.rs:13:52
+  --> tests/ui/only_used_in_recursion2.rs:14:52
    |
 LL |     if flag == 0 { 0 } else { _with_inner(flag, a, b + x) }
    |                                                    ^
@@ -13,49 +13,49 @@ LL |     if flag == 0 { 0 } else { _with_inner(flag, a, b + x) }
    = help: to override `-D warnings` add `#[allow(clippy::only_used_in_recursion)]`
 
 error: parameter is only used in recursion
-  --> tests/ui/only_used_in_recursion2.rs:6:25
+  --> tests/ui/only_used_in_recursion2.rs:7:25
    |
 LL |     fn inner(flag: u32, a: u32) -> u32 {
    |                         ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: parameter used here
-  --> tests/ui/only_used_in_recursion2.rs:9:47
+  --> tests/ui/only_used_in_recursion2.rs:10:47
    |
 LL |         if flag == 0 { 0 } else { inner(flag, a) }
    |                                               ^
 
 error: parameter is only used in recursion
-  --> tests/ui/only_used_in_recursion2.rs:16:34
+  --> tests/ui/only_used_in_recursion2.rs:17:34
    |
 LL | fn _with_closure(a: Option<u32>, b: u32, f: impl Fn(u32, u32) -> Option<u32>) -> u32 {
    |                                  ^ help: if this is intentional, prefix it with an underscore: `_b`
    |
 note: parameter used here
-  --> tests/ui/only_used_in_recursion2.rs:20:32
+  --> tests/ui/only_used_in_recursion2.rs:21:32
    |
 LL |         _with_closure(Some(x), b, f)
    |                                ^
 
 error: parameter is only used in recursion
-  --> tests/ui/only_used_in_recursion2.rs:68:37
+  --> tests/ui/only_used_in_recursion2.rs:69:37
    |
 LL | fn overwritten_param(flag: u32, mut a: usize) -> usize {
    |                                     ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: parameter used here
-  --> tests/ui/only_used_in_recursion2.rs:78:29
+  --> tests/ui/only_used_in_recursion2.rs:79:29
    |
 LL |     overwritten_param(flag, a)
    |                             ^
 
 error: parameter is only used in recursion
-  --> tests/ui/only_used_in_recursion2.rs:81:32
+  --> tests/ui/only_used_in_recursion2.rs:82:32
    |
 LL | fn field_direct(flag: u32, mut a: (usize,)) -> usize {
    |                                ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: parameter used here
-  --> tests/ui/only_used_in_recursion2.rs:88:32
+  --> tests/ui/only_used_in_recursion2.rs:89:32
    |
 LL |         field_direct(flag - 1, a)
    |                                ^

--- a/tests/ui/option_if_let_else.fixed
+++ b/tests/ui/option_if_let_else.fixed
@@ -6,7 +6,8 @@
     clippy::redundant_locals,
     clippy::manual_midpoint,
     clippy::manual_unwrap_or_default,
-    clippy::manual_unwrap_or
+    clippy::manual_unwrap_or,
+    clippy::disallowed_names
 )]
 
 fn bad1(string: Option<&str>) -> (bool, &str) {

--- a/tests/ui/option_if_let_else.rs
+++ b/tests/ui/option_if_let_else.rs
@@ -6,7 +6,8 @@
     clippy::redundant_locals,
     clippy::manual_midpoint,
     clippy::manual_unwrap_or_default,
-    clippy::manual_unwrap_or
+    clippy::manual_unwrap_or,
+    clippy::disallowed_names
 )]
 
 fn bad1(string: Option<&str>) -> (bool, &str) {

--- a/tests/ui/option_if_let_else.stderr
+++ b/tests/ui/option_if_let_else.stderr
@@ -1,5 +1,5 @@
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:13:5
+  --> tests/ui/option_if_let_else.rs:14:5
    |
 LL | /     if let Some(x) = string {
 LL | |
@@ -13,19 +13,19 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::option_if_let_else)]`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:32:13
+  --> tests/ui/option_if_let_else.rs:33:13
    |
 LL |     let _ = if let Some(s) = *string { s.len() } else { 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.map_or(0, |s| s.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:34:13
+  --> tests/ui/option_if_let_else.rs:35:13
    |
 LL |     let _ = if let Some(s) = &num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:36:13
+  --> tests/ui/option_if_let_else.rs:37:13
    |
 LL |       let _ = if let Some(s) = &mut num {
    |  _____________^
@@ -47,13 +47,13 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:43:13
+  --> tests/ui/option_if_let_else.rs:44:13
    |
 LL |     let _ = if let Some(ref s) = num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:45:13
+  --> tests/ui/option_if_let_else.rs:46:13
    |
 LL |       let _ = if let Some(mut s) = num {
    |  _____________^
@@ -75,7 +75,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:52:13
+  --> tests/ui/option_if_let_else.rs:53:13
    |
 LL |       let _ = if let Some(ref mut s) = num {
    |  _____________^
@@ -97,7 +97,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:62:5
+  --> tests/ui/option_if_let_else.rs:63:5
    |
 LL | /     if let Some(x) = arg {
 LL | |
@@ -118,7 +118,7 @@ LL +     })
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:76:13
+  --> tests/ui/option_if_let_else.rs:77:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -131,7 +131,7 @@ LL | |     };
    | |_____^ help: try: `arg.map_or_else(side_effect, |x| x)`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:86:13
+  --> tests/ui/option_if_let_else.rs:87:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -154,7 +154,7 @@ LL ~     }, |x| x * x * x * x);
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:120:13
+  --> tests/ui/option_if_let_else.rs:121:13
    |
 LL | /             if let Some(idx) = s.find('.') {
 LL | |
@@ -165,7 +165,7 @@ LL | |             }
    | |_____________^ help: try: `s.find('.').map_or_else(|| vec![s.to_string()], |idx| vec![s[..idx].to_string(), s[idx..].to_string()])`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:132:5
+  --> tests/ui/option_if_let_else.rs:133:5
    |
 LL | /     if let Ok(binding) = variable {
 LL | |
@@ -189,13 +189,13 @@ LL +     })
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:157:13
+  --> tests/ui/option_if_let_else.rs:158:13
    |
 LL |     let _ = if let Some(x) = optional { x + 2 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `optional.map_or(5, |x| x + 2)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:168:13
+  --> tests/ui/option_if_let_else.rs:169:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -217,13 +217,13 @@ LL ~         });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:197:13
+  --> tests/ui/option_if_let_else.rs:198:13
    |
 LL |     let _ = if let Some(x) = Some(0) { s.len() + x } else { s.len() };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(0).map_or(s.len(), |x| s.len() + x)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:202:13
+  --> tests/ui/option_if_let_else.rs:203:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -245,7 +245,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:242:13
+  --> tests/ui/option_if_let_else.rs:243:13
    |
 LL |       let _ = match s {
    |  _____________^
@@ -256,7 +256,7 @@ LL | |     };
    | |_____^ help: try: `s.map_or(1, |string| string.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:247:13
+  --> tests/ui/option_if_let_else.rs:248:13
    |
 LL |       let _ = match Some(10) {
    |  _____________^
@@ -267,7 +267,7 @@ LL | |     };
    | |_____^ help: try: `Some(10).map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:254:13
+  --> tests/ui/option_if_let_else.rs:255:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -278,7 +278,7 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:259:13
+  --> tests/ui/option_if_let_else.rs:260:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -289,13 +289,13 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:264:13
+  --> tests/ui/option_if_let_else.rs:265:13
    |
 LL |     let _ = if let Ok(a) = res { a + 1 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:282:17
+  --> tests/ui/option_if_let_else.rs:283:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -306,7 +306,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_ref().map_or(42, |value| do_something(value))`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:290:17
+  --> tests/ui/option_if_let_else.rs:291:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -317,7 +317,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_mut().map_or(42, |value| do_something2(value))`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:314:24
+  --> tests/ui/option_if_let_else.rs:315:24
    |
 LL |       let mut _hashmap = if let Some(hm) = &opt {
    |  ________________________^
@@ -329,7 +329,7 @@ LL | |     };
    | |_____^ help: try: `opt.as_ref().map_or_else(HashMap::new, |hm| hm.clone())`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:321:19
+  --> tests/ui/option_if_let_else.rs:322:19
    |
 LL |     let mut _hm = if let Some(hm) = &opt { hm.clone() } else { new_map!() };
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.as_ref().map_or_else(|| new_map!(), |hm| hm.clone())`

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(
     clippy::borrow_as_ptr,
+    clippy::disallowed_names,
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps,
     clippy::unnecessary_literal_unwrap,

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(
     clippy::borrow_as_ptr,
+    clippy::disallowed_names,
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps,
     clippy::unnecessary_literal_unwrap,

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -1,5 +1,5 @@
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:52:22
+  --> tests/ui/or_fun_call.rs:53:22
    |
 LL |     with_constructor.unwrap_or(make());
    |                      ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(make)`
@@ -8,7 +8,7 @@ LL |     with_constructor.unwrap_or(make());
    = help: to override `-D warnings` add `#[allow(clippy::or_fun_call)]`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:56:14
+  --> tests/ui/or_fun_call.rs:57:14
    |
 LL |     with_new.unwrap_or(Vec::new());
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
@@ -17,199 +17,199 @@ LL |     with_new.unwrap_or(Vec::new());
    = help: to override `-D warnings` add `#[allow(clippy::unwrap_or_default)]`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:60:21
+  --> tests/ui/or_fun_call.rs:61:21
    |
 LL |     with_const_args.unwrap_or(Vec::with_capacity(12));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Vec::with_capacity(12))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:64:14
+  --> tests/ui/or_fun_call.rs:65:14
    |
 LL |     with_err.unwrap_or(make());
    |              ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| make())`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:68:19
+  --> tests/ui/or_fun_call.rs:69:19
    |
 LL |     with_err_args.unwrap_or(Vec::with_capacity(12));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:72:24
+  --> tests/ui/or_fun_call.rs:73:24
    |
 LL |     with_default_trait.unwrap_or(Default::default());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:76:23
+  --> tests/ui/or_fun_call.rs:77:23
    |
 LL |     with_default_type.unwrap_or(u64::default());
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:80:18
+  --> tests/ui/or_fun_call.rs:81:18
    |
 LL |     self_default.unwrap_or(<FakeDefault>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(<FakeDefault>::default)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:84:18
+  --> tests/ui/or_fun_call.rs:85:18
    |
 LL |     real_default.unwrap_or(<FakeDefault as Default>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:88:14
+  --> tests/ui/or_fun_call.rs:89:14
    |
 LL |     with_vec.unwrap_or(vec![]);
    |              ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:92:21
+  --> tests/ui/or_fun_call.rs:93:21
    |
 LL |     without_default.unwrap_or(Foo::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(Foo::new)`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:96:19
+  --> tests/ui/or_fun_call.rs:97:19
    |
 LL |     map.entry(42).or_insert(String::new());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:100:23
+  --> tests/ui/or_fun_call.rs:101:23
    |
 LL |     map_vec.entry(42).or_insert(vec![]);
    |                       ^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:104:21
+  --> tests/ui/or_fun_call.rs:105:21
    |
 LL |     btree.entry(42).or_insert(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:108:25
+  --> tests/ui/or_fun_call.rs:109:25
    |
 LL |     btree_vec.entry(42).or_insert(vec![]);
    |                         ^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:112:21
+  --> tests/ui/or_fun_call.rs:113:21
    |
 LL |     let _ = stringy.unwrap_or(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `ok_or`
-  --> tests/ui/or_fun_call.rs:117:17
+  --> tests/ui/or_fun_call.rs:118:17
    |
 LL |     let _ = opt.ok_or(format!("{} world.", hello));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ok_or_else(|| format!("{} world.", hello))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:122:21
+  --> tests/ui/or_fun_call.rs:123:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:125:21
+  --> tests/ui/or_fun_call.rs:126:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: function call inside of `or`
-  --> tests/ui/or_fun_call.rs:150:35
+  --> tests/ui/or_fun_call.rs:151:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_else(|| Some("b".to_string()))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:193:18
+  --> tests/ui/or_fun_call.rs:191:14
    |
 LL |             None.unwrap_or(ptr_to_ref(s));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:201:14
+  --> tests/ui/or_fun_call.rs:198:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:204:14
+  --> tests/ui/or_fun_call.rs:201:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:280:25
+  --> tests/ui/or_fun_call.rs:277:25
    |
 LL |         let _ = Some(4).map_or(g(), |v| v);
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(g, |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:282:25
+  --> tests/ui/or_fun_call.rs:279:25
    |
 LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:314:18
+  --> tests/ui/or_fun_call.rs:311:18
    |
 LL |         with_new.unwrap_or_else(Vec::new);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:318:28
+  --> tests/ui/or_fun_call.rs:315:28
    |
 LL |         with_default_trait.unwrap_or_else(Default::default);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:322:27
+  --> tests/ui/or_fun_call.rs:319:27
    |
 LL |         with_default_type.unwrap_or_else(u64::default);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:326:22
+  --> tests/ui/or_fun_call.rs:323:22
    |
 LL |         real_default.unwrap_or_else(<FakeDefault as Default>::default);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:330:23
+  --> tests/ui/or_fun_call.rs:327:23
    |
 LL |         map.entry(42).or_insert_with(String::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:334:25
+  --> tests/ui/or_fun_call.rs:331:25
    |
 LL |         btree.entry(42).or_insert_with(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:338:25
+  --> tests/ui/or_fun_call.rs:335:25
    |
 LL |         let _ = stringy.unwrap_or_else(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:380:17
+  --> tests/ui/or_fun_call.rs:377:17
    |
 LL |     let _ = opt.unwrap_or({ f() }); // suggest `.unwrap_or_else(f)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(f)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:385:17
+  --> tests/ui/or_fun_call.rs:382:17
    |
 LL |     let _ = opt.unwrap_or(f() + 1); // suggest `.unwrap_or_else(|| f() + 1)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| f() + 1)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:390:17
+  --> tests/ui/or_fun_call.rs:387:17
    |
 LL |       let _ = opt.unwrap_or({
    |  _________________^
@@ -229,19 +229,19 @@ LL ~     });
    |
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:396:17
+  --> tests/ui/or_fun_call.rs:393:17
    |
 LL |     let _ = opt.map_or(f() + 1, |v| v); // suggest `.map_or_else(|| f() + 1, |v| v)`
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| f() + 1, |v| v)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:401:17
+  --> tests/ui/or_fun_call.rs:398:17
    |
 LL |     let _ = opt.unwrap_or({ i32::default() });
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:408:21
+  --> tests/ui/or_fun_call.rs:405:21
    |
 LL |     let _ = opt_foo.unwrap_or(Foo { val: String::default() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Foo { val: String::default() })`

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -125,91 +125,91 @@ LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_else(|| Some("b".to_string()))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:191:14
+  --> tests/ui/or_fun_call.rs:194:18
    |
 LL |             None.unwrap_or(ptr_to_ref(s));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:198:14
+  --> tests/ui/or_fun_call.rs:202:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:201:14
+  --> tests/ui/or_fun_call.rs:205:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:277:25
+  --> tests/ui/or_fun_call.rs:281:25
    |
 LL |         let _ = Some(4).map_or(g(), |v| v);
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(g, |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:279:25
+  --> tests/ui/or_fun_call.rs:283:25
    |
 LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:311:18
+  --> tests/ui/or_fun_call.rs:315:18
    |
 LL |         with_new.unwrap_or_else(Vec::new);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:315:28
+  --> tests/ui/or_fun_call.rs:319:28
    |
 LL |         with_default_trait.unwrap_or_else(Default::default);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:319:27
+  --> tests/ui/or_fun_call.rs:323:27
    |
 LL |         with_default_type.unwrap_or_else(u64::default);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:323:22
+  --> tests/ui/or_fun_call.rs:327:22
    |
 LL |         real_default.unwrap_or_else(<FakeDefault as Default>::default);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:327:23
+  --> tests/ui/or_fun_call.rs:331:23
    |
 LL |         map.entry(42).or_insert_with(String::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:331:25
+  --> tests/ui/or_fun_call.rs:335:25
    |
 LL |         btree.entry(42).or_insert_with(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:335:25
+  --> tests/ui/or_fun_call.rs:339:25
    |
 LL |         let _ = stringy.unwrap_or_else(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:377:17
+  --> tests/ui/or_fun_call.rs:381:17
    |
 LL |     let _ = opt.unwrap_or({ f() }); // suggest `.unwrap_or_else(f)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(f)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:382:17
+  --> tests/ui/or_fun_call.rs:386:17
    |
 LL |     let _ = opt.unwrap_or(f() + 1); // suggest `.unwrap_or_else(|| f() + 1)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| f() + 1)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:387:17
+  --> tests/ui/or_fun_call.rs:391:17
    |
 LL |       let _ = opt.unwrap_or({
    |  _________________^
@@ -229,19 +229,19 @@ LL ~     });
    |
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:393:17
+  --> tests/ui/or_fun_call.rs:397:17
    |
 LL |     let _ = opt.map_or(f() + 1, |v| v); // suggest `.map_or_else(|| f() + 1, |v| v)`
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| f() + 1, |v| v)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:398:17
+  --> tests/ui/or_fun_call.rs:402:17
    |
 LL |     let _ = opt.unwrap_or({ i32::default() });
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:405:21
+  --> tests/ui/or_fun_call.rs:409:21
    |
 LL |     let _ = opt_foo.unwrap_or(Foo { val: String::default() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Foo { val: String::default() })`

--- a/tests/ui/partialeq_to_none.fixed
+++ b/tests/ui/partialeq_to_none.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op, clippy::needless_if)]
+#![allow(clippy::disallowed_names, clippy::eq_op, clippy::needless_if)]
 
 struct Foobar;
 

--- a/tests/ui/partialeq_to_none.rs
+++ b/tests/ui/partialeq_to_none.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op, clippy::needless_if)]
+#![allow(clippy::disallowed_names, clippy::eq_op, clippy::needless_if)]
 
 struct Foobar;
 

--- a/tests/ui/pattern_type_mismatch/mutability.rs
+++ b/tests/ui/pattern_type_mismatch/mutability.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::pattern_type_mismatch)]
-#![allow(clippy::single_match)]
+#![allow(clippy::disallowed_names, clippy::single_match)]
 
 fn main() {}
 

--- a/tests/ui/pattern_type_mismatch/syntax.rs
+++ b/tests/ui/pattern_type_mismatch/syntax.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::pattern_type_mismatch)]
 #![allow(
+    clippy::disallowed_names,
     clippy::match_ref_pats,
     clippy::never_loop,
     clippy::redundant_pattern_matching,

--- a/tests/ui/pattern_type_mismatch/syntax.stderr
+++ b/tests/ui/pattern_type_mismatch/syntax.stderr
@@ -1,5 +1,5 @@
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:16:9
+  --> tests/ui/pattern_type_mismatch/syntax.rs:17:9
    |
 LL |         Some(_) => (),
    |         ^^^^^^^
@@ -9,7 +9,7 @@ LL |         Some(_) => (),
    = help: to override `-D warnings` add `#[allow(clippy::pattern_type_mismatch)]`
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:36:12
+  --> tests/ui/pattern_type_mismatch/syntax.rs:37:12
    |
 LL |     if let Some(_) = ref_value {}
    |            ^^^^^^^
@@ -17,7 +17,7 @@ LL |     if let Some(_) = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:48:15
+  --> tests/ui/pattern_type_mismatch/syntax.rs:49:15
    |
 LL |     while let Some(_) = ref_value {
    |               ^^^^^^^
@@ -25,7 +25,7 @@ LL |     while let Some(_) = ref_value {
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:68:9
+  --> tests/ui/pattern_type_mismatch/syntax.rs:69:9
    |
 LL |     for (_a, _b) in slice.iter() {}
    |         ^^^^^^^^
@@ -33,7 +33,7 @@ LL |     for (_a, _b) in slice.iter() {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:79:9
+  --> tests/ui/pattern_type_mismatch/syntax.rs:80:9
    |
 LL |     let (_n, _m) = ref_value;
    |         ^^^^^^^^
@@ -41,7 +41,7 @@ LL |     let (_n, _m) = ref_value;
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:89:12
+  --> tests/ui/pattern_type_mismatch/syntax.rs:90:12
    |
 LL |     fn foo((_a, _b): &(i32, i32)) {}
    |            ^^^^^^^^
@@ -49,7 +49,7 @@ LL |     fn foo((_a, _b): &(i32, i32)) {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:104:10
+  --> tests/ui/pattern_type_mismatch/syntax.rs:105:10
    |
 LL |     foo(|(_a, _b)| ());
    |          ^^^^^^^^
@@ -57,7 +57,7 @@ LL |     foo(|(_a, _b)| ());
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:121:9
+  --> tests/ui/pattern_type_mismatch/syntax.rs:122:9
    |
 LL |         Some(_) => (),
    |         ^^^^^^^
@@ -65,7 +65,7 @@ LL |         Some(_) => (),
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:142:17
+  --> tests/ui/pattern_type_mismatch/syntax.rs:143:17
    |
 LL |                 Some(_) => (),
    |                 ^^^^^^^

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -1,6 +1,7 @@
 // rustfix-only-machine-applicable
 #![warn(clippy::redundant_clone)]
 #![allow(
+    clippy::disallowed_names,
     clippy::drop_non_drop,
     clippy::implicit_clone,
     clippy::pathbuf_init_then_push,

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -1,6 +1,7 @@
 // rustfix-only-machine-applicable
 #![warn(clippy::redundant_clone)]
 #![allow(
+    clippy::disallowed_names,
     clippy::drop_non_drop,
     clippy::implicit_clone,
     clippy::pathbuf_init_then_push,

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -1,11 +1,11 @@
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:15:42
+  --> tests/ui/redundant_clone.rs:16:42
    |
 LL |     let _s = ["lorem", "ipsum"].join(" ").to_string();
    |                                          ^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:15:14
+  --> tests/ui/redundant_clone.rs:16:14
    |
 LL |     let _s = ["lorem", "ipsum"].join(" ").to_string();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,169 +13,169 @@ LL |     let _s = ["lorem", "ipsum"].join(" ").to_string();
    = help: to override `-D warnings` add `#[allow(clippy::redundant_clone)]`
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:19:15
+  --> tests/ui/redundant_clone.rs:20:15
    |
 LL |     let _s = s.clone();
    |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:19:14
+  --> tests/ui/redundant_clone.rs:20:14
    |
 LL |     let _s = s.clone();
    |              ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:23:15
+  --> tests/ui/redundant_clone.rs:24:15
    |
 LL |     let _s = s.to_string();
    |               ^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:23:14
+  --> tests/ui/redundant_clone.rs:24:14
    |
 LL |     let _s = s.to_string();
    |              ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:27:15
+  --> tests/ui/redundant_clone.rs:28:15
    |
 LL |     let _s = s.to_owned();
    |               ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:27:14
+  --> tests/ui/redundant_clone.rs:28:14
    |
 LL |     let _s = s.to_owned();
    |              ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:30:42
+  --> tests/ui/redundant_clone.rs:31:42
    |
 LL |     let _s = Path::new("/a/b/").join("c").to_owned();
    |                                          ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:30:14
+  --> tests/ui/redundant_clone.rs:31:14
    |
 LL |     let _s = Path::new("/a/b/").join("c").to_owned();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:33:42
+  --> tests/ui/redundant_clone.rs:34:42
    |
 LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
    |                                          ^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:33:14
+  --> tests/ui/redundant_clone.rs:34:14
    |
 LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:36:29
+  --> tests/ui/redundant_clone.rs:37:29
    |
 LL |     let _s = OsString::new().to_owned();
    |                             ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:36:14
+  --> tests/ui/redundant_clone.rs:37:14
    |
 LL |     let _s = OsString::new().to_owned();
    |              ^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:39:29
+  --> tests/ui/redundant_clone.rs:40:29
    |
 LL |     let _s = OsString::new().to_os_string();
    |                             ^^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:39:14
+  --> tests/ui/redundant_clone.rs:40:14
    |
 LL |     let _s = OsString::new().to_os_string();
    |              ^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:51:19
+  --> tests/ui/redundant_clone.rs:52:19
    |
 LL |     let _t = tup.0.clone();
    |                   ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:51:14
+  --> tests/ui/redundant_clone.rs:52:14
    |
 LL |     let _t = tup.0.clone();
    |              ^^^^^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:84:25
+  --> tests/ui/redundant_clone.rs:85:25
    |
 LL |     if b { (a.clone(), a.clone()) } else { (Alpha, a) }
    |                         ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:84:24
+  --> tests/ui/redundant_clone.rs:85:24
    |
 LL |     if b { (a.clone(), a.clone()) } else { (Alpha, a) }
    |                        ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:142:15
+  --> tests/ui/redundant_clone.rs:143:15
    |
 LL |     let _s = s.clone();
    |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:142:14
+  --> tests/ui/redundant_clone.rs:143:14
    |
 LL |     let _s = s.clone();
    |              ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:144:15
+  --> tests/ui/redundant_clone.rs:145:15
    |
 LL |     let _t = t.clone();
    |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:144:14
+  --> tests/ui/redundant_clone.rs:145:14
    |
 LL |     let _t = t.clone();
    |              ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:155:19
+  --> tests/ui/redundant_clone.rs:156:19
    |
 LL |         let _f = f.clone();
    |                   ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:155:18
+  --> tests/ui/redundant_clone.rs:156:18
    |
 LL |         let _f = f.clone();
    |                  ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:168:14
+  --> tests/ui/redundant_clone.rs:169:14
    |
 LL |     let y = x.clone().join("matthias");
    |              ^^^^^^^^ help: remove this
    |
 note: cloned value is neither consumed nor mutated
-  --> tests/ui/redundant_clone.rs:168:13
+  --> tests/ui/redundant_clone.rs:169:13
    |
 LL |     let y = x.clone().join("matthias");
    |             ^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:223:11
+  --> tests/ui/redundant_clone.rs:224:11
    |
 LL |     foo(&x.clone(), move || {
    |           ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:223:10
+  --> tests/ui/redundant_clone.rs:224:10
    |
 LL |     foo(&x.clone(), move || {
    |          ^

--- a/tests/ui/redundant_closure_call_fixable.fixed
+++ b/tests/ui/redundant_closure_call_fixable.fixed
@@ -1,6 +1,5 @@
 #![warn(clippy::redundant_closure_call)]
-#![allow(clippy::redundant_async_block)]
-#![allow(clippy::type_complexity)]
+#![allow(clippy::disallowed_names, clippy::redundant_async_block, clippy::type_complexity)]
 #![allow(unused)]
 
 async fn something() -> u32 {

--- a/tests/ui/redundant_closure_call_fixable.rs
+++ b/tests/ui/redundant_closure_call_fixable.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::redundant_closure_call)]
-#![allow(clippy::redundant_async_block)]
-#![allow(clippy::type_complexity)]
+#![allow(clippy::disallowed_names, clippy::redundant_async_block, clippy::type_complexity)]
 #![allow(unused)]
 
 async fn something() -> u32 {

--- a/tests/ui/redundant_closure_call_fixable.stderr
+++ b/tests/ui/redundant_closure_call_fixable.stderr
@@ -1,5 +1,5 @@
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:15:13
+  --> tests/ui/redundant_closure_call_fixable.rs:14:13
    |
 LL |     let a = (|| 42)();
    |             ^^^^^^^^^ help: try doing something like: `42`
@@ -8,7 +8,7 @@ LL |     let a = (|| 42)();
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_call)]`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:17:13
+  --> tests/ui/redundant_closure_call_fixable.rs:16:13
    |
 LL |       let b = (async || {
    |  _____________^
@@ -30,7 +30,7 @@ LL ~     };
    |
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:23:13
+  --> tests/ui/redundant_closure_call_fixable.rs:22:13
    |
 LL |       let c = (|| {
    |  _____________^
@@ -52,13 +52,13 @@ LL ~     };
    |
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:29:13
+  --> tests/ui/redundant_closure_call_fixable.rs:28:13
    |
 LL |     let d = (async || something().await)();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async { something().await }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:39:13
+  --> tests/ui/redundant_closure_call_fixable.rs:38:13
    |
 LL |             (|| m!())()
    |             ^^^^^^^^^^^ help: try doing something like: `m!()`
@@ -69,7 +69,7 @@ LL |     m2!();
    = note: this error originates in the macro `m2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:34:13
+  --> tests/ui/redundant_closure_call_fixable.rs:33:13
    |
 LL |             (|| 0)()
    |             ^^^^^^^^ help: try doing something like: `0`
@@ -80,67 +80,67 @@ LL |     m2!();
    = note: this error originates in the macro `m` which comes from the expansion of the macro `m2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:49:16
+  --> tests/ui/redundant_closure_call_fixable.rs:48:16
    |
 LL |     assert_eq!((|| || 43)()(), 42);
    |                ^^^^^^^^^^^^^^ help: try doing something like: `43`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:59:10
+  --> tests/ui/redundant_closure_call_fixable.rs:58:10
    |
 LL |     dbg!((|| 42)());
    |          ^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:63:13
+  --> tests/ui/redundant_closure_call_fixable.rs:62:13
    |
 LL |     let a = (|| || || 123)();
    |             ^^^^^^^^^^^^^^^^ help: try doing something like: `(|| || 123)`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:68:13
+  --> tests/ui/redundant_closure_call_fixable.rs:67:13
    |
 LL |     let a = (|| || || || async || 1)()()()()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async { 1 }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:78:13
+  --> tests/ui/redundant_closure_call_fixable.rs:77:13
    |
 LL |     let a = (|| echo!(|| echo!(|| 1)))()()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `1`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:81:13
+  --> tests/ui/redundant_closure_call_fixable.rs:80:13
    |
 LL |     let a = (|| echo!((|| 123)))()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `123`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:95:11
+  --> tests/ui/redundant_closure_call_fixable.rs:94:11
    |
 LL |     bar()((|| || 42)()(), 5);
    |           ^^^^^^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:97:9
+  --> tests/ui/redundant_closure_call_fixable.rs:96:9
    |
 LL |     foo((|| || 42)()(), 5);
    |         ^^^^^^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:102:5
+  --> tests/ui/redundant_closure_call_fixable.rs:101:5
    |
 LL |     (|| async {})().await;
    |     ^^^^^^^^^^^^^^^ help: try doing something like: `async {}`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:112:18
+  --> tests/ui/redundant_closure_call_fixable.rs:111:18
    |
 LL |         spawn_on((|| async move {})());
    |                  ^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async move {}`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:118:28
+  --> tests/ui/redundant_closure_call_fixable.rs:117:28
    |
 LL |     std::convert::identity((|| 13_i32 + 36_i32)()).leading_zeros();
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `13_i32 + 36_i32`

--- a/tests/ui/redundant_else.fixed
+++ b/tests/ui/redundant_else.fixed
@@ -1,5 +1,10 @@
 #![warn(clippy::redundant_else)]
-#![allow(clippy::needless_return, clippy::if_same_then_else, clippy::needless_late_init)]
+#![allow(
+    clippy::needless_return,
+    clippy::if_same_then_else,
+    clippy::needless_late_init,
+    clippy::disallowed_names
+)]
 
 fn main() {
     loop {

--- a/tests/ui/redundant_else.rs
+++ b/tests/ui/redundant_else.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::redundant_else)]
-#![allow(clippy::needless_return, clippy::if_same_then_else, clippy::needless_late_init)]
+#![allow(
+    clippy::needless_return,
+    clippy::if_same_then_else,
+    clippy::needless_late_init,
+    clippy::disallowed_names
+)]
 
 fn main() {
     loop {

--- a/tests/ui/redundant_else.stderr
+++ b/tests/ui/redundant_else.stderr
@@ -1,5 +1,5 @@
 error: redundant else block
-  --> tests/ui/redundant_else.rs:10:10
+  --> tests/ui/redundant_else.rs:15:10
    |
 LL |           } else {
    |  __________^
@@ -20,7 +20,7 @@ LL +         println!("yet don't pull down your hedge.");
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:19:10
+  --> tests/ui/redundant_else.rs:24:10
    |
 LL |           } else {
    |  __________^
@@ -39,7 +39,7 @@ LL +         println!("shall rise up with fleas.");
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:30:10
+  --> tests/ui/redundant_else.rs:35:10
    |
 LL |           } else {
    |  __________^
@@ -58,7 +58,7 @@ LL +         println!("You may delay, but time will not.");
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:41:6
+  --> tests/ui/redundant_else.rs:46:6
    |
 LL |       } else {
    |  ______^
@@ -77,7 +77,7 @@ LL +     println!("A fat kitchen makes a lean will.");
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:50:10
+  --> tests/ui/redundant_else.rs:55:10
    |
 LL |           } else {
    |  __________^
@@ -96,7 +96,7 @@ LL +         1
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:62:10
+  --> tests/ui/redundant_else.rs:67:10
    |
 LL |           } else {
    |  __________^
@@ -115,7 +115,7 @@ LL +         2
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:73:10
+  --> tests/ui/redundant_else.rs:78:10
    |
 LL |           } else {
    |  __________^

--- a/tests/ui/redundant_field_names.fixed
+++ b/tests/ui/redundant_field_names.fixed
@@ -1,6 +1,12 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::redundant_field_names)]
-#![allow(clippy::extra_unused_type_parameters, clippy::no_effect, dead_code, unused_variables)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::extra_unused_type_parameters,
+    clippy::no_effect,
+    dead_code,
+    unused_variables
+)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -1,6 +1,12 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::redundant_field_names)]
-#![allow(clippy::extra_unused_type_parameters, clippy::no_effect, dead_code, unused_variables)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::extra_unused_type_parameters,
+    clippy::no_effect,
+    dead_code,
+    unused_variables
+)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/redundant_field_names.stderr
+++ b/tests/ui/redundant_field_names.stderr
@@ -1,5 +1,5 @@
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:33:9
+  --> tests/ui/redundant_field_names.rs:39:9
    |
 LL |         gender: gender,
    |         ^^^^^^^^^^^^^^ help: replace it with: `gender`
@@ -8,43 +8,43 @@ LL |         gender: gender,
    = help: to override `-D warnings` add `#[allow(clippy::redundant_field_names)]`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:35:9
+  --> tests/ui/redundant_field_names.rs:41:9
    |
 LL |         age: age,
    |         ^^^^^^^^ help: replace it with: `age`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:56:25
+  --> tests/ui/redundant_field_names.rs:62:25
    |
 LL |     let _ = RangeFrom { start: start };
    |                         ^^^^^^^^^^^^ help: replace it with: `start`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:58:23
+  --> tests/ui/redundant_field_names.rs:64:23
    |
 LL |     let _ = RangeTo { end: end };
    |                       ^^^^^^^^ help: replace it with: `end`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:60:21
+  --> tests/ui/redundant_field_names.rs:66:21
    |
 LL |     let _ = Range { start: start, end: end };
    |                     ^^^^^^^^^^^^ help: replace it with: `start`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:60:35
+  --> tests/ui/redundant_field_names.rs:66:35
    |
 LL |     let _ = Range { start: start, end: end };
    |                                   ^^^^^^^^ help: replace it with: `end`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:64:32
+  --> tests/ui/redundant_field_names.rs:70:32
    |
 LL |     let _ = RangeToInclusive { end: end };
    |                                ^^^^^^^^ help: replace it with: `end`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:77:25
+  --> tests/ui/redundant_field_names.rs:83:25
    |
 LL |             let _ = S { v: v };
    |                         ^^^^ help: replace it with: `v`
@@ -55,7 +55,7 @@ LL |     internal!(v);
    = note: this error originates in the macro `internal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:106:25
+  --> tests/ui/redundant_field_names.rs:112:25
    |
 LL |     let _ = RangeFrom { start: start };
    |                         ^^^^^^^^^^^^ help: replace it with: `start`

--- a/tests/ui/redundant_locals.rs
+++ b/tests/ui/redundant_locals.rs
@@ -1,5 +1,10 @@
 //@aux-build:proc_macros.rs
-#![allow(unused, clippy::no_effect, clippy::needless_pass_by_ref_mut)]
+#![allow(
+    unused,
+    clippy::disallowed_names,
+    clippy::no_effect,
+    clippy::needless_pass_by_ref_mut
+)]
 #![warn(clippy::redundant_locals)]
 #![feature(coroutines, stmt_expr_attributes)]
 

--- a/tests/ui/redundant_locals.stderr
+++ b/tests/ui/redundant_locals.stderr
@@ -1,11 +1,11 @@
 error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:13:5
+  --> tests/ui/redundant_locals.rs:18:5
    |
 LL |     let x = x;
    |     ^^^^^^^^^^
    |
 help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:12:9
+  --> tests/ui/redundant_locals.rs:17:9
    |
 LL |     let x = 1;
    |         ^
@@ -13,67 +13,31 @@ LL |     let x = 1;
    = help: to override `-D warnings` add `#[allow(clippy::redundant_locals)]`
 
 error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:19:5
+  --> tests/ui/redundant_locals.rs:24:5
    |
 LL |     let mut x = x;
    |     ^^^^^^^^^^^^^^
    |
 help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:18:9
+  --> tests/ui/redundant_locals.rs:23:9
    |
 LL |     let mut x = 1;
    |         ^^^^^
 
 error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:50:5
+  --> tests/ui/redundant_locals.rs:55:5
    |
 LL |     let x = x;
    |     ^^^^^^^^^^
    |
 help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:49:14
+  --> tests/ui/redundant_locals.rs:54:14
    |
 LL | fn parameter(x: i32) {
    |              ^
 
 error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:56:5
-   |
-LL |     let x = x;
-   |     ^^^^^^^^^^
-   |
-help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:55:9
-   |
-LL |     let x = 1;
-   |         ^
-
-error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:58:5
-   |
-LL |     let x = x;
-   |     ^^^^^^^^^^
-   |
-help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:56:9
-   |
-LL |     let x = x;
-   |         ^
-
-error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:60:5
-   |
-LL |     let x = x;
-   |     ^^^^^^^^^^
-   |
-help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:58:9
-   |
-LL |     let x = x;
-   |         ^
-
-error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:62:5
+  --> tests/ui/redundant_locals.rs:61:5
    |
 LL |     let x = x;
    |     ^^^^^^^^^^
@@ -81,89 +45,125 @@ LL |     let x = x;
 help: `x` is initially defined here
   --> tests/ui/redundant_locals.rs:60:9
    |
+LL |     let x = 1;
+   |         ^
+
+error: redundant redefinition of a binding `x`
+  --> tests/ui/redundant_locals.rs:63:5
+   |
+LL |     let x = x;
+   |     ^^^^^^^^^^
+   |
+help: `x` is initially defined here
+  --> tests/ui/redundant_locals.rs:61:9
+   |
+LL |     let x = x;
+   |         ^
+
+error: redundant redefinition of a binding `x`
+  --> tests/ui/redundant_locals.rs:65:5
+   |
+LL |     let x = x;
+   |     ^^^^^^^^^^
+   |
+help: `x` is initially defined here
+  --> tests/ui/redundant_locals.rs:63:9
+   |
+LL |     let x = x;
+   |         ^
+
+error: redundant redefinition of a binding `x`
+  --> tests/ui/redundant_locals.rs:67:5
+   |
+LL |     let x = x;
+   |     ^^^^^^^^^^
+   |
+help: `x` is initially defined here
+  --> tests/ui/redundant_locals.rs:65:9
+   |
 LL |     let x = x;
    |         ^
 
 error: redundant redefinition of a binding `a`
-  --> tests/ui/redundant_locals.rs:69:5
+  --> tests/ui/redundant_locals.rs:74:5
    |
 LL |     let a = a;
    |     ^^^^^^^^^^
    |
 help: `a` is initially defined here
-  --> tests/ui/redundant_locals.rs:67:9
+  --> tests/ui/redundant_locals.rs:72:9
    |
 LL |     let a = 1;
    |         ^
 
 error: redundant redefinition of a binding `b`
-  --> tests/ui/redundant_locals.rs:71:5
+  --> tests/ui/redundant_locals.rs:76:5
    |
 LL |     let b = b;
    |     ^^^^^^^^^^
    |
 help: `b` is initially defined here
-  --> tests/ui/redundant_locals.rs:68:9
+  --> tests/ui/redundant_locals.rs:73:9
    |
 LL |     let b = 2;
    |         ^
 
 error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:78:9
+  --> tests/ui/redundant_locals.rs:83:9
    |
 LL |         let x = x;
    |         ^^^^^^^^^^
    |
 help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:77:13
+  --> tests/ui/redundant_locals.rs:82:13
    |
 LL |         let x = 1;
    |             ^
 
 error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:86:9
+  --> tests/ui/redundant_locals.rs:91:9
    |
 LL |         let x = x;
    |         ^^^^^^^^^^
    |
 help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:85:13
+  --> tests/ui/redundant_locals.rs:90:13
    |
 LL |         let x = 1;
    |             ^
 
 error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:90:9
+  --> tests/ui/redundant_locals.rs:95:9
    |
 LL |         let x = x;
    |         ^^^^^^^^^^
    |
 help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:89:6
+  --> tests/ui/redundant_locals.rs:94:6
    |
 LL |     |x: i32| {
    |      ^
 
 error: redundant redefinition of a binding `x`
-  --> tests/ui/redundant_locals.rs:110:9
+  --> tests/ui/redundant_locals.rs:115:9
    |
 LL |         let x = x;
    |         ^^^^^^^^^^
    |
 help: `x` is initially defined here
-  --> tests/ui/redundant_locals.rs:107:9
+  --> tests/ui/redundant_locals.rs:112:9
    |
 LL |     let x = 1;
    |         ^
 
 error: redundant redefinition of a binding `a`
-  --> tests/ui/redundant_locals.rs:166:5
+  --> tests/ui/redundant_locals.rs:171:5
    |
 LL |     let a = a;
    |     ^^^^^^^^^^
    |
 help: `a` is initially defined here
-  --> tests/ui/redundant_locals.rs:164:9
+  --> tests/ui/redundant_locals.rs:169:9
    |
 LL |     let a = WithoutDrop(1);
    |         ^

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -1,6 +1,7 @@
 #![feature(if_let_guard)]
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_bool,
     clippy::needless_if,
     clippy::match_like_matches_macro,

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -1,6 +1,7 @@
 #![feature(if_let_guard)]
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_bool,
     clippy::needless_if,
     clippy::match_like_matches_macro,

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:12:5
+  --> tests/ui/redundant_pattern_matching_option.rs:13:5
    |
 LL |     matches!(maybe_some, None if !boolean)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_some.is_none() && (!boolean)`
@@ -8,55 +8,55 @@ LL |     matches!(maybe_some, None if !boolean)
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:17:13
+  --> tests/ui/redundant_pattern_matching_option.rs:18:13
    |
 LL |     let _ = matches!(maybe_some, None if boolean || boolean2); // guard needs parentheses
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_some.is_none() && (boolean || boolean2)`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:33:12
+  --> tests/ui/redundant_pattern_matching_option.rs:34:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:36:12
+  --> tests/ui/redundant_pattern_matching_option.rs:37:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:39:12
+  --> tests/ui/redundant_pattern_matching_option.rs:40:12
    |
 LL |     if let Some(_) = Some(42) {
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:46:15
+  --> tests/ui/redundant_pattern_matching_option.rs:47:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:49:15
+  --> tests/ui/redundant_pattern_matching_option.rs:50:15
    |
 LL |     while let None = Some(42) {}
    |     ----------^^^^----------- help: try: `while Some(42).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:52:15
+  --> tests/ui/redundant_pattern_matching_option.rs:53:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:56:15
+  --> tests/ui/redundant_pattern_matching_option.rs:57:15
    |
 LL |     while let Some(_) = v.pop() {
    |     ----------^^^^^^^---------- help: try: `while v.pop().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:65:5
+  --> tests/ui/redundant_pattern_matching_option.rs:66:5
    |
 LL | /     match Some(42) {
 LL | |
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:71:5
+  --> tests/ui/redundant_pattern_matching_option.rs:72:5
    |
 LL | /     match None::<()> {
 LL | |
@@ -76,7 +76,7 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:77:13
+  --> tests/ui/redundant_pattern_matching_option.rs:78:13
    |
 LL |       let _ = match None::<()> {
    |  _____________^
@@ -87,55 +87,55 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:84:20
+  --> tests/ui/redundant_pattern_matching_option.rs:85:20
    |
 LL |     let _ = if let Some(_) = opt { true } else { false };
    |             -------^^^^^^^------ help: try: `if opt.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:91:20
+  --> tests/ui/redundant_pattern_matching_option.rs:92:20
    |
 LL |     let _ = if let Some(_) = gen_opt() {
    |             -------^^^^^^^------------ help: try: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:94:19
+  --> tests/ui/redundant_pattern_matching_option.rs:95:19
    |
 LL |     } else if let None = gen_opt() {
    |            -------^^^^------------ help: try: `if gen_opt().is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:101:12
+  --> tests/ui/redundant_pattern_matching_option.rs:102:12
    |
 LL |     if let Some(..) = gen_opt() {}
    |     -------^^^^^^^^------------ help: try: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:117:12
+  --> tests/ui/redundant_pattern_matching_option.rs:118:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:120:12
+  --> tests/ui/redundant_pattern_matching_option.rs:121:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:123:15
+  --> tests/ui/redundant_pattern_matching_option.rs:124:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:126:15
+  --> tests/ui/redundant_pattern_matching_option.rs:127:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:129:5
+  --> tests/ui/redundant_pattern_matching_option.rs:130:5
    |
 LL | /     match Some(42) {
 LL | |
@@ -145,7 +145,7 @@ LL | |     };
    | |_____^ help: try: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:135:5
+  --> tests/ui/redundant_pattern_matching_option.rs:136:5
    |
 LL | /     match None::<()> {
 LL | |
@@ -155,19 +155,19 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:144:12
+  --> tests/ui/redundant_pattern_matching_option.rs:145:12
    |
 LL |     if let None = *(&None::<()>) {}
    |     -------^^^^----------------- help: try: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:146:12
+  --> tests/ui/redundant_pattern_matching_option.rs:147:12
    |
 LL |     if let None = *&None::<()> {}
    |     -------^^^^--------------- help: try: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:153:5
+  --> tests/ui/redundant_pattern_matching_option.rs:154:5
    |
 LL | /     match x {
 LL | |
@@ -177,7 +177,7 @@ LL | |     };
    | |_____^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:159:5
+  --> tests/ui/redundant_pattern_matching_option.rs:160:5
    |
 LL | /     match x {
 LL | |
@@ -187,7 +187,7 @@ LL | |     };
    | |_____^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:165:5
+  --> tests/ui/redundant_pattern_matching_option.rs:166:5
    |
 LL | /     match x {
 LL | |
@@ -197,7 +197,7 @@ LL | |     };
    | |_____^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:171:5
+  --> tests/ui/redundant_pattern_matching_option.rs:172:5
    |
 LL | /     match x {
 LL | |
@@ -207,19 +207,19 @@ LL | |     };
    | |_____^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:187:13
+  --> tests/ui/redundant_pattern_matching_option.rs:188:13
    |
 LL |     let _ = matches!(x, Some(_));
    |             ^^^^^^^^^^^^^^^^^^^^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:190:13
+  --> tests/ui/redundant_pattern_matching_option.rs:191:13
    |
 LL |     let _ = matches!(x, None);
    |             ^^^^^^^^^^^^^^^^^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:201:17
+  --> tests/ui/redundant_pattern_matching_option.rs:202:17
    |
 LL |         let _ = matches!(*p, None);
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `(*p).is_none()`

--- a/tests/ui/redundant_pattern_matching_poll.fixed
+++ b/tests/ui/redundant_pattern_matching_poll.fixed
@@ -1,5 +1,6 @@
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_bool,
     clippy::needless_if,
     clippy::match_like_matches_macro,

--- a/tests/ui/redundant_pattern_matching_poll.rs
+++ b/tests/ui/redundant_pattern_matching_poll.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
+    clippy::disallowed_names,
     clippy::needless_bool,
     clippy::needless_if,
     clippy::match_like_matches_macro,

--- a/tests/ui/redundant_pattern_matching_poll.stderr
+++ b/tests/ui/redundant_pattern_matching_poll.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:13:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:14:12
    |
 LL |     if let Pending = Pending::<()> {}
    |     -------^^^^^^^---------------- help: try: `if Pending::<()>.is_pending()`
@@ -8,49 +8,49 @@ LL |     if let Pending = Pending::<()> {}
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:16:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:17:12
    |
 LL |     if let Ready(_) = Ready(42) {}
    |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:19:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:20:12
    |
 LL |     if let Ready(_) = Ready(42) {
    |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:27:8
+  --> tests/ui/redundant_pattern_matching_poll.rs:28:8
    |
 LL |     if matches!(Ready(42), Ready(_)) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:31:8
+  --> tests/ui/redundant_pattern_matching_poll.rs:32:8
    |
 LL |     if matches!(Pending::<()>, Pending) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:34:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:35:15
    |
 LL |     while let Ready(_) = Ready(42) {}
    |     ----------^^^^^^^^------------ help: try: `while Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:37:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:38:15
    |
 LL |     while let Pending = Ready(42) {}
    |     ----------^^^^^^^------------ help: try: `while Ready(42).is_pending()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:40:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:41:15
    |
 LL |     while let Pending = Pending::<()> {}
    |     ----------^^^^^^^---------------- help: try: `while Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:47:5
+  --> tests/ui/redundant_pattern_matching_poll.rs:48:5
    |
 LL | /     match Ready(42) {
 LL | |
@@ -60,7 +60,7 @@ LL | |     };
    | |_____^ help: try: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:53:5
+  --> tests/ui/redundant_pattern_matching_poll.rs:54:5
    |
 LL | /     match Pending::<()> {
 LL | |
@@ -70,7 +70,7 @@ LL | |     };
    | |_____^ help: try: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:59:13
+  --> tests/ui/redundant_pattern_matching_poll.rs:60:13
    |
 LL |       let _ = match Pending::<()> {
    |  _____________^
@@ -81,49 +81,49 @@ LL | |     };
    | |_____^ help: try: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:66:20
+  --> tests/ui/redundant_pattern_matching_poll.rs:67:20
    |
 LL |     let _ = if let Ready(_) = poll { true } else { false };
    |             -------^^^^^^^^------- help: try: `if poll.is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:71:20
+  --> tests/ui/redundant_pattern_matching_poll.rs:72:20
    |
 LL |     let _ = if let Ready(_) = gen_poll() {
    |             -------^^^^^^^^------------- help: try: `if gen_poll().is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:74:19
+  --> tests/ui/redundant_pattern_matching_poll.rs:75:19
    |
 LL |     } else if let Pending = gen_poll() {
    |            -------^^^^^^^------------- help: try: `if gen_poll().is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:91:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:92:12
    |
 LL |     if let Ready(_) = Ready(42) {}
    |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:94:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:95:12
    |
 LL |     if let Pending = Pending::<()> {}
    |     -------^^^^^^^---------------- help: try: `if Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:97:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:98:15
    |
 LL |     while let Ready(_) = Ready(42) {}
    |     ----------^^^^^^^^------------ help: try: `while Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:100:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:101:15
    |
 LL |     while let Pending = Pending::<()> {}
    |     ----------^^^^^^^---------------- help: try: `while Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:103:5
+  --> tests/ui/redundant_pattern_matching_poll.rs:104:5
    |
 LL | /     match Ready(42) {
 LL | |
@@ -133,7 +133,7 @@ LL | |     };
    | |_____^ help: try: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:109:5
+  --> tests/ui/redundant_pattern_matching_poll.rs:110:5
    |
 LL | /     match Pending::<()> {
 LL | |

--- a/tests/ui/ref_as_ptr.fixed
+++ b/tests/ui/ref_as_ptr.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::ref_as_ptr)]
-#![allow(clippy::unnecessary_mut_passed, clippy::needless_lifetimes)]
+#![allow(clippy::unnecessary_mut_passed, clippy::needless_lifetimes, clippy::disallowed_names)]
 
 fn f<T>(_: T) {}
 

--- a/tests/ui/ref_as_ptr.rs
+++ b/tests/ui/ref_as_ptr.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::ref_as_ptr)]
-#![allow(clippy::unnecessary_mut_passed, clippy::needless_lifetimes)]
+#![allow(clippy::unnecessary_mut_passed, clippy::needless_lifetimes, clippy::disallowed_names)]
 
 fn f<T>(_: T) {}
 

--- a/tests/ui/ref_option_ref.rs
+++ b/tests/ui/ref_option_ref.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::ref_option_ref)]
 //@no-rustfix
 // This lint is not tagged as run-rustfix because automatically

--- a/tests/ui/return_and_then.fixed
+++ b/tests/ui/return_and_then.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::return_and_then)]
+#![allow(clippy::disallowed_names)]
 
 fn main() {
     fn test_opt_block(opt: Option<i32>) -> Option<i32> {

--- a/tests/ui/return_and_then.rs
+++ b/tests/ui/return_and_then.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::return_and_then)]
+#![allow(clippy::disallowed_names)]
 
 fn main() {
     fn test_opt_block(opt: Option<i32>) -> Option<i32> {

--- a/tests/ui/return_and_then.stderr
+++ b/tests/ui/return_and_then.stderr
@@ -1,5 +1,5 @@
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:5:9
+  --> tests/ui/return_and_then.rs:6:9
    |
 LL | /         opt.and_then(|n| {
 LL | |
@@ -21,7 +21,7 @@ LL +         if n > 1 { Some(ret) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:14:9
+  --> tests/ui/return_and_then.rs:15:9
    |
 LL |         opt.and_then(|n| test_opt_block(Some(n)))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL +         test_opt_block(Some(n))
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:19:9
+  --> tests/ui/return_and_then.rs:20:9
    |
 LL |         gen_option(1).and_then(|n| test_opt_block(Some(n)))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL +         test_opt_block(Some(n))
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:24:9
+  --> tests/ui/return_and_then.rs:25:9
    |
 LL |         opt.and_then(|n| if n > 1 { Ok(n + 1) } else { Err(n) })
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL +         if n > 1 { Ok(n + 1) } else { Err(n) }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:29:9
+  --> tests/ui/return_and_then.rs:30:9
    |
 LL |         opt.and_then(|n| test_res_block(Ok(n)))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL +         test_res_block(Ok(n))
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:35:9
+  --> tests/ui/return_and_then.rs:36:9
    |
 LL |         Some("").and_then(|x| if x.len() > 2 { Some(3) } else { None })
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL +         if x.len() > 2 { Some(3) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:41:9
+  --> tests/ui/return_and_then.rs:42:9
    |
 LL | /         Some(match (vec![1, 2, 3], vec![1, 2, 4]) {
 LL | |
@@ -102,7 +102,7 @@ LL +         if x.len() > 2 { Some(3) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:69:13
+  --> tests/ui/return_and_then.rs:70:13
    |
 LL |             Some("").and_then(|x| if x.len() > 2 { Some(3) } else { None })
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL +             if x.len() > 2 { Some(3) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:77:20
+  --> tests/ui/return_and_then.rs:78:20
    |
 LL |             return Some("").and_then(|x| if x.len() > 2 { Some(3) } else { None });
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -128,7 +128,7 @@ LL ~             };
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:85:20
+  --> tests/ui/return_and_then.rs:86:20
    |
 LL |               return Some("").and_then(|mut x| {
    |  ____________________^

--- a/tests/ui/return_self_not_must_use.rs
+++ b/tests/ui/return_self_not_must_use.rs
@@ -1,5 +1,6 @@
 #![crate_type = "lib"]
 #![warn(clippy::return_self_not_must_use)]
+#![allow(clippy::disallowed_names)]
 
 #[derive(Clone)]
 pub struct Bar;

--- a/tests/ui/return_self_not_must_use.stderr
+++ b/tests/ui/return_self_not_must_use.stderr
@@ -1,5 +1,5 @@
 error: missing `#[must_use]` attribute on a method returning `Self`
-  --> tests/ui/return_self_not_must_use.rs:8:5
+  --> tests/ui/return_self_not_must_use.rs:9:5
    |
 LL |     fn what(&self) -> Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     fn what(&self) -> Self;
    = help: to override `-D warnings` add `#[allow(clippy::return_self_not_must_use)]`
 
 error: missing `#[must_use]` attribute on a method returning `Self`
-  --> tests/ui/return_self_not_must_use.rs:20:5
+  --> tests/ui/return_self_not_must_use.rs:21:5
    |
 LL | /     pub fn foo(&self) -> Self {
 LL | |
@@ -21,7 +21,7 @@ LL | |     }
    = help: consider adding the `#[must_use]` attribute to the method or directly to the `Self` type
 
 error: missing `#[must_use]` attribute on a method returning `Self`
-  --> tests/ui/return_self_not_must_use.rs:25:5
+  --> tests/ui/return_self_not_must_use.rs:26:5
    |
 LL | /     pub fn bar(self) -> Self {
 LL | |

--- a/tests/ui/same_name_method.rs
+++ b/tests/ui/same_name_method.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::same_name_method)]
-#![allow(dead_code, non_camel_case_types)]
+#![allow(dead_code, non_camel_case_types, clippy::disallowed_names)]
 
 trait T1 {
     fn foo() {}

--- a/tests/ui/semicolon_if_nothing_returned.fixed
+++ b/tests/ui/semicolon_if_nothing_returned.fixed
@@ -5,7 +5,8 @@
     clippy::redundant_closure,
     clippy::uninlined_format_args,
     clippy::needless_late_init,
-    clippy::empty_docs
+    clippy::empty_docs,
+    clippy::disallowed_names
 )]
 
 #[macro_use]

--- a/tests/ui/semicolon_if_nothing_returned.rs
+++ b/tests/ui/semicolon_if_nothing_returned.rs
@@ -5,7 +5,8 @@
     clippy::redundant_closure,
     clippy::uninlined_format_args,
     clippy::needless_late_init,
-    clippy::empty_docs
+    clippy::empty_docs,
+    clippy::disallowed_names
 )]
 
 #[macro_use]

--- a/tests/ui/semicolon_if_nothing_returned.stderr
+++ b/tests/ui/semicolon_if_nothing_returned.stderr
@@ -1,5 +1,5 @@
 error: consider adding a `;` to the last statement for consistent formatting
-  --> tests/ui/semicolon_if_nothing_returned.rs:18:5
+  --> tests/ui/semicolon_if_nothing_returned.rs:19:5
    |
 LL |     println!("Hello")
    |     ^^^^^^^^^^^^^^^^^ help: add a `;` here: `println!("Hello");`
@@ -8,25 +8,25 @@ LL |     println!("Hello")
    = help: to override `-D warnings` add `#[allow(clippy::semicolon_if_nothing_returned)]`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> tests/ui/semicolon_if_nothing_returned.rs:23:5
+  --> tests/ui/semicolon_if_nothing_returned.rs:24:5
    |
 LL |     get_unit()
    |     ^^^^^^^^^^ help: add a `;` here: `get_unit();`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> tests/ui/semicolon_if_nothing_returned.rs:29:5
+  --> tests/ui/semicolon_if_nothing_returned.rs:30:5
    |
 LL |     y = x + 1
    |     ^^^^^^^^^ help: add a `;` here: `y = x + 1;`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> tests/ui/semicolon_if_nothing_returned.rs:36:9
+  --> tests/ui/semicolon_if_nothing_returned.rs:37:9
    |
 LL |         hello()
    |         ^^^^^^^ help: add a `;` here: `hello();`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> tests/ui/semicolon_if_nothing_returned.rs:48:9
+  --> tests/ui/semicolon_if_nothing_returned.rs:49:9
    |
 LL |         ptr::drop_in_place(s.as_mut_ptr())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add a `;` here: `ptr::drop_in_place(s.as_mut_ptr());`

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -5,7 +5,8 @@
     clippy::let_unit_value,
     clippy::needless_if,
     clippy::redundant_guards,
-    clippy::redundant_locals
+    clippy::redundant_locals,
+    clippy::disallowed_names
 )]
 
 extern crate proc_macro_derive;

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -1,11 +1,11 @@
 error: `x` is shadowed by itself in `x`
-  --> tests/ui/shadow.rs:24:9
+  --> tests/ui/shadow.rs:25:9
    |
 LL |     let x = x;
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:23:9
+  --> tests/ui/shadow.rs:24:9
    |
 LL |     let x = 1;
    |         ^
@@ -13,49 +13,49 @@ LL |     let x = 1;
    = help: to override `-D warnings` add `#[allow(clippy::shadow_same)]`
 
 error: `mut x` is shadowed by itself in `&x`
-  --> tests/ui/shadow.rs:26:13
+  --> tests/ui/shadow.rs:27:13
    |
 LL |     let mut x = &x;
    |             ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:24:9
+  --> tests/ui/shadow.rs:25:9
    |
 LL |     let x = x;
    |         ^
 
 error: `x` is shadowed by itself in `&mut x`
-  --> tests/ui/shadow.rs:28:9
+  --> tests/ui/shadow.rs:29:9
    |
 LL |     let x = &mut x;
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:26:9
+  --> tests/ui/shadow.rs:27:9
    |
 LL |     let mut x = &x;
    |         ^^^^^
 
 error: `x` is shadowed by itself in `*x`
-  --> tests/ui/shadow.rs:30:9
+  --> tests/ui/shadow.rs:31:9
    |
 LL |     let x = *x;
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:28:9
+  --> tests/ui/shadow.rs:29:9
    |
 LL |     let x = &mut x;
    |         ^
 
 error: `x` is shadowed
-  --> tests/ui/shadow.rs:36:9
+  --> tests/ui/shadow.rs:37:9
    |
 LL |     let x = x.0;
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:35:9
+  --> tests/ui/shadow.rs:36:9
    |
 LL |     let x = ([[0]], ());
    |         ^
@@ -63,97 +63,97 @@ LL |     let x = ([[0]], ());
    = help: to override `-D warnings` add `#[allow(clippy::shadow_reuse)]`
 
 error: `x` is shadowed
-  --> tests/ui/shadow.rs:38:9
+  --> tests/ui/shadow.rs:39:9
    |
 LL |     let x = x[0];
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:36:9
+  --> tests/ui/shadow.rs:37:9
    |
 LL |     let x = x.0;
    |         ^
 
 error: `x` is shadowed
-  --> tests/ui/shadow.rs:40:10
+  --> tests/ui/shadow.rs:41:10
    |
 LL |     let [x] = x;
    |          ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:38:9
+  --> tests/ui/shadow.rs:39:9
    |
 LL |     let x = x[0];
    |         ^
 
 error: `x` is shadowed
-  --> tests/ui/shadow.rs:42:9
+  --> tests/ui/shadow.rs:43:9
    |
 LL |     let x = Some(x);
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:40:10
+  --> tests/ui/shadow.rs:41:10
    |
 LL |     let [x] = x;
    |          ^
 
 error: `x` is shadowed
-  --> tests/ui/shadow.rs:44:9
+  --> tests/ui/shadow.rs:45:9
    |
 LL |     let x = foo(x);
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:42:9
+  --> tests/ui/shadow.rs:43:9
    |
 LL |     let x = Some(x);
    |         ^
 
 error: `x` is shadowed
-  --> tests/ui/shadow.rs:46:9
+  --> tests/ui/shadow.rs:47:9
    |
 LL |     let x = || x;
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:44:9
+  --> tests/ui/shadow.rs:45:9
    |
 LL |     let x = foo(x);
    |         ^
 
 error: `x` is shadowed
-  --> tests/ui/shadow.rs:48:9
+  --> tests/ui/shadow.rs:49:9
    |
 LL |     let x = Some(1).map(|_| x)?;
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:46:9
+  --> tests/ui/shadow.rs:47:9
    |
 LL |     let x = || x;
    |         ^
 
 error: `y` is shadowed
-  --> tests/ui/shadow.rs:51:9
+  --> tests/ui/shadow.rs:52:9
    |
 LL |     let y = match y {
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:50:9
+  --> tests/ui/shadow.rs:51:9
    |
 LL |     let y = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:67:9
+  --> tests/ui/shadow.rs:68:9
    |
 LL |     let x = 2;
    |         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:66:9
+  --> tests/ui/shadow.rs:67:9
    |
 LL |     let x = 1;
    |         ^
@@ -161,157 +161,157 @@ LL |     let x = 1;
    = help: to override `-D warnings` add `#[allow(clippy::shadow_unrelated)]`
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:73:13
+  --> tests/ui/shadow.rs:74:13
    |
 LL |         let x = 1;
    |             ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:72:10
+  --> tests/ui/shadow.rs:73:10
    |
 LL |     fn f(x: u32) {
    |          ^
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:79:14
+  --> tests/ui/shadow.rs:80:14
    |
 LL |         Some(x) => {
    |              ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:76:9
+  --> tests/ui/shadow.rs:77:9
    |
 LL |     let x = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:81:17
+  --> tests/ui/shadow.rs:82:17
    |
 LL |             let x = 1;
    |                 ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:79:14
+  --> tests/ui/shadow.rs:80:14
    |
 LL |         Some(x) => {
    |              ^
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:86:17
+  --> tests/ui/shadow.rs:87:17
    |
 LL |     if let Some(x) = Some(1) {}
    |                 ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:76:9
+  --> tests/ui/shadow.rs:77:9
    |
 LL |     let x = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:88:20
+  --> tests/ui/shadow.rs:89:20
    |
 LL |     while let Some(x) = Some(1) {}
    |                    ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:76:9
+  --> tests/ui/shadow.rs:77:9
    |
 LL |     let x = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:90:15
+  --> tests/ui/shadow.rs:91:15
    |
 LL |     let _ = |[x]: [u32; 1]| {
    |               ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:76:9
+  --> tests/ui/shadow.rs:77:9
    |
 LL |     let x = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:92:13
+  --> tests/ui/shadow.rs:93:13
    |
 LL |         let x = 1;
    |             ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:90:15
+  --> tests/ui/shadow.rs:91:15
    |
 LL |     let _ = |[x]: [u32; 1]| {
    |               ^
 
 error: `y` is shadowed
-  --> tests/ui/shadow.rs:96:17
+  --> tests/ui/shadow.rs:97:17
    |
 LL |     if let Some(y) = y {}
    |                 ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:95:9
+  --> tests/ui/shadow.rs:96:9
    |
 LL |     let y = Some(1);
    |         ^
 
 error: `_b` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:133:9
+  --> tests/ui/shadow.rs:134:9
    |
 LL |     let _b = _a;
    |         ^^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:132:28
+  --> tests/ui/shadow.rs:133:28
    |
 LL | pub async fn foo2(_a: i32, _b: i64) {
    |                            ^^
 
 error: `x` shadows a previous, unrelated binding
-  --> tests/ui/shadow.rs:140:21
+  --> tests/ui/shadow.rs:141:21
    |
 LL |         if let Some(x) = Some(1) { x } else { 1 }
    |                     ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:139:13
+  --> tests/ui/shadow.rs:140:13
    |
 LL |         let x = 1;
    |             ^
 
 error: `x` is shadowed
-  --> tests/ui/shadow.rs:151:20
+  --> tests/ui/shadow.rs:152:20
    |
 LL |     let z = x.map(|x| x + 1);
    |                    ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:148:9
+  --> tests/ui/shadow.rs:149:9
    |
 LL |     let x = Some(1);
    |         ^
 
 error: `i` is shadowed
-  --> tests/ui/shadow.rs:156:25
+  --> tests/ui/shadow.rs:157:25
    |
 LL |         .map(|i| i.map(|i| i - 10))
    |                         ^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:156:15
+  --> tests/ui/shadow.rs:157:15
    |
 LL |         .map(|i| i.map(|i| i - 10))
    |               ^
 
 error: `value` is shadowed by itself in `value`
-  --> tests/ui/shadow.rs:166:22
+  --> tests/ui/shadow.rs:167:22
    |
 LL |     let Issue13795 { value, .. } = value;
    |                      ^^^^^
    |
 note: previous binding is here
-  --> tests/ui/shadow.rs:165:15
+  --> tests/ui/shadow.rs:166:15
    |
 LL | fn issue13795(value: Issue13795) {
    |               ^^^^^

--- a/tests/ui/significant_drop_in_scrutinee.rs
+++ b/tests/ui/significant_drop_in_scrutinee.rs
@@ -6,7 +6,8 @@
     clippy::match_single_binding,
     clippy::single_match,
     clippy::uninlined_format_args,
-    clippy::needless_lifetimes
+    clippy::needless_lifetimes,
+    clippy::disallowed_names
 )]
 
 use std::num::ParseIntError;

--- a/tests/ui/significant_drop_in_scrutinee.stderr
+++ b/tests/ui/significant_drop_in_scrutinee.stderr
@@ -1,5 +1,5 @@
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:60:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:61:11
    |
 LL |     match mutex.lock().unwrap().foo() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:147:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:148:11
    |
 LL |     match s.lock_m().get_the_value() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:169:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:170:11
    |
 LL |     match s.lock_m_m().get_the_value() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:218:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:219:11
    |
 LL |     match counter.temp_increment().len() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:242:16
+  --> tests/ui/significant_drop_in_scrutinee.rs:243:16
    |
 LL |         match (mutex1.lock().unwrap().s.len(), true) {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL ~         match (value, true) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:252:22
+  --> tests/ui/significant_drop_in_scrutinee.rs:253:22
    |
 LL |         match (true, mutex1.lock().unwrap().s.len(), true) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +118,7 @@ LL ~         match (true, value, true) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:263:16
+  --> tests/ui/significant_drop_in_scrutinee.rs:264:16
    |
 LL |         match (mutex1.lock().unwrap().s.len(), true, mutex2.lock().unwrap().s.len()) {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,7 +139,7 @@ LL ~         match (value, true, mutex2.lock().unwrap().s.len()) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:263:54
+  --> tests/ui/significant_drop_in_scrutinee.rs:264:54
    |
 LL |         match (mutex1.lock().unwrap().s.len(), true, mutex2.lock().unwrap().s.len()) {
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -160,7 +160,7 @@ LL ~         match (mutex1.lock().unwrap().s.len(), true, value) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:316:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:317:11
    |
 LL |     match mutex.lock().unwrap().s.len() > 1 {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -179,7 +179,7 @@ LL ~     match value > 1 {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:324:15
+  --> tests/ui/significant_drop_in_scrutinee.rs:325:15
    |
 LL |     match 1 < mutex.lock().unwrap().s.len() {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -198,7 +198,7 @@ LL ~     match 1 < value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:343:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:344:11
    |
 LL |     match mutex1.lock().unwrap().s.len() < mutex2.lock().unwrap().s.len() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ LL ~     match value < mutex2.lock().unwrap().s.len() {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:343:44
+  --> tests/ui/significant_drop_in_scrutinee.rs:344:44
    |
 LL |     match mutex1.lock().unwrap().s.len() < mutex2.lock().unwrap().s.len() {
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -240,7 +240,7 @@ LL ~     match mutex1.lock().unwrap().s.len() < value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:356:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:357:11
    |
 LL |     match mutex1.lock().unwrap().s.len() >= mutex2.lock().unwrap().s.len() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ LL ~     match value >= mutex2.lock().unwrap().s.len() {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:356:45
+  --> tests/ui/significant_drop_in_scrutinee.rs:357:45
    |
 LL |     match mutex1.lock().unwrap().s.len() >= mutex2.lock().unwrap().s.len() {
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -282,7 +282,7 @@ LL ~     match mutex1.lock().unwrap().s.len() >= value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:393:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:394:11
    |
 LL |     match get_mutex_guard().s.len() > 1 {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -301,7 +301,7 @@ LL ~     match value > 1 {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:411:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:412:11
    |
 LL |       match match i {
    |  ___________^
@@ -333,7 +333,7 @@ LL ~     match value
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:438:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:439:11
    |
 LL |       match if i > 1 {
    |  ___________^
@@ -366,7 +366,7 @@ LL ~     match value
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:493:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:494:11
    |
 LL |     match s.lock().deref().deref() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -384,7 +384,7 @@ LL ~     match (&value) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:542:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:543:11
    |
 LL |     match mutex.lock().unwrap().i = i {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -403,7 +403,7 @@ LL ~     match () {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:549:15
+  --> tests/ui/significant_drop_in_scrutinee.rs:550:15
    |
 LL |     match i = mutex.lock().unwrap().i {
    |               ^^^^^^^^^^^^^^^^^^^^^^^
@@ -422,7 +422,7 @@ LL ~     match i = value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:556:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:557:11
    |
 LL |     match mutex.lock().unwrap().i += 1 {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -441,7 +441,7 @@ LL ~     match () {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:563:16
+  --> tests/ui/significant_drop_in_scrutinee.rs:564:16
    |
 LL |     match i += mutex.lock().unwrap().i {
    |                ^^^^^^^^^^^^^^^^^^^^^^^
@@ -460,7 +460,7 @@ LL ~     match i += value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:627:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:628:11
    |
 LL |     match rwlock.read().unwrap().to_number() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -476,7 +476,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:654:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:655:11
    |
 LL |     match mutex.lock().unwrap().foo() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -492,7 +492,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:716:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:717:11
    |
 LL |     match guard.take().len() {
    |           ^^^^^^^^^^^^^^^^^^
@@ -508,7 +508,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `for` loop condition will live until the end of the `for` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:741:16
+  --> tests/ui/significant_drop_in_scrutinee.rs:742:16
    |
 LL |     for val in mutex.lock().unwrap().copy_old_lifetime() {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -524,7 +524,7 @@ LL ~     for val in value {
    |
 
 error: temporary with significant `Drop` in `for` loop condition will live until the end of the `for` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:780:17
+  --> tests/ui/significant_drop_in_scrutinee.rs:781:17
    |
 LL |     for val in [mutex.lock().unwrap()[0], 2] {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -540,7 +540,7 @@ LL ~     for val in [value, 2] {
    |
 
 error: temporary with significant `Drop` in `if let` scrutinee will live until the end of the `if let` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:789:24
+  --> tests/ui/significant_drop_in_scrutinee.rs:790:24
    |
 LL |     if let Some(val) = mutex.lock().unwrap().first().copied() {
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -556,7 +556,7 @@ LL ~     if let Some(val) = value {
    |
 
 error: temporary with significant `Drop` in `while let` scrutinee will live until the end of the `while let` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:804:27
+  --> tests/ui/significant_drop_in_scrutinee.rs:805:27
    |
 LL |     while let Some(val) = mutex.lock().unwrap().pop() {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -567,7 +567,7 @@ LL |     }
    = note: this might lead to deadlocks or other unexpected behavior
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:815:11
+  --> tests/ui/significant_drop_in_scrutinee.rs:816:11
    |
 LL |     match *foo_async(&mutex).await.unwrap() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -583,7 +583,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> tests/ui/significant_drop_in_scrutinee.rs:835:19
+  --> tests/ui/significant_drop_in_scrutinee.rs:836:19
    |
 LL |     let _ = match mutex.lock().unwrap().foo() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/significant_drop_tightening.fixed
+++ b/tests/ui/significant_drop_tightening.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::significant_drop_tightening)]
+#![allow(clippy::disallowed_names)]
 
 use std::sync::Mutex;
 

--- a/tests/ui/significant_drop_tightening.rs
+++ b/tests/ui/significant_drop_tightening.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::significant_drop_tightening)]
+#![allow(clippy::disallowed_names)]
 
 use std::sync::Mutex;
 

--- a/tests/ui/significant_drop_tightening.stderr
+++ b/tests/ui/significant_drop_tightening.stderr
@@ -1,5 +1,5 @@
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:10:9
+  --> tests/ui/significant_drop_tightening.rs:11:9
    |
 LL |   pub fn complex_return_triggers_the_lint() -> i32 {
    |  __________________________________________________-
@@ -23,7 +23,7 @@ LL +     drop(lock);
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:105:13
+  --> tests/ui/significant_drop_tightening.rs:106:13
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(1i32);
@@ -42,7 +42,7 @@ LL +         drop(lock);
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:127:13
+  --> tests/ui/significant_drop_tightening.rs:128:13
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(1i32);
@@ -63,7 +63,7 @@ LL ~
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:134:17
+  --> tests/ui/significant_drop_tightening.rs:135:17
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(vec![1i32]);

--- a/tests/ui/similar_names.rs
+++ b/tests/ui/similar_names.rs
@@ -5,7 +5,8 @@
     clippy::empty_loop,
     clippy::never_loop,
     clippy::diverging_sub_expression,
-    clippy::let_unit_value
+    clippy::let_unit_value,
+    clippy::disallowed_names
 )]
 
 struct Foo {

--- a/tests/ui/similar_names.stderr
+++ b/tests/ui/similar_names.stderr
@@ -1,11 +1,11 @@
 error: binding's name is too similar to existing binding
-  --> tests/ui/similar_names.rs:47:9
+  --> tests/ui/similar_names.rs:48:9
    |
 LL |     let bluby: i32;
    |         ^^^^^
    |
 note: existing binding defined here
-  --> tests/ui/similar_names.rs:46:9
+  --> tests/ui/similar_names.rs:47:9
    |
 LL |     let blubx: i32;
    |         ^^^^^
@@ -13,49 +13,49 @@ LL |     let blubx: i32;
    = help: to override `-D warnings` add `#[allow(clippy::similar_names)]`
 
 error: binding's name is too similar to existing binding
-  --> tests/ui/similar_names.rs:52:9
+  --> tests/ui/similar_names.rs:53:9
    |
 LL |     let coke: i32;
    |         ^^^^
    |
 note: existing binding defined here
-  --> tests/ui/similar_names.rs:50:9
+  --> tests/ui/similar_names.rs:51:9
    |
 LL |     let cake: i32;
    |         ^^^^
 
 error: binding's name is too similar to existing binding
-  --> tests/ui/similar_names.rs:71:9
+  --> tests/ui/similar_names.rs:72:9
    |
 LL |     let xyzeabc: i32;
    |         ^^^^^^^
    |
 note: existing binding defined here
-  --> tests/ui/similar_names.rs:69:9
+  --> tests/ui/similar_names.rs:70:9
    |
 LL |     let xyz1abc: i32;
    |         ^^^^^^^
 
 error: binding's name is too similar to existing binding
-  --> tests/ui/similar_names.rs:76:9
+  --> tests/ui/similar_names.rs:77:9
    |
 LL |     let parsee: i32;
    |         ^^^^^^
    |
 note: existing binding defined here
-  --> tests/ui/similar_names.rs:74:9
+  --> tests/ui/similar_names.rs:75:9
    |
 LL |     let parser: i32;
    |         ^^^^^^
 
 error: binding's name is too similar to existing binding
-  --> tests/ui/similar_names.rs:98:16
+  --> tests/ui/similar_names.rs:99:16
    |
 LL |         bpple: sprang,
    |                ^^^^^^
    |
 note: existing binding defined here
-  --> tests/ui/similar_names.rs:97:16
+  --> tests/ui/similar_names.rs:98:16
    |
 LL |         apple: spring,
    |                ^^^^^^

--- a/tests/ui/single_call_fn.rs
+++ b/tests/ui/single_call_fn.rs
@@ -1,6 +1,6 @@
 //@ignore-bitwidth: 32
 //@aux-build:proc_macros.rs
-#![allow(clippy::redundant_closure_call, unused)]
+#![allow(clippy::redundant_closure_call, unused, clippy::disallowed_names)]
 #![warn(clippy::single_call_fn)]
 #![no_main]
 

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -6,7 +6,8 @@
     clippy::needless_if,
     clippy::redundant_guards,
     clippy::redundant_pattern_matching,
-    clippy::manual_unwrap_or_default
+    clippy::manual_unwrap_or_default,
+    clippy::disallowed_names
 )]
 fn dummy() {}
 

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -6,7 +6,8 @@
     clippy::needless_if,
     clippy::redundant_guards,
     clippy::redundant_pattern_matching,
-    clippy::manual_unwrap_or_default
+    clippy::manual_unwrap_or_default,
+    clippy::disallowed_names
 )]
 fn dummy() {}
 

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:16:5
+  --> tests/ui/single_match.rs:17:5
    |
 LL | /     match x {
 LL | |         Some(y) => {
@@ -19,7 +19,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:25:5
+  --> tests/ui/single_match.rs:26:5
    |
 LL | /     match x {
 ...  |
@@ -30,7 +30,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:36:5
+  --> tests/ui/single_match.rs:37:5
    |
 LL | /     match z {
 LL | |         (2..=3, 7..=9) => dummy(),
@@ -39,7 +39,7 @@ LL | |     };
    | |_____^ help: try: `if let (2..=3, 7..=9) = z { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:66:5
+  --> tests/ui/single_match.rs:67:5
    |
 LL | /     match x {
 LL | |         Some(y) => dummy(),
@@ -48,7 +48,7 @@ LL | |     };
    | |_____^ help: try: `if let Some(y) = x { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:72:5
+  --> tests/ui/single_match.rs:73:5
    |
 LL | /     match y {
 LL | |         Ok(y) => dummy(),
@@ -57,7 +57,7 @@ LL | |     };
    | |_____^ help: try: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:80:5
+  --> tests/ui/single_match.rs:81:5
    |
 LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:102:5
+  --> tests/ui/single_match.rs:103:5
    |
 LL | /     match x {
 LL | |         "test" => println!(),
@@ -75,7 +75,7 @@ LL | |     }
    | |_____^ help: try: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:116:5
+  --> tests/ui/single_match.rs:117:5
    |
 LL | /     match x {
 LL | |         Foo::A => println!(),
@@ -84,7 +84,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:123:5
+  --> tests/ui/single_match.rs:124:5
    |
 LL | /     match x {
 LL | |         FOO_C => println!(),
@@ -93,7 +93,7 @@ LL | |     }
    | |_____^ help: try: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:129:5
+  --> tests/ui/single_match.rs:130:5
    |
 LL | /     match &&x {
 LL | |         Foo::A => println!(),
@@ -102,7 +102,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:136:5
+  --> tests/ui/single_match.rs:137:5
    |
 LL | /     match &x {
 LL | |         Foo::A => println!(),
@@ -111,7 +111,7 @@ LL | |     }
    | |_____^ help: try: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:154:5
+  --> tests/ui/single_match.rs:155:5
    |
 LL | /     match x {
 LL | |         Bar::A => println!(),
@@ -120,7 +120,7 @@ LL | |     }
    | |_____^ help: try: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:163:5
+  --> tests/ui/single_match.rs:164:5
    |
 LL | /     match x {
 LL | |         None => println!(),
@@ -129,7 +129,7 @@ LL | |     };
    | |_____^ help: try: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:186:5
+  --> tests/ui/single_match.rs:187:5
    |
 LL | /     match x {
 LL | |         (Some(_), _) => {},
@@ -138,7 +138,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:193:5
+  --> tests/ui/single_match.rs:194:5
    |
 LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
@@ -147,7 +147,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:200:5
+  --> tests/ui/single_match.rs:201:5
    |
 LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},
@@ -156,7 +156,7 @@ LL | |     }
    | |_____^ help: try: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:273:5
+  --> tests/ui/single_match.rs:274:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -176,7 +176,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:282:5
+  --> tests/ui/single_match.rs:283:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]
@@ -198,7 +198,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:363:5
+  --> tests/ui/single_match.rs:364:5
    |
 LL | /     match Ok::<_, u32>(Some(A)) {
 LL | |         Ok(Some(A)) => println!(),
@@ -207,7 +207,7 @@ LL | |     }
    | |_____^ help: try: `if let Ok(Some(A)) = Ok::<_, u32>(Some(A)) { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:379:5
+  --> tests/ui/single_match.rs:380:5
    |
 LL | /     match &Some(A) {
 LL | |         Some(A | B) => println!(),
@@ -216,7 +216,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(A | B) = &Some(A) { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:387:5
+  --> tests/ui/single_match.rs:388:5
    |
 LL | /     match &s[0..3] {
 LL | |         b"foo" => println!(),
@@ -225,7 +225,7 @@ LL | |     }
    | |_____^ help: try: `if &s[0..3] == b"foo" { println!() }`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:401:5
+  --> tests/ui/single_match.rs:402:5
    |
 LL | /     match DATA {
 LL | |         DATA => println!(),
@@ -234,7 +234,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:407:5
+  --> tests/ui/single_match.rs:408:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -243,7 +243,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:414:5
+  --> tests/ui/single_match.rs:415:5
    |
 LL | /     match i {
 LL | |         i => {
@@ -263,7 +263,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:423:5
+  --> tests/ui/single_match.rs:424:5
    |
 LL | /     match i {
 LL | |         i => {},
@@ -272,7 +272,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:429:5
+  --> tests/ui/single_match.rs:430:5
    |
 LL | /     match i {
 LL | |         i => (),
@@ -281,7 +281,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:435:5
+  --> tests/ui/single_match.rs:436:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -290,7 +290,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:443:5
+  --> tests/ui/single_match.rs:444:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -302,7 +302,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:452:5
+  --> tests/ui/single_match.rs:453:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -322,7 +322,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:478:5
+  --> tests/ui/single_match.rs:479:5
    |
 LL | /     match mac!(some) {
 LL | |         Some(u) => println!("{u}"),
@@ -331,7 +331,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(u) = mac!(some) { println!("{u}") }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:486:5
+  --> tests/ui/single_match.rs:487:5
    |
 LL | /     match mac!(str) {
 LL | |         "foo" => println!("eq"),

--- a/tests/ui/suspicious_doc_comments.fixed
+++ b/tests/ui/suspicious_doc_comments.fixed
@@ -1,6 +1,6 @@
 #![allow(unused)]
 #![warn(clippy::suspicious_doc_comments)]
-#![allow(clippy::empty_line_after_doc_comments)]
+#![allow(clippy::empty_line_after_doc_comments, clippy::disallowed_names)]
 
 //! Real module documentation.
 //! Fake module documentation.

--- a/tests/ui/suspicious_doc_comments.rs
+++ b/tests/ui/suspicious_doc_comments.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 #![warn(clippy::suspicious_doc_comments)]
-#![allow(clippy::empty_line_after_doc_comments)]
+#![allow(clippy::empty_line_after_doc_comments, clippy::disallowed_names)]
 
 //! Real module documentation.
 ///! Fake module documentation.

--- a/tests/ui/suspicious_doc_comments_unfixable.rs
+++ b/tests/ui/suspicious_doc_comments_unfixable.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::empty_line_after_doc_comments)]
+#![allow(unused, clippy::empty_line_after_doc_comments, clippy::disallowed_names)]
 #![warn(clippy::suspicious_doc_comments)]
 //@no-rustfix
 ///! a

--- a/tests/ui/suspicious_else_formatting.rs
+++ b/tests/ui/suspicious_else_formatting.rs
@@ -5,7 +5,8 @@
     clippy::if_same_then_else,
     clippy::let_unit_value,
     clippy::needless_if,
-    clippy::needless_else
+    clippy::needless_else,
+    clippy::disallowed_names
 )]
 
 extern crate proc_macro_suspicious_else_formatting;

--- a/tests/ui/suspicious_else_formatting.stderr
+++ b/tests/ui/suspicious_else_formatting.stderr
@@ -1,5 +1,5 @@
 error: this looks like an `else {..}` but the `else` is missing
-  --> tests/ui/suspicious_else_formatting.rs:22:6
+  --> tests/ui/suspicious_else_formatting.rs:23:6
    |
 LL |     } {
    |      ^
@@ -9,7 +9,7 @@ LL |     } {
    = help: to override `-D warnings` add `#[allow(clippy::suspicious_else_formatting)]`
 
 error: this looks like an `else if` but the `else` is missing
-  --> tests/ui/suspicious_else_formatting.rs:27:6
+  --> tests/ui/suspicious_else_formatting.rs:28:6
    |
 LL |     } if foo() {
    |      ^
@@ -17,7 +17,7 @@ LL |     } if foo() {
    = note: to remove this lint, add the missing `else` or add a new line before the second `if`
 
 error: this looks like an `else if` but the `else` is missing
-  --> tests/ui/suspicious_else_formatting.rs:35:10
+  --> tests/ui/suspicious_else_formatting.rs:36:10
    |
 LL |         } if foo() {
    |          ^
@@ -25,7 +25,7 @@ LL |         } if foo() {
    = note: to remove this lint, add the missing `else` or add a new line before the second `if`
 
 error: this looks like an `else if` but the `else` is missing
-  --> tests/ui/suspicious_else_formatting.rs:44:10
+  --> tests/ui/suspicious_else_formatting.rs:45:10
    |
 LL |         } if foo() {
    |          ^
@@ -33,7 +33,7 @@ LL |         } if foo() {
    = note: to remove this lint, add the missing `else` or add a new line before the second `if`
 
 error: this is an `else {..}` but the formatting might hide it
-  --> tests/ui/suspicious_else_formatting.rs:54:6
+  --> tests/ui/suspicious_else_formatting.rs:55:6
    |
 LL |       } else
    |  ______^
@@ -43,7 +43,7 @@ LL | |     {
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
 
 error: this is an `else if` but the formatting might hide it
-  --> tests/ui/suspicious_else_formatting.rs:67:6
+  --> tests/ui/suspicious_else_formatting.rs:68:6
    |
 LL |       } else
    |  ______^
@@ -53,7 +53,7 @@ LL | |     if foo() { // the span of the above error should continue here
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `if`
 
 error: this is an `else if` but the formatting might hide it
-  --> tests/ui/suspicious_else_formatting.rs:73:6
+  --> tests/ui/suspicious_else_formatting.rs:74:6
    |
 LL |       }
    |  ______^
@@ -64,7 +64,7 @@ LL | |     if foo() { // the span of the above error should continue here
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `if`
 
 error: this is an `else {..}` but the formatting might hide it
-  --> tests/ui/suspicious_else_formatting.rs:101:6
+  --> tests/ui/suspicious_else_formatting.rs:102:6
    |
 LL |       }
    |  ______^
@@ -76,7 +76,7 @@ LL | |     {
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
 
 error: this is an `else {..}` but the formatting might hide it
-  --> tests/ui/suspicious_else_formatting.rs:109:6
+  --> tests/ui/suspicious_else_formatting.rs:110:6
    |
 LL |       }
    |  ______^

--- a/tests/ui/transmutes_expressible_as_ptr_casts.fixed
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.fixed
@@ -3,7 +3,12 @@
 // would otherwise be responsible for
 #![warn(clippy::useless_transmute)]
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(unused, clippy::borrow_as_ptr, clippy::missing_transmute_annotations)]
+#![allow(
+    unused,
+    clippy::borrow_as_ptr,
+    clippy::missing_transmute_annotations,
+    clippy::disallowed_names
+)]
 
 use std::mem::{size_of, transmute};
 

--- a/tests/ui/transmutes_expressible_as_ptr_casts.rs
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.rs
@@ -3,7 +3,12 @@
 // would otherwise be responsible for
 #![warn(clippy::useless_transmute)]
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(unused, clippy::borrow_as_ptr, clippy::missing_transmute_annotations)]
+#![allow(
+    unused,
+    clippy::borrow_as_ptr,
+    clippy::missing_transmute_annotations,
+    clippy::disallowed_names
+)]
 
 use std::mem::{size_of, transmute};
 

--- a/tests/ui/transmutes_expressible_as_ptr_casts.stderr
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.stderr
@@ -1,5 +1,5 @@
 error: transmute from an integer to a pointer
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:17:39
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:22:39
    |
 LL |     let _ptr_i32_transmute = unsafe { transmute::<usize, *const i32>(usize::MAX) };
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `usize::MAX as *const i32`
@@ -8,7 +8,7 @@ LL |     let _ptr_i32_transmute = unsafe { transmute::<usize, *const i32>(usize:
    = help: to override `-D warnings` add `#[allow(clippy::useless_transmute)]`
 
 error: transmute from a pointer to a pointer
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:22:38
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:27:38
    |
 LL |     let _ptr_i8_transmute = unsafe { transmute::<*const i32, *const i8>(ptr_i32) };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL +     let _ptr_i8_transmute = unsafe { ptr_i32.cast::<i8>() };
    |
 
 error: transmute from a pointer to a pointer
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:29:46
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:34:46
    |
 LL |     let _ptr_to_unsized_transmute = unsafe { transmute::<*const [i32], *const [u32]>(slice_ptr) };
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ LL +     let _ptr_to_unsized_transmute = unsafe { slice_ptr as *const [u32] };
    |
 
 error: transmute from `*const i32` to `usize` which could be expressed as a pointer cast instead
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:36:50
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:41:50
    |
 LL |     let _usize_from_int_ptr_transmute = unsafe { transmute::<*const i32, usize>(ptr_i32) };
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ptr_i32 as usize`
@@ -43,37 +43,37 @@ LL |     let _usize_from_int_ptr_transmute = unsafe { transmute::<*const i32, us
    = help: to override `-D warnings` add `#[allow(clippy::transmutes_expressible_as_ptr_casts)]`
 
 error: transmute from a reference to a pointer
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:43:41
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:48:41
    |
 LL |     let _array_ptr_transmute = unsafe { transmute::<&[i32; 4], *const [i32; 4]>(array_ref) };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `array_ref as *const [i32; 4]`
 
 error: transmute from `fn(usize) -> u8` to `*const usize` which could be expressed as a pointer cast instead
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:52:41
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:57:41
    |
 LL |     let _usize_ptr_transmute = unsafe { transmute::<fn(usize) -> u8, *const usize>(foo) };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `foo as *const usize`
 
 error: transmute from `fn(usize) -> u8` to `usize` which could be expressed as a pointer cast instead
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:57:49
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:62:49
    |
 LL |     let _usize_from_fn_ptr_transmute = unsafe { transmute::<fn(usize) -> u8, usize>(foo) };
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `foo as usize`
 
 error: transmute from `*const u32` to `usize` which could be expressed as a pointer cast instead
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:61:36
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:66:36
    |
 LL |     let _usize_from_ref = unsafe { transmute::<*const u32, usize>(&1u32) };
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&1u32 as *const u32 as usize`
 
 error: transmute from a reference to a pointer
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:73:14
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:78:14
    |
 LL |     unsafe { transmute::<&[i32; 1], *const u8>(in_param) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `in_param as *const [i32; 1] as *const u8`
 
 error: transmute from `fn()` to `*const u8` which could be expressed as a pointer cast instead
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:92:28
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:97:28
    |
 LL |     let _x: u8 = unsafe { *std::mem::transmute::<fn(), *const u8>(f) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(f as *const u8)`

--- a/tests/ui/type_repetition_in_bounds.rs
+++ b/tests/ui/type_repetition_in_bounds.rs
@@ -2,7 +2,8 @@
 #![allow(
     clippy::extra_unused_type_parameters,
     clippy::multiple_bound_locations,
-    clippy::needless_maybe_sized
+    clippy::needless_maybe_sized,
+    clippy::disallowed_names
 )]
 
 use serde::Deserialize;

--- a/tests/ui/type_repetition_in_bounds.stderr
+++ b/tests/ui/type_repetition_in_bounds.stderr
@@ -1,5 +1,5 @@
 error: type `T` has already been used as a bound predicate
-  --> tests/ui/type_repetition_in_bounds.rs:14:5
+  --> tests/ui/type_repetition_in_bounds.rs:15:5
    |
 LL |     T: Clone,
    |     ^^^^^^^^
@@ -12,7 +12,7 @@ LL | #![deny(clippy::type_repetition_in_bounds)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `Self` has already been used as a bound predicate
-  --> tests/ui/type_repetition_in_bounds.rs:32:5
+  --> tests/ui/type_repetition_in_bounds.rs:33:5
    |
 LL |     Self: Copy + Default + Ord,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |     Self: Copy + Default + Ord,
    = help: consider combining the bounds: `Self: Clone + Copy + Default + Ord`
 
 error: type `T` has already been used as a bound predicate
-  --> tests/ui/type_repetition_in_bounds.rs:107:5
+  --> tests/ui/type_repetition_in_bounds.rs:108:5
    |
 LL |     T: Clone,
    |     ^^^^^^^^
@@ -28,7 +28,7 @@ LL |     T: Clone,
    = help: consider combining the bounds: `T: ?Sized + Clone`
 
 error: type `T` has already been used as a bound predicate
-  --> tests/ui/type_repetition_in_bounds.rs:113:5
+  --> tests/ui/type_repetition_in_bounds.rs:114:5
    |
 LL |     T: ?Sized,
    |     ^^^^^^^^^
@@ -36,7 +36,7 @@ LL |     T: ?Sized,
    = help: consider combining the bounds: `T: Clone + ?Sized`
 
 error: type `T` has already been used as a bound predicate
-  --> tests/ui/type_repetition_in_bounds.rs:139:9
+  --> tests/ui/type_repetition_in_bounds.rs:140:9
    |
 LL |         T: Trait<Option<usize>, Box<[String]>, bool> + 'static,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |         T: Trait<Option<usize>, Box<[String]>, bool> + 'static,
    = help: consider combining the bounds: `T: ?Sized + Trait<Option<usize>, Box<[String]>, bool> + 'static`
 
 error: type `K` has already been used as a bound predicate
-  --> tests/ui/type_repetition_in_bounds.rs:148:5
+  --> tests/ui/type_repetition_in_bounds.rs:149:5
    |
 LL |     K: Clone,
    |     ^^^^^^^^
@@ -52,7 +52,7 @@ LL |     K: Clone,
    = help: consider combining the bounds: `K: 'a + Clone`
 
 error: type `Vec<T>` has already been used as a bound predicate
-  --> tests/ui/type_repetition_in_bounds.rs:157:5
+  --> tests/ui/type_repetition_in_bounds.rs:158:5
    |
 LL |     Vec<T>: Clone,
    |     ^^^^^^^^^^^^^

--- a/tests/ui/unit_arg.rs
+++ b/tests/ui/unit_arg.rs
@@ -11,7 +11,8 @@
     clippy::self_named_constructors,
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps,
-    clippy::unused_unit
+    clippy::unused_unit,
+    clippy::disallowed_names
 )]
 
 extern crate proc_macros;

--- a/tests/ui/unit_arg.stderr
+++ b/tests/ui/unit_arg.stderr
@@ -1,5 +1,5 @@
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:63:5
+  --> tests/ui/unit_arg.rs:64:5
    |
 LL | /     foo({
 LL | |
@@ -24,7 +24,7 @@ LL ~     foo(());
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:67:5
+  --> tests/ui/unit_arg.rs:68:5
    |
 LL |     foo(foo(1));
    |     ^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL ~     foo(());
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:69:5
+  --> tests/ui/unit_arg.rs:70:5
    |
 LL | /     foo({
 LL | |
@@ -61,7 +61,7 @@ LL ~     foo(());
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:75:5
+  --> tests/ui/unit_arg.rs:76:5
    |
 LL | /     b.bar({
 LL | |
@@ -84,7 +84,7 @@ LL ~     b.bar(());
    |
 
 error: passing unit values to a function
-  --> tests/ui/unit_arg.rs:79:5
+  --> tests/ui/unit_arg.rs:80:5
    |
 LL |     taking_multiple_units(foo(0), foo(1));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL ~     taking_multiple_units((), ());
    |
 
 error: passing unit values to a function
-  --> tests/ui/unit_arg.rs:81:5
+  --> tests/ui/unit_arg.rs:82:5
    |
 LL | /     taking_multiple_units(foo(0), {
 LL | |
@@ -123,7 +123,7 @@ LL ~     taking_multiple_units((), ());
    |
 
 error: passing unit values to a function
-  --> tests/ui/unit_arg.rs:86:5
+  --> tests/ui/unit_arg.rs:87:5
    |
 LL | /     taking_multiple_units(
 LL | |
@@ -162,7 +162,7 @@ LL ~     );
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:98:13
+  --> tests/ui/unit_arg.rs:99:13
    |
 LL |     None.or(Some(foo(2)));
    |             ^^^^^^^^^^^^
@@ -176,7 +176,7 @@ LL ~     });
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:102:5
+  --> tests/ui/unit_arg.rs:103:5
    |
 LL |     foo(foo(()));
    |     ^^^^^^^^^^^^
@@ -188,7 +188,7 @@ LL ~     foo(());
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:140:5
+  --> tests/ui/unit_arg.rs:141:5
    |
 LL |     Some(foo(1))
    |     ^^^^^^^^^^^^

--- a/tests/ui/unit_arg_empty_blocks.fixed
+++ b/tests/ui/unit_arg_empty_blocks.fixed
@@ -1,6 +1,6 @@
 #![warn(clippy::unit_arg)]
 #![allow(unused_must_use, unused_variables)]
-#![allow(clippy::no_effect, clippy::uninlined_format_args)]
+#![allow(clippy::no_effect, clippy::uninlined_format_args, clippy::disallowed_names)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/unit_arg_empty_blocks.rs
+++ b/tests/ui/unit_arg_empty_blocks.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::unit_arg)]
 #![allow(unused_must_use, unused_variables)]
-#![allow(clippy::no_effect, clippy::uninlined_format_args)]
+#![allow(clippy::no_effect, clippy::uninlined_format_args, clippy::disallowed_names)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/unnecessary_box_returns.rs
+++ b/tests/ui/unnecessary_box_returns.rs
@@ -1,4 +1,6 @@
 #![warn(clippy::unnecessary_box_returns)]
+#![allow(clippy::disallowed_names)]
+
 //@no-rustfix
 trait Bar {
     // lint

--- a/tests/ui/unnecessary_box_returns.stderr
+++ b/tests/ui/unnecessary_box_returns.stderr
@@ -1,5 +1,5 @@
 error: boxed return of the sized type `usize`
-  --> tests/ui/unnecessary_box_returns.rs:5:22
+  --> tests/ui/unnecessary_box_returns.rs:7:22
    |
 LL |     fn baz(&self) -> Box<usize>;
    |                      ^^^^^^^^^^ help: try: `usize`
@@ -9,7 +9,7 @@ LL |     fn baz(&self) -> Box<usize>;
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_box_returns)]`
 
 error: boxed return of the sized type `usize`
-  --> tests/ui/unnecessary_box_returns.rs:19:22
+  --> tests/ui/unnecessary_box_returns.rs:21:22
    |
 LL |     fn baz(&self) -> Box<usize> {
    |                      ^^^^^^^^^^ help: try: `usize`
@@ -17,7 +17,7 @@ LL |     fn baz(&self) -> Box<usize> {
    = help: changing this also requires a change to the return expressions in this function
 
 error: boxed return of the sized type `usize`
-  --> tests/ui/unnecessary_box_returns.rs:28:20
+  --> tests/ui/unnecessary_box_returns.rs:30:20
    |
 LL | fn bxed_usize() -> Box<usize> {
    |                    ^^^^^^^^^^ help: try: `usize`
@@ -25,7 +25,7 @@ LL | fn bxed_usize() -> Box<usize> {
    = help: changing this also requires a change to the return expressions in this function
 
 error: boxed return of the sized type `Foo`
-  --> tests/ui/unnecessary_box_returns.rs:35:19
+  --> tests/ui/unnecessary_box_returns.rs:37:19
    |
 LL | fn _bxed_foo() -> Box<Foo> {
    |                   ^^^^^^^^ help: try: `Foo`

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -7,7 +7,8 @@
     clippy::nonstandard_macro_braces,
     clippy::unnecessary_operation,
     nonstandard_style,
-    unused
+    unused,
+    clippy::disallowed_names
 )]
 
 extern crate extern_fake_libc;

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -7,7 +7,8 @@
     clippy::nonstandard_macro_braces,
     clippy::unnecessary_operation,
     nonstandard_style,
-    unused
+    unused,
+    clippy::disallowed_names
 )]
 
 extern crate extern_fake_libc;

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -248,19 +248,19 @@ LL |         (*x as usize).pow(2)
    |         ^^^^^^^^^^^^^ help: try: `(*x)`
 
 error: casting to the same type is unnecessary (`usize` -> `usize`)
-  --> tests/ui/unnecessary_cast.rs:277:31
+  --> tests/ui/unnecessary_cast.rs:278:31
    |
 LL |         assert_eq!(vec.len(), x as usize);
    |                               ^^^^^^^^^^ help: try: `x`
 
 error: casting to the same type is unnecessary (`i64` -> `i64`)
-  --> tests/ui/unnecessary_cast.rs:280:17
+  --> tests/ui/unnecessary_cast.rs:281:17
    |
 LL |         let _ = (5i32 as i64 as i64).abs();
    |                 ^^^^^^^^^^^^^^^^^^^^ help: try: `(5i32 as i64)`
 
 error: casting to the same type is unnecessary (`i64` -> `i64`)
-  --> tests/ui/unnecessary_cast.rs:283:17
+  --> tests/ui/unnecessary_cast.rs:284:17
    |
 LL |         let _ = 5i32 as i64 as i64;
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `5i32 as i64`

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -1,5 +1,5 @@
 error: casting raw pointers to the same type and constness is unnecessary (`*const T` -> `*const T`)
-  --> tests/ui/unnecessary_cast.rs:19:5
+  --> tests/ui/unnecessary_cast.rs:20:5
    |
 LL |     ptr as *const T
    |     ^^^^^^^^^^^^^^^ help: try: `ptr`
@@ -8,241 +8,241 @@ LL |     ptr as *const T
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_cast)]`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:55:5
+  --> tests/ui/unnecessary_cast.rs:56:5
    |
 LL |     1i32 as i32;
    |     ^^^^^^^^^^^ help: try: `1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:57:5
+  --> tests/ui/unnecessary_cast.rs:58:5
    |
 LL |     1f32 as f32;
    |     ^^^^^^^^^^^ help: try: `1_f32`
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> tests/ui/unnecessary_cast.rs:59:5
+  --> tests/ui/unnecessary_cast.rs:60:5
    |
 LL |     false as bool;
    |     ^^^^^^^^^^^^^ help: try: `false`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:63:5
+  --> tests/ui/unnecessary_cast.rs:64:5
    |
 LL |     -1_i32 as i32;
    |     ^^^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:65:5
+  --> tests/ui/unnecessary_cast.rs:66:5
    |
 LL |     - 1_i32 as i32;
    |     ^^^^^^^^^^^^^^ help: try: `- 1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:67:5
+  --> tests/ui/unnecessary_cast.rs:68:5
    |
 LL |     -1f32 as f32;
    |     ^^^^^^^^^^^^ help: try: `-1_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:69:5
+  --> tests/ui/unnecessary_cast.rs:70:5
    |
 LL |     1_i32 as i32;
    |     ^^^^^^^^^^^^ help: try: `1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:71:5
+  --> tests/ui/unnecessary_cast.rs:72:5
    |
 LL |     1_f32 as f32;
    |     ^^^^^^^^^^^^ help: try: `1_f32`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
-  --> tests/ui/unnecessary_cast.rs:74:22
+  --> tests/ui/unnecessary_cast.rs:75:22
    |
 LL |     let _: *mut u8 = [1u8, 2].as_ptr() as *const u8 as *mut u8;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_ptr()`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
-  --> tests/ui/unnecessary_cast.rs:77:5
+  --> tests/ui/unnecessary_cast.rs:78:5
    |
 LL |     [1u8, 2].as_ptr() as *const u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_ptr()`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*mut u8` -> `*mut u8`)
-  --> tests/ui/unnecessary_cast.rs:80:5
+  --> tests/ui/unnecessary_cast.rs:81:5
    |
 LL |     [1u8, 2].as_mut_ptr() as *mut u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_mut_ptr()`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u32` -> `*const u32`)
-  --> tests/ui/unnecessary_cast.rs:92:5
+  --> tests/ui/unnecessary_cast.rs:93:5
    |
 LL |     owo::<u32>([1u32].as_ptr()) as *const u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `owo::<u32>([1u32].as_ptr())`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
-  --> tests/ui/unnecessary_cast.rs:94:5
+  --> tests/ui/unnecessary_cast.rs:95:5
    |
 LL |     uwu::<u32, u8>([1u32].as_ptr()) as *const u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u8>([1u32].as_ptr())`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u32` -> `*const u32`)
-  --> tests/ui/unnecessary_cast.rs:97:5
+  --> tests/ui/unnecessary_cast.rs:98:5
    |
 LL |     uwu::<u32, u32>([1u32].as_ptr()) as *const u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u32>([1u32].as_ptr())`
 
 error: casting to the same type is unnecessary (`u32` -> `u32`)
-  --> tests/ui/unnecessary_cast.rs:133:5
+  --> tests/ui/unnecessary_cast.rs:134:5
    |
 LL |     aaa() as u32;
    |     ^^^^^^^^^^^^ help: try: `aaa()`
 
 error: casting to the same type is unnecessary (`u32` -> `u32`)
-  --> tests/ui/unnecessary_cast.rs:136:5
+  --> tests/ui/unnecessary_cast.rs:137:5
    |
 LL |     aaa() as u32;
    |     ^^^^^^^^^^^^ help: try: `aaa()`
 
 error: casting integer literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:173:9
+  --> tests/ui/unnecessary_cast.rs:174:9
    |
 LL |         100 as f32;
    |         ^^^^^^^^^^ help: try: `100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:175:9
+  --> tests/ui/unnecessary_cast.rs:176:9
    |
 LL |         100 as f64;
    |         ^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:177:9
+  --> tests/ui/unnecessary_cast.rs:178:9
    |
 LL |         100_i32 as f64;
    |         ^^^^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:179:17
+  --> tests/ui/unnecessary_cast.rs:180:17
    |
 LL |         let _ = -100 as f32;
    |                 ^^^^^^^^^^^ help: try: `-100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:181:17
+  --> tests/ui/unnecessary_cast.rs:182:17
    |
 LL |         let _ = -100 as f64;
    |                 ^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:183:17
+  --> tests/ui/unnecessary_cast.rs:184:17
    |
 LL |         let _ = -100_i32 as f64;
    |                 ^^^^^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:185:9
+  --> tests/ui/unnecessary_cast.rs:186:9
    |
 LL |         100. as f32;
    |         ^^^^^^^^^^^ help: try: `100_f32`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:187:9
+  --> tests/ui/unnecessary_cast.rs:188:9
    |
 LL |         100. as f64;
    |         ^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `u32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:200:9
+  --> tests/ui/unnecessary_cast.rs:201:9
    |
 LL |         1 as u32;
    |         ^^^^^^^^ help: try: `1_u32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:202:9
+  --> tests/ui/unnecessary_cast.rs:203:9
    |
 LL |         0x10 as i32;
    |         ^^^^^^^^^^^ help: try: `0x10_i32`
 
 error: casting integer literal to `usize` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:204:9
+  --> tests/ui/unnecessary_cast.rs:205:9
    |
 LL |         0b10 as usize;
    |         ^^^^^^^^^^^^^ help: try: `0b10_usize`
 
 error: casting integer literal to `u16` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:206:9
+  --> tests/ui/unnecessary_cast.rs:207:9
    |
 LL |         0o73 as u16;
    |         ^^^^^^^^^^^ help: try: `0o73_u16`
 
 error: casting integer literal to `u32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:208:9
+  --> tests/ui/unnecessary_cast.rs:209:9
    |
 LL |         1_000_000_000 as u32;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `1_000_000_000_u32`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:211:9
+  --> tests/ui/unnecessary_cast.rs:212:9
    |
 LL |         1.0 as f64;
    |         ^^^^^^^^^^ help: try: `1.0_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:213:9
+  --> tests/ui/unnecessary_cast.rs:214:9
    |
 LL |         0.5 as f32;
    |         ^^^^^^^^^^ help: try: `0.5_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:218:17
+  --> tests/ui/unnecessary_cast.rs:219:17
    |
 LL |         let _ = -1 as i32;
    |                 ^^^^^^^^^ help: try: `-1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:220:17
+  --> tests/ui/unnecessary_cast.rs:221:17
    |
 LL |         let _ = -1.0 as f32;
    |                 ^^^^^^^^^^^ help: try: `-1.0_f32`
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> tests/ui/unnecessary_cast.rs:227:18
+  --> tests/ui/unnecessary_cast.rs:228:18
    |
 LL |         let _ = &(x as i32);
    |                  ^^^^^^^^^^ help: try: `{ x }`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:234:22
+  --> tests/ui/unnecessary_cast.rs:235:22
    |
 LL |         let _: i32 = -(1) as i32;
    |                      ^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:237:22
+  --> tests/ui/unnecessary_cast.rs:238:22
    |
 LL |         let _: i64 = -(1) as i64;
    |                      ^^^^^^^^^^^ help: try: `-1_i64`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:245:22
+  --> tests/ui/unnecessary_cast.rs:246:22
    |
 LL |         let _: f64 = (-8.0 as f64).exp();
    |                      ^^^^^^^^^^^^^ help: try: `(-8.0_f64)`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:248:23
+  --> tests/ui/unnecessary_cast.rs:249:23
    |
 LL |         let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
    |                       ^^^^^^^^^^^^ help: try: `8.0_f64`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> tests/ui/unnecessary_cast.rs:258:20
+  --> tests/ui/unnecessary_cast.rs:259:20
    |
 LL |         let _num = foo() as f32;
    |                    ^^^^^^^^^^^^ help: try: `foo()`
 
 error: casting to the same type is unnecessary (`usize` -> `usize`)
-  --> tests/ui/unnecessary_cast.rs:269:9
+  --> tests/ui/unnecessary_cast.rs:270:9
    |
 LL |         (*x as usize).pow(2)
    |         ^^^^^^^^^^^^^ help: try: `(*x)`

--- a/tests/ui/unnecessary_filter_map.rs
+++ b/tests/ui/unnecessary_filter_map.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::redundant_closure)]
+#![allow(clippy::redundant_closure, clippy::disallowed_names)]
 
 fn main() {
     let _ = (0..4).filter_map(|x| if x > 1 { Some(x) } else { None });

--- a/tests/ui/unnecessary_iter_cloned.fixed
+++ b/tests/ui/unnecessary_iter_cloned.fixed
@@ -1,4 +1,4 @@
-#![allow(unused_assignments, clippy::uninlined_format_args)]
+#![allow(unused_assignments, clippy::uninlined_format_args, clippy::disallowed_names)]
 #![warn(clippy::unnecessary_to_owned)]
 
 #[allow(dead_code)]

--- a/tests/ui/unnecessary_iter_cloned.rs
+++ b/tests/ui/unnecessary_iter_cloned.rs
@@ -1,4 +1,4 @@
-#![allow(unused_assignments, clippy::uninlined_format_args)]
+#![allow(unused_assignments, clippy::uninlined_format_args, clippy::disallowed_names)]
 #![warn(clippy::unnecessary_to_owned)]
 
 #[allow(dead_code)]

--- a/tests/ui/unnecessary_operation.fixed
+++ b/tests/ui/unnecessary_operation.fixed
@@ -4,7 +4,8 @@
     clippy::uninlined_format_args,
     clippy::unnecessary_struct_initialization,
     dead_code,
-    unused
+    unused,
+    clippy::disallowed_names
 )]
 #![warn(clippy::unnecessary_operation)]
 

--- a/tests/ui/unnecessary_operation.rs
+++ b/tests/ui/unnecessary_operation.rs
@@ -4,7 +4,8 @@
     clippy::uninlined_format_args,
     clippy::unnecessary_struct_initialization,
     dead_code,
-    unused
+    unused,
+    clippy::disallowed_names
 )]
 #![warn(clippy::unnecessary_operation)]
 

--- a/tests/ui/unnecessary_operation.stderr
+++ b/tests/ui/unnecessary_operation.stderr
@@ -1,5 +1,5 @@
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:71:5
+  --> tests/ui/unnecessary_operation.rs:72:5
    |
 LL |     Tuple(get_number());
    |     ^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
@@ -8,103 +8,103 @@ LL |     Tuple(get_number());
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_operation)]`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:73:5
+  --> tests/ui/unnecessary_operation.rs:74:5
    |
 LL |     Struct { field: get_number() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:75:5
+  --> tests/ui/unnecessary_operation.rs:76:5
    |
 LL |     Struct { ..get_struct() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_struct();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:77:5
+  --> tests/ui/unnecessary_operation.rs:78:5
    |
 LL |     Enum::Tuple(get_number());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:79:5
+  --> tests/ui/unnecessary_operation.rs:80:5
    |
 LL |     Enum::Struct { field: get_number() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:81:5
+  --> tests/ui/unnecessary_operation.rs:82:5
    |
 LL |     5 + get_number();
    |     ^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `5;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:83:5
+  --> tests/ui/unnecessary_operation.rs:84:5
    |
 LL |     *&get_number();
    |     ^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:85:5
+  --> tests/ui/unnecessary_operation.rs:86:5
    |
 LL |     &get_number();
    |     ^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:87:5
+  --> tests/ui/unnecessary_operation.rs:88:5
    |
 LL |     (5, 6, get_number());
    |     ^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `5;6;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:89:5
+  --> tests/ui/unnecessary_operation.rs:90:5
    |
 LL |     get_number()..;
    |     ^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:91:5
+  --> tests/ui/unnecessary_operation.rs:92:5
    |
 LL |     ..get_number();
    |     ^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:93:5
+  --> tests/ui/unnecessary_operation.rs:94:5
    |
 LL |     5..get_number();
    |     ^^^^^^^^^^^^^^^^ help: statement can be reduced to: `5;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:95:5
+  --> tests/ui/unnecessary_operation.rs:96:5
    |
 LL |     [42, get_number()];
    |     ^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `42;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:97:5
+  --> tests/ui/unnecessary_operation.rs:98:5
    |
 LL |     [42, 55][get_usize()];
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:99:5
+  --> tests/ui/unnecessary_operation.rs:100:5
    |
 LL |     (42, get_number()).1;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `42;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:101:5
+  --> tests/ui/unnecessary_operation.rs:102:5
    |
 LL |     [get_number(); 55];
    |     ^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:103:5
+  --> tests/ui/unnecessary_operation.rs:104:5
    |
 LL |     [42; 55][get_usize()];
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42; 55].len() > get_usize());`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:105:5
+  --> tests/ui/unnecessary_operation.rs:106:5
    |
 LL | /     {
 LL | |
@@ -113,7 +113,7 @@ LL | |     };
    | |______^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:109:5
+  --> tests/ui/unnecessary_operation.rs:110:5
    |
 LL | /     FooString {
 LL | |
@@ -122,7 +122,7 @@ LL | |     };
    | |______^ help: statement can be reduced to: `String::from("blah");`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:150:5
+  --> tests/ui/unnecessary_operation.rs:151:5
    |
 LL |     [42, 55][get_usize()];
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`

--- a/tests/ui/unnecessary_to_owned.fixed
+++ b/tests/ui/unnecessary_to_owned.fixed
@@ -1,4 +1,5 @@
 #![allow(
+    clippy::disallowed_names,
     clippy::manual_async_fn,
     clippy::needless_borrow,
     clippy::needless_borrows_for_generic_args,

--- a/tests/ui/unnecessary_to_owned.rs
+++ b/tests/ui/unnecessary_to_owned.rs
@@ -1,4 +1,5 @@
 #![allow(
+    clippy::disallowed_names,
     clippy::manual_async_fn,
     clippy::needless_borrow,
     clippy::needless_borrows_for_generic_args,

--- a/tests/ui/unnecessary_to_owned.stderr
+++ b/tests/ui/unnecessary_to_owned.stderr
@@ -1,11 +1,11 @@
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:218:64
+  --> tests/ui/unnecessary_to_owned.rs:219:64
    |
 LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned());
    |                                                                ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:218:20
+  --> tests/ui/unnecessary_to_owned.rs:219:20
    |
 LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,55 +13,55 @@ LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned())
    = help: to override `-D warnings` add `#[allow(clippy::redundant_clone)]`
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:220:40
+  --> tests/ui/unnecessary_to_owned.rs:221:40
    |
 LL |     require_os_str(&OsString::from("x").to_os_string());
    |                                        ^^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:220:21
+  --> tests/ui/unnecessary_to_owned.rs:221:21
    |
 LL |     require_os_str(&OsString::from("x").to_os_string());
    |                     ^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:222:48
+  --> tests/ui/unnecessary_to_owned.rs:223:48
    |
 LL |     require_path(&std::path::PathBuf::from("x").to_path_buf());
    |                                                ^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:222:19
+  --> tests/ui/unnecessary_to_owned.rs:223:19
    |
 LL |     require_path(&std::path::PathBuf::from("x").to_path_buf());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:224:35
+  --> tests/ui/unnecessary_to_owned.rs:225:35
    |
 LL |     require_str(&String::from("x").to_string());
    |                                   ^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:224:18
+  --> tests/ui/unnecessary_to_owned.rs:225:18
    |
 LL |     require_str(&String::from("x").to_string());
    |                  ^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:226:39
+  --> tests/ui/unnecessary_to_owned.rs:227:39
    |
 LL |     require_slice(&[String::from("x")].to_owned());
    |                                       ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:226:20
+  --> tests/ui/unnecessary_to_owned.rs:227:20
    |
 LL |     require_slice(&[String::from("x")].to_owned());
    |                    ^^^^^^^^^^^^^^^^^^^
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:66:36
+  --> tests/ui/unnecessary_to_owned.rs:67:36
    |
 LL |     require_c_str(&Cow::from(c_str).into_owned());
    |                                    ^^^^^^^^^^^^^ help: remove this
@@ -70,391 +70,391 @@ LL |     require_c_str(&Cow::from(c_str).into_owned());
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_to_owned)]`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:68:19
+  --> tests/ui/unnecessary_to_owned.rs:69:19
    |
 LL |     require_c_str(&c_str.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_os_string`
-  --> tests/ui/unnecessary_to_owned.rs:71:20
+  --> tests/ui/unnecessary_to_owned.rs:72:20
    |
 LL |     require_os_str(&os_str.to_os_string());
    |                    ^^^^^^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:73:38
+  --> tests/ui/unnecessary_to_owned.rs:74:38
    |
 LL |     require_os_str(&Cow::from(os_str).into_owned());
    |                                      ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:75:20
+  --> tests/ui/unnecessary_to_owned.rs:76:20
    |
 LL |     require_os_str(&os_str.to_owned());
    |                    ^^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_path_buf`
-  --> tests/ui/unnecessary_to_owned.rs:78:18
+  --> tests/ui/unnecessary_to_owned.rs:79:18
    |
 LL |     require_path(&path.to_path_buf());
    |                  ^^^^^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:80:34
+  --> tests/ui/unnecessary_to_owned.rs:81:34
    |
 LL |     require_path(&Cow::from(path).into_owned());
    |                                  ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:82:18
+  --> tests/ui/unnecessary_to_owned.rs:83:18
    |
 LL |     require_path(&path.to_owned());
    |                  ^^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:85:17
+  --> tests/ui/unnecessary_to_owned.rs:86:17
    |
 LL |     require_str(&s.to_string());
    |                 ^^^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:87:30
+  --> tests/ui/unnecessary_to_owned.rs:88:30
    |
 LL |     require_str(&Cow::from(s).into_owned());
    |                              ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:89:17
+  --> tests/ui/unnecessary_to_owned.rs:90:17
    |
 LL |     require_str(&s.to_owned());
    |                 ^^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:91:17
+  --> tests/ui/unnecessary_to_owned.rs:92:17
    |
 LL |     require_str(&x_ref.to_string());
    |                 ^^^^^^^^^^^^^^^^^^ help: use: `x_ref.as_ref()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:94:19
+  --> tests/ui/unnecessary_to_owned.rs:95:19
    |
 LL |     require_slice(&slice.to_vec());
    |                   ^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:96:36
+  --> tests/ui/unnecessary_to_owned.rs:97:36
    |
 LL |     require_slice(&Cow::from(slice).into_owned());
    |                                    ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:98:19
+  --> tests/ui/unnecessary_to_owned.rs:99:19
    |
 LL |     require_slice(&array.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `array.as_ref()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:100:19
+  --> tests/ui/unnecessary_to_owned.rs:101:19
    |
 LL |     require_slice(&array_ref.to_owned());
    |                   ^^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref.as_ref()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:102:19
+  --> tests/ui/unnecessary_to_owned.rs:103:19
    |
 LL |     require_slice(&slice.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:106:42
+  --> tests/ui/unnecessary_to_owned.rs:107:42
    |
 LL |     require_x(&Cow::<X>::Owned(x.clone()).into_owned());
    |                                          ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:110:25
+  --> tests/ui/unnecessary_to_owned.rs:111:25
    |
 LL |     require_deref_c_str(c_str.to_owned());
    |                         ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:112:26
+  --> tests/ui/unnecessary_to_owned.rs:113:26
    |
 LL |     require_deref_os_str(os_str.to_owned());
    |                          ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:114:24
+  --> tests/ui/unnecessary_to_owned.rs:115:24
    |
 LL |     require_deref_path(path.to_owned());
    |                        ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:116:23
+  --> tests/ui/unnecessary_to_owned.rs:117:23
    |
 LL |     require_deref_str(s.to_owned());
    |                       ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:118:25
+  --> tests/ui/unnecessary_to_owned.rs:119:25
    |
 LL |     require_deref_slice(slice.to_owned());
    |                         ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:121:30
+  --> tests/ui/unnecessary_to_owned.rs:122:30
    |
 LL |     require_impl_deref_c_str(c_str.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:123:31
+  --> tests/ui/unnecessary_to_owned.rs:124:31
    |
 LL |     require_impl_deref_os_str(os_str.to_owned());
    |                               ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:125:29
+  --> tests/ui/unnecessary_to_owned.rs:126:29
    |
 LL |     require_impl_deref_path(path.to_owned());
    |                             ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:127:28
+  --> tests/ui/unnecessary_to_owned.rs:128:28
    |
 LL |     require_impl_deref_str(s.to_owned());
    |                            ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:129:30
+  --> tests/ui/unnecessary_to_owned.rs:130:30
    |
 LL |     require_impl_deref_slice(slice.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:132:29
+  --> tests/ui/unnecessary_to_owned.rs:133:29
    |
 LL |     require_deref_str_slice(s.to_owned(), slice.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:132:43
+  --> tests/ui/unnecessary_to_owned.rs:133:43
    |
 LL |     require_deref_str_slice(s.to_owned(), slice.to_owned());
    |                                           ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:135:29
+  --> tests/ui/unnecessary_to_owned.rs:136:29
    |
 LL |     require_deref_slice_str(slice.to_owned(), s.to_owned());
    |                             ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:135:47
+  --> tests/ui/unnecessary_to_owned.rs:136:47
    |
 LL |     require_deref_slice_str(slice.to_owned(), s.to_owned());
    |                                               ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:139:26
+  --> tests/ui/unnecessary_to_owned.rs:140:26
    |
 LL |     require_as_ref_c_str(c_str.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:141:27
+  --> tests/ui/unnecessary_to_owned.rs:142:27
    |
 LL |     require_as_ref_os_str(os_str.to_owned());
    |                           ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:143:25
+  --> tests/ui/unnecessary_to_owned.rs:144:25
    |
 LL |     require_as_ref_path(path.to_owned());
    |                         ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:145:24
+  --> tests/ui/unnecessary_to_owned.rs:146:24
    |
 LL |     require_as_ref_str(s.to_owned());
    |                        ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:147:24
+  --> tests/ui/unnecessary_to_owned.rs:148:24
    |
 LL |     require_as_ref_str(x.to_owned());
    |                        ^^^^^^^^^^^^ help: use: `&x`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:149:26
+  --> tests/ui/unnecessary_to_owned.rs:150:26
    |
 LL |     require_as_ref_slice(array.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:151:26
+  --> tests/ui/unnecessary_to_owned.rs:152:26
    |
 LL |     require_as_ref_slice(array_ref.to_owned());
    |                          ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:153:26
+  --> tests/ui/unnecessary_to_owned.rs:154:26
    |
 LL |     require_as_ref_slice(slice.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:156:31
+  --> tests/ui/unnecessary_to_owned.rs:157:31
    |
 LL |     require_impl_as_ref_c_str(c_str.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:158:32
+  --> tests/ui/unnecessary_to_owned.rs:159:32
    |
 LL |     require_impl_as_ref_os_str(os_str.to_owned());
    |                                ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:160:30
+  --> tests/ui/unnecessary_to_owned.rs:161:30
    |
 LL |     require_impl_as_ref_path(path.to_owned());
    |                              ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:162:29
+  --> tests/ui/unnecessary_to_owned.rs:163:29
    |
 LL |     require_impl_as_ref_str(s.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:164:29
+  --> tests/ui/unnecessary_to_owned.rs:165:29
    |
 LL |     require_impl_as_ref_str(x.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `&x`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:166:31
+  --> tests/ui/unnecessary_to_owned.rs:167:31
    |
 LL |     require_impl_as_ref_slice(array.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:168:31
+  --> tests/ui/unnecessary_to_owned.rs:169:31
    |
 LL |     require_impl_as_ref_slice(array_ref.to_owned());
    |                               ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:170:31
+  --> tests/ui/unnecessary_to_owned.rs:171:31
    |
 LL |     require_impl_as_ref_slice(slice.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:173:30
+  --> tests/ui/unnecessary_to_owned.rs:174:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:173:44
+  --> tests/ui/unnecessary_to_owned.rs:174:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array.to_owned());
    |                                            ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:176:30
+  --> tests/ui/unnecessary_to_owned.rs:177:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array_ref.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:176:44
+  --> tests/ui/unnecessary_to_owned.rs:177:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array_ref.to_owned());
    |                                            ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:179:30
+  --> tests/ui/unnecessary_to_owned.rs:180:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), slice.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:179:44
+  --> tests/ui/unnecessary_to_owned.rs:180:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), slice.to_owned());
    |                                            ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:182:30
+  --> tests/ui/unnecessary_to_owned.rs:183:30
    |
 LL |     require_as_ref_slice_str(array.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:182:48
+  --> tests/ui/unnecessary_to_owned.rs:183:48
    |
 LL |     require_as_ref_slice_str(array.to_owned(), s.to_owned());
    |                                                ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:185:30
+  --> tests/ui/unnecessary_to_owned.rs:186:30
    |
 LL |     require_as_ref_slice_str(array_ref.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:185:52
+  --> tests/ui/unnecessary_to_owned.rs:186:52
    |
 LL |     require_as_ref_slice_str(array_ref.to_owned(), s.to_owned());
    |                                                    ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:188:30
+  --> tests/ui/unnecessary_to_owned.rs:189:30
    |
 LL |     require_as_ref_slice_str(slice.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:188:48
+  --> tests/ui/unnecessary_to_owned.rs:189:48
    |
 LL |     require_as_ref_slice_str(slice.to_owned(), s.to_owned());
    |                                                ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:192:20
+  --> tests/ui/unnecessary_to_owned.rs:193:20
    |
 LL |     let _ = x.join(&x_ref.to_string());
    |                    ^^^^^^^^^^^^^^^^^^ help: use: `x_ref`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:195:13
+  --> tests/ui/unnecessary_to_owned.rs:196:13
    |
 LL |     let _ = slice.to_vec().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:197:13
+  --> tests/ui/unnecessary_to_owned.rs:198:13
    |
 LL |     let _ = slice.to_owned().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:200:13
+  --> tests/ui/unnecessary_to_owned.rs:201:13
    |
 LL |     let _ = IntoIterator::into_iter(slice.to_vec());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:202:13
+  --> tests/ui/unnecessary_to_owned.rs:203:13
    |
 LL |     let _ = IntoIterator::into_iter(slice.to_owned());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:230:26
+  --> tests/ui/unnecessary_to_owned.rs:231:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(slice.to_vec()).expect("not UTF-8");
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -466,7 +466,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(&slice).expect("not UTF-8");
    |
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:232:26
+  --> tests/ui/unnecessary_to_owned.rs:233:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(b"foo".to_vec()).unwrap();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -478,7 +478,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(b"foo").unwrap();
    |
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:234:26
+  --> tests/ui/unnecessary_to_owned.rs:235:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(b"foo".as_slice().to_owned()).unwrap();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -490,7 +490,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(b"foo".as_slice()).unwrap();
    |
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:292:14
+  --> tests/ui/unnecessary_to_owned.rs:293:14
    |
 LL |     for t in file_types.to_vec() {
    |              ^^^^^^^^^^^^^^^^^^^
@@ -503,49 +503,49 @@ LL ~         let path = match get_file_path(t) {
    |
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:358:24
+  --> tests/ui/unnecessary_to_owned.rs:359:24
    |
 LL |         Box::new(build(y.to_string()))
    |                        ^^^^^^^^^^^^^ help: use: `y`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:468:12
+  --> tests/ui/unnecessary_to_owned.rs:469:12
    |
 LL |         id("abc".to_string())
    |            ^^^^^^^^^^^^^^^^^ help: use: `"abc"`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:612:37
+  --> tests/ui/unnecessary_to_owned.rs:613:37
    |
 LL |         IntoFuture::into_future(foo([].to_vec(), &0));
    |                                     ^^^^^^^^^^^ help: use: `[]`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:623:18
+  --> tests/ui/unnecessary_to_owned.rs:624:18
    |
 LL |         s.remove(&a.to_vec());
    |                  ^^^^^^^^^^^ help: replace it with: `a`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:628:14
+  --> tests/ui/unnecessary_to_owned.rs:629:14
    |
 LL |     s.remove(&"b".to_owned());
    |              ^^^^^^^^^^^^^^^ help: replace it with: `"b"`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:630:14
+  --> tests/ui/unnecessary_to_owned.rs:631:14
    |
 LL |     s.remove(&"b".to_string());
    |              ^^^^^^^^^^^^^^^^ help: replace it with: `"b"`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:636:14
+  --> tests/ui/unnecessary_to_owned.rs:637:14
    |
 LL |     s.remove(&["b"].to_vec());
    |              ^^^^^^^^^^^^^^^ help: replace it with: `["b"].as_slice()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:638:14
+  --> tests/ui/unnecessary_to_owned.rs:639:14
    |
 LL |     s.remove(&(&["b"]).to_vec());
    |              ^^^^^^^^^^^^^^^^^^ help: replace it with: `(&["b"]).as_slice()`

--- a/tests/ui/unused_async.rs
+++ b/tests/ui/unused_async.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::unused_async)]
-#![allow(incomplete_features)]
+#![allow(incomplete_features, clippy::disallowed_names)]
 
 use std::future::Future;
 use std::pin::Pin;

--- a/tests/ui/unused_self.rs
+++ b/tests/ui/unused_self.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::unused_self)]
-#![allow(clippy::boxed_local, clippy::fn_params_excessive_bools)]
+#![allow(clippy::boxed_local, clippy::fn_params_excessive_bools, clippy::disallowed_names)]
 
 mod unused_self {
     use std::pin::Pin;

--- a/tests/ui/unused_trait_names.fixed
+++ b/tests/ui/unused_trait_names.fixed
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::unused_trait_names)]
 #![feature(decl_macro)]
 

--- a/tests/ui/unused_trait_names.rs
+++ b/tests/ui/unused_trait_names.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 
-#![allow(unused)]
+#![allow(unused, clippy::disallowed_names)]
 #![warn(clippy::unused_trait_names)]
 #![feature(decl_macro)]
 

--- a/tests/ui/unused_unit.edition2021.fixed
+++ b/tests/ui/unused_unit.edition2021.fixed
@@ -14,7 +14,7 @@
 
 #![deny(clippy::unused_unit)]
 #![allow(dead_code)]
-#![allow(clippy::from_over_into)]
+#![allow(clippy::from_over_into, clippy::disallowed_names)]
 
 struct Unitter;
 impl Unitter {

--- a/tests/ui/unused_unit.edition2024.fixed
+++ b/tests/ui/unused_unit.edition2024.fixed
@@ -14,7 +14,7 @@
 
 #![deny(clippy::unused_unit)]
 #![allow(dead_code)]
-#![allow(clippy::from_over_into)]
+#![allow(clippy::from_over_into, clippy::disallowed_names)]
 
 struct Unitter;
 impl Unitter {

--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -12,7 +12,7 @@
 
 #![deny(clippy::unused_unit)]
 #![allow(dead_code)]
-#![allow(clippy::from_over_into)]
+#![allow(clippy::from_over_into, clippy::disallowed_names)]
 
 struct Unitter;
 impl Unitter {

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -14,7 +14,7 @@
 
 #![deny(clippy::unused_unit)]
 #![allow(dead_code)]
-#![allow(clippy::from_over_into)]
+#![allow(clippy::from_over_into, clippy::disallowed_names)]
 
 struct Unitter;
 impl Unitter {

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -8,7 +8,8 @@
     clippy::from_over_into,
     clippy::self_named_constructors,
     clippy::needless_lifetimes,
-    clippy::missing_transmute_annotations
+    clippy::missing_transmute_annotations,
+    clippy::disallowed_names
 )]
 
 #[macro_use]

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -8,7 +8,8 @@
     clippy::from_over_into,
     clippy::self_named_constructors,
     clippy::needless_lifetimes,
-    clippy::missing_transmute_annotations
+    clippy::missing_transmute_annotations,
+    clippy::disallowed_names
 )]
 
 #[macro_use]

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -1,5 +1,5 @@
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:23:21
+  --> tests/ui/use_self.rs:24:21
    |
 LL |         fn new() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
@@ -8,253 +8,253 @@ LL |         fn new() -> Foo {
    = help: to override `-D warnings` add `#[allow(clippy::use_self)]`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:25:13
+  --> tests/ui/use_self.rs:26:13
    |
 LL |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:28:22
+  --> tests/ui/use_self.rs:29:22
    |
 LL |         fn test() -> Foo {
    |                      ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:30:13
+  --> tests/ui/use_self.rs:31:13
    |
 LL |             Foo::new()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:36:25
+  --> tests/ui/use_self.rs:37:25
    |
 LL |         fn default() -> Foo {
    |                         ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:38:13
+  --> tests/ui/use_self.rs:39:13
    |
 LL |             Foo::new()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:80:28
+  --> tests/ui/use_self.rs:81:28
    |
 LL |         fn clone(&self) -> Foo<'a> {
    |                            ^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:114:24
+  --> tests/ui/use_self.rs:115:24
    |
 LL |         fn bad(foos: &[Foo]) -> impl Iterator<Item = &Foo> {
    |                        ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:114:55
+  --> tests/ui/use_self.rs:115:55
    |
 LL |         fn bad(foos: &[Foo]) -> impl Iterator<Item = &Foo> {
    |                                                       ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:131:13
+  --> tests/ui/use_self.rs:132:13
    |
 LL |             TS(0)
    |             ^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:167:29
+  --> tests/ui/use_self.rs:168:29
    |
 LL |                 fn bar() -> Bar {
    |                             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:169:21
+  --> tests/ui/use_self.rs:170:21
    |
 LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:181:21
+  --> tests/ui/use_self.rs:182:21
    |
 LL |         fn baz() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:183:13
+  --> tests/ui/use_self.rs:184:13
    |
 LL |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:201:21
+  --> tests/ui/use_self.rs:202:21
    |
 LL |             let _ = Enum::B(42);
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:203:21
+  --> tests/ui/use_self.rs:204:21
    |
 LL |             let _ = Enum::C { field: true };
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:205:21
+  --> tests/ui/use_self.rs:206:21
    |
 LL |             let _ = Enum::A;
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:248:13
+  --> tests/ui/use_self.rs:249:13
    |
 LL |             nested::A::fun_1();
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:250:13
+  --> tests/ui/use_self.rs:251:13
    |
 LL |             nested::A::A;
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:253:13
+  --> tests/ui/use_self.rs:254:13
    |
 LL |             nested::A {};
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:273:13
+  --> tests/ui/use_self.rs:274:13
    |
 LL |             TestStruct::from_something()
    |             ^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:288:25
+  --> tests/ui/use_self.rs:289:25
    |
 LL |         async fn g() -> S {
    |                         ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:290:13
+  --> tests/ui/use_self.rs:291:13
    |
 LL |             S {}
    |             ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:295:16
+  --> tests/ui/use_self.rs:296:16
    |
 LL |             &p[S::A..S::B]
    |                ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:295:22
+  --> tests/ui/use_self.rs:296:22
    |
 LL |             &p[S::A..S::B]
    |                      ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:320:29
+  --> tests/ui/use_self.rs:321:29
    |
 LL |         fn foo(value: T) -> Foo<T> {
    |                             ^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:322:13
+  --> tests/ui/use_self.rs:323:13
    |
 LL |             Foo::<T> { value }
    |             ^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:495:13
+  --> tests/ui/use_self.rs:496:13
    |
 LL |             A::new::<submod::B>(submod::B {})
    |             ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:533:13
+  --> tests/ui/use_self.rs:534:13
    |
 LL |             S2::new()
    |             ^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:571:17
+  --> tests/ui/use_self.rs:572:17
    |
 LL |                 Foo::Bar => unimplemented!(),
    |                 ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:573:17
+  --> tests/ui/use_self.rs:574:17
    |
 LL |                 Foo::Baz => unimplemented!(),
    |                 ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:580:20
+  --> tests/ui/use_self.rs:581:20
    |
 LL |             if let Foo::Bar = self {
    |                    ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:605:17
+  --> tests/ui/use_self.rs:606:17
    |
 LL |                 Something::Num(n) => *n,
    |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:607:17
+  --> tests/ui/use_self.rs:608:17
    |
 LL |                 Something::TupleNums(n, _m) => *n,
    |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:609:17
+  --> tests/ui/use_self.rs:610:17
    |
 LL |                 Something::StructNums { one, two: _ } => *one,
    |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:616:17
+  --> tests/ui/use_self.rs:617:17
    |
 LL |                 crate::issue8845::Something::Num(n) => *n,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:618:17
+  --> tests/ui/use_self.rs:619:17
    |
 LL |                 crate::issue8845::Something::TupleNums(n, _m) => *n,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:620:17
+  --> tests/ui/use_self.rs:621:17
    |
 LL |                 crate::issue8845::Something::StructNums { one, two: _ } => *one,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:637:17
+  --> tests/ui/use_self.rs:638:17
    |
 LL |             let Foo(x) = self;
    |                 ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:643:17
+  --> tests/ui/use_self.rs:644:17
    |
 LL |             let crate::issue8845::Foo(x) = self;
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:651:17
+  --> tests/ui/use_self.rs:652:17
    |
 LL |             let Bar { x, .. } = self;
    |                 ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:657:17
+  --> tests/ui/use_self.rs:658:17
    |
 LL |             let crate::issue8845::Bar { x, .. } = self;
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:697:17
+  --> tests/ui/use_self.rs:698:17
    |
 LL |                 E::A => {},
    |                 ^ help: use the applicable keyword: `Self`

--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -4,7 +4,8 @@
     clippy::uninlined_format_args,
     clippy::map_clone,
     clippy::needless_pass_by_ref_mut,
-    clippy::redundant_closure
+    clippy::redundant_closure,
+    clippy::disallowed_names
 )]
 
 use std::fmt::Debug;

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -4,7 +4,8 @@
     clippy::uninlined_format_args,
     clippy::map_clone,
     clippy::needless_pass_by_ref_mut,
-    clippy::redundant_closure
+    clippy::redundant_closure,
+    clippy::disallowed_names
 )]
 
 use std::fmt::Debug;

--- a/tests/ui/useless_asref.stderr
+++ b/tests/ui/useless_asref.stderr
@@ -1,5 +1,5 @@
 error: this call to `as_ref` does nothing
-  --> tests/ui/useless_asref.rs:51:18
+  --> tests/ui/useless_asref.rs:52:18
    |
 LL |         foo_rstr(rstr.as_ref());
    |                  ^^^^^^^^^^^^^ help: try: `rstr`
@@ -11,103 +11,103 @@ LL | #![deny(clippy::useless_asref)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `as_ref` does nothing
-  --> tests/ui/useless_asref.rs:54:20
+  --> tests/ui/useless_asref.rs:55:20
    |
 LL |         foo_rslice(rslice.as_ref());
    |                    ^^^^^^^^^^^^^^^ help: try: `rslice`
 
 error: this call to `as_mut` does nothing
-  --> tests/ui/useless_asref.rs:59:21
+  --> tests/ui/useless_asref.rs:60:21
    |
 LL |         foo_mrslice(mrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^ help: try: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> tests/ui/useless_asref.rs:62:20
+  --> tests/ui/useless_asref.rs:63:20
    |
 LL |         foo_rslice(mrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^ help: try: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> tests/ui/useless_asref.rs:70:20
+  --> tests/ui/useless_asref.rs:71:20
    |
 LL |         foo_rslice(rrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^ help: try: `rrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> tests/ui/useless_asref.rs:73:18
+  --> tests/ui/useless_asref.rs:74:18
    |
 LL |         foo_rstr(rrrrrstr.as_ref());
    |                  ^^^^^^^^^^^^^^^^^ help: try: `rrrrrstr`
 
 error: this call to `as_mut` does nothing
-  --> tests/ui/useless_asref.rs:79:21
+  --> tests/ui/useless_asref.rs:80:21
    |
 LL |         foo_mrslice(mrrrrrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^^^^^ help: try: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> tests/ui/useless_asref.rs:82:20
+  --> tests/ui/useless_asref.rs:83:20
    |
 LL |         foo_rslice(mrrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: try: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> tests/ui/useless_asref.rs:87:16
+  --> tests/ui/useless_asref.rs:88:16
    |
 LL |     foo_rrrrmr((&&&&MoreRef).as_ref());
    |                ^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&&&&MoreRef)`
 
 error: this call to `as_mut` does nothing
-  --> tests/ui/useless_asref.rs:138:13
+  --> tests/ui/useless_asref.rs:139:13
    |
 LL |     foo_mrt(mrt.as_mut());
    |             ^^^^^^^^^^^^ help: try: `mrt`
 
 error: this call to `as_ref` does nothing
-  --> tests/ui/useless_asref.rs:141:12
+  --> tests/ui/useless_asref.rs:142:12
    |
 LL |     foo_rt(mrt.as_ref());
    |            ^^^^^^^^^^^^ help: try: `mrt`
 
 error: this call to `as_ref.map(...)` does nothing
-  --> tests/ui/useless_asref.rs:153:13
+  --> tests/ui/useless_asref.rs:154:13
    |
 LL |     let z = x.as_ref().map(String::clone);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.clone()`
 
 error: this call to `as_ref.map(...)` does nothing
-  --> tests/ui/useless_asref.rs:156:13
+  --> tests/ui/useless_asref.rs:157:13
    |
 LL |     let z = x.as_ref().map(|z| z.clone());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.clone()`
 
 error: this call to `as_ref.map(...)` does nothing
-  --> tests/ui/useless_asref.rs:159:13
+  --> tests/ui/useless_asref.rs:160:13
    |
 LL |     let z = x.as_ref().map(|z| String::clone(z));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.clone()`
 
 error: this call to `as_ref.map(...)` does nothing
-  --> tests/ui/useless_asref.rs:183:9
+  --> tests/ui/useless_asref.rs:184:9
    |
 LL |         x.field.as_ref().map(|v| v.clone());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.field.clone()`
 
 error: this call to `as_ref.map(...)` does nothing
-  --> tests/ui/useless_asref.rs:186:9
+  --> tests/ui/useless_asref.rs:187:9
    |
 LL |         x.field.as_ref().map(Clone::clone);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.field.clone()`
 
 error: this call to `as_ref.map(...)` does nothing
-  --> tests/ui/useless_asref.rs:189:9
+  --> tests/ui/useless_asref.rs:190:9
    |
 LL |         x.field.as_ref().map(|v| Clone::clone(v));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.field.clone()`
 
 error: this call to `as_ref.map(...)` does nothing
-  --> tests/ui/useless_asref.rs:194:9
+  --> tests/ui/useless_asref.rs:195:9
    |
 LL |         Some(1).as_ref().map(|&x| x.clone());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(1).clone()`

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -1,5 +1,5 @@
 #![deny(clippy::useless_conversion)]
-#![allow(clippy::needless_if, clippy::unnecessary_wraps)]
+#![allow(clippy::needless_if, clippy::unnecessary_wraps, clippy::disallowed_names)]
 // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
 #![allow(static_mut_refs)]
 

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::useless_conversion)]
-#![allow(clippy::needless_if, clippy::unnecessary_wraps)]
+#![allow(clippy::needless_if, clippy::unnecessary_wraps, clippy::disallowed_names)]
 // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
 #![allow(static_mut_refs)]
 

--- a/tests/ui/useless_vec.rs
+++ b/tests/ui/useless_vec.rs
@@ -1,6 +1,7 @@
 //@no-rustfix: no suggestions
 
 #![warn(clippy::useless_vec)]
+#![allow(clippy::disallowed_names)]
 
 // Regression test for <https://github.com/rust-lang/rust-clippy/issues/13692>.
 fn foo() {

--- a/tests/ui/useless_vec.stderr
+++ b/tests/ui/useless_vec.stderr
@@ -1,5 +1,5 @@
 error: useless use of `vec!`
-  --> tests/ui/useless_vec.rs:8:26
+  --> tests/ui/useless_vec.rs:9:26
    |
 LL |       let _some_variable = vec![
    |  __________________________^

--- a/tests/ui/wildcard_imports.fixed
+++ b/tests/ui/wildcard_imports.fixed
@@ -7,7 +7,7 @@
 // no longer detects some of the cases starting with Rust 2018.
 
 #![warn(clippy::wildcard_imports)]
-#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value)]
+#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value, clippy::disallowed_names)]
 #![warn(unused_imports)]
 
 extern crate wildcard_imports_helper;

--- a/tests/ui/wildcard_imports.rs
+++ b/tests/ui/wildcard_imports.rs
@@ -7,7 +7,7 @@
 // no longer detects some of the cases starting with Rust 2018.
 
 #![warn(clippy::wildcard_imports)]
-#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value)]
+#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value, clippy::disallowed_names)]
 #![warn(unused_imports)]
 
 extern crate wildcard_imports_helper;

--- a/tests/ui/wildcard_imports_2021.edition2018.fixed
+++ b/tests/ui/wildcard_imports_2021.edition2018.fixed
@@ -5,7 +5,7 @@
 //@aux-build:wildcard_imports_helper.rs
 
 #![warn(clippy::wildcard_imports)]
-#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value)]
+#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value, clippy::disallowed_names)]
 #![warn(unused_imports)]
 
 extern crate wildcard_imports_helper;

--- a/tests/ui/wildcard_imports_2021.edition2021.fixed
+++ b/tests/ui/wildcard_imports_2021.edition2021.fixed
@@ -5,7 +5,7 @@
 //@aux-build:wildcard_imports_helper.rs
 
 #![warn(clippy::wildcard_imports)]
-#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value)]
+#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value, clippy::disallowed_names)]
 #![warn(unused_imports)]
 
 extern crate wildcard_imports_helper;

--- a/tests/ui/wildcard_imports_2021.rs
+++ b/tests/ui/wildcard_imports_2021.rs
@@ -5,7 +5,7 @@
 //@aux-build:wildcard_imports_helper.rs
 
 #![warn(clippy::wildcard_imports)]
-#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value)]
+#![allow(unused, clippy::unnecessary_wraps, clippy::let_unit_value, clippy::disallowed_names)]
 #![warn(unused_imports)]
 
 extern crate wildcard_imports_helper;

--- a/tests/ui/zero_ptr.fixed
+++ b/tests/ui/zero_ptr.fixed
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_names)]
+
 pub fn foo(_const: *const f32, _mut: *mut i64) {}
 
 fn main() {

--- a/tests/ui/zero_ptr.rs
+++ b/tests/ui/zero_ptr.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_names)]
+
 pub fn foo(_const: *const f32, _mut: *mut i64) {}
 
 fn main() {

--- a/tests/ui/zero_ptr.stderr
+++ b/tests/ui/zero_ptr.stderr
@@ -1,5 +1,5 @@
 error: `0 as *const _` detected
-  --> tests/ui/zero_ptr.rs:4:13
+  --> tests/ui/zero_ptr.rs:6:13
    |
 LL |     let _ = 0 as *const usize;
    |             ^^^^^^^^^^^^^^^^^ help: try: `std::ptr::null::<usize>()`
@@ -8,25 +8,25 @@ LL |     let _ = 0 as *const usize;
    = help: to override `-D warnings` add `#[allow(clippy::zero_ptr)]`
 
 error: `0 as *mut _` detected
-  --> tests/ui/zero_ptr.rs:6:13
+  --> tests/ui/zero_ptr.rs:8:13
    |
 LL |     let _ = 0 as *mut f64;
    |             ^^^^^^^^^^^^^ help: try: `std::ptr::null_mut::<f64>()`
 
 error: `0 as *const _` detected
-  --> tests/ui/zero_ptr.rs:8:24
+  --> tests/ui/zero_ptr.rs:10:24
    |
 LL |     let _: *const u8 = 0 as *const _;
    |                        ^^^^^^^^^^^^^ help: try: `std::ptr::null()`
 
 error: `0 as *const _` detected
-  --> tests/ui/zero_ptr.rs:12:9
+  --> tests/ui/zero_ptr.rs:14:9
    |
 LL |     foo(0 as *const _, 0 as *mut _);
    |         ^^^^^^^^^^^^^ help: try: `std::ptr::null()`
 
 error: `0 as *mut _` detected
-  --> tests/ui/zero_ptr.rs:12:24
+  --> tests/ui/zero_ptr.rs:14:24
    |
 LL |     foo(0 as *const _, 0 as *mut _);
    |                        ^^^^^^^^^^^ help: try: `std::ptr::null_mut()`

--- a/tests/ui/zombie_processes.rs
+++ b/tests/ui/zombie_processes.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::zombie_processes)]
-#![allow(clippy::if_same_then_else, clippy::ifs_same_cond, clippy::needless_return)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::if_same_then_else,
+    clippy::ifs_same_cond,
+    clippy::needless_return
+)]
 
 use std::process::{Child, Command, ExitStatus};
 

--- a/tests/ui/zombie_processes.stderr
+++ b/tests/ui/zombie_processes.stderr
@@ -1,5 +1,5 @@
 error: spawned process is never `wait()`ed on
-  --> tests/ui/zombie_processes.rs:14:21
+  --> tests/ui/zombie_processes.rs:19:21
    |
 LL |         let mut x = Command::new("").spawn().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |         let mut x = Command::new("").spawn().unwrap();
    = help: to override `-D warnings` add `#[allow(clippy::zombie_processes)]`
 
 error: spawned process is never `wait()`ed on
-  --> tests/ui/zombie_processes.rs:42:21
+  --> tests/ui/zombie_processes.rs:47:21
    |
 LL |         let mut x = Command::new("").spawn().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL |         let mut x = Command::new("").spawn().unwrap();
    = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
 
 error: spawned process is never `wait()`ed on
-  --> tests/ui/zombie_processes.rs:68:21
+  --> tests/ui/zombie_processes.rs:73:21
    |
 LL |         let mut x = Command::new("").spawn().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |         let mut x = Command::new("").spawn().unwrap();
    = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
 
 error: spawned process is never `wait()`ed on
-  --> tests/ui/zombie_processes.rs:76:21
+  --> tests/ui/zombie_processes.rs:81:21
    |
 LL |         let mut x = Command::new("").spawn().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,18 +41,18 @@ LL |         let mut x = Command::new("").spawn().unwrap();
    = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
 
 error: spawned process is not `wait()`ed on in all code paths
-  --> tests/ui/zombie_processes.rs:103:21
+  --> tests/ui/zombie_processes.rs:108:21
    |
 LL |         let mut x = Command::new("").spawn().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: no `wait()` call exists on the code path to this early return
-  --> tests/ui/zombie_processes.rs:107:13
+  --> tests/ui/zombie_processes.rs:112:13
    |
 LL |             return;
    |             ^^^^^^
 note: `wait()` call exists, but it is unreachable due to the early return
-  --> tests/ui/zombie_processes.rs:109:9
+  --> tests/ui/zombie_processes.rs:114:9
    |
 LL |         x.wait().unwrap();
    |         ^
@@ -61,20 +61,20 @@ LL |         x.wait().unwrap();
    = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
 
 error: spawned process is not `wait()`ed on in all code paths
-  --> tests/ui/zombie_processes.rs:113:21
+  --> tests/ui/zombie_processes.rs:118:21
    |
 LL |         let mut x = Command::new("").spawn().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this if expression has a `wait()` call, but it is missing an else block
-  --> tests/ui/zombie_processes.rs:116:9
+  --> tests/ui/zombie_processes.rs:121:9
    |
 LL | /         if true {
 LL | |             x.wait().unwrap();
 LL | |         }
    | |_________^
 note: `wait()` called here
-  --> tests/ui/zombie_processes.rs:117:13
+  --> tests/ui/zombie_processes.rs:122:13
    |
 LL |             x.wait().unwrap();
    |             ^
@@ -83,13 +83,13 @@ LL |             x.wait().unwrap();
    = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
 
 error: spawned process is not `wait()`ed on in all code paths
-  --> tests/ui/zombie_processes.rs:122:21
+  --> tests/ui/zombie_processes.rs:127:21
    |
 LL |         let mut x = Command::new("").spawn().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `wait()` is not called in this if branch
-  --> tests/ui/zombie_processes.rs:127:10
+  --> tests/ui/zombie_processes.rs:132:10
    |
 LL |           } else {
    |  __________^
@@ -97,7 +97,7 @@ LL | |             // this else block exists to test the other help message
 LL | |         }
    | |_________^
 note: `wait()` is called in the other branch
-  --> tests/ui/zombie_processes.rs:126:13
+  --> tests/ui/zombie_processes.rs:131:13
    |
 LL |             x.wait().unwrap();
    |             ^
@@ -106,20 +106,20 @@ LL |             x.wait().unwrap();
    = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
 
 error: spawned process is not `wait()`ed on in all code paths
-  --> tests/ui/zombie_processes.rs:133:21
+  --> tests/ui/zombie_processes.rs:138:21
    |
 LL |         let mut x = Command::new("").spawn().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `wait()` is not called in this if branch
-  --> tests/ui/zombie_processes.rs:136:9
+  --> tests/ui/zombie_processes.rs:141:9
    |
 LL | /         if true {
 LL | |             // this else block exists to test the other help message
 LL | |         } else {
    | |_________^
 note: `wait()` is called in the other branch
-  --> tests/ui/zombie_processes.rs:139:13
+  --> tests/ui/zombie_processes.rs:144:13
    |
 LL |             x.wait().unwrap();
    |             ^

--- a/tests/workspace_test/module_style/pass_mod_with_dep_in_subdir/dep_no_mod/src/lib.rs
+++ b/tests/workspace_test/module_style/pass_mod_with_dep_in_subdir/dep_no_mod/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_names)]
 pub mod foo;
 
 pub fn foo() {

--- a/tests/workspace_test/module_style/pass_mod_with_dep_in_subdir/dep_no_mod/src/lib.rs
+++ b/tests/workspace_test/module_style/pass_mod_with_dep_in_subdir/dep_no_mod/src/lib.rs
@@ -1,6 +1,5 @@
-#![allow(clippy::disallowed_names)]
 pub mod foo;
 
-pub fn foo() {
+pub fn foo_thing() {
     let _ = foo::Thing;
 }

--- a/tests/workspace_test/module_style/pass_no_mod_with_dep_in_subdir/dep_with_mod/src/lib.rs
+++ b/tests/workspace_test/module_style/pass_no_mod_with_dep_in_subdir/dep_with_mod/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod with_mod;
 
-pub fn foo() {
+pub fn access_nested_types() {
     let _ = with_mod::Thing;
     let _ = with_mod::inner::stuff::Inner;
     let _ = with_mod::inner::stuff::most::Snarks;


### PR DESCRIPTION
This PR fixes a part of rust-lang/rust-clippy#11306.  

Note that `disallowed_names` still doesn't warn about using disallowed struct (and its field) /module/crate names. I'm planning to address this in a separate PR (if it makes sense to you).

The changes are a bit large, but they primarily involve two updates:
- Enhancing the disallowed_names lint to emit warnings for functions with disallowed names.
- Updating tests that include such functions to explicitly allow the lint.

changelog: [`disallowed_names`]: Warn on usage of disallowed function names
