### PR TITLE
Allow any rust-lang team member to close an issue with rustbot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -13,6 +13,8 @@ allow-unauthenticated = [
 
 [note]
 
+[close]
+
 [issue-links]
 
 # Prevents mentions in commits to avoid users being spammed


### PR DESCRIPTION
changelog: none

It is useful, and happened in https://github.com/rust-lang/rust-clippy/issues/12806#issuecomment-2863646739