### PR TITLE
Document how to use `rust-toolchain.toml` to avoid breaking changes (e.g. in CI)

### DIFF
--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -15,6 +15,22 @@ If Clippy was not installed for a toolchain, it can be installed with
 $ rustup component add clippy [--toolchain=<name>]
 ```
 
+### Use a specific version of Clippy
+
+Clippy may introduce new warnings and errors between associated Rust versions.
+This may be desirable if you want to learn about newly detectable issues in your
+codebase over time, but it can cause [continuous integration](./continuous_integration/index.md)
+to fail even if you haven't touched your Rust code. If you'd like to keep Clippy's
+behaviour stable for your project, use
+[`rust-toolchain.toml`](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)
+to pin your entire Rust toolchain. For example:
+
+```toml
+[toolchain]
+channel = "1.83.0"
+components = ["clippy"]
+```
+
 ## From Source
 
 Take a look at the [Basics] chapter in the Clippy developer guide to find step-by-step


### PR DESCRIPTION
I've had Clippy suddenly start to fail in GitHub Actions for me in multiple ways over the last year.

If Clippy was still used as a crate, I'd just pin it as a dependency and run https://crates.io/crates/cargo-run-bin/1.7.2

However, that's unfortunately not possible and I found it far from obvious what to do instead. My understanding is that pinning it using `rust-toolchain.toml` like this is the "correct" way to avoid breaking changes in CI. This took me some time and research (and personal help from a Rust expert) to figure out and I'd like to save others the trouble by documenting it.

```
changelog: none
```

Note that this issue talks about CI because that's that's a common forcing function for consistent linting, but it applies to local invocations as well.[^1] I think this is much better to document on the installation page instead of the CI pages specifically.

[^1]: For example, I collaborate on a project where another team member regularly touches just the non-Rust code in the repo but runs all project tests locally before pushing. These local tests runs have failed for all sorts of ecosystem issues in the past, and that's never a good experience. So it's important for tools like Clippy to be stable even outside of CI, and I would personally want to know about how to do this when learning how to install Clippy for the first time.