### PR TITLE
Add relative_path_in_macro_definition lint (#14472) #14645

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See [Changelog Update](book/src/development/infrastructure/changelog_update.md) 
 document.
 
 ## Unreleased / Beta / In Rust Nightly
+### New Lints
+- **`relative_path_in_macro_definition`**:
+  Warns about relative paths to `core` or `kernel` in macro definitions, recommending absolute paths to avoid ambiguity.
 
 [1e5237f4...master](https://github.com/rust-lang/rust-clippy/compare/1e5237f4...master)
 
@@ -6226,6 +6229,7 @@ Released 2018-09-13
 [`ref_patterns`]: https://rust-lang.github.io/rust-clippy/master/index.html#ref_patterns
 [`regex_creation_in_loops`]: https://rust-lang.github.io/rust-clippy/master/index.html#regex_creation_in_loops
 [`regex_macro`]: https://rust-lang.github.io/rust-clippy/master/index.html#regex_macro
+[`relative_path_in_macro_definition`]: https://rust-lang.github.io/rust-clippy/master/index.html#relative_path_in_macro_definition
 [`renamed_function_params`]: https://rust-lang.github.io/rust-clippy/master/index.html#renamed_function_params
 [`repeat_once`]: https://rust-lang.github.io/rust-clippy/master/index.html#repeat_once
 [`repeat_vec_with_capacity`]: https://rust-lang.github.io/rust-clippy/master/index.html#repeat_vec_with_capacity

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::relative_path_in_macro_definition)]
+
 use crate::ClippyConfiguration;
 use crate::types::{
     DisallowedPath, DisallowedPathWithoutReplacement, MacroMatcher, MatchLintBehaviour, PubUnderscoreFieldsBehaviour,

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::relative_path_in_macro_definition)]
+
 use clippy_utils::paths::{PathNS, find_crates, lookup_path};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{Applicability, Diag};

--- a/clippy_lints/src/declare_clippy_lint.rs
+++ b/clippy_lints/src/declare_clippy_lint.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::relative_path_in_macro_definition)]
 #[macro_export]
 #[allow(clippy::crate_in_macro_def)]
 macro_rules! declare_clippy_lint {

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -648,6 +648,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::regex::INVALID_REGEX_INFO,
     crate::regex::REGEX_CREATION_IN_LOOPS_INFO,
     crate::regex::TRIVIAL_REGEX_INFO,
+    crate::relative_path_in_macro_definition::RELATIVE_PATH_IN_MACRO_DEFINITION_INFO,
     crate::repeat_vec_with_capacity::REPEAT_VEC_WITH_CAPACITY_INFO,
     crate::reserve_after_initialization::RESERVE_AFTER_INITIALIZATION_INFO,
     crate::return_self_not_must_use::RETURN_SELF_NOT_MUST_USE_INFO,

--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -1,5 +1,6 @@
 // This file is managed by `cargo dev rename_lint` and `cargo dev deprecate_lint`.
 // Prefer to use those when possible.
+#![allow(clippy::relative_path_in_macro_definition)]
 
 macro_rules! declare_with_version {
     ($name:ident($name_version:ident) = [$(

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -324,6 +324,7 @@ mod ref_option_ref;
 mod ref_patterns;
 mod reference;
 mod regex;
+mod relative_path_in_macro_definition;
 mod repeat_vec_with_capacity;
 mod reserve_after_initialization;
 mod return_self_not_must_use;
@@ -946,5 +947,6 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(|_| Box::new(single_option_map::SingleOptionMap));
     store.register_late_pass(move |_| Box::new(redundant_test_prefix::RedundantTestPrefix));
     store.register_late_pass(|_| Box::new(cloned_ref_to_slice_refs::ClonedRefToSliceRefs::new(conf)));
+    store.register_early_pass(|| Box::new(relative_path_in_macro_definition::RelativePathInMacroDefinition));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::relative_path_in_macro_definition)]
+
 use std::mem;
 use std::ops::ControlFlow;
 

--- a/clippy_lints/src/operators/double_comparison.rs
+++ b/clippy_lints/src/operators/double_comparison.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::relative_path_in_macro_definition)]
+
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::eq_expr_value;
 use clippy_utils::source::snippet_with_applicability;

--- a/clippy_lints/src/relative_path_in_macro_definition.rs
+++ b/clippy_lints/src/relative_path_in_macro_definition.rs
@@ -1,0 +1,93 @@
+use clippy_utils::diagnostics::span_lint;
+use rustc_ast::ast::{Item, ItemKind};
+use rustc_ast::token::TokenKind;
+use rustc_ast::tokenstream::{TokenStream, TokenTree};
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::declare_lint_pass;
+use rustc_span::symbol::sym;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks that references to the `core` or `kernel` crate in macro definitions use absolute paths (`::core` or `::kernel`).
+    ///
+    /// ### Why is this bad?
+    /// Using relative paths (e.g., `core::...`) in macros can lead to ambiguity if the macro is used in a context
+    /// where a user defines a module named `core` or `kernel`. Absolute paths ensure the macro always refers to the intended crate.
+    ///
+    /// ### Example
+    /// ```rust
+    /// // Bad
+    /// macro_rules! my_macro {
+    ///     () => {
+    ///         core::mem::drop(0);
+    ///     };
+    /// }
+    ///
+    /// // Good
+    /// macro_rules! my_macro {
+    ///     () => {
+    ///         ::core::mem::drop(0);
+    ///     };
+    /// }
+    /// ```
+    #[clippy::version = "1.88.0"]
+    pub RELATIVE_PATH_IN_MACRO_DEFINITION,
+    correctness,
+    "using relative paths in declarative macros can lead to context-dependent behavior"
+}
+
+declare_lint_pass!(RelativePathInMacroDefinition => [RELATIVE_PATH_IN_MACRO_DEFINITION]);
+
+impl EarlyLintPass for RelativePathInMacroDefinition {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
+        if let ItemKind::MacroDef(_, macro_def) = &item.kind {
+            check_token_stream(cx, &macro_def.body.tokens);
+        }
+    }
+}
+
+fn check_token_stream(cx: &EarlyContext<'_>, tokens: &TokenStream) {
+    let mut iter = tokens.iter().peekable();
+    let mut prev_token: Option<&TokenTree> = None;
+
+    while let Some(tree) = iter.next() {
+        match tree {
+            TokenTree::Token(token, _) => {
+                if let TokenKind::Ident(ident, _) = token.kind
+                    && (ident == sym::core || ident.as_str() == "kernel")
+                {
+                    let is_path_start = iter.peek().is_some_and(|next_tree| {
+                        if let TokenTree::Token(next_token, _) = next_tree {
+                            next_token.kind == TokenKind::PathSep
+                        } else {
+                            false
+                        }
+                    });
+
+                    if is_path_start {
+                        let is_absolute = prev_token.is_some_and(|prev| {
+                            if let TokenTree::Token(prev_token, _) = prev {
+                                prev_token.kind == TokenKind::PathSep
+                            } else {
+                                false
+                            }
+                        });
+
+                        if !is_absolute {
+                            span_lint(
+                                cx,
+                                RELATIVE_PATH_IN_MACRO_DEFINITION,
+                                token.span,
+                                "relative path to `core` or `kernel` used in macro definition",
+                            );
+                        }
+                    }
+                }
+            },
+            TokenTree::Delimited(_open_span, _close_span, _delim, token_stream) => {
+                check_token_stream(cx, token_stream);
+            },
+        }
+        prev_token = Some(tree);
+    }
+}

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::relative_path_in_macro_definition)]
+
 use clippy_utils::{MaybePath, get_attr, higher, path_def_id, sym};
 use itertools::Itertools;
 use rustc_ast::LitIntType;

--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -11,6 +11,7 @@
 //! must exist at both the start and the end of an item (e.g. an expression or a path) assuming the
 //! code was written, and check if the span contains that text. Note this will only work correctly
 //! if the span is not from a `macro_rules` based macro.
+#![allow(clippy::relative_path_in_macro_definition)]
 
 use rustc_abi::ExternAbi;
 use rustc_ast::AttrStyle;

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(array_windows)]
 #![recursion_limit = "512"]
 #![allow(
+    clippy::relative_path_in_macro_definition,
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
     clippy::must_use_candidate,

--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::similar_names)] // `expr` and `expn`
+#![allow(clippy::relative_path_in_macro_definition)]
 
 use std::sync::{Arc, OnceLock};
 

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -3,6 +3,7 @@
 //!
 //! Whenever possible, please consider diagnostic items over hardcoded paths.
 //! See <https://github.com/rust-lang/rust-clippy/issues/5393> for more information.
+#![allow(clippy::relative_path_in_macro_definition)]
 
 use crate::{MaybePath, path_def_id, sym};
 use rustc_ast::Mutability;

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -1,5 +1,6 @@
 //! Contains utility functions to generate suggestions.
 #![deny(clippy::missing_docs_in_private_items)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 use crate::source::{snippet, snippet_opt, snippet_with_applicability, snippet_with_context};
 use crate::ty::expr_sig;

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -1,4 +1,5 @@
 #![allow(non_upper_case_globals)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 use rustc_span::symbol::PREDEFINED_SYMBOLS_COUNT;
 

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::relative_path_in_macro_definition)]
+
 use crate::ty::needs_ordered_drop;
 use crate::{get_enclosing_block, path_to_local_id};
 use core::ops::ControlFlow;

--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::relative_path_in_macro_definition)]
+
 use std::path::PathBuf;
 use std::process::Command;
 use std::str;

--- a/tests/ui-toml/absolute_paths/absolute_paths.allow_crates.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.allow_crates.stderr
@@ -1,5 +1,5 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,31 +11,31 @@ LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:44:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/absolute_paths/absolute_paths.allow_long.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.allow_long.stderr
@@ -1,5 +1,5 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/absolute_paths/absolute_paths.default.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.default.stderr
@@ -1,5 +1,5 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,67 +11,67 @@ LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:37:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:38:13
    |
 LL |     let _ = ::core::clone::Clone::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:40:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:41:13
    |
 LL |     let _ = <i32 as core::clone::Clone>::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:44:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:17
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:66:17
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                 ^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:18
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:71:18
    |
 LL |         where T: core::clone::Clone
    |                  ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:32
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:66:32
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                                ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:116:5
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:117:5
    |
 LL |     crate::m1::S
    |     ^^^^^^^^^^^^

--- a/tests/ui-toml/absolute_paths/absolute_paths.no_short.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.no_short.stderr
@@ -1,5 +1,5 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,85 +11,85 @@ LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:37:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:38:13
    |
 LL |     let _ = ::core::clone::Clone::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:40:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:41:13
    |
 LL |     let _ = <i32 as core::clone::Clone>::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:44:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:17
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:66:17
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                 ^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:18
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:71:18
    |
 LL |         where T: core::clone::Clone
    |                  ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:32
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:66:32
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                                ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:113:14
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:114:14
    |
 LL | pub const _: crate::S = {
    |              ^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:114:9
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:115:9
    |
 LL |     let crate::S = m1::S;
    |         ^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:116:5
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:117:5
    |
 LL |     crate::m1::S
    |     ^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:122:14
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:123:14
    |
 LL |     let _ = <crate::S as Clone>::clone(&m1::S);
    |              ^^^^^^^^

--- a/tests/ui-toml/absolute_paths/absolute_paths.rs
+++ b/tests/ui-toml/absolute_paths/absolute_paths.rs
@@ -5,6 +5,7 @@
 //@[allow_long] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/allow_long
 //@[no_short] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/no_short
 #![deny(clippy::absolute_paths)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros, with_span};

--- a/tests/ui-toml/arithmetic_side_effects_allowed/arithmetic_side_effects_allowed.rs
+++ b/tests/ui-toml/arithmetic_side_effects_allowed/arithmetic_side_effects_allowed.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::arithmetic_side_effects)]
-#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(clippy::relative_path_in_macro_definition, clippy::unnecessary_literal_unwrap)]
 
 use core::ops::{Add, Neg};
 

--- a/tests/ui-toml/macro_metavars_in_unsafe/default/test.rs
+++ b/tests/ui-toml/macro_metavars_in_unsafe/default/test.rs
@@ -2,7 +2,7 @@
 #![feature(decl_macro)]
 #![warn(clippy::macro_metavars_in_unsafe)]
 #![allow(clippy::no_effect, clippy::not_unsafe_ptr_arg_deref)]
-
+#![allow(clippy::relative_path_in_macro_definition)]
 #[macro_export]
 macro_rules! allow_works {
     ($v:expr) => {

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -8,6 +8,7 @@
     clippy::identity_op,
     clippy::no_effect,
     clippy::op_ref,
+    clippy::relative_path_in_macro_definition,
     clippy::unnecessary_owned_empty_strings,
     arithmetic_overflow,
     unconditional_panic

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -1,5 +1,5 @@
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:166:13
+  --> tests/ui/arithmetic_side_effects.rs:167:13
    |
 LL |     let _ = 1f16 + 1f16;
    |             ^^^^^^^^^^^
@@ -8,763 +8,763 @@ LL |     let _ = 1f16 + 1f16;
    = help: to override `-D warnings` add `#[allow(clippy::arithmetic_side_effects)]`
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:170:13
+  --> tests/ui/arithmetic_side_effects.rs:171:13
    |
 LL |     let _ = 1f128 + 1f128;
    |             ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:175:13
+  --> tests/ui/arithmetic_side_effects.rs:176:13
    |
 LL |     let _ = String::new() + &String::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:311:5
+  --> tests/ui/arithmetic_side_effects.rs:312:5
    |
 LL |     _n += 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:313:5
+  --> tests/ui/arithmetic_side_effects.rs:314:5
    |
 LL |     _n += &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:315:5
+  --> tests/ui/arithmetic_side_effects.rs:316:5
    |
 LL |     _n -= 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:317:5
+  --> tests/ui/arithmetic_side_effects.rs:318:5
    |
 LL |     _n -= &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:319:5
+  --> tests/ui/arithmetic_side_effects.rs:320:5
    |
 LL |     _n /= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:321:5
+  --> tests/ui/arithmetic_side_effects.rs:322:5
    |
 LL |     _n /= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:323:5
+  --> tests/ui/arithmetic_side_effects.rs:324:5
    |
 LL |     _n %= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:325:5
+  --> tests/ui/arithmetic_side_effects.rs:326:5
    |
 LL |     _n %= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:327:5
+  --> tests/ui/arithmetic_side_effects.rs:328:5
    |
 LL |     _n *= 2;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:329:5
+  --> tests/ui/arithmetic_side_effects.rs:330:5
    |
 LL |     _n *= &2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:331:5
+  --> tests/ui/arithmetic_side_effects.rs:332:5
    |
 LL |     _n += -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:333:5
+  --> tests/ui/arithmetic_side_effects.rs:334:5
    |
 LL |     _n += &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:335:5
+  --> tests/ui/arithmetic_side_effects.rs:336:5
    |
 LL |     _n -= -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:337:5
+  --> tests/ui/arithmetic_side_effects.rs:338:5
    |
 LL |     _n -= &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:339:5
+  --> tests/ui/arithmetic_side_effects.rs:340:5
    |
 LL |     _n /= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:341:5
+  --> tests/ui/arithmetic_side_effects.rs:342:5
    |
 LL |     _n /= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:343:5
+  --> tests/ui/arithmetic_side_effects.rs:344:5
    |
 LL |     _n %= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:345:5
+  --> tests/ui/arithmetic_side_effects.rs:346:5
    |
 LL |     _n %= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:347:5
+  --> tests/ui/arithmetic_side_effects.rs:348:5
    |
 LL |     _n *= -2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:349:5
+  --> tests/ui/arithmetic_side_effects.rs:350:5
    |
 LL |     _n *= &-2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:351:5
+  --> tests/ui/arithmetic_side_effects.rs:352:5
    |
 LL |     _custom += Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:353:5
+  --> tests/ui/arithmetic_side_effects.rs:354:5
    |
 LL |     _custom += &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:355:5
+  --> tests/ui/arithmetic_side_effects.rs:356:5
    |
 LL |     _custom -= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:357:5
+  --> tests/ui/arithmetic_side_effects.rs:358:5
    |
 LL |     _custom -= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:359:5
+  --> tests/ui/arithmetic_side_effects.rs:360:5
    |
 LL |     _custom /= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:361:5
+  --> tests/ui/arithmetic_side_effects.rs:362:5
    |
 LL |     _custom /= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:363:5
+  --> tests/ui/arithmetic_side_effects.rs:364:5
    |
 LL |     _custom %= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:365:5
+  --> tests/ui/arithmetic_side_effects.rs:366:5
    |
 LL |     _custom %= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:367:5
+  --> tests/ui/arithmetic_side_effects.rs:368:5
    |
 LL |     _custom *= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:369:5
+  --> tests/ui/arithmetic_side_effects.rs:370:5
    |
 LL |     _custom *= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:371:5
+  --> tests/ui/arithmetic_side_effects.rs:372:5
    |
 LL |     _custom >>= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:373:5
+  --> tests/ui/arithmetic_side_effects.rs:374:5
    |
 LL |     _custom >>= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:375:5
+  --> tests/ui/arithmetic_side_effects.rs:376:5
    |
 LL |     _custom <<= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:377:5
+  --> tests/ui/arithmetic_side_effects.rs:378:5
    |
 LL |     _custom <<= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:379:5
+  --> tests/ui/arithmetic_side_effects.rs:380:5
    |
 LL |     _custom += -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:381:5
+  --> tests/ui/arithmetic_side_effects.rs:382:5
    |
 LL |     _custom += &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:383:5
+  --> tests/ui/arithmetic_side_effects.rs:384:5
    |
 LL |     _custom -= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:385:5
+  --> tests/ui/arithmetic_side_effects.rs:386:5
    |
 LL |     _custom -= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:387:5
+  --> tests/ui/arithmetic_side_effects.rs:388:5
    |
 LL |     _custom /= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:389:5
+  --> tests/ui/arithmetic_side_effects.rs:390:5
    |
 LL |     _custom /= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:391:5
+  --> tests/ui/arithmetic_side_effects.rs:392:5
    |
 LL |     _custom %= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:393:5
+  --> tests/ui/arithmetic_side_effects.rs:394:5
    |
 LL |     _custom %= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:395:5
+  --> tests/ui/arithmetic_side_effects.rs:396:5
    |
 LL |     _custom *= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:397:5
+  --> tests/ui/arithmetic_side_effects.rs:398:5
    |
 LL |     _custom *= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:399:5
+  --> tests/ui/arithmetic_side_effects.rs:400:5
    |
 LL |     _custom >>= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:401:5
+  --> tests/ui/arithmetic_side_effects.rs:402:5
    |
 LL |     _custom >>= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:403:5
+  --> tests/ui/arithmetic_side_effects.rs:404:5
    |
 LL |     _custom <<= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:405:5
+  --> tests/ui/arithmetic_side_effects.rs:406:5
    |
 LL |     _custom <<= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:409:10
+  --> tests/ui/arithmetic_side_effects.rs:410:10
    |
 LL |     _n = _n + 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:411:10
+  --> tests/ui/arithmetic_side_effects.rs:412:10
    |
 LL |     _n = _n + &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:413:10
+  --> tests/ui/arithmetic_side_effects.rs:414:10
    |
 LL |     _n = 1 + _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:415:10
+  --> tests/ui/arithmetic_side_effects.rs:416:10
    |
 LL |     _n = &1 + _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:417:10
+  --> tests/ui/arithmetic_side_effects.rs:418:10
    |
 LL |     _n = _n - 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:419:10
+  --> tests/ui/arithmetic_side_effects.rs:420:10
    |
 LL |     _n = _n - &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:421:10
+  --> tests/ui/arithmetic_side_effects.rs:422:10
    |
 LL |     _n = 1 - _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:423:10
+  --> tests/ui/arithmetic_side_effects.rs:424:10
    |
 LL |     _n = &1 - _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:425:10
+  --> tests/ui/arithmetic_side_effects.rs:426:10
    |
 LL |     _n = _n / 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:427:10
+  --> tests/ui/arithmetic_side_effects.rs:428:10
    |
 LL |     _n = _n / &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:429:10
+  --> tests/ui/arithmetic_side_effects.rs:430:10
    |
 LL |     _n = _n % 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:431:10
+  --> tests/ui/arithmetic_side_effects.rs:432:10
    |
 LL |     _n = _n % &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:433:10
+  --> tests/ui/arithmetic_side_effects.rs:434:10
    |
 LL |     _n = _n * 2;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:435:10
+  --> tests/ui/arithmetic_side_effects.rs:436:10
    |
 LL |     _n = _n * &2;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:437:10
+  --> tests/ui/arithmetic_side_effects.rs:438:10
    |
 LL |     _n = 2 * _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:439:10
+  --> tests/ui/arithmetic_side_effects.rs:440:10
    |
 LL |     _n = &2 * _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:441:10
+  --> tests/ui/arithmetic_side_effects.rs:442:10
    |
 LL |     _n = 23 + &85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:443:10
+  --> tests/ui/arithmetic_side_effects.rs:444:10
    |
 LL |     _n = &23 + 85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:445:10
+  --> tests/ui/arithmetic_side_effects.rs:446:10
    |
 LL |     _n = &23 + &85;
    |          ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:447:15
+  --> tests/ui/arithmetic_side_effects.rs:448:15
    |
 LL |     _custom = _custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:449:15
+  --> tests/ui/arithmetic_side_effects.rs:450:15
    |
 LL |     _custom = _custom + &_custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:451:15
+  --> tests/ui/arithmetic_side_effects.rs:452:15
    |
 LL |     _custom = Custom + _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:453:15
+  --> tests/ui/arithmetic_side_effects.rs:454:15
    |
 LL |     _custom = &Custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:455:15
+  --> tests/ui/arithmetic_side_effects.rs:456:15
    |
 LL |     _custom = _custom - Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:457:15
+  --> tests/ui/arithmetic_side_effects.rs:458:15
    |
 LL |     _custom = _custom - &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:459:15
+  --> tests/ui/arithmetic_side_effects.rs:460:15
    |
 LL |     _custom = Custom - _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:461:15
+  --> tests/ui/arithmetic_side_effects.rs:462:15
    |
 LL |     _custom = &Custom - _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:463:15
+  --> tests/ui/arithmetic_side_effects.rs:464:15
    |
 LL |     _custom = _custom / Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:465:15
+  --> tests/ui/arithmetic_side_effects.rs:466:15
    |
 LL |     _custom = _custom / &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:467:15
+  --> tests/ui/arithmetic_side_effects.rs:468:15
    |
 LL |     _custom = _custom % Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:469:15
+  --> tests/ui/arithmetic_side_effects.rs:470:15
    |
 LL |     _custom = _custom % &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:471:15
+  --> tests/ui/arithmetic_side_effects.rs:472:15
    |
 LL |     _custom = _custom * Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:473:15
+  --> tests/ui/arithmetic_side_effects.rs:474:15
    |
 LL |     _custom = _custom * &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:475:15
+  --> tests/ui/arithmetic_side_effects.rs:476:15
    |
 LL |     _custom = Custom * _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:477:15
+  --> tests/ui/arithmetic_side_effects.rs:478:15
    |
 LL |     _custom = &Custom * _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:479:15
+  --> tests/ui/arithmetic_side_effects.rs:480:15
    |
 LL |     _custom = Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:481:15
+  --> tests/ui/arithmetic_side_effects.rs:482:15
    |
 LL |     _custom = &Custom + Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:483:15
+  --> tests/ui/arithmetic_side_effects.rs:484:15
    |
 LL |     _custom = &Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:485:15
+  --> tests/ui/arithmetic_side_effects.rs:486:15
    |
 LL |     _custom = _custom >> _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:487:15
+  --> tests/ui/arithmetic_side_effects.rs:488:15
    |
 LL |     _custom = _custom >> &_custom;
    |               ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:489:15
+  --> tests/ui/arithmetic_side_effects.rs:490:15
    |
 LL |     _custom = Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:491:15
+  --> tests/ui/arithmetic_side_effects.rs:492:15
    |
 LL |     _custom = &Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:495:23
+  --> tests/ui/arithmetic_side_effects.rs:496:23
    |
 LL |     _n.saturating_div(0);
    |                       ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:497:21
+  --> tests/ui/arithmetic_side_effects.rs:498:21
    |
 LL |     _n.wrapping_div(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:499:21
+  --> tests/ui/arithmetic_side_effects.rs:500:21
    |
 LL |     _n.wrapping_rem(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:501:28
+  --> tests/ui/arithmetic_side_effects.rs:502:28
    |
 LL |     _n.wrapping_rem_euclid(0);
    |                            ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:504:23
+  --> tests/ui/arithmetic_side_effects.rs:505:23
    |
 LL |     _n.saturating_div(_n);
    |                       ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:506:21
+  --> tests/ui/arithmetic_side_effects.rs:507:21
    |
 LL |     _n.wrapping_div(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:508:21
+  --> tests/ui/arithmetic_side_effects.rs:509:21
    |
 LL |     _n.wrapping_rem(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:510:28
+  --> tests/ui/arithmetic_side_effects.rs:511:28
    |
 LL |     _n.wrapping_rem_euclid(_n);
    |                            ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:513:23
+  --> tests/ui/arithmetic_side_effects.rs:514:23
    |
 LL |     _n.saturating_div(*Box::new(_n));
    |                       ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:517:10
+  --> tests/ui/arithmetic_side_effects.rs:518:10
    |
 LL |     _n = -_n;
    |          ^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:519:10
+  --> tests/ui/arithmetic_side_effects.rs:520:10
    |
 LL |     _n = -&_n;
    |          ^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:521:15
+  --> tests/ui/arithmetic_side_effects.rs:522:15
    |
 LL |     _custom = -_custom;
    |               ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:523:15
+  --> tests/ui/arithmetic_side_effects.rs:524:15
    |
 LL |     _custom = -&_custom;
    |               ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:525:9
+  --> tests/ui/arithmetic_side_effects.rs:526:9
    |
 LL |     _ = -*Box::new(_n);
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:535:5
+  --> tests/ui/arithmetic_side_effects.rs:536:5
    |
 LL |     1 + i;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:537:5
+  --> tests/ui/arithmetic_side_effects.rs:538:5
    |
 LL |     i * 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:539:5
+  --> tests/ui/arithmetic_side_effects.rs:540:5
    |
 LL |     1 % i / 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:541:5
+  --> tests/ui/arithmetic_side_effects.rs:542:5
    |
 LL |     i - 2 + 2 - i;
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:543:5
+  --> tests/ui/arithmetic_side_effects.rs:544:5
    |
 LL |     -i;
    |     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:555:5
+  --> tests/ui/arithmetic_side_effects.rs:556:5
    |
 LL |     i += 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:557:5
+  --> tests/ui/arithmetic_side_effects.rs:558:5
    |
 LL |     i -= 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:559:5
+  --> tests/ui/arithmetic_side_effects.rs:560:5
    |
 LL |     i *= 2;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:562:5
+  --> tests/ui/arithmetic_side_effects.rs:563:5
    |
 LL |     i /= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:565:5
+  --> tests/ui/arithmetic_side_effects.rs:566:5
    |
 LL |     i /= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:567:5
+  --> tests/ui/arithmetic_side_effects.rs:568:5
    |
 LL |     i /= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:570:5
+  --> tests/ui/arithmetic_side_effects.rs:571:5
    |
 LL |     i %= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:573:5
+  --> tests/ui/arithmetic_side_effects.rs:574:5
    |
 LL |     i %= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:575:5
+  --> tests/ui/arithmetic_side_effects.rs:576:5
    |
 LL |     i %= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:586:5
+  --> tests/ui/arithmetic_side_effects.rs:587:5
    |
 LL |     10 / a
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:641:9
+  --> tests/ui/arithmetic_side_effects.rs:642:9
    |
 LL |         x / maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:646:9
+  --> tests/ui/arithmetic_side_effects.rs:647:9
    |
 LL |         x % maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:658:5
+  --> tests/ui/arithmetic_side_effects.rs:659:5
    |
 LL |     one.add_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:663:5
+  --> tests/ui/arithmetic_side_effects.rs:664:5
    |
 LL |     one.sub_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:670:5
+  --> tests/ui/arithmetic_side_effects.rs:671:5
    |
 LL |     one.add(&one);
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:672:5
+  --> tests/ui/arithmetic_side_effects.rs:673:5
    |
 LL |     Box::new(one).add(one);
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/assertions_on_result_states.fixed
+++ b/tests/ui/assertions_on_result_states.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::assertions_on_result_states)]
-#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::relative_path_in_macro_definition)]
 
 use std::result::Result;
 

--- a/tests/ui/assertions_on_result_states.rs
+++ b/tests/ui/assertions_on_result_states.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::assertions_on_result_states)]
-#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::relative_path_in_macro_definition)]
 
 use std::result::Result;
 

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 //! Used to test that certain lints don't trigger in imported external macros
 #[macro_export]

--- a/tests/ui/auxiliary/macro_use_helper.rs
+++ b/tests/ui/auxiliary/macro_use_helper.rs
@@ -1,4 +1,5 @@
 //@aux-build:macro_rules.rs
+#![allow(clippy::relative_path_in_macro_definition)]
 
 extern crate macro_rules;
 

--- a/tests/ui/box_collection.rs
+++ b/tests/ui/box_collection.rs
@@ -2,6 +2,7 @@
     clippy::boxed_local,
     clippy::needless_pass_by_value,
     clippy::disallowed_names,
+    clippy::relative_path_in_macro_definition,
     unused
 )]
 

