### PR TITLE
`ptr_cast_constness`: show snippet from the right context

### DIFF
--- a/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -53,7 +53,8 @@ pub(super) fn check<'tcx>(
         }
 
         if msrv.meets(cx, msrvs::POINTER_CAST_CONSTNESS) {
-            let sugg = Sugg::hir(cx, cast_expr, "_");
+            let mut app = Applicability::MachineApplicable;
+            let sugg = Sugg::hir_with_context(cx, cast_expr, expr.span.ctxt(), "_", &mut app);
             let constness = match *to_mutbl {
                 Mutability::Not => "const",
                 Mutability::Mut => "mut",
@@ -66,7 +67,7 @@ pub(super) fn check<'tcx>(
                 "`as` casting between raw pointers while changing only its constness",
                 format!("try `pointer::cast_{constness}`, a safer alternative"),
                 format!("{}.cast_{constness}()", sugg.maybe_paren()),
-                Applicability::MachineApplicable,
+                app,
             );
         }
     }

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -100,3 +100,9 @@ fn null_pointers() {
     let _ = external!(ptr::null::<u32>() as *mut u32);
     let _ = external!(ptr::null::<u32>().cast_mut());
 }
+
+fn issue14621() {
+    let mut local = 4;
+    let _ = std::ptr::addr_of_mut!(local).cast_const();
+    //~^ ptr_cast_constness
+}

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -100,3 +100,9 @@ fn null_pointers() {
     let _ = external!(ptr::null::<u32>() as *mut u32);
     let _ = external!(ptr::null::<u32>().cast_mut());
 }
+
+fn issue14621() {
+    let mut local = 4;
+    let _ = std::ptr::addr_of_mut!(local) as *const _;
+    //~^ ptr_cast_constness
+}

--- a/tests/ui/ptr_cast_constness.stderr
+++ b/tests/ui/ptr_cast_constness.stderr
@@ -83,5 +83,11 @@ LL |     let _ = inline!(ptr::null::<u32>().cast_mut());
    |
    = note: this error originates in the macro `__inline_mac_fn_null_pointers` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 13 previous errors
+error: `as` casting between raw pointers while changing only its constness
+  --> tests/ui/ptr_cast_constness.rs:106:13
+   |
+LL |     let _ = std::ptr::addr_of_mut!(local) as *const _;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `std::ptr::addr_of_mut!(local).cast_const()`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
changelog: [`ptr_cast_constness`]: do not replace suggestion by content of macro

Fixes rust-lang/rust-clippy#14621