### PR TITLE
Post `non_std_lazy_statics` type warnings onto the right node

### DIFF
--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.fixed
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.fixed
@@ -70,3 +70,10 @@ mod external_macros {
     once_cell::external!();
     lazy_static::external!();
 }
+
+mod issue14729 {
+    use once_cell::sync::Lazy;
+
+    #[expect(clippy::non_std_lazy_statics)]
+    static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
+}

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs
@@ -70,3 +70,10 @@ mod external_macros {
     once_cell::external!();
     lazy_static::external!();
 }
+
+mod issue14729 {
+    use once_cell::sync::Lazy;
+
+    #[expect(clippy::non_std_lazy_statics)]
+    static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
+}


### PR DESCRIPTION
When a `non_std_lazy_statics` warning is generated about an item type which can be replaced by a standard library one, ensure that the lint happens on the item HIR node so that it can be expected.

changelog: [`non_std_lazy_statics`]: generate the warning onto the right node

Fixes rust-lang/rust-clippy#14729 

Note that this doesn't change anything on lints generated for the `lazy_static::lazy_static` macro because the `expect` attribute cannot be applied to a macro.