### PR TITLE
Add relative_path_in_macro_definition lint (#14472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ See [Changelog Update](book/src/development/infrastructure/changelog_update.md) 
 document.
 
 ## Unreleased / Beta / In Rust Nightly
+### New Lints
+- **`relative_path_in_macro_definition`**: Warns about relative paths to `core` or `kernel` in macro definitions, recommending absolute paths to avoid ambiguity.
 
 [3e3715c3...master](https://github.com/rust-lang/rust-clippy/compare/3e3715c3...master)
 
@@ -6126,6 +6128,7 @@ Released 2018-09-13
 [`ref_patterns`]: https://rust-lang.github.io/rust-clippy/master/index.html#ref_patterns
 [`regex_creation_in_loops`]: https://rust-lang.github.io/rust-clippy/master/index.html#regex_creation_in_loops
 [`regex_macro`]: https://rust-lang.github.io/rust-clippy/master/index.html#regex_macro
+[`relative_path_in_macro_definition`]: https://rust-lang.github.io/rust-clippy/master/index.html#relative_path_in_macro_definition
 [`renamed_function_params`]: https://rust-lang.github.io/rust-clippy/master/index.html#renamed_function_params
 [`repeat_once`]: https://rust-lang.github.io/rust-clippy/master/index.html#repeat_once
 [`repeat_vec_with_capacity`]: https://rust-lang.github.io/rust-clippy/master/index.html#repeat_vec_with_capacity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ See [Changelog Update](book/src/development/infrastructure/changelog_update.md) 
 document.
 
 ## Unreleased / Beta / In Rust Nightly
-### New Lints
-- **`relative_path_in_macro_definition`**: Warns about relative paths to `core` or `kernel` in macro definitions, recommending absolute paths to avoid ambiguity.
 
 [3e3715c3...master](https://github.com/rust-lang/rust-clippy/compare/3e3715c3...master)
 

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -675,6 +675,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::regex::INVALID_REGEX_INFO,
     crate::regex::REGEX_CREATION_IN_LOOPS_INFO,
     crate::regex::TRIVIAL_REGEX_INFO,
+    crate::relative_path_in_macro_definition::RELATIVE_PATH_IN_MACRO_DEFINITION_INFO,
     crate::repeat_vec_with_capacity::REPEAT_VEC_WITH_CAPACITY_INFO,
     crate::reserve_after_initialization::RESERVE_AFTER_INITIALIZATION_INFO,
     crate::return_self_not_must_use::RETURN_SELF_NOT_MUST_USE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -326,6 +326,7 @@ mod ref_option_ref;
 mod ref_patterns;
 mod reference;
 mod regex;
+mod relative_path_in_macro_definition;
 mod repeat_vec_with_capacity;
 mod reserve_after_initialization;
 mod return_self_not_must_use;
@@ -986,5 +987,6 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(|_| Box::new(manual_option_as_slice::ManualOptionAsSlice::new(conf)));
     store.register_late_pass(|_| Box::new(single_option_map::SingleOptionMap));
     store.register_late_pass(move |_| Box::new(redundant_test_prefix::RedundantTestPrefix));
+    store.register_early_pass(|| Box::new(relative_path_in_macro_definition::RelativePathInMacroDefinition));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/clippy_lints/src/relative_path_in_macro_definition.rs
+++ b/clippy_lints/src/relative_path_in_macro_definition.rs
@@ -1,0 +1,92 @@
+use clippy_utils::diagnostics::span_lint;
+use rustc_ast::ast::{Item, ItemKind};
+use rustc_ast::token::TokenKind;
+use rustc_ast::tokenstream::{TokenStream, TokenTree};
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks that references to the `core` or `kernel` crate in macro definitions use absolute paths (`::core` or `::kernel`).
+    ///
+    /// ### Why is this bad?
+    /// Using relative paths (e.g., `core::...`) in macros can lead to ambiguity if the macro is used in a context
+    /// where a user defines a module named `core` or `kernel`. Absolute paths ensure the macro always refers to the intended crate.
+    ///
+    /// ### Example
+    /// ```rust
+    /// // Bad
+    /// macro_rules! my_macro {
+    ///     () => {
+    ///         core::mem::drop(0);
+    ///     };
+    /// }
+    ///
+    /// // Good
+    /// macro_rules! my_macro {
+    ///     () => {
+    ///         ::core::mem::drop(0);
+    ///     };
+    /// }
+    /// ```
+    #[clippy::version = "1.87.0"]
+    pub RELATIVE_PATH_IN_MACRO_DEFINITION,
+    correctness,
+    "using relative paths in declarative macros can lead to context-dependent behavior"
+}
+
+declare_lint_pass!(RelativePathInMacroDefinition => [RELATIVE_PATH_IN_MACRO_DEFINITION]);
+
+impl EarlyLintPass for RelativePathInMacroDefinition {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
+        if let ItemKind::MacroDef(_, macro_def) = &item.kind {
+            check_token_stream(cx, &macro_def.body.tokens);
+        }
+    }
+}
+
+fn check_token_stream(cx: &EarlyContext<'_>, tokens: &TokenStream) {
+    let mut iter = tokens.iter().peekable();
+    let mut prev_token: Option<&TokenTree> = None;
+
+    while let Some(tree) = iter.next() {
+        match tree {
+            TokenTree::Token(token, _) => {
+                if let TokenKind::Ident(ident, _) = token.kind
+                    && (ident.as_str() == "core" || ident.as_str() == "kernel")
+                {
+                    let is_path_start = iter.peek().is_some_and(|next_tree| {
+                        if let TokenTree::Token(next_token, _) = next_tree {
+                            next_token.kind == TokenKind::PathSep
+                        } else {
+                            false
+                        }
+                    });
+
+                    if is_path_start {
+                        let is_absolute = prev_token.is_some_and(|prev| {
+                            if let TokenTree::Token(prev_token, _) = prev {
+                                prev_token.kind == TokenKind::PathSep
+                            } else {
+                                false
+                            }
+                        });
+
+                        if !is_absolute {
+                            span_lint(
+                                cx,
+                                RELATIVE_PATH_IN_MACRO_DEFINITION,
+                                token.span,
+                                "relative path to `core` or `kernel` used in macro definition",
+                            );
+                        }
+                    }
+                }
+            },
+            TokenTree::Delimited(_open_span, _close_span, _delim, token_stream) => {
+                check_token_stream(cx, token_stream);
+            },
+        }
+        prev_token = Some(tree);
+    }
+}

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -8,6 +8,7 @@
     clippy::identity_op,
     clippy::no_effect,
     clippy::op_ref,
+    clippy::relative_path_in_macro_definition,
     clippy::unnecessary_owned_empty_strings,
     arithmetic_overflow,
     unconditional_panic

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -1,5 +1,5 @@
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:166:13
+  --> tests/ui/arithmetic_side_effects.rs:167:13
    |
 LL |     let _ = 1f16 + 1f16;
    |             ^^^^^^^^^^^
@@ -8,763 +8,763 @@ LL |     let _ = 1f16 + 1f16;
    = help: to override `-D warnings` add `#[allow(clippy::arithmetic_side_effects)]`
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:170:13
+  --> tests/ui/arithmetic_side_effects.rs:171:13
    |
 LL |     let _ = 1f128 + 1f128;
    |             ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:175:13
+  --> tests/ui/arithmetic_side_effects.rs:176:13
    |
 LL |     let _ = String::new() + &String::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:311:5
+  --> tests/ui/arithmetic_side_effects.rs:312:5
    |
 LL |     _n += 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:313:5
+  --> tests/ui/arithmetic_side_effects.rs:314:5
    |
 LL |     _n += &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:315:5
+  --> tests/ui/arithmetic_side_effects.rs:316:5
    |
 LL |     _n -= 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:317:5
+  --> tests/ui/arithmetic_side_effects.rs:318:5
    |
 LL |     _n -= &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:319:5
+  --> tests/ui/arithmetic_side_effects.rs:320:5
    |
 LL |     _n /= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:321:5
+  --> tests/ui/arithmetic_side_effects.rs:322:5
    |
 LL |     _n /= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:323:5
+  --> tests/ui/arithmetic_side_effects.rs:324:5
    |
 LL |     _n %= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:325:5
+  --> tests/ui/arithmetic_side_effects.rs:326:5
    |
 LL |     _n %= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:327:5
+  --> tests/ui/arithmetic_side_effects.rs:328:5
    |
 LL |     _n *= 2;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:329:5
+  --> tests/ui/arithmetic_side_effects.rs:330:5
    |
 LL |     _n *= &2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:331:5
+  --> tests/ui/arithmetic_side_effects.rs:332:5
    |
 LL |     _n += -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:333:5
+  --> tests/ui/arithmetic_side_effects.rs:334:5
    |
 LL |     _n += &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:335:5
+  --> tests/ui/arithmetic_side_effects.rs:336:5
    |
 LL |     _n -= -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:337:5
+  --> tests/ui/arithmetic_side_effects.rs:338:5
    |
 LL |     _n -= &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:339:5
+  --> tests/ui/arithmetic_side_effects.rs:340:5
    |
 LL |     _n /= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:341:5
+  --> tests/ui/arithmetic_side_effects.rs:342:5
    |
 LL |     _n /= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:343:5
+  --> tests/ui/arithmetic_side_effects.rs:344:5
    |
 LL |     _n %= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:345:5
+  --> tests/ui/arithmetic_side_effects.rs:346:5
    |
 LL |     _n %= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:347:5
+  --> tests/ui/arithmetic_side_effects.rs:348:5
    |
 LL |     _n *= -2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:349:5
+  --> tests/ui/arithmetic_side_effects.rs:350:5
    |
 LL |     _n *= &-2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:351:5
+  --> tests/ui/arithmetic_side_effects.rs:352:5
    |
 LL |     _custom += Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:353:5
+  --> tests/ui/arithmetic_side_effects.rs:354:5
    |
 LL |     _custom += &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:355:5
+  --> tests/ui/arithmetic_side_effects.rs:356:5
    |
 LL |     _custom -= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:357:5
+  --> tests/ui/arithmetic_side_effects.rs:358:5
    |
 LL |     _custom -= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:359:5
+  --> tests/ui/arithmetic_side_effects.rs:360:5
    |
 LL |     _custom /= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:361:5
+  --> tests/ui/arithmetic_side_effects.rs:362:5
    |
 LL |     _custom /= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:363:5
+  --> tests/ui/arithmetic_side_effects.rs:364:5
    |
 LL |     _custom %= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:365:5
+  --> tests/ui/arithmetic_side_effects.rs:366:5
    |
 LL |     _custom %= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:367:5
+  --> tests/ui/arithmetic_side_effects.rs:368:5
    |
 LL |     _custom *= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:369:5
+  --> tests/ui/arithmetic_side_effects.rs:370:5
    |
 LL |     _custom *= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:371:5
+  --> tests/ui/arithmetic_side_effects.rs:372:5
    |
 LL |     _custom >>= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:373:5
+  --> tests/ui/arithmetic_side_effects.rs:374:5
    |
 LL |     _custom >>= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:375:5
+  --> tests/ui/arithmetic_side_effects.rs:376:5
    |
 LL |     _custom <<= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:377:5
+  --> tests/ui/arithmetic_side_effects.rs:378:5
    |
 LL |     _custom <<= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:379:5
+  --> tests/ui/arithmetic_side_effects.rs:380:5
    |
 LL |     _custom += -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:381:5
+  --> tests/ui/arithmetic_side_effects.rs:382:5
    |
 LL |     _custom += &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:383:5
+  --> tests/ui/arithmetic_side_effects.rs:384:5
    |
 LL |     _custom -= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:385:5
+  --> tests/ui/arithmetic_side_effects.rs:386:5
    |
 LL |     _custom -= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:387:5
+  --> tests/ui/arithmetic_side_effects.rs:388:5
    |
 LL |     _custom /= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:389:5
+  --> tests/ui/arithmetic_side_effects.rs:390:5
    |
 LL |     _custom /= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:391:5
+  --> tests/ui/arithmetic_side_effects.rs:392:5
    |
 LL |     _custom %= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:393:5
+  --> tests/ui/arithmetic_side_effects.rs:394:5
    |
 LL |     _custom %= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:395:5
+  --> tests/ui/arithmetic_side_effects.rs:396:5
    |
 LL |     _custom *= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:397:5
+  --> tests/ui/arithmetic_side_effects.rs:398:5
    |
 LL |     _custom *= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:399:5
+  --> tests/ui/arithmetic_side_effects.rs:400:5
    |
 LL |     _custom >>= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:401:5
+  --> tests/ui/arithmetic_side_effects.rs:402:5
    |
 LL |     _custom >>= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:403:5
+  --> tests/ui/arithmetic_side_effects.rs:404:5
    |
 LL |     _custom <<= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:405:5
+  --> tests/ui/arithmetic_side_effects.rs:406:5
    |
 LL |     _custom <<= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:409:10
+  --> tests/ui/arithmetic_side_effects.rs:410:10
    |
 LL |     _n = _n + 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:411:10
+  --> tests/ui/arithmetic_side_effects.rs:412:10
    |
 LL |     _n = _n + &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:413:10
+  --> tests/ui/arithmetic_side_effects.rs:414:10
    |
 LL |     _n = 1 + _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:415:10
+  --> tests/ui/arithmetic_side_effects.rs:416:10
    |
 LL |     _n = &1 + _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:417:10
+  --> tests/ui/arithmetic_side_effects.rs:418:10
    |
 LL |     _n = _n - 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:419:10
+  --> tests/ui/arithmetic_side_effects.rs:420:10
    |
 LL |     _n = _n - &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:421:10
+  --> tests/ui/arithmetic_side_effects.rs:422:10
    |
 LL |     _n = 1 - _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:423:10
+  --> tests/ui/arithmetic_side_effects.rs:424:10
    |
 LL |     _n = &1 - _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:425:10
+  --> tests/ui/arithmetic_side_effects.rs:426:10
    |
 LL |     _n = _n / 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:427:10
+  --> tests/ui/arithmetic_side_effects.rs:428:10
    |
 LL |     _n = _n / &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:429:10
+  --> tests/ui/arithmetic_side_effects.rs:430:10
    |
 LL |     _n = _n % 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:431:10
+  --> tests/ui/arithmetic_side_effects.rs:432:10
    |
 LL |     _n = _n % &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:433:10
+  --> tests/ui/arithmetic_side_effects.rs:434:10
    |
 LL |     _n = _n * 2;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:435:10
+  --> tests/ui/arithmetic_side_effects.rs:436:10
    |
 LL |     _n = _n * &2;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:437:10
+  --> tests/ui/arithmetic_side_effects.rs:438:10
    |
 LL |     _n = 2 * _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:439:10
+  --> tests/ui/arithmetic_side_effects.rs:440:10
    |
 LL |     _n = &2 * _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:441:10
+  --> tests/ui/arithmetic_side_effects.rs:442:10
    |
 LL |     _n = 23 + &85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:443:10
+  --> tests/ui/arithmetic_side_effects.rs:444:10
    |
 LL |     _n = &23 + 85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:445:10
+  --> tests/ui/arithmetic_side_effects.rs:446:10
    |
 LL |     _n = &23 + &85;
    |          ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:447:15
+  --> tests/ui/arithmetic_side_effects.rs:448:15
    |
 LL |     _custom = _custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:449:15
+  --> tests/ui/arithmetic_side_effects.rs:450:15
    |
 LL |     _custom = _custom + &_custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:451:15
+  --> tests/ui/arithmetic_side_effects.rs:452:15
    |
 LL |     _custom = Custom + _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:453:15
+  --> tests/ui/arithmetic_side_effects.rs:454:15
    |
 LL |     _custom = &Custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:455:15
+  --> tests/ui/arithmetic_side_effects.rs:456:15
    |
 LL |     _custom = _custom - Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:457:15
+  --> tests/ui/arithmetic_side_effects.rs:458:15
    |
 LL |     _custom = _custom - &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:459:15
+  --> tests/ui/arithmetic_side_effects.rs:460:15
    |
 LL |     _custom = Custom - _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:461:15
+  --> tests/ui/arithmetic_side_effects.rs:462:15
    |
 LL |     _custom = &Custom - _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:463:15
+  --> tests/ui/arithmetic_side_effects.rs:464:15
    |
 LL |     _custom = _custom / Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:465:15
+  --> tests/ui/arithmetic_side_effects.rs:466:15
    |
 LL |     _custom = _custom / &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:467:15
+  --> tests/ui/arithmetic_side_effects.rs:468:15
    |
 LL |     _custom = _custom % Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:469:15
+  --> tests/ui/arithmetic_side_effects.rs:470:15
    |
 LL |     _custom = _custom % &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:471:15
+  --> tests/ui/arithmetic_side_effects.rs:472:15
    |
 LL |     _custom = _custom * Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:473:15
+  --> tests/ui/arithmetic_side_effects.rs:474:15
    |
 LL |     _custom = _custom * &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:475:15
+  --> tests/ui/arithmetic_side_effects.rs:476:15
    |
 LL |     _custom = Custom * _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:477:15
+  --> tests/ui/arithmetic_side_effects.rs:478:15
    |
 LL |     _custom = &Custom * _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:479:15
+  --> tests/ui/arithmetic_side_effects.rs:480:15
    |
 LL |     _custom = Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:481:15
+  --> tests/ui/arithmetic_side_effects.rs:482:15
    |
 LL |     _custom = &Custom + Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:483:15
+  --> tests/ui/arithmetic_side_effects.rs:484:15
    |
 LL |     _custom = &Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:485:15
+  --> tests/ui/arithmetic_side_effects.rs:486:15
    |
 LL |     _custom = _custom >> _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:487:15
+  --> tests/ui/arithmetic_side_effects.rs:488:15
    |
 LL |     _custom = _custom >> &_custom;
    |               ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:489:15
+  --> tests/ui/arithmetic_side_effects.rs:490:15
    |
 LL |     _custom = Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:491:15
+  --> tests/ui/arithmetic_side_effects.rs:492:15
    |
 LL |     _custom = &Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:495:23
+  --> tests/ui/arithmetic_side_effects.rs:496:23
    |
 LL |     _n.saturating_div(0);
    |                       ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:497:21
+  --> tests/ui/arithmetic_side_effects.rs:498:21
    |
 LL |     _n.wrapping_div(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:499:21
+  --> tests/ui/arithmetic_side_effects.rs:500:21
    |
 LL |     _n.wrapping_rem(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:501:28
+  --> tests/ui/arithmetic_side_effects.rs:502:28
    |
 LL |     _n.wrapping_rem_euclid(0);
    |                            ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:504:23
+  --> tests/ui/arithmetic_side_effects.rs:505:23
    |
 LL |     _n.saturating_div(_n);
    |                       ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:506:21
+  --> tests/ui/arithmetic_side_effects.rs:507:21
    |
 LL |     _n.wrapping_div(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:508:21
+  --> tests/ui/arithmetic_side_effects.rs:509:21
    |
 LL |     _n.wrapping_rem(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:510:28
+  --> tests/ui/arithmetic_side_effects.rs:511:28
    |
 LL |     _n.wrapping_rem_euclid(_n);
    |                            ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:513:23
+  --> tests/ui/arithmetic_side_effects.rs:514:23
    |
 LL |     _n.saturating_div(*Box::new(_n));
    |                       ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:517:10
+  --> tests/ui/arithmetic_side_effects.rs:518:10
    |
 LL |     _n = -_n;
    |          ^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:519:10
+  --> tests/ui/arithmetic_side_effects.rs:520:10
    |
 LL |     _n = -&_n;
    |          ^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:521:15
+  --> tests/ui/arithmetic_side_effects.rs:522:15
    |
 LL |     _custom = -_custom;
    |               ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:523:15
+  --> tests/ui/arithmetic_side_effects.rs:524:15
    |
 LL |     _custom = -&_custom;
    |               ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:525:9
+  --> tests/ui/arithmetic_side_effects.rs:526:9
    |
 LL |     _ = -*Box::new(_n);
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:535:5
+  --> tests/ui/arithmetic_side_effects.rs:536:5
    |
 LL |     1 + i;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:537:5
+  --> tests/ui/arithmetic_side_effects.rs:538:5
    |
 LL |     i * 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:539:5
+  --> tests/ui/arithmetic_side_effects.rs:540:5
    |
 LL |     1 % i / 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:541:5
+  --> tests/ui/arithmetic_side_effects.rs:542:5
    |
 LL |     i - 2 + 2 - i;
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:543:5
+  --> tests/ui/arithmetic_side_effects.rs:544:5
    |
 LL |     -i;
    |     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:555:5
+  --> tests/ui/arithmetic_side_effects.rs:556:5
    |
 LL |     i += 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:557:5
+  --> tests/ui/arithmetic_side_effects.rs:558:5
    |
 LL |     i -= 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:559:5
+  --> tests/ui/arithmetic_side_effects.rs:560:5
    |
 LL |     i *= 2;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:562:5
+  --> tests/ui/arithmetic_side_effects.rs:563:5
    |
 LL |     i /= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:565:5
+  --> tests/ui/arithmetic_side_effects.rs:566:5
    |
 LL |     i /= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:567:5
+  --> tests/ui/arithmetic_side_effects.rs:568:5
    |
 LL |     i /= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:570:5
+  --> tests/ui/arithmetic_side_effects.rs:571:5
    |
 LL |     i %= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:573:5
+  --> tests/ui/arithmetic_side_effects.rs:574:5
    |
 LL |     i %= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:575:5
+  --> tests/ui/arithmetic_side_effects.rs:576:5
    |
 LL |     i %= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:586:5
+  --> tests/ui/arithmetic_side_effects.rs:587:5
    |
 LL |     10 / a
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:641:9
+  --> tests/ui/arithmetic_side_effects.rs:642:9
    |
 LL |         x / maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:646:9
+  --> tests/ui/arithmetic_side_effects.rs:647:9
    |
 LL |         x % maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:658:5
+  --> tests/ui/arithmetic_side_effects.rs:659:5
    |
 LL |     one.add_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:663:5
+  --> tests/ui/arithmetic_side_effects.rs:664:5
    |
 LL |     one.sub_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:670:5
+  --> tests/ui/arithmetic_side_effects.rs:671:5
    |
 LL |     one.add(&one);
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:672:5
+  --> tests/ui/arithmetic_side_effects.rs:673:5
    |
 LL |     Box::new(one).add(one);
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::incompatible_msrv)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![feature(custom_inner_attributes)]
 #![feature(panic_internals)]
 #![clippy::msrv = "1.3.0"]

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -1,5 +1,5 @@
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.10.0`
-  --> tests/ui/incompatible_msrv.rs:14:39
+  --> tests/ui/incompatible_msrv.rs:15:39
    |
 LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    |                                       ^^^^^
@@ -8,25 +8,25 @@ LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.12.0`
-  --> tests/ui/incompatible_msrv.rs:18:11
+  --> tests/ui/incompatible_msrv.rs:19:11
    |
 LL |         v.into_key();
    |           ^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.4.0`
-  --> tests/ui/incompatible_msrv.rs:22:5
+  --> tests/ui/incompatible_msrv.rs:23:5
    |
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:46:9
+  --> tests/ui/incompatible_msrv.rs:47:9
    |
 LL |         core::panicking::panic("foo");
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:53:13
+  --> tests/ui/incompatible_msrv.rs:54:13
    |
 LL |             core::panicking::panic($msg)
    |             ^^^^^^^^^^^^^^^^^^^^^^
@@ -37,13 +37,13 @@ LL |     my_panic!("foo");
    = note: this error originates in the macro `my_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:59:13
+  --> tests/ui/incompatible_msrv.rs:60:13
    |
 LL |     assert!(core::panicking::panic("out of luck"));
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.80.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:72:13
+  --> tests/ui/incompatible_msrv.rs:73:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/relative_path_in_macro_definition.rs
+++ b/tests/ui/relative_path_in_macro_definition.rs
@@ -1,0 +1,24 @@
+#![allow(unused)]
+#![warn(clippy::relative_path_in_macro_definition)]
+
+#[macro_export]
+macro_rules! relative_path_macro {
+    ($condition:expr) => {
+        const _: () = core::assert!($condition);
+        //~^ relative_path_in_macro_definition
+    };
+}
+
+#[macro_export]
+macro_rules! absolute_path_assert {
+    ($condition:expr) => {
+        const _: () = ::core::assert!($condition);
+    };
+}
+
+fn main() {
+    const X: &[u8] = b"rust";
+    relative_path_macro!(X[0] == b'r');
+    absolute_path_assert!(X[0] == b'r');
+}
+

--- a/tests/ui/relative_path_in_macro_definition.stderr
+++ b/tests/ui/relative_path_in_macro_definition.stderr
@@ -1,0 +1,11 @@
+error: relative path to `core` or `kernel` used in macro definition
+  --> tests/ui/relative_path_in_macro_definition.rs:7:23
+   |
+LL |         const _: () = core::assert!($condition);
+   |                       ^^^^
+   |
+   = note: `-D clippy::relative-path-in-macro-definition` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::relative_path_in_macro_definition)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/swap_ptr_to_ref_unfixable.rs
+++ b/tests/ui/swap_ptr_to_ref_unfixable.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::swap_ptr_to_ref)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 macro_rules! addr_of_mut_to_ref {
     ($e:expr) => {

--- a/tests/ui/swap_ptr_to_ref_unfixable.stderr
+++ b/tests/ui/swap_ptr_to_ref_unfixable.stderr
@@ -1,5 +1,5 @@
 error: call to `core::mem::swap` with a parameter derived from a raw pointer
-  --> tests/ui/swap_ptr_to_ref_unfixable.rs:14:9
+  --> tests/ui/swap_ptr_to_ref_unfixable.rs:15:9
    |
 LL |         core::mem::swap(addr_of_mut_to_ref!(x), &mut *y);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL |         core::mem::swap(addr_of_mut_to_ref!(x), &mut *y);
    = help: to override `-D warnings` add `#[allow(clippy::swap_ptr_to_ref)]`
 
 error: call to `core::mem::swap` with a parameter derived from a raw pointer
-  --> tests/ui/swap_ptr_to_ref_unfixable.rs:17:9
+  --> tests/ui/swap_ptr_to_ref_unfixable.rs:18:9
    |
 LL |         core::mem::swap(&mut *y, addr_of_mut_to_ref!(x));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: call to `core::mem::swap` with a parameter derived from a raw pointer
-  --> tests/ui/swap_ptr_to_ref_unfixable.rs:20:9
+  --> tests/ui/swap_ptr_to_ref_unfixable.rs:21:9
    |
 LL |         core::mem::swap(addr_of_mut_to_ref!(x), addr_of_mut_to_ref!(x));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Implements the `relative_path_in_macro_definition` lint to warn about relative paths to `core` or `kernel` in macro definitions, as requested in rust-lang/rust-clippy#14472. 
Includes tests in `tests/ui/relative_path_in_macro_definition.rs` and updates existing tests (`incompatible_msrv.rs`, `swap_ptr_to_ref_unfixable.rs`, `arithmetic_side_effects.rs`) with `#![allow]` to avoid interference. 

- Fixes rust-lang/rust-clippy#14472
- Tests pass: `cargo test`, `cargo test --test compile-test`, `cargo test --test integration`
- `cargo fmt`  clean
```

changelog: add 'relative_path_in_macro_definition' lint. Warns about relative paths to `core` or `kernel` in macro definitions, recommending absolute paths to avoid ambiguity (#14472)