### PR TITLE
Run UI tests in edition 2024 mode

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -14,6 +14,7 @@ use pulldown_cmark::{Options, Parser, html};
 use serde::Deserialize;
 use test_utils::IS_RUSTC_TEST_SUITE;
 use ui_test::custom_flags::Flag;
+use ui_test::custom_flags::edition::Edition;
 use ui_test::custom_flags::rustfix::RustfixMode;
 use ui_test::spanned::Spanned;
 use ui_test::{Args, CommandBuilder, Config, Match, error_on_output_conflict, status_emitter};
@@ -156,6 +157,7 @@ impl TestContext {
             ..Config::rustc(Path::new("tests").join(test_dir))
         };
         let defaults = config.comment_defaults.base();
+        defaults.set_custom("edition", Edition("2024".into()));
         defaults.exit_status = None.into();
         if mandatory_annotations {
             defaults.require_annotations = Some(Spanned::dummy(true)).into();

--- a/tests/ui-toml/strict_non_send_fields_in_send_ty/test.rs
+++ b/tests/ui-toml/strict_non_send_fields_in_send_ty/test.rs
@@ -29,7 +29,7 @@ unsafe impl<T> Send for MyOption<T> {}
 //~^ non_send_fields_in_send_ty
 
 // All fields are disallowed when raw pointer heuristic is off
-extern "C" {
+unsafe extern "C" {
     type NonSend;
 }
 

--- a/tests/ui/asm_syntax_not_x86.rs
+++ b/tests/ui/asm_syntax_not_x86.rs
@@ -8,9 +8,11 @@ mod dont_warn {
     use std::arch::{asm, global_asm};
 
     pub(super) unsafe fn use_asm() {
-        asm!("");
-        asm!("", options());
-        asm!("", options(nostack));
+        unsafe {
+            asm!("");
+            asm!("", options());
+            asm!("", options(nostack));
+        }
     }
 
     global_asm!("");

--- a/tests/ui/asm_syntax_x86.rs
+++ b/tests/ui/asm_syntax_x86.rs
@@ -5,17 +5,19 @@ mod warn_intel {
     use std::arch::{asm, global_asm};
 
     pub(super) unsafe fn use_asm() {
-        asm!("");
-        //~^ inline_asm_x86_intel_syntax
+        unsafe {
+            asm!("");
+            //~^ inline_asm_x86_intel_syntax
 
-        asm!("", options());
-        //~^ inline_asm_x86_intel_syntax
+            asm!("", options());
+            //~^ inline_asm_x86_intel_syntax
 
-        asm!("", options(nostack));
-        //~^ inline_asm_x86_intel_syntax
+            asm!("", options(nostack));
+            //~^ inline_asm_x86_intel_syntax
 
-        asm!("", options(att_syntax));
-        asm!("", options(nostack, att_syntax));
+            asm!("", options(att_syntax));
+            asm!("", options(nostack, att_syntax));
+        }
     }
 
     global_asm!("");
@@ -32,14 +34,16 @@ mod warn_att {
     use std::arch::{asm, global_asm};
 
     pub(super) unsafe fn use_asm() {
-        asm!("");
-        asm!("", options());
-        asm!("", options(nostack));
-        asm!("", options(att_syntax));
-        //~^ inline_asm_x86_att_syntax
+        unsafe {
+            asm!("");
+            asm!("", options());
+            asm!("", options(nostack));
+            asm!("", options(att_syntax));
+            //~^ inline_asm_x86_att_syntax
 
-        asm!("", options(nostack, att_syntax));
-        //~^ inline_asm_x86_att_syntax
+            asm!("", options(nostack, att_syntax));
+            //~^ inline_asm_x86_att_syntax
+        }
     }
 
     global_asm!("");

--- a/tests/ui/asm_syntax_x86.stderr
+++ b/tests/ui/asm_syntax_x86.stderr
@@ -1,31 +1,31 @@
 error: Intel x86 assembly syntax used
-  --> tests/ui/asm_syntax_x86.rs:8:9
+  --> tests/ui/asm_syntax_x86.rs:9:13
    |
-LL |         asm!("");
-   |         ^^^^^^^^
+LL |             asm!("");
+   |             ^^^^^^^^
    |
    = help: use AT&T x86 assembly syntax
    = note: `-D clippy::inline-asm-x86-intel-syntax` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::inline_asm_x86_intel_syntax)]`
 
 error: Intel x86 assembly syntax used
-  --> tests/ui/asm_syntax_x86.rs:11:9
+  --> tests/ui/asm_syntax_x86.rs:12:13
    |
-LL |         asm!("", options());
-   |         ^^^^^^^^^^^^^^^^^^^
-   |
-   = help: use AT&T x86 assembly syntax
-
-error: Intel x86 assembly syntax used
-  --> tests/ui/asm_syntax_x86.rs:14:9
-   |
-LL |         asm!("", options(nostack));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             asm!("", options());
+   |             ^^^^^^^^^^^^^^^^^^^
    |
    = help: use AT&T x86 assembly syntax
 
 error: Intel x86 assembly syntax used
-  --> tests/ui/asm_syntax_x86.rs:21:5
+  --> tests/ui/asm_syntax_x86.rs:15:13
+   |
+LL |             asm!("", options(nostack));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use AT&T x86 assembly syntax
+
+error: Intel x86 assembly syntax used
+  --> tests/ui/asm_syntax_x86.rs:23:5
    |
 LL |     global_asm!("");
    |     ^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     global_asm!("");
    = help: use AT&T x86 assembly syntax
 
 error: Intel x86 assembly syntax used
-  --> tests/ui/asm_syntax_x86.rs:24:5
+  --> tests/ui/asm_syntax_x86.rs:26:5
    |
 LL |     global_asm!("", options());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,25 +41,25 @@ LL |     global_asm!("", options());
    = help: use AT&T x86 assembly syntax
 
 error: AT&T x86 assembly syntax used
-  --> tests/ui/asm_syntax_x86.rs:38:9
+  --> tests/ui/asm_syntax_x86.rs:41:13
    |
-LL |         asm!("", options(att_syntax));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             asm!("", options(att_syntax));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use Intel x86 assembly syntax
    = note: `-D clippy::inline-asm-x86-att-syntax` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::inline_asm_x86_att_syntax)]`
 
 error: AT&T x86 assembly syntax used
-  --> tests/ui/asm_syntax_x86.rs:41:9
+  --> tests/ui/asm_syntax_x86.rs:44:13
    |
-LL |         asm!("", options(nostack, att_syntax));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             asm!("", options(nostack, att_syntax));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use Intel x86 assembly syntax
 
 error: AT&T x86 assembly syntax used
-  --> tests/ui/asm_syntax_x86.rs:47:5
+  --> tests/ui/asm_syntax_x86.rs:51:5
    |
 LL |     global_asm!("", options(att_syntax));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/blocks_in_conditions.fixed
+++ b/tests/ui/blocks_in_conditions.fixed
@@ -1,12 +1,7 @@
 //@aux-build:proc_macro_attr.rs
 
 #![warn(clippy::blocks_in_conditions)]
-#![allow(
-    unused,
-    clippy::let_and_return,
-    clippy::needless_if,
-    clippy::missing_transmute_annotations
-)]
+#![allow(unused, clippy::needless_if, clippy::missing_transmute_annotations)]
 #![warn(clippy::nonminimal_bool)]
 
 macro_rules! blocky {
@@ -69,28 +64,6 @@ fn block_in_assert() {
             })
             .is_some()
     );
-}
-
-// issue #11814
-fn block_in_match_expr(num: i32) -> i32 {
-    let res = {
-        //~^ ERROR: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-        let opt = Some(2);
-        opt
-    }; match res {
-        Some(0) => 1,
-        Some(n) => num * 2,
-        None => 0,
-    };
-
-    match unsafe {
-        let hearty_hearty_hearty = vec![240, 159, 146, 150];
-        String::from_utf8_unchecked(hearty_hearty_hearty).as_str()
-    } {
-        "💖" => 1,
-        "what" => 2,
-        _ => 3,
-    }
 }
 
 // issue #12162

--- a/tests/ui/blocks_in_conditions.rs
+++ b/tests/ui/blocks_in_conditions.rs
@@ -1,12 +1,7 @@
 //@aux-build:proc_macro_attr.rs
 
 #![warn(clippy::blocks_in_conditions)]
-#![allow(
-    unused,
-    clippy::let_and_return,
-    clippy::needless_if,
-    clippy::missing_transmute_annotations
-)]
+#![allow(unused, clippy::needless_if, clippy::missing_transmute_annotations)]
 #![warn(clippy::nonminimal_bool)]
 
 macro_rules! blocky {
@@ -69,28 +64,6 @@ fn block_in_assert() {
             })
             .is_some()
     );
-}
-
-// issue #11814
-fn block_in_match_expr(num: i32) -> i32 {
-    match {
-        //~^ ERROR: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-        let opt = Some(2);
-        opt
-    } {
-        Some(0) => 1,
-        Some(n) => num * 2,
-        None => 0,
-    };
-
-    match unsafe {
-        let hearty_hearty_hearty = vec![240, 159, 146, 150];
-        String::from_utf8_unchecked(hearty_hearty_hearty).as_str()
-    } {
-        "💖" => 1,
-        "what" => 2,
-        _ => 3,
-    }
 }
 
 // issue #12162

--- a/tests/ui/blocks_in_conditions.stderr
+++ b/tests/ui/blocks_in_conditions.stderr
@@ -1,5 +1,5 @@
 error: in an `if` condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-  --> tests/ui/blocks_in_conditions.rs:30:5
