### PR TITLE
Don't warn about unloaded crates

### DIFF
--- a/tests/ui-toml/toml_unloaded_crate/clippy.toml
+++ b/tests/ui-toml/toml_unloaded_crate/clippy.toml
@@ -1,0 +1,10 @@
+# The first two `disallowed-methods` paths should generate warnings, but the third should not.
+
+[[disallowed-methods]]
+path = "regex::Regex::new_"
+
+[[disallowed-methods]]
+path = "regex::Regex_::new"
+
+[[disallowed-methods]]
+path = "regex_::Regex::new"

--- a/tests/ui-toml/toml_unloaded_crate/conf_unloaded_crate.rs
+++ b/tests/ui-toml/toml_unloaded_crate/conf_unloaded_crate.rs
@@ -1,0 +1,6 @@
+//@error-in-other-file: `regex::Regex::new_` does not refer to an existing function
+//@error-in-other-file: `regex::Regex_::new` does not refer to an existing function
+
+extern crate regex;
+
+fn main() {}

--- a/tests/ui-toml/toml_unloaded_crate/conf_unloaded_crate.stderr
+++ b/tests/ui-toml/toml_unloaded_crate/conf_unloaded_crate.stderr
@@ -1,0 +1,16 @@
+warning: `regex::Regex::new_` does not refer to an existing function
+  --> $DIR/tests/ui-toml/toml_unloaded_crate/clippy.toml:3:1
+   |
+LL | / [[disallowed-methods]]
+LL | | path = "regex::Regex::new_"
+   | |___________________________^
+
+warning: `regex::Regex_::new` does not refer to an existing function
+  --> $DIR/tests/ui-toml/toml_unloaded_crate/clippy.toml:6:1
+   |
+LL | / [[disallowed-methods]]
+LL | | path = "regex::Regex_::new"
+   | |___________________________^
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/pull/14397#issuecomment-2848328221

r? @samueltardieu

changelog: Don't warn about clippy.toml disallowed paths for crates that were not loaded