### PR TITLE
fix(or_fun_call): respect MSRV for unwrap_or_default suggestion

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4412,7 +4412,7 @@ declare_clippy_lint! {
     /// Checks for calls to `Read::bytes` on types which don't implement `BufRead`.
     ///
     /// ### Why is this bad?
-    /// The default implementation calls `read` for each byte, which can be very inefficient for data that’s not in memory, such as `File`.
+    /// The default implementation calls `read` for each byte, which can be very inefficient for data that's not in memory, such as `File`.
     ///
     /// ### Example
     /// ```no_run
@@ -4741,7 +4741,7 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
             },
             ExprKind::MethodCall(method_call, receiver, args, _) => {
                 let method_span = method_call.ident.span;
-                or_fun_call::check(cx, expr, method_span, method_call.ident.name, receiver, args);
+                or_fun_call::check(cx, expr, method_span, method_call.ident.name, receiver, args, self.msrv);
                 expect_fun_call::check(
                     cx,
                     &self.format_args,


### PR DESCRIPTION
changelog: [`unwrap_or_default`]: respect MSRV by not suggesting the method when MSRV is below 1.16