### PR TITLE
Change applicability to Applicability::HasPlaceholders

### DIFF
--- a/clippy_lints/src/loops/manual_flatten.rs
+++ b/clippy_lints/src/loops/manual_flatten.rs
@@ -44,7 +44,7 @@ pub(super) fn check<'tcx>(
             format!("unnecessary `if let` since only the `{if_let_type}` variant of the iterator element is used");
 
         // Prepare the help message
-        let mut applicability = Applicability::MaybeIncorrect;
+        let mut applicability = Applicability::HasPlaceholders;
         let arg_snippet = make_iterator_snippet(cx, arg, &mut applicability);
         let copied = match cx.typeck_results().expr_ty(let_expr).kind() {
             ty::Ref(_, inner, _) => match inner.kind() {


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14692

The current `manual_flatten` lint may produce suggestions that change the iterator's item type, causing compilation error if the suggestion is accepted.
This can confuse users because `Applicability::MaybeIncorrect` implies that the suggested code will compile.

changelog: [`manual_flatten`] change applicability to Applicability::HasPlaceholders
