### PR TITLE
`manual_div_ceil`: fix suggestions when macro is involved

### DIFF
--- a/clippy_lints/src/manual_div_ceil.rs
+++ b/clippy_lints/src/manual_div_ceil.rs
@@ -1,7 +1,7 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::source::snippet_with_context;
 use clippy_utils::sugg::{Sugg, has_enclosing_paren};
 use clippy_utils::{SpanlessEq, sym};
 use rustc_ast::{BinOpKind, LitIntType, LitKind, UnOp};
@@ -199,9 +199,9 @@ fn build_suggestion(
     } else {
         format!("{dividend_sugg_str}{type_suffix}")
     };
-    let divisor_snippet = snippet_with_applicability(cx, rhs.span.source_callsite(), "..", applicability);
+    let divisor_snippet = snippet_with_context(cx, rhs.span, expr.span.ctxt(), "..", applicability);
 
-    let sugg = format!("{suggestion_before_div_ceil}.div_ceil({divisor_snippet})");
+    let sugg = format!("{suggestion_before_div_ceil}.div_ceil({})", divisor_snippet.0);
 
     span_lint_and_sugg(
         cx,

--- a/tests/ui/manual_div_ceil.fixed
+++ b/tests/ui/manual_div_ceil.fixed
@@ -1,5 +1,21 @@
 #![warn(clippy::manual_div_ceil)]
 
+macro_rules! y {
+    () => {
+        let x = 33u32;
+        let _ = x.div_ceil(8);
+        //~^ manual_div_ceil
+        let _ = x.div_ceil(8);
+        //~^ manual_div_ceil
+    };
+}
+
+macro_rules! eight {
+    () => {
+        8
+    };
+}
+
 fn main() {
     let x = 7_u32;
     let y = 4_u32;
@@ -32,6 +48,13 @@ fn main() {
     let _ = (z as i32 + (y_i - 1)) / y_i;
     let _ = (7_u32 as i32 + (y_i - 1)) / y_i;
     let _ = (7_u32 as i32 + (4 - 1)) / 4;
+
+    // Test lint with macro
+    y!();
+
+    // Also test if RHS should be result of macro expansion
+    let _ = 33u32.div_ceil(eight!());
+    //~^ manual_div_ceil
 }
 
 fn issue_13843() {

--- a/tests/ui/manual_div_ceil.rs
+++ b/tests/ui/manual_div_ceil.rs
@@ -1,5 +1,21 @@
 #![warn(clippy::manual_div_ceil)]
 
+macro_rules! y {
+    () => {
+        let x = 33u32;
+        let _ = (x + 7) / 8;
+        //~^ manual_div_ceil
+        let _ = (7 + x) / 8;
+        //~^ manual_div_ceil
+    };
+}
+
+macro_rules! eight {
+    () => {
+        8
+    };
+}
+
 fn main() {
     let x = 7_u32;
     let y = 4_u32;
@@ -32,6 +48,13 @@ fn main() {
     let _ = (z as i32 + (y_i - 1)) / y_i;
     let _ = (7_u32 as i32 + (y_i - 1)) / y_i;
     let _ = (7_u32 as i32 + (4 - 1)) / 4;
+
+    // Test lint with macro
+    y!();
+
+    // Also test if RHS should be result of macro expansion
+    let _ = (33u32 + 7) / eight!();
+    //~^ manual_div_ceil
 }
 
 fn issue_13843() {

--- a/tests/ui/manual_div_ceil.stderr
+++ b/tests/ui/manual_div_ceil.stderr
@@ -1,5 +1,5 @@
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:9:13
+  --> tests/ui/manual_div_ceil.rs:25:13
    |
 LL |     let _ = (x + (y - 1)) / y;
    |             ^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(y)`
@@ -8,94 +8,122 @@ LL |     let _ = (x + (y - 1)) / y;
    = help: to override `-D warnings` add `#[allow(clippy::manual_div_ceil)]`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:11:13
+  --> tests/ui/manual_div_ceil.rs:27:13
    |
 LL |     let _ = ((y - 1) + x) / y;
    |             ^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(y)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:13:13
+  --> tests/ui/manual_div_ceil.rs:29:13
    |
 LL |     let _ = (x + y - 1) / y;
    |             ^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(y)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:16:13
+  --> tests/ui/manual_div_ceil.rs:32:13
    |
 LL |     let _ = (7_u32 + (4 - 1)) / 4;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `7_u32.div_ceil(4)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:18:13
+  --> tests/ui/manual_div_ceil.rs:34:13
    |
 LL |     let _ = (7_i32 as u32 + (4 - 1)) / 4;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `(7_i32 as u32).div_ceil(4)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:39:13
+  --> tests/ui/manual_div_ceil.rs:6:17
+   |
+LL |         let _ = (x + 7) / 8;
+   |                 ^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(8)`
+...
+LL |     y!();
+   |     ---- in this macro invocation
+   |
+   = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: manually reimplementing `div_ceil`
+  --> tests/ui/manual_div_ceil.rs:8:17
+   |
+LL |         let _ = (7 + x) / 8;
+   |                 ^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(8)`
+...
+LL |     y!();
+   |     ---- in this macro invocation
+   |
+   = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: manually reimplementing `div_ceil`
+  --> tests/ui/manual_div_ceil.rs:56:13
+   |
+LL |     let _ = (33u32 + 7) / eight!();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `33u32.div_ceil(eight!())`
+
+error: manually reimplementing `div_ceil`
+  --> tests/ui/manual_div_ceil.rs:62:13
    |
 LL |     let _ = (2048 + x - 1) / x;
    |             ^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `2048_usize.div_ceil(x)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:43:13
+  --> tests/ui/manual_div_ceil.rs:66:13
    |
 LL |     let _ = (2048usize + x - 1) / x;
    |             ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `2048usize.div_ceil(x)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:47:13
+  --> tests/ui/manual_div_ceil.rs:70:13
    |
 LL |     let _ = (2048_usize + x - 1) / x;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `2048_usize.div_ceil(x)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:51:13
+  --> tests/ui/manual_div_ceil.rs:74:13
    |
 LL |     let _ = (x + 4 - 1) / 4;
    |             ^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(4)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:54:18
+  --> tests/ui/manual_div_ceil.rs:77:18
    |
 LL |     let _: u32 = (2048 + 6 - 1) / 6;
    |                  ^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `2048_u32.div_ceil(6)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:56:20
+  --> tests/ui/manual_div_ceil.rs:79:20
    |
 LL |     let _: usize = (2048 + 6 - 1) / 6;
    |                    ^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `2048_usize.div_ceil(6)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:58:18
+  --> tests/ui/manual_div_ceil.rs:81:18
    |
 LL |     let _: u32 = (0x2048 + 0x6 - 1) / 0x6;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `0x2048_u32.div_ceil(0x6)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:61:13
+  --> tests/ui/manual_div_ceil.rs:84:13
    |
 LL |     let _ = (2048 + 6u32 - 1) / 6u32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `2048_u32.div_ceil(6u32)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:64:13
+  --> tests/ui/manual_div_ceil.rs:87:13
    |
 LL |     let _ = (1_000_000 + 6u32 - 1) / 6u32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `1_000_000_u32.div_ceil(6u32)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:70:13
+  --> tests/ui/manual_div_ceil.rs:93:13
    |
 LL |     let _ = (x + 7) / 8;
    |             ^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(8)`
 
 error: manually reimplementing `div_ceil`
-  --> tests/ui/manual_div_ceil.rs:72:13
+  --> tests/ui/manual_div_ceil.rs:95:13
    |
 LL |     let _ = (7 + x) / 8;
    |             ^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(8)`
 
-error: aborting due to 16 previous errors
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
here is my small fix

changelog: fix suggestion span to avoid showing macro name in `.div_ceil()` suggestion



i changed this line
`let divisor_snippet = snippet_with_applicability(cx, rhs.spansource_callsite(), "..", applicability);`
to this line
`let divisor_snippet = snippet_with_applicability(cx, rhs.span, "..", applicability);`
to fix problem where this warning in macro expands like this
```rust
4  |         let _ = (x + 7) / 8;
   |                 ^^^^^^^^^^^ help: consider using `.div_ceil()`: `x.div_ceil(y!())`
```
[play it yourself](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=397aa8cd2ffffb24a286fbddbc75446c)

as you can see here it looks like `x.div_ceil(y!())` and contains macro signature
so i fixed this problem, i will look closely if there any more problems like this and fix them in order

**Related issue** 

fixes [rust-lang/rust-clippy#14665](https://github.com/rust-lang/rust-clippy/issues/14665)