### PR TITLE
Fulfill the lint expectation even if allowed at the type level

### DIFF
--- a/tests/ui/len_without_is_empty_expect.rs
+++ b/tests/ui/len_without_is_empty_expect.rs
@@ -1,0 +1,28 @@
+//@no-rustfix
+#![allow(clippy::len_without_is_empty)]
+
+// Check that the lint expectation is fulfilled even if the lint is allowed at the type level.
+pub struct Empty;
+
+impl Empty {
+    #[expect(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        0
+    }
+}
+
+// Check that the lint expectation is not triggered if it should not
+pub struct Empty2;
+
+impl Empty2 {
+    #[expect(clippy::len_without_is_empty)] //~ ERROR: this lint expectation is unfulfilled
+    pub fn len(&self) -> usize {
+        0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+fn main() {}

--- a/tests/ui/len_without_is_empty_expect.stderr
+++ b/tests/ui/len_without_is_empty_expect.stderr
@@ -1,0 +1,11 @@
+error: this lint expectation is unfulfilled
+  --> tests/ui/len_without_is_empty_expect.rs:18:14
+   |
+LL |     #[expect(clippy::len_without_is_empty)]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unfulfilled_lint_expectations)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
`clippy::len_without_is_empty` can be allowed at the type declaration site, and this will prevent the lint from triggering even though the lint is shown on the `len()` method definition.

This allows the lint to be expected even though it is allowed at the type declaration site.

changelog: [`len_without_is_empty`]: the lint can now be `#[expect]`ed on the `len()` method even when it is `#[allow]`ed on the definining type.

Fixes rust-lang/rust-clippy#14597