### PR TITLE
Do not call `TyCtxt::type_of()` on a trait

### DIFF
--- a/clippy_lints/src/methods/useless_asref.rs
+++ b/clippy_lints/src/methods/useless_asref.rs
@@ -79,9 +79,9 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, call_name: &str,
                 applicability,
             );
         }
-    } else if let Some(impl_id) = cx.tcx.opt_parent(def_id)
+    } else if let Some(impl_id) = cx.tcx.impl_of_method(def_id)
         && let Some(adt) = cx.tcx.type_of(impl_id).instantiate_identity().ty_adt_def()
-        && (cx.tcx.lang_items().option_type() == Some(adt.did()) || cx.tcx.is_diagnostic_item(sym::Result, adt.did()))
+        && matches!(cx.tcx.get_diagnostic_name(adt.did()), Some(sym::Option | sym::Result))
     {
         let rcv_ty = cx.typeck_results().expr_ty(recvr).peel_refs();
         let res_ty = cx.typeck_results().expr_ty(expr).peel_refs();

--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -248,6 +248,16 @@ impl Issue12357 {
     }
 }
 
+fn issue_14828() {
+    pub trait T {
+        fn as_ref(&self) {}
+    }
+
+    impl T for () {}
+
+    ().as_ref();
+}
+
 fn main() {
     not_ok();
     ok();

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -248,6 +248,16 @@ impl Issue12357 {
     }
 }
 
+fn issue_14828() {
+    pub trait T {
+        fn as_ref(&self) {}
+    }
+
+    impl T for () {}
+
+    ().as_ref();
+}
+
 fn main() {
     not_ok();
     ok();


### PR DESCRIPTION
changelog: [`useless_as_ref`]: fix ICE on trait method

Fixes rust-lang/rust-clippy#14828