### PR TITLE
Do not recurse forever in `significant_drop_tightening`

### DIFF
--- a/tests/ui/crashes/ice-13544-original.rs
+++ b/tests/ui/crashes/ice-13544-original.rs
@@ -1,0 +1,45 @@
+//@ check-pass
+#![warn(clippy::significant_drop_tightening)]
+
+use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
+
+trait Scopable: Sized {
+    type SubType: Scopable;
+}
+
+struct Subtree<T: Scopable>(ManuallyDrop<Box<Tree<T::SubType>>>);
+
+impl<T: Scopable> Drop for Subtree<T> {
+    fn drop(&mut self) {
+        // SAFETY: The field cannot be used after we drop
+        unsafe { ManuallyDrop::drop(&mut self.0) }
+    }
+}
+
+impl<T: Scopable> Deref for Subtree<T> {
+    type Target = Tree<T::SubType>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Scopable> DerefMut for Subtree<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+enum Tree<T: Scopable> {
+    Group(Vec<Tree<T>>),
+    Subtree(Subtree<T>),
+    Leaf(T),
+}
+
+impl<T: Scopable> Tree<T> {
+    fn foo(self) -> Self {
+        self
+    }
+}
+
+fn main() {}

--- a/tests/ui/crashes/ice-13544-reduced.rs
+++ b/tests/ui/crashes/ice-13544-reduced.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+#![warn(clippy::significant_drop_tightening)]
+#![allow(unused, clippy::no_effect)]
+
+use std::marker::PhantomData;
+
+trait Trait {
+    type Assoc: Trait;
+}
+struct S<T: Trait>(*const S<T::Assoc>, PhantomData<T>);
+
+fn f<T: Trait>(x: &mut S<T>) {
+    &mut x.0;
+}
+
+fn main() {}


### PR DESCRIPTION
Limit the recursion depth, as each level of nesting adds another deeper projection.

There might be a more complex way of handling the problem, but infinite recursions are bad, and don't allow Clippy to terminate properly.

changelog: [`significant_drop_tightening`]: do not recurse forever when checking for attribute on type or its constituent

Fixes rust-lang/rust-clippy#13544

@rustbot label +L-nursery