### PR TITLE
Improve better suggestion for `useless_conversion`

### DIFF
--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -459,5 +459,18 @@ fn adjustments(cx: &LateContext<'_>, expr: &Expr<'_>) -> String {
             _ => {},
         }
     }
-    prefix
+    resolve_deref(prefix)
+}
+
+fn resolve_deref(mut s: String) -> String {
+    loop {
+        if let Some(rest) = s.strip_prefix("&*") {
+            s = rest.to_string();
+        } else if let Some(rest) = s.strip_prefix("&*mut ") {
+            s = format!("mut {rest}");
+        } else {
+            break;
+        }
+    }
+    s
 }

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -175,7 +175,16 @@ fn main() {
     let _ = vec![s4, s4, s4].into_iter().into_iter();
     //~^ useless_conversion
 
+    issue14847();
     issue11300::bar();
+}
+
+fn issue14847() {
+    use std::option::IntoIter;
+    fn takes_into_iter<'a>(_: impl IntoIterator<Item = &'a i32>) {}
+
+    let x = &&[1];
+    let _ = takes_into_iter(x.into_iter());
 }
 
 #[allow(dead_code)]

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -118,8 +118,43 @@ error: useless conversion to the same type: `std::vec::IntoIter<Foo<'a'>>`
 LL |     let _ = vec![s4, s4, s4].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![s4, s4, s4].into_iter()`
 
+error: this let-binding has unit value
+  --> tests/ui/useless_conversion.rs:187:5
+   |
+LL |     let _ = takes_into_iter(x.into_iter());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `takes_into_iter(x.into_iter());`
+   |
+   = note: `-D clippy::let-unit-value` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::let_unit_value)]`
+
+error: this `.into_iter()` call is equivalent to `.iter()` and will not consume the `array`
+  --> tests/ui/useless_conversion.rs:187:31
+   |
+LL |     let _ = takes_into_iter(x.into_iter());
+   |                               ^^^^^^^^^ help: call directly: `iter`
+   |
+   = note: `-D clippy::into-iter-on-ref` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::into_iter_on_ref)]`
+
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:208:7
+  --> tests/ui/useless_conversion.rs:187:29
+   |
+LL |     let _ = takes_into_iter(x.into_iter());
+   |                             ^^^^^^^^^^^^^
+   |
+note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
+  --> tests/ui/useless_conversion.rs:184:36
+   |
+LL |     fn takes_into_iter<'a>(_: impl IntoIterator<Item = &'a i32>) {}
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -     let _ = takes_into_iter(x.into_iter());
+LL +     let _ = takes_into_iter(*x);
+   |
+
+error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
+  --> tests/ui/useless_conversion.rs:217:7
    |
 LL |     b(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -127,13 +162,13 @@ LL |     b(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:198:13
+  --> tests/ui/useless_conversion.rs:207:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:210:7
+  --> tests/ui/useless_conversion.rs:219:7
    |
 LL |     c(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -141,13 +176,13 @@ LL |     c(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:199:18
+  --> tests/ui/useless_conversion.rs:208:18
    |
 LL |     fn c(_: impl IntoIterator<Item = i32>) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:212:7
+  --> tests/ui/useless_conversion.rs:221:7
    |
 LL |     d(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -155,13 +190,13 @@ LL |     d(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:202:12
+  --> tests/ui/useless_conversion.rs:211:12
    |
 LL |         T: IntoIterator<Item = i32>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:216:7
+  --> tests/ui/useless_conversion.rs:225:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter());
    |       ^^^^^^^^^^------------------------
@@ -169,13 +204,13 @@ LL |     b(vec![1, 2].into_iter().into_iter());
    |                 help: consider removing the `.into_iter()`s
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:198:13
+  --> tests/ui/useless_conversion.rs:207:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:218:7
+  --> tests/ui/useless_conversion.rs:227:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter().into_iter());
    |       ^^^^^^^^^^------------------------------------
@@ -183,13 +218,13 @@ LL |     b(vec![1, 2].into_iter().into_iter().into_iter());
    |                 help: consider removing the `.into_iter()`s
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:198:13
+  --> tests/ui/useless_conversion.rs:207:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:265:24
+  --> tests/ui/useless_conversion.rs:274:24
    |
 LL |         foo2::<i32, _>([1, 2, 3].into_iter());
    |                        ^^^^^^^^^------------
@@ -197,13 +232,13 @@ LL |         foo2::<i32, _>([1, 2, 3].into_iter());
    |                                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:244:12
+  --> tests/ui/useless_conversion.rs:253:12
    |
 LL |         I: IntoIterator<Item = i32> + Helper<X>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:274:14
+  --> tests/ui/useless_conversion.rs:283:14
    |
 LL |         foo3([1, 2, 3].into_iter());
    |              ^^^^^^^^^------------
@@ -211,13 +246,13 @@ LL |         foo3([1, 2, 3].into_iter());
    |                       help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:253:12
+  --> tests/ui/useless_conversion.rs:262:12
    |
 LL |         I: IntoIterator<Item = i32>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:284:16
+  --> tests/ui/useless_conversion.rs:293:16
    |
 LL |         S1.foo([1, 2].into_iter());
    |                ^^^^^^------------
@@ -225,13 +260,13 @@ LL |         S1.foo([1, 2].into_iter());
    |                      help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:281:27
+  --> tests/ui/useless_conversion.rs:290:27
    |
 LL |             pub fn foo<I: IntoIterator>(&self, _: I) {}
    |                           ^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:304:44
+  --> tests/ui/useless_conversion.rs:313:44
    |
 LL |         v0.into_iter().interleave_shortest(v1.into_iter());
    |                                            ^^------------
@@ -239,67 +274,67 @@ LL |         v0.into_iter().interleave_shortest(v1.into_iter());
    |                                              help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:291:20
+  --> tests/ui/useless_conversion.rs:300:20
    |
 LL |                 J: IntoIterator,
    |                    ^^^^^^^^^^^^
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:332:58
+  --> tests/ui/useless_conversion.rs:341:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map(Into::into);
    |                                                          ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `std::io::Error`
-  --> tests/ui/useless_conversion.rs:335:58
+  --> tests/ui/useless_conversion.rs:344:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map_err(Into::into);
    |                                                          ^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:338:58
+  --> tests/ui/useless_conversion.rs:347:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map(From::from);
    |                                                          ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `std::io::Error`
-  --> tests/ui/useless_conversion.rs:341:58
+  --> tests/ui/useless_conversion.rs:350:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map_err(From::from);
    |                                                          ^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:345:31
+  --> tests/ui/useless_conversion.rs:354:31
    |
 LL |     let _: ControlFlow<()> = c.map_break(Into::into);
    |                               ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:349:31
+  --> tests/ui/useless_conversion.rs:358:31
    |
 LL |     let _: ControlFlow<()> = c.map_continue(Into::into);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `u32`
-  --> tests/ui/useless_conversion.rs:363:41
+  --> tests/ui/useless_conversion.rs:372:41
    |
 LL |     let _: Vec<u32> = [1u32].into_iter().map(Into::into).collect();
    |                                         ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `T`
-  --> tests/ui/useless_conversion.rs:374:18
+  --> tests/ui/useless_conversion.rs:383:18
    |
 LL |     x.into_iter().map(Into::into).collect()
    |                  ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:390:29
+  --> tests/ui/useless_conversion.rs:399:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:388:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -310,13 +345,13 @@ LL +             takes_into_iter(&self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:398:29
+  --> tests/ui/useless_conversion.rs:407:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:388:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -327,13 +362,13 @@ LL +             takes_into_iter(&mut self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:407:29
+  --> tests/ui/useless_conversion.rs:416:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:388:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -344,30 +379,27 @@ LL +             takes_into_iter(*self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:416:29
-   |
-LL |             takes_into_iter(self.my_field.into_iter());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
-   |
-LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider removing the `.into_iter()`
-   |
-LL -             takes_into_iter(self.my_field.into_iter());
-LL +             takes_into_iter(&*self.my_field);
-   |
-
-error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:425:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
+   |                             ^^^^^^^^^^^^^------------
+   |                                          |
+   |                                          help: consider removing the `.into_iter()`
+   |
+note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
+  --> tests/ui/useless_conversion.rs:388:32
+   |
+LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
+  --> tests/ui/useless_conversion.rs:434:29
+   |
+LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:388:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -378,16 +410,16 @@ LL +             takes_into_iter(&mut *self.my_field);
    |
 
 error: useless conversion to the same type: `std::ops::Range<u32>`
-  --> tests/ui/useless_conversion.rs:440:5
+  --> tests/ui/useless_conversion.rs:449:5
    |
 LL |     R.into_iter().for_each(|_x| {});
    |     ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
 error: useless conversion to the same type: `std::ops::Range<u32>`
-  --> tests/ui/useless_conversion.rs:442:13
+  --> tests/ui/useless_conversion.rs:451:13
    |
 LL |     let _ = R.into_iter().map(|_x| 0);
    |             ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
-error: aborting due to 43 previous errors
+error: aborting due to 46 previous errors
 


### PR DESCRIPTION
Fixes #14847

This PR simplify the adjustment output when the explicit `.into_iter()` was called.

changelog: [`useless_conversion`] simplify the adjustment output