### PR TITLE
Fix an incorrect error message regarding the size of `usize` and `isize` in `cast_precision_loss`.

### DIFF
--- a/clippy_lints/src/casts/cast_precision_loss.rs
+++ b/clippy_lints/src/casts/cast_precision_loss.rs
@@ -28,8 +28,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_from: Ty<'_>, ca
     let from_nbits_str = if arch_dependent {
         "64".to_owned()
     } else if is_isize_or_usize(cast_from) {
-        // FIXME: handle 16 bits `usize` type
-        "32 or 64".to_owned()
+        "16, 32, or 64".to_owned()
     } else {
         from_nbits.to_string()
     };

--- a/tests/ui/cast_size.32bit.stderr
+++ b/tests/ui/cast_size.32bit.stderr
@@ -13,7 +13,7 @@ LL -     1isize as i8;
 LL +     i8::try_from(1isize);
    |
 
-error: casting `isize` to `f32` causes a loss of precision (`isize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
+error: casting `isize` to `f32` causes a loss of precision (`isize` is 16, 32, or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> tests/ui/cast_size.rs:24:5
    |
 LL |     x0 as f32;
@@ -22,7 +22,7 @@ LL |     x0 as f32;
    = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::cast_precision_loss)]`
 
-error: casting `usize` to `f32` causes a loss of precision (`usize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
+error: casting `usize` to `f32` causes a loss of precision (`usize` is 16, 32, or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> tests/ui/cast_size.rs:26:5
    |
 LL |     x1 as f32;

--- a/tests/ui/cast_size.64bit.stderr
+++ b/tests/ui/cast_size.64bit.stderr
@@ -13,7 +13,7 @@ LL -     1isize as i8;
 LL +     i8::try_from(1isize);
    |
 
-error: casting `isize` to `f32` causes a loss of precision (`isize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
+error: casting `isize` to `f32` causes a loss of precision (`isize` is 16, 32, or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> tests/ui/cast_size.rs:24:5
    |
 LL |     x0 as f32;
@@ -22,7 +22,7 @@ LL |     x0 as f32;
    = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::cast_precision_loss)]`
 
-error: casting `usize` to `f32` causes a loss of precision (`usize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
+error: casting `usize` to `f32` causes a loss of precision (`usize` is 16, 32, or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> tests/ui/cast_size.rs:26:5
    |
 LL |     x1 as f32;


### PR DESCRIPTION
When trying to cast a `usize` or `isize` using `as` to a type of potentially smaller size the `cast_precision_loss` would claim that the size of `usize` is "32 or 64 bits". It is now corrected to "16, 32, or 64 bits".

changelog: [`cast_precision_loss`]: fix the error messages claim regarding the size of `usize` and `isize`.
