### PR TITLE
`empty_struct_with_brackets`: do not lint code coming from macro expansion

### DIFF
--- a/clippy_lints/src/empty_with_brackets.rs
+++ b/clippy_lints/src/empty_with_brackets.rs
@@ -75,6 +75,7 @@ declare_lint_pass!(EmptyWithBrackets => [EMPTY_STRUCTS_WITH_BRACKETS, EMPTY_ENUM
 impl EarlyLintPass for EmptyWithBrackets {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if let ItemKind::Struct(ident, var_data, _) = &item.kind
+            && !item.span.from_expansion()
             && has_brackets(var_data)
             && let span_after_ident = item.span.with_lo(ident.span.hi())
             && has_no_fields(cx, var_data, span_after_ident)

--- a/tests/ui/empty_structs_with_brackets.fixed
+++ b/tests/ui/empty_structs_with_brackets.fixed
@@ -23,4 +23,12 @@ struct MyTupleStruct(usize, String); // should not trigger lint
 struct MySingleTupleStruct(usize); // should not trigger lint
 struct MyUnitLikeStruct; // should not trigger lint
 
+macro_rules! empty_struct {
+    ($s:ident) => {
+        struct $s {}
+    };
+}
+
+empty_struct!(FromMacro);
+
 fn main() {}

--- a/tests/ui/empty_structs_with_brackets.rs
+++ b/tests/ui/empty_structs_with_brackets.rs
@@ -23,4 +23,12 @@ struct MyTupleStruct(usize, String); // should not trigger lint
 struct MySingleTupleStruct(usize); // should not trigger lint
 struct MyUnitLikeStruct; // should not trigger lint
 
+macro_rules! empty_struct {
+    ($s:ident) => {
+        struct $s {}
+    };
+}
+
+empty_struct!(FromMacro);
+
 fn main() {}


### PR DESCRIPTION
Do not attempt to fetch a snippet from expansion. Without this change, the inside of macros could[*] be shown as the source of the problem.

[*] Due to the way the source code is processed and reparsed in this macro, the declarative macro has to be located outside the current source file for the bug to appear. Otherwise, the macro call itself will be (mis)identified as a potential `struct` field definition and the lint will not trigger.

changelog: [`empty_struct_with_brackets`]: do not lint code coming from macro expansion