### PR TITLE
triagebot: enable issue transfer

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -15,6 +15,8 @@ allow-unauthenticated = [
 
 [close]
 
+[transfer]
+
 [issue-links]
 
 # Prevents mentions in commits to avoid users being spammed


### PR DESCRIPTION
I think it's pretty common for a lint to be proposed for clippy only for consensus to be it belongs in rustc, and additionally sometimes bugs get filed here when the fault is actually with rustc.

https://forge.rust-lang.org/triagebot/transfer.html#issue-transfer

changelog: none
