### PR TITLE
fix: `unused_async` FP on default impl

### DIFF
--- a/tests/ui/unused_async.rs
+++ b/tests/ui/unused_async.rs
@@ -119,3 +119,11 @@ fn main() {
     foo();
     bar();
 }
+
+mod issue14704 {
+    use std::sync::Arc;
+
+    trait Action {
+        async fn cancel(self: Arc<Self>) {}
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14704

changelog: [`unused_async`] fix FP on default impl
