### PR TITLE
triagebot: `canonicalize-issue-links` → `issue-links`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -13,7 +13,7 @@ allow-unauthenticated = [
 
 [note]
 
-[canonicalize-issue-links]
+[issue-links]
 
 # Prevents mentions in commits to avoid users being spammed
 [no-mentions]


### PR DESCRIPTION
The feature [has been renamed](https://forge.rust-lang.org/triagebot/canonicalize-issue-links.html).

changelog: none