### PR TITLE
Fix ICE in `missing_const_for_fn`

### DIFF
--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -155,9 +155,9 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
             return;
         }
 
-        let mir = cx.tcx.mir_drops_elaborated_and_const_checked(def_id);
+        let mir = cx.tcx.optimized_mir(def_id);
 
-        if let Ok(()) = is_min_const_fn(cx, &mir.borrow(), self.msrv)
+        if let Ok(()) = is_min_const_fn(cx, mir, self.msrv)
             && let hir::Node::Item(hir::Item { vis_span, .. }) | hir::Node::ImplItem(hir::ImplItem { vis_span, .. }) =
                 cx.tcx.hir_node_by_def_id(def_id)
         {

--- a/tests/ui/crashes/missing_const_for_fn_14774.fixed
+++ b/tests/ui/crashes/missing_const_for_fn_14774.fixed
@@ -1,0 +1,13 @@
+//@compile-flags: -Z validate-mir
+#![warn(clippy::missing_const_for_fn)]
+
+static BLOCK_FN_DEF: fn(usize) -> usize = {
+    //~v missing_const_for_fn
+    const fn foo(a: usize) -> usize {
+        a + 10
+    }
+    foo
+};
+struct X;
+
+fn main() {}

--- a/tests/ui/crashes/missing_const_for_fn_14774.rs
+++ b/tests/ui/crashes/missing_const_for_fn_14774.rs
@@ -1,0 +1,13 @@
+//@compile-flags: -Z validate-mir
+#![warn(clippy::missing_const_for_fn)]
+
+static BLOCK_FN_DEF: fn(usize) -> usize = {
+    //~v missing_const_for_fn
+    fn foo(a: usize) -> usize {
+        a + 10
+    }
+    foo
+};
+struct X;
+
+fn main() {}

--- a/tests/ui/crashes/missing_const_for_fn_14774.stderr
+++ b/tests/ui/crashes/missing_const_for_fn_14774.stderr
@@ -1,0 +1,17 @@
+error: this could be a `const fn`
+  --> tests/ui/crashes/missing_const_for_fn_14774.rs:6:5
+   |
+LL | /     fn foo(a: usize) -> usize {
+LL | |         a + 10
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::missing-const-for-fn` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_const_for_fn)]`
+help: make the function `const`
+   |
+LL |     const fn foo(a: usize) -> usize {
+   |     +++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
The `mir_drops_elaborated_and_const_checked` query result has been stolen already and cannot be borrowed again. Use the `optimized_mir` query result instead.

changelog: [`missing_const_for_fn`]: fix ICE with some compilation options

Fixes rust-lang/rust-clippy#14774 

r? @Jarcho