### PR TITLE
Fix `new_lint` clippy command

### DIFF
--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -448,7 +448,7 @@ fn setup_mod_file(path: &Path, lint: &LintData<'_>) -> io::Result<&'static str> 
 
     let mut file_contents = fs::read_to_string(path)?;
     assert!(
-        !file_contents.contains(&lint_name_upper),
+        !file_contents.contains(&format!("pub {lint_name_upper},")),
         "Lint `{}` already defined in `{}`",
         lint.name,
         path.display()


### PR DESCRIPTION
I'm working on https://github.com/rust-lang/rust-clippy/issues/14542 and I decided to name the lint `unnecessary_map` originally. However when I ran the command, I got:

```
thread 'main' panicked at clippy_dev/src/new_lint.rs:450:5:
Lint `unnecessary_map` already defined in `/home/imperio/rust/clippy/clippy_lints/src/methods/mod.rs`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It's because there is already a `unnecessary_map_or`, which matches the `.contains()` call. This PR strengthens this check.

changelog: Fix `new_lint` clippy command

r? @flip1995 