### PR TITLE
Add `note` feature to triagebot's config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -11,6 +11,8 @@ allow-unauthenticated = [
 
 [merge-conflicts]
 
+[note]
+
 [canonicalize-issue-links]
 
 # Prevents mentions in commits to avoid users being spammed


### PR DESCRIPTION
This will let people [add summary notes](https://forge.rust-lang.org/triagebot/note.html) to an issue, for example to add that an issue is best kept for first-timers.

changelog: none

I wanted to use it in https://github.com/rust-lang/rust-clippy/issues/14617#issuecomment-2807090281.