### PR TITLE
`zombie_processes`: do not complain about early early returns

### DIFF
--- a/tests/ui/zombie_processes.rs
+++ b/tests/ui/zombie_processes.rs
@@ -198,3 +198,13 @@ mod issue14677 {
         child.wait().unwrap();
     }
 }
+
+fn issue14911() -> std::io::Result<String> {
+    let (mut recv, send) = std::io::pipe()?;
+    let mut command = Command::new("ls")
+        .stdout(send.try_clone()?)
+        .spawn()
+        .expect("Could not spawn new process...");
+    command.wait()?;
+    Ok("".into())
+}


### PR DESCRIPTION
If an early return is found under the HIR local declaration node but before the child process is created, it should not trigger the lint because the child process has not yet been created.

changelog: [`zombie_process`]: do not complain about early early returns

Fixes rust-lang/rust-clippy#14911 