### PR TITLE
Do not count deprecated lints in lint total

### DIFF
--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -602,7 +602,7 @@ filters.filterLints();
 updateLintCount();
 
 function updateLintCount() {
-    const allLints = filters.getAllLints();
+    const allLints = filters.getAllLints().filter(lint => lint.group != "deprecated");
     const totalLints = allLints.length;
     
     const countElement = document.getElementById("lint-count");


### PR DESCRIPTION
In order to be consistent with our documentation, deprecated lints should not be counted when displaying the total number of lints on the [web site](https://rust-lang.github.io/rust-clippy/master/index.html).

For example, as of 2025-06-01, there are 784 non-deprecated lints which are referred to as "over 750 lints" in the documentation, but the web site displays "Total number: 799". When one new lint will be added, there will be a discrepancy ("over 750 lints" vs. "Total number: 800") if this is not fixed.

changelog: none

r? @llogiq 