### PR TITLE
Use `tempfile::TempDir::keep()` instead of deprecated `into_path()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ clippy_lints = { path = "clippy_lints" }
 clippy_utils = { path = "clippy_utils" }
 rustc_tools_util = { path = "rustc_tools_util", version = "0.4.2" }
 clippy_lints_internal = { path = "clippy_lints_internal", optional = true }
-tempfile = { version = "3.3", optional = true }
+tempfile = { version = "3.20", optional = true }
 termize = "0.1"
 color-print = "0.3.4"
 anstream = "0.6.18"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -30,7 +30,7 @@ fn integration_test() {
 
     let repo_dir = tempfile::tempdir()
         .expect("couldn't create temp dir")
-        .into_path()
+        .keep()
         .join(crate_name);
 
     let st = Command::new("git")


### PR DESCRIPTION
`tempfile` has deprecated `TempDir::into_path()` (replacing it by `TempDir::keep()` between version `3.3` which Clippy required and version `3.20` which is the latest semver-compatible version. Since Clippy doesn't use a `Cargo.lock` file, the latest version of `tempfile` is used which leads to CI failure.

changelog: none

r? @flip1995 