### PR TITLE
[feat]: make `UNNECESSARY_MUT_PASSED` lint auto applicable

### DIFF
--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -1,15 +1,10 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet;
 use rustc_errors::Applicability;
-use rustc_hir::{
-    AssocItemKind, BorrowKind, Expr, ExprKind, FieldDef, HirId, ImplItemRef, IsAuto, Item, ItemKind, Mod, Mutability,
-    QPath, TraitItemRef, TyKind, Variant, VariantData,
-};
+use rustc_hir::{BorrowKind, Expr, ExprKind, Mutability};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty::print::with_forced_trimmed_paths;
-use rustc_middle::ty::{self, GenericArgKind, Ty};
+use rustc_middle::ty::{self, Ty};
 use rustc_session::declare_lint_pass;
-use rustc_span::symbol::sym;
 use std::iter;
 
 declare_clippy_lint! {

--- a/tests/ui/mut_reference.stderr
+++ b/tests/ui/mut_reference.stderr
@@ -2,7 +2,7 @@ error: the function `takes_an_immutable_reference` doesn't need a mutable refere
   --> tests/ui/mut_reference.rs:30:34
    |
 LL |     takes_an_immutable_reference(&mut 42);
-   |                                  ^^^^^^^
+   |                                  ^^^^^^^ help: try: `&42`
    |
    = note: `-D clippy::unnecessary-mut-passed` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_mut_passed)]`
@@ -11,13 +11,13 @@ error: the function `as_ptr` doesn't need a mutable reference
   --> tests/ui/mut_reference.rs:34:12
    |
 LL |     as_ptr(&mut 42);
-   |            ^^^^^^^
+   |            ^^^^^^^ help: try: `&42`
 
 error: the method `takes_an_immutable_reference` doesn't need a mutable reference
   --> tests/ui/mut_reference.rs:39:44
    |
 LL |     my_struct.takes_an_immutable_reference(&mut 42);
-   |                                            ^^^^^^^
+   |                                            ^^^^^^^ help: try: `&42`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
# Description

Make [`UNNECESSARY_MUT_PASSED`] auto applicable and automatically fixable via `cargo clippy --fix`
```
changelog: [`UNNECESSARY_MUT_PASSED`]: is auto applicable now
```

# Why it is necessary

There is no case where auto-applying this lint can harm, and it is always nice to have lint applied automatically.

fixes #14617


# Checklist

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Edited UI tests (including committed `.stderr` file) and make them passing
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[x] Run `cargo dev fmt`

# Disclaimer

It's my first PR in clippy, so sorry if my PR deviates from any guidelines or traditions, and thanks you for the feedback!