### PR TITLE
`manual_ok_err`: don't lint subpatterns

### DIFF
--- a/clippy_lints/src/matches/manual_ok_err.rs
+++ b/clippy_lints/src/matches/manual_ok_err.rs
@@ -85,7 +85,7 @@ fn is_variant_or_wildcard(cx: &LateContext<'_>, pat: &Pat<'_>, can_be_wild: bool
 /// contains `Err(IDENT)`, `None` otherwise.
 fn is_ok_or_err<'hir>(cx: &LateContext<'_>, pat: &Pat<'hir>) -> Option<(bool, &'hir Ident)> {
     if let PatKind::TupleStruct(qpath, [arg], _) = &pat.kind
-        && let PatKind::Binding(BindingMode::NONE, _, ident, _) = &arg.kind
+        && let PatKind::Binding(BindingMode::NONE, _, ident, None) = &arg.kind
         && let res = cx.qpath_res(qpath, pat.hir_id)
         && let Res::Def(DefKind::Ctor(..), id) = res
         && let id @ Some(_) = cx.tcx.opt_parent(id)

--- a/tests/ui/manual_ok_err.fixed
+++ b/tests/ui/manual_ok_err.fixed
@@ -80,6 +80,11 @@ fn no_lint() {
         Ok(3) => None,
         Ok(v) => Some(v),
     };
+
+    let _ = match funcall() {
+        Ok(v @ 1..) => Some(v),
+        _ => None,
+    };
 }
 
 const fn cf(x: Result<u32, &'static str>) -> Option<u32> {

--- a/tests/ui/manual_ok_err.rs
+++ b/tests/ui/manual_ok_err.rs
@@ -116,6 +116,11 @@ fn no_lint() {
         Ok(3) => None,
         Ok(v) => Some(v),
     };
+
+    let _ = match funcall() {
+        Ok(v @ 1..) => Some(v),
+        _ => None,
+    };
 }
 
 const fn cf(x: Result<u32, &'static str>) -> Option<u32> {

--- a/tests/ui/manual_ok_err.stderr
+++ b/tests/ui/manual_ok_err.stderr
@@ -94,7 +94,7 @@ LL | |     };
    | |_____^ help: replace with: `(-S).ok()`
 
 error: manual implementation of `ok`
-  --> tests/ui/manual_ok_err.rs:132:12
+  --> tests/ui/manual_ok_err.rs:137:12
    |
 LL |       } else if let Ok(n) = "1".parse::<u8>() {
    |  ____________^


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/14660

changelog: none
