### PR TITLE
Add Triagebot's `concern` capability to the Clippy repository

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -40,6 +40,10 @@ reviewed_label = "S-waiting-on-author"
 [autolabel."S-waiting-on-review"]
 new_pr = true
 
+[concern]
+# These labels are set when there are unresolved concerns, removed otherwise
+labels = ["S-waiting-on-concerns"]
+
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
 users_on_vacation = [


### PR DESCRIPTION
This is a newly added triagebot capability, which allows registering and then resolving concerns with an issue or a pull request. The concerns are gathered by Triagebot in the issue/PR summary.

Concerns are different from notes: when a concern is resolved, it is striked through in the issue/PR summary, and a link to the comment resolving it is also added, whereas a note can only be removed and then disappears from the summary.

The `has-concerns` label, which must be created at the time of merging this change, will be automatically set on issues/PRs that have unresolved concerns, and cleared when all concerns are resolved.

changelog: none