### PR TITLE
Soft rename `clippy::all` to `clippy::default`

### DIFF
--- a/declare_clippy_lint/src/lib.rs
+++ b/declare_clippy_lint/src/lib.rs
@@ -48,7 +48,8 @@ impl LintListBuilder {
 
     pub fn register(self, store: &mut LintStore) {
         store.register_lints(&self.lints);
-        store.register_group(true, "clippy::all", Some("clippy_all"), self.all);
+        store.register_group(true, "clippy::default", Some("clippy_all"), self.all);
+        store.register_group_alias("clippy::default", "clippy::all");
         store.register_group(true, "clippy::cargo", Some("clippy_cargo"), self.cargo);
         store.register_group(true, "clippy::complexity", Some("clippy_complexity"), self.complexity);
         store.register_group(

--- a/tests/ui/clippy_all_group.rs
+++ b/tests/ui/clippy_all_group.rs
@@ -1,0 +1,11 @@
+// Tests that `clippy::all` still works without a deprecation warning
+
+//@require-annotations-for-level: WARN
+
+#![deny(clippy::all)]
+
+fn f() {
+    "a".replace("a", "a");
+    //~^ no_effect_replace
+    //~| NOTE: implied by `#[deny(clippy::all)]`
+}

--- a/tests/ui/clippy_all_group.stderr
+++ b/tests/ui/clippy_all_group.stderr
@@ -1,0 +1,15 @@
+error: replacing text with itself
+  --> tests/ui/clippy_all_group.rs:8:5
+   |
+LL |     "a".replace("a", "a");
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> tests/ui/clippy_all_group.rs:5:9
+   |
+LL | #![deny(clippy::all)]
+   |         ^^^^^^^^^^^
+   = note: `#[deny(clippy::no_effect_replace)]` implied by `#[deny(clippy::all)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
r? @flip1995

For now I haven't updated the docs since people read the current README/etc for stable usage

changelog: `clippy::all` has been renamed to `clippy::default`, existing uses of `clippy::all` do not need to be changed
