### PR TITLE
comparison_chain: do not lint on 2 blocks expression

### DIFF
--- a/clippy_lints/src/comparison_chain.rs
+++ b/clippy_lints/src/comparison_chain.rs
@@ -75,8 +75,12 @@ impl<'tcx> LateLintPass<'tcx> for ComparisonChain {
         }
 
         // Check that there exists at least one explicit else condition
-        let (conds, _) = if_sequence(expr);
+        let (conds, blocks) = if_sequence(expr);
         if conds.len() < 2 {
+            return;
+        }
+
+        if blocks.len() < 3 {
             return;
         }
 
@@ -125,6 +129,7 @@ impl<'tcx> LateLintPass<'tcx> for ComparisonChain {
         let ExprKind::Binary(_, lhs, rhs) = conds[0].kind else {
             unreachable!();
         };
+
         let lhs = Sugg::hir(cx, lhs, "..").maybe_paren();
         let rhs = Sugg::hir(cx, rhs, "..").addr();
         span_lint_and_sugg(

--- a/tests/ui/comparison_chain.rs
+++ b/tests/ui/comparison_chain.rs
@@ -12,11 +12,10 @@ fn f(x: u8, y: u8, z: u8) {
         a()
     }
 
-    if x > y {
-        //~^ comparison_chain
-
+    // Ignored: Not all cases are covered
+    if x < y {
         a()
-    } else if x < y {
+    } else if x > y {
         b()
     }
 
@@ -123,9 +122,8 @@ fn g(x: f64, y: f64, z: f64) {
 }
 
 fn h<T: Ord>(x: T, y: T, z: T) {
+    // Ignored: Not all cases are covered
     if x > y {
-        //~^ comparison_chain
-
         a()
     } else if x < y {
         b()

--- a/tests/ui/comparison_chain.stderr
+++ b/tests/ui/comparison_chain.stderr
@@ -1,12 +1,12 @@
 error: `if` chain can be rewritten with `match`
-  --> tests/ui/comparison_chain.rs:15:5
+  --> tests/ui/comparison_chain.rs:29:5
    |
 LL | /     if x > y {
 LL | |
 LL | |
 LL | |         a()
-LL | |     } else if x < y {
-LL | |         b()
+...  |
+LL | |         c()
 LL | |     }
    | |_____^ help: consider rewriting the `if` chain with `match`: `match x.cmp(&y) {...}`
    |
@@ -14,7 +14,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::comparison_chain)]`
 
 error: `if` chain can be rewritten with `match`
-  --> tests/ui/comparison_chain.rs:30:5
+  --> tests/ui/comparison_chain.rs:39:5
    |
 LL | /     if x > y {
 LL | |
@@ -26,19 +26,7 @@ LL | |     }
    | |_____^ help: consider rewriting the `if` chain with `match`: `match x.cmp(&y) {...}`
 
 error: `if` chain can be rewritten with `match`
-  --> tests/ui/comparison_chain.rs:40:5
-   |
-LL | /     if x > y {
-LL | |
-LL | |
-LL | |         a()
-...  |
-LL | |         c()
-LL | |     }
-   | |_____^ help: consider rewriting the `if` chain with `match`: `match x.cmp(&y) {...}`
-
-error: `if` chain can be rewritten with `match`
-  --> tests/ui/comparison_chain.rs:50:5
+  --> tests/ui/comparison_chain.rs:49:5
    |
 LL | /     if x > 1 {
 LL | |
@@ -50,19 +38,7 @@ LL | |     }
    | |_____^ help: consider rewriting the `if` chain with `match`: `match x.cmp(&1) {...}`
 
 error: `if` chain can be rewritten with `match`
-  --> tests/ui/comparison_chain.rs:126:5
-   |
-LL | /     if x > y {
-LL | |
-LL | |
-LL | |         a()
-LL | |     } else if x < y {
-LL | |         b()
-LL | |     }
-   | |_____^ help: consider rewriting the `if` chain with `match`: `match x.cmp(&y) {...}`
-
-error: `if` chain can be rewritten with `match`
-  --> tests/ui/comparison_chain.rs:134:5
+  --> tests/ui/comparison_chain.rs:132:5
    |
 LL | /     if x > y {
 LL | |
@@ -74,7 +50,7 @@ LL | |     }
    | |_____^ help: consider rewriting the `if` chain with `match`: `match x.cmp(&y) {...}`
 
 error: `if` chain can be rewritten with `match`
-  --> tests/ui/comparison_chain.rs:144:5
+  --> tests/ui/comparison_chain.rs:142:5
    |
 LL | /     if x > y {
 LL | |
@@ -86,7 +62,7 @@ LL | |     }
    | |_____^ help: consider rewriting the `if` chain with `match`: `match x.cmp(&y) {...}`
 
 error: `if` chain can be rewritten with `match`
-  --> tests/ui/comparison_chain.rs:251:5
+  --> tests/ui/comparison_chain.rs:249:5
    |
 LL | /     if x + 1 > y * 2 {
 LL | |
@@ -97,5 +73,5 @@ LL | |         "cc"
 LL | |     }
    | |_____^ help: consider rewriting the `if` chain with `match`: `match (x + 1).cmp(&(y * 2)) {...}`
 
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Clippy should not lint 2 blocks expression for comparison_chain.

Fixes rust-lang/rust-clippy#4725

changelog: [`comparison_chain`]: do not lint 2 blocks expression
