### PR TITLE
Fix integer_division false negative for NonZero denominators

### DIFF
--- a/clippy_lints/src/operators/integer_division.rs
+++ b/clippy_lints/src/operators/integer_division.rs
@@ -1,6 +1,8 @@
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::ty::is_type_diagnostic_item;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::symbol::sym;
 
 use super::INTEGER_DIVISION;
 
@@ -13,7 +15,8 @@ pub(crate) fn check<'tcx>(
 ) {
     if op == hir::BinOpKind::Div
         && cx.typeck_results().expr_ty(left).is_integral()
-        && cx.typeck_results().expr_ty(right).is_integral()
+        && let right_ty = cx.typeck_results().expr_ty(right)
+        && (right_ty.is_integral() || is_type_diagnostic_item(cx, right_ty, sym::NonZero))
     {
         #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
         span_lint_and_then(cx, INTEGER_DIVISION, expr.span, "integer division", |diag| {

--- a/tests/ui/integer_division.rs
+++ b/tests/ui/integer_division.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::integer_division)]
 
+use std::num::NonZeroU32;
+
+const TWO: NonZeroU32 = NonZeroU32::new(2).unwrap();
+
 fn main() {
     let two = 2;
     let n = 1 / 2;
@@ -12,4 +16,8 @@ fn main() {
     //~^ integer_division
 
     let x = 1. / 2.0;
+
+    let a = 1;
+    let s = a / TWO;
+    //~^ integer_division
 }

--- a/tests/ui/integer_division.stderr
+++ b/tests/ui/integer_division.stderr
@@ -1,5 +1,5 @@
 error: integer division
-  --> tests/ui/integer_division.rs:5:13
+  --> tests/ui/integer_division.rs:9:13
    |
 LL |     let n = 1 / 2;
    |             ^^^^^
@@ -9,7 +9,7 @@ LL |     let n = 1 / 2;
    = help: to override `-D warnings` add `#[allow(clippy::integer_division)]`
 
 error: integer division
-  --> tests/ui/integer_division.rs:8:13
+  --> tests/ui/integer_division.rs:12:13
    |
 LL |     let o = 1 / two;
    |             ^^^^^^^
@@ -17,12 +17,20 @@ LL |     let o = 1 / two;
    = help: division of integers may cause loss of precision. consider using floats
 
 error: integer division
-  --> tests/ui/integer_division.rs:11:13
+  --> tests/ui/integer_division.rs:15:13
    |
 LL |     let p = two / 4;
    |             ^^^^^^^
    |
    = help: division of integers may cause loss of precision. consider using floats
 
-error: aborting due to 3 previous errors
+error: integer division
+  --> tests/ui/integer_division.rs:21:13
+   |
+LL |     let s = a / TWO;
+   |             ^^^^^^^
+   |
+   = help: division of integers may cause loss of precision. consider using floats
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Close rust-lang/rust-clippy#14652

changelog: [`integer_division`]: fix false negative for NonZero denominators