+  --> tests/ui/blocks_in_conditions.rs:25:5
    |
 LL | /     if {
 LL | |
@@ -20,13 +20,13 @@ LL ~     }; if res {
    |
 
 error: omit braces around single expression condition
-  --> tests/ui/blocks_in_conditions.rs:42:8
+  --> tests/ui/blocks_in_conditions.rs:37:8
    |
 LL |     if { true } { 6 } else { 10 }
    |        ^^^^^^^^ help: try: `true`
 
 error: this boolean expression can be simplified
-  --> tests/ui/blocks_in_conditions.rs:48:8
+  --> tests/ui/blocks_in_conditions.rs:43:8
    |
 LL |     if true && x == 3 { 6 } else { 10 }
    |        ^^^^^^^^^^^^^^ help: try: `x == 3`
@@ -34,24 +34,5 @@ LL |     if true && x == 3 { 6 } else { 10 }
    = note: `-D clippy::nonminimal-bool` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::nonminimal_bool)]`
 
-error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-  --> tests/ui/blocks_in_conditions.rs:76:5
-   |
-LL | /     match {
-LL | |
-LL | |         let opt = Some(2);
-LL | |         opt
-LL | |     } {
-   | |_____^
-   |
-help: try
-   |
-LL ~     let res = {
-LL +
-LL +         let opt = Some(2);
-LL +         opt
-LL ~     }; match res {
-   |
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/blocks_in_conditions_2021.fixed
+++ b/tests/ui/blocks_in_conditions_2021.fixed
@@ -1,0 +1,25 @@
+//@edition: 2021
+
+#![allow(clippy::let_and_return)]
+
+// issue #11814
+fn block_in_match_expr(num: i32) -> i32 {
+    let res = {
+        //~^ ERROR: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
+        let opt = Some(2);
+        opt
+    }; match res {
+        Some(0) => 1,
+        Some(n) => num * 2,
+        None => 0,
+    };
+
+    match unsafe {
+        let hearty_hearty_hearty = vec![240, 159, 146, 150];
+        String::from_utf8_unchecked(hearty_hearty_hearty).as_str()
+    } {
+        "💖" => 1,
+        "what" => 2,
+        _ => 3,
+    }
+}

--- a/tests/ui/blocks_in_conditions_2021.rs
+++ b/tests/ui/blocks_in_conditions_2021.rs
@@ -1,0 +1,25 @@
+//@edition: 2021
+
+#![allow(clippy::let_and_return)]
+
+// issue #11814
+fn block_in_match_expr(num: i32) -> i32 {
+    match {
+        //~^ ERROR: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
+        let opt = Some(2);
+        opt
+    } {
+        Some(0) => 1,
+        Some(n) => num * 2,
+        None => 0,
+    };
+
+    match unsafe {
+        let hearty_hearty_hearty = vec![240, 159, 146, 150];
+        String::from_utf8_unchecked(hearty_hearty_hearty).as_str()
+    } {
+        "💖" => 1,
+        "what" => 2,
+        _ => 3,
+    }
+}

--- a/tests/ui/blocks_in_conditions_2021.stderr
+++ b/tests/ui/blocks_in_conditions_2021.stderr
@@ -1,0 +1,23 @@
+error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
+  --> tests/ui/blocks_in_conditions_2021.rs:7:5
+   |
+LL | /     match {
+LL | |
+LL | |         let opt = Some(2);
+LL | |         opt
+LL | |     } {
+   | |_____^
+   |
+   = note: `-D clippy::blocks-in-conditions` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::blocks_in_conditions)]`
+help: try
+   |
+LL ~     let res = {
+LL +
+LL +         let opt = Some(2);
+LL +         opt
+LL ~     }; match res {
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -244,8 +244,7 @@ LL |         if X.is_some() {
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `-D static-mut-refs` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(static_mut_refs)]`
+   = note: `#[deny(static_mut_refs)]` on by default
 
 error: aborting due to 26 previous errors
 

--- a/tests/ui/crashes/ice-7423.rs
+++ b/tests/ui/crashes/ice-7423.rs
@@ -6,7 +6,7 @@ pub trait Trait {
 
 impl Trait for usize {
     fn f() {
-        extern "C" {
+        unsafe extern "C" {
             fn g() -> usize;
         }
     }

--- a/tests/ui/def_id_nocore.rs
+++ b/tests/ui/def_id_nocore.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 #[link(name = "c")]
-extern "C" {}
+unsafe extern "C" {}
 
 #[lang = "sized"]
 pub trait Sized {}

--- a/tests/ui/doc/doc-fixable.fixed
+++ b/tests/ui/doc/doc-fixable.fixed
@@ -1,4 +1,3 @@
-
 //! This file tests for the `DOC_MARKDOWN` lint.
 
 #![allow(dead_code, incomplete_features)]
@@ -272,7 +271,7 @@ fn parenthesized_word() {}
 /// UXes
 fn plural_acronym_test() {}
 
-extern "C" {
+unsafe extern "C" {
     /// `foo()`
     //~^ doc_markdown
     fn in_extern();

--- a/tests/ui/doc/doc-fixable.rs
+++ b/tests/ui/doc/doc-fixable.rs
@@ -1,4 +1,3 @@
-
 //! This file tests for the `DOC_MARKDOWN` lint.
 
 #![allow(dead_code, incomplete_features)]
@@ -272,7 +271,7 @@ fn parenthesized_word() {}
 /// UXes
 fn plural_acronym_test() {}
 
-extern "C" {
+unsafe extern "C" {
     /// foo()
     //~^ doc_markdown
     fn in_extern();

--- a/tests/ui/doc/doc-fixable.stderr
+++ b/tests/ui/doc/doc-fixable.stderr
@@ -1,5 +1,5 @@
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:9:9
+  --> tests/ui/doc/doc-fixable.rs:8:9
    |
 LL | /// The foo_bar function does _nothing_. See also foo::bar. (note the dot there)
    |         ^^^^^^^
@@ -13,7 +13,7 @@ LL + /// The `foo_bar` function does _nothing_. See also foo::bar. (note the dot
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:9:51
+  --> tests/ui/doc/doc-fixable.rs:8:51
    |
 LL | /// The foo_bar function does _nothing_. See also foo::bar. (note the dot there)
    |                                                   ^^^^^^^^
@@ -25,7 +25,7 @@ LL + /// The foo_bar function does _nothing_. See also `foo::bar`. (note the dot
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:12:83
+  --> tests/ui/doc/doc-fixable.rs:11:83
    |
 LL | /// Markdown is _weird_. I mean _really weird_. This \_ is ok. So is `_`. But not Foo::some_fun
    |                                                                                   ^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL + /// Markdown is _weird_. I mean _really weird_. This \_ is ok. So is `_`. B
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:15:13
+  --> tests/ui/doc/doc-fixable.rs:14:13
    |
 LL | /// Here be ::a::global:path, and _::another::global::path_.  :: is not a path though.
    |             ^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL + /// Here be `::a::global:path`, and _::another::global::path_.  :: is not a
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:15:36
+  --> tests/ui/doc/doc-fixable.rs:14:36
    |
 LL | /// Here be ::a::global:path, and _::another::global::path_.  :: is not a path though.
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL + /// Here be ::a::global:path, and _`::another::global::path`_.  :: is not a
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:18:25
+  --> tests/ui/doc/doc-fixable.rs:17:25
    |
 LL | /// Import an item from ::awesome::global::blob:: (Intended postfix)
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL + /// Import an item from `::awesome::global::blob::` (Intended postfix)
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:20:31
+  --> tests/ui/doc/doc-fixable.rs:19:31
    |
 LL | /// These are the options for ::Cat: (Intended trailing single colon, shouldn't be linted)
    |                               ^^^^^
@@ -85,7 +85,7 @@ LL + /// These are the options for `::Cat`: (Intended trailing single colon, sho
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:22:22
+  --> tests/ui/doc/doc-fixable.rs:21:22
    |
 LL | /// That's not code ~NotInCodeBlock~.
    |                      ^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL + /// That's not code ~`NotInCodeBlock`~.
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:24:5
+  --> tests/ui/doc/doc-fixable.rs:23:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:39:5
+  --> tests/ui/doc/doc-fixable.rs:38:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:47:5
+  --> tests/ui/doc/doc-fixable.rs:46:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:62:5
+  --> tests/ui/doc/doc-fixable.rs:61:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:91:5
+  --> tests/ui/doc/doc-fixable.rs:90:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:109:5
+  --> tests/ui/doc/doc-fixable.rs:108:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:118:8
+  --> tests/ui/doc/doc-fixable.rs:117:8
    |
 LL | /// ## CamelCaseThing
    |        ^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL + /// ## `CamelCaseThing`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:122:7
+  --> tests/ui/doc/doc-fixable.rs:121:7
    |
 LL | /// # CamelCaseThing
    |       ^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL + /// # `CamelCaseThing`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:125:22
+  --> tests/ui/doc/doc-fixable.rs:124:22
    |
 LL | /// Not a title #897 CamelCaseThing
    |                      ^^^^^^^^^^^^^^
@@ -205,7 +205,7 @@ LL + /// Not a title #897 `CamelCaseThing`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:127:5
+  --> tests/ui/doc/doc-fixable.rs:126:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +217,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:135:5
+  --> tests/ui/doc/doc-fixable.rs:134:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:149:5
+  --> tests/ui/doc/doc-fixable.rs:148:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +241,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:161:43
+  --> tests/ui/doc/doc-fixable.rs:160:43
    |
 LL | /** E.g., serialization of an empty list: FooBar
    |                                           ^^^^^^
@@ -253,7 +253,7 @@ LL + /** E.g., serialization of an empty list: `FooBar`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:166:5
+  --> tests/ui/doc/doc-fixable.rs:165:5
    |
 LL | And BarQuz too.
    |     ^^^^^^
@@ -265,7 +265,7 @@ LL + And `BarQuz` too.
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:167:1
+  --> tests/ui/doc/doc-fixable.rs:166:1
    |
 LL | be_sure_we_got_to_the_end_of_it
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,7 +277,7 @@ LL + `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:175:43
+  --> tests/ui/doc/doc-fixable.rs:174:43
    |
 LL | /** E.g., serialization of an empty list: FooBar
    |                                           ^^^^^^
@@ -289,7 +289,7 @@ LL + /** E.g., serialization of an empty list: `FooBar`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:180:5
+  --> tests/ui/doc/doc-fixable.rs:179:5
    |
 LL | And BarQuz too.
    |     ^^^^^^
@@ -301,7 +301,7 @@ LL + And `BarQuz` too.
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:181:1
+  --> tests/ui/doc/doc-fixable.rs:180:1
    |
 LL | be_sure_we_got_to_the_end_of_it
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -313,7 +313,7 @@ LL + `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:195:5
+  --> tests/ui/doc/doc-fixable.rs:194:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -325,7 +325,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:215:22
+  --> tests/ui/doc/doc-fixable.rs:214:22
    |
 LL | /// An iterator over mycrate::Collection's values.
    |                      ^^^^^^^^^^^^^^^^^^^
@@ -337,7 +337,7 @@ LL + /// An iterator over `mycrate::Collection`'s values.
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:240:34
+  --> tests/ui/doc/doc-fixable.rs:239:34
    |
 LL | /// Foo \[bar\] \[baz\] \[qux\]. DocMarkdownLint
    |                                  ^^^^^^^^^^^^^^^
@@ -349,7 +349,7 @@ LL + /// Foo \[bar\] \[baz\] \[qux\]. `DocMarkdownLint`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:264:22
+  --> tests/ui/doc/doc-fixable.rs:263:22
    |
 LL | /// There is no try (do() or do_not()).
    |                      ^^^^
@@ -361,7 +361,7 @@ LL + /// There is no try (`do()` or do_not()).
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:264:30
+  --> tests/ui/doc/doc-fixable.rs:263:30
    |
 LL | /// There is no try (do() or do_not()).
    |                              ^^^^^^^^
@@ -373,7 +373,7 @@ LL + /// There is no try (do() or `do_not()`).
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:269:5
+  --> tests/ui/doc/doc-fixable.rs:268:5
    |
 LL | /// ABes
    |     ^^^^
@@ -385,7 +385,7 @@ LL + /// `ABes`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:276:9
+  --> tests/ui/doc/doc-fixable.rs:275:9
    |
 LL |     /// foo()
    |         ^^^^^
@@ -397,7 +397,7 @@ LL +     /// `foo()`
    |
 
 error: you should put bare URLs between `<`/`>` or make a proper Markdown link
-  --> tests/ui/doc/doc-fixable.rs:281:5
+  --> tests/ui/doc/doc-fixable.rs:280:5
    |
 LL | /// https://github.com/rust-lang/rust-clippy/pull/12836
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `<https://github.com/rust-lang/rust-clippy/pull/12836>`

--- a/tests/ui/doc_unsafe.rs
+++ b/tests/ui/doc_unsafe.rs
@@ -103,7 +103,7 @@ macro_rules! very_unsafe {
         ///
         /// Please keep the seat belt fastened
         pub unsafe fn drive() {
-            whee()
+            unsafe { whee() }
         }
     };
 }

--- a/tests/ui/eager_transmute.fixed
+++ b/tests/ui/eager_transmute.fixed
@@ -71,8 +71,10 @@ fn f(op: u8, op2: Data, unrelated: u8) {
 }
 
 unsafe fn f2(op: u8) {
-    (op < 4).then(|| std::mem::transmute::<_, Opcode>(op));
-    //~^ eager_transmute
+    unsafe {
+        (op < 4).then(|| std::mem::transmute::<_, Opcode>(op));
+        //~^ eager_transmute
+    }
 }
 
 #[rustc_layout_scalar_valid_range_end(254)]

--- a/tests/ui/eager_transmute.rs
+++ b/tests/ui/eager_transmute.rs
@@ -71,8 +71,10 @@ fn f(op: u8, op2: Data, unrelated: u8) {
 }
 
 unsafe fn f2(op: u8) {
-    (op < 4).then_some(std::mem::transmute::<_, Opcode>(op));
-    //~^ eager_transmute
+    unsafe {
+        (op < 4).then_some(std::mem::transmute::<_, Opcode>(op));
+        //~^ eager_transmute
+    }
 }
 
 #[rustc_layout_scalar_valid_range_end(254)]

--- a/tests/ui/eager_transmute.stderr
+++ b/tests/ui/eager_transmute.stderr
@@ -157,19 +157,19 @@ LL +     let _: Option<Opcode> = (..=3).contains(&op).then(|| unsafe { std::mem:
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:74:24
+  --> tests/ui/eager_transmute.rs:75:28
    |
-LL |     (op < 4).then_some(std::mem::transmute::<_, Opcode>(op));
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         (op < 4).then_some(std::mem::transmute::<_, Opcode>(op));
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider using `bool::then` to only transmute if the condition holds
    |
-LL -     (op < 4).then_some(std::mem::transmute::<_, Opcode>(op));
-LL +     (op < 4).then(|| std::mem::transmute::<_, Opcode>(op));
+LL -         (op < 4).then_some(std::mem::transmute::<_, Opcode>(op));
+LL +         (op < 4).then(|| std::mem::transmute::<_, Opcode>(op));
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:104:62
+  --> tests/ui/eager_transmute.rs:106:62
    |
 LL |     let _: Option<NonZero<u8>> = (v1 > 0).then_some(unsafe { std::mem::transmute(v1) });
    |                                                              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     let _: Option<NonZero<u8>> = (v1 > 0).then(|| unsafe { std::mem::transm
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:111:86
+  --> tests/ui/eager_transmute.rs:113:86
    |
 LL |     let _: Option<NonMaxU8> = (v2 < NonZero::new(255u8).unwrap()).then_some(unsafe { std::mem::transmute(v2) });
    |                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL +     let _: Option<NonMaxU8> = (v2 < NonZero::new(255u8).unwrap()).then(|| u
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:118:93
+  --> tests/ui/eager_transmute.rs:120:93
    |
 LL |     let _: Option<NonZeroNonMaxU8> = (v2 < NonZero::new(255u8).unwrap()).then_some(unsafe { std::mem::transmute(v2) });
    |                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/empty_docs.rs
+++ b/tests/ui/empty_docs.rs
@@ -84,7 +84,7 @@ mod issue_12377 {
     use proc_macro_attr::with_empty_docs;
 
     #[with_empty_docs]
-    extern "C" {
+    unsafe extern "C" {
         type Test;
     }
 

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -59,7 +59,7 @@ fn f_str_t<T>(_: &str, _: T) {}
 
 fn f_box_t<T>(_: &Box<T>) {}
 
-extern "C" {
+unsafe extern "C" {
     fn var(_: u32, ...);
 }
 

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -59,7 +59,7 @@ fn f_str_t<T>(_: &str, _: T) {}
 
 fn f_box_t<T>(_: &Box<T>) {}
 
-extern "C" {
+unsafe extern "C" {
     fn var(_: u32, ...);
 }
 

--- a/tests/ui/fn_params_excessive_bools.rs
+++ b/tests/ui/fn_params_excessive_bools.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::fn_params_excessive_bools)]
 #![allow(clippy::too_many_arguments)]
 
-extern "C" {
+unsafe extern "C" {
     // Should not lint, most of the time users have no control over extern function signatures
     fn f(_: bool, _: bool, _: bool, _: bool);
 }
@@ -14,8 +14,8 @@ macro_rules! foo {
 
 foo!();
 
-#[no_mangle]
-extern "C" fn k(_: bool, _: bool, _: bool, _: bool) {}
+#[unsafe(no_mangle)]
+unsafe extern "C" fn k(_: bool, _: bool, _: bool, _: bool) {}
 fn g(_: bool, _: bool, _: bool, _: bool) {}
 //~^ ERROR: more than 3 bools in function parameters
 fn h(_: bool, _: bool, _: bool) {}
@@ -39,8 +39,8 @@ impl S {
     fn f(&self, _: bool, _: bool, _: bool, _: bool) {}
     //~^ ERROR: more than 3 bools in function parameters
     fn g(&self, _: bool, _: bool, _: bool) {}
-    #[no_mangle]
-    extern "C" fn h(_: bool, _: bool, _: bool, _: bool) {}
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn h(_: bool, _: bool, _: bool, _: bool) {}
 }
 
 impl Trait for S {

--- a/tests/ui/iter_overeager_cloned.fixed
+++ b/tests/ui/iter_overeager_cloned.fixed
@@ -59,7 +59,7 @@ fn main() {
         iter: impl Iterator<Item = &'a (&'a u32, String)> + 'a,
         target: String,
     ) -> impl Iterator<Item = (&'a u32, String)> + 'a {
-        iter.filter(move |&(&a, b)| a == 1 && b == &target).cloned()
+        iter.filter(move |&&(&a, ref b)| a == 1 && b == &target).cloned()
         //~^ iter_overeager_cloned
     }
 

--- a/tests/ui/iter_overeager_cloned.rs
+++ b/tests/ui/iter_overeager_cloned.rs
@@ -60,7 +60,7 @@ fn main() {
         iter: impl Iterator<Item = &'a (&'a u32, String)> + 'a,
         target: String,
     ) -> impl Iterator<Item = (&'a u32, String)> + 'a {
-        iter.cloned().filter(move |(&a, b)| a == 1 && b == &target)
+        iter.cloned().filter(move |&(&a, ref b)| a == 1 && b == &target)
         //~^ iter_overeager_cloned
     }
 

--- a/tests/ui/iter_overeager_cloned.stderr
+++ b/tests/ui/iter_overeager_cloned.stderr
@@ -120,10 +120,10 @@ LL |         let _ = vec.iter().cloned().find(f);
 error: unnecessarily eager cloning of iterator items
   --> tests/ui/iter_overeager_cloned.rs:63:9
    |
-LL |         iter.cloned().filter(move |(&a, b)| a == 1 && b == &target)
-   |         ^^^^-------------------------------------------------------
+LL |         iter.cloned().filter(move |&(&a, ref b)| a == 1 && b == &target)
+   |         ^^^^------------------------------------------------------------
    |             |
-   |             help: try: `.filter(move |&(&a, b)| a == 1 && b == &target).cloned()`
+   |             help: try: `.filter(move |&&(&a, ref b)| a == 1 && b == &target).cloned()`
 
 error: unnecessarily eager cloning of iterator items
   --> tests/ui/iter_overeager_cloned.rs:75:13

--- a/tests/ui/manual_async_fn.fixed
+++ b/tests/ui/manual_async_fn.fixed
@@ -75,7 +75,7 @@ impl S {
 async fn elided(_: &i32) -> i32 { 42 }
 
 // should be ignored
-fn elided_not_bound(_: &i32) -> impl Future<Output = i32> {
+fn elided_not_bound(_: &i32) -> impl Future<Output = i32> + use<> {
     async { 42 }
 }
 
@@ -84,7 +84,7 @@ async fn explicit<'a, 'b>(_: &'a i32, _: &'b i32) -> i32 { 42 }
 
 // should be ignored
 #[allow(clippy::needless_lifetimes)]
-fn explicit_not_bound<'a, 'b>(_: &'a i32, _: &'b i32) -> impl Future<Output = i32> {
+fn explicit_not_bound<'a, 'b>(_: &'a i32, _: &'b i32) -> impl Future<Output = i32> + use<> {
     async { 42 }
 }
 
@@ -94,7 +94,7 @@ mod issue_5765 {
 
     struct A;
     impl A {
-        fn f(&self) -> impl Future<Output = ()> {
+        fn f(&self) -> impl Future<Output = ()> + use<> {
             async {}
         }
     }

--- a/tests/ui/manual_async_fn.rs
+++ b/tests/ui/manual_async_fn.rs
@@ -102,7 +102,7 @@ fn elided(_: &i32) -> impl Future<Output = i32> + '_ {
 }
 
 // should be ignored
-fn elided_not_bound(_: &i32) -> impl Future<Output = i32> {
+fn elided_not_bound(_: &i32) -> impl Future<Output = i32> + use<> {
     async { 42 }
 }
 
@@ -114,7 +114,7 @@ fn explicit<'a, 'b>(_: &'a i32, _: &'b i32) -> impl Future<Output = i32> + 'a + 
 
 // should be ignored
 #[allow(clippy::needless_lifetimes)]
-fn explicit_not_bound<'a, 'b>(_: &'a i32, _: &'b i32) -> impl Future<Output = i32> {
+fn explicit_not_bound<'a, 'b>(_: &'a i32, _: &'b i32) -> impl Future<Output = i32> + use<> {
     async { 42 }
 }
 
@@ -124,7 +124,7 @@ mod issue_5765 {
 
     struct A;
     impl A {
-        fn f(&self) -> impl Future<Output = ()> {
+        fn f(&self) -> impl Future<Output = ()> + use<> {
             async {}
         }
     }

--- a/tests/ui/manual_map_option.rs
+++ b/tests/ui/manual_map_option.rs
@@ -101,7 +101,7 @@ fn main() {
 
     match &mut Some(String::new()) {
         //~^ manual_map
-        Some(ref x) => Some(x.len()),
+        &mut Some(ref x) => Some(x.len()),
         None => None,
     };
 

--- a/tests/ui/manual_map_option.stderr
+++ b/tests/ui/manual_map_option.stderr
@@ -127,7 +127,7 @@ error: manual implementation of `Option::map`
    |
 LL | /     match &mut Some(String::new()) {
 LL | |
-LL | |         Some(ref x) => Some(x.len()),
+LL | |         &mut Some(ref x) => Some(x.len()),
 LL | |         None => None,
 LL | |     };
    | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.len())`

--- a/tests/ui/manual_map_option_2.fixed
+++ b/tests/ui/manual_map_option_2.fixed
@@ -115,7 +115,7 @@ mod with_type_coercion {
     fn with_fn_ret(s: &Option<String>) -> Option<(String, &str)> {
         // Don't lint, `map` doesn't work as the return type is adjusted.
         match s {
-            Some(x) => Some({ if let Some(ref s) = s { (x.clone(), s) } else { panic!() } }),
+            Some(x) => Some({ if let Some(s) = s { (x.clone(), s) } else { panic!() } }),
             None => None,
         }
     }
@@ -124,7 +124,7 @@ mod with_type_coercion {
         if true {
             // Don't lint, `map` doesn't work as the return type is adjusted.
             return match s {
-                Some(x) => Some({ if let Some(ref s) = s { (x.clone(), s) } else { panic!() } }),
+                Some(x) => Some({ if let Some(s) = s { (x.clone(), s) } else { panic!() } }),
                 None => None,
             };
         }
@@ -136,7 +136,7 @@ mod with_type_coercion {
         let x: Option<(String, &'a str)>;
         x = {
             match s {
-                Some(x) => Some({ if let Some(ref s) = s { (x.clone(), s) } else { panic!() } }),
+                Some(x) => Some({ if let Some(s) = s { (x.clone(), s) } else { panic!() } }),
                 None => None,
             }
         };

--- a/tests/ui/manual_map_option_2.rs
+++ b/tests/ui/manual_map_option_2.rs
@@ -143,7 +143,7 @@ mod with_type_coercion {
     fn with_fn_ret(s: &Option<String>) -> Option<(String, &str)> {
         // Don't lint, `map` doesn't work as the return type is adjusted.
         match s {
-            Some(x) => Some({ if let Some(ref s) = s { (x.clone(), s) } else { panic!() } }),
+            Some(x) => Some({ if let Some(s) = s { (x.clone(), s) } else { panic!() } }),
             None => None,
         }
     }
@@ -152,7 +152,7 @@ mod with_type_coercion {
         if true {
             // Don't lint, `map` doesn't work as the return type is adjusted.
             return match s {
-                Some(x) => Some({ if let Some(ref s) = s { (x.clone(), s) } else { panic!() } }),
+                Some(x) => Some({ if let Some(s) = s { (x.clone(), s) } else { panic!() } }),
                 None => None,
             };
         }
@@ -164,7 +164,7 @@ mod with_type_coercion {
         let x: Option<(String, &'a str)>;
         x = {
             match s {
-                Some(x) => Some({ if let Some(ref s) = s { (x.clone(), s) } else { panic!() } }),
+                Some(x) => Some({ if let Some(s) = s { (x.clone(), s) } else { panic!() } }),
                 None => None,
             }
         };

--- a/tests/ui/manual_retain.fixed
+++ b/tests/ui/manual_retain.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_retain)]
-#![allow(unused, clippy::redundant_clone)]
+#![allow(unused, clippy::needless_borrowed_reference, clippy::redundant_clone)]
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 
 fn main() {
@@ -31,7 +31,7 @@ fn binary_heap_retain() {
 
     // Do lint, because we use pattern matching
     let mut tuples = BinaryHeap::from([(0, 1), (1, 2), (2, 3)]);
-    tuples.retain(|(ref x, ref y)| *x == 0);
+    tuples.retain(|&(ref x, ref y)| *x == 0);
     //~^ manual_retain
     tuples.retain(|(x, y)| *x == 0);
     //~^ manual_retain
@@ -99,7 +99,7 @@ fn btree_set_retain() {
 
     // Do lint, because we use pattern matching
     let mut tuples = BTreeSet::from([(0, 1), (1, 2), (2, 3)]);
-    tuples.retain(|(ref x, ref y)| *x == 0);
+    tuples.retain(|&(ref x, ref y)| *x == 0);
     //~^ manual_retain
     tuples.retain(|(x, y)| *x == 0);
     //~^ manual_retain
@@ -166,7 +166,7 @@ fn hash_set_retain() {
 
     // Do lint, because we use pattern matching
     let mut tuples = HashSet::from([(0, 1), (1, 2), (2, 3)]);
-    tuples.retain(|(ref x, ref y)| *x == 0);
+    tuples.retain(|&(ref x, ref y)| *x == 0);
     //~^ manual_retain
     tuples.retain(|(x, y)| *x == 0);
     //~^ manual_retain
@@ -220,7 +220,7 @@ fn vec_retain() {
 
     // Do lint, because we use pattern matching
     let mut tuples = vec![(0, 1), (1, 2), (2, 3)];
-    tuples.retain(|(ref x, ref y)| *x == 0);
+    tuples.retain(|&(ref x, ref y)| *x == 0);
     //~^ manual_retain
     tuples.retain(|(x, y)| *x == 0);
     //~^ manual_retain

--- a/tests/ui/manual_retain.rs
+++ b/tests/ui/manual_retain.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_retain)]
-#![allow(unused, clippy::redundant_clone)]
+#![allow(unused, clippy::needless_borrowed_reference, clippy::redundant_clone)]
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 
 fn main() {
@@ -31,7 +31,7 @@ fn binary_heap_retain() {
 
     // Do lint, because we use pattern matching
     let mut tuples = BinaryHeap::from([(0, 1), (1, 2), (2, 3)]);
-    tuples = tuples.iter().filter(|(ref x, ref y)| *x == 0).copied().collect();
+    tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
     //~^ manual_retain
     tuples = tuples.iter().filter(|(x, y)| *x == 0).copied().collect();
     //~^ manual_retain
@@ -103,7 +103,7 @@ fn btree_set_retain() {
 
     // Do lint, because we use pattern matching
     let mut tuples = BTreeSet::from([(0, 1), (1, 2), (2, 3)]);
-    tuples = tuples.iter().filter(|(ref x, ref y)| *x == 0).copied().collect();
+    tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
     //~^ manual_retain
     tuples = tuples.iter().filter(|(x, y)| *x == 0).copied().collect();
     //~^ manual_retain
@@ -174,7 +174,7 @@ fn hash_set_retain() {
 
     // Do lint, because we use pattern matching
     let mut tuples = HashSet::from([(0, 1), (1, 2), (2, 3)]);
-    tuples = tuples.iter().filter(|(ref x, ref y)| *x == 0).copied().collect();
+    tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
     //~^ manual_retain
     tuples = tuples.iter().filter(|(x, y)| *x == 0).copied().collect();
     //~^ manual_retain
@@ -228,7 +228,7 @@ fn vec_retain() {
 
     // Do lint, because we use pattern matching
     let mut tuples = vec![(0, 1), (1, 2), (2, 3)];
-    tuples = tuples.iter().filter(|(ref x, ref y)| *x == 0).copied().collect();
+    tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
     //~^ manual_retain
     tuples = tuples.iter().filter(|(x, y)| *x == 0).copied().collect();
     //~^ manual_retain

--- a/tests/ui/manual_retain.stderr
+++ b/tests/ui/manual_retain.stderr
@@ -22,8 +22,8 @@ LL |     binary_heap = binary_heap.iter().filter(|&x| x % 2 == 0).cloned().colle
 error: this expression can be written more simply using `.retain()`
   --> tests/ui/manual_retain.rs:34:5
    |
-LL |     tuples = tuples.iter().filter(|(ref x, ref y)| *x == 0).copied().collect();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(ref x, ref y)| *x == 0)`
+LL |     tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|&(ref x, ref y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
   --> tests/ui/manual_retain.rs:36:5
@@ -74,8 +74,8 @@ LL |     btree_set = btree_set.into_iter().filter(|x| x % 2 == 0).collect();
 error: this expression can be written more simply using `.retain()`
   --> tests/ui/manual_retain.rs:106:5
    |
-LL |     tuples = tuples.iter().filter(|(ref x, ref y)| *x == 0).copied().collect();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(ref x, ref y)| *x == 0)`
+LL |     tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|&(ref x, ref y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
   --> tests/ui/manual_retain.rs:108:5
@@ -126,8 +126,8 @@ LL |     hash_set = hash_set.iter().filter(|&x| x % 2 == 0).cloned().collect();
 error: this expression can be written more simply using `.retain()`
   --> tests/ui/manual_retain.rs:177:5
    |
-LL |     tuples = tuples.iter().filter(|(ref x, ref y)| *x == 0).copied().collect();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(ref x, ref y)| *x == 0)`
+LL |     tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|&(ref x, ref y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
   --> tests/ui/manual_retain.rs:179:5
@@ -162,8 +162,8 @@ LL |     vec = vec.into_iter().filter(|x| x % 2 == 0).collect();
 error: this expression can be written more simply using `.retain()`
   --> tests/ui/manual_retain.rs:231:5
    |
-LL |     tuples = tuples.iter().filter(|(ref x, ref y)| *x == 0).copied().collect();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(ref x, ref y)| *x == 0)`
+LL |     tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|&(ref x, ref y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
   --> tests/ui/manual_retain.rs:233:5

--- a/tests/ui/manual_unwrap_or_default.fixed
+++ b/tests/ui/manual_unwrap_or_default.fixed
@@ -36,10 +36,12 @@ fn main() {
 
 // Issue #12531
 unsafe fn no_deref_ptr(a: Option<i32>, b: *const Option<i32>) -> i32 {
-    match a {
-        // `*b` being correct depends on `a == Some(_)`
-        Some(_) => (*b).unwrap_or_default(),
-        _ => 0,
+    unsafe {
+        match a {
+            // `*b` being correct depends on `a == Some(_)`
+            Some(_) => (*b).unwrap_or_default(),
+            _ => 0,
+        }
     }
 }
 

--- a/tests/ui/manual_unwrap_or_default.rs
+++ b/tests/ui/manual_unwrap_or_default.rs
@@ -68,14 +68,16 @@ fn main() {
 
 // Issue #12531
 unsafe fn no_deref_ptr(a: Option<i32>, b: *const Option<i32>) -> i32 {
-    match a {
-        // `*b` being correct depends on `a == Some(_)`
-        Some(_) => match *b {
-            //~^ manual_unwrap_or_default
-            Some(v) => v,
+    unsafe {
+        match a {
+            // `*b` being correct depends on `a == Some(_)`
+            Some(_) => match *b {
+                //~^ manual_unwrap_or_default
+                Some(v) => v,
+                _ => 0,
+            },
             _ => 0,
-        },
-        _ => 0,
+        }
     }
 }
 

--- a/tests/ui/manual_unwrap_or_default.stderr
+++ b/tests/ui/manual_unwrap_or_default.stderr
@@ -76,18 +76,18 @@ LL | |     };
    | |_____^ help: replace it with: `x.unwrap_or_default()`
 
 error: match can be simplified with `.unwrap_or_default()`
-  --> tests/ui/manual_unwrap_or_default.rs:73:20
+  --> tests/ui/manual_unwrap_or_default.rs:74:24
    |
-LL |           Some(_) => match *b {
-   |  ____________________^
+LL |               Some(_) => match *b {
+   |  ________________________^
 LL | |
-LL | |             Some(v) => v,
-LL | |             _ => 0,
-LL | |         },
-   | |_________^ help: replace it with: `(*b).unwrap_or_default()`
+LL | |                 Some(v) => v,
+LL | |                 _ => 0,
+LL | |             },
+   | |_____________^ help: replace it with: `(*b).unwrap_or_default()`
 
 error: if let can be simplified with `.unwrap_or_default()`
-  --> tests/ui/manual_unwrap_or_default.rs:141:5
+  --> tests/ui/manual_unwrap_or_default.rs:143:5
    |
 LL | /     if let Some(x) = Some(42) {
 LL | |

--- a/tests/ui/misnamed_getters.fixed
+++ b/tests/ui/misnamed_getters.fixed
@@ -54,63 +54,63 @@ impl B {
     unsafe fn a(&self) -> &u8 {
         //~^ misnamed_getters
 
-        &self.a
+        unsafe { &self.a }
     }
     unsafe fn a_mut(&mut self) -> &mut u8 {
         //~^ misnamed_getters
 
-        &mut self.a
+        unsafe { &mut self.a }
     }
 
     unsafe fn b(self) -> u8 {
         //~^ misnamed_getters
 
-        self.b
+        unsafe { self.b }
     }
 
     unsafe fn b_mut(&mut self) -> &mut u8 {
         //~^ misnamed_getters
 
-        &mut self.b
+        unsafe { &mut self.b }
     }
 
     unsafe fn c(&self) -> &u8 {
-        &self.b
+        unsafe { &self.b }
     }
 
     unsafe fn c_mut(&mut self) -> &mut u8 {
-        &mut self.a
+        unsafe { &mut self.a }
     }
 
     unsafe fn a_unchecked(&self) -> &u8 {
         //~^ misnamed_getters
 
-        &self.a
+        unsafe { &self.a }
     }
     unsafe fn a_unchecked_mut(&mut self) -> &mut u8 {
         //~^ misnamed_getters
 
-        &mut self.a
+        unsafe { &mut self.a }
     }
 
     unsafe fn b_unchecked(self) -> u8 {
         //~^ misnamed_getters
 
-        self.b
+        unsafe { self.b }
     }
 
     unsafe fn b_unchecked_mut(&mut self) -> &mut u8 {
         //~^ misnamed_getters
 
-        &mut self.b
+        unsafe { &mut self.b }
     }
 
     unsafe fn c_unchecked(&self) -> &u8 {
-        &self.b
+        unsafe { &self.b }
     }
 
     unsafe fn c_unchecked_mut(&mut self) -> &mut u8 {
-        &mut self.a
+        unsafe { &mut self.a }
     }
 }
 

--- a/tests/ui/misnamed_getters.rs
+++ b/tests/ui/misnamed_getters.rs
@@ -54,63 +54,63 @@ impl B {
     unsafe fn a(&self) -> &u8 {
         //~^ misnamed_getters
 
-        &self.b
+        unsafe { &self.b }
     }
     unsafe fn a_mut(&mut self) -> &mut u8 {
         //~^ misnamed_getters
 
-        &mut self.b
+        unsafe { &mut self.b }
     }
 
     unsafe fn b(self) -> u8 {
         //~^ misnamed_getters
 
-        self.a
+        unsafe { self.a }
     }
 
     unsafe fn b_mut(&mut self) -> &mut u8 {
         //~^ misnamed_getters
 
-        &mut self.a
+        unsafe { &mut self.a }
     }
 
     unsafe fn c(&self) -> &u8 {
-        &self.b
+        unsafe { &self.b }
     }
 
     unsafe fn c_mut(&mut self) -> &mut u8 {
-        &mut self.a
+        unsafe { &mut self.a }
     }
 
     unsafe fn a_unchecked(&self) -> &u8 {
         //~^ misnamed_getters
 
-        &self.b
+        unsafe { &self.b }
     }
     unsafe fn a_unchecked_mut(&mut self) -> &mut u8 {
         //~^ misnamed_getters
 
-        &mut self.b
+        unsafe { &mut self.b }
     }
 
     unsafe fn b_unchecked(self) -> u8 {
         //~^ misnamed_getters
 
-        self.a
+        unsafe { self.a }
     }
 
     unsafe fn b_unchecked_mut(&mut self) -> &mut u8 {
         //~^ misnamed_getters
 
-        &mut self.a
+        unsafe { &mut self.a }
     }
 
     unsafe fn c_unchecked(&self) -> &u8 {
-        &self.b
+        unsafe { &self.b }
     }
 
     unsafe fn c_unchecked_mut(&mut self) -> &mut u8 {
-        &mut self.a
+        unsafe { &mut self.a }
     }
 }
 

--- a/tests/ui/misnamed_getters.stderr
+++ b/tests/ui/misnamed_getters.stderr
@@ -73,8 +73,8 @@ error: getter function appears to return the wrong field
 LL | /     unsafe fn a(&self) -> &u8 {
 LL | |
 LL | |
-LL | |         &self.b
-   | |         ------- help: consider using: `&self.a`
+LL | |         unsafe { &self.b }
+   | |                  ------- help: consider using: `&self.a`
 LL | |     }
    | |_____^
 
@@ -84,8 +84,8 @@ error: getter function appears to return the wrong field
 LL | /     unsafe fn a_mut(&mut self) -> &mut u8 {
 LL | |
 LL | |
-LL | |         &mut self.b
-   | |         ----------- help: consider using: `&mut self.a`
+LL | |         unsafe { &mut self.b }
+   | |                  ----------- help: consider using: `&mut self.a`
 LL | |     }
    | |_____^
 
@@ -95,8 +95,8 @@ error: getter function appears to return the wrong field
 LL | /     unsafe fn b(self) -> u8 {
 LL | |
 LL | |
-LL | |         self.a
-   | |         ------ help: consider using: `self.b`
+LL | |         unsafe { self.a }
+   | |                  ------ help: consider using: `self.b`
 LL | |     }
    | |_____^
 
@@ -106,8 +106,8 @@ error: getter function appears to return the wrong field
 LL | /     unsafe fn b_mut(&mut self) -> &mut u8 {
 LL | |
 LL | |
-LL | |         &mut self.a
-   | |         ----------- help: consider using: `&mut self.b`
+LL | |         unsafe { &mut self.a }
+   | |                  ----------- help: consider using: `&mut self.b`
 LL | |     }
    | |_____^
 
@@ -117,8 +117,8 @@ error: getter function appears to return the wrong field
 LL | /     unsafe fn a_unchecked(&self) -> &u8 {
 LL | |
 LL | |
-LL | |         &self.b
-   | |         ------- help: consider using: `&self.a`
+LL | |         unsafe { &self.b }
+   | |                  ------- help: consider using: `&self.a`
 LL | |     }
    | |_____^
 
@@ -128,8 +128,8 @@ error: getter function appears to return the wrong field
 LL | /     unsafe fn a_unchecked_mut(&mut self) -> &mut u8 {
 LL | |
 LL | |
-LL | |         &mut self.b
-   | |         ----------- help: consider using: `&mut self.a`
+LL | |         unsafe { &mut self.b }
+   | |                  ----------- help: consider using: `&mut self.a`
 LL | |     }
    | |_____^
 
@@ -139,8 +139,8 @@ error: getter function appears to return the wrong field
 LL | /     unsafe fn b_unchecked(self) -> u8 {
 LL | |
 LL | |
-LL | |         self.a
-   | |         ------ help: consider using: `self.b`
+LL | |         unsafe { self.a }
+   | |                  ------ help: consider using: `self.b`
 LL | |     }
    | |_____^
 
@@ -150,8 +150,8 @@ error: getter function appears to return the wrong field
 LL | /     unsafe fn b_unchecked_mut(&mut self) -> &mut u8 {
 LL | |
 LL | |
-LL | |         &mut self.a
-   | |         ----------- help: consider using: `&mut self.b`
+LL | |         unsafe { &mut self.a }
+   | |                  ----------- help: consider using: `&mut self.b`
 LL | |     }
    | |_____^
 

--- a/tests/ui/misnamed_getters_2021.fixed
+++ b/tests/ui/misnamed_getters_2021.fixed
@@ -1,0 +1,24 @@
+//@edition: 2021
+#![allow(unused)]
+#![allow(clippy::struct_field_names)]
+#![warn(clippy::misnamed_getters)]
+
+// Edition 2021 specific check, where `unsafe` blocks are not required
+// inside `unsafe fn`.
+
+union B {
+    a: u8,
+    b: u8,
+}
+
+impl B {
+    unsafe fn a(&self) -> &u8 {
+        //~^ misnamed_getters
+
+        &self.a
+    }
+}
+
+fn main() {
+    // test code goes here
+}

--- a/tests/ui/misnamed_getters_2021.rs
+++ b/tests/ui/misnamed_getters_2021.rs
@@ -1,0 +1,24 @@
+//@edition: 2021
+#![allow(unused)]
+#![allow(clippy::struct_field_names)]
+#![warn(clippy::misnamed_getters)]
+
+// Edition 2021 specific check, where `unsafe` blocks are not required
+// inside `unsafe fn`.
+
+union B {
+    a: u8,
+    b: u8,
+}
+
+impl B {
+    unsafe fn a(&self) -> &u8 {
+        //~^ misnamed_getters
+
+        &self.b
+    }
+}
+
+fn main() {
+    // test code goes here
+}

--- a/tests/ui/misnamed_getters_2021.stderr
+++ b/tests/ui/misnamed_getters_2021.stderr
@@ -1,0 +1,16 @@
+error: getter function appears to return the wrong field
+  --> tests/ui/misnamed_getters_2021.rs:15:5
+   |
+LL | /     unsafe fn a(&self) -> &u8 {
+LL | |
+LL | |
+LL | |         &self.b
+   | |         ------- help: consider using: `&self.a`
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::misnamed-getters` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::misnamed_getters)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/missing_const_for_fn/could_be_const.fixed
+++ b/tests/ui/missing_const_for_fn/could_be_const.fixed
@@ -144,7 +144,7 @@ mod msrv {
 
     #[clippy::msrv = "1.62"]
     mod with_extern {
-        const extern "C" fn c() {}
+        const unsafe extern "C" fn c() {}
         //~^ missing_const_for_fn
 
         #[rustfmt::skip]
@@ -153,7 +153,7 @@ mod msrv {
         //~^ missing_const_for_fn
 
         // any item functions in extern block won't trigger this lint
-        extern "C" {
+        unsafe extern "C" {
             fn c_in_block();
         }
     }

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -144,7 +144,7 @@ mod msrv {
 
     #[clippy::msrv = "1.62"]
     mod with_extern {
-        extern "C" fn c() {}
+        unsafe extern "C" fn c() {}
         //~^ missing_const_for_fn
 
         #[rustfmt::skip]
@@ -153,7 +153,7 @@ mod msrv {
         //~^ missing_const_for_fn
 
         // any item functions in extern block won't trigger this lint
-        extern "C" {
+        unsafe extern "C" {
             fn c_in_block();
         }
     }

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -212,12 +212,12 @@ LL |     const fn union_access_can_be_const() {
 error: this could be a `const fn`
   --> tests/ui/missing_const_for_fn/could_be_const.rs:147:9
    |
-LL |         extern "C" fn c() {}
-   |         ^^^^^^^^^^^^^^^^^^^^
+LL |         unsafe extern "C" fn c() {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: make the function `const`
    |
-LL |         const extern "C" fn c() {}
+LL |         const unsafe extern "C" fn c() {}
    |         +++++
 
 error: this could be a `const fn`

--- a/tests/ui/missing_transmute_annotations.fixed
+++ b/tests/ui/missing_transmute_annotations.fixed
@@ -18,8 +18,10 @@ fn bar(x: i32) -> i32 {
 }
 
 unsafe fn foo1() -> i32 {
-    // Should not warn!
-    std::mem::transmute([1u16, 2u16])
+    unsafe {
+        // Should not warn!
+        std::mem::transmute([1u16, 2u16])
+    }
 }
 
 // Should not warn!
@@ -31,33 +33,35 @@ enum Foo {
 }
 
 unsafe fn foo2() -> i32 {
-    let mut i: i32 = 0;
-    i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-    //~^ ERROR: transmute used without annotations
-    i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-    //~^ ERROR: transmute used without annotations
-    i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-    //~^ ERROR: transmute used without annotations
-    i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-    //~^ ERROR: transmute used without annotations
+    unsafe {
+        let mut i: i32 = 0;
+        i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
 
-    let x: i32 = bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
-    //~^ ERROR: transmute used without annotations
-    bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
-    //~^ ERROR: transmute used without annotations
+        let x: i32 = bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
+        //~^ ERROR: transmute used without annotations
+        bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
+        //~^ ERROR: transmute used without annotations
 
-    i = local_bad_transmute!([1u16, 2u16]);
+        i = local_bad_transmute!([1u16, 2u16]);
 
-    // Should not warn.
-    i = bad_transmute!([1u16, 2u16]);
+        // Should not warn.
+        i = bad_transmute!([1u16, 2u16]);
 
-    i = std::mem::transmute::<[i16; 2], i32>([0i16, 0i16]);
-    //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute::<[i16; 2], i32>([0i16, 0i16]);
+        //~^ ERROR: transmute used without annotations
 
-    i = std::mem::transmute::<Foo, i32>(Foo::A);
-    //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute::<Foo, i32>(Foo::A);
+        //~^ ERROR: transmute used without annotations
 
-    i
+        i
+    }
 }
 
 fn main() {

--- a/tests/ui/missing_transmute_annotations.rs
+++ b/tests/ui/missing_transmute_annotations.rs
@@ -18,8 +18,10 @@ fn bar(x: i32) -> i32 {
 }
 
 unsafe fn foo1() -> i32 {
-    // Should not warn!
-    std::mem::transmute([1u16, 2u16])
+    unsafe {
+        // Should not warn!
+        std::mem::transmute([1u16, 2u16])
+    }
 }
 
 // Should not warn!
@@ -31,33 +33,35 @@ enum Foo {
 }
 
 unsafe fn foo2() -> i32 {
-    let mut i: i32 = 0;
-    i = std::mem::transmute([1u16, 2u16]);
-    //~^ ERROR: transmute used without annotations
-    i = std::mem::transmute::<_, _>([1u16, 2u16]);
-    //~^ ERROR: transmute used without annotations
-    i = std::mem::transmute::<_, i32>([1u16, 2u16]);
-    //~^ ERROR: transmute used without annotations
-    i = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
-    //~^ ERROR: transmute used without annotations
+    unsafe {
+        let mut i: i32 = 0;
+        i = std::mem::transmute([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute::<_, _>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute::<_, i32>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
 
-    let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
-    //~^ ERROR: transmute used without annotations
-    bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
-    //~^ ERROR: transmute used without annotations
+        let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
+        //~^ ERROR: transmute used without annotations
+        bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
+        //~^ ERROR: transmute used without annotations
 
-    i = local_bad_transmute!([1u16, 2u16]);
+        i = local_bad_transmute!([1u16, 2u16]);
 
-    // Should not warn.
-    i = bad_transmute!([1u16, 2u16]);
+        // Should not warn.
+        i = bad_transmute!([1u16, 2u16]);
 
-    i = std::mem::transmute([0i16, 0i16]);
-    //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute([0i16, 0i16]);
+        //~^ ERROR: transmute used without annotations
 
-    i = std::mem::transmute(Foo::A);
-    //~^ ERROR: transmute used without annotations
+        i = std::mem::transmute(Foo::A);
+        //~^ ERROR: transmute used without annotations
 
-    i
+        i
+    }
 }
 
 fn main() {

--- a/tests/ui/missing_transmute_annotations.stderr
+++ b/tests/ui/missing_transmute_annotations.stderr
@@ -1,41 +1,41 @@
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:35:19
+  --> tests/ui/missing_transmute_annotations.rs:38:23
    |
-LL |     i = std::mem::transmute([1u16, 2u16]);
-   |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |         i = std::mem::transmute([1u16, 2u16]);
+   |                       ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
    |
    = note: `-D clippy::missing-transmute-annotations` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::missing_transmute_annotations)]`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:37:19
+  --> tests/ui/missing_transmute_annotations.rs:40:23
    |
-LL |     i = std::mem::transmute::<_, _>([1u16, 2u16]);
-   |                   ^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |         i = std::mem::transmute::<_, _>([1u16, 2u16]);
+   |                       ^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:39:19
+  --> tests/ui/missing_transmute_annotations.rs:42:23
    |
-LL |     i = std::mem::transmute::<_, i32>([1u16, 2u16]);
-   |                   ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |         i = std::mem::transmute::<_, i32>([1u16, 2u16]);
+   |                       ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:41:19
+  --> tests/ui/missing_transmute_annotations.rs:44:23
    |
-LL |     i = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |         i = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:44:32
+  --> tests/ui/missing_transmute_annotations.rs:47:36
    |
-LL |     let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |         let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:46:19
+  --> tests/ui/missing_transmute_annotations.rs:49:23
    |
-LL |     bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |         bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
   --> tests/ui/missing_transmute_annotations.rs:11:19
@@ -43,31 +43,31 @@ error: transmute used without annotations
 LL |         std::mem::transmute($e)
    |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 ...
-LL |     i = local_bad_transmute!([1u16, 2u16]);
-   |         ---------------------------------- in this macro invocation
+LL |         i = local_bad_transmute!([1u16, 2u16]);
+   |             ---------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `local_bad_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:54:19
+  --> tests/ui/missing_transmute_annotations.rs:57:23
    |
-LL |     i = std::mem::transmute([0i16, 0i16]);
-   |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[i16; 2], i32>`
+LL |         i = std::mem::transmute([0i16, 0i16]);
+   |                       ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[i16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:57:19
+  --> tests/ui/missing_transmute_annotations.rs:60:23
    |
-LL |     i = std::mem::transmute(Foo::A);
-   |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<Foo, i32>`
+LL |         i = std::mem::transmute(Foo::A);
+   |                       ^^^^^^^^^ help: consider adding missing annotations: `transmute::<Foo, i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:64:35
+  --> tests/ui/missing_transmute_annotations.rs:68:35
    |
 LL |     let x: _ = unsafe { std::mem::transmute::<_, i32>([1u16, 2u16]) };
    |                                   ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:67:30
+  --> tests/ui/missing_transmute_annotations.rs:71:30
    |
 LL |         let x: _ = std::mem::transmute::<_, i32>([1u16, 2u16]);
    |                              ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -88,11 +88,13 @@ static mut COUNTER: usize = 0;
 ///
 /// Don't ever call this from multiple threads
 pub unsafe fn mutates_static() -> usize {
-    COUNTER += 1;
-    COUNTER
+    unsafe {
+        COUNTER += 1;
+        COUNTER
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn unmangled(i: bool) -> bool {
     !i
 }

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -88,11 +88,13 @@ static mut COUNTER: usize = 0;
 ///
 /// Don't ever call this from multiple threads
 pub unsafe fn mutates_static() -> usize {
-    COUNTER += 1;
-    COUNTER
+    unsafe {
+        COUNTER += 1;
+        COUNTER
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn unmangled(i: bool) -> bool {
     !i
 }

--- a/tests/ui/needless_borrowed_ref.fixed
+++ b/tests/ui/needless_borrowed_ref.fixed
@@ -89,7 +89,7 @@ fn should_not_lint(
     tuple_struct: TupleStruct,
     s: Struct,
 ) {
-    if let [ref a] = slice {}
+    if let [a] = slice {}
     if let &[ref a, b] = slice {}
     if let &[ref a, .., b] = slice {}
 

--- a/tests/ui/needless_borrowed_ref.rs
+++ b/tests/ui/needless_borrowed_ref.rs
@@ -89,7 +89,7 @@ fn should_not_lint(
     tuple_struct: TupleStruct,
     s: Struct,
 ) {
-    if let [ref a] = slice {}
+    if let [a] = slice {}
     if let &[ref a, b] = slice {}
     if let &[ref a, .., b] = slice {}
 

--- a/tests/ui/needless_pass_by_ref_mut.rs
+++ b/tests/ui/needless_pass_by_ref_mut.rs
@@ -301,7 +301,7 @@ struct Data<T: ?Sized> {
 }
 // Unsafe functions should not warn.
 unsafe fn get_mut_unchecked<T>(ptr: &mut NonNull<Data<T>>) -> &mut T {
-    &mut (*ptr.as_ptr()).value
+    unsafe { &mut (*ptr.as_ptr()).value }
 }
 // Unsafe blocks should not warn.
 fn get_mut_unchecked2<T>(ptr: &mut NonNull<Data<T>>) -> &mut T {

--- a/tests/ui/needless_pass_by_ref_mut_2021.rs
+++ b/tests/ui/needless_pass_by_ref_mut_2021.rs
@@ -1,0 +1,12 @@
+//@edition: 2021
+//@check-pass
+#![warn(clippy::needless_pass_by_ref_mut)]
+
+struct Data<T: ?Sized> {
+    value: T,
+}
+
+// Unsafe functions should not warn.
+unsafe fn get_mut_unchecked<T>(ptr: &mut std::ptr::NonNull<Data<T>>) -> &mut T {
+    &mut (*ptr.as_ptr()).value
+}

--- a/tests/ui/no_mangle_with_rust_abi.rs
+++ b/tests/ui/no_mangle_with_rust_abi.rs
@@ -43,7 +43,7 @@ extern "C" fn c_abi_fn(arg_one: u32, arg_two: usize) {}
 
 extern "C" fn c_abi_fn_again(arg_one: u32, arg_two: usize) {}
 
-extern "C" {
+unsafe extern "C" {
     fn c_abi_in_block(arg_one: u32, arg_two: usize);
 }
 

--- a/tests/ui/non_send_fields_in_send_ty.rs
+++ b/tests/ui/non_send_fields_in_send_ty.rs
@@ -35,7 +35,7 @@ unsafe impl<RC, T: Send> Send for ArcGuard<RC, T> {}
 //~^ ERROR: some fields in `ArcGuard<RC, T>` are not safe to be sent to another thread
 
 // rusb / RUSTSEC-2020-0098
-extern "C" {
+unsafe extern "C" {
     type libusb_device_handle;
 }
 
@@ -90,7 +90,7 @@ unsafe impl<A, B> Send for MultiParam<A, B> {}
 //~^ ERROR: some fields in `MultiParam<A, B>` are not safe to be sent to another thread
 
 // Tests for raw pointer heuristic
-extern "C" {
+unsafe extern "C" {
     type NonSend;
 }
 

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -179,16 +179,20 @@ fn f() -> Option<()> {
 
 mod issue6675 {
     unsafe fn ptr_to_ref<'a, T>(p: *const T) -> &'a T {
-        #[allow(unused)]
-        let x = vec![0; 1000]; // future-proofing, make this function expensive.
-        &*p
+        unsafe {
+            #[allow(unused)]
+            let x = vec![0; 1000]; // future-proofing, make this function expensive.
+            &*p
+        }
     }
 
     unsafe fn foo() {
-        let s = "test".to_owned();
-        let s = &s as *const _;
-        None.unwrap_or_else(|| ptr_to_ref(s));
-        //~^ or_fun_call
+        unsafe {
+            let s = "test".to_owned();
+            let s = &s as *const _;
+            None.unwrap_or_else(|| ptr_to_ref(s));
+            //~^ or_fun_call
+        }
     }
 
     fn bar() {

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -179,16 +179,20 @@ fn f() -> Option<()> {
 
 mod issue6675 {
     unsafe fn ptr_to_ref<'a, T>(p: *const T) -> &'a T {
-        #[allow(unused)]
-        let x = vec![0; 1000]; // future-proofing, make this function expensive.
-        &*p
+        unsafe {
+            #[allow(unused)]
+            let x = vec![0; 1000]; // future-proofing, make this function expensive.
+            &*p
+        }
     }
 
     unsafe fn foo() {
-        let s = "test".to_owned();
-        let s = &s as *const _;
-        None.unwrap_or(ptr_to_ref(s));
-        //~^ or_fun_call
+        unsafe {
+            let s = "test".to_owned();
+            let s = &s as *const _;
+            None.unwrap_or(ptr_to_ref(s));
+            //~^ or_fun_call
+        }
     }
 
     fn bar() {

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -125,91 +125,91 @@ LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_else(|| Some("b".to_string()))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:190:14
+  --> tests/ui/or_fun_call.rs:193:18
    |
-LL |         None.unwrap_or(ptr_to_ref(s));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| ptr_to_ref(s))`
+LL |             None.unwrap_or(ptr_to_ref(s));
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:197:14
+  --> tests/ui/or_fun_call.rs:201:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:200:14
+  --> tests/ui/or_fun_call.rs:204:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:276:25
+  --> tests/ui/or_fun_call.rs:280:25
    |
 LL |         let _ = Some(4).map_or(g(), |v| v);
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(g, |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:278:25
+  --> tests/ui/or_fun_call.rs:282:25
    |
 LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:310:18
+  --> tests/ui/or_fun_call.rs:314:18
    |
 LL |         with_new.unwrap_or_else(Vec::new);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:314:28
+  --> tests/ui/or_fun_call.rs:318:28
    |
 LL |         with_default_trait.unwrap_or_else(Default::default);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:318:27
+  --> tests/ui/or_fun_call.rs:322:27
    |
 LL |         with_default_type.unwrap_or_else(u64::default);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:322:22
+  --> tests/ui/or_fun_call.rs:326:22
    |
 LL |         real_default.unwrap_or_else(<FakeDefault as Default>::default);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:326:23
+  --> tests/ui/or_fun_call.rs:330:23
    |
 LL |         map.entry(42).or_insert_with(String::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:330:25
+  --> tests/ui/or_fun_call.rs:334:25
    |
 LL |         btree.entry(42).or_insert_with(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:334:25
+  --> tests/ui/or_fun_call.rs:338:25
    |
 LL |         let _ = stringy.unwrap_or_else(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:376:17
+  --> tests/ui/or_fun_call.rs:380:17
    |
 LL |     let _ = opt.unwrap_or({ f() }); // suggest `.unwrap_or_else(f)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(f)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:381:17
+  --> tests/ui/or_fun_call.rs:385:17
    |
 LL |     let _ = opt.unwrap_or(f() + 1); // suggest `.unwrap_or_else(|| f() + 1)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| f() + 1)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:386:17
+  --> tests/ui/or_fun_call.rs:390:17
    |
 LL |       let _ = opt.unwrap_or({
    |  _________________^
@@ -229,19 +229,19 @@ LL ~     });
    |
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:392:17
+  --> tests/ui/or_fun_call.rs:396:17
    |
 LL |     let _ = opt.map_or(f() + 1, |v| v); // suggest `.map_or_else(|| f() + 1, |v| v)`
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| f() + 1, |v| v)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:397:17
+  --> tests/ui/or_fun_call.rs:401:17
    |
 LL |     let _ = opt.unwrap_or({ i32::default() });
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:404:21
+  --> tests/ui/or_fun_call.rs:408:21
    |
 LL |     let _ = opt_foo.unwrap_or(Foo { val: String::default() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Foo { val: String::default() })`

--- a/tests/ui/pointers_in_nomem_asm_block.rs
+++ b/tests/ui/pointers_in_nomem_asm_block.rs
@@ -6,29 +6,37 @@
 use core::arch::asm;
 
 unsafe fn nomem_bad(p: &i32) {
-    asm!(
-        "asdf {p1}, {p2}, {p3}",
-        p1 = in(reg) p,
-        //~^ pointers_in_nomem_asm_block
+    unsafe {
+        asm!(
+            "asdf {p1}, {p2}, {p3}",
+            p1 = in(reg) p,
+            //~^ pointers_in_nomem_asm_block
 
-        p2 = in(reg) p as *const _ as usize,
-        p3 = in(reg) p,
-        options(nomem, nostack, preserves_flags)
-    );
+            p2 = in(reg) p as *const _ as usize,
+            p3 = in(reg) p,
+            options(nomem, nostack, preserves_flags)
+        );
+    }
 }
 
 unsafe fn nomem_good(p: &i32) {
-    asm!("asdf {p}", p = in(reg) p, options(readonly, nostack, preserves_flags));
-    let p = p as *const i32 as usize;
-    asm!("asdf {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+    unsafe {
+        asm!("asdf {p}", p = in(reg) p, options(readonly, nostack, preserves_flags));
+        let p = p as *const i32 as usize;
+        asm!("asdf {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+    }
 }
 
 unsafe fn nomem_bad2(p: &mut i32) {
-    asm!("asdf {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
-    //~^ pointers_in_nomem_asm_block
+    unsafe {
+        asm!("asdf {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+        //~^ pointers_in_nomem_asm_block
+    }
 }
 
 unsafe fn nomem_fn(p: extern "C" fn()) {
-    asm!("call {p}", p = in(reg) p, options(nomem));
-    //~^ pointers_in_nomem_asm_block
+    unsafe {
+        asm!("call {p}", p = in(reg) p, options(nomem));
+        //~^ pointers_in_nomem_asm_block
+    }
 }

--- a/tests/ui/pointers_in_nomem_asm_block.stderr
+++ b/tests/ui/pointers_in_nomem_asm_block.stderr
@@ -1,11 +1,11 @@
 error: passing pointers to nomem asm block
-  --> tests/ui/pointers_in_nomem_asm_block.rs:11:9
+  --> tests/ui/pointers_in_nomem_asm_block.rs:12:13
    |
-LL |         p1 = in(reg) p,
-   |         ^^^^^^^^^^^^^^
+LL |             p1 = in(reg) p,
+   |             ^^^^^^^^^^^^^^
 ...
-LL |         p3 = in(reg) p,
-   |         ^^^^^^^^^^^^^^
+LL |             p3 = in(reg) p,
+   |             ^^^^^^^^^^^^^^
    |
    = note: `nomem` means that no memory write or read happens inside the asm! block
    = note: if this is intentional and no pointers are read or written to, consider allowing the lint
@@ -13,19 +13,19 @@ LL |         p3 = in(reg) p,
    = help: to override `-D warnings` add `#[allow(clippy::pointers_in_nomem_asm_block)]`
 
 error: passing pointers to nomem asm block
-  --> tests/ui/pointers_in_nomem_asm_block.rs:27:22
+  --> tests/ui/pointers_in_nomem_asm_block.rs:32:26
    |
-LL |     asm!("asdf {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
-   |                      ^^^^^^^^^^^^^
+LL |         asm!("asdf {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+   |                          ^^^^^^^^^^^^^
    |
    = note: `nomem` means that no memory write or read happens inside the asm! block
    = note: if this is intentional and no pointers are read or written to, consider allowing the lint
 
 error: passing pointers to nomem asm block
-  --> tests/ui/pointers_in_nomem_asm_block.rs:32:22
+  --> tests/ui/pointers_in_nomem_asm_block.rs:39:26
    |
-LL |     asm!("call {p}", p = in(reg) p, options(nomem));
-   |                      ^^^^^^^^^^^^^
+LL |         asm!("call {p}", p = in(reg) p, options(nomem));
+   |                          ^^^^^^^^^^^^^
    |
    = note: `nomem` means that no memory write or read happens inside the asm! block
    = note: if this is intentional and no pointers are read or written to, consider allowing the lint

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -12,11 +12,13 @@ extern crate proc_macros;
 use proc_macros::{external, inline_macros};
 
 unsafe fn ptr_to_ref<T, U>(p: *const T, om: *mut U) {
-    let _: &mut T = std::mem::transmute(p.cast_mut());
-    //~^ ptr_cast_constness
-    let _ = &mut *p.cast_mut();
-    //~^ ptr_cast_constness
-    let _: &T = &*(om as *const T);
+    unsafe {
+        let _: &mut T = std::mem::transmute(p.cast_mut());
+        //~^ ptr_cast_constness
+        let _ = &mut *p.cast_mut();
+        //~^ ptr_cast_constness
+        let _: &T = &*(om as *const T);
+    }
 }
 
 #[inline_macros]

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -12,11 +12,13 @@ extern crate proc_macros;
 use proc_macros::{external, inline_macros};
 
 unsafe fn ptr_to_ref<T, U>(p: *const T, om: *mut U) {
-    let _: &mut T = std::mem::transmute(p as *mut T);
-    //~^ ptr_cast_constness
-    let _ = &mut *(p as *mut T);
-    //~^ ptr_cast_constness
-    let _: &T = &*(om as *const T);
+    unsafe {
+        let _: &mut T = std::mem::transmute(p as *mut T);
+        //~^ ptr_cast_constness
+        let _ = &mut *(p as *mut T);
+        //~^ ptr_cast_constness
+        let _: &T = &*(om as *const T);
+    }
 }
 
 #[inline_macros]

--- a/tests/ui/ptr_cast_constness.stderr
+++ b/tests/ui/ptr_cast_constness.stderr
@@ -1,74 +1,74 @@
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:15:41
+  --> tests/ui/ptr_cast_constness.rs:16:45
    |
-LL |     let _: &mut T = std::mem::transmute(p as *mut T);
-   |                                         ^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
+LL |         let _: &mut T = std::mem::transmute(p as *mut T);
+   |                                             ^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
    |
    = note: `-D clippy::ptr-cast-constness` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ptr_cast_constness)]`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:17:19
+  --> tests/ui/ptr_cast_constness.rs:18:23
    |
-LL |     let _ = &mut *(p as *mut T);
-   |                   ^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
+LL |         let _ = &mut *(p as *mut T);
+   |                       ^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:33:17
+  --> tests/ui/ptr_cast_constness.rs:35:17
    |
 LL |         let _ = *ptr_ptr as *mut u32;
    |                 ^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `(*ptr_ptr).cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:37:13
+  --> tests/ui/ptr_cast_constness.rs:39:13
    |
 LL |     let _ = ptr as *mut u32;
    |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:39:13
+  --> tests/ui/ptr_cast_constness.rs:41:13
    |
 LL |     let _ = mut_ptr as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:73:13
+  --> tests/ui/ptr_cast_constness.rs:75:13
    |
 LL |     let _ = ptr as *mut u32;
    |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:75:13
+  --> tests/ui/ptr_cast_constness.rs:77:13
    |
 LL |     let _ = mut_ptr as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
 error: `as` casting to make a const null pointer into a mutable null pointer
-  --> tests/ui/ptr_cast_constness.rs:82:13
+  --> tests/ui/ptr_cast_constness.rs:84:13
    |
 LL |     let _ = ptr::null::<String>() as *mut String;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null_mut()` directly instead: `std::ptr::null_mut::<String>()`
 
 error: `as` casting to make a mutable null pointer into a const null pointer
-  --> tests/ui/ptr_cast_constness.rs:84:13
+  --> tests/ui/ptr_cast_constness.rs:86:13
    |
 LL |     let _ = ptr::null_mut::<u32>() as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null()` directly instead: `std::ptr::null::<u32>()`
 
 error: changing constness of a null pointer
-  --> tests/ui/ptr_cast_constness.rs:86:13
+  --> tests/ui/ptr_cast_constness.rs:88:13
    |
 LL |     let _ = ptr::null::<u32>().cast_mut();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null_mut()` directly instead: `std::ptr::null_mut::<u32>()`
 
 error: changing constness of a null pointer
-  --> tests/ui/ptr_cast_constness.rs:88:13
+  --> tests/ui/ptr_cast_constness.rs:90:13
    |
 LL |     let _ = ptr::null_mut::<u32>().cast_const();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null()` directly instead: `std::ptr::null::<u32>()`
 
 error: `as` casting to make a const null pointer into a mutable null pointer
-  --> tests/ui/ptr_cast_constness.rs:92:21
+  --> tests/ui/ptr_cast_constness.rs:94:21
    |
 LL |     let _ = inline!(ptr::null::<u32>() as *mut u32);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null_mut()` directly instead: `std::ptr::null_mut::<u32>()`
@@ -76,7 +76,7 @@ LL |     let _ = inline!(ptr::null::<u32>() as *mut u32);
    = note: this error originates in the macro `__inline_mac_fn_null_pointers` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: changing constness of a null pointer
-  --> tests/ui/ptr_cast_constness.rs:94:21
+  --> tests/ui/ptr_cast_constness.rs:96:21
    |
 LL |     let _ = inline!(ptr::null::<u32>().cast_mut());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null_mut()` directly instead: `std::ptr::null_mut::<u32>()`

--- a/tests/ui/result_unit_error_no_std.rs
+++ b/tests/ui/result_unit_error_no_std.rs
@@ -14,7 +14,7 @@ pub fn returns_unit_error_lint() -> Result<u32, ()> {
     Err(())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn main(_argc: core::ffi::c_int, _argv: *const *const u8) -> core::ffi::c_int {
     0
 }

--- a/tests/ui/search_is_some_fixable_none.fixed
+++ b/tests/ui/search_is_some_fixable_none.fixed
@@ -214,10 +214,9 @@ mod issue7392 {
     }
 
     fn ref_bindings() {
-        let _ = ![&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y);
-        //~^ search_is_some
-        let _ = ![&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y);
-        //~^ search_is_some
+        let _ = ![&(&1, 2), &(&3, 4), &(&5, 4)]
+            //~^ search_is_some
+            .iter().any(|&&(&x, ref y)| x == *y);
     }
 
     fn test_string_1(s: &str) -> bool {

--- a/tests/ui/search_is_some_fixable_none.rs
+++ b/tests/ui/search_is_some_fixable_none.rs
@@ -221,10 +221,11 @@ mod issue7392 {
     }
 
     fn ref_bindings() {
-        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|(&x, y)| x == *y).is_none();
-        //~^ search_is_some
-        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|&(&x, y)| x == *y).is_none();
-        //~^ search_is_some
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)]
+            //~^ search_is_some
+            .iter()
+            .find(|&&&(&x, ref y)| x == *y)
+            .is_none();
     }
 
     fn test_string_1(s: &str) -> bool {

--- a/tests/ui/search_is_some_fixable_none.stderr
+++ b/tests/ui/search_is_some_fixable_none.stderr
@@ -248,116 +248,122 @@ LL |         let _ = vfoo.iter().find(|v| v.by_ref(&v.bar)).is_none();
 error: called `is_none()` after searching an `Iterator` with `find`
   --> tests/ui/search_is_some_fixable_none.rs:224:17
    |
-LL |         let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|(&x, y)| x == *y).is_none();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `![&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y)`
-
-error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:226:17
+LL |           let _ = [&(&1, 2), &(&3, 4), &(&5, 4)]
+   |  _________________^
+LL | |
+LL | |             .iter()
+LL | |             .find(|&&&(&x, ref y)| x == *y)
+LL | |             .is_none();
+   | |______________________^
    |
-LL |         let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|&(&x, y)| x == *y).is_none();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `![&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y)`
+help: consider using
+   |
+LL ~         let _ = ![&(&1, 2), &(&3, 4), &(&5, 4)]
+LL +
+LL ~             .iter().any(|&&(&x, ref y)| x == *y);
+   |
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:246:17
+  --> tests/ui/search_is_some_fixable_none.rs:247:17
    |
 LL |         let _ = v.iter().find(|s| s[0].is_empty()).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|s| s[0].is_empty())`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:248:17
+  --> tests/ui/search_is_some_fixable_none.rs:249:17
    |
 LL |         let _ = v.iter().find(|s| test_string_1(&s[0])).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|s| test_string_1(&s[0]))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:258:17
+  --> tests/ui/search_is_some_fixable_none.rs:259:17
    |
 LL |         let _ = v.iter().find(|fp| fp.field.is_power_of_two()).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|fp| fp.field.is_power_of_two())`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:260:17
+  --> tests/ui/search_is_some_fixable_none.rs:261:17
    |
 LL |         let _ = v.iter().find(|fp| test_u32_1(fp.field)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|fp| test_u32_1(fp.field))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:262:17
+  --> tests/ui/search_is_some_fixable_none.rs:263:17
    |
 LL |         let _ = v.iter().find(|fp| test_u32_2(*fp.field)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|fp| test_u32_2(*fp.field))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:279:17
+  --> tests/ui/search_is_some_fixable_none.rs:280:17
    |
 LL |         let _ = v.iter().find(|x| **x == 42).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|x| *x == 42)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:281:17
+  --> tests/ui/search_is_some_fixable_none.rs:282:17
    |
 LL |         Foo.bar(v.iter().find(|x| **x == 42).is_none());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|x| *x == 42)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:287:9
+  --> tests/ui/search_is_some_fixable_none.rs:288:9
    |
 LL |         v.iter().find(|x| **x == 42).is_none().then(computations);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!v.iter().any(|x| *x == 42))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:293:9
+  --> tests/ui/search_is_some_fixable_none.rs:294:9
    |
 LL |         v.iter().find(|x| **x == 42).is_none().then_some(0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!v.iter().any(|x| *x == 42))`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:299:17
+  --> tests/ui/search_is_some_fixable_none.rs:300:17
    |
 LL |         let _ = s.find("world").is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:301:17
+  --> tests/ui/search_is_some_fixable_none.rs:302:17
    |
 LL |         Foo.bar(s.find("world").is_none());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:304:17
+  --> tests/ui/search_is_some_fixable_none.rs:305:17
    |
 LL |         let _ = s.find("world").is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:306:17
+  --> tests/ui/search_is_some_fixable_none.rs:307:17
    |
 LL |         Foo.bar(s.find("world").is_none());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:312:17
+  --> tests/ui/search_is_some_fixable_none.rs:313:17
    |
 LL |         let _ = s.find("world").is_none().then(computations);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!s.contains("world"))`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:315:17
+  --> tests/ui/search_is_some_fixable_none.rs:316:17
    |
 LL |         let _ = s.find("world").is_none().then(computations);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!s.contains("world"))`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:321:17
+  --> tests/ui/search_is_some_fixable_none.rs:322:17
    |
 LL |         let _ = s.find("world").is_none().then_some(0);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!s.contains("world"))`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:324:17
+  --> tests/ui/search_is_some_fixable_none.rs:325:17
    |
 LL |         let _ = s.find("world").is_none().then_some(0);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!s.contains("world"))`
 
-error: aborting due to 55 previous errors
+error: aborting due to 54 previous errors
 

--- a/tests/ui/search_is_some_fixable_none_2021.fixed
+++ b/tests/ui/search_is_some_fixable_none_2021.fixed
@@ -1,0 +1,14 @@
+//@edition: 2021
+#![warn(clippy::search_is_some)]
+
+fn main() {
+    fn ref_bindings() {
+        let _ = ![&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y);
+        //~^ search_is_some
+        let _ = ![&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y);
+        //~^ search_is_some
+        let _ = ![&(&1, 2), &(&3, 4), &(&5, 4)]
+            //~^ search_is_some
+            .iter().any(|&&(&x, ref y)| x == *y);
+    }
+}

--- a/tests/ui/search_is_some_fixable_none_2021.rs
+++ b/tests/ui/search_is_some_fixable_none_2021.rs
@@ -1,0 +1,16 @@
+//@edition: 2021
+#![warn(clippy::search_is_some)]
+
+fn main() {
+    fn ref_bindings() {
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|(&x, y)| x == *y).is_none();
+        //~^ search_is_some
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|&(&x, y)| x == *y).is_none();
+        //~^ search_is_some
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)]
+            //~^ search_is_some
+            .iter()
+            .find(|&&&(&x, ref y)| x == *y)
+            .is_none();
+    }
+}

--- a/tests/ui/search_is_some_fixable_none_2021.stderr
+++ b/tests/ui/search_is_some_fixable_none_2021.stderr
@@ -1,0 +1,35 @@
+error: called `is_none()` after searching an `Iterator` with `find`
+  --> tests/ui/search_is_some_fixable_none_2021.rs:6:17
+   |
+LL |         let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|(&x, y)| x == *y).is_none();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `![&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y)`
+   |
+   = note: `-D clippy::search-is-some` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::search_is_some)]`
+
+error: called `is_none()` after searching an `Iterator` with `find`
+  --> tests/ui/search_is_some_fixable_none_2021.rs:8:17
+   |
+LL |         let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|&(&x, y)| x == *y).is_none();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `![&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y)`
+
+error: called `is_none()` after searching an `Iterator` with `find`
+  --> tests/ui/search_is_some_fixable_none_2021.rs:10:17
+   |
+LL |           let _ = [&(&1, 2), &(&3, 4), &(&5, 4)]
+   |  _________________^
+LL | |
+LL | |             .iter()
+LL | |             .find(|&&&(&x, ref y)| x == *y)
+LL | |             .is_none();
+   | |______________________^
+   |
+help: consider using
+   |
+LL ~         let _ = ![&(&1, 2), &(&3, 4), &(&5, 4)]
+LL +
+LL ~             .iter().any(|&&(&x, ref y)| x == *y);
+   |
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/search_is_some_fixable_some.fixed
+++ b/tests/ui/search_is_some_fixable_some.fixed
@@ -214,10 +214,9 @@ mod issue7392 {
     }
 
     fn ref_bindings() {
-        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y);
-        //~^ search_is_some
-        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y);
-        //~^ search_is_some
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)]
+            .iter()
+            .any(|&&(&x, ref y)| x == *y);
     }
 
     fn test_string_1(s: &str) -> bool {

--- a/tests/ui/search_is_some_fixable_some.rs
+++ b/tests/ui/search_is_some_fixable_some.rs
@@ -220,10 +220,11 @@ mod issue7392 {
     }
 
     fn ref_bindings() {
-        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|(&x, y)| x == *y).is_some();
-        //~^ search_is_some
-        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|&(&x, y)| x == *y).is_some();
-        //~^ search_is_some
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)]
+            .iter()
+            .find(|&&&(&x, ref y)| x == *y)
+            //~^ search_is_some
+            .is_some();
     }
 
     fn test_string_1(s: &str) -> bool {

--- a/tests/ui/search_is_some_fixable_some.stderr
+++ b/tests/ui/search_is_some_fixable_some.stderr
@@ -227,70 +227,67 @@ LL |         let _ = vfoo.iter().find(|v| v.by_ref(&v.bar)).is_some();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|v| v.by_ref(&v.bar))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:223:55
+  --> tests/ui/search_is_some_fixable_some.rs:225:14
    |
-LL |         let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|(&x, y)| x == *y).is_some();
-   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|(&x, y)| x == *y)`
+LL |               .find(|&&&(&x, ref y)| x == *y)
+   |  ______________^
+LL | |
+LL | |             .is_some();
+   | |______________________^ help: consider using: `any(|&&(&x, ref y)| x == *y)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:225:55
-   |
-LL |         let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|&(&x, y)| x == *y).is_some();
-   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|(&x, y)| x == *y)`
-
-error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:245:26
+  --> tests/ui/search_is_some_fixable_some.rs:246:26
    |
 LL |         let _ = v.iter().find(|s| s[0].is_empty()).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|s| s[0].is_empty())`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:247:26
+  --> tests/ui/search_is_some_fixable_some.rs:248:26
    |
 LL |         let _ = v.iter().find(|s| test_string_1(&s[0])).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|s| test_string_1(&s[0]))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:257:26
+  --> tests/ui/search_is_some_fixable_some.rs:258:26
    |
 LL |         let _ = v.iter().find(|fp| fp.field.is_power_of_two()).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|fp| fp.field.is_power_of_two())`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:259:26
+  --> tests/ui/search_is_some_fixable_some.rs:260:26
    |
 LL |         let _ = v.iter().find(|fp| test_u32_1(fp.field)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|fp| test_u32_1(fp.field))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:261:26
+  --> tests/ui/search_is_some_fixable_some.rs:262:26
    |
 LL |         let _ = v.iter().find(|fp| test_u32_2(*fp.field)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|fp| test_u32_2(*fp.field))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:277:18
+  --> tests/ui/search_is_some_fixable_some.rs:278:18
    |
 LL |         v.iter().find(|x: &&u32| func(x)).is_some()
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| func(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:287:26
+  --> tests/ui/search_is_some_fixable_some.rs:288:26
    |
 LL |         let _ = v.iter().find(|x: &&u32| arg_no_deref_impl(x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| arg_no_deref_impl(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:291:26
+  --> tests/ui/search_is_some_fixable_some.rs:292:26
    |
 LL |         let _ = v.iter().find(|x: &&u32| arg_no_deref_dyn(x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| arg_no_deref_dyn(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:295:26
+  --> tests/ui/search_is_some_fixable_some.rs:296:26
    |
 LL |         let _ = v.iter().find(|x: &&u32| (*arg_no_deref_dyn)(x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| (*arg_no_deref_dyn)(&x))`
 
-error: aborting due to 47 previous errors
+error: aborting due to 46 previous errors
 

--- a/tests/ui/search_is_some_fixable_some_2021.fixed
+++ b/tests/ui/search_is_some_fixable_some_2021.fixed
@@ -1,0 +1,11 @@
+//@edition: 2021
+#![warn(clippy::search_is_some)]
+
+fn main() {
+    fn ref_bindings() {
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y);
+        //~^ search_is_some
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().any(|(&x, y)| x == *y);
+        //~^ search_is_some
+    }
+}

--- a/tests/ui/search_is_some_fixable_some_2021.rs
+++ b/tests/ui/search_is_some_fixable_some_2021.rs
@@ -1,0 +1,11 @@
+//@edition: 2021
+#![warn(clippy::search_is_some)]
+
+fn main() {
+    fn ref_bindings() {
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|(&x, y)| x == *y).is_some();
+        //~^ search_is_some
+        let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|&(&x, y)| x == *y).is_some();
+        //~^ search_is_some
+    }
+}

--- a/tests/ui/search_is_some_fixable_some_2021.stderr
+++ b/tests/ui/search_is_some_fixable_some_2021.stderr
@@ -1,0 +1,17 @@
+error: called `is_some()` after searching an `Iterator` with `find`
+  --> tests/ui/search_is_some_fixable_some_2021.rs:6:55
+   |
+LL |         let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|(&x, y)| x == *y).is_some();
+   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|(&x, y)| x == *y)`
+   |
+   = note: `-D clippy::search-is-some` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::search_is_some)]`
+
+error: called `is_some()` after searching an `Iterator` with `find`
+  --> tests/ui/search_is_some_fixable_some_2021.rs:8:55
+   |
+LL |         let _ = [&(&1, 2), &(&3, 4), &(&5, 4)].iter().find(|&(&x, y)| x == *y).is_some();
+   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|(&x, y)| x == *y)`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/single_call_fn.rs
+++ b/tests/ui/single_call_fn.rs
@@ -94,7 +94,7 @@ trait Trait {
     //~^ single_call_fn
     fn foo(&self);
 }
-extern "C" {
+unsafe extern "C" {
     // test some kind of foreign item
     fn rand() -> std::ffi::c_int;
 }

--- a/tests/ui/transmute.rs
+++ b/tests/ui/transmute.rs
@@ -23,19 +23,21 @@ fn my_vec() -> MyVec<i32> {
 #[allow(clippy::needless_lifetimes, clippy::transmute_ptr_to_ptr)]
 #[warn(clippy::useless_transmute)]
 unsafe fn _generic<'a, T, U: 'a>(t: &'a T) {
-    // FIXME: should lint
-    // let _: &'a T = core::mem::transmute(t);
+    unsafe {
+        // FIXME: should lint
+        // let _: &'a T = core::mem::transmute(t);
 
-    let _: &'a U = core::mem::transmute(t);
+        let _: &'a U = core::mem::transmute(t);
 
-    let _: *const T = core::mem::transmute(t);
-    //~^ useless_transmute
+        let _: *const T = core::mem::transmute(t);
+        //~^ useless_transmute
 
-    let _: *mut T = core::mem::transmute(t);
-    //~^ useless_transmute
+        let _: *mut T = core::mem::transmute(t);
+        //~^ useless_transmute
 
-    let _: *const U = core::mem::transmute(t);
-    //~^ useless_transmute
+        let _: *const U = core::mem::transmute(t);
+        //~^ useless_transmute
+    }
 }
 
 #[warn(clippy::useless_transmute)]
@@ -68,19 +70,19 @@ fn useless() {
     }
 
     unsafe fn _f<'a, 'b>(x: &'a u32) -> &'b u32 {
-        std::mem::transmute(x)
+        unsafe { std::mem::transmute(x) }
     }
 
     unsafe fn _f2<'a, 'b>(x: *const (dyn Iterator<Item = u32> + 'a)) -> *const (dyn Iterator<Item = u32> + 'b) {
-        std::mem::transmute(x)
+        unsafe { std::mem::transmute(x) }
     }
 
     unsafe fn _f3<'a, 'b>(x: fn(&'a u32)) -> fn(&'b u32) {
-        std::mem::transmute(x)
+        unsafe { std::mem::transmute(x) }
     }
 
     unsafe fn _f4<'a, 'b>(x: std::borrow::Cow<'a, str>) -> std::borrow::Cow<'b, str> {
-        std::mem::transmute(x)
+        unsafe { std::mem::transmute(x) }
     }
 }
 

--- a/tests/ui/transmute.stderr
+++ b/tests/ui/transmute.stderr
@@ -1,68 +1,68 @@
 error: transmute from a reference to a pointer
-  --> tests/ui/transmute.rs:31:23
+  --> tests/ui/transmute.rs:32:27
    |
-LL |     let _: *const T = core::mem::transmute(t);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T`
+LL |         let _: *const T = core::mem::transmute(t);
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T`
    |
    = note: `-D clippy::useless-transmute` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_transmute)]`
 
 error: transmute from a reference to a pointer
-  --> tests/ui/transmute.rs:34:21
+  --> tests/ui/transmute.rs:35:25
    |
-LL |     let _: *mut T = core::mem::transmute(t);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T as *mut T`
+LL |         let _: *mut T = core::mem::transmute(t);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T as *mut T`
 
 error: transmute from a reference to a pointer
-  --> tests/ui/transmute.rs:37:23
+  --> tests/ui/transmute.rs:38:27
    |
-LL |     let _: *const U = core::mem::transmute(t);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T as *const U`
+LL |         let _: *const U = core::mem::transmute(t);
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T as *const U`
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:44:27
-   |
-LL |         let _: Vec<i32> = core::mem::transmute(my_vec());
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:47:27
+  --> tests/ui/transmute.rs:46:27
    |
 LL |         let _: Vec<i32> = core::mem::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:50:27
+  --> tests/ui/transmute.rs:49:27
+   |
+LL |         let _: Vec<i32> = core::mem::transmute(my_vec());
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: transmute from a type (`std::vec::Vec<i32>`) to itself
+  --> tests/ui/transmute.rs:52:27
    |
 LL |         let _: Vec<i32> = std::mem::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:53:27
+  --> tests/ui/transmute.rs:55:27
    |
 LL |         let _: Vec<i32> = std::mem::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:56:27
+  --> tests/ui/transmute.rs:58:27
    |
 LL |         let _: Vec<i32> = my_transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from an integer to a pointer
-  --> tests/ui/transmute.rs:59:31
+  --> tests/ui/transmute.rs:61:31
    |
 LL |         let _: *const usize = std::mem::transmute(5_isize);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `5_isize as *const usize`
 
 error: transmute from an integer to a pointer
-  --> tests/ui/transmute.rs:64:31
+  --> tests/ui/transmute.rs:66:31
    |
 LL |         let _: *const usize = std::mem::transmute(1 + 1usize);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(1 + 1usize) as *const usize`
 
 error: transmute from a type (`*const Usize`) to the type that it points to (`Usize`)
-  --> tests/ui/transmute.rs:96:24
+  --> tests/ui/transmute.rs:98:24
    |
 LL |         let _: Usize = core::mem::transmute(int_const_ptr);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,25 +71,25 @@ LL |         let _: Usize = core::mem::transmute(int_const_ptr);
    = help: to override `-D warnings` add `#[allow(clippy::crosspointer_transmute)]`
 
 error: transmute from a type (`*mut Usize`) to the type that it points to (`Usize`)
-  --> tests/ui/transmute.rs:99:24
+  --> tests/ui/transmute.rs:101:24
    |
 LL |         let _: Usize = core::mem::transmute(int_mut_ptr);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`Usize`) to a pointer to that type (`*const Usize`)
-  --> tests/ui/transmute.rs:102:31
+  --> tests/ui/transmute.rs:104:31
    |
 LL |         let _: *const Usize = core::mem::transmute(my_int());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`Usize`) to a pointer to that type (`*mut Usize`)
-  --> tests/ui/transmute.rs:105:29
+  --> tests/ui/transmute.rs:107:29
    |
 LL |         let _: *mut Usize = core::mem::transmute(my_int());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a `u8` to a `bool`
-  --> tests/ui/transmute.rs:112:28
+  --> tests/ui/transmute.rs:114:28
    |
 LL |     let _: bool = unsafe { std::mem::transmute(0_u8) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `0_u8 != 0`
@@ -98,7 +98,7 @@ LL |     let _: bool = unsafe { std::mem::transmute(0_u8) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_bool)]`
 
 error: transmute from a `u16` to a `f16`
-  --> tests/ui/transmute.rs:119:31
+  --> tests/ui/transmute.rs:121:31
    |
 LL |         let _: f16 = unsafe { std::mem::transmute(0_u16) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f16::from_bits(0_u16)`
@@ -107,97 +107,97 @@ LL |         let _: f16 = unsafe { std::mem::transmute(0_u16) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_float)]`
 
 error: transmute from a `i16` to a `f16`
-  --> tests/ui/transmute.rs:122:31
+  --> tests/ui/transmute.rs:124:31
    |
 LL |         let _: f16 = unsafe { std::mem::transmute(0_i16) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f16::from_bits(0_i16 as u16)`
 
 error: transmute from a `u32` to a `f32`
-  --> tests/ui/transmute.rs:125:31
+  --> tests/ui/transmute.rs:127:31
    |
 LL |         let _: f32 = unsafe { std::mem::transmute(0_u32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f32::from_bits(0_u32)`
 
 error: transmute from a `i32` to a `f32`
-  --> tests/ui/transmute.rs:128:31
+  --> tests/ui/transmute.rs:130:31
    |
 LL |         let _: f32 = unsafe { std::mem::transmute(0_i32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f32::from_bits(0_i32 as u32)`
 
 error: transmute from a `u64` to a `f64`
-  --> tests/ui/transmute.rs:131:31
+  --> tests/ui/transmute.rs:133:31
    |
 LL |         let _: f64 = unsafe { std::mem::transmute(0_u64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f64::from_bits(0_u64)`
 
 error: transmute from a `i64` to a `f64`
-  --> tests/ui/transmute.rs:134:31
+  --> tests/ui/transmute.rs:136:31
    |
 LL |         let _: f64 = unsafe { std::mem::transmute(0_i64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f64::from_bits(0_i64 as u64)`
 
 error: transmute from a `u128` to a `f128`
-  --> tests/ui/transmute.rs:137:32
+  --> tests/ui/transmute.rs:139:32
    |
 LL |         let _: f128 = unsafe { std::mem::transmute(0_u128) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f128::from_bits(0_u128)`
 
 error: transmute from a `i128` to a `f128`
-  --> tests/ui/transmute.rs:140:32
+  --> tests/ui/transmute.rs:142:32
    |
 LL |         let _: f128 = unsafe { std::mem::transmute(0_i128) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f128::from_bits(0_i128 as u128)`
 
 error: transmute from a `u16` to a `f16`
-  --> tests/ui/transmute.rs:145:39
+  --> tests/ui/transmute.rs:147:39
    |
 LL |         const VALUE16: f16 = unsafe { std::mem::transmute(0_u16) };
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f16::from_bits(0_u16)`
 
 error: transmute from a `u32` to a `f32`
-  --> tests/ui/transmute.rs:148:39
+  --> tests/ui/transmute.rs:150:39
    |
 LL |         const VALUE32: f32 = unsafe { std::mem::transmute(0_u32) };
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f32::from_bits(0_u32)`
 
 error: transmute from a `i64` to a `f64`
-  --> tests/ui/transmute.rs:151:39
+  --> tests/ui/transmute.rs:153:39
    |
 LL |         const VALUE64: f64 = unsafe { std::mem::transmute(0_i64) };
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f64::from_bits(0_i64 as u64)`
 
 error: transmute from a `i128` to a `f128`
-  --> tests/ui/transmute.rs:154:41
+  --> tests/ui/transmute.rs:156:41
    |
 LL |         const VALUE128: f128 = unsafe { std::mem::transmute(0_i128) };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f128::from_bits(0_i128 as u128)`
 
 error: transmute from a `i16` to a `f16`
-  --> tests/ui/transmute.rs:158:22
+  --> tests/ui/transmute.rs:160:22
    |
 LL |             unsafe { std::mem::transmute(v) }
    |                      ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f16::from_bits(v as u16)`
 
 error: transmute from a `i32` to a `f32`
-  --> tests/ui/transmute.rs:163:22
+  --> tests/ui/transmute.rs:165:22
    |
 LL |             unsafe { std::mem::transmute(v) }
    |                      ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f32::from_bits(v as u32)`
 
 error: transmute from a `u64` to a `f64`
-  --> tests/ui/transmute.rs:168:22
+  --> tests/ui/transmute.rs:170:22
    |
 LL |             unsafe { std::mem::transmute(v) }
    |                      ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f64::from_bits(v)`
 
 error: transmute from a `u128` to a `f128`
-  --> tests/ui/transmute.rs:173:22
+  --> tests/ui/transmute.rs:175:22
    |
 LL |             unsafe { std::mem::transmute(v) }
    |                      ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f128::from_bits(v)`
 
 error: transmute from a `u8` to a `[u8; 1]`
-  --> tests/ui/transmute.rs:182:30
+  --> tests/ui/transmute.rs:184:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u8.to_ne_bytes()`
@@ -206,121 +206,121 @@ LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    = help: to override `-D warnings` add `#[allow(clippy::transmute_num_to_bytes)]`
 
 error: transmute from a `u32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:185:30
+  --> tests/ui/transmute.rs:187:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0u32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u32.to_ne_bytes()`
 
 error: transmute from a `u128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:188:31
+  --> tests/ui/transmute.rs:190:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0u128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u128.to_ne_bytes()`
 
 error: transmute from a `i8` to a `[u8; 1]`
-  --> tests/ui/transmute.rs:191:30
+  --> tests/ui/transmute.rs:193:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0i8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i8.to_ne_bytes()`
 
 error: transmute from a `i32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:194:30
+  --> tests/ui/transmute.rs:196:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0i32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i32.to_ne_bytes()`
 
 error: transmute from a `i128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:197:31
+  --> tests/ui/transmute.rs:199:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0i128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i128.to_ne_bytes()`
 
 error: transmute from a `f16` to a `[u8; 2]`
-  --> tests/ui/transmute.rs:200:30
+  --> tests/ui/transmute.rs:202:30
    |
 LL |             let _: [u8; 2] = std::mem::transmute(0.0f16);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f16.to_ne_bytes()`
 
 error: transmute from a `f32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:203:30
+  --> tests/ui/transmute.rs:205:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0.0f32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f32.to_ne_bytes()`
 
 error: transmute from a `f64` to a `[u8; 8]`
-  --> tests/ui/transmute.rs:206:30
+  --> tests/ui/transmute.rs:208:30
    |
 LL |             let _: [u8; 8] = std::mem::transmute(0.0f64);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f64.to_ne_bytes()`
 
 error: transmute from a `f128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:209:31
+  --> tests/ui/transmute.rs:211:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0.0f128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f128.to_ne_bytes()`
 
 error: transmute from a `u8` to a `[u8; 1]`
-  --> tests/ui/transmute.rs:215:30
+  --> tests/ui/transmute.rs:217:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u8.to_ne_bytes()`
 
 error: transmute from a `u32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:218:30
+  --> tests/ui/transmute.rs:220:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0u32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u32.to_ne_bytes()`
 
 error: transmute from a `u128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:221:31
+  --> tests/ui/transmute.rs:223:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0u128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u128.to_ne_bytes()`
 
 error: transmute from a `i8` to a `[u8; 1]`
-  --> tests/ui/transmute.rs:224:30
+  --> tests/ui/transmute.rs:226:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0i8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i8.to_ne_bytes()`
 
 error: transmute from a `i32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:227:30
+  --> tests/ui/transmute.rs:229:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0i32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i32.to_ne_bytes()`
 
 error: transmute from a `i128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:230:31
+  --> tests/ui/transmute.rs:232:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0i128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i128.to_ne_bytes()`
 
 error: transmute from a `f16` to a `[u8; 2]`
-  --> tests/ui/transmute.rs:233:30
+  --> tests/ui/transmute.rs:235:30
    |
 LL |             let _: [u8; 2] = std::mem::transmute(0.0f16);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f16.to_ne_bytes()`
 
 error: transmute from a `f32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:236:30
+  --> tests/ui/transmute.rs:238:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0.0f32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f32.to_ne_bytes()`
 
 error: transmute from a `f64` to a `[u8; 8]`
-  --> tests/ui/transmute.rs:239:30
+  --> tests/ui/transmute.rs:241:30
    |
 LL |             let _: [u8; 8] = std::mem::transmute(0.0f64);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f64.to_ne_bytes()`
 
 error: transmute from a `f128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:242:31
+  --> tests/ui/transmute.rs:244:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0.0f128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f128.to_ne_bytes()`
 
 error: transmute from a `&[u8]` to a `&str`
-  --> tests/ui/transmute.rs:251:28
+  --> tests/ui/transmute.rs:253:28
    |
 LL |     let _: &str = unsafe { std::mem::transmute(B) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8(B).unwrap()`
@@ -329,13 +329,13 @@ LL |     let _: &str = unsafe { std::mem::transmute(B) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_bytes_to_str)]`
 
 error: transmute from a `&mut [u8]` to a `&mut str`
-  --> tests/ui/transmute.rs:254:32
+  --> tests/ui/transmute.rs:256:32
    |
 LL |     let _: &mut str = unsafe { std::mem::transmute(mb) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_mut(mb).unwrap()`
 
 error: transmute from a `&[u8]` to a `&str`
-  --> tests/ui/transmute.rs:257:30
+  --> tests/ui/transmute.rs:259:30
    |
 LL |     const _: &str = unsafe { std::mem::transmute(B) };
    |                              ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_unchecked(B)`

--- a/tests/ui/transmute_ptr_to_ptr.fixed
+++ b/tests/ui/transmute_ptr_to_ptr.fixed
@@ -8,12 +8,12 @@ use std::mem::transmute;
 
 // Make sure we can do static lifetime transmutes
 unsafe fn transmute_lifetime_to_static<'a, T>(t: &'a T) -> &'static T {
-    transmute::<&'a T, &'static T>(t)
+    unsafe { transmute::<&'a T, &'static T>(t) }
 }
 
 // Make sure we can do non-static lifetime transmutes
 unsafe fn transmute_lifetime<'a, 'b, T>(t: &'a T, u: &'b T) -> &'b T {
-    transmute::<&'a T, &'b T>(t)
+    unsafe { transmute::<&'a T, &'b T>(t) }
 }
 
 struct LifetimeParam<'a> {

--- a/tests/ui/transmute_ptr_to_ptr.rs
+++ b/tests/ui/transmute_ptr_to_ptr.rs
@@ -8,12 +8,12 @@ use std::mem::transmute;
 
 // Make sure we can do static lifetime transmutes
 unsafe fn transmute_lifetime_to_static<'a, T>(t: &'a T) -> &'static T {
-    transmute::<&'a T, &'static T>(t)
+    unsafe { transmute::<&'a T, &'static T>(t) }
 }
 
 // Make sure we can do non-static lifetime transmutes
 unsafe fn transmute_lifetime<'a, 'b, T>(t: &'a T, u: &'b T) -> &'b T {
-    transmute::<&'a T, &'b T>(t)
+    unsafe { transmute::<&'a T, &'b T>(t) }
 }
 
 struct LifetimeParam<'a> {

--- a/tests/ui/transmute_ptr_to_ref.fixed
+++ b/tests/ui/transmute_ptr_to_ref.fixed
@@ -6,33 +6,35 @@
 )]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
-    let _: &T = &*p;
-    //~^ transmute_ptr_to_ref
-    let _: &T = &*p;
+    unsafe {
+        let _: &T = &*p;
+        //~^ transmute_ptr_to_ref
+        let _: &T = &*p;
 
-    let _: &mut T = &mut *m;
-    //~^ transmute_ptr_to_ref
-    let _: &mut T = &mut *m;
+        let _: &mut T = &mut *m;
+        //~^ transmute_ptr_to_ref
+        let _: &mut T = &mut *m;
 
-    let _: &T = &*m;
-    //~^ transmute_ptr_to_ref
-    let _: &T = &*m;
+        let _: &T = &*m;
+        //~^ transmute_ptr_to_ref
+        let _: &T = &*m;
 
-    let _: &mut T = &mut *(p as *mut T);
-    //~^ transmute_ptr_to_ref
-    let _ = &mut *(p as *mut T);
+        let _: &mut T = &mut *(p as *mut T);
+        //~^ transmute_ptr_to_ref
+        let _ = &mut *(p as *mut T);
 
-    let _: &T = &*(o as *const T);
-    //~^ transmute_ptr_to_ref
-    let _: &T = &*(o as *const T);
+        let _: &T = &*(o as *const T);
+        //~^ transmute_ptr_to_ref
+        let _: &T = &*(o as *const T);
 
-    let _: &mut T = &mut *(om as *mut T);
-    //~^ transmute_ptr_to_ref
-    let _: &mut T = &mut *(om as *mut T);
+        let _: &mut T = &mut *(om as *mut T);
+        //~^ transmute_ptr_to_ref
+        let _: &mut T = &mut *(om as *mut T);
 
-    let _: &T = &*(om as *const T);
-    //~^ transmute_ptr_to_ref
-    let _: &T = &*(om as *const T);
+        let _: &T = &*(om as *const T);
+        //~^ transmute_ptr_to_ref
+        let _: &T = &*(om as *const T);
+    }
 }
 
 fn _issue1231() {
@@ -54,47 +56,53 @@ fn _issue1231() {
 }
 
 unsafe fn _issue8924<'a, 'b, 'c>(x: *const &'a u32, y: *const &'b u32) -> &'c &'b u32 {
-    match 0 {
-        0 => &*x.cast::<&u32>(),
-        //~^ transmute_ptr_to_ref
-        1 => &*y.cast::<&u32>(),
-        //~^ transmute_ptr_to_ref
-        2 => &*x.cast::<&'b u32>(),
-        //~^ transmute_ptr_to_ref
-        _ => &*y.cast::<&'b u32>(),
-        //~^ transmute_ptr_to_ref
+    unsafe {
+        match 0 {
+            0 => &*x.cast::<&u32>(),
+            //~^ transmute_ptr_to_ref
+            1 => &*y.cast::<&u32>(),
+            //~^ transmute_ptr_to_ref
+            2 => &*x.cast::<&'b u32>(),
+            //~^ transmute_ptr_to_ref
+            _ => &*y.cast::<&'b u32>(),
+            //~^ transmute_ptr_to_ref
+        }
     }
 }
 
 #[clippy::msrv = "1.38"]
 unsafe fn _meets_msrv<'a, 'b, 'c>(x: *const &'a u32) -> &'c &'b u32 {
-    let a = 0u32;
-    let a = &a as *const u32;
-    let _: &u32 = &*a;
-    //~^ transmute_ptr_to_ref
-    let _: &u32 = &*a.cast::<u32>();
-    //~^ transmute_ptr_to_ref
-    match 0 {
-        0 => &*x.cast::<&u32>(),
+    unsafe {
+        let a = 0u32;
+        let a = &a as *const u32;
+        let _: &u32 = &*a;
         //~^ transmute_ptr_to_ref
-        _ => &*x.cast::<&'b u32>(),
+        let _: &u32 = &*a.cast::<u32>();
         //~^ transmute_ptr_to_ref
+        match 0 {
+            0 => &*x.cast::<&u32>(),
+            //~^ transmute_ptr_to_ref
+            _ => &*x.cast::<&'b u32>(),
+            //~^ transmute_ptr_to_ref
+        }
     }
 }
 
 #[clippy::msrv = "1.37"]
 unsafe fn _under_msrv<'a, 'b, 'c>(x: *const &'a u32) -> &'c &'b u32 {
-    let a = 0u32;
-    let a = &a as *const u32;
-    let _: &u32 = &*a;
-    //~^ transmute_ptr_to_ref
-    let _: &u32 = &*(a as *const u32);
-    //~^ transmute_ptr_to_ref
-    match 0 {
-        0 => &*(x as *const () as *const &u32),
+    unsafe {
+        let a = 0u32;
+        let a = &a as *const u32;
+        let _: &u32 = &*a;
         //~^ transmute_ptr_to_ref
-        _ => &*(x as *const () as *const &'b u32),
+        let _: &u32 = &*(a as *const u32);
         //~^ transmute_ptr_to_ref
+        match 0 {
+            0 => &*(x as *const () as *const &u32),
+            //~^ transmute_ptr_to_ref
+            _ => &*(x as *const () as *const &'b u32),
+            //~^ transmute_ptr_to_ref
+        }
     }
 }
 

--- a/tests/ui/transmute_ptr_to_ref.rs
+++ b/tests/ui/transmute_ptr_to_ref.rs
@@ -6,33 +6,35 @@
 )]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
-    let _: &T = std::mem::transmute(p);
-    //~^ transmute_ptr_to_ref
-    let _: &T = &*p;
+    unsafe {
+        let _: &T = std::mem::transmute(p);
+        //~^ transmute_ptr_to_ref
+        let _: &T = &*p;
 
-    let _: &mut T = std::mem::transmute(m);
-    //~^ transmute_ptr_to_ref
-    let _: &mut T = &mut *m;
+        let _: &mut T = std::mem::transmute(m);
+        //~^ transmute_ptr_to_ref
+        let _: &mut T = &mut *m;
 
-    let _: &T = std::mem::transmute(m);
-    //~^ transmute_ptr_to_ref
-    let _: &T = &*m;
+        let _: &T = std::mem::transmute(m);
+        //~^ transmute_ptr_to_ref
+        let _: &T = &*m;
 
-    let _: &mut T = std::mem::transmute(p as *mut T);
-    //~^ transmute_ptr_to_ref
-    let _ = &mut *(p as *mut T);
+        let _: &mut T = std::mem::transmute(p as *mut T);
+        //~^ transmute_ptr_to_ref
+        let _ = &mut *(p as *mut T);
 
-    let _: &T = std::mem::transmute(o);
-    //~^ transmute_ptr_to_ref
-    let _: &T = &*(o as *const T);
+        let _: &T = std::mem::transmute(o);
+        //~^ transmute_ptr_to_ref
+        let _: &T = &*(o as *const T);
 
-    let _: &mut T = std::mem::transmute(om);
-    //~^ transmute_ptr_to_ref
-    let _: &mut T = &mut *(om as *mut T);
+        let _: &mut T = std::mem::transmute(om);
+        //~^ transmute_ptr_to_ref
+        let _: &mut T = &mut *(om as *mut T);
 
-    let _: &T = std::mem::transmute(om);
-    //~^ transmute_ptr_to_ref
-    let _: &T = &*(om as *const T);
+        let _: &T = std::mem::transmute(om);
+        //~^ transmute_ptr_to_ref
+        let _: &T = &*(om as *const T);
+    }
 }
 
 fn _issue1231() {
@@ -54,47 +56,53 @@ fn _issue1231() {
 }
 
 unsafe fn _issue8924<'a, 'b, 'c>(x: *const &'a u32, y: *const &'b u32) -> &'c &'b u32 {
-    match 0 {
-        0 => std::mem::transmute(x),
-        //~^ transmute_ptr_to_ref
-        1 => std::mem::transmute(y),
-        //~^ transmute_ptr_to_ref
-        2 => std::mem::transmute::<_, &&'b u32>(x),
-        //~^ transmute_ptr_to_ref
-        _ => std::mem::transmute::<_, &&'b u32>(y),
-        //~^ transmute_ptr_to_ref
+    unsafe {
+        match 0 {
+            0 => std::mem::transmute(x),
+            //~^ transmute_ptr_to_ref
+            1 => std::mem::transmute(y),
+            //~^ transmute_ptr_to_ref
+            2 => std::mem::transmute::<_, &&'b u32>(x),
+            //~^ transmute_ptr_to_ref
+            _ => std::mem::transmute::<_, &&'b u32>(y),
+            //~^ transmute_ptr_to_ref
+        }
     }
 }
 
 #[clippy::msrv = "1.38"]
 unsafe fn _meets_msrv<'a, 'b, 'c>(x: *const &'a u32) -> &'c &'b u32 {
-    let a = 0u32;
-    let a = &a as *const u32;
-    let _: &u32 = std::mem::transmute(a);
-    //~^ transmute_ptr_to_ref
-    let _: &u32 = std::mem::transmute::<_, &u32>(a);
-    //~^ transmute_ptr_to_ref
-    match 0 {
-        0 => std::mem::transmute(x),
+    unsafe {
+        let a = 0u32;
+        let a = &a as *const u32;
+        let _: &u32 = std::mem::transmute(a);
         //~^ transmute_ptr_to_ref
-        _ => std::mem::transmute::<_, &&'b u32>(x),
+        let _: &u32 = std::mem::transmute::<_, &u32>(a);
         //~^ transmute_ptr_to_ref
+        match 0 {
+            0 => std::mem::transmute(x),
+            //~^ transmute_ptr_to_ref
+            _ => std::mem::transmute::<_, &&'b u32>(x),
+            //~^ transmute_ptr_to_ref
+        }
     }
 }
 
 #[clippy::msrv = "1.37"]
 unsafe fn _under_msrv<'a, 'b, 'c>(x: *const &'a u32) -> &'c &'b u32 {
-    let a = 0u32;
-    let a = &a as *const u32;
-    let _: &u32 = std::mem::transmute(a);
-    //~^ transmute_ptr_to_ref
-    let _: &u32 = std::mem::transmute::<_, &u32>(a);
-    //~^ transmute_ptr_to_ref
-    match 0 {
-        0 => std::mem::transmute(x),
+    unsafe {
+        let a = 0u32;
+        let a = &a as *const u32;
+        let _: &u32 = std::mem::transmute(a);
         //~^ transmute_ptr_to_ref
-        _ => std::mem::transmute::<_, &&'b u32>(x),
+        let _: &u32 = std::mem::transmute::<_, &u32>(a);
         //~^ transmute_ptr_to_ref
+        match 0 {
+            0 => std::mem::transmute(x),
+            //~^ transmute_ptr_to_ref
+            _ => std::mem::transmute::<_, &&'b u32>(x),
+            //~^ transmute_ptr_to_ref
+        }
     }
 }
 

--- a/tests/ui/transmute_ptr_to_ref.stderr
+++ b/tests/ui/transmute_ptr_to_ref.stderr
@@ -1,137 +1,137 @@
 error: transmute from a pointer type (`*const T`) to a reference type (`&T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:9:17
+  --> tests/ui/transmute_ptr_to_ref.rs:10:21
    |
-LL |     let _: &T = std::mem::transmute(p);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*p`
+LL |         let _: &T = std::mem::transmute(p);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*p`
    |
    = note: `-D clippy::transmute-ptr-to-ref` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::transmute_ptr_to_ref)]`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&mut T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:13:21
+  --> tests/ui/transmute_ptr_to_ref.rs:14:25
    |
-LL |     let _: &mut T = std::mem::transmute(m);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *m`
+LL |         let _: &mut T = std::mem::transmute(m);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *m`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:17:17
+  --> tests/ui/transmute_ptr_to_ref.rs:18:21
    |
-LL |     let _: &T = std::mem::transmute(m);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*m`
+LL |         let _: &T = std::mem::transmute(m);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*m`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&mut T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:21:21
+  --> tests/ui/transmute_ptr_to_ref.rs:22:25
    |
-LL |     let _: &mut T = std::mem::transmute(p as *mut T);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(p as *mut T)`
+LL |         let _: &mut T = std::mem::transmute(p as *mut T);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(p as *mut T)`
 
 error: transmute from a pointer type (`*const U`) to a reference type (`&T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:25:17
+  --> tests/ui/transmute_ptr_to_ref.rs:26:21
    |
-LL |     let _: &T = std::mem::transmute(o);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(o as *const T)`
+LL |         let _: &T = std::mem::transmute(o);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(o as *const T)`
 
 error: transmute from a pointer type (`*mut U`) to a reference type (`&mut T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:29:21
+  --> tests/ui/transmute_ptr_to_ref.rs:30:25
    |
-LL |     let _: &mut T = std::mem::transmute(om);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(om as *mut T)`
+LL |         let _: &mut T = std::mem::transmute(om);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(om as *mut T)`
 
 error: transmute from a pointer type (`*mut U`) to a reference type (`&T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:33:17
+  --> tests/ui/transmute_ptr_to_ref.rs:34:21
    |
-LL |     let _: &T = std::mem::transmute(om);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(om as *const T)`
+LL |         let _: &T = std::mem::transmute(om);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(om as *const T)`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<'_, u8>`)
-  --> tests/ui/transmute_ptr_to_ref.rs:44:32
+  --> tests/ui/transmute_ptr_to_ref.rs:46:32
    |
 LL |     let _: &Foo<u8> = unsafe { std::mem::transmute::<_, &Foo<_>>(raw) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*raw.cast::<Foo<_>>()`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<'_, &u8>`)
-  --> tests/ui/transmute_ptr_to_ref.rs:47:33
+  --> tests/ui/transmute_ptr_to_ref.rs:49:33
    |
 LL |     let _: &Foo<&u8> = unsafe { std::mem::transmute::<_, &Foo<&_>>(raw) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*raw.cast::<Foo<&_>>()`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&u8`)
-  --> tests/ui/transmute_ptr_to_ref.rs:52:14
+  --> tests/ui/transmute_ptr_to_ref.rs:54:14
    |
 LL |     unsafe { std::mem::transmute::<_, Bar>(raw) };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(raw as *const u8)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:58:14
+  --> tests/ui/transmute_ptr_to_ref.rs:61:18
    |
-LL |         0 => std::mem::transmute(x),
-   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&u32>()`
+LL |             0 => std::mem::transmute(x),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:60:14
+  --> tests/ui/transmute_ptr_to_ref.rs:63:18
    |
-LL |         1 => std::mem::transmute(y),
-   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*y.cast::<&u32>()`
+LL |             1 => std::mem::transmute(y),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*y.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:62:14
+  --> tests/ui/transmute_ptr_to_ref.rs:65:18
    |
-LL |         2 => std::mem::transmute::<_, &&'b u32>(x),
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&'b u32>()`
+LL |             2 => std::mem::transmute::<_, &&'b u32>(x),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:64:14
+  --> tests/ui/transmute_ptr_to_ref.rs:67:18
    |
-LL |         _ => std::mem::transmute::<_, &&'b u32>(y),
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*y.cast::<&'b u32>()`
+LL |             _ => std::mem::transmute::<_, &&'b u32>(y),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*y.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:73:19
+  --> tests/ui/transmute_ptr_to_ref.rs:78:23
    |
-LL |     let _: &u32 = std::mem::transmute(a);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a`
+LL |         let _: &u32 = std::mem::transmute(a);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:75:19
+  --> tests/ui/transmute_ptr_to_ref.rs:80:23
    |
-LL |     let _: &u32 = std::mem::transmute::<_, &u32>(a);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a.cast::<u32>()`
+LL |         let _: &u32 = std::mem::transmute::<_, &u32>(a);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a.cast::<u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:78:14
+  --> tests/ui/transmute_ptr_to_ref.rs:83:18
    |
-LL |         0 => std::mem::transmute(x),
-   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&u32>()`
+LL |             0 => std::mem::transmute(x),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:80:14
+  --> tests/ui/transmute_ptr_to_ref.rs:85:18
    |
-LL |         _ => std::mem::transmute::<_, &&'b u32>(x),
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&'b u32>()`
+LL |             _ => std::mem::transmute::<_, &&'b u32>(x),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:89:19
+  --> tests/ui/transmute_ptr_to_ref.rs:96:23
    |
-LL |     let _: &u32 = std::mem::transmute(a);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a`
+LL |         let _: &u32 = std::mem::transmute(a);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:91:19
+  --> tests/ui/transmute_ptr_to_ref.rs:98:23
    |
-LL |     let _: &u32 = std::mem::transmute::<_, &u32>(a);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(a as *const u32)`
+LL |         let _: &u32 = std::mem::transmute::<_, &u32>(a);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(a as *const u32)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:94:14
+  --> tests/ui/transmute_ptr_to_ref.rs:101:18
    |
-LL |         0 => std::mem::transmute(x),
-   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &u32)`
+LL |             0 => std::mem::transmute(x),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &u32)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:96:14
+  --> tests/ui/transmute_ptr_to_ref.rs:103:18
    |
-LL |         _ => std::mem::transmute::<_, &&'b u32>(x),
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &'b u32)`
+LL |             _ => std::mem::transmute::<_, &&'b u32>(x),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &'b u32)`
 
 error: aborting due to 22 previous errors
 

--- a/tests/ui/uninit_vec.rs
+++ b/tests/ui/uninit_vec.rs
@@ -15,9 +15,17 @@ union MyOwnMaybeUninit {
 
 // https://github.com/rust-lang/rust/issues/119620
 unsafe fn requires_paramenv<S>() {
-    let mut vec = Vec::<UnsafeCell<*mut S>>::with_capacity(1);
+    unsafe {
+        let mut vec = Vec::<UnsafeCell<*mut S>>::with_capacity(1);
+        //~^ uninit_vec
+        vec.set_len(1);
+    }
+
+    let mut vec = Vec::<UnsafeCell<*mut S>>::with_capacity(2);
     //~^ uninit_vec
-    vec.set_len(1);
+    unsafe {
+        vec.set_len(2);
+    }
 }
 
 fn main() {

--- a/tests/ui/uninit_vec.stderr
+++ b/tests/ui/uninit_vec.stderr
@@ -1,18 +1,29 @@
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:18:5
+  --> tests/ui/uninit_vec.rs:24:5
    |
-LL |     let mut vec = Vec::<UnsafeCell<*mut S>>::with_capacity(1);
+LL |     let mut vec = Vec::<UnsafeCell<*mut S>>::with_capacity(2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     vec.set_len(1);
-   |     ^^^^^^^^^^^^^^
+...
+LL |         vec.set_len(2);
+   |         ^^^^^^^^^^^^^^
    |
    = help: initialize the buffer or wrap the content in `MaybeUninit`
    = note: `-D clippy::uninit-vec` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::uninit_vec)]`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:25:5
+  --> tests/ui/uninit_vec.rs:19:9
+   |
+LL |         let mut vec = Vec::<UnsafeCell<*mut S>>::with_capacity(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         vec.set_len(1);
+   |         ^^^^^^^^^^^^^^
+   |
+   = help: initialize the buffer or wrap the content in `MaybeUninit`
+
+error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+  --> tests/ui/uninit_vec.rs:33:5
    |
 LL |     let mut vec: Vec<u8> = Vec::with_capacity(1000);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +34,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:33:5
+  --> tests/ui/uninit_vec.rs:41:5
    |
 LL |     vec.reserve(1000);
    |     ^^^^^^^^^^^^^^^^^^
@@ -34,7 +45,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` on empty `Vec` creates out-of-bound values
-  --> tests/ui/uninit_vec.rs:41:5
+  --> tests/ui/uninit_vec.rs:49:5
    |
 LL |     let mut vec: Vec<u8> = Vec::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,7 +54,7 @@ LL |         vec.set_len(200);
    |         ^^^^^^^^^^^^^^^^
 
 error: calling `set_len()` on empty `Vec` creates out-of-bound values
-  --> tests/ui/uninit_vec.rs:49:5
+  --> tests/ui/uninit_vec.rs:57:5
    |
 LL |     let mut vec: Vec<u8> = Default::default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +63,7 @@ LL |         vec.set_len(200);
    |         ^^^^^^^^^^^^^^^^
 
 error: calling `set_len()` on empty `Vec` creates out-of-bound values
-  --> tests/ui/uninit_vec.rs:56:5
+  --> tests/ui/uninit_vec.rs:64:5
    |
 LL |     let mut vec: Vec<u8> = Vec::default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +72,7 @@ LL |         vec.set_len(200);
    |         ^^^^^^^^^^^^^^^^
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:76:5
+  --> tests/ui/uninit_vec.rs:84:5
    |
 LL |     let mut vec: Vec<u8> = Vec::with_capacity(1000);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +83,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:87:5
+  --> tests/ui/uninit_vec.rs:95:5
    |
 LL |     my_vec.vec.reserve(1000);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +94,7 @@ LL |         my_vec.vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:94:5
+  --> tests/ui/uninit_vec.rs:102:5
    |
 LL |     my_vec.vec = Vec::with_capacity(1000);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,7 +105,7 @@ LL |         my_vec.vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:65:9
+  --> tests/ui/uninit_vec.rs:73:9
    |
 LL |         let mut vec: Vec<u8> = Vec::with_capacity(1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +116,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:70:9
+  --> tests/ui/uninit_vec.rs:78:9
    |
 LL |         vec.reserve(1000);
    |         ^^^^^^^^^^^^^^^^^^
@@ -116,7 +127,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:150:9
+  --> tests/ui/uninit_vec.rs:158:9
    |
 LL |         let mut vec: Vec<T> = Vec::with_capacity(1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,7 +138,7 @@ LL |             vec.set_len(10);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:178:9
+  --> tests/ui/uninit_vec.rs:186:9
    |
 LL |         let mut vec: Vec<Recursive<T>> = Vec::with_capacity(1);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +149,7 @@ LL |             vec.set_len(1);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> tests/ui/uninit_vec.rs:192:9
+  --> tests/ui/uninit_vec.rs:200:9
    |
 LL |         let mut vec: Vec<Enum<T>> = Vec::with_capacity(1);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -148,5 +159,5 @@ LL |             vec.set_len(1);
    |
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
-error: aborting due to 14 previous errors
+error: aborting due to 15 previous errors
 

--- a/tests/ui/unnecessary_cast_unfixable.rs
+++ b/tests/ui/unnecessary_cast_unfixable.rs
@@ -17,8 +17,10 @@ mod issue11113 {
 
     impl TearOff {
         unsafe fn query(&self) {
-            ((*(*(self.object as *mut *mut _) as *mut Vtbl)).query)()
-            //~^ unnecessary_cast
+            unsafe {
+                ((*(*(self.object as *mut *mut _) as *mut Vtbl)).query)()
+                //~^ unnecessary_cast
+            }
         }
     }
 }

--- a/tests/ui/unnecessary_cast_unfixable.stderr
+++ b/tests/ui/unnecessary_cast_unfixable.stderr
@@ -8,10 +8,10 @@ LL |     let _ = std::ptr::null() as *const u8;
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_cast)]`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*mut issue11113::Vtbl` -> `*mut issue11113::Vtbl`)
-  --> tests/ui/unnecessary_cast_unfixable.rs:20:16
+  --> tests/ui/unnecessary_cast_unfixable.rs:21:20
    |
-LL |             ((*(*(self.object as *mut *mut _) as *mut Vtbl)).query)()
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `*(self.object as *mut *mut _)`
+LL |                 ((*(*(self.object as *mut *mut _) as *mut Vtbl)).query)()
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `*(self.object as *mut *mut _)`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/used_underscore_items.rs
+++ b/tests/ui/used_underscore_items.rs
@@ -73,7 +73,7 @@ fn external_item_call() {
 
 // should not lint foreign functions.
 // issue #14156
-extern "C" {
+unsafe extern "C" {
     pub fn _exit(code: i32) -> !;
 }
 


### PR DESCRIPTION
The `ui_test` package runs test in edition 2021 mode by default. This PR switches our tests to edition 2024. The commits progressively make our test suite compatible with both edition 2021 and edition 2024, then switches the testing mode to edition 2024, which is compatible with what `cargo dev lint` also uses by default.

The changes are (without functionality changes in tests):
- Add `unsafe` when [calling unsafe constructs inside `unsafe fn`](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html), to [unsafe attributes](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html), and to [`extern` blocks](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html).
- Use stricter reference patterns to accomodate with  the [new match ergonomics rules](https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html).
- Add some `use<>` markers where required to keep the same semantics under the [new RPIT lifetime rules](https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html).

Some other changes ensure that non-regression tests are still enforced:
- Add edition 2021 specific tests when switching rules would make some explicitly tested constructs untested, or when the test require using the older [temporary tail expression scoping rules](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html).
- In `misnamed_getters`, check that getters containing an `unsafe` block (for example a getter on an `Union` field) trigger the lint.

The last commit switches the default edition for running UI tests to edition 2024.

changelog: [`misnamed_getters`]: getters containing an `unsafe` block are also linted