### PR TITLE
`unnecessary_wraps`: do not include the whole body in the lint span

### DIFF
--- a/tests/ui/unnecessary_wraps.stderr
+++ b/tests/ui/unnecessary_wraps.stderr
@@ -1,13 +1,8 @@
 error: this function's return value is unnecessarily wrapped by `Option`
   --> tests/ui/unnecessary_wraps.rs:9:1
    |
-LL | / fn func1(a: bool, b: bool) -> Option<i32> {
-LL | |
-LL | |
-LL | |     if a && b {
-...  |
-LL | | }
-   | |_^
+LL | fn func1(a: bool, b: bool) -> Option<i32> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unnecessary-wraps` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_wraps)]`
@@ -16,7 +11,7 @@ help: remove `Option` from the return type...
 LL - fn func1(a: bool, b: bool) -> Option<i32> {
 LL + fn func1(a: bool, b: bool) -> i32 {
    |
-help: ...and then change returning expressions
+help: ...and then remove the surrounding `Some()` from returning expressions
    |
 LL ~         return 42;
 LL |     }
@@ -30,21 +25,15 @@ LL ~         return 1337;
 error: this function's return value is unnecessarily wrapped by `Option`
   --> tests/ui/unnecessary_wraps.rs:24:1
    |
-LL | / fn func2(a: bool, b: bool) -> Option<i32> {
-LL | |
-LL | |
-LL | |     if a && b {
-...  |
-LL | |     if a { Some(20) } else { Some(30) }
-LL | | }
-   | |_^
+LL | fn func2(a: bool, b: bool) -> Option<i32> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove `Option` from the return type...
    |
 LL - fn func2(a: bool, b: bool) -> Option<i32> {
 LL + fn func2(a: bool, b: bool) -> i32 {
    |
-help: ...and then change returning expressions
+help: ...and then remove the surrounding `Some()` from returning expressions
    |
 LL ~         return 10;
 LL |     }
@@ -54,19 +43,15 @@ LL ~     if a { 20 } else { 30 }
 error: this function's return value is unnecessarily wrapped by `Option`
   --> tests/ui/unnecessary_wraps.rs:44:1
    |
-LL | / fn func5() -> Option<i32> {
-LL | |
-LL | |
-LL | |     Some(1)
-LL | | }
-   | |_^
+LL | fn func5() -> Option<i32> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove `Option` from the return type...
    |
 LL - fn func5() -> Option<i32> {
 LL + fn func5() -> i32 {
    |
-help: ...and then change returning expressions
+help: ...and then remove the surrounding `Some()` from returning expressions
    |
 LL -     Some(1)
 LL +     1
@@ -75,19 +60,15 @@ LL +     1
 error: this function's return value is unnecessarily wrapped by `Result`
   --> tests/ui/unnecessary_wraps.rs:56:1
    |
-LL | / fn func7() -> Result<i32, ()> {
-LL | |
-LL | |
-LL | |     Ok(1)
-LL | | }
-   | |_^
+LL | fn func7() -> Result<i32, ()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove `Result` from the return type...
    |
 LL - fn func7() -> Result<i32, ()> {
 LL + fn func7() -> i32 {
    |
-help: ...and then change returning expressions
+help: ...and then remove the surrounding `Ok()` from returning expressions
    |
 LL -     Ok(1)
 LL +     1
@@ -96,19 +77,15 @@ LL +     1
 error: this function's return value is unnecessarily wrapped by `Option`
   --> tests/ui/unnecessary_wraps.rs:86:5
    |
-LL | /     fn func12() -> Option<i32> {
-LL | |
-LL | |
-LL | |         Some(1)
-LL | |     }
-   | |_____^
+LL |     fn func12() -> Option<i32> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove `Option` from the return type...
    |
 LL -     fn func12() -> Option<i32> {
 LL +     fn func12() -> i32 {
    |
-help: ...and then change returning expressions
+help: ...and then remove the surrounding `Some()` from returning expressions
    |
 LL -         Some(1)
 LL +         1
@@ -117,13 +94,8 @@ LL +         1
 error: this function's return value is unnecessary
   --> tests/ui/unnecessary_wraps.rs:115:1
    |
-LL | / fn issue_6640_1(a: bool, b: bool) -> Option<()> {
-LL | |
-LL | |
-LL | |     if a && b {
-...  |
-LL | | }
-   | |_^
+LL | fn issue_6640_1(a: bool, b: bool) -> Option<()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the return type...
    |
@@ -144,13 +116,8 @@ LL ~         return ;
 error: this function's return value is unnecessary
   --> tests/ui/unnecessary_wraps.rs:130:1
    |
-LL | / fn issue_6640_2(a: bool, b: bool) -> Result<(), i32> {
-LL | |
-LL | |
-LL | |     if a && b {
-...  |
-LL | | }
-   | |_^
+LL | fn issue_6640_2(a: bool, b: bool) -> Result<(), i32> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the return type...
    |


### PR DESCRIPTION
Using the function declaration, by stripping the body, is enough to convey the lint message.

changelog: [`unnecessary_wraps`]: do not include the whole body in the lint span

Closes rust-lang/rust-clippy#14773 