### PR TITLE
docs(trait_checking): import the right function

### DIFF
--- a/book/src/development/trait_checking.md
+++ b/book/src/development/trait_checking.md
@@ -17,7 +17,7 @@ providing the `LateContext` (`cx`), our expression at hand, and
 the symbol of the trait in question:
 
 ```rust
-use clippy_utils::is_trait_method;
+use clippy_utils::implements_trait;
 use rustc_hir::Expr;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::symbol::sym;


### PR DESCRIPTION
`is_trait_method` is not even used in this codeblock, whereas `implements_trait` is used but not imported

(not sure if this is _actually_ a "changelog: none", since the documentation is at least contributor-facing)

changelog: none