### PR TITLE
Reenable linting on UFCS `deref` calls

### DIFF
--- a/tests/ui/explicit_deref_methods.fixed
+++ b/tests/ui/explicit_deref_methods.fixed
@@ -8,7 +8,8 @@
     clippy::needless_borrow,
     clippy::no_effect,
     clippy::uninlined_format_args,
-    clippy::unnecessary_literal_unwrap
+    clippy::unnecessary_literal_unwrap,
+    clippy::deref_addrof
 )]
 
 use std::ops::{Deref, DerefMut};
@@ -87,9 +88,6 @@ fn main() {
     let b = &*opt_a.unwrap();
     //~^ explicit_deref_methods
 
-    // make sure `Aaa::deref` instead of `aaa.deref()` is not linted, as well as fully qualified
-    // syntax
-
     Aaa::deref(&Aaa);
     Aaa::deref_mut(&mut Aaa);
     <Aaa as Deref>::deref(&Aaa);
@@ -139,4 +137,9 @@ fn main() {
     let no_lint = NoLint(42);
     let b = no_lint.deref();
     let b = no_lint.deref_mut();
+
+    let _ = &*&"foo"; //~ explicit_deref_methods
+    let mut x = String::new();
+    let _ = &&mut **&mut x; //~ explicit_deref_methods
+    let _ = &&mut ***(&mut &mut x); //~ explicit_deref_methods
 }

--- a/tests/ui/explicit_deref_methods.rs
+++ b/tests/ui/explicit_deref_methods.rs
@@ -8,7 +8,8 @@
     clippy::needless_borrow,
     clippy::no_effect,
     clippy::uninlined_format_args,
-    clippy::unnecessary_literal_unwrap
+    clippy::unnecessary_literal_unwrap,
+    clippy::deref_addrof
 )]
 
 use std::ops::{Deref, DerefMut};
@@ -87,9 +88,6 @@ fn main() {
     let b = opt_a.unwrap().deref();
     //~^ explicit_deref_methods
 
-    // make sure `Aaa::deref` instead of `aaa.deref()` is not linted, as well as fully qualified
-    // syntax
-
     Aaa::deref(&Aaa);
     Aaa::deref_mut(&mut Aaa);
     <Aaa as Deref>::deref(&Aaa);
@@ -139,4 +137,9 @@ fn main() {
     let no_lint = NoLint(42);
     let b = no_lint.deref();
     let b = no_lint.deref_mut();
+
+    let _ = &Deref::deref(&"foo"); //~ explicit_deref_methods
+    let mut x = String::new();
+    let _ = &DerefMut::deref_mut(&mut x); //~ explicit_deref_methods
+    let _ = &DerefMut::deref_mut((&mut &mut x).deref_mut()); //~ explicit_deref_methods
 }

--- a/tests/ui/explicit_deref_methods.stderr
+++ b/tests/ui/explicit_deref_methods.stderr
@@ -1,5 +1,5 @@
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:54:19
+  --> tests/ui/explicit_deref_methods.rs:55:19
    |
 LL |     let b: &str = a.deref();
    |                   ^^^^^^^^^ help: try: `&*a`
@@ -8,70 +8,88 @@ LL |     let b: &str = a.deref();
    = help: to override `-D warnings` add `#[allow(clippy::explicit_deref_methods)]`
 
 error: explicit `deref_mut` method call
-  --> tests/ui/explicit_deref_methods.rs:57:23
+  --> tests/ui/explicit_deref_methods.rs:58:23
    |
 LL |     let b: &mut str = a.deref_mut();
    |                       ^^^^^^^^^^^^^ help: try: `&mut **a`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:61:39
+  --> tests/ui/explicit_deref_methods.rs:62:39
    |
 LL |     let b: String = format!("{}, {}", a.deref(), a.deref());
    |                                       ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:61:50
+  --> tests/ui/explicit_deref_methods.rs:62:50
    |
 LL |     let b: String = format!("{}, {}", a.deref(), a.deref());
    |                                                  ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:65:20
+  --> tests/ui/explicit_deref_methods.rs:66:20
    |
 LL |     println!("{}", a.deref());
    |                    ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:69:11
+  --> tests/ui/explicit_deref_methods.rs:70:11
    |
 LL |     match a.deref() {
    |           ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:74:28
+  --> tests/ui/explicit_deref_methods.rs:75:28
    |
 LL |     let b: String = concat(a.deref());
    |                            ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:77:13
+  --> tests/ui/explicit_deref_methods.rs:78:13
    |
 LL |     let b = just_return(a).deref();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `just_return(a)`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:80:28
+  --> tests/ui/explicit_deref_methods.rs:81:28
    |
 LL |     let b: String = concat(just_return(a).deref());
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: try: `just_return(a)`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:83:19
+  --> tests/ui/explicit_deref_methods.rs:84:19
    |
 LL |     let b: &str = a.deref().deref();
    |                   ^^^^^^^^^^^^^^^^^ help: try: `&**a`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:87:13
+  --> tests/ui/explicit_deref_methods.rs:88:13
    |
 LL |     let b = opt_a.unwrap().deref();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*opt_a.unwrap()`
 
 error: explicit `deref` method call
-  --> tests/ui/explicit_deref_methods.rs:125:31
+  --> tests/ui/explicit_deref_methods.rs:123:31
    |
 LL |     let b: &str = expr_deref!(a.deref());
    |                               ^^^^^^^^^ help: try: `&*a`
 
-error: aborting due to 12 previous errors
+error: explicit `deref` method call
+  --> tests/ui/explicit_deref_methods.rs:141:14
+   |
+LL |     let _ = &Deref::deref(&"foo");
+   |              ^^^^^^^^^^^^^^^^^^^^ help: try: `*&"foo"`
+
+error: explicit `deref_mut` method call
+  --> tests/ui/explicit_deref_methods.rs:143:14
+   |
+LL |     let _ = &DerefMut::deref_mut(&mut x);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut **&mut x`
+
+error: explicit `deref_mut` method call
+  --> tests/ui/explicit_deref_methods.rs:144:14
+   |
+LL |     let _ = &DerefMut::deref_mut((&mut &mut x).deref_mut());
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut ***(&mut &mut x)`
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Was disabled in rust-lang/rust-clippy#10855 due to a broken suggestion. This will only lint if a type is not proveded (e.g. `T::deref`).

changelog: none
