### PR TITLE
Check for lifetime uses in closures as well

### DIFF
--- a/tests/ui/needless_lifetimes.fixed
+++ b/tests/ui/needless_lifetimes.fixed
@@ -534,4 +534,11 @@ mod issue13749bis {
     impl<'a, T: 'a> Generic<T> {}
 }
 
+pub fn issue14607<'s>(x: &'s u8) {
+    #[expect(clippy::redundant_closure_call)]
+    (|| {
+        let _: &'s u8 = x;
+    })();
+}
+
 fn main() {}

--- a/tests/ui/needless_lifetimes.rs
+++ b/tests/ui/needless_lifetimes.rs
@@ -534,4 +534,11 @@ mod issue13749bis {
     impl<'a, T: 'a> Generic<T> {}
 }
 
+pub fn issue14607<'s>(x: &'s u8) {
+    #[expect(clippy::redundant_closure_call)]
+    (|| {
+        let _: &'s u8 = x;
+    })();
+}
+
 fn main() {}


### PR DESCRIPTION
The `BodyLifetimeChecker` which checks for the use of any non-anonymous non-static lifetime did not recurse into closures, missing lifetime uses. This would lead to a bogus elision suggestion.

The `BodyLifetimeChecker` is not refined enough to avoid false positives, as any conforming lifetime, including one coming from the outer context, would be considered a hit. The number of false positives might increase now that we check closures as well, in case those closures define and use lifetimes themselves.

changelog: [`needless_lifetimes`]: do not suggest removing a lifetime which is later used in a closure

Fixes rust-lang/rust-clippy#14607 