### PR TITLE
Replace stray `println!()` in lint code by `bug!()`

### DIFF
--- a/clippy_lints/src/arbitrary_source_item_ordering.rs
+++ b/clippy_lints/src/arbitrary_source_item_ordering.rs
@@ -382,7 +382,9 @@ impl<'tcx> LateLintPass<'tcx> for ArbitrarySourceItemOrdering {
                         // Filters the auto-included Rust standard library.
                         continue;
                     }
-                    println!("Unknown item: {item:?}");
+                    if cfg!(debug_assertions) {
+                        rustc_middle::bug!("unknown item: {item:?}");
+                    }
                 }
             } else if let ItemKind::Impl(_) = item.kind
                 && get_item_name(item).is_some()


### PR DESCRIPTION
To avoid crashing Clippy, the `bug!()` is used only when debug assertions are enabled. In regular usage, the result will be the same as before, but without the extra line printed on the standard output which has the potential for disrupting shell scripts.

changelog: none