### PR TITLE
remove non-existent pathspec from pre-commit hook

### DIFF
--- a/util/etc/pre-commit.sh
+++ b/util/etc/pre-commit.sh
@@ -6,7 +6,6 @@ set -e
 # Update lints
 cargo dev update_lints
 git add clippy_lints/src/lib.rs
-git add clippy_lints/src/lib.*.rs
 
 # Formatting:
 #     Git will not automatically add the formatted code to the staged changes once


### PR DESCRIPTION
it was added back in 6035e050e83cc991f94797eef4d720c0b61d8955, at which time there were some files matching it, e.g.
https://github.com/rust-lang/rust-clippy/blob/6035e050e83cc991f94797eef4d720c0b61d8955/clippy_lints/src/lib.deprecated.rs

fixes rust-lang/rust-clippy#14670

changelog: none
