### PR TITLE
Rework `module_inception`

### DIFF
--- a/tests/ui/module_inception.rs
+++ b/tests/ui/module_inception.rs
@@ -38,4 +38,13 @@ mod bar {
     mod bar {}
 }
 
+mod with_inner_impl {
+    struct S;
+    impl S {
+        fn f() {
+            mod with_inner_impl {}
+        }
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
* Don't check for repetition if the previous module crosses a body boundary.
* Don't take a snippet of the entire item.
* Check each item's visibility once.
* Use `is_from_proc_macro` before linting

changelog: none