--- a/tests/ui/box_collection.stderr
+++ b/tests/ui/box_collection.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `Box<Vec<..>>`. Consider using just `Vec<..>`
-  --> tests/ui/box_collection.rs:20:15
+  --> tests/ui/box_collection.rs:21:15
    |
 LL | fn test1(foo: Box<Vec<bool>>) {}
    |               ^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | fn test1(foo: Box<Vec<bool>>) {}
    = help: to override `-D warnings` add `#[allow(clippy::box_collection)]`
 
 error: you seem to be trying to use `Box<String>`. Consider using just `String`
-  --> tests/ui/box_collection.rs:28:15
+  --> tests/ui/box_collection.rs:29:15
    |
 LL | fn test3(foo: Box<String>) {}
    |               ^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | fn test3(foo: Box<String>) {}
    = help: `String` is already on the heap, `Box<String>` makes an extra allocation
 
 error: you seem to be trying to use `Box<HashMap<..>>`. Consider using just `HashMap<..>`
-  --> tests/ui/box_collection.rs:31:15
+  --> tests/ui/box_collection.rs:32:15
    |
 LL | fn test4(foo: Box<HashMap<String, String>>) {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | fn test4(foo: Box<HashMap<String, String>>) {}
    = help: `HashMap<..>` is already on the heap, `Box<HashMap<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<HashSet<..>>`. Consider using just `HashSet<..>`
-  --> tests/ui/box_collection.rs:34:15
+  --> tests/ui/box_collection.rs:35:15
    |
 LL | fn test5(foo: Box<HashSet<i64>>) {}
    |               ^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL | fn test5(foo: Box<HashSet<i64>>) {}
    = help: `HashSet<..>` is already on the heap, `Box<HashSet<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<VecDeque<..>>`. Consider using just `VecDeque<..>`
-  --> tests/ui/box_collection.rs:37:15
+  --> tests/ui/box_collection.rs:38:15
    |
 LL | fn test6(foo: Box<VecDeque<i32>>) {}
    |               ^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL | fn test6(foo: Box<VecDeque<i32>>) {}
    = help: `VecDeque<..>` is already on the heap, `Box<VecDeque<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<LinkedList<..>>`. Consider using just `LinkedList<..>`
-  --> tests/ui/box_collection.rs:40:15
+  --> tests/ui/box_collection.rs:41:15
    |
 LL | fn test7(foo: Box<LinkedList<i16>>) {}
    |               ^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL | fn test7(foo: Box<LinkedList<i16>>) {}
    = help: `LinkedList<..>` is already on the heap, `Box<LinkedList<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<BTreeMap<..>>`. Consider using just `BTreeMap<..>`
-  --> tests/ui/box_collection.rs:43:15
+  --> tests/ui/box_collection.rs:44:15
    |
 LL | fn test8(foo: Box<BTreeMap<i8, String>>) {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL | fn test8(foo: Box<BTreeMap<i8, String>>) {}
    = help: `BTreeMap<..>` is already on the heap, `Box<BTreeMap<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<BTreeSet<..>>`. Consider using just `BTreeSet<..>`
-  --> tests/ui/box_collection.rs:46:15
+  --> tests/ui/box_collection.rs:47:15
    |
 LL | fn test9(foo: Box<BTreeSet<u64>>) {}
    |               ^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL | fn test9(foo: Box<BTreeSet<u64>>) {}
    = help: `BTreeSet<..>` is already on the heap, `Box<BTreeSet<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<BinaryHeap<..>>`. Consider using just `BinaryHeap<..>`
-  --> tests/ui/box_collection.rs:49:16
+  --> tests/ui/box_collection.rs:50:16
    |
 LL | fn test10(foo: Box<BinaryHeap<u32>>) {}
    |                ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/box_default.fixed
+++ b/tests/ui/box_default.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::box_default)]
-#![allow(clippy::boxed_local, clippy::default_constructed_unit_structs)]
+#![allow(
+    clippy::boxed_local,
+    clippy::default_constructed_unit_structs,
+    clippy::relative_path_in_macro_definition
+)]
 
 #[derive(Default)]
 struct ImplementsDefault;

--- a/tests/ui/box_default.rs
+++ b/tests/ui/box_default.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::box_default)]
-#![allow(clippy::boxed_local, clippy::default_constructed_unit_structs)]
+#![allow(
+    clippy::boxed_local,
+    clippy::default_constructed_unit_structs,
+    clippy::relative_path_in_macro_definition
+)]
 
 #[derive(Default)]
 struct ImplementsDefault;

--- a/tests/ui/box_default.stderr
+++ b/tests/ui/box_default.stderr
@@ -1,5 +1,5 @@
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:34:32
+  --> tests/ui/box_default.rs:38:32
    |
 LL |     let string1: Box<String> = Box::new(Default::default());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
@@ -8,55 +8,55 @@ LL |     let string1: Box<String> = Box::new(Default::default());
    = help: to override `-D warnings` add `#[allow(clippy::box_default)]`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:36:32
+  --> tests/ui/box_default.rs:40:32
    |
 LL |     let string2: Box<String> = Box::new(String::new());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:38:41
+  --> tests/ui/box_default.rs:42:41
    |
 LL |     let impl1: Box<ImplementsDefault> = Box::new(Default::default());
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:40:29
+  --> tests/ui/box_default.rs:44:29
    |
 LL |     let vec: Box<Vec<u8>> = Box::new(Vec::new());
    |                             ^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:42:25
+  --> tests/ui/box_default.rs:46:25
    |
 LL |     let byte: Box<u8> = Box::new(u8::default());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:44:45
+  --> tests/ui/box_default.rs:48:45
    |
 LL |     let vec2: Box<Vec<ImplementsDefault>> = Box::new(vec![]);
    |                                             ^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:46:32
+  --> tests/ui/box_default.rs:50:32
    |
 LL |     let vec3: Box<Vec<bool>> = Box::new(Vec::from([]));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:49:25
+  --> tests/ui/box_default.rs:53:25
    |
 LL |     let plain_default = Box::new(Default::default());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:67:16
+  --> tests/ui/box_default.rs:71:16
    |
 LL |     call_ty_fn(Box::new(u8::default()));
    |                ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
 error: `Box::new(_)` of default value
-  --> tests/ui/box_default.rs:95:17
+  --> tests/ui/box_default.rs:99:17
    |
 LL |         Self::x(Box::new(T::default()));
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -14,7 +14,8 @@
     clippy::unnecessary_min_or_max,
     clippy::unnecessary_operation,
     clippy::unnecessary_literal_unwrap,
-    clippy::identity_op
+    clippy::identity_op,
+    clippy::relative_path_in_macro_definition
 )]
 
 // FIXME(f16_f128): add tests once const casting is available for these types

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -1,5 +1,5 @@
 error: casting `i32` to `f32` causes a loss of precision (`i32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:25:5
+  --> tests/ui/cast.rs:26:5
    |
 LL |     x0 as f32;
    |     ^^^^^^^^^
@@ -8,37 +8,37 @@ LL |     x0 as f32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_precision_loss)]`
 
 error: casting `i64` to `f32` causes a loss of precision (`i64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:29:5
+  --> tests/ui/cast.rs:30:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
 error: casting `i64` to `f64` causes a loss of precision (`i64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> tests/ui/cast.rs:32:5
+  --> tests/ui/cast.rs:33:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
 error: casting `u32` to `f32` causes a loss of precision (`u32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:36:5
+  --> tests/ui/cast.rs:37:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f32` causes a loss of precision (`u64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:40:5
+  --> tests/ui/cast.rs:41:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> tests/ui/cast.rs:43:5
+  --> tests/ui/cast.rs:44:5
    |
 LL |     x3 as f64;
    |     ^^^^^^^^^
 
 error: casting `f32` to `i32` may truncate the value
-  --> tests/ui/cast.rs:47:5
+  --> tests/ui/cast.rs:48:5
    |
 LL |     1f32 as i32;
    |     ^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     1f32 as i32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_truncation)]`
 
 error: casting `f32` to `u32` may truncate the value
-  --> tests/ui/cast.rs:50:5
+  --> tests/ui/cast.rs:51:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     1f32 as u32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:50:5
+  --> tests/ui/cast.rs:51:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     1f32 as u32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_sign_loss)]`
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:54:5
+  --> tests/ui/cast.rs:55:5
    |
 LL |     1f64 as f32;
    |     ^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     1f64 as f32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `i32` to `i8` may truncate the value
-  --> tests/ui/cast.rs:57:5
+  --> tests/ui/cast.rs:58:5
    |
 LL |     1i32 as i8;
    |     ^^^^^^^^^^
@@ -86,7 +86,7 @@ LL +     i8::try_from(1i32);
    |
 
 error: casting `i32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:60:5
+  --> tests/ui/cast.rs:61:5
    |
 LL |     1i32 as u8;
    |     ^^^^^^^^^^
@@ -99,7 +99,7 @@ LL +     u8::try_from(1i32);
    |
 
 error: casting `f64` to `isize` may truncate the value
-  --> tests/ui/cast.rs:63:5
+  --> tests/ui/cast.rs:64:5
    |
 LL |     1f64 as isize;
    |     ^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     1f64 as isize;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `usize` may truncate the value
-  --> tests/ui/cast.rs:66:5
+  --> tests/ui/cast.rs:67:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
@@ -115,13 +115,13 @@ LL |     1f64 as usize;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:66:5
+  --> tests/ui/cast.rs:67:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u32` to `u16` may truncate the value
-  --> tests/ui/cast.rs:70:5
+  --> tests/ui/cast.rs:71:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^^^^^^^^
@@ -134,7 +134,7 @@ LL +     u16::try_from(1f32 as u32);
    |
 
 error: casting `f32` to `u32` may truncate the value
-  --> tests/ui/cast.rs:70:5
+  --> tests/ui/cast.rs:71:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
@@ -142,13 +142,13 @@ LL |     1f32 as u32 as u16;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:70:5
+  --> tests/ui/cast.rs:71:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
 
 error: casting `i32` to `i8` may truncate the value
-  --> tests/ui/cast.rs:76:22
+  --> tests/ui/cast.rs:77:22
    |
 LL |         let _x: i8 = 1i32 as _;
    |                      ^^^^^^^^^
@@ -161,7 +161,7 @@ LL +         let _x: i8 = 1i32.try_into();
    |
 
 error: casting `f32` to `i32` may truncate the value
-  --> tests/ui/cast.rs:79:9
+  --> tests/ui/cast.rs:80:9
    |
 LL |         1f32 as i32;
    |         ^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL |         1f32 as i32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `i32` may truncate the value
-  --> tests/ui/cast.rs:82:9
+  --> tests/ui/cast.rs:83:9
    |
 LL |         1f64 as i32;
    |         ^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL |         1f64 as i32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:85:9
+  --> tests/ui/cast.rs:86:9
    |
 LL |         1f32 as u8;
    |         ^^^^^^^^^^
@@ -185,13 +185,13 @@ LL |         1f32 as u8;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u8` may lose the sign of the value
-  --> tests/ui/cast.rs:85:9
+  --> tests/ui/cast.rs:86:9
    |
 LL |         1f32 as u8;
    |         ^^^^^^^^^^
 
 error: casting `u8` to `i8` may wrap around the value
-  --> tests/ui/cast.rs:90:5
+  --> tests/ui/cast.rs:91:5
    |
 LL |     1u8 as i8;
    |     ^^^^^^^^^
@@ -200,31 +200,31 @@ LL |     1u8 as i8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_wrap)]`
 
 error: casting `u16` to `i16` may wrap around the value
-  --> tests/ui/cast.rs:93:5
+  --> tests/ui/cast.rs:94:5
    |
 LL |     1u16 as i16;
    |     ^^^^^^^^^^^
 
 error: casting `u32` to `i32` may wrap around the value
-  --> tests/ui/cast.rs:96:5
+  --> tests/ui/cast.rs:97:5
    |
 LL |     1u32 as i32;
    |     ^^^^^^^^^^^
 
 error: casting `u64` to `i64` may wrap around the value
-  --> tests/ui/cast.rs:99:5
+  --> tests/ui/cast.rs:100:5
    |
 LL |     1u64 as i64;
    |     ^^^^^^^^^^^
 
 error: casting `usize` to `isize` may wrap around the value
-  --> tests/ui/cast.rs:102:5
+  --> tests/ui/cast.rs:103:5
    |
 LL |     1usize as isize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `usize` to `i8` may truncate the value
-  --> tests/ui/cast.rs:106:5
+  --> tests/ui/cast.rs:107:5
    |
 LL |     1usize as i8;
    |     ^^^^^^^^^^^^
@@ -237,7 +237,7 @@ LL +     i8::try_from(1usize);
    |
 
 error: casting `usize` to `i16` may truncate the value
-  --> tests/ui/cast.rs:110:5
+  --> tests/ui/cast.rs:111:5
    |
 LL |     1usize as i16;
    |     ^^^^^^^^^^^^^
@@ -250,7 +250,7 @@ LL +     i16::try_from(1usize);
    |
 
 error: casting `usize` to `i16` may wrap around the value on targets with 16-bit wide pointers
-  --> tests/ui/cast.rs:110:5
+  --> tests/ui/cast.rs:111:5
    |
 LL |     1usize as i16;
    |     ^^^^^^^^^^^^^
@@ -259,7 +259,7 @@ LL |     1usize as i16;
    = note: for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
 
 error: casting `usize` to `i32` may truncate the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:115:5
+  --> tests/ui/cast.rs:116:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
@@ -272,19 +272,19 @@ LL +     i32::try_from(1usize);
    |
 
 error: casting `usize` to `i32` may wrap around the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:115:5
+  --> tests/ui/cast.rs:116:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting `usize` to `i64` may wrap around the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:120:5
+  --> tests/ui/cast.rs:121:5
    |
 LL |     1usize as i64;
    |     ^^^^^^^^^^^^^
 
 error: casting `u16` to `isize` may wrap around the value on targets with 16-bit wide pointers
-  --> tests/ui/cast.rs:126:5
+  --> tests/ui/cast.rs:127:5
    |
 LL |     1u16 as isize;
    |     ^^^^^^^^^^^^^
@@ -293,13 +293,13 @@ LL |     1u16 as isize;
    = note: for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
 
 error: casting `u32` to `isize` may wrap around the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:130:5
+  --> tests/ui/cast.rs:131:5
    |
 LL |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u64` to `isize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:134:5
+  --> tests/ui/cast.rs:135:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
@@ -312,55 +312,55 @@ LL +     isize::try_from(1u64);
    |
 
 error: casting `u64` to `isize` may wrap around the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:134:5
+  --> tests/ui/cast.rs:135:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:140:5
+  --> tests/ui/cast.rs:141:5
    |
 LL |     -1i32 as u32;
    |     ^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:144:5
+  --> tests/ui/cast.rs:145:5
    |
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
 error: casting `i8` to `u8` may lose the sign of the value
-  --> tests/ui/cast.rs:156:5
+  --> tests/ui/cast.rs:157:5
    |
 LL |     (i8::MIN).abs() as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:161:5
+  --> tests/ui/cast.rs:162:5
    |
 LL |     (-1i64).abs() as u64;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:163:5
+  --> tests/ui/cast.rs:164:5
    |
 LL |     (-1isize).abs() as usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:171:5
+  --> tests/ui/cast.rs:172:5
    |
 LL |     (unsafe { (-1i64).checked_abs().unwrap_unchecked() }) as u64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:187:5
+  --> tests/ui/cast.rs:188:5
    |
 LL |     (unsafe { (-1i64).checked_isqrt().unwrap_unchecked() }) as u64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `i8` may truncate the value
-  --> tests/ui/cast.rs:239:5
+  --> tests/ui/cast.rs:240:5
    |
 LL |     (-99999999999i64).min(1) as i8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -373,7 +373,7 @@ LL +     i8::try_from((-99999999999i64).min(1));
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:253:5
+  --> tests/ui/cast.rs:254:5
    |
 LL |     999999u64.clamp(0, 256) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -386,7 +386,7 @@ LL +     u8::try_from(999999u64.clamp(0, 256));
    |
 
 error: casting `main::E2` to `u8` may truncate the value
-  --> tests/ui/cast.rs:276:21
+  --> tests/ui/cast.rs:277:21
    |
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
@@ -399,7 +399,7 @@ LL +             let _ = u8::try_from(self);
    |
 
 error: casting `main::E2::B` to `u8` will truncate the value
-  --> tests/ui/cast.rs:279:21
+  --> tests/ui/cast.rs:280:21
    |
 LL |             let _ = Self::B as u8;
    |                     ^^^^^^^^^^^^^
@@ -408,7 +408,7 @@ LL |             let _ = Self::B as u8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_enum_truncation)]`
 
 error: casting `main::E5` to `i8` may truncate the value
-  --> tests/ui/cast.rs:321:21
+  --> tests/ui/cast.rs:322:21
    |
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
@@ -421,13 +421,13 @@ LL +             let _ = i8::try_from(self);
    |
 
 error: casting `main::E5::A` to `i8` will truncate the value
-  --> tests/ui/cast.rs:324:21
+  --> tests/ui/cast.rs:325:21
    |
 LL |             let _ = Self::A as i8;
    |                     ^^^^^^^^^^^^^
 
 error: casting `main::E6` to `i16` may truncate the value
-  --> tests/ui/cast.rs:342:21
+  --> tests/ui/cast.rs:343:21
    |
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
@@ -440,7 +440,7 @@ LL +             let _ = i16::try_from(self);
    |
 
 error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:362:21
+  --> tests/ui/cast.rs:363:21
    |
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
@@ -453,7 +453,7 @@ LL +             let _ = usize::try_from(self);
    |
 
 error: casting `main::E10` to `u16` may truncate the value
-  --> tests/ui/cast.rs:410:21
+  --> tests/ui/cast.rs:411:21
    |
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
@@ -466,7 +466,7 @@ LL +             let _ = u16::try_from(self);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:422:13
+  --> tests/ui/cast.rs:423:13
    |
 LL |     let c = (q >> 16) as u8;
    |             ^^^^^^^^^^^^^^^
@@ -479,7 +479,7 @@ LL +     let c = u8::try_from(q >> 16);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:427:13
+  --> tests/ui/cast.rs:428:13
    |
 LL |     let c = (q / 1000) as u8;
    |             ^^^^^^^^^^^^^^^^
@@ -492,85 +492,85 @@ LL +     let c = u8::try_from(q / 1000);
    |
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:440:9
+  --> tests/ui/cast.rs:441:9
    |
 LL |         (x * x) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:446:32
+  --> tests/ui/cast.rs:447:32
    |
 LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
    |                                ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:449:5
+  --> tests/ui/cast.rs:450:5
    |
 LL |     (2_i32).checked_pow(3).unwrap() as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:451:5
+  --> tests/ui/cast.rs:452:5
    |
 LL |     (-2_i32).pow(3) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:456:5
