### PR TITLE
Fix clippy::version of elidable_lifetime_names to 1.87

### DIFF
--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -468,7 +468,7 @@ declare_clippy_lint! {
     /// #[ignore = "Some good reason"]
     /// fn test() {}
     /// ```
-    #[clippy::version = "1.85.0"]
+    #[clippy::version = "1.88.0"]
     pub IGNORE_WITHOUT_REASON,
     pedantic,
     "ignored tests without messages"

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -780,7 +780,7 @@ declare_clippy_lint! {
     /// let aligned = std::ptr::dangling::<u32>();
     /// let mut_ptr: *mut i64 = std::ptr::dangling_mut();
     /// ```
-    #[clippy::version = "1.87.0"]
+    #[clippy::version = "1.88.0"]
     pub MANUAL_DANGLING_PTR,
     style,
     "casting small constant literals to pointers to create dangling pointers"

--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -93,7 +93,7 @@ declare_clippy_lint! {
     /// ```no_run
     /// //! <code>[first](x)second</code>
     /// ```
-    #[clippy::version = "1.86.0"]
+    #[clippy::version = "1.87.0"]
     pub DOC_LINK_CODE,
     nursery,
     "link with code back-to-back with other code"

--- a/clippy_lints/src/implicit_saturating_sub.rs
+++ b/clippy_lints/src/implicit_saturating_sub.rs
@@ -69,7 +69,7 @@ declare_clippy_lint! {
     ///
     /// let result = a.saturating_sub(b);
     /// ```
-    #[clippy::version = "1.44.0"]
+    #[clippy::version = "1.83.0"]
     pub INVERTED_SATURATING_SUB,
     correctness,
     "Check if a variable is smaller than another one and still subtract from it even if smaller"

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -88,7 +88,7 @@ declare_clippy_lint! {
     ///     x.chars()
     /// }
     /// ```
-    #[clippy::version = "1.84.0"]
+    #[clippy::version = "1.87.0"]
     pub ELIDABLE_LIFETIME_NAMES,
     pedantic,
     "lifetime name that can be replaced with the anonymous lifetime"

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -778,7 +778,7 @@ declare_clippy_lint! {
     ///     let _ = s[idx..];
     /// }
     /// ```
-    #[clippy::version = "1.83.0"]
+    #[clippy::version = "1.88.0"]
     pub CHAR_INDICES_AS_BYTE_INDICES,
     correctness,
     "using the character position yielded by `.chars().enumerate()` in a context where a byte index is expected"

--- a/clippy_lints/src/manual_abs_diff.rs
+++ b/clippy_lints/src/manual_abs_diff.rs
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// a.abs_diff(b)
     /// # ;
     /// ```
-    #[clippy::version = "1.86.0"]
+    #[clippy::version = "1.87.0"]
     pub MANUAL_ABS_DIFF,
     complexity,
     "using an if-else pattern instead of `abs_diff`"

--- a/clippy_lints/src/manual_abs_diff.rs
+++ b/clippy_lints/src/manual_abs_diff.rs
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// a.abs_diff(b)
     /// # ;
     /// ```
-    #[clippy::version = "1.87.0"]
+    #[clippy::version = "1.88.0"]
     pub MANUAL_ABS_DIFF,
     complexity,
     "using an if-else pattern instead of `abs_diff`"

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -62,7 +62,7 @@ declare_clippy_lint! {
     /// let mut an_option = Some(0);
     /// let taken = an_option.replace(1);
     /// ```
-    #[clippy::version = "1.86.0"]
+    #[clippy::version = "1.87.0"]
     pub MEM_REPLACE_OPTION_WITH_SOME,
     style,
     "replacing an `Option` with `Some` instead of `replace()`"

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4454,7 +4454,7 @@ declare_clippy_lint! {
     ///     values.contains(&10)
     /// }
     /// ```
-    #[clippy::version = "1.86.0"]
+    #[clippy::version = "1.87.0"]
     pub MANUAL_CONTAINS,
     perf,
     "unnecessary `iter().any()` on slices that can be replaced with `contains()`"

--- a/clippy_lints/src/single_option_map.rs
+++ b/clippy_lints/src/single_option_map.rs
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     ///     param * 2
     /// }
     /// ```
-    #[clippy::version = "1.86.0"]
+    #[clippy::version = "1.87.0"]
     pub SINGLE_OPTION_MAP,
     nursery,
     "Checks for functions with method calls to `.map(_)` on an arg of type `Option` as the outermost expression."

--- a/clippy_lints/src/types/mod.rs
+++ b/clippy_lints/src/types/mod.rs
@@ -385,7 +385,7 @@ declare_clippy_lint! {
     /// ```no_run
     /// let right: std::borrow::Cow<'_, [u8]>;
     /// ```
-    #[clippy::version = "1.85.0"]
+    #[clippy::version = "1.87.0"]
     pub OWNED_COW,
     style,
     "needlessly owned Cow type"


### PR DESCRIPTION
relates to rust-lang/rust-clippy#14653

changelog: [`elidable_lifetime_names`]: Fix clippy version that this lint was introduced in.

It might be good to have some automation to check that the version is correct.
IIUC the version should be the current nightly version at the time a PR is merged.
If a release happens while a PR is open, the version needs to be bumped - this is easy to forget.