### PR TITLE
chore(lints): move excessive_nesting to pedantic group (#14923)

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -610,7 +610,7 @@ The maximum size of an enum's variant to avoid box suggestion
 ## `excessive-nesting-threshold`
 The maximum amount of nesting a block can reside in
 
-**Default Value:** `0`
+**Default Value:** `6`
 
 ---
 **Affected lints:**

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -631,7 +631,7 @@ define_Conf! {
     enum_variant_size_threshold: u64 = 200,
     /// The maximum amount of nesting a block can reside in
     #[lints(excessive_nesting)]
-    excessive_nesting_threshold: u64 = 0,
+    excessive_nesting_threshold: u64 = 6,
     /// The maximum byte size a `Future` can have, before it triggers the `clippy::large_futures` lint
     #[lints(large_futures)]
     future_size_threshold: u64 = 16 * 1024,

--- a/clippy_lints/src/excessive_nesting.rs
+++ b/clippy_lints/src/excessive_nesting.rs
@@ -12,8 +12,6 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for blocks which are nested beyond a certain threshold.
     ///
-    /// Note: Even though this lint is warn-by-default, it will only trigger if a maximum nesting level is defined in the clippy.toml file.
-    ///
     /// ### Why is this bad?
     /// It can severely hinder readability.
     ///
@@ -58,7 +56,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.72.0"]
     pub EXCESSIVE_NESTING,
-    complexity,
+    pedantic,
     "checks for blocks nested beyond a certain threshold"
 }
 impl_lint_pass!(ExcessiveNesting => [EXCESSIVE_NESTING]);
@@ -92,10 +90,6 @@ impl ExcessiveNesting {
 
 impl EarlyLintPass for ExcessiveNesting {
     fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &Crate) {
-        if self.excessive_nesting_threshold == 0 {
-            return;
-        }
-
         let mut visitor = NestingVisitor {
             conf: self,
             cx,

--- a/tests/ui/excessive_nesting.rs
+++ b/tests/ui/excessive_nesting.rs
@@ -1,0 +1,96 @@
+#![warn(clippy::pedantic)]
+#![allow(
+    unused,
+    clippy::let_and_return,
+    clippy::redundant_closure_call,
+    clippy::no_effect,
+    clippy::unnecessary_operation,
+    clippy::needless_if,
+    clippy::single_match,
+    clippy::unused_self
+)]
+
+fn main() {
+    // This should not trigger with default threshold of 6
+    let a = {
+        let b = {
+            let c = {
+                let d = {
+                    let e = {
+                        let f = { 42 };
+                        //~^ ERROR: this block is too nested
+                        f
+                    };
+                    e
+                };
+                d
+            };
+            c
+        };
+        b
+    };
+
+    // This should trigger with default threshold of 6
+    let x = {
+        let y = {
+            let z = {
+                let w = {
+                    let v = {
+                        let u = {
+                            //~^ ERROR: this block is too nested
+                            let t = { 42 };
+                            t
+                        };
+                        u
+                    };
+                    v
+                };
+                w
+            };
+            z
+        };
+        y
+    };
+}
+
+struct A;
+
+impl A {
+    fn test() {
+        // This should not trigger
+        struct B;
+        impl B {
+            fn test() {
+                struct C;
+                impl C {
+                    fn test() {
+                        if true {
+                            //~^ ERROR: this block is too nested
+                            let x = { 1 };
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+trait TestTrait {
+    fn test() {
+        // This should trigger (7 levels)
+        struct B;
+        impl B {
+            fn test() {
+                struct C;
+                impl C {
+                    fn test() {
+                        if true {
+                            //~^ ERROR: this block is too nested
+                            let x = { 1 };
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/ui/excessive_nesting.stderr
+++ b/tests/ui/excessive_nesting.stderr
@@ -1,0 +1,49 @@
+error: this block is too nested
+  --> tests/ui/excessive_nesting.rs:20:33
+   |
+LL |                         let f = { 42 };
+   |                                 ^^^^^^
+   |
+   = help: try refactoring your code to minimize nesting
+   = note: `-D clippy::excessive-nesting` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::excessive_nesting)]`
+
+error: this block is too nested
+  --> tests/ui/excessive_nesting.rs:39:33
+   |
+LL |                           let u = {
+   |  _________________________________^
+LL | |
+LL | |                             let t = { 42 };
+LL | |                             t
+LL | |                         };
+   | |_________________________^
+   |
+   = help: try refactoring your code to minimize nesting
+
+error: this block is too nested
+  --> tests/ui/excessive_nesting.rs:67:33
+   |
+LL |                           if true {
+   |  _________________________________^
+LL | |
+LL | |                             let x = { 1 };
+LL | |                         }
+   | |_________________________^
+   |
+   = help: try refactoring your code to minimize nesting
+
+error: this block is too nested
+  --> tests/ui/excessive_nesting.rs:87:33
+   |
+LL |                           if true {
+   |  _________________________________^
+LL | |
+LL | |                             let x = { 1 };
+LL | |                         }
+   | |_________________________^
+   |
+   = help: try refactoring your code to minimize nesting
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
changelog: [`excessive_nesting`]: moved to `pedantic` group and changed default threshold from 0 to 6

This PR moves the `excessive_nesting` lint to the `pedantic` group and adjusts its default threshold from 0 to 6 to make it more practical and less noisy. The changes include:

- Moving the lint to the `pedantic` group
- Setting default threshold to 6
- Adding UI tests for the default behavior
- Updating documentation to reflect the new default value

fixes #14923