### PR TITLE
`Sugg`: do not parenthesize a double unary operator

### DIFF
--- a/tests/ui/nonminimal_bool.stderr
+++ b/tests/ui/nonminimal_bool.stderr
@@ -179,7 +179,7 @@ error: inequality checks against true can be replaced by a negation
   --> tests/ui/nonminimal_bool.rs:186:8
    |
 LL |     if !b != true {}
-   |        ^^^^^^^^^^ help: try simplifying it as shown: `!(!b)`
+   |        ^^^^^^^^^^ help: try simplifying it as shown: `!!b`
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:189:8
@@ -209,7 +209,7 @@ error: inequality checks against true can be replaced by a negation
   --> tests/ui/nonminimal_bool.rs:193:8
    |
 LL |     if true != !b {}
-   |        ^^^^^^^^^^ help: try simplifying it as shown: `!(!b)`
+   |        ^^^^^^^^^^ help: try simplifying it as shown: `!!b`
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:196:8


### PR DESCRIPTION
For example, adding `*` in front of `*expression` is best shown as `**expression` rather than `*(*expression)`.

This is not perfect, as it checks whether the operator is already a prefix of the expression, but it is better than it was before. For example, `&`+`&mut x` will get `&&mut x` but `&mut `+`&x` will get `&mut (&x)` as it did before this change.

changelog: none
