### PR TITLE
Fix `return_and_then` FP when return type is not `Option` or `Result`

### DIFF
--- a/tests/ui/return_and_then.fixed
+++ b/tests/ui/return_and_then.fixed
@@ -124,3 +124,29 @@ mod issue14781 {
         Ok(())
     }
 }
+
+mod issue14927 {
+    use std::path::Path;
+
+    struct A {
+        pub func: fn(check: bool, a: &Path, b: Option<&Path>),
+    }
+
+    const MY_A: A = A {
+        func: |check, a, b| {
+            if check {
+                let _ = ();
+            } else if let Some(parent) = b.and_then(|p| p.parent()) {
+                let _ = ();
+            }
+        },
+    };
+
+    fn foo(check: bool, a: &Path, b: Option<&Path>) {
+        if check {
+            let _ = ();
+        } else if let Some(parent) = b.and_then(|p| p.parent()) {
+            let _ = ();
+        }
+    }
+}

--- a/tests/ui/return_and_then.rs
+++ b/tests/ui/return_and_then.rs
@@ -115,3 +115,29 @@ mod issue14781 {
         Ok(())
     }
 }
+
+mod issue14927 {
+    use std::path::Path;
+
+    struct A {
+        pub func: fn(check: bool, a: &Path, b: Option<&Path>),
+    }
+
+    const MY_A: A = A {
+        func: |check, a, b| {
+            if check {
+                let _ = ();
+            } else if let Some(parent) = b.and_then(|p| p.parent()) {
+                let _ = ();
+            }
+        },
+    };
+
+    fn foo(check: bool, a: &Path, b: Option<&Path>) {
+        if check {
+            let _ = ();
+        } else if let Some(parent) = b.and_then(|p| p.parent()) {
+            let _ = ();
+        }
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14927 

changelog: [`return_and_then`] fix FP when return type is not `Option` or `Result`