+  --> tests/ui/cast.rs:457:5
    |
 LL |     (-5_i32 % 2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:459:5
+  --> tests/ui/cast.rs:460:5
    |
 LL |     (-5_i32 % -2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:463:5
+  --> tests/ui/cast.rs:464:5
    |
 LL |     (-2_i32 >> 1) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:467:5
+  --> tests/ui/cast.rs:468:5
    |
 LL |     (x * x) as u32;
    |     ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:469:5
+  --> tests/ui/cast.rs:470:5
    |
 LL |     (x * x * x) as u32;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:473:5
+  --> tests/ui/cast.rs:474:5
    |
 LL |     (y * y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:476:5
+  --> tests/ui/cast.rs:477:5
    |
 LL |     (y * y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:478:5
+  --> tests/ui/cast.rs:479:5
    |
 LL |     (y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:481:5
+  --> tests/ui/cast.rs:482:5
    |
 LL |     (y / y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `/`
-  --> tests/ui/cast.rs:481:6
+  --> tests/ui/cast.rs:482:6
    |
 LL |     (y / y * y * -2) as u16;
    |      ^^^^^
@@ -578,97 +578,97 @@ LL |     (y / y * y * -2) as u16;
    = note: `#[deny(clippy::eq_op)]` on by default
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:485:5
+  --> tests/ui/cast.rs:486:5
    |
 LL |     (y + y + y + -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:488:5
+  --> tests/ui/cast.rs:489:5
    |
 LL |     (y + y + y + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:492:5
+  --> tests/ui/cast.rs:493:5
    |
 LL |     (z + -2) as u16;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:495:5
+  --> tests/ui/cast.rs:496:5
    |
 LL |     (z + z + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:499:9
+  --> tests/ui/cast.rs:500:9
    |
 LL |         (a * a * b * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:501:9
+  --> tests/ui/cast.rs:502:9
    |
 LL |         (a * b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:504:9
+  --> tests/ui/cast.rs:505:9
    |
 LL |         (a * -b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:507:9
+  --> tests/ui/cast.rs:508:9
    |
 LL |         (a * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:509:9
+  --> tests/ui/cast.rs:510:9
    |
 LL |         (a * -2) as u32;
    |         ^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:512:9
+  --> tests/ui/cast.rs:513:9
    |
 LL |         (a * b * c * -2) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:515:9
+  --> tests/ui/cast.rs:516:9
    |
 LL |         (a / b) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:517:9
+  --> tests/ui/cast.rs:518:9
    |
 LL |         (a / b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:520:9
+  --> tests/ui/cast.rs:521:9
    |
 LL |         (a / b + b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:523:9
+  --> tests/ui/cast.rs:524:9
    |
 LL |         a.saturating_pow(3) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:526:9
+  --> tests/ui/cast.rs:527:9
    |
 LL |         (a.abs() * b.pow(2) / c.abs()) as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:534:21
+  --> tests/ui/cast.rs:535:21
    |
 LL |             let _ = i32::MIN as u32; // cast_sign_loss
    |                     ^^^^^^^^^^^^^^^
@@ -679,7 +679,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:537:21
+  --> tests/ui/cast.rs:538:21
    |
 LL |             let _ = u32::MAX as u8; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^
@@ -696,7 +696,7 @@ LL +             let _ = u8::try_from(u32::MAX); // cast_possible_truncation
    |
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:540:21
+  --> tests/ui/cast.rs:541:21
    |
 LL |             let _ = std::f64::consts::PI as f32; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -708,7 +708,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `i64` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:551:5
+  --> tests/ui/cast.rs:552:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -721,13 +721,13 @@ LL +     usize::try_from(bar.unwrap().unwrap())
    |
 
 error: casting `i64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:551:5
+  --> tests/ui/cast.rs:552:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:568:5
+  --> tests/ui/cast.rs:569:5
    |
 LL |     (256 & 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -740,7 +740,7 @@ LL +     u8::try_from(256 & 999999u64);
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:571:5
+  --> tests/ui/cast.rs:572:5
    |
 LL |     (255 % 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cast_lossless_integer.fixed
+++ b/tests/ui/cast_lossless_integer.fixed
@@ -1,4 +1,5 @@
 #![allow(clippy::no_effect, clippy::unnecessary_operation, dead_code)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::cast_lossless)]
 
 type I64Alias = i64;

--- a/tests/ui/cast_lossless_integer.rs
+++ b/tests/ui/cast_lossless_integer.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::no_effect, clippy::unnecessary_operation, dead_code)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::cast_lossless)]
 
 type I64Alias = i64;

--- a/tests/ui/cast_lossless_integer.stderr
+++ b/tests/ui/cast_lossless_integer.stderr
@@ -1,5 +1,5 @@
 error: casts from `u8` to `u16` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:8:5
+  --> tests/ui/cast_lossless_integer.rs:9:5
    |
 LL |     0u8 as u16;
    |     ^^^^^^^^^^
@@ -14,7 +14,7 @@ LL +     u16::from(0u8);
    |
 
 error: casts from `u8` to `i16` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:11:5
+  --> tests/ui/cast_lossless_integer.rs:12:5
    |
 LL |     0u8 as i16;
    |     ^^^^^^^^^^
@@ -27,7 +27,7 @@ LL +     i16::from(0u8);
    |
 
 error: casts from `u8` to `u32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:14:5
+  --> tests/ui/cast_lossless_integer.rs:15:5
    |
 LL |     0u8 as u32;
    |     ^^^^^^^^^^
@@ -40,7 +40,7 @@ LL +     u32::from(0u8);
    |
 
 error: casts from `u8` to `i32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:17:5
+  --> tests/ui/cast_lossless_integer.rs:18:5
    |
 LL |     0u8 as i32;
    |     ^^^^^^^^^^
@@ -53,7 +53,7 @@ LL +     i32::from(0u8);
    |
 
 error: casts from `u8` to `u64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:20:5
+  --> tests/ui/cast_lossless_integer.rs:21:5
    |
 LL |     0u8 as u64;
    |     ^^^^^^^^^^
@@ -66,7 +66,7 @@ LL +     u64::from(0u8);
    |
 
 error: casts from `u8` to `i64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:23:5
+  --> tests/ui/cast_lossless_integer.rs:24:5
    |
 LL |     0u8 as i64;
    |     ^^^^^^^^^^
@@ -79,7 +79,7 @@ LL +     i64::from(0u8);
    |
 
 error: casts from `u8` to `u128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:26:5
+  --> tests/ui/cast_lossless_integer.rs:27:5
    |
 LL |     0u8 as u128;
    |     ^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL +     u128::from(0u8);
    |
 
 error: casts from `u8` to `i128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:29:5
+  --> tests/ui/cast_lossless_integer.rs:30:5
    |
 LL |     0u8 as i128;
    |     ^^^^^^^^^^^
@@ -105,7 +105,7 @@ LL +     i128::from(0u8);
    |
 
 error: casts from `u16` to `u32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:32:5
+  --> tests/ui/cast_lossless_integer.rs:33:5
    |
 LL |     0u16 as u32;
    |     ^^^^^^^^^^^
@@ -118,7 +118,7 @@ LL +     u32::from(0u16);
    |
 
 error: casts from `u16` to `i32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:35:5
+  --> tests/ui/cast_lossless_integer.rs:36:5
    |
 LL |     0u16 as i32;
    |     ^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL +     i32::from(0u16);
    |
 
 error: casts from `u16` to `u64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:38:5
+  --> tests/ui/cast_lossless_integer.rs:39:5
    |
 LL |     0u16 as u64;
    |     ^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL +     u64::from(0u16);
    |
 
 error: casts from `u16` to `i64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:41:5
+  --> tests/ui/cast_lossless_integer.rs:42:5
    |
 LL |     0u16 as i64;
    |     ^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     i64::from(0u16);
    |
 
 error: casts from `u16` to `u128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:44:5
+  --> tests/ui/cast_lossless_integer.rs:45:5
    |
 LL |     0u16 as u128;
    |     ^^^^^^^^^^^^
@@ -170,7 +170,7 @@ LL +     u128::from(0u16);
    |
 
 error: casts from `u16` to `i128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:47:5
+  --> tests/ui/cast_lossless_integer.rs:48:5
    |
 LL |     0u16 as i128;
    |     ^^^^^^^^^^^^
@@ -183,7 +183,7 @@ LL +     i128::from(0u16);
    |
 
 error: casts from `u32` to `u64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:50:5
+  --> tests/ui/cast_lossless_integer.rs:51:5
    |
 LL |     0u32 as u64;
    |     ^^^^^^^^^^^
@@ -196,7 +196,7 @@ LL +     u64::from(0u32);
    |
 
 error: casts from `u32` to `i64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:53:5
+  --> tests/ui/cast_lossless_integer.rs:54:5
    |
 LL |     0u32 as i64;
    |     ^^^^^^^^^^^
@@ -209,7 +209,7 @@ LL +     i64::from(0u32);
    |
 
 error: casts from `u32` to `u128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:56:5
+  --> tests/ui/cast_lossless_integer.rs:57:5
    |
 LL |     0u32 as u128;
    |     ^^^^^^^^^^^^
@@ -222,7 +222,7 @@ LL +     u128::from(0u32);
    |
 
 error: casts from `u32` to `i128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:59:5
+  --> tests/ui/cast_lossless_integer.rs:60:5
    |
 LL |     0u32 as i128;
    |     ^^^^^^^^^^^^
@@ -235,7 +235,7 @@ LL +     i128::from(0u32);
    |
 
 error: casts from `u64` to `u128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:62:5
+  --> tests/ui/cast_lossless_integer.rs:63:5
    |
 LL |     0u64 as u128;
    |     ^^^^^^^^^^^^
@@ -248,7 +248,7 @@ LL +     u128::from(0u64);
    |
 
 error: casts from `u64` to `i128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:65:5
+  --> tests/ui/cast_lossless_integer.rs:66:5
    |
 LL |     0u64 as i128;
    |     ^^^^^^^^^^^^
@@ -261,7 +261,7 @@ LL +     i128::from(0u64);
    |
 
 error: casts from `i8` to `i16` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:68:5
+  --> tests/ui/cast_lossless_integer.rs:69:5
    |
 LL |     0i8 as i16;
    |     ^^^^^^^^^^
@@ -274,7 +274,7 @@ LL +     i16::from(0i8);
    |
 
 error: casts from `i8` to `i32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:71:5
+  --> tests/ui/cast_lossless_integer.rs:72:5
    |
 LL |     0i8 as i32;
    |     ^^^^^^^^^^
@@ -287,7 +287,7 @@ LL +     i32::from(0i8);
    |
 
 error: casts from `i8` to `i64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:74:5
+  --> tests/ui/cast_lossless_integer.rs:75:5
    |
 LL |     0i8 as i64;
    |     ^^^^^^^^^^
@@ -300,7 +300,7 @@ LL +     i64::from(0i8);
    |
 
 error: casts from `i8` to `i128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:77:5
+  --> tests/ui/cast_lossless_integer.rs:78:5
    |
 LL |     0i8 as i128;
    |     ^^^^^^^^^^^
@@ -313,7 +313,7 @@ LL +     i128::from(0i8);
    |
 
 error: casts from `i16` to `i32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:80:5
+  --> tests/ui/cast_lossless_integer.rs:81:5
    |
 LL |     0i16 as i32;
    |     ^^^^^^^^^^^
@@ -326,7 +326,7 @@ LL +     i32::from(0i16);
    |
 
 error: casts from `i16` to `i64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:83:5
+  --> tests/ui/cast_lossless_integer.rs:84:5
    |
 LL |     0i16 as i64;
    |     ^^^^^^^^^^^
@@ -339,7 +339,7 @@ LL +     i64::from(0i16);
    |
 
 error: casts from `i16` to `i128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:86:5
+  --> tests/ui/cast_lossless_integer.rs:87:5
    |
 LL |     0i16 as i128;
    |     ^^^^^^^^^^^^
@@ -352,7 +352,7 @@ LL +     i128::from(0i16);
    |
 
 error: casts from `i32` to `i64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:89:5
+  --> tests/ui/cast_lossless_integer.rs:90:5
    |
 LL |     0i32 as i64;
    |     ^^^^^^^^^^^
@@ -365,7 +365,7 @@ LL +     i64::from(0i32);
    |
 
 error: casts from `i32` to `i128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:92:5
+  --> tests/ui/cast_lossless_integer.rs:93:5
    |
 LL |     0i32 as i128;
    |     ^^^^^^^^^^^^
@@ -378,7 +378,7 @@ LL +     i128::from(0i32);
    |
 
 error: casts from `i64` to `i128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:95:5
+  --> tests/ui/cast_lossless_integer.rs:96:5
    |
 LL |     0i64 as i128;
    |     ^^^^^^^^^^^^
@@ -391,7 +391,7 @@ LL +     i128::from(0i64);
    |
 
 error: casts from `u8` to `u16` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:99:13
+  --> tests/ui/cast_lossless_integer.rs:100:13
    |
 LL |     let _ = (1u8 + 1u8) as u16;
    |             ^^^^^^^^^^^^^^^^^^
@@ -404,7 +404,7 @@ LL +     let _ = u16::from(1u8 + 1u8);
    |
 
 error: casts from `i8` to `i64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:102:13
+  --> tests/ui/cast_lossless_integer.rs:103:13
    |
 LL |     let _ = 1i8 as I64Alias;
    |             ^^^^^^^^^^^^^^^
@@ -417,7 +417,7 @@ LL +     let _ = I64Alias::from(1i8);
    |
 
 error: casts from `u8` to `u16` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:105:18
+  --> tests/ui/cast_lossless_integer.rs:106:18
    |
 LL |     let _: u16 = 0u8 as _;
    |                  ^^^^^^^^
@@ -430,7 +430,7 @@ LL +     let _: u16 = 0u8.into();
    |
 
 error: casts from `i8` to `i16` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:108:18
+  --> tests/ui/cast_lossless_integer.rs:109:18
    |
 LL |     let _: i16 = -1i8 as _;
    |                  ^^^^^^^^^
@@ -443,7 +443,7 @@ LL +     let _: i16 = (-1i8).into();
    |
 
 error: casts from `u8` to `u16` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:111:18
+  --> tests/ui/cast_lossless_integer.rs:112:18
    |
 LL |     let _: u16 = (1u8 + 2) as _;
    |                  ^^^^^^^^^^^^^^
@@ -456,7 +456,7 @@ LL +     let _: u16 = (1u8 + 2).into();
    |
 
 error: casts from `u16` to `u32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:114:18
+  --> tests/ui/cast_lossless_integer.rs:115:18
    |
 LL |     let _: u32 = 1i8 as u16 as _;
    |                  ^^^^^^^^^^^^^^^
@@ -469,7 +469,7 @@ LL +     let _: u32 = (1i8 as u16).into();
    |
 
 error: casts from `i8` to `i32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:149:13
+  --> tests/ui/cast_lossless_integer.rs:150:13
    |
 LL |     let _ = sign_cast!(x, u8, i8) as i32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -482,7 +482,7 @@ LL +     let _ = i32::from(sign_cast!(x, u8, i8));
    |
 
 error: casts from `i8` to `i32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:152:13
+  --> tests/ui/cast_lossless_integer.rs:153:13
    |
 LL |     let _ = (sign_cast!(x, u8, i8) + 1) as i32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -495,7 +495,7 @@ LL +     let _ = i32::from(sign_cast!(x, u8, i8) + 1);
    |
 
 error: casts from `u8` to `u32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:159:13
+  --> tests/ui/cast_lossless_integer.rs:160:13
    |
 LL |             1u8 as u32
    |             ^^^^^^^^^^
@@ -512,7 +512,7 @@ LL +             u32::from(1u8)
    |
 
 error: casts from `u8` to `u32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_integer.rs:174:13
+  --> tests/ui/cast_lossless_integer.rs:175:13
    |
 LL |     let _ = 0u8 as ty!();
    |             ^^^^^^^^^^^^

--- a/tests/ui/cmp_owned/asymmetric_partial_eq.fixed
+++ b/tests/ui/cmp_owned/asymmetric_partial_eq.fixed
@@ -2,7 +2,8 @@
     unused,
     clippy::needless_if,
     clippy::redundant_clone,
-    clippy::derive_partial_eq_without_eq
+    clippy::derive_partial_eq_without_eq,
+    clippy::relative_path_in_macro_definition
 )] // See #5700
 
 // Define the types in each module to avoid trait impls leaking between modules.

--- a/tests/ui/cmp_owned/asymmetric_partial_eq.rs
+++ b/tests/ui/cmp_owned/asymmetric_partial_eq.rs
@@ -2,7 +2,8 @@
     unused,
     clippy::needless_if,
     clippy::redundant_clone,
-    clippy::derive_partial_eq_without_eq
+    clippy::derive_partial_eq_without_eq,
+    clippy::relative_path_in_macro_definition
 )] // See #5700
 
 // Define the types in each module to avoid trait impls leaking between modules.

--- a/tests/ui/cmp_owned/asymmetric_partial_eq.stderr
+++ b/tests/ui/cmp_owned/asymmetric_partial_eq.stderr
@@ -1,5 +1,5 @@
 error: this creates an owned instance just for comparison
-  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:46:12
+  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:47:12
    |
 LL |         if borrowed.to_owned() == owned {}
    |            ^^^^^^^^^^^^^^^^^^^ help: try: `borrowed`
@@ -8,7 +8,7 @@ LL |         if borrowed.to_owned() == owned {}
    = help: to override `-D warnings` add `#[allow(clippy::cmp_owned)]`
 
 error: this creates an owned instance just for comparison
-  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:48:21
+  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:49:21
    |
 LL |         if owned == borrowed.to_owned() {}
    |            ---------^^^^^^^^^^^^^^^^^^^
@@ -16,13 +16,13 @@ LL |         if owned == borrowed.to_owned() {}
    |            help: try: `borrowed == owned`
 
 error: this creates an owned instance just for comparison
-  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:67:21
+  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:68:21
    |
 LL |         if owned == borrowed.to_owned() {}
    |                     ^^^^^^^^^^^^^^^^^^^ help: try: `borrowed`
 
 error: this creates an owned instance just for comparison
-  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:69:12
+  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:70:12
    |
 LL |         if borrowed.to_owned() == owned {}
    |            ^^^^^^^^^^^^^^^^^^^---------
@@ -30,7 +30,7 @@ LL |         if borrowed.to_owned() == owned {}
    |            help: try: `owned == borrowed`
 
 error: this creates an owned instance just for comparison
-  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:96:20
+  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:97:20
    |
 LL |         if "Hi" == borrowed.to_string() {}
    |            --------^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL |         if "Hi" == borrowed.to_string() {}
    |            help: try: `borrowed == "Hi"`
 
 error: this creates an owned instance just for comparison
-  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:98:12
+  --> tests/ui/cmp_owned/asymmetric_partial_eq.rs:99:12
    |
 LL |         if borrowed.to_string() == "Hi" {}
    |            ^^^^^^^^^^^^^^^^^^^^ help: try: `borrowed`

--- a/tests/ui/crashes/auxiliary/ice-7272-aux.rs
+++ b/tests/ui/crashes/auxiliary/ice-7272-aux.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::relative_path_in_macro_definition)]
+
 pub fn warn<T>(_: T) {}
 
 macro_rules! define_macro {

--- a/tests/ui/crashes/ice-3462.rs
+++ b/tests/ui/crashes/ice-3462.rs
@@ -1,6 +1,6 @@
 //@ check-pass
-
 #![expect(clippy::disallowed_names)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 // Test for https://github.com/rust-lang/rust-clippy/issues/3462
 

--- a/tests/ui/crate_in_macro_def.fixed
+++ b/tests/ui/crate_in_macro_def.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::crate_in_macro_def)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 mod hygienic {
     #[macro_export]

--- a/tests/ui/crate_in_macro_def.rs
+++ b/tests/ui/crate_in_macro_def.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::crate_in_macro_def)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 mod hygienic {
     #[macro_export]

--- a/tests/ui/crate_in_macro_def.stderr
+++ b/tests/ui/crate_in_macro_def.stderr
@@ -1,5 +1,5 @@
 error: `crate` references the macro call's crate
-  --> tests/ui/crate_in_macro_def.rs:18:28
+  --> tests/ui/crate_in_macro_def.rs:19:28
    |
 LL |             println!("{}", crate::unhygienic::MESSAGE);
    |                            ^^^^^ help: to reference the macro definition's crate, use: `$crate`

--- a/tests/ui/default_constructed_unit_structs.fixed
+++ b/tests/ui/default_constructed_unit_structs.fixed
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(clippy::relative_path_in_macro_definition, unused)]
 #![warn(clippy::default_constructed_unit_structs)]
 use std::marker::PhantomData;
 

--- a/tests/ui/default_constructed_unit_structs.rs
+++ b/tests/ui/default_constructed_unit_structs.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(clippy::relative_path_in_macro_definition, unused)]
 #![warn(clippy::default_constructed_unit_structs)]
 use std::marker::PhantomData;
 

--- a/tests/ui/eager_transmute.fixed
+++ b/tests/ui/eager_transmute.fixed
@@ -1,6 +1,10 @@
 #![feature(rustc_attrs)]
 #![warn(clippy::eager_transmute)]
-#![allow(clippy::transmute_int_to_non_zero, clippy::missing_transmute_annotations)]
+#![allow(
+    clippy::transmute_int_to_non_zero,
+    clippy::missing_transmute_annotations,
+    clippy::relative_path_in_macro_definition
+)]
 
 use std::num::NonZero;
 

--- a/tests/ui/eager_transmute.rs
+++ b/tests/ui/eager_transmute.rs
@@ -1,6 +1,10 @@
 #![feature(rustc_attrs)]
 #![warn(clippy::eager_transmute)]
-#![allow(clippy::transmute_int_to_non_zero, clippy::missing_transmute_annotations)]
+#![allow(
+    clippy::transmute_int_to_non_zero,
+    clippy::missing_transmute_annotations,
+    clippy::relative_path_in_macro_definition
+)]
 
 use std::num::NonZero;
 

--- a/tests/ui/eager_transmute.stderr
+++ b/tests/ui/eager_transmute.stderr
@@ -1,5 +1,5 @@
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:21:33
+  --> tests/ui/eager_transmute.rs:25:33
    |
 LL |     (op < 4).then_some(unsafe { std::mem::transmute(op) })
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     (op < 4).then(|| unsafe { std::mem::transmute(op) })
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:28:33
+  --> tests/ui/eager_transmute.rs:32:33
    |
 LL |     (op < 4).then_some(unsafe { std::mem::transmute::<_, Opcode>(op) });
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     (op < 4).then(|| unsafe { std::mem::transmute::<_, Opcode>(op) });
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:30:33
+  --> tests/ui/eager_transmute.rs:34:33
    |
 LL |     (op > 4).then_some(unsafe { std::mem::transmute::<_, Opcode>(op) });
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL +     (op > 4).then(|| unsafe { std::mem::transmute::<_, Opcode>(op) });
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:32:34
+  --> tests/ui/eager_transmute.rs:36:34
    |
 LL |     (op == 0).then_some(unsafe { std::mem::transmute::<_, Opcode>(op) });
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +     (op == 0).then(|| unsafe { std::mem::transmute::<_, Opcode>(op) });
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:35:68
+  --> tests/ui/eager_transmute.rs:39:68
    |
 LL |     let _: Option<Opcode> = (op > 0 && op < 10).then_some(unsafe { std::mem::transmute(op) });
    |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL +     let _: Option<Opcode> = (op > 0 && op < 10).then(|| unsafe { std::mem::
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:37:86
+  --> tests/ui/eager_transmute.rs:41:86
    |
 LL |     let _: Option<Opcode> = (op > 0 && op < 10 && unrelated == 0).then_some(unsafe { std::mem::transmute(op) });
    |                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +     let _: Option<Opcode> = (op > 0 && op < 10 && unrelated == 0).then(|| u
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:41:84
+  --> tests/ui/eager_transmute.rs:45:84
    |
 LL |     let _: Option<Opcode> = (op2.foo[0] > 0 && op2.foo[0] < 10).then_some(unsafe { std::mem::transmute(op2.foo[0]) });
    |                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +     let _: Option<Opcode> = (op2.foo[0] > 0 && op2.foo[0] < 10).then(|| uns
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:54:70
+  --> tests/ui/eager_transmute.rs:58:70
    |
 LL |     let _: Option<Opcode> = (1..=3).contains(&op).then_some(unsafe { std::mem::transmute(op) });
    |                                                                      ^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL +     let _: Option<Opcode> = (1..=3).contains(&op).then(|| unsafe { std::mem
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:56:83
+  --> tests/ui/eager_transmute.rs:60:83
    |
 LL |     let _: Option<Opcode> = ((1..=3).contains(&op) || op == 4).then_some(unsafe { std::mem::transmute(op) });
    |                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL +     let _: Option<Opcode> = ((1..=3).contains(&op) || op == 4).then(|| unsa
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:58:69
+  --> tests/ui/eager_transmute.rs:62:69
    |
 LL |     let _: Option<Opcode> = (1..3).contains(&op).then_some(unsafe { std::mem::transmute(op) });
    |                                                                     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL +     let _: Option<Opcode> = (1..3).contains(&op).then(|| unsafe { std::mem:
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:60:68
+  --> tests/ui/eager_transmute.rs:64:68
    |
 LL |     let _: Option<Opcode> = (1..).contains(&op).then_some(unsafe { std::mem::transmute(op) });
    |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL +     let _: Option<Opcode> = (1..).contains(&op).then(|| unsafe { std::mem::
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:62:68
+  --> tests/ui/eager_transmute.rs:66:68
    |
 LL |     let _: Option<Opcode> = (..3).contains(&op).then_some(unsafe { std::mem::transmute(op) });
    |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL +     let _: Option<Opcode> = (..3).contains(&op).then(|| unsafe { std::mem::
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:64:69
+  --> tests/ui/eager_transmute.rs:68:69
    |
 LL |     let _: Option<Opcode> = (..=3).contains(&op).then_some(unsafe { std::mem::transmute(op) });
    |                                                                     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     let _: Option<Opcode> = (..=3).contains(&op).then(|| unsafe { std::mem:
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:75:28
+  --> tests/ui/eager_transmute.rs:79:28
    |
 LL |         (op < 4).then_some(std::mem::transmute::<_, Opcode>(op));
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL +         (op < 4).then(|| std::mem::transmute::<_, Opcode>(op));
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:106:62
+  --> tests/ui/eager_transmute.rs:110:62
    |
 LL |     let _: Option<NonZero<u8>> = (v1 > 0).then_some(unsafe { std::mem::transmute(v1) });
    |                                                              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     let _: Option<NonZero<u8>> = (v1 > 0).then(|| unsafe { std::mem::transm
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:113:86
+  --> tests/ui/eager_transmute.rs:117:86
    |
 LL |     let _: Option<NonMaxU8> = (v2 < NonZero::new(255u8).unwrap()).then_some(unsafe { std::mem::transmute(v2) });
    |                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL +     let _: Option<NonMaxU8> = (v2 < NonZero::new(255u8).unwrap()).then(|| u
    |
 
 error: this transmute is always evaluated eagerly, even if the condition is false
-  --> tests/ui/eager_transmute.rs:120:93
+  --> tests/ui/eager_transmute.rs:124:93
    |
 LL |     let _: Option<NonZeroNonMaxU8> = (v2 < NonZero::new(255u8).unwrap()).then_some(unsafe { std::mem::transmute(v2) });
    |                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/endian_bytes.rs
+++ b/tests/ui/endian_bytes.rs
@@ -1,5 +1,5 @@
 #![allow(unused)]
-#![allow(clippy::diverging_sub_expression)]
+#![allow(clippy::diverging_sub_expression, clippy::relative_path_in_macro_definition)]
 #![no_main]
 
 // FIXME(f16_f128): add these types when `{to_from}_*_bytes` are available

--- a/tests/ui/field_reassign_with_default.rs
+++ b/tests/ui/field_reassign_with_default.rs
@@ -2,7 +2,7 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::field_reassign_with_default)]
-#![allow(clippy::assigning_clones)]
+#![allow(clippy::assigning_clones, clippy::relative_path_in_macro_definition)]
 
 #[macro_use]
 extern crate proc_macro_derive;

--- a/tests/ui/format_args.fixed
+++ b/tests/ui/format_args.fixed
@@ -5,6 +5,7 @@
     clippy::double_parens,
     clippy::eq_op,
     clippy::print_literal,
+    clippy::relative_path_in_macro_definition,
     clippy::uninlined_format_args
 )]
 

--- a/tests/ui/format_args.rs
+++ b/tests/ui/format_args.rs
@@ -5,6 +5,7 @@
     clippy::double_parens,
     clippy::eq_op,
     clippy::print_literal,
+    clippy::relative_path_in_macro_definition,
     clippy::uninlined_format_args
 )]
 

--- a/tests/ui/format_args.stderr
+++ b/tests/ui/format_args.stderr
@@ -1,5 +1,5 @@
 error: `to_string` applied to a type that implements `Display` in `format!` args
-  --> tests/ui/format_args.rs:77:72
+  --> tests/ui/format_args.rs:78:72
    |
 LL |     let _ = format!("error: something failed at {}", Location::caller().to_string());
    |                                                                        ^^^^^^^^^^^^ help: remove this
@@ -8,151 +8,151 @@ LL |     let _ = format!("error: something failed at {}", Location::caller().to_
    = help: to override `-D warnings` add `#[allow(clippy::to_string_in_format_args)]`
 
 error: `to_string` applied to a type that implements `Display` in `write!` args
-  --> tests/ui/format_args.rs:82:27
+  --> tests/ui/format_args.rs:83:27
    |
 LL |         Location::caller().to_string(),
    |                           ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `writeln!` args
-  --> tests/ui/format_args.rs:88:27
+  --> tests/ui/format_args.rs:89:27
    |
 LL |         Location::caller().to_string(),
    |                           ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `print!` args
-  --> tests/ui/format_args.rs:91:63
+  --> tests/ui/format_args.rs:92:63
    |
 LL |     print!("error: something failed at {}", Location::caller().to_string());
    |                                                               ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:93:65
+  --> tests/ui/format_args.rs:94:65
    |
 LL |     println!("error: something failed at {}", Location::caller().to_string());
    |                                                                 ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `eprint!` args
-  --> tests/ui/format_args.rs:95:64
+  --> tests/ui/format_args.rs:96:64
    |
 LL |     eprint!("error: something failed at {}", Location::caller().to_string());
    |                                                                ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `eprintln!` args
-  --> tests/ui/format_args.rs:97:66
+  --> tests/ui/format_args.rs:98:66
    |
 LL |     eprintln!("error: something failed at {}", Location::caller().to_string());
    |                                                                  ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `format_args!` args
-  --> tests/ui/format_args.rs:99:77
+  --> tests/ui/format_args.rs:100:77
    |
 LL |     let _ = format_args!("error: something failed at {}", Location::caller().to_string());
    |                                                                             ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `assert!` args
-  --> tests/ui/format_args.rs:101:70
+  --> tests/ui/format_args.rs:102:70
    |
 LL |     assert!(true, "error: something failed at {}", Location::caller().to_string());
    |                                                                      ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `assert_eq!` args
-  --> tests/ui/format_args.rs:103:73
+  --> tests/ui/format_args.rs:104:73
    |
 LL |     assert_eq!(0, 0, "error: something failed at {}", Location::caller().to_string());
    |                                                                         ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `assert_ne!` args
-  --> tests/ui/format_args.rs:105:73
+  --> tests/ui/format_args.rs:106:73
    |
 LL |     assert_ne!(0, 0, "error: something failed at {}", Location::caller().to_string());
    |                                                                         ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `panic!` args
-  --> tests/ui/format_args.rs:107:63
+  --> tests/ui/format_args.rs:108:63
    |
 LL |     panic!("error: something failed at {}", Location::caller().to_string());
    |                                                               ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:109:20
+  --> tests/ui/format_args.rs:110:20
    |
 LL |     println!("{}", X(1).to_string());
    |                    ^^^^^^^^^^^^^^^^ help: use this: `*X(1)`
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:111:20
+  --> tests/ui/format_args.rs:112:20
    |
 LL |     println!("{}", Y(&X(1)).to_string());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: use this: `***Y(&X(1))`
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:113:24
+  --> tests/ui/format_args.rs:114:24
    |
 LL |     println!("{}", Z(1).to_string());
    |                        ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:115:20
+  --> tests/ui/format_args.rs:116:20
    |
 LL |     println!("{}", x.to_string());
    |                    ^^^^^^^^^^^^^ help: use this: `**x`
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:117:20
+  --> tests/ui/format_args.rs:118:20
    |
 LL |     println!("{}", x_ref.to_string());
    |                    ^^^^^^^^^^^^^^^^^ help: use this: `***x_ref`
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:120:39
+  --> tests/ui/format_args.rs:121:39
    |
 LL |     println!("{foo}{bar}", foo = "foo".to_string(), bar = "bar");
    |                                       ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:122:52
+  --> tests/ui/format_args.rs:123:52
    |
 LL |     println!("{foo}{bar}", foo = "foo", bar = "bar".to_string());
    |                                                    ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:124:39
+  --> tests/ui/format_args.rs:125:39
    |
 LL |     println!("{foo}{bar}", bar = "bar".to_string(), foo = "foo");
    |                                       ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:126:52
+  --> tests/ui/format_args.rs:127:52
    |
 LL |     println!("{foo}{bar}", bar = "bar", foo = "foo".to_string());
    |                                                    ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:128:37
+  --> tests/ui/format_args.rs:129:37
    |
 LL |     println!("{}", my_other_macro!().to_string());
    |                                     ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `print!` args
-  --> tests/ui/format_args.rs:141:37
+  --> tests/ui/format_args.rs:142:37
    |
 LL |     print!("{}", (Location::caller().to_string()));
    |                                     ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `print!` args
-  --> tests/ui/format_args.rs:143:39
+  --> tests/ui/format_args.rs:144:39
    |
 LL |     print!("{}", ((Location::caller()).to_string()));
    |                                       ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `format!` args
-  --> tests/ui/format_args.rs:172:38
+  --> tests/ui/format_args.rs:173:38
    |
 LL |         let x = format!("{} {}", a, b.to_string());
    |                                      ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:187:24
+  --> tests/ui/format_args.rs:188:24
    |
 LL |         println!("{}", original[..10].to_string());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use this: `&original[..10]`

--- a/tests/ui/format_args_unfixable.rs
+++ b/tests/ui/format_args_unfixable.rs
@@ -1,6 +1,11 @@
 #![warn(clippy::format_in_format_args, clippy::to_string_in_format_args)]
 #![allow(unused)]
-#![allow(clippy::assertions_on_constants, clippy::eq_op, clippy::uninlined_format_args)]
+#![allow(
+    clippy::assertions_on_constants,
+    clippy::eq_op,
+    clippy::relative_path_in_macro_definition,
+    clippy::uninlined_format_args
+)]
 
 use std::io::{Error, Write, stdout};
 use std::ops::Deref;

--- a/tests/ui/format_args_unfixable.stderr
+++ b/tests/ui/format_args_unfixable.stderr
@@ -1,5 +1,5 @@
 error: `format!` in `println!` args
-  --> tests/ui/format_args_unfixable.rs:26:5
+  --> tests/ui/format_args_unfixable.rs:31:5
    |
 LL |     println!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     println!("error: {}", format!("something failed at {}", Location::calle
    = help: to override `-D warnings` add `#[allow(clippy::format_in_format_args)]`
 
 error: `format!` in `println!` args
-  --> tests/ui/format_args_unfixable.rs:29:5
+  --> tests/ui/format_args_unfixable.rs:34:5
    |
 LL |     println!("{}: {}", error, format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     println!("{}: {}", error, format!("something failed at {}", Location::c
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> tests/ui/format_args_unfixable.rs:32:5
+  --> tests/ui/format_args_unfixable.rs:37:5
    |
 LL |     println!("{:?}: {}", error, format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL |     println!("{:?}: {}", error, format!("something failed at {}", Location:
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> tests/ui/format_args_unfixable.rs:35:5
+  --> tests/ui/format_args_unfixable.rs:40:5
    |
 LL |     println!("{{}}: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL |     println!("{{}}: {}", format!("something failed at {}", Location::caller
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> tests/ui/format_args_unfixable.rs:38:5
+  --> tests/ui/format_args_unfixable.rs:43:5
    |
 LL |     println!(r#"error: "{}""#, format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -46,7 +46,7 @@ LL |     println!(r#"error: "{}""#, format!("something failed at {}", Location::
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> tests/ui/format_args_unfixable.rs:41:5
+  --> tests/ui/format_args_unfixable.rs:46:5
    |
 LL |     println!("error: {}", format!(r#"something failed at "{}""#, Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     println!("error: {}", format!(r#"something failed at "{}""#, Location::
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> tests/ui/format_args_unfixable.rs:44:5
+  --> tests/ui/format_args_unfixable.rs:49:5
    |
 LL |     println!("error: {}", format!("something failed at {} {0}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |     println!("error: {}", format!("something failed at {} {0}", Location::c
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `format!` args
-  --> tests/ui/format_args_unfixable.rs:47:13
+  --> tests/ui/format_args_unfixable.rs:52:13
    |
 LL |     let _ = format!("error: {}", format!("something failed at {}", Location::caller()));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     let _ = format!("error: {}", format!("something failed at {}", Location
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `write!` args
-  --> tests/ui/format_args_unfixable.rs:50:13
+  --> tests/ui/format_args_unfixable.rs:55:13
    |
 LL |       let _ = write!(
    |  _____________^
@@ -88,7 +88,7 @@ LL | |     );
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `writeln!` args
-  --> tests/ui/format_args_unfixable.rs:56:13
+  --> tests/ui/format_args_unfixable.rs:61:13
    |
 LL |       let _ = writeln!(
    |  _____________^
@@ -103,7 +103,7 @@ LL | |     );
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `print!` args
-  --> tests/ui/format_args_unfixable.rs:62:5
+  --> tests/ui/format_args_unfixable.rs:67:5
    |
 LL |     print!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +112,7 @@ LL |     print!("error: {}", format!("something failed at {}", Location::caller(
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `eprint!` args
-  --> tests/ui/format_args_unfixable.rs:65:5
+  --> tests/ui/format_args_unfixable.rs:70:5
    |
 LL |     eprint!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     eprint!("error: {}", format!("something failed at {}", Location::caller
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `eprintln!` args
-  --> tests/ui/format_args_unfixable.rs:68:5
+  --> tests/ui/format_args_unfixable.rs:73:5
    |
 LL |     eprintln!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -130,7 +130,7 @@ LL |     eprintln!("error: {}", format!("something failed at {}", Location::call
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `format_args!` args
-  --> tests/ui/format_args_unfixable.rs:71:13
+  --> tests/ui/format_args_unfixable.rs:76:13
    |
 LL |     let _ = format_args!("error: {}", format!("something failed at {}", Location::caller()));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,7 +139,7 @@ LL |     let _ = format_args!("error: {}", format!("something failed at {}", Loc
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `assert!` args
-  --> tests/ui/format_args_unfixable.rs:74:5
+  --> tests/ui/format_args_unfixable.rs:79:5
    |
 LL |     assert!(true, "error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -148,7 +148,7 @@ LL |     assert!(true, "error: {}", format!("something failed at {}", Location::
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `assert_eq!` args
-  --> tests/ui/format_args_unfixable.rs:77:5
+  --> tests/ui/format_args_unfixable.rs:82:5
    |
 LL |     assert_eq!(0, 0, "error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL |     assert_eq!(0, 0, "error: {}", format!("something failed at {}", Locatio
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `assert_ne!` args
-  --> tests/ui/format_args_unfixable.rs:80:5
+  --> tests/ui/format_args_unfixable.rs:85:5
    |
 LL |     assert_ne!(0, 0, "error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +166,7 @@ LL |     assert_ne!(0, 0, "error: {}", format!("something failed at {}", Locatio
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `panic!` args
-  --> tests/ui/format_args_unfixable.rs:83:5
+  --> tests/ui/format_args_unfixable.rs:88:5
    |
 LL |     panic!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -175,7 +175,7 @@ LL |     panic!("error: {}", format!("something failed at {}", Location::caller(
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `usr_println!` args
-  --> tests/ui/format_args_unfixable.rs:151:5
+  --> tests/ui/format_args_unfixable.rs:156:5
    |
 LL |     usr_println!(true, "error: {}", format!("boom at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -184,7 +184,7 @@ LL |     usr_println!(true, "error: {}", format!("boom at {}", Location::caller(
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `usr_println!` args
-  --> tests/ui/format_args_unfixable.rs:154:5
+  --> tests/ui/format_args_unfixable.rs:159:5
    |
 LL |     usr_println!(true, "{}: {}", error, format!("boom at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL |     usr_println!(true, "{}: {}", error, format!("boom at {}", Location::cal
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `usr_println!` args
-  --> tests/ui/format_args_unfixable.rs:157:5
+  --> tests/ui/format_args_unfixable.rs:162:5
    |
 LL |     usr_println!(true, "{:?}: {}", error, format!("boom at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -202,7 +202,7 @@ LL |     usr_println!(true, "{:?}: {}", error, format!("boom at {}", Location::c
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `usr_println!` args
-  --> tests/ui/format_args_unfixable.rs:160:5
+  --> tests/ui/format_args_unfixable.rs:165:5
    |
 LL |     usr_println!(true, "{{}}: {}", format!("boom at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -211,7 +211,7 @@ LL |     usr_println!(true, "{{}}: {}", format!("boom at {}", Location::caller()
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `usr_println!` args
-  --> tests/ui/format_args_unfixable.rs:163:5
+  --> tests/ui/format_args_unfixable.rs:168:5
    |
 LL |     usr_println!(true, r#"error: "{}""#, format!("boom at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -220,7 +220,7 @@ LL |     usr_println!(true, r#"error: "{}""#, format!("boom at {}", Location::ca
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `usr_println!` args
-  --> tests/ui/format_args_unfixable.rs:166:5
+  --> tests/ui/format_args_unfixable.rs:171:5
    |
 LL |     usr_println!(true, "error: {}", format!(r#"boom at "{}""#, Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ LL |     usr_println!(true, "error: {}", format!(r#"boom at "{}""#, Location::ca
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `usr_println!` args
-  --> tests/ui/format_args_unfixable.rs:169:5
+  --> tests/ui/format_args_unfixable.rs:174:5
    |
 LL |     usr_println!(true, "error: {}", format!("boom at {} {0}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/from_over_into_unfixable.rs
+++ b/tests/ui/from_over_into_unfixable.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::from_over_into)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 struct InMacro(String);
 

--- a/tests/ui/from_over_into_unfixable.stderr
+++ b/tests/ui/from_over_into_unfixable.stderr
@@ -1,5 +1,5 @@
 error: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
-  --> tests/ui/from_over_into_unfixable.rs:11:1
+  --> tests/ui/from_over_into_unfixable.rs:12:1
    |
 LL | impl Into<InMacro> for String {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | impl Into<InMacro> for String {
    = help: to override `-D warnings` add `#[allow(clippy::from_over_into)]`
 
 error: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
-  --> tests/ui/from_over_into_unfixable.rs:21:1
+  --> tests/ui/from_over_into_unfixable.rs:22:1
    |
 LL | impl Into<WeirdUpperSelf> for &'static [u8] {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | impl Into<WeirdUpperSelf> for &'static [u8] {
    = help: replace the `Into` implementation with `From<&'static [u8]>`
 
 error: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
-  --> tests/ui/from_over_into_unfixable.rs:32:1
+  --> tests/ui/from_over_into_unfixable.rs:33:1
    |
 LL | impl Into<u8> for ContainsVal {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL | impl Into<u8> for ContainsVal {
    = help: replace the `Into` implementation with `From<ContainsVal>`
 
 error: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
-  --> tests/ui/from_over_into_unfixable.rs:45:1
+  --> tests/ui/from_over_into_unfixable.rs:46:1
    |
 LL | impl<T> Into<Rval<Self>> for Lval<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/implicit_hasher.fixed
+++ b/tests/ui/implicit_hasher.fixed
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![deny(clippy::implicit_hasher)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/implicit_hasher.rs
+++ b/tests/ui/implicit_hasher.rs
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![deny(clippy::implicit_hasher)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/implicit_hasher.stderr
+++ b/tests/ui/implicit_hasher.stderr
@@ -1,5 +1,5 @@
 error: impl for `HashMap` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:15:35
+  --> tests/ui/implicit_hasher.rs:16:35
    |
 LL | impl<K: Hash + Eq, V> Foo<i8> for HashMap<K, V> {
    |                                   ^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL ~         (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default:
    |
 
 error: impl for `HashMap` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:25:36
+  --> tests/ui/implicit_hasher.rs:26:36
    |
 LL | impl<K: Hash + Eq, V> Foo<i8> for (HashMap<K, V>,) {
    |                                    ^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL ~         ((HashMap::default(),), (HashMap::with_capacity_and_hasher(10, Defa
    |
 
 error: impl for `HashMap` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:31:19
+  --> tests/ui/implicit_hasher.rs:32:19
    |
 LL | impl Foo<i16> for HashMap<String, String> {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL ~         (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default:
    |
 
 error: impl for `HashSet` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:49:32
+  --> tests/ui/implicit_hasher.rs:50:32
    |
 LL | impl<T: Hash + Eq> Foo<i8> for HashSet<T> {
    |                                ^^^^^^^^^^
@@ -61,7 +61,7 @@ LL ~         (HashSet::default(), HashSet::with_capacity_and_hasher(10, Default:
    |
 
 error: impl for `HashSet` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:55:19
+  --> tests/ui/implicit_hasher.rs:56:19
    |
 LL | impl Foo<i16> for HashSet<String> {
    |                   ^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL ~         (HashSet::default(), HashSet::with_capacity_and_hasher(10, Default:
    |
 
 error: parameter of type `HashMap` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:73:22
+  --> tests/ui/implicit_hasher.rs:74:22
    |
 LL | pub fn map(map: &mut HashMap<i32, i32>) {}
    |                      ^^^^^^^^^^^^^^^^^
@@ -86,7 +86,7 @@ LL | pub fn map<S: ::std::hash::BuildHasher>(map: &mut HashMap<i32, i32, S>) {}
    |           +++++++++++++++++++++++++++++                           +++
 
 error: parameter of type `HashSet` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:76:22
+  --> tests/ui/implicit_hasher.rs:77:22
    |
 LL | pub fn set(set: &mut HashSet<i32>) {}
    |                      ^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL | pub fn set<S: ::std::hash::BuildHasher>(set: &mut HashSet<i32, S>) {}
    |           +++++++++++++++++++++++++++++                      +++
 
 error: impl for `HashMap` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:83:43
+  --> tests/ui/implicit_hasher.rs:84:43
    |
 LL |         impl<K: Hash + Eq, V> Foo<u8> for HashMap<K, V> {
    |                                           ^^^^^^^^^^^^^
@@ -112,7 +112,7 @@ LL ~                 (HashMap::default(), HashMap::with_capacity_and_hasher(10, 
    |
 
 error: parameter of type `HashMap` should be generalized over different hashers
-  --> tests/ui/implicit_hasher.rs:108:35
+  --> tests/ui/implicit_hasher.rs:109:35
    |
 LL | pub async fn election_vote(_data: HashMap<i32, i32>) {}
    |                                   ^^^^^^^^^^^^^^^^^

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::incompatible_msrv)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![feature(custom_inner_attributes)]
 #![feature(panic_internals)]
 #![clippy::msrv = "1.3.0"]

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -1,5 +1,5 @@
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.10.0`
-  --> tests/ui/incompatible_msrv.rs:14:39
+  --> tests/ui/incompatible_msrv.rs:15:39
    |
 LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    |                                       ^^^^^
@@ -8,25 +8,25 @@ LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.12.0`
-  --> tests/ui/incompatible_msrv.rs:18:11
+  --> tests/ui/incompatible_msrv.rs:19:11
    |
 LL |         v.into_key();
    |           ^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.4.0`
-  --> tests/ui/incompatible_msrv.rs:22:5
+  --> tests/ui/incompatible_msrv.rs:23:5
    |
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:46:9
+  --> tests/ui/incompatible_msrv.rs:47:9
    |
 LL |         core::panicking::panic("foo");
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:53:13
+  --> tests/ui/incompatible_msrv.rs:54:13
    |
 LL |             core::panicking::panic($msg)
    |             ^^^^^^^^^^^^^^^^^^^^^^
@@ -37,13 +37,13 @@ LL |     my_panic!("foo");
    = note: this error originates in the macro `my_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:59:13
+  --> tests/ui/incompatible_msrv.rs:60:13
    |
 LL |     assert!(core::panicking::panic("out of luck"));
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.80.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:72:13
+  --> tests/ui/incompatible_msrv.rs:73:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/infallible_destructuring_match.fixed
+++ b/tests/ui/infallible_destructuring_match.fixed
@@ -1,6 +1,10 @@
 #![feature(exhaustive_patterns, never_type)]
 #![allow(dead_code, unreachable_code, unused_variables)]
-#![allow(clippy::let_and_return, clippy::uninhabited_references)]
+#![allow(
+    clippy::let_and_return,
+    clippy::relative_path_in_macro_definition,
+    clippy::uninhabited_references
+)]
 
 enum SingleVariantEnum {
     Variant(i32),

--- a/tests/ui/infallible_destructuring_match.rs
+++ b/tests/ui/infallible_destructuring_match.rs
@@ -1,6 +1,10 @@
 #![feature(exhaustive_patterns, never_type)]
 #![allow(dead_code, unreachable_code, unused_variables)]
-#![allow(clippy::let_and_return, clippy::uninhabited_references)]
+#![allow(
+    clippy::let_and_return,
+    clippy::relative_path_in_macro_definition,
+    clippy::uninhabited_references
+)]
 
 enum SingleVariantEnum {
     Variant(i32),

--- a/tests/ui/infallible_destructuring_match.stderr
+++ b/tests/ui/infallible_destructuring_match.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
-  --> tests/ui/infallible_destructuring_match.rs:28:5
+  --> tests/ui/infallible_destructuring_match.rs:32:5
    |
 LL | /     let data = match wrapper {
 LL | |
@@ -11,7 +11,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::infallible_destructuring_match)]`
 
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
-  --> tests/ui/infallible_destructuring_match.rs:61:5
+  --> tests/ui/infallible_destructuring_match.rs:65:5
    |
 LL | /     let data = match wrapper {
 LL | |
@@ -20,7 +20,7 @@ LL | |     };
    | |______^ help: try: `let TupleStruct(data) = wrapper;`
 
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
-  --> tests/ui/infallible_destructuring_match.rs:86:5
+  --> tests/ui/infallible_destructuring_match.rs:90:5
    |
 LL | /     let data = match wrapper {
 LL | |
@@ -29,7 +29,7 @@ LL | |     };
    | |______^ help: try: `let TupleStructWithNonCopy(ref data) = wrapper;`
 
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
-  --> tests/ui/infallible_destructuring_match.rs:106:5
+  --> tests/ui/infallible_destructuring_match.rs:110:5
    |
 LL | /     let data = match wrapper {
 LL | |

--- a/tests/ui/into_iter_without_iter.rs
+++ b/tests/ui/into_iter_without_iter.rs
@@ -1,6 +1,7 @@
 //@no-rustfix: suggestions reference out of scope lifetimes/types
 //@aux-build:proc_macros.rs
 #![warn(clippy::into_iter_without_iter)]
+#![allow(clippy::relative_path_in_macro_definition)]
 extern crate proc_macros;
 
 use std::iter::IntoIterator;

--- a/tests/ui/into_iter_without_iter.stderr
+++ b/tests/ui/into_iter_without_iter.stderr
@@ -1,5 +1,5 @@
 error: `IntoIterator` implemented for a reference type without an `iter` method
-  --> tests/ui/into_iter_without_iter.rs:9:1
+  --> tests/ui/into_iter_without_iter.rs:10:1
    |
 LL | / impl<'a> IntoIterator for &'a S1 {
 LL | |
@@ -22,7 +22,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter_mut` method
-  --> tests/ui/into_iter_without_iter.rs:17:1
+  --> tests/ui/into_iter_without_iter.rs:18:1
    |
 LL | / impl<'a> IntoIterator for &'a mut S1 {
 LL | |
@@ -43,7 +43,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter` method
-  --> tests/ui/into_iter_without_iter.rs:27:1
+  --> tests/ui/into_iter_without_iter.rs:28:1
    |
 LL | / impl<'a, T> IntoIterator for &'a S2<T> {
 LL | |
@@ -64,7 +64,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter_mut` method
-  --> tests/ui/into_iter_without_iter.rs:35:1
+  --> tests/ui/into_iter_without_iter.rs:36:1
    |
 LL | / impl<'a, T> IntoIterator for &'a mut S2<T> {
 LL | |
@@ -85,7 +85,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter_mut` method
-  --> tests/ui/into_iter_without_iter.rs:86:1
+  --> tests/ui/into_iter_without_iter.rs:87:1
    |
 LL | / impl<'a, T> IntoIterator for &mut S4<'a, T> {
 LL | |
@@ -106,7 +106,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter` method
-  --> tests/ui/into_iter_without_iter.rs:120:9
+  --> tests/ui/into_iter_without_iter.rs:121:9
    |
 LL | /         impl<'a> IntoIterator for &'a Issue12037 {
 LL | |

--- a/tests/ui/io_other_error.fixed
+++ b/tests/ui/io_other_error.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::io_other_error)]
+#![allow(clippy::relative_path_in_macro_definition)]
 use std::fmt;
 
 #[derive(Debug)]

--- a/tests/ui/io_other_error.rs
+++ b/tests/ui/io_other_error.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::io_other_error)]
+#![allow(clippy::relative_path_in_macro_definition)]
 use std::fmt;
 
 #[derive(Debug)]

--- a/tests/ui/io_other_error.stderr
+++ b/tests/ui/io_other_error.stderr
@@ -1,5 +1,5 @@
 error: this can be `std::io::Error::other(_)`
-  --> tests/ui/io_other_error.rs:23:16
+  --> tests/ui/io_other_error.rs:24:16
    |
 LL |     let _err = std::io::Error::new(std::io::ErrorKind::Other, E);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     let _err = std::io::Error::other(E);
    |
 
 error: this can be `std::io::Error::other(_)`
-  --> tests/ui/io_other_error.rs:26:16
+  --> tests/ui/io_other_error.rs:27:16
    |
 LL |     let _err = std::io::Error::new(other, E);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     let _err = std::io::Error::other(E);
    |
 
 error: this can be `std::io::Error::other(_)`
-  --> tests/ui/io_other_error.rs:45:20
+  --> tests/ui/io_other_error.rs:46:20
    |
 LL |         let _err = Error::new(ErrorKind::Other, super::E);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL +         let _err = Error::other(super::E);
    |
 
 error: this can be `std::io::Error::other(_)`
-  --> tests/ui/io_other_error.rs:47:20
+  --> tests/ui/io_other_error.rs:48:20
    |
 LL |         let _err = io::Error::new(io::ErrorKind::Other, super::E);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +         let _err = io::Error::other(super::E);
    |
 
 error: this can be `std::io::Error::other(_)`
-  --> tests/ui/io_other_error.rs:58:5
+  --> tests/ui/io_other_error.rs:59:5
    |
 LL |     std::io::Error::new(std::io::ErrorKind::Other, format!("{x}"))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/iter_on_empty_collections.fixed
+++ b/tests/ui/iter_on_empty_collections.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::iter_on_empty_collections)]
-#![allow(clippy::iter_next_slice, clippy::redundant_clone)]
+#![allow(
+    clippy::iter_next_slice,
+    clippy::redundant_clone,
+    clippy::relative_path_in_macro_definition
+)]
 
 fn array() {
     assert_eq!(std::iter::empty().next(), Option::<i32>::None);

--- a/tests/ui/iter_on_empty_collections.rs
+++ b/tests/ui/iter_on_empty_collections.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::iter_on_empty_collections)]
-#![allow(clippy::iter_next_slice, clippy::redundant_clone)]
+#![allow(
+    clippy::iter_next_slice,
+    clippy::redundant_clone,
+    clippy::relative_path_in_macro_definition
+)]
 
 fn array() {
     assert_eq!([].into_iter().next(), Option::<i32>::None);

--- a/tests/ui/iter_on_empty_collections.stderr
+++ b/tests/ui/iter_on_empty_collections.stderr
@@ -1,5 +1,5 @@
 error: `into_iter` call on an empty collection
-  --> tests/ui/iter_on_empty_collections.rs:5:16
+  --> tests/ui/iter_on_empty_collections.rs:9:16
    |
 LL |     assert_eq!([].into_iter().next(), Option::<i32>::None);
    |                ^^^^^^^^^^^^^^ help: try: `std::iter::empty()`
@@ -8,37 +8,37 @@ LL |     assert_eq!([].into_iter().next(), Option::<i32>::None);
    = help: to override `-D warnings` add `#[allow(clippy::iter_on_empty_collections)]`
 
 error: `iter_mut` call on an empty collection
-  --> tests/ui/iter_on_empty_collections.rs:7:16
+  --> tests/ui/iter_on_empty_collections.rs:11:16
    |
 LL |     assert_eq!([].iter_mut().next(), Option::<&mut i32>::None);
    |                ^^^^^^^^^^^^^ help: try: `std::iter::empty()`
 
 error: `iter` call on an empty collection
-  --> tests/ui/iter_on_empty_collections.rs:9:16
+  --> tests/ui/iter_on_empty_collections.rs:13:16
    |
 LL |     assert_eq!([].iter().next(), Option::<&i32>::None);
    |                ^^^^^^^^^ help: try: `std::iter::empty()`
 
 error: `into_iter` call on an empty collection
-  --> tests/ui/iter_on_empty_collections.rs:11:16
+  --> tests/ui/iter_on_empty_collections.rs:15:16
    |
 LL |     assert_eq!(None.into_iter().next(), Option::<i32>::None);
    |                ^^^^^^^^^^^^^^^^ help: try: `std::iter::empty()`
 
 error: `iter_mut` call on an empty collection
-  --> tests/ui/iter_on_empty_collections.rs:13:16
+  --> tests/ui/iter_on_empty_collections.rs:17:16
    |
 LL |     assert_eq!(None.iter_mut().next(), Option::<&mut i32>::None);
    |                ^^^^^^^^^^^^^^^ help: try: `std::iter::empty()`
 
 error: `iter` call on an empty collection
-  --> tests/ui/iter_on_empty_collections.rs:15:16
+  --> tests/ui/iter_on_empty_collections.rs:19:16
    |
 LL |     assert_eq!(None.iter().next(), Option::<&i32>::None);
    |                ^^^^^^^^^^^ help: try: `std::iter::empty()`
 
 error: `iter` call on an empty collection
-  --> tests/ui/iter_on_empty_collections.rs:34:66
+  --> tests/ui/iter_on_empty_collections.rs:38:66
    |
 LL |     for i in smth.as_ref().map_or([].iter(), |s| s.iter()).chain([].iter()) {
    |                                                                  ^^^^^^^^^ help: try: `std::iter::empty()`

--- a/tests/ui/iter_without_into_iter.rs
+++ b/tests/ui/iter_without_into_iter.rs
@@ -1,7 +1,7 @@
 //@no-rustfix
 //@aux-build:proc_macros.rs
 #![warn(clippy::iter_without_into_iter)]
-#![allow(clippy::needless_lifetimes)]
+#![allow(clippy::needless_lifetimes, clippy::relative_path_in_macro_definition)]
 extern crate proc_macros;
 
 pub struct S1;

--- a/tests/ui/large_futures.fixed
+++ b/tests/ui/large_futures.fixed
@@ -2,6 +2,7 @@
     clippy::future_not_send,
     clippy::manual_async_fn,
     clippy::never_loop,
+    clippy::relative_path_in_macro_definition,
     clippy::uninlined_format_args
 )]
 #![warn(clippy::large_futures)]

--- a/tests/ui/large_futures.rs
+++ b/tests/ui/large_futures.rs
@@ -2,6 +2,7 @@
     clippy::future_not_send,
     clippy::manual_async_fn,
     clippy::never_loop,
+    clippy::relative_path_in_macro_definition,
     clippy::uninlined_format_args
 )]
 #![warn(clippy::large_futures)]

--- a/tests/ui/large_futures.stderr
+++ b/tests/ui/large_futures.stderr
@@ -1,5 +1,5 @@
 error: large future with a size of 16385 bytes
-  --> tests/ui/large_futures.rs:13:9
+  --> tests/ui/large_futures.rs:14:9
    |
 LL |         big_fut([0u8; 1024 * 16]).await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(big_fut([0u8; 1024 * 16]))`
@@ -8,37 +8,37 @@ LL |         big_fut([0u8; 1024 * 16]).await;
    = help: to override `-D warnings` add `#[allow(clippy::large_futures)]`
 
 error: large future with a size of 16386 bytes
-  --> tests/ui/large_futures.rs:16:5
+  --> tests/ui/large_futures.rs:17:5
    |
 LL |     f.await
    |     ^ help: consider `Box::pin` on it: `Box::pin(f)`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:21:9
+  --> tests/ui/large_futures.rs:22:9
    |
 LL |         wait().await;
    |         ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:27:13
+  --> tests/ui/large_futures.rs:28:13
    |
 LL |             wait().await;
    |             ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:35:5
+  --> tests/ui/large_futures.rs:36:5
    |
 LL |     foo().await;
    |     ^^^^^ help: consider `Box::pin` on it: `Box::pin(foo())`
 
 error: large future with a size of 49159 bytes
-  --> tests/ui/large_futures.rs:38:5
+  --> tests/ui/large_futures.rs:39:5
    |
 LL |     calls_fut(fut).await;
    |     ^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(calls_fut(fut))`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:51:5
+  --> tests/ui/large_futures.rs:52:5
    |
 LL | /     async {
 LL | |
@@ -61,7 +61,7 @@ LL +     })
    |
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:64:13
+  --> tests/ui/large_futures.rs:65:13
    |
 LL | /             async {
 LL | |

--- a/tests/ui/legacy_numeric_constants.fixed
+++ b/tests/ui/legacy_numeric_constants.fixed
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 //@require-annotations-for-level: WARN
 #![allow(clippy::no_effect, deprecated, unused)]
-#![allow(clippy::legacy_numeric_constants)] // For imports.
+#![allow(clippy::legacy_numeric_constants, clippy::relative_path_in_macro_definition)] // For imports.
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/legacy_numeric_constants.rs
+++ b/tests/ui/legacy_numeric_constants.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 //@require-annotations-for-level: WARN
 #![allow(clippy::no_effect, deprecated, unused)]
-#![allow(clippy::legacy_numeric_constants)] // For imports.
+#![allow(clippy::legacy_numeric_constants, clippy::relative_path_in_macro_definition)] // For imports.
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/legacy_numeric_constants_unfixable.rs
+++ b/tests/ui/legacy_numeric_constants_unfixable.rs
@@ -1,7 +1,7 @@
 //@no-rustfix
 //@require-annotations-for-level: WARN
 //@aux-build:proc_macros.rs
-#![allow(clippy::no_effect, deprecated, unused)]
+#![allow(clippy::no_effect, clippy::relative_path_in_macro_definition, deprecated, unused)]
 #![warn(clippy::legacy_numeric_constants)]
 
 #[macro_use]

--- a/tests/ui/let_and_return.edition2021.fixed
+++ b/tests/ui/let_and_return.edition2021.fixed
@@ -3,6 +3,7 @@
 //@[edition2024] edition:2024
 
 #![allow(unused)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::let_and_return)]
 
 use std::cell::RefCell;

--- a/tests/ui/let_and_return.edition2021.stderr
+++ b/tests/ui/let_and_return.edition2021.stderr
@@ -1,5 +1,5 @@
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:13:5
+  --> tests/ui/let_and_return.rs:14:5
    |
 LL |     let x = 5;
    |     ---------- unnecessary `let` binding
@@ -15,7 +15,7 @@ LL ~     5
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:20:9
+  --> tests/ui/let_and_return.rs:21:9
    |
 LL |         let x = 5;
    |         ---------- unnecessary `let` binding
@@ -29,7 +29,7 @@ LL ~         5
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:83:5
+  --> tests/ui/let_and_return.rs:84:5
    |
 LL |     let line = stdin.lock().lines().next().unwrap().unwrap();
    |     --------------------------------------------------------- unnecessary `let` binding
@@ -43,7 +43,7 @@ LL ~     stdin.lock().lines().next().unwrap().unwrap()
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:178:13
+  --> tests/ui/let_and_return.rs:179:13
    |
 LL |             let clone = Arc::clone(&self.foo);
    |             ---------------------------------- unnecessary `let` binding
@@ -57,7 +57,7 @@ LL ~             (Arc::clone(&self.foo)) as _
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:197:13
+  --> tests/ui/let_and_return.rs:198:13
    |
 LL | /             let result = match self {
 LL | |                 E::A(x) => x,
@@ -79,7 +79,7 @@ LL +             }) as _
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:223:9
+  --> tests/ui/let_and_return.rs:224:9
    |
 LL |         let s = if true { "a".to_string() } else { "b".to_string() } + "c";
    |         ------------------------------------------------------------------- unnecessary `let` binding
@@ -93,7 +93,7 @@ LL ~         (if true { "a".to_string() } else { "b".to_string() } + "c")
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:229:9
+  --> tests/ui/let_and_return.rs:230:9
    |
 LL |         let s = "c".to_string() + if true { "a" } else { "b" };
    |         ------------------------------------------------------- unnecessary `let` binding
@@ -107,7 +107,7 @@ LL ~         "c".to_string() + if true { "a" } else { "b" }
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:235:9
+  --> tests/ui/let_and_return.rs:236:9
    |
 LL |         let s = { "a".to_string() } + "b" + { "c" } + "d";
    |         -------------------------------------------------- unnecessary `let` binding
@@ -121,7 +121,7 @@ LL ~         ({ "a".to_string() } + "b" + { "c" } + "d")
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:243:13
+  --> tests/ui/let_and_return.rs:244:13
    |
 LL |             let s = if true { 2 } else { 3 } << 4;
    |             -------------------------------------- unnecessary `let` binding
@@ -135,7 +135,7 @@ LL ~             (if true { 2 } else { 3 } << 4)
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:248:13
+  --> tests/ui/let_and_return.rs:249:13
    |
 LL |             let s = { true } || { false } && { 2 <= 3 };
    |             -------------------------------------------- unnecessary `let` binding

--- a/tests/ui/let_and_return.edition2024.fixed
+++ b/tests/ui/let_and_return.edition2024.fixed
@@ -3,6 +3,7 @@
 //@[edition2024] edition:2024
 
 #![allow(unused)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::let_and_return)]
 
 use std::cell::RefCell;

--- a/tests/ui/let_and_return.edition2024.stderr
+++ b/tests/ui/let_and_return.edition2024.stderr
@@ -1,5 +1,5 @@
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:13:5
+  --> tests/ui/let_and_return.rs:14:5
    |
 LL |     let x = 5;
    |     ---------- unnecessary `let` binding
@@ -15,7 +15,7 @@ LL ~     5
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:20:9
+  --> tests/ui/let_and_return.rs:21:9
    |
 LL |         let x = 5;
    |         ---------- unnecessary `let` binding
@@ -29,7 +29,7 @@ LL ~         5
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:83:5
+  --> tests/ui/let_and_return.rs:84:5
    |
 LL |     let line = stdin.lock().lines().next().unwrap().unwrap();
    |     --------------------------------------------------------- unnecessary `let` binding
@@ -43,7 +43,7 @@ LL ~     stdin.lock().lines().next().unwrap().unwrap()
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:106:9
+  --> tests/ui/let_and_return.rs:107:9
    |
 LL |         let ret = value.borrow().baz();
    |         ------------------------------- unnecessary `let` binding
@@ -57,7 +57,7 @@ LL ~         value.borrow().baz()
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:117:9
+  --> tests/ui/let_and_return.rs:118:9
    |
 LL |         let ret = f(|| value.borrow().baz())();
    |         --------------------------------------- unnecessary `let` binding
@@ -71,7 +71,7 @@ LL ~         f(|| value.borrow().baz())()
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:149:13
+  --> tests/ui/let_and_return.rs:150:13
    |
 LL |             let value = some_foo(&x).value();
    |             --------------------------------- unnecessary `let` binding
@@ -85,7 +85,7 @@ LL ~             some_foo(&x).value()
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:156:13
+  --> tests/ui/let_and_return.rs:157:13
    |
 LL |             let value = Foo::new(&x).value();
    |             --------------------------------- unnecessary `let` binding
@@ -99,7 +99,7 @@ LL ~             Foo::new(&x).value()
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:178:13
+  --> tests/ui/let_and_return.rs:179:13
    |
 LL |             let clone = Arc::clone(&self.foo);
    |             ---------------------------------- unnecessary `let` binding
@@ -113,7 +113,7 @@ LL ~             (Arc::clone(&self.foo)) as _
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:197:13
+  --> tests/ui/let_and_return.rs:198:13
    |
 LL | /             let result = match self {
 LL | |                 E::A(x) => x,
@@ -135,7 +135,7 @@ LL +             }) as _
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:223:9
+  --> tests/ui/let_and_return.rs:224:9
    |
 LL |         let s = if true { "a".to_string() } else { "b".to_string() } + "c";
    |         ------------------------------------------------------------------- unnecessary `let` binding
@@ -149,7 +149,7 @@ LL ~         (if true { "a".to_string() } else { "b".to_string() } + "c")
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:229:9
+  --> tests/ui/let_and_return.rs:230:9
    |
 LL |         let s = "c".to_string() + if true { "a" } else { "b" };
    |         ------------------------------------------------------- unnecessary `let` binding
@@ -163,7 +163,7 @@ LL ~         "c".to_string() + if true { "a" } else { "b" }
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:235:9
+  --> tests/ui/let_and_return.rs:236:9
    |
 LL |         let s = { "a".to_string() } + "b" + { "c" } + "d";
    |         -------------------------------------------------- unnecessary `let` binding
@@ -177,7 +177,7 @@ LL ~         ({ "a".to_string() } + "b" + { "c" } + "d")
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:243:13
+  --> tests/ui/let_and_return.rs:244:13
    |
 LL |             let s = if true { 2 } else { 3 } << 4;
    |             -------------------------------------- unnecessary `let` binding
@@ -191,7 +191,7 @@ LL ~             (if true { 2 } else { 3 } << 4)
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:248:13
+  --> tests/ui/let_and_return.rs:249:13
    |
 LL |             let s = { true } || { false } && { 2 <= 3 };
    |             -------------------------------------------- unnecessary `let` binding
@@ -205,7 +205,7 @@ LL ~             ({ true } || { false } && { 2 <= 3 })
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:260:5
+  --> tests/ui/let_and_return.rs:261:5
    |
 LL | /     let r = match &*v.borrow() {
 LL | |         Some(v) => Ok(Ok(v[0])),

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -3,6 +3,7 @@
 //@[edition2024] edition:2024
 
 #![allow(unused)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::let_and_return)]
 
 use std::cell::RefCell;

--- a/tests/ui/macro_use_imports.fixed
+++ b/tests/ui/macro_use_imports.fixed
@@ -5,7 +5,7 @@
 //@ignore-bitwidth: 32
 
 #![allow(unused_imports, unreachable_code, unused_variables, dead_code, unused_attributes)]
-#![allow(clippy::single_component_path_imports)]
+#![allow(clippy::relative_path_in_macro_definition, clippy::single_component_path_imports)]
 #![warn(clippy::macro_use_imports)]
 
 #[macro_use]

--- a/tests/ui/macro_use_imports.rs
+++ b/tests/ui/macro_use_imports.rs
@@ -5,7 +5,7 @@
 //@ignore-bitwidth: 32
 
 #![allow(unused_imports, unreachable_code, unused_variables, dead_code, unused_attributes)]
-#![allow(clippy::single_component_path_imports)]
+#![allow(clippy::relative_path_in_macro_definition, clippy::single_component_path_imports)]
 #![warn(clippy::macro_use_imports)]
 
 #[macro_use]

--- a/tests/ui/macro_use_imports_expect.rs
+++ b/tests/ui/macro_use_imports_expect.rs
@@ -5,7 +5,7 @@
 //@ignore-bitwidth: 32
 
 #![allow(unused_imports, unreachable_code, unused_variables, dead_code, unused_attributes)]
-#![allow(clippy::single_component_path_imports)]
+#![allow(clippy::relative_path_in_macro_definition, clippy::single_component_path_imports)]
 #![warn(clippy::macro_use_imports)]
 
 #[macro_use]

--- a/tests/ui/manual_bits.fixed
+++ b/tests/ui/manual_bits.fixed
@@ -1,6 +1,7 @@
 #![warn(clippy::manual_bits)]
 #![allow(
     clippy::no_effect,
+    clippy::relative_path_in_macro_definition,
     clippy::useless_conversion,
     path_statements,
     unused_must_use,

--- a/tests/ui/manual_bits.rs
+++ b/tests/ui/manual_bits.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::manual_bits)]
 #![allow(
     clippy::no_effect,
+    clippy::relative_path_in_macro_definition,
     clippy::useless_conversion,
     path_statements,
     unused_must_use,

--- a/tests/ui/manual_bits.stderr
+++ b/tests/ui/manual_bits.stderr
@@ -1,5 +1,5 @@
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:14:5
+  --> tests/ui/manual_bits.rs:15:5
    |
 LL |     size_of::<i8>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `i8::BITS as usize`
@@ -8,169 +8,169 @@ LL |     size_of::<i8>() * 8;
    = help: to override `-D warnings` add `#[allow(clippy::manual_bits)]`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:16:5
+  --> tests/ui/manual_bits.rs:17:5
    |
 LL |     size_of::<i16>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i16::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:18:5
+  --> tests/ui/manual_bits.rs:19:5
    |
 LL |     size_of::<i32>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i32::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:20:5
+  --> tests/ui/manual_bits.rs:21:5
    |
 LL |     size_of::<i64>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i64::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:22:5
+  --> tests/ui/manual_bits.rs:23:5
    |
 LL |     size_of::<i128>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `i128::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:24:5
+  --> tests/ui/manual_bits.rs:25:5
    |
 LL |     size_of::<isize>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `isize::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:27:5
+  --> tests/ui/manual_bits.rs:28:5
    |
 LL |     size_of::<u8>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `u8::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:29:5
+  --> tests/ui/manual_bits.rs:30:5
    |
 LL |     size_of::<u16>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u16::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:31:5
+  --> tests/ui/manual_bits.rs:32:5
    |
 LL |     size_of::<u32>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u32::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:33:5
+  --> tests/ui/manual_bits.rs:34:5
    |
 LL |     size_of::<u64>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u64::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:35:5
+  --> tests/ui/manual_bits.rs:36:5
    |
 LL |     size_of::<u128>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:37:5
+  --> tests/ui/manual_bits.rs:38:5
    |
 LL |     size_of::<usize>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `usize::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:40:5
+  --> tests/ui/manual_bits.rs:41:5
    |
 LL |     8 * size_of::<i8>();
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `i8::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:42:5
+  --> tests/ui/manual_bits.rs:43:5
    |
 LL |     8 * size_of::<i16>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i16::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:44:5
+  --> tests/ui/manual_bits.rs:45:5
    |
 LL |     8 * size_of::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i32::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:46:5
+  --> tests/ui/manual_bits.rs:47:5
    |
 LL |     8 * size_of::<i64>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i64::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:48:5
+  --> tests/ui/manual_bits.rs:49:5
    |
 LL |     8 * size_of::<i128>();
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `i128::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:50:5
+  --> tests/ui/manual_bits.rs:51:5
    |
 LL |     8 * size_of::<isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `isize::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:53:5
+  --> tests/ui/manual_bits.rs:54:5
    |
 LL |     8 * size_of::<u8>();
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `u8::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:55:5
+  --> tests/ui/manual_bits.rs:56:5
    |
 LL |     8 * size_of::<u16>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u16::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:57:5
+  --> tests/ui/manual_bits.rs:58:5
    |
 LL |     8 * size_of::<u32>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u32::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:59:5
+  --> tests/ui/manual_bits.rs:60:5
    |
 LL |     8 * size_of::<u64>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u64::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:61:5
+  --> tests/ui/manual_bits.rs:62:5
    |
 LL |     8 * size_of::<u128>();
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:63:5
+  --> tests/ui/manual_bits.rs:64:5
    |
 LL |     8 * size_of::<usize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `usize::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:74:5
+  --> tests/ui/manual_bits.rs:75:5
    |
 LL |     size_of::<Word>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `Word::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:79:18
+  --> tests/ui/manual_bits.rs:80:18
    |
 LL |     let _: u32 = (size_of::<u128>() * 8) as u32;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:81:18
+  --> tests/ui/manual_bits.rs:82:18
    |
 LL |     let _: u32 = (size_of::<u128>() * 8).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:83:13
+  --> tests/ui/manual_bits.rs:84:13
    |
 LL |     let _ = (size_of::<u128>() * 8).pow(5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(u128::BITS as usize)`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:85:14
+  --> tests/ui/manual_bits.rs:86:14
    |
 LL |     let _ = &(size_of::<u128>() * 8);
    |              ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(u128::BITS as usize)`

--- a/tests/ui/manual_c_str_literals.edition2021.fixed
+++ b/tests/ui/manual_c_str_literals.edition2021.fixed
@@ -3,7 +3,7 @@
 //@[edition2021] edition:2021
 //@[edition2018] check-pass
 #![warn(clippy::manual_c_str_literals)]
-#![allow(clippy::no_effect)]
+#![allow(clippy::no_effect, clippy::relative_path_in_macro_definition)]
 
 use std::ffi::CStr;
 

--- a/tests/ui/manual_c_str_literals.rs
+++ b/tests/ui/manual_c_str_literals.rs
@@ -3,7 +3,7 @@
 //@[edition2021] edition:2021
 //@[edition2018] check-pass
 #![warn(clippy::manual_c_str_literals)]
-#![allow(clippy::no_effect)]
+#![allow(clippy::no_effect, clippy::relative_path_in_macro_definition)]
 
 use std::ffi::CStr;
 

--- a/tests/ui/match_ref_pats.fixed
+++ b/tests/ui/match_ref_pats.fixed
@@ -1,6 +1,7 @@
 #![warn(clippy::match_ref_pats)]
 #![allow(dead_code, unused_variables)]
 #![allow(clippy::enum_variant_names, clippy::equatable_if_let, clippy::uninlined_format_args)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 fn ref_pats() {
     {

--- a/tests/ui/match_ref_pats.rs
+++ b/tests/ui/match_ref_pats.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::match_ref_pats)]
 #![allow(dead_code, unused_variables)]
 #![allow(clippy::enum_variant_names, clippy::equatable_if_let, clippy::uninlined_format_args)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 fn ref_pats() {
     {

--- a/tests/ui/match_ref_pats.stderr
+++ b/tests/ui/match_ref_pats.stderr
@@ -1,5 +1,5 @@
 error: you don't need to add `&` to all patterns
-  --> tests/ui/match_ref_pats.rs:8:9
+  --> tests/ui/match_ref_pats.rs:9:9
    |
 LL | /         match v {
 LL | |
@@ -19,7 +19,7 @@ LL ~             None => println!("none"),
    |
 
 error: you don't need to add `&` to both the expression and the patterns
-  --> tests/ui/match_ref_pats.rs:26:5
+  --> tests/ui/match_ref_pats.rs:27:5
    |
 LL | /     match &w {
 LL | |
@@ -37,7 +37,7 @@ LL ~         None => println!("none"),
    |
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/match_ref_pats.rs:39:12
+  --> tests/ui/match_ref_pats.rs:40:12
    |
 LL |     if let &None = a {
    |     -------^^^^^---- help: try: `if a.is_none()`
@@ -46,13 +46,13 @@ LL |     if let &None = a {
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/match_ref_pats.rs:45:12
+  --> tests/ui/match_ref_pats.rs:46:12
    |
 LL |     if let &None = &b {
    |     -------^^^^^----- help: try: `if b.is_none()`
 
 error: you don't need to add `&` to all patterns
-  --> tests/ui/match_ref_pats.rs:106:9
+  --> tests/ui/match_ref_pats.rs:107:9
    |
 LL | /         match foobar_variant!(0) {
 LL | |

--- a/tests/ui/mem_replace_macro.rs
+++ b/tests/ui/mem_replace_macro.rs
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::mem_replace_with_default)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/mem_replace_macro.stderr
+++ b/tests/ui/mem_replace_macro.stderr
@@ -1,5 +1,5 @@
 error: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
-  --> tests/ui/mem_replace_macro.rs:10:21
+  --> tests/ui/mem_replace_macro.rs:11:21
    |
 LL |     let _ = inline!(std::mem::replace($s, Default::default()));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/missing_transmute_annotations.fixed
+++ b/tests/ui/missing_transmute_annotations.fixed
@@ -1,7 +1,7 @@
 //@aux-build:macro_rules.rs
 
 #![warn(clippy::missing_transmute_annotations)]
-#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::let_with_type_underscore, clippy::relative_path_in_macro_definition)]
 
 #[macro_use]
 extern crate macro_rules;

--- a/tests/ui/missing_transmute_annotations.rs
+++ b/tests/ui/missing_transmute_annotations.rs
@@ -1,7 +1,7 @@
 //@aux-build:macro_rules.rs
 
 #![warn(clippy::missing_transmute_annotations)]
-#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::let_with_type_underscore, clippy::relative_path_in_macro_definition)]
 
 #[macro_use]
 extern crate macro_rules;

--- a/tests/ui/non_std_lazy_static/auxiliary/lazy_static.rs
+++ b/tests/ui/non_std_lazy_static/auxiliary/lazy_static.rs
@@ -1,4 +1,5 @@
 //! **FAKE** lazy_static crate.
+#![allow(clippy::relative_path_in_macro_definition)]
 
 #[macro_export]
 macro_rules! lazy_static {

--- a/tests/ui/non_std_lazy_static/auxiliary/once_cell.rs
+++ b/tests/ui/non_std_lazy_static/auxiliary/once_cell.rs
@@ -1,4 +1,5 @@
 //! **FAKE** once_cell crate.
+#![allow(clippy::relative_path_in_macro_definition)]
 
 pub mod sync {
     use std::marker::PhantomData;

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_no_std.rs
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_no_std.rs
@@ -3,6 +3,7 @@
 //@aux-build:lazy_static.rs
 
 #![warn(clippy::non_std_lazy_statics)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![no_std]
 
 use lazy_static::lazy_static;

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_other_once_cell.rs
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_other_once_cell.rs
@@ -2,6 +2,7 @@
 //@aux-build:once_cell.rs
 
 #![warn(clippy::non_std_lazy_statics)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 // Should not error, since we used a type besides `sync::Lazy`
 fn use_once_cell_race(x: once_cell::race::OnceBox<String>) {

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs
@@ -3,6 +3,7 @@
 //@no-rustfix
 
 #![warn(clippy::non_std_lazy_statics)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![allow(static_mut_refs)]
 
 mod once_cell_lazy {

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.stderr
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.stderr
@@ -1,5 +1,5 @@
 error: this macro has been superseded by `std::sync::LazyLock`
-  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:31:5
+  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:32:5
    |
 LL | /     lazy_static! {
 LL | |         static ref LAZY_FOO: String = "foo".to_uppercase();
@@ -10,7 +10,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::non_std_lazy_statics)]`
 
 error: this macro has been superseded by `std::sync::LazyLock`
-  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:35:5
+  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:36:5
    |
 LL | /     lazy_static! {
 LL | |         static ref LAZY_BAR: String = "bar".to_uppercase();
@@ -19,7 +19,7 @@ LL | |     }
    | |_____^
 
 error: this macro has been superseded by `std::sync::LazyLock`
-  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:35:5
+  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:36:5
    |
 LL | /     lazy_static! {
 LL | |         static ref LAZY_BAR: String = "bar".to_uppercase();
@@ -30,7 +30,7 @@ LL | |     }
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: this type has been superseded by `LazyLock` in the standard library
-  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:11:22
+  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:12:22
    |
 LL |     static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
    |                      ^^^^
@@ -42,7 +42,7 @@ LL +     static LAZY_FOO: std::sync::LazyLock<String> = std::sync::LazyLock::new
    |
 
 error: this type has been superseded by `LazyLock` in the standard library
-  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:13:26
+  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:14:26
    |
 LL |     static mut LAZY_BAR: Lazy<String> = Lazy::new(|| "bar".to_uppercase());
    |                          ^^^^
@@ -54,7 +54,7 @@ LL +     static mut LAZY_BAR: std::sync::LazyLock<String> = std::sync::LazyLock:
    |
 
 error: this type has been superseded by `LazyLock` in the standard library
-  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:15:26
+  --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:16:26
    |
 LL |     static mut LAZY_BAZ: Lazy<String> = Lazy::new(|| "baz".to_uppercase());
    |                          ^^^^

--- a/tests/ui/nonminimal_bool.rs
+++ b/tests/ui/nonminimal_bool.rs
@@ -3,7 +3,8 @@
     unused,
     clippy::diverging_sub_expression,
     clippy::needless_if,
-    clippy::redundant_pattern_matching
+    clippy::redundant_pattern_matching,
+    clippy::relative_path_in_macro_definition
 )]
 #![warn(clippy::nonminimal_bool)]
 #![allow(clippy::useless_vec)]

--- a/tests/ui/nonminimal_bool.stderr
+++ b/tests/ui/nonminimal_bool.stderr
@@ -1,5 +1,5 @@
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:17:13
+  --> tests/ui/nonminimal_bool.rs:18:13
    |
 LL |     let _ = !true;
    |             ^^^^^ help: try: `false`
@@ -8,43 +8,43 @@ LL |     let _ = !true;
    = help: to override `-D warnings` add `#[allow(clippy::nonminimal_bool)]`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:20:13
+  --> tests/ui/nonminimal_bool.rs:21:13
    |
 LL |     let _ = !false;
    |             ^^^^^^ help: try: `true`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:23:13
+  --> tests/ui/nonminimal_bool.rs:24:13
    |
 LL |     let _ = !!a;
    |             ^^^ help: try: `a`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:26:13
+  --> tests/ui/nonminimal_bool.rs:27:13
    |
 LL |     let _ = false || a;
    |             ^^^^^^^^^^ help: try: `a`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:32:13
+  --> tests/ui/nonminimal_bool.rs:33:13
    |
 LL |     let _ = !(!a && b);
    |             ^^^^^^^^^^ help: try: `a || !b`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:35:13
+  --> tests/ui/nonminimal_bool.rs:36:13
    |
 LL |     let _ = !(!a || b);
    |             ^^^^^^^^^^ help: try: `a && !b`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:38:13
+  --> tests/ui/nonminimal_bool.rs:39:13
    |
 LL |     let _ = !a && !(b && c);
    |             ^^^^^^^^^^^^^^^ help: try: `!(a || b && c)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:47:13
+  --> tests/ui/nonminimal_bool.rs:48:13
    |
 LL |     let _ = a == b && c == 5 && a == b;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL +     let _ = a == b && c == 5;
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:50:13
+  --> tests/ui/nonminimal_bool.rs:51:13
    |
 LL |     let _ = a == b || c == 5 || a == b;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,7 +74,7 @@ LL +     let _ = a == b || c == 5;
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:53:13
+  --> tests/ui/nonminimal_bool.rs:54:13
    |
 LL |     let _ = a == b && c == 5 && b == a;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +89,7 @@ LL +     let _ = a == b && c == 5;
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:56:13
+  --> tests/ui/nonminimal_bool.rs:57:13
    |
 LL |     let _ = a != b || !(a != b || c == d);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +104,7 @@ LL +     let _ = a != b || c != d;
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:59:13
+  --> tests/ui/nonminimal_bool.rs:60:13
    |
 LL |     let _ = a != b && !(a != b && c == d);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,43 +119,43 @@ LL +     let _ = a != b && c != d;
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:90:8
+  --> tests/ui/nonminimal_bool.rs:91:8
    |
 LL |     if matches!(true, true) && true {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(true, true)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:171:8
+  --> tests/ui/nonminimal_bool.rs:172:8
    |
 LL |     if !(12 == a) {}
    |        ^^^^^^^^^^ help: try: `(12 != a)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:173:8
+  --> tests/ui/nonminimal_bool.rs:174:8
    |
 LL |     if !(a == 12) {}
    |        ^^^^^^^^^^ help: try: `(a != 12)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:175:8
+  --> tests/ui/nonminimal_bool.rs:176:8
    |
 LL |     if !(12 != a) {}
    |        ^^^^^^^^^^ help: try: `(12 == a)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:177:8
+  --> tests/ui/nonminimal_bool.rs:178:8
    |
 LL |     if !(a != 12) {}
    |        ^^^^^^^^^^ help: try: `(a == 12)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:182:8
+  --> tests/ui/nonminimal_bool.rs:183:8
    |
 LL |     if !b == true {}
    |        ^^^^^^^^^^ help: try: `b != true`
 
 error: this comparison might be written more concisely
-  --> tests/ui/nonminimal_bool.rs:182:8
+  --> tests/ui/nonminimal_bool.rs:183:8
    |
 LL |     if !b == true {}
    |        ^^^^^^^^^^ help: try simplifying it as shown: `b != true`
@@ -164,73 +164,73 @@ LL |     if !b == true {}
    = help: to override `-D warnings` add `#[allow(clippy::bool_comparison)]`
 
 error: equality checks against true are unnecessary
-  --> tests/ui/nonminimal_bool.rs:182:8
+  --> tests/ui/nonminimal_bool.rs:183:8
    |
 LL |     if !b == true {}
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!b`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:186:8
+  --> tests/ui/nonminimal_bool.rs:187:8
    |
 LL |     if !b != true {}
    |        ^^^^^^^^^^ help: try: `b == true`
 
 error: inequality checks against true can be replaced by a negation
-  --> tests/ui/nonminimal_bool.rs:186:8
+  --> tests/ui/nonminimal_bool.rs:187:8
    |
 LL |     if !b != true {}
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!(!b)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:189:8
+  --> tests/ui/nonminimal_bool.rs:190:8
    |
 LL |     if true == !b {}
    |        ^^^^^^^^^^ help: try: `true != b`
 
 error: this comparison might be written more concisely
-  --> tests/ui/nonminimal_bool.rs:189:8
+  --> tests/ui/nonminimal_bool.rs:190:8
    |
 LL |     if true == !b {}
    |        ^^^^^^^^^^ help: try simplifying it as shown: `true != b`
 
 error: equality checks against true are unnecessary
-  --> tests/ui/nonminimal_bool.rs:189:8
+  --> tests/ui/nonminimal_bool.rs:190:8
    |
 LL |     if true == !b {}
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!b`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:193:8
+  --> tests/ui/nonminimal_bool.rs:194:8
    |
 LL |     if true != !b {}
    |        ^^^^^^^^^^ help: try: `true == b`
 
 error: inequality checks against true can be replaced by a negation
-  --> tests/ui/nonminimal_bool.rs:193:8
+  --> tests/ui/nonminimal_bool.rs:194:8
    |
 LL |     if true != !b {}
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!(!b)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:196:8
+  --> tests/ui/nonminimal_bool.rs:197:8
    |
 LL |     if !b == !c {}
    |        ^^^^^^^^ help: try: `b == c`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:198:8
+  --> tests/ui/nonminimal_bool.rs:199:8
    |
 LL |     if !b != !c {}
    |        ^^^^^^^^ help: try: `b != c`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:214:8
+  --> tests/ui/nonminimal_bool.rs:215:8
    |
 LL |     if !(a < 2.0 && !b) {
    |        ^^^^^^^^^^^^^^^^ help: try: `a >= 2.0 || b`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:233:12
+  --> tests/ui/nonminimal_bool.rs:234:12
    |
 LL |         if !(matches!(ty, TyKind::Ref(_, _, _)) && !is_mutable(&expr)) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `!matches!(ty, TyKind::Ref(_, _, _)) || is_mutable(&expr)`

--- a/tests/ui/option_if_let_else.fixed
+++ b/tests/ui/option_if_let_else.fixed
@@ -4,6 +4,7 @@
     clippy::equatable_if_let,
     clippy::let_unit_value,
     clippy::redundant_locals,
+    clippy::relative_path_in_macro_definition,
     clippy::manual_midpoint,
     clippy::manual_unwrap_or_default,
     clippy::manual_unwrap_or

--- a/tests/ui/option_if_let_else.rs
+++ b/tests/ui/option_if_let_else.rs
@@ -4,6 +4,7 @@
     clippy::equatable_if_let,
     clippy::let_unit_value,
     clippy::redundant_locals,
+    clippy::relative_path_in_macro_definition,
     clippy::manual_midpoint,
     clippy::manual_unwrap_or_default,
     clippy::manual_unwrap_or

--- a/tests/ui/option_if_let_else.stderr
+++ b/tests/ui/option_if_let_else.stderr
@@ -1,5 +1,5 @@
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:13:5
+  --> tests/ui/option_if_let_else.rs:14:5
    |
 LL | /     if let Some(x) = string {
 LL | |
@@ -13,19 +13,19 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::option_if_let_else)]`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:32:13
+  --> tests/ui/option_if_let_else.rs:33:13
    |
 LL |     let _ = if let Some(s) = *string { s.len() } else { 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.map_or(0, |s| s.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:34:13
+  --> tests/ui/option_if_let_else.rs:35:13
    |
 LL |     let _ = if let Some(s) = &num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:36:13
+  --> tests/ui/option_if_let_else.rs:37:13
    |
 LL |       let _ = if let Some(s) = &mut num {
    |  _____________^
@@ -47,13 +47,13 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:43:13
+  --> tests/ui/option_if_let_else.rs:44:13
    |
 LL |     let _ = if let Some(ref s) = num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:45:13
+  --> tests/ui/option_if_let_else.rs:46:13
    |
 LL |       let _ = if let Some(mut s) = num {
    |  _____________^
@@ -75,7 +75,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:52:13
+  --> tests/ui/option_if_let_else.rs:53:13
    |
 LL |       let _ = if let Some(ref mut s) = num {
    |  _____________^
@@ -97,7 +97,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:62:5
+  --> tests/ui/option_if_let_else.rs:63:5
    |
 LL | /     if let Some(x) = arg {
 LL | |
@@ -118,7 +118,7 @@ LL +     })
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:76:13
+  --> tests/ui/option_if_let_else.rs:77:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -131,7 +131,7 @@ LL | |     };
    | |_____^ help: try: `arg.map_or_else(side_effect, |x| x)`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:86:13
+  --> tests/ui/option_if_let_else.rs:87:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -154,7 +154,7 @@ LL ~     }, |x| x * x * x * x);
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:120:13
+  --> tests/ui/option_if_let_else.rs:121:13
    |
 LL | /             if let Some(idx) = s.find('.') {
 LL | |
@@ -165,7 +165,7 @@ LL | |             }
    | |_____________^ help: try: `s.find('.').map_or_else(|| vec![s.to_string()], |idx| vec![s[..idx].to_string(), s[idx..].to_string()])`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:132:5
+  --> tests/ui/option_if_let_else.rs:133:5
    |
 LL | /     if let Ok(binding) = variable {
 LL | |
@@ -189,13 +189,13 @@ LL +     })
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:157:13
+  --> tests/ui/option_if_let_else.rs:158:13
    |
 LL |     let _ = if let Some(x) = optional { x + 2 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `optional.map_or(5, |x| x + 2)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:168:13
+  --> tests/ui/option_if_let_else.rs:169:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -217,13 +217,13 @@ LL ~         });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:197:13
+  --> tests/ui/option_if_let_else.rs:198:13
    |
 LL |     let _ = if let Some(x) = Some(0) { s.len() + x } else { s.len() };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(0).map_or(s.len(), |x| s.len() + x)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:202:13
+  --> tests/ui/option_if_let_else.rs:203:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -245,7 +245,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:242:13
+  --> tests/ui/option_if_let_else.rs:243:13
    |
 LL |       let _ = match s {
    |  _____________^
@@ -256,7 +256,7 @@ LL | |     };
    | |_____^ help: try: `s.map_or(1, |string| string.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:247:13
+  --> tests/ui/option_if_let_else.rs:248:13
    |
 LL |       let _ = match Some(10) {
    |  _____________^
@@ -267,7 +267,7 @@ LL | |     };
    | |_____^ help: try: `Some(10).map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:254:13
+  --> tests/ui/option_if_let_else.rs:255:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -278,7 +278,7 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:259:13
+  --> tests/ui/option_if_let_else.rs:260:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -289,13 +289,13 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:264:13
+  --> tests/ui/option_if_let_else.rs:265:13
    |
 LL |     let _ = if let Ok(a) = res { a + 1 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:282:17
+  --> tests/ui/option_if_let_else.rs:283:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -306,7 +306,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_ref().map_or(42, |value| do_something(value))`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:290:17
+  --> tests/ui/option_if_let_else.rs:291:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -317,7 +317,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_mut().map_or(42, |value| do_something2(value))`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:314:24
+  --> tests/ui/option_if_let_else.rs:315:24
    |
 LL |       let mut _hashmap = if let Some(hm) = &opt {
    |  ________________________^
@@ -329,7 +329,7 @@ LL | |     };
    | |_____^ help: try: `opt.as_ref().map_or_else(HashMap::new, |hm| hm.clone())`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:321:19
+  --> tests/ui/option_if_let_else.rs:322:19
    |
 LL |     let mut _hm = if let Some(hm) = &opt { hm.clone() } else { new_map!() };
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.as_ref().map_or_else(|| new_map!(), |hm| hm.clone())`

--- a/tests/ui/partialeq_to_none.fixed
+++ b/tests/ui/partialeq_to_none.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op, clippy::needless_if)]
+#![allow(clippy::eq_op, clippy::needless_if, clippy::relative_path_in_macro_definition)]
 
 struct Foobar;
 

--- a/tests/ui/partialeq_to_none.rs
+++ b/tests/ui/partialeq_to_none.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op, clippy::needless_if)]
+#![allow(clippy::eq_op, clippy::needless_if, clippy::relative_path_in_macro_definition)]
 
 struct Foobar;
 

--- a/tests/ui/ptr_as_ptr.fixed
+++ b/tests/ui/ptr_as_ptr.fixed
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::ptr_as_ptr)]
 
 #[macro_use]

--- a/tests/ui/ptr_as_ptr.rs
+++ b/tests/ui/ptr_as_ptr.rs
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::ptr_as_ptr)]
 
 #[macro_use]

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -5,6 +5,7 @@
     clippy::transmute_ptr_to_ref,
     clippy::unnecessary_cast,
     unused,
+    clippy::relative_path_in_macro_definition,
     clippy::missing_transmute_annotations
 )]
 

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -5,6 +5,7 @@
     clippy::transmute_ptr_to_ref,
     clippy::unnecessary_cast,
     unused,
+    clippy::relative_path_in_macro_definition,
     clippy::missing_transmute_annotations
 )]
 

--- a/tests/ui/ptr_cast_constness.stderr
+++ b/tests/ui/ptr_cast_constness.stderr
@@ -1,5 +1,5 @@
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:16:45
+  --> tests/ui/ptr_cast_constness.rs:17:45
    |
 LL |         let _: &mut T = std::mem::transmute(p as *mut T);
    |                                             ^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
@@ -8,67 +8,67 @@ LL |         let _: &mut T = std::mem::transmute(p as *mut T);
    = help: to override `-D warnings` add `#[allow(clippy::ptr_cast_constness)]`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:18:23
+  --> tests/ui/ptr_cast_constness.rs:19:23
    |
 LL |         let _ = &mut *(p as *mut T);
    |                       ^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:35:17
+  --> tests/ui/ptr_cast_constness.rs:36:17
    |
 LL |         let _ = *ptr_ptr as *mut u32;
    |                 ^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `(*ptr_ptr).cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:39:13
+  --> tests/ui/ptr_cast_constness.rs:40:13
    |
 LL |     let _ = ptr as *mut u32;
    |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:41:13
+  --> tests/ui/ptr_cast_constness.rs:42:13
    |
 LL |     let _ = mut_ptr as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:75:13
+  --> tests/ui/ptr_cast_constness.rs:76:13
    |
 LL |     let _ = ptr as *mut u32;
    |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:77:13
+  --> tests/ui/ptr_cast_constness.rs:78:13
    |
 LL |     let _ = mut_ptr as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
 error: `as` casting to make a const null pointer into a mutable null pointer
-  --> tests/ui/ptr_cast_constness.rs:84:13
+  --> tests/ui/ptr_cast_constness.rs:85:13
    |
 LL |     let _ = ptr::null::<String>() as *mut String;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null_mut()` directly instead: `std::ptr::null_mut::<String>()`
 
 error: `as` casting to make a mutable null pointer into a const null pointer
-  --> tests/ui/ptr_cast_constness.rs:86:13
+  --> tests/ui/ptr_cast_constness.rs:87:13
    |
 LL |     let _ = ptr::null_mut::<u32>() as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null()` directly instead: `std::ptr::null::<u32>()`
 
 error: changing constness of a null pointer
-  --> tests/ui/ptr_cast_constness.rs:88:13
+  --> tests/ui/ptr_cast_constness.rs:89:13
    |
 LL |     let _ = ptr::null::<u32>().cast_mut();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null_mut()` directly instead: `std::ptr::null_mut::<u32>()`
 
 error: changing constness of a null pointer
-  --> tests/ui/ptr_cast_constness.rs:90:13
+  --> tests/ui/ptr_cast_constness.rs:91:13
    |
 LL |     let _ = ptr::null_mut::<u32>().cast_const();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null()` directly instead: `std::ptr::null::<u32>()`
 
 error: `as` casting to make a const null pointer into a mutable null pointer
-  --> tests/ui/ptr_cast_constness.rs:94:21
+  --> tests/ui/ptr_cast_constness.rs:95:21
    |
 LL |     let _ = inline!(ptr::null::<u32>() as *mut u32);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null_mut()` directly instead: `std::ptr::null_mut::<u32>()`
@@ -76,7 +76,7 @@ LL |     let _ = inline!(ptr::null::<u32>() as *mut u32);
    = note: this error originates in the macro `__inline_mac_fn_null_pointers` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: changing constness of a null pointer
-  --> tests/ui/ptr_cast_constness.rs:96:21
+  --> tests/ui/ptr_cast_constness.rs:97:21
    |
 LL |     let _ = inline!(ptr::null::<u32>().cast_mut());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `null_mut()` directly instead: `std::ptr::null_mut::<u32>()`
@@ -84,7 +84,7 @@ LL |     let _ = inline!(ptr::null::<u32>().cast_mut());
    = note: this error originates in the macro `__inline_mac_fn_null_pointers` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:106:13
+  --> tests/ui/ptr_cast_constness.rs:107:13
    |
 LL |     let _ = std::ptr::addr_of_mut!(local) as *const _;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `std::ptr::addr_of_mut!(local).cast_const()`

--- a/tests/ui/relative_path_in_macro_definition.rs
+++ b/tests/ui/relative_path_in_macro_definition.rs
@@ -1,0 +1,23 @@
+#![allow(unused)]
+#![warn(clippy::relative_path_in_macro_definition)]
+
+#[macro_export]
+macro_rules! relative_path_macro {
+    ($condition:expr) => {
+        const _: () = core::assert!($condition);
+        //~^ relative_path_in_macro_definition
+    };
+}
+
+#[macro_export]
+macro_rules! absolute_path_assert {
+    ($condition:expr) => {
+        const _: () = ::core::assert!($condition);
+    };
+}
+
+fn main() {
+    const X: &[u8] = b"rust";
+    relative_path_macro!(X[0] == b'r');
+    absolute_path_assert!(X[0] == b'r');
+}

--- a/tests/ui/relative_path_in_macro_definition.rs
+++ b/tests/ui/relative_path_in_macro_definition.rs
@@ -1,6 +1,8 @@
 #![allow(unused)]
+// Enable lint to check relative paths in macro definitions
 #![warn(clippy::relative_path_in_macro_definition)]
 
+// Macro with relative path to core (triggers lint)
 #[macro_export]
 macro_rules! relative_path_macro {
     ($condition:expr) => {
@@ -9,6 +11,16 @@ macro_rules! relative_path_macro {
     };
 }
 
+// Macro with relative path to std (triggers lint)
+#[macro_export]
+macro_rules! relative_std {
+    () => {
+        let _ = std::mem::size_of::<i32>();
+        //~^ relative_path_in_macro_definition
+    };
+}
+
+// Macro with absolute path to core (no lint)
 #[macro_export]
 macro_rules! absolute_path_assert {
     ($condition:expr) => {
@@ -16,8 +28,28 @@ macro_rules! absolute_path_assert {
     };
 }
 
+// Macro with absolute path to std (no lint)
+#[macro_export]
+macro_rules! absolute_std {
+    () => {
+        let _ = ::std::mem::size_of::<i32>();
+    };
+}
+
+// Macro with no path references (no lint)
+#[macro_export]
+macro_rules! no_path {
+    () => {
+        let x = 42;
+    };
+}
+
+// Test all macros
 fn main() {
     const X: &[u8] = b"rust";
-    relative_path_macro!(X[0] == b'r');
-    absolute_path_assert!(X[0] == b'r');
+    relative_path_macro!(X[0] == b'r'); // Test relative core path
+    absolute_path_assert!(X[0] == b'r'); // Test absolute core path
+    relative_std!(); // Test relative std path
+    absolute_std!(); // Test absolute std path
+    no_path!(); // Test no path
 }

--- a/tests/ui/relative_path_in_macro_definition.stderr
+++ b/tests/ui/relative_path_in_macro_definition.stderr
@@ -1,5 +1,5 @@
-error: relative path to `core` or `kernel` used in macro definition
-  --> tests/ui/relative_path_in_macro_definition.rs:7:23
+error: avoid relative path to `core` in macro definitions
+  --> tests/ui/relative_path_in_macro_definition.rs:9:23
    |
 LL |         const _: () = core::assert!($condition);
    |                       ^^^^
@@ -7,5 +7,11 @@ LL |         const _: () = core::assert!($condition);
    = note: `-D clippy::relative-path-in-macro-definition` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::relative_path_in_macro_definition)]`
 
-error: aborting due to 1 previous error
+error: avoid relative path to `std` in macro definitions
+  --> tests/ui/relative_path_in_macro_definition.rs:18:17
+   |
+LL |         let _ = std::mem::size_of::<i32>();
+   |                 ^^^
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/relative_path_in_macro_definition.stderr
+++ b/tests/ui/relative_path_in_macro_definition.stderr
@@ -1,0 +1,11 @@
+error: relative path to `core` or `kernel` used in macro definition
+  --> tests/ui/relative_path_in_macro_definition.rs:7:23
+   |
+LL |         const _: () = core::assert!($condition);
+   |                       ^^^^
+   |
+   = note: `-D clippy::relative-path-in-macro-definition` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::relative_path_in_macro_definition)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/repeat_vec_with_capacity.fixed
+++ b/tests/ui/repeat_vec_with_capacity.fixed
@@ -1,4 +1,7 @@
-#![allow(clippy::map_with_unused_argument_over_ranges)]
+#![allow(
+    clippy::relative_path_in_macro_definition,
+    clippy::map_with_unused_argument_over_ranges
+)]
 #![warn(clippy::repeat_vec_with_capacity)]
 
 fn main() {

--- a/tests/ui/repeat_vec_with_capacity.rs
+++ b/tests/ui/repeat_vec_with_capacity.rs
@@ -1,4 +1,7 @@
-#![allow(clippy::map_with_unused_argument_over_ranges)]
+#![allow(
+    clippy::relative_path_in_macro_definition,
+    clippy::map_with_unused_argument_over_ranges
+)]
 #![warn(clippy::repeat_vec_with_capacity)]
 
 fn main() {

--- a/tests/ui/repeat_vec_with_capacity.stderr
+++ b/tests/ui/repeat_vec_with_capacity.stderr
@@ -1,5 +1,5 @@
 error: repeating `Vec::with_capacity` using `vec![x; n]`, which does not retain capacity
-  --> tests/ui/repeat_vec_with_capacity.rs:6:9
+  --> tests/ui/repeat_vec_with_capacity.rs:9:9
    |
 LL |         vec![Vec::<()>::with_capacity(42); 123];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL +         (0..123).map(|_| Vec::<()>::with_capacity(42)).collect::<Vec<_>>();
    |
 
 error: repeating `Vec::with_capacity` using `vec![x; n]`, which does not retain capacity
-  --> tests/ui/repeat_vec_with_capacity.rs:12:9
+  --> tests/ui/repeat_vec_with_capacity.rs:15:9
    |
 LL |         vec![Vec::<()>::with_capacity(42); n];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL +         (0..n).map(|_| Vec::<()>::with_capacity(42)).collect::<Vec<_>>();
    |
 
 error: repeating `Vec::with_capacity` using `iter::repeat`, which does not retain capacity
-  --> tests/ui/repeat_vec_with_capacity.rs:27:9
+  --> tests/ui/repeat_vec_with_capacity.rs:30:9
    |
 LL |         std::iter::repeat(Vec::<()>::with_capacity(42));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/single_char_add_str.fixed
+++ b/tests/ui/single_char_add_str.fixed
@@ -1,5 +1,6 @@
 #![warn(clippy::single_char_add_str)]
 #![allow(clippy::needless_raw_strings, clippy::needless_raw_string_hashes)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 macro_rules! get_string {
     () => {

--- a/tests/ui/single_char_add_str.rs
+++ b/tests/ui/single_char_add_str.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::single_char_add_str)]
 #![allow(clippy::needless_raw_strings, clippy::needless_raw_string_hashes)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 macro_rules! get_string {
     () => {

--- a/tests/ui/single_char_add_str.stderr
+++ b/tests/ui/single_char_add_str.stderr
@@ -1,5 +1,5 @@
 error: calling `push_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:14:5
+  --> tests/ui/single_char_add_str.rs:15:5
    |
 LL |     string.push_str("R");
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('R')`
@@ -8,121 +8,121 @@ LL |     string.push_str("R");
    = help: to override `-D warnings` add `#[allow(clippy::single_char_add_str)]`
 
 error: calling `push_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:16:5
+  --> tests/ui/single_char_add_str.rs:17:5
    |
 LL |     string.push_str("'");
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('\'')`
 
 error: calling `push_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:22:5
+  --> tests/ui/single_char_add_str.rs:23:5
    |
 LL |     string.push_str("\x52");
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('\x52')`
 
 error: calling `push_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:24:5
+  --> tests/ui/single_char_add_str.rs:25:5
    |
 LL |     string.push_str("\u{0052}");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('\u{0052}')`
 
 error: calling `push_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:26:5
+  --> tests/ui/single_char_add_str.rs:27:5
    |
 LL |     string.push_str(r##"a"##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('a')`
 
 error: calling `push_str()` using a single-character converted to string
-  --> tests/ui/single_char_add_str.rs:30:5
+  --> tests/ui/single_char_add_str.rs:31:5
    |
 LL |     string.push_str(&c_ref.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` without `to_string()`: `string.push(*c_ref)`
 
 error: calling `push_str()` using a single-character converted to string
-  --> tests/ui/single_char_add_str.rs:33:5
+  --> tests/ui/single_char_add_str.rs:34:5
    |
 LL |     string.push_str(&c.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` without `to_string()`: `string.push(c)`
 
 error: calling `push_str()` using a single-character converted to string
-  --> tests/ui/single_char_add_str.rs:35:5
+  --> tests/ui/single_char_add_str.rs:36:5
    |
 LL |     string.push_str(&'a'.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` without `to_string()`: `string.push('a')`
 
 error: calling `push_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:38:5
+  --> tests/ui/single_char_add_str.rs:39:5
    |
 LL |     get_string!().push_str("ö");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `get_string!().push('ö')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:44:5
+  --> tests/ui/single_char_add_str.rs:45:5
    |
 LL |     string.insert_str(0, "R");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(0, 'R')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:46:5
+  --> tests/ui/single_char_add_str.rs:47:5
    |
 LL |     string.insert_str(1, "'");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(1, '\'')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:52:5
+  --> tests/ui/single_char_add_str.rs:53:5
    |
 LL |     string.insert_str(0, "\x52");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(0, '\x52')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:54:5
+  --> tests/ui/single_char_add_str.rs:55:5
    |
 LL |     string.insert_str(0, "\u{0052}");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(0, '\u{0052}')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:57:5
+  --> tests/ui/single_char_add_str.rs:58:5
    |
 LL |     string.insert_str(x, r##"a"##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(x, 'a')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:60:5
+  --> tests/ui/single_char_add_str.rs:61:5
    |
 LL |     string.insert_str(Y, r##"a"##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(Y, 'a')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:62:5
+  --> tests/ui/single_char_add_str.rs:63:5
    |
 LL |     string.insert_str(Y, r##"""##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(Y, '"')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:64:5
+  --> tests/ui/single_char_add_str.rs:65:5
    |
 LL |     string.insert_str(Y, r##"'"##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(Y, '\'')`
 
 error: calling `insert_str()` using a single-character converted to string
-  --> tests/ui/single_char_add_str.rs:67:5
+  --> tests/ui/single_char_add_str.rs:68:5
    |
 LL |     string.insert_str(0, &c_ref.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` without `to_string()`: `string.insert(0, *c_ref)`
 
 error: calling `insert_str()` using a single-character converted to string
-  --> tests/ui/single_char_add_str.rs:69:5
+  --> tests/ui/single_char_add_str.rs:70:5
    |
 LL |     string.insert_str(0, &c.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` without `to_string()`: `string.insert(0, c)`
 
 error: calling `insert_str()` using a single-character converted to string
-  --> tests/ui/single_char_add_str.rs:71:5
+  --> tests/ui/single_char_add_str.rs:72:5
    |
 LL |     string.insert_str(0, &'a'.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` without `to_string()`: `string.insert(0, 'a')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> tests/ui/single_char_add_str.rs:74:5
+  --> tests/ui/single_char_add_str.rs:75:5
    |
 LL |     get_string!().insert_str(1, "?");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `get_string!().insert(1, '?')`

--- a/tests/ui/single_match_else.fixed
+++ b/tests/ui/single_match_else.fixed
@@ -3,6 +3,8 @@
 
 #![warn(clippy::single_match_else)]
 #![allow(unused, clippy::needless_return, clippy::no_effect, clippy::uninlined_format_args)]
+#![allow(clippy::relative_path_in_macro_definition)]
+
 extern crate proc_macros;
 use proc_macros::with_span;
 

--- a/tests/ui/single_match_else.rs
+++ b/tests/ui/single_match_else.rs
@@ -3,6 +3,8 @@
 
 #![warn(clippy::single_match_else)]
 #![allow(unused, clippy::needless_return, clippy::no_effect, clippy::uninlined_format_args)]
+#![allow(clippy::relative_path_in_macro_definition)]
+
 extern crate proc_macros;
 use proc_macros::with_span;
 

--- a/tests/ui/single_match_else.stderr
+++ b/tests/ui/single_match_else.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:18:13
+  --> tests/ui/single_match_else.rs:20:13
    |
 LL |       let _ = match ExprNode::Butterflies {
    |  _____________^
@@ -22,7 +22,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:84:5
+  --> tests/ui/single_match_else.rs:86:5
    |
 LL | /     match Some(1) {
 LL | |         Some(a) => println!("${:?}", a),
@@ -42,7 +42,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:94:5
+  --> tests/ui/single_match_else.rs:96:5
    |
 LL | /     match Some(1) {
 LL | |         Some(a) => println!("${:?}", a),
@@ -62,7 +62,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:103:5
+  --> tests/ui/single_match_else.rs:105:5
    |
 LL | /     match Some(1) {
 LL | |         Some(a) => println!("${:?}", a),
@@ -83,7 +83,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:116:5
+  --> tests/ui/single_match_else.rs:118:5
    |
 LL | /     match Result::<i32, &Infallible>::Ok(1) {
 LL | |         Ok(a) => println!("${:?}", a),
@@ -102,7 +102,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:126:5
+  --> tests/ui/single_match_else.rs:128:5
    |
 LL | /     match Cow::from("moo") {
 LL | |         Cow::Owned(a) => println!("${:?}", a),
@@ -121,7 +121,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:137:5
+  --> tests/ui/single_match_else.rs:139:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -144,7 +144,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:149:5
+  --> tests/ui/single_match_else.rs:151:5
    |
 LL | /     match bar {
 LL | |         Some(v) => {
@@ -168,7 +168,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:162:5
+  --> tests/ui/single_match_else.rs:164:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -192,7 +192,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:175:5
+  --> tests/ui/single_match_else.rs:177:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]
@@ -217,7 +217,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match_else.rs:225:5
+  --> tests/ui/single_match_else.rs:227:5
    |
 LL | /     match ExprNode::Butterflies {
 LL | |         ExprNode::Butterflies => Some(&NODE),

--- a/tests/ui/swap_ptr_to_ref_unfixable.rs
+++ b/tests/ui/swap_ptr_to_ref_unfixable.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::swap_ptr_to_ref)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 macro_rules! addr_of_mut_to_ref {
     ($e:expr) => {

--- a/tests/ui/swap_ptr_to_ref_unfixable.stderr
+++ b/tests/ui/swap_ptr_to_ref_unfixable.stderr
@@ -1,5 +1,5 @@
 error: call to `core::mem::swap` with a parameter derived from a raw pointer
-  --> tests/ui/swap_ptr_to_ref_unfixable.rs:14:9
+  --> tests/ui/swap_ptr_to_ref_unfixable.rs:15:9
    |
 LL |         core::mem::swap(addr_of_mut_to_ref!(x), &mut *y);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL |         core::mem::swap(addr_of_mut_to_ref!(x), &mut *y);
    = help: to override `-D warnings` add `#[allow(clippy::swap_ptr_to_ref)]`
 
 error: call to `core::mem::swap` with a parameter derived from a raw pointer
-  --> tests/ui/swap_ptr_to_ref_unfixable.rs:17:9
+  --> tests/ui/swap_ptr_to_ref_unfixable.rs:18:9
    |
 LL |         core::mem::swap(&mut *y, addr_of_mut_to_ref!(x));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: call to `core::mem::swap` with a parameter derived from a raw pointer
-  --> tests/ui/swap_ptr_to_ref_unfixable.rs:20:9
+  --> tests/ui/swap_ptr_to_ref_unfixable.rs:21:9
    |
 LL |         core::mem::swap(addr_of_mut_to_ref!(x), addr_of_mut_to_ref!(x));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/swap_with_temporary_unfixable.rs
+++ b/tests/ui/swap_with_temporary_unfixable.rs
@@ -1,5 +1,6 @@
 //@no-rustfix
 #![warn(clippy::swap_with_temporary)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 use std::mem::swap;
 

--- a/tests/ui/swap_with_temporary_unfixable.stderr
+++ b/tests/ui/swap_with_temporary_unfixable.stderr
@@ -1,16 +1,16 @@
 error: swapping temporary values has no effect
-  --> tests/ui/swap_with_temporary_unfixable.rs:20:5
+  --> tests/ui/swap_with_temporary_unfixable.rs:21:5
    |
 LL |     swap(&mut func(), &mut func());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:20:15
+  --> tests/ui/swap_with_temporary_unfixable.rs:21:15
    |
 LL |     swap(&mut func(), &mut func());
    |               ^^^^^^
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:20:28
+  --> tests/ui/swap_with_temporary_unfixable.rs:21:28
    |
 LL |     swap(&mut func(), &mut func());
    |                            ^^^^^^
@@ -18,105 +18,105 @@ LL |     swap(&mut func(), &mut func());
    = help: to override `-D warnings` add `#[allow(clippy::swap_with_temporary)]`
 
 error: swapping temporary values has no effect
-  --> tests/ui/swap_with_temporary_unfixable.rs:23:17
+  --> tests/ui/swap_with_temporary_unfixable.rs:24:17
    |
 LL |     if matches!(swap(&mut func(), &mut func()), ()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:23:27
+  --> tests/ui/swap_with_temporary_unfixable.rs:24:27
    |
 LL |     if matches!(swap(&mut func(), &mut func()), ()) {
    |                           ^^^^^^
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:23:40
+  --> tests/ui/swap_with_temporary_unfixable.rs:24:40
    |
 LL |     if matches!(swap(&mut func(), &mut func()), ()) {
    |                                        ^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary_unfixable.rs:28:17
+  --> tests/ui/swap_with_temporary_unfixable.rs:29:17
    |
 LL |     if matches!(swap(z, &mut func()), ()) {
    |                 ^^^^^^^^^^^^^^^^^^^^
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:28:30
+  --> tests/ui/swap_with_temporary_unfixable.rs:29:30
    |
 LL |     if matches!(swap(z, &mut func()), ()) {
    |                              ^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary_unfixable.rs:45:5
+  --> tests/ui/swap_with_temporary_unfixable.rs:46:5
    |
 LL |     swap(mac!(refmut func()), z);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this is a mutable reference to a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:45:10
+  --> tests/ui/swap_with_temporary_unfixable.rs:46:10
    |
 LL |     swap(mac!(refmut func()), z);
    |          ^^^^^^^^^^^^^^^^^^^
 
 error: swapping temporary values has no effect
-  --> tests/ui/swap_with_temporary_unfixable.rs:47:5
+  --> tests/ui/swap_with_temporary_unfixable.rs:48:5
    |
 LL |     swap(&mut mac!(funcall func), &mut mac!(funcall func));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:47:15
+  --> tests/ui/swap_with_temporary_unfixable.rs:48:15
    |
 LL |     swap(&mut mac!(funcall func), &mut mac!(funcall func));
    |               ^^^^^^^^^^^^^^^^^^
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:47:40
+  --> tests/ui/swap_with_temporary_unfixable.rs:48:40
    |
 LL |     swap(&mut mac!(funcall func), &mut mac!(funcall func));
    |                                        ^^^^^^^^^^^^^^^^^^
 
 error: swapping temporary values has no effect
-  --> tests/ui/swap_with_temporary_unfixable.rs:49:5
+  --> tests/ui/swap_with_temporary_unfixable.rs:50:5
    |
 LL |     swap(mac!(refmut), mac!(refmut));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this is a mutable reference to a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:49:10
+  --> tests/ui/swap_with_temporary_unfixable.rs:50:10
    |
 LL |     swap(mac!(refmut), mac!(refmut));
    |          ^^^^^^^^^^^^
 note: this is a mutable reference to a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:49:24
+  --> tests/ui/swap_with_temporary_unfixable.rs:50:24
    |
 LL |     swap(mac!(refmut), mac!(refmut));
    |                        ^^^^^^^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary_unfixable.rs:51:5
+  --> tests/ui/swap_with_temporary_unfixable.rs:52:5
    |
 LL |     swap(mac!(refmut y), mac!(refmut));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this is a mutable reference to a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:51:26
+  --> tests/ui/swap_with_temporary_unfixable.rs:52:26
    |
 LL |     swap(mac!(refmut y), mac!(refmut));
    |                          ^^^^^^^^^^^^
 
 error: swapping temporary values has no effect
-  --> tests/ui/swap_with_temporary_unfixable.rs:57:5
+  --> tests/ui/swap_with_temporary_unfixable.rs:58:5
    |
 LL |     std::mem::swap(&mut v1.last_mut().unwrap(), &mut v2.last_mut().unwrap());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:57:25
+  --> tests/ui/swap_with_temporary_unfixable.rs:58:25
    |
 LL |     std::mem::swap(&mut v1.last_mut().unwrap(), &mut v2.last_mut().unwrap());
    |                         ^^^^^^^^^^^^^^^^^^^^^^
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary_unfixable.rs:57:54
+  --> tests/ui/swap_with_temporary_unfixable.rs:58:54
    |
 LL |     std::mem::swap(&mut v1.last_mut().unwrap(), &mut v2.last_mut().unwrap());
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/try_err.fixed
+++ b/tests/ui/try_err.fixed
@@ -2,6 +2,7 @@
 #![feature(try_blocks)]
 #![deny(clippy::try_err)]
 #![allow(
+    clippy::relative_path_in_macro_definition,
     clippy::unnecessary_wraps,
     clippy::needless_question_mark,
     clippy::needless_return_with_question_mark

--- a/tests/ui/try_err.rs
+++ b/tests/ui/try_err.rs
@@ -2,6 +2,7 @@
 #![feature(try_blocks)]
 #![deny(clippy::try_err)]
 #![allow(
+    clippy::relative_path_in_macro_definition,
     clippy::unnecessary_wraps,
     clippy::needless_question_mark,
     clippy::needless_return_with_question_mark

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -1,5 +1,5 @@
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:22:9
+  --> tests/ui/try_err.rs:23:9
    |
 LL |         Err(err)?;
    |         ^^^^^^^^^ help: try: `return Err(err)`
@@ -11,25 +11,25 @@ LL | #![deny(clippy::try_err)]
    |         ^^^^^^^^^^^^^^^
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:33:9
+  --> tests/ui/try_err.rs:34:9
    |
 LL |         Err(err)?;
    |         ^^^^^^^^^ help: try: `return Err(err.into())`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:54:17
+  --> tests/ui/try_err.rs:55:17
    |
 LL |                 Err(err)?;
    |                 ^^^^^^^^^ help: try: `return Err(err)`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:74:17
+  --> tests/ui/try_err.rs:75:17
    |
 LL |                 Err(err)?;
    |                 ^^^^^^^^^ help: try: `return Err(err.into())`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:95:23
+  --> tests/ui/try_err.rs:96:23
    |
 LL |             Err(_) => Err(1)?,
    |                       ^^^^^^^ help: try: `return Err(1)`
@@ -37,7 +37,7 @@ LL |             Err(_) => Err(1)?,
    = note: this error originates in the macro `__inline_mac_fn_calling_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:103:23
+  --> tests/ui/try_err.rs:104:23
    |
 LL |             Err(_) => Err(inline!(1))?,
    |                       ^^^^^^^^^^^^^^^^ help: try: `return Err(inline!(1))`
@@ -45,31 +45,31 @@ LL |             Err(_) => Err(inline!(1))?,
    = note: this error originates in the macro `__inline_mac_fn_calling_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:131:9
+  --> tests/ui/try_err.rs:132:9
    |
 LL |         Err(inline!(inline!(String::from("aasdfasdfasdfa"))))?;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Err(inline!(inline!(String::from("aasdfasdfasdfa"))))`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:139:9
+  --> tests/ui/try_err.rs:140:9
    |
 LL |         Err(io::ErrorKind::WriteZero)?
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:142:9
+  --> tests/ui/try_err.rs:143:9
    |
 LL |         Err(io::Error::new(io::ErrorKind::InvalidInput, "error"))?
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidInput, "error")))`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:151:9
+  --> tests/ui/try_err.rs:152:9
    |
 LL |         Err(io::ErrorKind::NotFound)?
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Some(Err(io::ErrorKind::NotFound.into())))`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:161:16
+  --> tests/ui/try_err.rs:162:16
    |
 LL |         return Err(42)?;
    |                ^^^^^^^^ help: try: `Err(42)`

--- a/tests/ui/unnecessary_clone.rs
+++ b/tests/ui/unnecessary_clone.rs
@@ -2,6 +2,8 @@
 #![warn(clippy::clone_on_ref_ptr)]
 #![allow(unused)]
 #![allow(clippy::redundant_clone, clippy::uninlined_format_args, clippy::unnecessary_wraps)]
+#![allow(clippy::relative_path_in_macro_definition)]
+
 //@no-rustfix
 use std::cell::RefCell;
 use std::rc::{self, Rc};

--- a/tests/ui/unnecessary_clone.stderr
+++ b/tests/ui/unnecessary_clone.stderr
@@ -1,5 +1,5 @@
 error: using `.clone()` on a ref-counted pointer
-  --> tests/ui/unnecessary_clone.rs:23:5
+  --> tests/ui/unnecessary_clone.rs:25:5
    |
 LL |     rc.clone();
    |     ^^^^^^^^^^ help: try: `Rc::<bool>::clone(&rc)`
@@ -8,31 +8,31 @@ LL |     rc.clone();
    = help: to override `-D warnings` add `#[allow(clippy::clone_on_ref_ptr)]`
 
 error: using `.clone()` on a ref-counted pointer
-  --> tests/ui/unnecessary_clone.rs:28:5
+  --> tests/ui/unnecessary_clone.rs:30:5
    |
 LL |     arc.clone();
    |     ^^^^^^^^^^^ help: try: `Arc::<bool>::clone(&arc)`
 
 error: using `.clone()` on a ref-counted pointer
-  --> tests/ui/unnecessary_clone.rs:33:5
+  --> tests/ui/unnecessary_clone.rs:35:5
    |
 LL |     rcweak.clone();
    |     ^^^^^^^^^^^^^^ help: try: `Weak::<bool>::clone(&rcweak)`
 
 error: using `.clone()` on a ref-counted pointer
-  --> tests/ui/unnecessary_clone.rs:38:5
+  --> tests/ui/unnecessary_clone.rs:40:5
    |
 LL |     arc_weak.clone();
    |     ^^^^^^^^^^^^^^^^ help: try: `Weak::<bool>::clone(&arc_weak)`
 
 error: using `.clone()` on a ref-counted pointer
-  --> tests/ui/unnecessary_clone.rs:44:33
+  --> tests/ui/unnecessary_clone.rs:46:33
    |
 LL |     let _: Arc<dyn SomeTrait> = x.clone();
    |                                 ^^^^^^^^^ help: try: `Arc::<SomeImpl>::clone(&x)`
 
 error: using `clone` on type `T` which implements the `Copy` trait
-  --> tests/ui/unnecessary_clone.rs:49:5
+  --> tests/ui/unnecessary_clone.rs:51:5
    |
 LL |     t.clone();
    |     ^^^^^^^^^ help: try removing the `clone` call: `t`
@@ -41,19 +41,19 @@ LL |     t.clone();
    = help: to override `-D warnings` add `#[allow(clippy::clone_on_copy)]`
 
 error: using `clone` on type `Option<T>` which implements the `Copy` trait
-  --> tests/ui/unnecessary_clone.rs:52:5
+  --> tests/ui/unnecessary_clone.rs:54:5
    |
 LL |     Some(t).clone();
    |     ^^^^^^^^^^^^^^^ help: try removing the `clone` call: `Some(t)`
 
 error: using `clone` on type `E` which implements the `Copy` trait
-  --> tests/ui/unnecessary_clone.rs:87:20
+  --> tests/ui/unnecessary_clone.rs:89:20
    |
 LL |         let _: E = a.clone();
    |                    ^^^^^^^^^ help: try dereferencing it: `*****a`
 
 error: using `.clone()` on a ref-counted pointer
-  --> tests/ui/unnecessary_clone.rs:108:14
+  --> tests/ui/unnecessary_clone.rs:110:14
    |
 LL |         Some(try_opt!(Some(rc)).clone())
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Rc::<u8>::clone(&try_opt!(Some(rc)))`

--- a/tests/ui/unnecessary_to_owned.fixed
+++ b/tests/ui/unnecessary_to_owned.fixed
@@ -5,6 +5,7 @@
     clippy::needless_lifetimes,
     clippy::owned_cow,
     clippy::ptr_arg,
+    clippy::relative_path_in_macro_definition,
     clippy::uninlined_format_args
 )]
 #![warn(clippy::unnecessary_to_owned, clippy::redundant_clone)]

--- a/tests/ui/unnecessary_to_owned.rs
+++ b/tests/ui/unnecessary_to_owned.rs
@@ -5,6 +5,7 @@
     clippy::needless_lifetimes,
     clippy::owned_cow,
     clippy::ptr_arg,
+    clippy::relative_path_in_macro_definition,
     clippy::uninlined_format_args
 )]
 #![warn(clippy::unnecessary_to_owned, clippy::redundant_clone)]

--- a/tests/ui/unnecessary_to_owned.stderr
+++ b/tests/ui/unnecessary_to_owned.stderr
@@ -1,11 +1,11 @@
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:218:64
+  --> tests/ui/unnecessary_to_owned.rs:219:64
    |
 LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned());
    |                                                                ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:218:20
+  --> tests/ui/unnecessary_to_owned.rs:219:20
    |
 LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,55 +13,55 @@ LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned())
    = help: to override `-D warnings` add `#[allow(clippy::redundant_clone)]`
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:220:40
+  --> tests/ui/unnecessary_to_owned.rs:221:40
    |
 LL |     require_os_str(&OsString::from("x").to_os_string());
    |                                        ^^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:220:21
+  --> tests/ui/unnecessary_to_owned.rs:221:21
    |
 LL |     require_os_str(&OsString::from("x").to_os_string());
    |                     ^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:222:48
+  --> tests/ui/unnecessary_to_owned.rs:223:48
    |
 LL |     require_path(&std::path::PathBuf::from("x").to_path_buf());
    |                                                ^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:222:19
+  --> tests/ui/unnecessary_to_owned.rs:223:19
    |
 LL |     require_path(&std::path::PathBuf::from("x").to_path_buf());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:224:35
+  --> tests/ui/unnecessary_to_owned.rs:225:35
    |
 LL |     require_str(&String::from("x").to_string());
    |                                   ^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:224:18
+  --> tests/ui/unnecessary_to_owned.rs:225:18
    |
 LL |     require_str(&String::from("x").to_string());
    |                  ^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:226:39
+  --> tests/ui/unnecessary_to_owned.rs:227:39
    |
 LL |     require_slice(&[String::from("x")].to_owned());
    |                                       ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:226:20
+  --> tests/ui/unnecessary_to_owned.rs:227:20
    |
 LL |     require_slice(&[String::from("x")].to_owned());
    |                    ^^^^^^^^^^^^^^^^^^^
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:66:36
+  --> tests/ui/unnecessary_to_owned.rs:67:36
    |
 LL |     require_c_str(&Cow::from(c_str).into_owned());
    |                                    ^^^^^^^^^^^^^ help: remove this
@@ -70,391 +70,391 @@ LL |     require_c_str(&Cow::from(c_str).into_owned());
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_to_owned)]`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:68:19
+  --> tests/ui/unnecessary_to_owned.rs:69:19
    |
 LL |     require_c_str(&c_str.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_os_string`
-  --> tests/ui/unnecessary_to_owned.rs:71:20
+  --> tests/ui/unnecessary_to_owned.rs:72:20
    |
 LL |     require_os_str(&os_str.to_os_string());
    |                    ^^^^^^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:73:38
+  --> tests/ui/unnecessary_to_owned.rs:74:38
    |
 LL |     require_os_str(&Cow::from(os_str).into_owned());
    |                                      ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:75:20
+  --> tests/ui/unnecessary_to_owned.rs:76:20
    |
 LL |     require_os_str(&os_str.to_owned());
    |                    ^^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_path_buf`
-  --> tests/ui/unnecessary_to_owned.rs:78:18
+  --> tests/ui/unnecessary_to_owned.rs:79:18
    |
 LL |     require_path(&path.to_path_buf());
    |                  ^^^^^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:80:34
+  --> tests/ui/unnecessary_to_owned.rs:81:34
    |
 LL |     require_path(&Cow::from(path).into_owned());
    |                                  ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:82:18
+  --> tests/ui/unnecessary_to_owned.rs:83:18
    |
 LL |     require_path(&path.to_owned());
    |                  ^^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:85:17
+  --> tests/ui/unnecessary_to_owned.rs:86:17
    |
 LL |     require_str(&s.to_string());
    |                 ^^^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:87:30
+  --> tests/ui/unnecessary_to_owned.rs:88:30
    |
 LL |     require_str(&Cow::from(s).into_owned());
    |                              ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:89:17
+  --> tests/ui/unnecessary_to_owned.rs:90:17
    |
 LL |     require_str(&s.to_owned());
    |                 ^^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:91:17
+  --> tests/ui/unnecessary_to_owned.rs:92:17
    |
 LL |     require_str(&x_ref.to_string());
    |                 ^^^^^^^^^^^^^^^^^^ help: use: `x_ref.as_ref()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:94:19
+  --> tests/ui/unnecessary_to_owned.rs:95:19
    |
 LL |     require_slice(&slice.to_vec());
    |                   ^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:96:36
+  --> tests/ui/unnecessary_to_owned.rs:97:36
    |
 LL |     require_slice(&Cow::from(slice).into_owned());
    |                                    ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:98:19
+  --> tests/ui/unnecessary_to_owned.rs:99:19
    |
 LL |     require_slice(&array.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `array.as_ref()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:100:19
+  --> tests/ui/unnecessary_to_owned.rs:101:19
    |
 LL |     require_slice(&array_ref.to_owned());
    |                   ^^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref.as_ref()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:102:19
+  --> tests/ui/unnecessary_to_owned.rs:103:19
    |
 LL |     require_slice(&slice.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:106:42
+  --> tests/ui/unnecessary_to_owned.rs:107:42
    |
 LL |     require_x(&Cow::<X>::Owned(x.clone()).into_owned());
    |                                          ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:110:25
+  --> tests/ui/unnecessary_to_owned.rs:111:25
    |
 LL |     require_deref_c_str(c_str.to_owned());
    |                         ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:112:26
+  --> tests/ui/unnecessary_to_owned.rs:113:26
    |
 LL |     require_deref_os_str(os_str.to_owned());
    |                          ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:114:24
+  --> tests/ui/unnecessary_to_owned.rs:115:24
    |
 LL |     require_deref_path(path.to_owned());
    |                        ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:116:23
+  --> tests/ui/unnecessary_to_owned.rs:117:23
    |
 LL |     require_deref_str(s.to_owned());
    |                       ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:118:25
+  --> tests/ui/unnecessary_to_owned.rs:119:25
    |
 LL |     require_deref_slice(slice.to_owned());
    |                         ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:121:30
+  --> tests/ui/unnecessary_to_owned.rs:122:30
    |
 LL |     require_impl_deref_c_str(c_str.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:123:31
+  --> tests/ui/unnecessary_to_owned.rs:124:31
    |
 LL |     require_impl_deref_os_str(os_str.to_owned());
    |                               ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:125:29
+  --> tests/ui/unnecessary_to_owned.rs:126:29
    |
 LL |     require_impl_deref_path(path.to_owned());
    |                             ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:127:28
+  --> tests/ui/unnecessary_to_owned.rs:128:28
    |
 LL |     require_impl_deref_str(s.to_owned());
    |                            ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:129:30
+  --> tests/ui/unnecessary_to_owned.rs:130:30
    |
 LL |     require_impl_deref_slice(slice.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:132:29
+  --> tests/ui/unnecessary_to_owned.rs:133:29
    |
 LL |     require_deref_str_slice(s.to_owned(), slice.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:132:43
+  --> tests/ui/unnecessary_to_owned.rs:133:43
    |
 LL |     require_deref_str_slice(s.to_owned(), slice.to_owned());
    |                                           ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:135:29
+  --> tests/ui/unnecessary_to_owned.rs:136:29
    |
 LL |     require_deref_slice_str(slice.to_owned(), s.to_owned());
    |                             ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:135:47
+  --> tests/ui/unnecessary_to_owned.rs:136:47
    |
 LL |     require_deref_slice_str(slice.to_owned(), s.to_owned());
    |                                               ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:139:26
+  --> tests/ui/unnecessary_to_owned.rs:140:26
    |
 LL |     require_as_ref_c_str(c_str.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:141:27
+  --> tests/ui/unnecessary_to_owned.rs:142:27
    |
 LL |     require_as_ref_os_str(os_str.to_owned());
    |                           ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:143:25
+  --> tests/ui/unnecessary_to_owned.rs:144:25
    |
 LL |     require_as_ref_path(path.to_owned());
    |                         ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:145:24
+  --> tests/ui/unnecessary_to_owned.rs:146:24
    |
 LL |     require_as_ref_str(s.to_owned());
    |                        ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:147:24
+  --> tests/ui/unnecessary_to_owned.rs:148:24
    |
 LL |     require_as_ref_str(x.to_owned());
    |                        ^^^^^^^^^^^^ help: use: `&x`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:149:26
+  --> tests/ui/unnecessary_to_owned.rs:150:26
    |
 LL |     require_as_ref_slice(array.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:151:26
+  --> tests/ui/unnecessary_to_owned.rs:152:26
    |
 LL |     require_as_ref_slice(array_ref.to_owned());
    |                          ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:153:26
+  --> tests/ui/unnecessary_to_owned.rs:154:26
    |
 LL |     require_as_ref_slice(slice.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:156:31
+  --> tests/ui/unnecessary_to_owned.rs:157:31
    |
 LL |     require_impl_as_ref_c_str(c_str.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:158:32
+  --> tests/ui/unnecessary_to_owned.rs:159:32
    |
 LL |     require_impl_as_ref_os_str(os_str.to_owned());
    |                                ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:160:30
+  --> tests/ui/unnecessary_to_owned.rs:161:30
    |
 LL |     require_impl_as_ref_path(path.to_owned());
    |                              ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:162:29
+  --> tests/ui/unnecessary_to_owned.rs:163:29
    |
 LL |     require_impl_as_ref_str(s.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:164:29
+  --> tests/ui/unnecessary_to_owned.rs:165:29
    |
 LL |     require_impl_as_ref_str(x.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `&x`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:166:31
+  --> tests/ui/unnecessary_to_owned.rs:167:31
    |
 LL |     require_impl_as_ref_slice(array.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:168:31
+  --> tests/ui/unnecessary_to_owned.rs:169:31
    |
 LL |     require_impl_as_ref_slice(array_ref.to_owned());
    |                               ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:170:31
+  --> tests/ui/unnecessary_to_owned.rs:171:31
    |
 LL |     require_impl_as_ref_slice(slice.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:173:30
+  --> tests/ui/unnecessary_to_owned.rs:174:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:173:44
+  --> tests/ui/unnecessary_to_owned.rs:174:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array.to_owned());
    |                                            ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:176:30
+  --> tests/ui/unnecessary_to_owned.rs:177:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array_ref.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:176:44
+  --> tests/ui/unnecessary_to_owned.rs:177:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array_ref.to_owned());
    |                                            ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:179:30
+  --> tests/ui/unnecessary_to_owned.rs:180:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), slice.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:179:44
+  --> tests/ui/unnecessary_to_owned.rs:180:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), slice.to_owned());
    |                                            ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:182:30
+  --> tests/ui/unnecessary_to_owned.rs:183:30
    |
 LL |     require_as_ref_slice_str(array.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:182:48
+  --> tests/ui/unnecessary_to_owned.rs:183:48
    |
 LL |     require_as_ref_slice_str(array.to_owned(), s.to_owned());
    |                                                ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:185:30
+  --> tests/ui/unnecessary_to_owned.rs:186:30
    |
 LL |     require_as_ref_slice_str(array_ref.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:185:52
+  --> tests/ui/unnecessary_to_owned.rs:186:52
    |
 LL |     require_as_ref_slice_str(array_ref.to_owned(), s.to_owned());
    |                                                    ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:188:30
+  --> tests/ui/unnecessary_to_owned.rs:189:30
    |
 LL |     require_as_ref_slice_str(slice.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:188:48
+  --> tests/ui/unnecessary_to_owned.rs:189:48
    |
 LL |     require_as_ref_slice_str(slice.to_owned(), s.to_owned());
    |                                                ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:192:20
+  --> tests/ui/unnecessary_to_owned.rs:193:20
    |
 LL |     let _ = x.join(&x_ref.to_string());
    |                    ^^^^^^^^^^^^^^^^^^ help: use: `x_ref`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:195:13
+  --> tests/ui/unnecessary_to_owned.rs:196:13
    |
 LL |     let _ = slice.to_vec().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:197:13
+  --> tests/ui/unnecessary_to_owned.rs:198:13
    |
 LL |     let _ = slice.to_owned().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:200:13
+  --> tests/ui/unnecessary_to_owned.rs:201:13
    |
 LL |     let _ = IntoIterator::into_iter(slice.to_vec());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:202:13
+  --> tests/ui/unnecessary_to_owned.rs:203:13
    |
 LL |     let _ = IntoIterator::into_iter(slice.to_owned());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:230:26
+  --> tests/ui/unnecessary_to_owned.rs:231:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(slice.to_vec()).expect("not UTF-8");
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -466,7 +466,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(&slice).expect("not UTF-8");
    |
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:232:26
+  --> tests/ui/unnecessary_to_owned.rs:233:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(b"foo".to_vec()).unwrap();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -478,7 +478,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(b"foo").unwrap();
    |
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:234:26
+  --> tests/ui/unnecessary_to_owned.rs:235:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(b"foo".as_slice().to_owned()).unwrap();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -490,7 +490,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(b"foo".as_slice()).unwrap();
    |
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:292:14
+  --> tests/ui/unnecessary_to_owned.rs:293:14
    |
 LL |     for t in file_types.to_vec() {
    |              ^^^^^^^^^^^^^^^^^^^
@@ -503,49 +503,49 @@ LL ~         let path = match get_file_path(t) {
    |
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:358:24
+  --> tests/ui/unnecessary_to_owned.rs:359:24
    |
 LL |         Box::new(build(y.to_string()))
    |                        ^^^^^^^^^^^^^ help: use: `y`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:468:12
+  --> tests/ui/unnecessary_to_owned.rs:469:12
    |
 LL |         id("abc".to_string())
    |            ^^^^^^^^^^^^^^^^^ help: use: `"abc"`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:612:37
+  --> tests/ui/unnecessary_to_owned.rs:613:37
    |
 LL |         IntoFuture::into_future(foo([].to_vec(), &0));
    |                                     ^^^^^^^^^^^ help: use: `[]`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:623:18
+  --> tests/ui/unnecessary_to_owned.rs:624:18
    |
 LL |         s.remove(&a.to_vec());
    |                  ^^^^^^^^^^^ help: replace it with: `a`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:628:14
+  --> tests/ui/unnecessary_to_owned.rs:629:14
    |
 LL |     s.remove(&"b".to_owned());
    |              ^^^^^^^^^^^^^^^ help: replace it with: `"b"`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:630:14
+  --> tests/ui/unnecessary_to_owned.rs:631:14
    |
 LL |     s.remove(&"b".to_string());
    |              ^^^^^^^^^^^^^^^^ help: replace it with: `"b"`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:636:14
+  --> tests/ui/unnecessary_to_owned.rs:637:14
    |
 LL |     s.remove(&["b"].to_vec());
    |              ^^^^^^^^^^^^^^^ help: replace it with: `["b"].as_slice()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:638:14
+  --> tests/ui/unnecessary_to_owned.rs:639:14
    |
 LL |     s.remove(&(&["b"]).to_vec());
    |              ^^^^^^^^^^^^^^^^^^ help: replace it with: `(&["b"]).as_slice()`

--- a/tests/ui/unused_async.rs
+++ b/tests/ui/unused_async.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::unused_async)]
-#![allow(incomplete_features)]
+#![allow(incomplete_features, clippy::relative_path_in_macro_definition)]
 
 use std::future::Future;
 use std::pin::Pin;

--- a/tests/ui/unused_peekable.rs
+++ b/tests/ui/unused_peekable.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::unused_peekable)]
-#![allow(clippy::no_effect)]
+#![allow(clippy::no_effect, clippy::relative_path_in_macro_definition)]
 
 use std::iter::{Empty, Peekable};
 

--- a/tests/ui/unused_result_ok.fixed
+++ b/tests/ui/unused_result_ok.fixed
@@ -1,6 +1,7 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::unused_result_ok)]
 #![allow(dead_code)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/unused_result_ok.rs
+++ b/tests/ui/unused_result_ok.rs
@@ -1,6 +1,7 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::unused_result_ok)]
 #![allow(dead_code)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/unused_result_ok.stderr
+++ b/tests/ui/unused_result_ok.stderr
@@ -1,5 +1,5 @@
 error: ignoring a result with `.ok()` is misleading
-  --> tests/ui/unused_result_ok.rs:9:5
+  --> tests/ui/unused_result_ok.rs:10:5
    |
 LL |     x.parse::<u32>().ok();
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     let _ = x.parse::<u32>();
    |
 
 error: ignoring a result with `.ok()` is misleading
-  --> tests/ui/unused_result_ok.rs:19:5
+  --> tests/ui/unused_result_ok.rs:20:5
    |
 LL |     x   .   parse::<i32>()   .   ok   ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     let _ = x   .   parse::<i32>();
    |
 
 error: ignoring a result with `.ok()` is misleading
-  --> tests/ui/unused_result_ok.rs:37:5
+  --> tests/ui/unused_result_ok.rs:38:5
    |
 LL |     v!().ok();
    |     ^^^^^^^^^
@@ -37,7 +37,7 @@ LL +     let _ = v!();
    |
 
 error: ignoring a result with `.ok()` is misleading
-  --> tests/ui/unused_result_ok.rs:31:9
+  --> tests/ui/unused_result_ok.rs:32:9
    |
 LL |         Ok::<(), ()>(()).ok();
    |         ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unused_trait_names.fixed
+++ b/tests/ui/unused_trait_names.fixed
@@ -1,6 +1,7 @@
 //@aux-build:proc_macros.rs
 
 #![allow(unused)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::unused_trait_names)]
 #![feature(decl_macro)]
 

--- a/tests/ui/unused_trait_names.rs
+++ b/tests/ui/unused_trait_names.rs
@@ -1,6 +1,7 @@
 //@aux-build:proc_macros.rs
 
 #![allow(unused)]
+#![allow(clippy::relative_path_in_macro_definition)]
 #![warn(clippy::unused_trait_names)]
 #![feature(decl_macro)]
 

--- a/tests/ui/unused_trait_names.stderr
+++ b/tests/ui/unused_trait_names.stderr
@@ -1,5 +1,5 @@
 error: unused import: `std::any::Any`
-  --> tests/ui/unused_trait_names.rs:254:9
+  --> tests/ui/unused_trait_names.rs:255:9
    |
 LL |     use std::any::Any;
    |         ^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     use std::any::Any;
    = help: to override `-D warnings` add `#[allow(unused_imports)]`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:12:19
+  --> tests/ui/unused_trait_names.rs:13:19
    |
 LL |     use std::any::Any;
    |                   ^^^ help: use: `Any as _`
@@ -17,49 +17,49 @@ LL |     use std::any::Any;
    = help: to override `-D warnings` add `#[allow(clippy::unused_trait_names)]`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:32:26
+  --> tests/ui/unused_trait_names.rs:33:26
    |
 LL |     use std::any::{self, Any, TypeId};
    |                          ^^^ help: use: `Any as _`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:45:19
+  --> tests/ui/unused_trait_names.rs:46:19
    |
 LL |     use std::any::Any as MyAny;
    |                   ^^^^^^^^^^^^ help: use: `Any as _`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:52:20
+  --> tests/ui/unused_trait_names.rs:53:20
    |
 LL |     use std::any::{Any as MyAny, TypeId as MyTypeId};
    |                    ^^^^^^^^^^^^ help: use: `Any as _`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:76:23
+  --> tests/ui/unused_trait_names.rs:77:23
    |
 LL |         use std::any::Any;
    |                       ^^^ help: use: `Any as _`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:118:19
+  --> tests/ui/unused_trait_names.rs:119:19
    |
 LL |     use std::any::Any;
    |                   ^^^ help: use: `Any as _`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:138:19
+  --> tests/ui/unused_trait_names.rs:139:19
    |
 LL |     use std::any::Any;
    |                   ^^^ help: use: `Any as _`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:198:34
+  --> tests/ui/unused_trait_names.rs:199:34
    |
 LL |     use simple_trait::{MyStruct, MyTrait};
    |                                  ^^^^^^^ help: use: `MyTrait as _`
 
 error: importing trait that is only used anonymously
-  --> tests/ui/unused_trait_names.rs:206:27
+  --> tests/ui/unused_trait_names.rs:207:27
    |
 LL |             use std::any::Any;
    |                           ^^^ help: use: `Any as _`

--- a/tests/ui/unwrap_expect_used.rs
+++ b/tests/ui/unwrap_expect_used.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::unwrap_used, clippy::expect_used)]
-#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::relative_path_in_macro_definition)]
 #![feature(never_type)]
 
 use std::convert::Infallible;

--- a/tests/ui/useless_nonzero_new_unchecked.fixed
+++ b/tests/ui/useless_nonzero_new_unchecked.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::useless_nonzero_new_unchecked)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 use std::num::{NonZero, NonZeroUsize};
 

--- a/tests/ui/useless_nonzero_new_unchecked.rs
+++ b/tests/ui/useless_nonzero_new_unchecked.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::useless_nonzero_new_unchecked)]
+#![allow(clippy::relative_path_in_macro_definition)]
 
 use std::num::{NonZero, NonZeroUsize};
 

--- a/tests/ui/useless_nonzero_new_unchecked.stderr
+++ b/tests/ui/useless_nonzero_new_unchecked.stderr
@@ -1,5 +1,5 @@
 error: `NonZeroUsize::new()` and `Option::unwrap()` can be safely used in a `const` context
-  --> tests/ui/useless_nonzero_new_unchecked.rs:7:13
+  --> tests/ui/useless_nonzero_new_unchecked.rs:8:13
    |
 LL |     const { unsafe { NonZeroUsize::new_unchecked(3) } }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use instead: `NonZeroUsize::new(3).unwrap()`
@@ -8,19 +8,19 @@ LL |     const { unsafe { NonZeroUsize::new_unchecked(3) } }
    = help: to override `-D warnings` add `#[allow(clippy::useless_nonzero_new_unchecked)]`
 
 error: `NonZeroUsize::new()` and `Option::unwrap()` can be safely used in a `const` context
-  --> tests/ui/useless_nonzero_new_unchecked.rs:37:30
+  --> tests/ui/useless_nonzero_new_unchecked.rs:38:30
    |
 LL |     const _A: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(3) };
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use instead: `NonZeroUsize::new(3).unwrap()`
 
 error: `NonZero::<u8>::new()` and `Option::unwrap()` can be safely used in a `const` context
-  --> tests/ui/useless_nonzero_new_unchecked.rs:40:30
+  --> tests/ui/useless_nonzero_new_unchecked.rs:41:30
    |
 LL |     static _B: NonZero<u8> = unsafe { NonZero::<u8>::new_unchecked(42) };
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use instead: `NonZero::<u8>::new(42).unwrap()`
 
 error: `NonZeroUsize::new()` and `Option::unwrap()` can be safely used in a `const` context
-  --> tests/ui/useless_nonzero_new_unchecked.rs:43:32
+  --> tests/ui/useless_nonzero_new_unchecked.rs:44:32
    |
 LL |     const _C: usize = unsafe { NonZeroUsize::new_unchecked(3).get() };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use instead: `NonZeroUsize::new(3).unwrap()`
@@ -28,7 +28,7 @@ LL |     const _C: usize = unsafe { NonZeroUsize::new_unchecked(3).get() };
    = note: the fixed expression does not require an `unsafe` context
 
 error: `NonZeroUsize::new()` and `Option::unwrap()` can be safely used in a `const` context
-  --> tests/ui/useless_nonzero_new_unchecked.rs:47:30
+  --> tests/ui/useless_nonzero_new_unchecked.rs:48:30
    |
 LL |     const _D: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(AUX) };
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use instead: `NonZeroUsize::new(AUX).unwrap()`


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/14648)*

Add relative_path_in_macro_definition lint (rust-lang/rust-clippy#14472) rust-lang/rust-clippy#14645

Implements the relative_path_in_macro_definition lint to warn about relative paths to core or kernel in macro definitions, as requested in rust-lang/rust-clippy#14472.
Includes tests in tests/ui/relative_path_in_macro_definition.rs and updates existing tests (incompatible_msrv.rs, swap_ptr_to_ref_unfixable.rs, arithmetic_side_effects.rs) with #![allow] to avoid interference.

Fixes New lint: relative_path_in_macro_definition rust-lang/rust-clippy#14472
Tests pass: cargo test, cargo test --test compile-test, cargo test --test integration
cargo fmt clean

changelog: add 'relative_path_in_macro_definition' lint.

Signed-off-by: Kunwu Chan <kunwu.chan@hotmail.com>
Co-developed-by: Grace Deng <Grace.Deng006@Gmail.com>
Signed-off-by: Grace Deng <Grace.Deng006@Gmail.com>
