### PR TITLE
`item_name_repetitions`: exclude enum variants with identical path components

### DIFF
--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -220,4 +220,19 @@ mod issue11494 {
     }
 }
 
+mod encapsulated {
+    mod types {
+        pub struct FooError;
+        pub struct BarError;
+        pub struct BazError;
+    }
+
+    enum Error {
+        FooError(types::FooError),
+        BarError(types::BarError),
+        BazError(types::BazError),
+        Other,
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
fix rust-lang/rust-clippy#13637

As suggested in the PR above, we should not lint enum variants containing matching path names.

changelog: [`item_name_repetitions`]: exclude enum variants with identical path components
