### PR TITLE
`cargo dev fmt`: format `clippy_lints_internal` as well

### DIFF
--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -247,6 +247,7 @@ fn run_rustfmt(clippy: &ClippyInfo, update_mode: UpdateMode) {
         "clippy_config",
         "clippy_dev",
         "clippy_lints",
+        "clippy_lints_internal",
         "clippy_utils",
         "rustc_tools_util",
         "lintcheck",


### PR DESCRIPTION
changelog: none
r? @Jarcho