### PR TITLE
Skip `disallowed-*` checking for current crate

### DIFF
--- a/tests/ui-cargo/disallowed_types/fail_local_crate/Cargo.stderr
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/Cargo.stderr
@@ -1,0 +1,19 @@
+warning: expected a type, found an import
+ --> $DIR/tests/ui-cargo/disallowed_types/fail_local_crate/clippy.toml:2:5
+  |
+2 |     { path = "foo::Fooo", reason = "Noooooooooo" },
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: add `allow-invalid = true` to the entry to suppress this warning
+
+error: use of a disallowed type `foo::Fooo`
+ --> src/lib.rs:1:1
+  |
+1 | use foo::Fooo;
+  | ^^^^^^^^^^^^^^
+  |
+  = note: Noooooooooo
+  = note: `-D clippy::disallowed-types` implied by `-D warnings`
+  = help: to override `-D warnings` add `#[allow(clippy::disallowed_types)]`
+
+error: could not compile `fail-local-crate` (lib) due to 1 previous error

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/Cargo.stderr
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/Cargo.stderr
@@ -1,11 +1,3 @@
-warning: expected a type, found an import
- --> $DIR/tests/ui-cargo/disallowed_types/fail_local_crate/clippy.toml:2:5
-  |
-2 |     { path = "foo::Fooo", reason = "Noooooooooo" },
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = help: add `allow-invalid = true` to the entry to suppress this warning
-
 error: use of a disallowed type `foo::Fooo`
  --> src/lib.rs:1:1
   |

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/Cargo.toml
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fail-local-crate"
+version = "0.1.0"
+rust-version = "1.56.1"
+edition = "2021"
+publish = false
+
+[dependencies]
+foo.path = "foo"
+
+[workspace]
+members = [
+    "foo",
+]

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/clippy.toml
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-types = [
+    { path = "foo::Fooo", reason = "Noooooooooo" },
+]

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/foo/Cargo.stderr
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/foo/Cargo.stderr
@@ -1,8 +1,0 @@
-warning: expected a type, found an import
- --> $DIR/tests/ui-cargo/disallowed_types/fail_local_crate/clippy.toml:2:5
-  |
-2 |     { path = "foo::Fooo", reason = "Noooooooooo" },
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = help: add `allow-invalid = true` to the entry to suppress this warning
-

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/foo/Cargo.stderr
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/foo/Cargo.stderr
@@ -1,0 +1,8 @@
+warning: expected a type, found an import
+ --> $DIR/tests/ui-cargo/disallowed_types/fail_local_crate/clippy.toml:2:5
+  |
+2 |     { path = "foo::Fooo", reason = "Noooooooooo" },
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: add `allow-invalid = true` to the entry to suppress this warning
+

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/foo/Cargo.toml
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/foo/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/foo/src/fooo.rs
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/foo/src/fooo.rs
@@ -1,0 +1,1 @@
+pub struct Fooo;

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/foo/src/lib.rs
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/foo/src/lib.rs
@@ -1,0 +1,2 @@
+mod fooo;
+pub use fooo::Fooo;

--- a/tests/ui-cargo/disallowed_types/fail_local_crate/src/lib.rs
+++ b/tests/ui-cargo/disallowed_types/fail_local_crate/src/lib.rs
@@ -1,0 +1,5 @@
+use foo::Fooo;
+
+pub fn bar() {
+    let _foo = Fooo;
+}


### PR DESCRIPTION
fixes rust-lang/rust-clippy#14767 

If `foo::Fooo` was added to `disallowed-types` and the `foo` crate is in current workspace, checking it on `foo` crate is unnecessary.

changelog: Skip `disallowed-*` checking for current crate
