### PR TITLE
Do not lint macro generated codes

### DIFF
--- a/clippy_lints/src/disallowed_names.rs
+++ b/clippy_lints/src/disallowed_names.rs
@@ -1,6 +1,6 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::is_in_test;
+use clippy_utils::{is_from_proc_macro, is_in_test};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::{Pat, PatKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -43,8 +43,10 @@ impl_lint_pass!(DisallowedNames => [DISALLOWED_NAMES]);
 impl<'tcx> LateLintPass<'tcx> for DisallowedNames {
     fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>) {
         if let PatKind::Binding(.., ident, _) = pat.kind
+            && !ident.span.from_expansion()
             && self.disallow.contains(&ident.name)
             && !is_in_test(cx.tcx, pat.hir_id)
+            && !is_from_proc_macro(cx, &ident)
         {
             span_lint(
                 cx,

--- a/tests/ui/disallowed_names.rs
+++ b/tests/ui/disallowed_names.rs
@@ -1,3 +1,4 @@
+//@aux-build:proc_macros.rs
 #![allow(
     dead_code,
     clippy::needless_if,
@@ -8,6 +9,9 @@
     unused_variables
 )]
 #![warn(clippy::disallowed_names)]
+
+extern crate proc_macros;
+use proc_macros::{external, with_span};
 
 fn test(foo: ()) {}
 //~^ disallowed_names
@@ -64,6 +68,17 @@ fn issue_1647_ref_mut() {
 
     if let Some(ref mut quux) = Some(42) {}
     //~^ disallowed_names
+}
+
+pub fn issue_14958_proc_macro() {
+    // does not lint macro-generated code
+    external! {
+        let foo = 0;
+    }
+    with_span! {
+        span
+        let foo = 0;
+    }
 }
 
 #[cfg(test)]

--- a/tests/ui/disallowed_names.stderr
+++ b/tests/ui/disallowed_names.stderr
@@ -1,5 +1,5 @@
 error: use of a disallowed/placeholder name `foo`
-  --> tests/ui/disallowed_names.rs:12:9
+  --> tests/ui/disallowed_names.rs:16:9
    |
 LL | fn test(foo: ()) {}
    |         ^^^
@@ -8,79 +8,79 @@ LL | fn test(foo: ()) {}
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_names)]`
 
 error: use of a disallowed/placeholder name `foo`
-  --> tests/ui/disallowed_names.rs:16:9
+  --> tests/ui/disallowed_names.rs:20:9
    |
 LL |     let foo = 42;
    |         ^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> tests/ui/disallowed_names.rs:19:9
+  --> tests/ui/disallowed_names.rs:23:9
    |
 LL |     let baz = 42;
    |         ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> tests/ui/disallowed_names.rs:22:9
+  --> tests/ui/disallowed_names.rs:26:9
    |
 LL |     let quux = 42;
    |         ^^^^
 
 error: use of a disallowed/placeholder name `foo`
-  --> tests/ui/disallowed_names.rs:35:10
+  --> tests/ui/disallowed_names.rs:39:10
    |
 LL |         (foo, Some(baz), quux @ Some(_)) => (),
    |          ^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> tests/ui/disallowed_names.rs:35:20
+  --> tests/ui/disallowed_names.rs:39:20
    |
 LL |         (foo, Some(baz), quux @ Some(_)) => (),
    |                    ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> tests/ui/disallowed_names.rs:35:26
+  --> tests/ui/disallowed_names.rs:39:26
    |
 LL |         (foo, Some(baz), quux @ Some(_)) => (),
    |                          ^^^^
 
 error: use of a disallowed/placeholder name `foo`
-  --> tests/ui/disallowed_names.rs:43:19
+  --> tests/ui/disallowed_names.rs:47:19
    |
 LL | fn issue_1647(mut foo: u8) {
    |                   ^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> tests/ui/disallowed_names.rs:46:13
+  --> tests/ui/disallowed_names.rs:50:13
    |
 LL |     let mut baz = 0;
    |             ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> tests/ui/disallowed_names.rs:49:21
+  --> tests/ui/disallowed_names.rs:53:21
    |
 LL |     if let Some(mut quux) = Some(42) {}
    |                     ^^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> tests/ui/disallowed_names.rs:54:13
+  --> tests/ui/disallowed_names.rs:58:13
    |
 LL |     let ref baz = 0;
    |             ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> tests/ui/disallowed_names.rs:57:21
+  --> tests/ui/disallowed_names.rs:61:21
    |
 LL |     if let Some(ref quux) = Some(42) {}
    |                     ^^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> tests/ui/disallowed_names.rs:62:17
+  --> tests/ui/disallowed_names.rs:66:17
    |
 LL |     let ref mut baz = 0;
    |                 ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> tests/ui/disallowed_names.rs:65:25
+  --> tests/ui/disallowed_names.rs:69:25
    |
 LL |     if let Some(ref mut quux) = Some(42) {}
    |                         ^^^^


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#14958

`disallowed_names` was used to lint code generated by macros. This behavior can confuse programmers who did not write the macro themselves. This change suppresses lints for code originating from macros, including external ones.

changelog: [`disallowed_names`] do not lint macro generated codes