### PR TITLE
add `impl-ordering-except-fn-names` config field for `arbitrary_source_item_ordering`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6425,6 +6425,7 @@ Released 2018-09-13
 [`excessive-nesting-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#excessive-nesting-threshold
 [`future-size-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#future-size-threshold
 [`ignore-interior-mutability`]: https://doc.rust-lang.org/clippy/lint_configuration.html#ignore-interior-mutability
+[`impl-ordering-except-fn-names`]: https://doc.rust-lang.org/clippy/lint_configuration.html#impl-ordering-except-fn-names
 [`large-error-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#large-error-threshold
 [`lint-commented-code`]: https://doc.rust-lang.org/clippy/lint_configuration.html#lint-commented-code
 [`literal-representation-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#literal-representation-threshold

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -630,6 +630,16 @@ A list of paths to types that should be treated as if they do not contain interi
 * [`mutable_key_type`](https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type)
 
 
+## `impl-ordering-except-fn-names`
+A list of function names that should be ignored when ordering functions in impl blocks.
+
+**Default Value:** `[]`
+
+---
+**Affected lints:**
+* [`arbitrary_source_item_ordering`](https://rust-lang.github.io/rust-clippy/master/index.html#arbitrary_source_item_ordering)
+
+
 ## `large-error-threshold`
 The maximum size of the `Err`-variant in a `Result` returned from a function
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -635,6 +635,9 @@ define_Conf! {
     /// A list of paths to types that should be treated as if they do not contain interior mutability
     #[lints(borrow_interior_mutable_const, declare_interior_mutable_const, ifs_same_cond, mutable_key_type)]
     ignore_interior_mutability: Vec<String> = Vec::from(["bytes::Bytes".into()]),
+    /// A list of function names that should be ignored when ordering functions in impl blocks.
+    #[lints(arbitrary_source_item_ordering)]
+    impl_ordering_except_fn_names: Vec<String> = Vec::new(),
     /// The maximum size of the `Err`-variant in a `Result` returned from a function
     #[lints(result_large_err)]
     large_error_threshold: u64 = 128,

--- a/tests/ui-toml/arbitrary_source_item_ordering/exceptions/clippy.toml
+++ b/tests/ui-toml/arbitrary_source_item_ordering/exceptions/clippy.toml
@@ -1,0 +1,1 @@
+impl-ordering-except-fn-names = ["new"]

--- a/tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.exceptions.stderr
+++ b/tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.exceptions.stderr
@@ -1,0 +1,40 @@
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.rs:35:8
+   |
+LL |     fn a() {}
+   |        ^
+   |
+note: should be placed before `b`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.rs:31:8
+   |
+LL |     fn b() {}
+   |        ^
+   = note: `-D clippy::arbitrary-source-item-ordering` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::arbitrary_source_item_ordering)]`
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.rs:47:8
+   |
+LL |     fn b() {}
+   |        ^
+   |
+note: should be placed before `c`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.rs:46:8
+   |
+LL |     fn c() {}
+   |        ^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.rs:59:8
+   |
+LL |     fn a() {}
+   |        ^
+   |
+note: should be placed before `c`
+  --> tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.rs:58:8
+   |
+LL |     fn c() {}
+   |        ^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/ordering_exceptions.rs
@@ -1,0 +1,65 @@
+//@aux-build:../../ui/auxiliary/proc_macros.rs
+//@revisions: exceptions
+//@[exceptions] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/arbitrary_source_item_ordering/exceptions
+
+#![allow(dead_code)]
+#![warn(clippy::arbitrary_source_item_ordering)]
+
+struct BasicStruct1 {}
+
+impl BasicStruct1 {
+    fn new() -> Self {
+        Self {}
+    }
+    fn a() {}
+    fn b() {}
+}
+
+struct BasicStruct2 {}
+
+impl BasicStruct2 {
+    fn a() {}
+    fn new() -> Self {
+        Self {}
+    }
+    fn b() {}
+}
+
+struct BasicStruct3 {}
+
+impl BasicStruct3 {
+    fn b() {}
+    fn new() -> Self {
+        Self {}
+    }
+    fn a() {}
+    //~^ arbitrary_source_item_ordering
+}
+
+struct BasicStruct4 {}
+
+impl BasicStruct4 {
+    fn a() {}
+    fn new() -> Self {
+        Self {}
+    }
+    fn c() {}
+    fn b() {}
+    //~^ arbitrary_source_item_ordering
+}
+
+struct BasicStruct5 {}
+
+impl BasicStruct5 {
+    fn new() -> Self {
+        Self {}
+    }
+    fn b() {}
+    fn c() {}
+    fn a() {}
+    //~^ arbitrary_source_item_ordering
+}
+
+fn main() {
+    // test code goes here
+}

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -47,6 +47,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           impl-ordering-except-fn-names
            large-error-threshold
            lint-commented-code
            literal-representation-threshold
@@ -140,6 +141,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           impl-ordering-except-fn-names
            large-error-threshold
            lint-commented-code
            literal-representation-threshold
@@ -233,6 +235,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           impl-ordering-except-fn-names
            large-error-threshold
            lint-commented-code
            literal-representation-threshold


### PR DESCRIPTION
I think it makes sense to set up a list of function names to exclude certain functions in the `impl` block from being checked.

Some functions, such as `new`, are typically used as constructors—either as the first item or in other positions—so we need a configuration to exclude them.

I added a config filed `impl-ordering-except-fn-names`(Vec\<String\>) to define the list of function names that should be excluded.

This modification does not change the existing behavior of Clippy; it only takes effect after being explicitly configured.

changelog: [`arbitrary_source_item_ordering`]: add `impl-ordering-except-fn-names` config field to exclude some functions in impl blocks.

Close: rust-lang/rust-clippy#14739