### PR TITLE
Fix `collapsible_if` FP on block stmt before expr

### DIFF
--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -4,7 +4,7 @@ use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::{IntoSpan as _, SpanRangeExt, snippet, snippet_block, snippet_block_with_applicability};
 use rustc_ast::BinOpKind;
 use rustc_errors::Applicability;
-use rustc_hir::{Block, Expr, ExprKind, StmtKind};
+use rustc_hir::{Block, Expr, ExprKind, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
 use rustc_span::Span;
@@ -203,13 +203,12 @@ fn block_starts_with_comment(cx: &LateContext<'_>, block: &Block<'_>) -> bool {
 fn expr_block<'tcx>(block: &Block<'tcx>) -> Option<&'tcx Expr<'tcx>> {
     match block.stmts {
         [] => block.expr,
-        [stmt] => {
-            if let StmtKind::Semi(expr) = stmt.kind {
-                Some(expr)
-            } else {
-                None
-            }
-        },
+        [
+            Stmt {
+                kind: StmtKind::Semi(expr),
+                ..
+            },
+        ] if block.expr.is_none() => Some(expr),
         _ => None,
     }
 }

--- a/tests/ui/collapsible_if.fixed
+++ b/tests/ui/collapsible_if.fixed
@@ -143,3 +143,14 @@ fn layout_check() -> u32 {
     ; 3
     //~^^^^^ collapsible_if
 }
+
+fn issue14722() {
+    let x = if true {
+        Some(1)
+    } else {
+        if true {
+            println!("Some debug information");
+        };
+        None
+    };
+}

--- a/tests/ui/collapsible_if.rs
+++ b/tests/ui/collapsible_if.rs
@@ -153,3 +153,14 @@ fn layout_check() -> u32 {
     }; 3
     //~^^^^^ collapsible_if
 }
+
+fn issue14722() {
+    let x = if true {
+        Some(1)
+    } else {
+        if true {
+            println!("Some debug information");
+        };
+        None
+    };
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14722 

changelog: [`collapsible_if`] fix FP on block stmt before expr
