### PR TITLE
Fix false positive for unused_unit

### DIFF
--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -109,6 +109,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedUnit {
             && let AssocItemConstraintKind::Equality { term: Term::Ty(hir_ty) } = constraints[0].kind
             && args.span_ext.hi() != poly.span.hi()
             && !hir_ty.span.from_expansion()
+            && args.span_ext.hi() != hir_ty.span.hi()
             && is_unit_ty(hir_ty)
         {
             lint_unneeded_unit_return(cx, hir_ty.span, poly.span);

--- a/tests/ui/unused_unit.edition2021.fixed
+++ b/tests/ui/unused_unit.edition2021.fixed
@@ -145,7 +145,7 @@ mod issue14577 {
     }
 }
 
-mod pr_to_be_determined {
+mod pr14962 {
     #[allow(unused_parens)]
     type UnusedParensButNoUnit = Box<dyn (Fn())>;
 }

--- a/tests/ui/unused_unit.edition2021.fixed
+++ b/tests/ui/unused_unit.edition2021.fixed
@@ -144,3 +144,9 @@ mod issue14577 {
         }
     }
 }
+
+mod pr_to_be_determined {
+    #[allow(unused_parens)]
+    type UnusedParensButNoUnit = Box<dyn (Fn())>;
+}
+

--- a/tests/ui/unused_unit.edition2024.fixed
+++ b/tests/ui/unused_unit.edition2024.fixed
@@ -145,7 +145,7 @@ mod issue14577 {
     }
 }
 
-mod pr_to_be_determined {
+mod pr14962 {
     #[allow(unused_parens)]
     type UnusedParensButNoUnit = Box<dyn (Fn())>;
 }

--- a/tests/ui/unused_unit.edition2024.fixed
+++ b/tests/ui/unused_unit.edition2024.fixed
@@ -144,3 +144,9 @@ mod issue14577 {
         }
     }
 }
+
+mod pr_to_be_determined {
+    #[allow(unused_parens)]
+    type UnusedParensButNoUnit = Box<dyn (Fn())>;
+}
+

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -145,7 +145,7 @@ mod issue14577 {
     }
 }
 
-mod pr_to_be_determined {
+mod pr14962 {
     #[allow(unused_parens)]
     type UnusedParensButNoUnit = Box<dyn (Fn())>;
 }

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -144,3 +144,9 @@ mod issue14577 {
         }
     }
 }
+
+mod pr_to_be_determined {
+    #[allow(unused_parens)]
+    type UnusedParensButNoUnit = Box<dyn (Fn())>;
+}
+


### PR DESCRIPTION
Given a type alias as follows, clippy would detect a false positive for `unused_unit`.

```rust
type UnusedParensButNoUnit = Box<dyn (Fn())>;
```

changelog: [`unused_unit`]: fix false positive for `Fn` bounds
