### PR TITLE
`char::is_digit()` is const-stable only since Rust 1.87

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -849,6 +849,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`same_item_push`](https://rust-lang.github.io/rust-clippy/master/index.html#same_item_push)
 * [`seek_from_current`](https://rust-lang.github.io/rust-clippy/master/index.html#seek_from_current)
 * [`seek_rewind`](https://rust-lang.github.io/rust-clippy/master/index.html#seek_rewind)
+* [`to_digit_is_some`](https://rust-lang.github.io/rust-clippy/master/index.html#to_digit_is_some)
 * [`transmute_ptr_to_ref`](https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ref)
 * [`tuple_array_conversions`](https://rust-lang.github.io/rust-clippy/master/index.html#tuple_array_conversions)
 * [`type_repetition_in_bounds`](https://rust-lang.github.io/rust-clippy/master/index.html#type_repetition_in_bounds)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -759,6 +759,7 @@ define_Conf! {
         same_item_push,
         seek_from_current,
         seek_rewind,
+        to_digit_is_some,
         transmute_ptr_to_ref,
         tuple_array_conversions,
         type_repetition_in_bounds,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -746,7 +746,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(move |_| Box::new(unused_self::UnusedSelf::new(conf)));
     store.register_late_pass(|_| Box::new(mutable_debug_assertion::DebugAssertWithMutCall));
     store.register_late_pass(|_| Box::new(exit::Exit));
-    store.register_late_pass(|_| Box::new(to_digit_is_some::ToDigitIsSome));
+    store.register_late_pass(move |_| Box::new(to_digit_is_some::ToDigitIsSome::new(conf)));
     store.register_late_pass(move |_| Box::new(large_stack_arrays::LargeStackArrays::new(conf)));
     store.register_late_pass(move |_| Box::new(large_const_arrays::LargeConstArrays::new(conf)));
     store.register_late_pass(|_| Box::new(floating_point_arithmetic::FloatingPointArithmetic));

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -23,7 +23,7 @@ macro_rules! msrv_aliases {
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
     1,88,0 { LET_CHAINS }
-    1,87,0 { OS_STR_DISPLAY, INT_MIDPOINT }
+    1,87,0 { OS_STR_DISPLAY, INT_MIDPOINT, CONST_CHAR_IS_DIGIT }
     1,85,0 { UINT_FLOAT_MIDPOINT }
     1,84,0 { CONST_OPTION_AS_SLICE, MANUAL_DANGLING_PTR }
     1,83,0 { CONST_EXTERN_FN, CONST_FLOAT_BITS_CONV, CONST_FLOAT_CLASSIFY, CONST_MUT_REFS, CONST_UNWRAP }

--- a/tests/ui/to_digit_is_some.fixed
+++ b/tests/ui/to_digit_is_some.fixed
@@ -9,3 +9,20 @@ fn main() {
     let _ = char::is_digit(c, 8);
     //~^ to_digit_is_some
 }
+
+#[clippy::msrv = "1.86"]
+mod cannot_lint_in_const_context {
+    fn without_const(c: char) -> bool {
+        c.is_digit(8)
+        //~^ to_digit_is_some
+    }
+    const fn with_const(c: char) -> bool {
+        c.to_digit(8).is_some()
+    }
+}
+
+#[clippy::msrv = "1.87"]
+const fn with_const(c: char) -> bool {
+    c.is_digit(8)
+    //~^ to_digit_is_some
+}

--- a/tests/ui/to_digit_is_some.rs
+++ b/tests/ui/to_digit_is_some.rs
@@ -9,3 +9,20 @@ fn main() {
     let _ = char::to_digit(c, 8).is_some();
     //~^ to_digit_is_some
 }
+
+#[clippy::msrv = "1.86"]
+mod cannot_lint_in_const_context {
+    fn without_const(c: char) -> bool {
+        c.to_digit(8).is_some()
+        //~^ to_digit_is_some
+    }
+    const fn with_const(c: char) -> bool {
+        c.to_digit(8).is_some()
+    }
+}
+
+#[clippy::msrv = "1.87"]
+const fn with_const(c: char) -> bool {
+    c.to_digit(8).is_some()
+    //~^ to_digit_is_some
+}

--- a/tests/ui/to_digit_is_some.stderr
+++ b/tests/ui/to_digit_is_some.stderr
@@ -13,5 +13,17 @@ error: use of `.to_digit(..).is_some()`
 LL |     let _ = char::to_digit(c, 8).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `char::is_digit(c, 8)`
 
-error: aborting due to 2 previous errors
+error: use of `.to_digit(..).is_some()`
+  --> tests/ui/to_digit_is_some.rs:16:9
+   |
+LL |         c.to_digit(8).is_some()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `c.is_digit(8)`
+
+error: use of `.to_digit(..).is_some()`
+  --> tests/ui/to_digit_is_some.rs:26:5
+   |
+LL |     c.to_digit(8).is_some()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `c.is_digit(8)`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
The `to_digit_is_some()` lint suggests using `char::is_digit()`. It should not trigger in const contexts before Rust 1.87.

changelog: [`to_digit_is_some`]: Do not lint in const contexts when MSRV is below 1.87