### PR TITLE
book: modify FnKind::Fn matching

### DIFF
--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -416,7 +416,7 @@ In our example, `is_foo_fn` looks like:
 
 fn is_foo_fn(fn_kind: FnKind<'_>) -> bool {
     match fn_kind {
-        FnKind::Fn(_, ident, ..) => {
+        FnKind::Fn(_, _, Fn { ident, .. }) => {
             // check if `fn` name is `foo`
             ident.name.as_str() == "foo"
         }


### PR DESCRIPTION
This PR update the sample code in the development guide because `ident` was moved to the struct `Fn` in https://github.com/rust-lang/rust/pull/138740 .

changelog: none
