### PR TITLE
Skip inner ordering checking in presence of `#[repr(…)]`

### DIFF
--- a/clippy_lints/src/arbitrary_source_item_ordering.rs
+++ b/clippy_lints/src/arbitrary_source_item_ordering.rs
@@ -6,9 +6,10 @@ use clippy_config::types::{
 };
 use clippy_utils::diagnostics::span_lint_and_note;
 use clippy_utils::is_cfg_test;
+use rustc_attr_parsing::AttributeKind;
 use rustc_hir::{
-    AssocItemKind, FieldDef, HirId, ImplItemRef, IsAuto, Item, ItemKind, Mod, QPath, TraitItemRef, TyKind, Variant,
-    VariantData,
+    AssocItemKind, Attribute, FieldDef, HirId, ImplItemRef, IsAuto, Item, ItemKind, Mod, QPath, TraitItemRef, TyKind,
+    Variant, VariantData,
 };
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::impl_lint_pass;
@@ -27,6 +28,11 @@ declare_clippy_lint! {
     /// a topic that is (under most circumstances) not relevant to the logic
     /// implemented in the code. Sometimes this will be referred to as
     /// "bikeshedding".
+    ///
+    /// The content of items with a representation clause attribute, such as
+    /// `#[repr(C)]` will not be checked, as the order of their fields or
+    /// variants might be dictated by an external API (application binary
+    /// interface).
     ///
     /// ### Default Ordering and Configuration
     ///
@@ -256,6 +262,15 @@ impl ArbitrarySourceItemOrdering {
 
 impl<'tcx> LateLintPass<'tcx> for ArbitrarySourceItemOrdering {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if cx
+            .tcx
+            .hir_attrs(item.hir_id())
+            .iter()
+            .any(|attr| matches!(attr, Attribute::Parsed(AttributeKind::Repr(..))))
+        {
+            // Do not lint items with a `#[repr]` attribute as their layout may be imposed by an external API.
+            return;
+        }
         match &item.kind {
             ItemKind::Enum(_, enum_def, _generics) if self.enable_ordering_for_enum => {
                 let mut cur_v: Option<&Variant<'_>> = None;

--- a/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.default.stderr
+++ b/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.default.stderr
@@ -13,37 +13,37 @@ LL | const SNAKE_CASE: &str = "zzzzzzzz";
    = help: to override `-D warnings` add `#[allow(clippy::arbitrary_source_item_ordering)]`
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:149:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:165:7
    |
 LL | const ZIS_SHOULD_BE_REALLY_EARLY: () = ();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `TraitUnorderedItemKinds`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:136:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:152:7
    |
 LL | trait TraitUnorderedItemKinds {
    |       ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:188:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:204:5
    |
 LL | mod this_is_in_the_wrong_position {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `main`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:183:4
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:199:4
    |
 LL | fn main() {
    |    ^^^^
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:198:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:214:7
    |
 LL | const ZIS_SHOULD_BE_EVEN_EARLIER: () = ();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `ZisShouldBeBeforeZeMainFn`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:196:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:212:8
    |
 LL | struct ZisShouldBeBeforeZeMainFn;
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,100 +61,124 @@ LL |     C,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:96:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:57:5
+   |
+LL |     g: u8,
+   |     ^
+   |
+note: should be placed before `r`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:56:5
+   |
+LL |     r: u8,
+   |     ^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:59:5
+   |
+LL |     b: u8,
+   |     ^
+   |
+note: should be placed before `g`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:57:5
+   |
+LL |     g: u8,
+   |     ^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:112:5
    |
 LL |     b: bool,
    |     ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:95:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:111:5
    |
 LL |     c: bool,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:105:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:121:5
    |
 LL |     b: bool,
    |     ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:104:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:120:5
    |
 LL |     c: bool,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:125:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:141:11
    |
 LL |     const B: bool;
    |           ^
    |
 note: should be placed before `C`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:124:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:140:11
    |
 LL |     const C: bool;
    |           ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:132:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:148:8
    |
 LL |     fn b();
    |        ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:131:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:147:8
    |
 LL |     fn c();
    |        ^
 
 error: incorrect ordering of trait items (defined order: [Const, Type, Fn])
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:139:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:5
    |
 LL |     const A: bool;
    |     ^^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:137:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:153:5
    |
 LL |     type SomeType;
    |     ^^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:11
    |
 LL |     const B: bool = false;
    |           ^
    |
 note: should be placed before `C`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:154:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:170:11
    |
 LL |     const C: bool = false;
    |           ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:162:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:178:8
    |
 LL |     fn b() {}
    |        ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:161:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:177:8
    |
 LL |     fn c() {}
    |        ^
 
 error: incorrect ordering of impl items (defined order: [Const, Type, Fn])
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:173:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:189:5
    |
 LL |     const A: bool = false;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:187:5
    |
 LL |     type SomeType = ();
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 

--- a/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.default_exp.stderr
+++ b/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.default_exp.stderr
@@ -13,37 +13,37 @@ LL | const SNAKE_CASE: &str = "zzzzzzzz";
    = help: to override `-D warnings` add `#[allow(clippy::arbitrary_source_item_ordering)]`
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:149:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:165:7
    |
 LL | const ZIS_SHOULD_BE_REALLY_EARLY: () = ();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `TraitUnorderedItemKinds`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:136:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:152:7
    |
 LL | trait TraitUnorderedItemKinds {
    |       ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:188:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:204:5
    |
 LL | mod this_is_in_the_wrong_position {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `main`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:183:4
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:199:4
    |
 LL | fn main() {
    |    ^^^^
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:198:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:214:7
    |
 LL | const ZIS_SHOULD_BE_EVEN_EARLIER: () = ();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `ZisShouldBeBeforeZeMainFn`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:196:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:212:8
    |
 LL | struct ZisShouldBeBeforeZeMainFn;
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,100 +61,124 @@ LL |     C,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:96:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:57:5
+   |
+LL |     g: u8,
+   |     ^
+   |
+note: should be placed before `r`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:56:5
+   |
+LL |     r: u8,
+   |     ^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:59:5
+   |
+LL |     b: u8,
+   |     ^
+   |
+note: should be placed before `g`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:57:5
+   |
+LL |     g: u8,
+   |     ^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:112:5
    |
 LL |     b: bool,
    |     ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:95:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:111:5
    |
 LL |     c: bool,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:105:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:121:5
    |
 LL |     b: bool,
    |     ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:104:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:120:5
    |
 LL |     c: bool,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:125:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:141:11
    |
 LL |     const B: bool;
    |           ^
    |
 note: should be placed before `C`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:124:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:140:11
    |
 LL |     const C: bool;
    |           ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:132:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:148:8
    |
 LL |     fn b();
    |        ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:131:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:147:8
    |
 LL |     fn c();
    |        ^
 
 error: incorrect ordering of trait items (defined order: [Const, Type, Fn])
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:139:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:5
    |
 LL |     const A: bool;
    |     ^^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:137:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:153:5
    |
 LL |     type SomeType;
    |     ^^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:11
    |
 LL |     const B: bool = false;
    |           ^
    |
 note: should be placed before `C`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:154:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:170:11
    |
 LL |     const C: bool = false;
    |           ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:162:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:178:8
    |
 LL |     fn b() {}
    |        ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:161:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:177:8
    |
 LL |     fn c() {}
    |        ^
 
 error: incorrect ordering of impl items (defined order: [Const, Type, Fn])
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:173:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:189:5
    |
 LL |     const A: bool = false;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:187:5
    |
 LL |     type SomeType = ();
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 

--- a/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.ord_within.stderr
+++ b/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.ord_within.stderr
@@ -25,7 +25,19 @@ LL | const SNAKE_CASE: &str = "zzzzzzzz";
    |       ^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:71:1
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:64:8
+   |
+LL | struct EnumWithExternButAtWrongPosition {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: should be placed before `EnumWithoutExtern`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:55:8
+   |
+LL | struct EnumWithoutExtern {
+   |        ^^^^^^^^^^^^^^^^^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:87:1
    |
 LL | / impl CloneSelf for StructOrdered {
 LL | |
@@ -36,7 +48,7 @@ LL | | }
    | |_^
    |
 note: should be placed before the following item
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:61:1
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:77:1
    |
 LL | / impl Default for StructOrdered {
 LL | |     fn default() -> Self {
@@ -47,25 +59,25 @@ LL | | }
    | |_^
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:149:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:165:7
    |
 LL | const ZIS_SHOULD_BE_REALLY_EARLY: () = ();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `TraitUnorderedItemKinds`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:136:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:152:7
    |
 LL | trait TraitUnorderedItemKinds {
    |       ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:167:1
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:183:1
    |
 LL | impl BasicEmptyTrait for StructOrdered {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before the following item
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:152:1
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:168:1
    |
 LL | / impl TraitUnordered for StructUnordered {
 LL | |     const A: bool = false;
@@ -76,25 +88,25 @@ LL | | }
    | |_^
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:188:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:204:5
    |
 LL | mod this_is_in_the_wrong_position {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `main`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:183:4
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:199:4
    |
 LL | fn main() {
    |    ^^^^
 
 error: incorrect ordering of items (module item groupings specify another order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:198:7
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:214:7
    |
 LL | const ZIS_SHOULD_BE_EVEN_EARLIER: () = ();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `ZisShouldBeBeforeZeMainFn`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:196:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:212:8
    |
 LL | struct ZisShouldBeBeforeZeMainFn;
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,112 +136,136 @@ LL |     C,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:96:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:57:5
+   |
+LL |     g: u8,
+   |     ^
+   |
+note: should be placed before `r`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:56:5
+   |
+LL |     r: u8,
+   |     ^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:59:5
+   |
+LL |     b: u8,
+   |     ^
+   |
+note: should be placed before `g`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:57:5
+   |
+LL |     g: u8,
+   |     ^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:112:5
    |
 LL |     b: bool,
    |     ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:95:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:111:5
    |
 LL |     c: bool,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:105:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:121:5
    |
 LL |     b: bool,
    |     ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:104:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:120:5
    |
 LL |     c: bool,
    |     ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:125:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:141:11
    |
 LL |     const B: bool;
    |           ^
    |
 note: should be placed before `C`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:124:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:140:11
    |
 LL |     const C: bool;
    |           ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:132:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:148:8
    |
 LL |     fn b();
    |        ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:131:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:147:8
    |
 LL |     fn c();
    |        ^
 
 error: incorrect ordering of trait items (defined order: [Const, Type, Fn])
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:139:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:5
    |
 LL |     const A: bool;
    |     ^^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:137:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:153:5
    |
 LL |     type SomeType;
    |     ^^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:11
    |
 LL |     const B: bool = false;
    |           ^
    |
 note: should be placed before `C`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:154:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:170:11
    |
 LL |     const C: bool = false;
    |           ^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:162:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:178:8
    |
 LL |     fn b() {}
    |        ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:161:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:177:8
    |
 LL |     fn c() {}
    |        ^
 
 error: incorrect ordering of impl items (defined order: [Const, Type, Fn])
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:173:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:189:5
    |
 LL |     const A: bool = false;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:187:5
    |
 LL |     type SomeType = ();
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:191:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:207:11
    |
 LL |     const A: i8 = 1;
    |           ^
    |
 note: should be placed before `C`
-  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:190:11
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:206:11
    |
 LL |     const C: i8 = 0;
    |           ^
 
-error: aborting due to 18 previous errors
+error: aborting due to 21 previous errors
 

--- a/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs
@@ -52,6 +52,22 @@ enum EnumUnorderedAllowed {
     B,
 }
 
+struct EnumWithoutExtern {
+    r: u8,
+    g: u8,
+    //~^ arbitrary_source_item_ordering
+    b: u8,
+    //~^ arbitrary_source_item_ordering
+}
+
+#[repr(C)]
+struct EnumWithExternButAtWrongPosition {
+    //~[ord_within]^ arbitrary_source_item_ordering
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
 struct StructOrdered {
     a: bool,
     b: bool,


### PR DESCRIPTION
A representation attribute `#[repr(…)]` might indicate that the ordering of the fields or the variants is dictated by the API the code is interfacing with. Better not lint with `arbitrary_source_item_ordering` in this case.

changelog: [`arbitrary_source_item_ordering`]: do not lint inside items with `#[repr]` attribute
