### PR TITLE
Fix messages for `type_repetition_in_bounds`

### DIFF
--- a/tests/ui-toml/type_repetition_in_bounds/main.rs
+++ b/tests/ui-toml/type_repetition_in_bounds/main.rs
@@ -12,7 +12,7 @@ fn f2<T>()
 where
     T: Copy + Clone + Sync + Send + ?Sized,
     T: Unpin + PartialEq,
-    //~^ ERROR: this type has already been used as a bound predicate
+    //~^ type_repetition_in_bounds
 {
 }
 

--- a/tests/ui-toml/type_repetition_in_bounds/main.stderr
+++ b/tests/ui-toml/type_repetition_in_bounds/main.stderr
@@ -1,4 +1,4 @@
-error: this type has already been used as a bound predicate
+error: type `T` has already been used as a bound predicate
   --> tests/ui-toml/type_repetition_in_bounds/main.rs:14:5
    |
 LL |     T: Unpin + PartialEq,

--- a/tests/ui/type_repetition_in_bounds.rs
+++ b/tests/ui/type_repetition_in_bounds.rs
@@ -12,7 +12,7 @@ pub fn foo<T>(_t: T)
 where
     T: Copy,
     T: Clone,
-    //~^ ERROR: this type has already been used as a bound predicate
+    //~^ type_repetition_in_bounds
 {
     unimplemented!();
 }
@@ -30,7 +30,7 @@ trait LintBounds
 where
     Self: Clone,
     Self: Copy + Default + Ord,
-    //~^ ERROR: this type has already been used as a bound predicate
+    //~^ type_repetition_in_bounds
     Self: Add<Output = Self> + AddAssign + Sub<Output = Self> + SubAssign,
     Self: Mul<Output = Self> + MulAssign + Div<Output = Self> + DivAssign,
 {
@@ -105,13 +105,13 @@ where
 pub fn f<T: ?Sized>()
 where
     T: Clone,
-    //~^ ERROR: this type has already been used as a bound predicate
+    //~^ type_repetition_in_bounds
 {
 }
 pub fn g<T: Clone>()
 where
     T: ?Sized,
-    //~^ ERROR: this type has already been used as a bound predicate
+    //~^ type_repetition_in_bounds
 {
 }
 
@@ -137,10 +137,27 @@ mod issue8772_pass {
     pub fn f<T: ?Sized, U>(arg: usize)
     where
         T: Trait<Option<usize>, Box<[String]>, bool> + 'static,
-        //~^ ERROR: this type has already been used as a bound predicate
+        //~^ type_repetition_in_bounds
         U: Clone + Sync + 'static,
     {
     }
 }
+
+struct Issue14744<'a, K: 'a>
+where
+    K: Clone,
+{
+    phantom: std::marker::PhantomData<&'a K>,
+}
+//~^^^^ type_repetition_in_bounds
+
+struct ComplexType<T>
+where
+    Vec<T>: Clone,
+    Vec<T>: Clone,
+{
+    t: T,
+}
+//~^^^^ type_repetition_in_bounds
 
 fn main() {}

--- a/tests/ui/type_repetition_in_bounds.stderr
+++ b/tests/ui/type_repetition_in_bounds.stderr
@@ -1,4 +1,4 @@
-error: this type has already been used as a bound predicate
+error: type `T` has already been used as a bound predicate
   --> tests/ui/type_repetition_in_bounds.rs:14:5
    |
 LL |     T: Clone,
@@ -11,7 +11,7 @@ note: the lint level is defined here
 LL | #![deny(clippy::type_repetition_in_bounds)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: this type has already been used as a bound predicate
+error: type `Self` has already been used as a bound predicate
   --> tests/ui/type_repetition_in_bounds.rs:32:5
    |
 LL |     Self: Copy + Default + Ord,
@@ -19,7 +19,7 @@ LL |     Self: Copy + Default + Ord,
    |
    = help: consider combining the bounds: `Self: Clone + Copy + Default + Ord`
 
-error: this type has already been used as a bound predicate
+error: type `T` has already been used as a bound predicate
   --> tests/ui/type_repetition_in_bounds.rs:107:5
    |
 LL |     T: Clone,
@@ -27,7 +27,7 @@ LL |     T: Clone,
    |
    = help: consider combining the bounds: `T: ?Sized + Clone`
 
-error: this type has already been used as a bound predicate
+error: type `T` has already been used as a bound predicate
   --> tests/ui/type_repetition_in_bounds.rs:113:5
    |
 LL |     T: ?Sized,
@@ -35,13 +35,29 @@ LL |     T: ?Sized,
    |
    = help: consider combining the bounds: `T: Clone + ?Sized`
 
-error: this type has already been used as a bound predicate
+error: type `T` has already been used as a bound predicate
   --> tests/ui/type_repetition_in_bounds.rs:139:9
    |
 LL |         T: Trait<Option<usize>, Box<[String]>, bool> + 'static,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider combining the bounds: `T: ?Sized + Trait<Option<usize>, Box<[String]>, bool>`
+   = help: consider combining the bounds: `T: ?Sized + Trait<Option<usize>, Box<[String]>, bool> + 'static`
 
-error: aborting due to 5 previous errors
+error: type `K` has already been used as a bound predicate
+  --> tests/ui/type_repetition_in_bounds.rs:148:5
+   |
+LL |     K: Clone,
+   |     ^^^^^^^^
+   |
+   = help: consider combining the bounds: `K: 'a + Clone`
+
+error: type `Vec<T>` has already been used as a bound predicate
+  --> tests/ui/type_repetition_in_bounds.rs:157:5
+   |
+LL |     Vec<T>: Clone,
+   |     ^^^^^^^^^^^^^
+   |
+   = help: consider combining the bounds: `Vec<T>: Clone + Clone`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
changelog: [`type_repetition_in_bounds`]: include all generic bounds in suggestion, clearer message which now includes the repeated type name

Fixes rust-lang/rust-clippy#14744 