### PR TITLE
add new lints: `rest_pattern_accessible_field` and `unnecessary_rest_pattern`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7286,6 +7286,7 @@ Released 2018-09-13
 [`repr_packed_without_abi`]: https://rust-lang.github.io/rust-clippy/master/index.html#repr_packed_without_abi
 [`reserve_after_initialization`]: https://rust-lang.github.io/rust-clippy/master/index.html#reserve_after_initialization
 [`rest_pat_in_fully_bound_structs`]: https://rust-lang.github.io/rust-clippy/master/index.html#rest_pat_in_fully_bound_structs
+[`rest_pattern_accessible_field`]: https://rust-lang.github.io/rust-clippy/master/index.html#rest_pattern_accessible_field
 [`result_expect_used`]: https://rust-lang.github.io/rust-clippy/master/index.html#result_expect_used
 [`result_filter_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#result_filter_map
 [`result_large_err`]: https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
@@ -7451,6 +7452,7 @@ Released 2018-09-13
 [`unnecessary_operation`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_operation
 [`unnecessary_option_map_or_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_option_map_or_else
 [`unnecessary_owned_empty_strings`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_owned_empty_strings
+[`unnecessary_rest_pattern`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_rest_pattern
 [`unnecessary_result_map_or_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_result_map_or_else
 [`unnecessary_safety_comment`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_safety_comment
 [`unnecessary_safety_doc`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_safety_doc

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -684,6 +684,8 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::repeat_vec_with_capacity::REPEAT_VEC_WITH_CAPACITY_INFO,
     crate::replace_box::REPLACE_BOX_INFO,
     crate::reserve_after_initialization::RESERVE_AFTER_INITIALIZATION_INFO,
+    crate::rest_when_destructuring_struct::REST_PATTERN_ACCESSIBLE_FIELD_INFO,
+    crate::rest_when_destructuring_struct::UNNECESSARY_REST_PATTERN_INFO,
     crate::return_self_not_must_use::RETURN_SELF_NOT_MUST_USE_INFO,
     crate::returns::LET_AND_RETURN_INFO,
     crate::returns::NEEDLESS_RETURN_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -326,6 +326,7 @@ mod regex;
 mod repeat_vec_with_capacity;
 mod replace_box;
 mod reserve_after_initialization;
+mod rest_when_destructuring_struct;
 mod return_self_not_must_use;
 mod returns;
 mod same_length_and_capacity;
@@ -859,6 +860,7 @@ rustc_lint::late_lint_methods!(
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
         RedundantElse: redundant_else::RedundantElse = redundant_else::RedundantElse,
+        RestWhenDestructuringStruct: rest_when_destructuring_struct::RestWhenDestructuringStruct = rest_when_destructuring_struct::RestWhenDestructuringStruct,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/rest_when_destructuring_struct.rs
+++ b/clippy_lints/src/rest_when_destructuring_struct.rs
@@ -1,0 +1,164 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::is_from_proc_macro;
+use rustc_errors::Applicability;
+use rustc_lint::LateLintPass;
+use rustc_middle::ty;
+use rustc_session::declare_lint_pass;
+
+use std::fmt::Write as _;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Disallow the use of rest patterns for accesible fields
+    ///
+    /// ### Why restrict this?
+    /// It might lead to unhandled fields when the struct changes.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// struct S {
+    ///     a: u8,
+    ///     b: u8,
+    ///     c: u8,
+    /// }
+    ///
+    /// let s = S { a: 1, b: 2, c: 3 };
+    ///
+    /// let S { a, b, .. } = s;
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// struct S {
+    ///     a: u8,
+    ///     b: u8,
+    ///     c: u8,
+    /// }
+    ///
+    /// let s = S { a: 1, b: 2, c: 3 };
+    ///
+    /// let S { a, b, c: _ } = s;
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub REST_PATTERN_ACCESSIBLE_FIELD,
+    restriction,
+    "rest pattern (`..`) used for accessible field"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Disallow the use of rest patterns that don't capture any fields.
+    ///
+    /// ### Why restrict this?
+    /// It might lead to unhandled fields when the struct changes.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// struct S {
+    ///     a: u8,
+    ///     b: u8,
+    ///     c: u8,
+    /// }
+    ///
+    /// let s = S { a: 1, b: 2, c: 3 };
+    ///
+    /// let S { a, b, c, .. } = s;
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// struct S {
+    ///     a: u8,
+    ///     b: u8,
+    ///     c: u8,
+    /// }
+    ///
+    /// let s = S { a: 1, b: 2, c: 3 };
+    ///
+    /// let S { a, b, c } = s;
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub UNNECESSARY_REST_PATTERN,
+    restriction,
+    "unnecessary rest pattern (`..`) in destructuring expression"
+}
+
+declare_lint_pass!(RestWhenDestructuringStruct => [
+    REST_PATTERN_ACCESSIBLE_FIELD,
+    UNNECESSARY_REST_PATTERN,
+]);
+
+impl<'tcx> LateLintPass<'tcx> for RestWhenDestructuringStruct {
+    fn check_pat(&mut self, cx: &rustc_lint::LateContext<'tcx>, pat: &'tcx rustc_hir::Pat<'tcx>) {
+        if let rustc_hir::PatKind::Struct(path, fields, Some(dotdot)) = pat.kind
+            && let qty = cx.typeck_results().qpath_res(&path, pat.hir_id)
+            && let ty = cx.typeck_results().pat_ty(pat)
+            && let ty::Adt(a, _) = ty.kind()
+            && let Some(vid) = qty.opt_def_id().map(|x| a.variant_index_with_id(x))
+            && let Some(variant) = a.variants().get(vid)
+        {
+            let mut missing_suggestions = String::new();
+            let mut needs_dotdot = variant.field_list_has_applicable_non_exhaustive();
+
+            for field in &variant.fields {
+                if field.vis.is_accessible_from(cx.tcx.parent_module(pat.hir_id), cx.tcx) {
+                    if !fields.iter().any(|x| x.ident.name == field.name) {
+                        if !missing_suggestions.is_empty() {
+                            missing_suggestions.push_str(", ");
+                        }
+                        let _ = write!(missing_suggestions, "{}: _", field.name.as_str());
+                    }
+                } else {
+                    needs_dotdot = true;
+                }
+            }
+
+            // Filter out results from macros
+            if (missing_suggestions.is_empty() && needs_dotdot)
+                || pat.span.in_external_macro(cx.tcx.sess.source_map())
+                || is_from_proc_macro(cx, pat)
+            {
+                return;
+            }
+
+            if !missing_suggestions.is_empty() {
+                let suggestion_span = if needs_dotdot {
+                    missing_suggestions.push_str(", ");
+                    dotdot.shrink_to_lo()
+                } else {
+                    dotdot
+                };
+
+                let message = if fields.is_empty() {
+                    "consider explicitly ignoring fields with wildcard patterns (`x: _`)"
+                } else {
+                    "consider explicitly ignoring remaining fields with wildcard patterns (`x: _`)"
+                };
+
+                span_lint_and_then(
+                    cx,
+                    REST_PATTERN_ACCESSIBLE_FIELD,
+                    pat.span,
+                    "struct destructuring with rest (`..`)",
+                    |diag| {
+                        diag.span_suggestion_verbose(
+                            suggestion_span,
+                            message,
+                            &missing_suggestions,
+                            Applicability::MachineApplicable,
+                        );
+                    },
+                );
+            } else if !needs_dotdot {
+                let message = "consider removing the unnecessary rest pattern (`..`)";
+                span_lint_and_then(
+                    cx,
+                    UNNECESSARY_REST_PATTERN,
+                    pat.span,
+                    "unnecessary rest pattern (`..`)",
+                    |diag| {
+                        diag.span_suggestion_verbose(dotdot, message, "", Applicability::MachineApplicable);
+                    },
+                );
+            }
+        }
+    }
+}

--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -16,15 +16,16 @@ use rustc_abi::ExternAbi;
 use rustc_ast as ast;
 use rustc_ast::AttrStyle;
 use rustc_ast::ast::{
-    AttrKind, Attribute, GenericArgs, IntTy, LitIntType, LitKind, StrStyle, TraitObjectSyntax, UintTy,
+    AttrKind, Attribute, BindingMode, GenericArgs, IntTy, LitIntType, LitKind, StrStyle, TraitObjectSyntax, UintTy,
 };
 use rustc_ast::token::CommentKind;
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{
     Block, BlockCheckMode, Body, BoundConstness, BoundPolarity, Closure, Destination, Expr, ExprKind, FieldDef,
     FnHeader, FnRetTy, HirId, Impl, ImplItem, ImplItemImplKind, ImplItemKind, IsAuto, Item, ItemKind, Lit, LoopSource,
-    MatchSource, MutTy, Node, Path, PolyTraitRef, QPath, Safety, TraitBoundModifiers, TraitImplHeader, TraitItem,
-    TraitItemKind, TraitRef, Ty, TyKind, UnOp, UnsafeSource, Variant, VariantData, YieldSource,
+    MatchSource, MutTy, Node, PatExpr, PatExprKind, PatKind, Path, PolyTraitRef, QPath, Safety, TraitBoundModifiers,
+    TraitImplHeader, TraitItem, TraitItemKind, TraitRef, Ty, TyKind, UnOp, UnsafeSource, Variant, VariantData,
+    YieldSource,
 };
 use rustc_lint::{EarlyContext, LateContext, LintContext};
 use rustc_middle::ty::TyCtxt;
@@ -589,6 +590,99 @@ fn ident_search_pat(ident: Ident) -> (Pat, Pat) {
     (Pat::Sym(ident.name), Pat::Sym(ident.name))
 }
 
+fn pat_search_pat(tcx: TyCtxt<'_>, pat: &rustc_hir::Pat<'_>) -> (Pat, Pat) {
+    match pat.kind {
+        // Tuple patterns cannot show up in proc-macro checks
+        PatKind::Missing | PatKind::Err(_) | PatKind::Tuple(_, _) => (Pat::Str(""), Pat::Str("")),
+        PatKind::Wild => (Pat::Sym(kw::Underscore), Pat::Sym(kw::Underscore)),
+        PatKind::Binding(binding_mode, _, ident, Some(end_pat)) => {
+            let start = if binding_mode == BindingMode::NONE {
+                ident_search_pat(ident).0
+            } else {
+                Pat::Str(binding_mode.prefix_str())
+            };
+
+            let (_, end) = pat_search_pat(tcx, end_pat);
+            (start, end)
+        },
+        PatKind::Binding(binding_mode, _, ident, None) => {
+            let (s, end) = ident_search_pat(ident);
+            let start = if binding_mode == BindingMode::NONE {
+                s
+            } else {
+                Pat::Str(binding_mode.prefix_str())
+            };
+
+            (start, end)
+        },
+        PatKind::Struct(path, _, _) => {
+            let (start, _) = qpath_search_pat(&path);
+            (start, Pat::Str("}"))
+        },
+        PatKind::TupleStruct(path, _, _) => {
+            let (start, _) = qpath_search_pat(&path);
+            // This pattern cannot show up in proc-macro checks
+            (start, Pat::Str(""))
+        },
+        PatKind::Or(plist) => {
+            // documented invariant
+            debug_assert!(plist.len() >= 2);
+            let (start, _) = pat_search_pat(tcx, plist.first().unwrap());
+            let (_, end) = pat_search_pat(tcx, plist.last().unwrap());
+            (start, end)
+        },
+        PatKind::Never => (Pat::Str("!"), Pat::Str("")),
+        PatKind::Box(p) => {
+            let (_, end) = pat_search_pat(tcx, p);
+            (Pat::Str("box"), end)
+        },
+        PatKind::Deref(_) => (Pat::Str("deref!"), Pat::Str("")),
+        PatKind::Ref(p, _, _) => {
+            let (_, end) = pat_search_pat(tcx, p);
+            (Pat::Str("&"), end)
+        },
+        PatKind::Expr(expr) => pat_expr_search_pat(expr),
+        PatKind::Guard(pat, guard) => {
+            let (start, _) = pat_search_pat(tcx, pat);
+            let (_, end) = expr_search_pat(tcx, guard);
+            (start, end)
+        },
+        PatKind::Range(None, None, range) => match range {
+            rustc_hir::RangeEnd::Included => (Pat::Str("..="), Pat::Str("")),
+            rustc_hir::RangeEnd::Excluded => (Pat::Str(".."), Pat::Str("")),
+        },
+        PatKind::Range(r_start, r_end, range) => {
+            let start = match r_start {
+                Some(e) => pat_expr_search_pat(e).0,
+                None => match range {
+                    rustc_hir::RangeEnd::Included => Pat::Str("..="),
+                    rustc_hir::RangeEnd::Excluded => Pat::Str(".."),
+                },
+            };
+
+            let end = match r_end {
+                Some(e) => pat_expr_search_pat(e).1,
+                None => match range {
+                    rustc_hir::RangeEnd::Included => Pat::Str("..="),
+                    rustc_hir::RangeEnd::Excluded => Pat::Str(".."),
+                },
+            };
+            (start, end)
+        },
+        PatKind::Slice(_, _, _) => (Pat::Str("["), Pat::Str("]")),
+    }
+}
+
+fn pat_expr_search_pat(expr: &PatExpr<'_>) -> (Pat, Pat) {
+    match expr.kind {
+        PatExprKind::Lit { lit, negated } => {
+            let (start, end) = lit_search_pat(&lit.node);
+            if negated { (Pat::Str("!"), end) } else { (start, end) }
+        },
+        PatExprKind::Path(path) => qpath_search_pat(&path),
+    }
+}
+
 pub trait WithSearchPat<'cx> {
     type Context: LintContext;
     fn search_pat(&self, cx: &Self::Context) -> (Pat, Pat);
@@ -618,6 +712,7 @@ impl_with_search_pat!((_cx: LateContext<'tcx>, self: Ident) => ident_search_pat(
 impl_with_search_pat!((_cx: LateContext<'tcx>, self: Lit) => lit_search_pat(&self.node));
 impl_with_search_pat!((_cx: LateContext<'tcx>, self: Path<'_>) => path_search_pat(self));
 impl_with_search_pat!((_cx: LateContext<'tcx>, self: PolyTraitRef<'_>) => poly_trait_ref_search_pat(self));
+impl_with_search_pat!((cx: LateContext<'tcx>, self: rustc_hir::Pat<'_>) => pat_search_pat(cx.tcx, self));
 
 impl_with_search_pat!((_cx: EarlyContext<'tcx>, self: Attribute) => attr_search_pat(self));
 impl_with_search_pat!((_cx: EarlyContext<'tcx>, self: ast::Ty) => ast_ty_search_pat(self));

--- a/tests/ui/auxiliary/non-exhaustive-struct.rs
+++ b/tests/ui/auxiliary/non-exhaustive-struct.rs
@@ -1,0 +1,13 @@
+#[non_exhaustive]
+#[derive(Default)]
+pub struct NonExhaustiveStruct {
+    pub field1: i32,
+    pub field2: i32,
+    _private: i32,
+}
+
+#[non_exhaustive]
+#[derive(Default)]
+pub struct NonExhaustiveStructNoPrivateFields {
+    pub field: i32,
+}

--- a/tests/ui/rest_pattern_accessible_field.fixed
+++ b/tests/ui/rest_pattern_accessible_field.fixed
@@ -1,0 +1,108 @@
+//@aux-build:proc_macros.rs
+//@aux-build:non-exhaustive-struct.rs
+#![warn(clippy::rest_pattern_accessible_field)]
+#![allow(clippy::unneeded_wildcard_pattern)]
+
+use non_exhaustive_struct::{NonExhaustiveStruct, NonExhaustiveStructNoPrivateFields};
+
+struct S {
+    a: u8,
+    b: u8,
+    c: u8,
+}
+
+#[derive(Default)]
+#[non_exhaustive]
+struct LocalNonExhaustive {
+    field: i32,
+}
+
+enum E {
+    A { a1: u8, a2: u8 },
+    B { b1: u8, b2: u8 },
+    C {},
+}
+
+mod m {
+    #[derive(Default)]
+    pub struct Sm {
+        pub a: u8,
+        pub(crate) b: u8,
+        c: u8,
+    }
+}
+
+fn main() {
+    let s = S { a: 1, b: 2, c: 3 };
+
+    let S { a, b, c: _ } = s;
+    //~^ rest_pattern_accessible_field
+
+    let S { c, a: _, b: _ } = s;
+    //~^ rest_pattern_accessible_field
+
+    let S { a, b, c, .. } = s;
+
+    S { a: _, b: _, c: _ } = S { a: 1, b: 2, c: 3 };
+    //~^ rest_pattern_accessible_field
+
+    let e = E::A { a1: 1, a2: 2 };
+
+    match e {
+        E::A { a1, a2 } => (),
+        E::B { b1: _, b2: _ } => (),
+        //~^ rest_pattern_accessible_field
+        E::C { .. } => (),
+    }
+
+    match e {
+        E::A { a1: _, a2: _ } => (),
+        E::B { b1: _, b2: _ } => (),
+        //~^ rest_pattern_accessible_field
+        E::C {} => (),
+    }
+
+    proc_macros::external! {
+        let s1 = S { a: 1, b: 2, c: 3 };
+        let S { a, b, .. } = s1;
+    }
+
+    proc_macros::with_span! {
+        span
+        let s2 = S { a: 1, b: 2, c: 3 };
+        let S { a, b, .. } = s2;
+    }
+
+    let ne = NonExhaustiveStruct::default();
+    let NonExhaustiveStruct { field1: _, field2: _, .. } = ne;
+    //~^ rest_pattern_accessible_field
+
+    let ne = NonExhaustiveStruct::default();
+    let NonExhaustiveStruct {
+        field1: _, field2: _, ..
+    } = ne;
+
+    let ne = NonExhaustiveStructNoPrivateFields::default();
+    let NonExhaustiveStructNoPrivateFields { field: _, .. } = ne;
+    //~^ rest_pattern_accessible_field
+
+    let ne = NonExhaustiveStructNoPrivateFields::default();
+    let NonExhaustiveStructNoPrivateFields { field: _, .. } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _ } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _, .. } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _ } = ne;
+    //~^ rest_pattern_accessible_field
+
+    use m::Sm;
+
+    let Sm { a: _, b: _, .. } = Sm::default();
+    //~^ rest_pattern_accessible_field
+
+    let Sm { a: _, b: _, .. } = Sm::default();
+}

--- a/tests/ui/rest_pattern_accessible_field.rs
+++ b/tests/ui/rest_pattern_accessible_field.rs
@@ -1,0 +1,108 @@
+//@aux-build:proc_macros.rs
+//@aux-build:non-exhaustive-struct.rs
+#![warn(clippy::rest_pattern_accessible_field)]
+#![allow(clippy::unneeded_wildcard_pattern)]
+
+use non_exhaustive_struct::{NonExhaustiveStruct, NonExhaustiveStructNoPrivateFields};
+
+struct S {
+    a: u8,
+    b: u8,
+    c: u8,
+}
+
+#[derive(Default)]
+#[non_exhaustive]
+struct LocalNonExhaustive {
+    field: i32,
+}
+
+enum E {
+    A { a1: u8, a2: u8 },
+    B { b1: u8, b2: u8 },
+    C {},
+}
+
+mod m {
+    #[derive(Default)]
+    pub struct Sm {
+        pub a: u8,
+        pub(crate) b: u8,
+        c: u8,
+    }
+}
+
+fn main() {
+    let s = S { a: 1, b: 2, c: 3 };
+
+    let S { a, b, .. } = s;
+    //~^ rest_pattern_accessible_field
+
+    let S { c, .. } = s;
+    //~^ rest_pattern_accessible_field
+
+    let S { a, b, c, .. } = s;
+
+    S { a: _, b: _, .. } = S { a: 1, b: 2, c: 3 };
+    //~^ rest_pattern_accessible_field
+
+    let e = E::A { a1: 1, a2: 2 };
+
+    match e {
+        E::A { a1, a2 } => (),
+        E::B { .. } => (),
+        //~^ rest_pattern_accessible_field
+        E::C { .. } => (),
+    }
+
+    match e {
+        E::A { a1: _, a2: _ } => (),
+        E::B { b1: _, .. } => (),
+        //~^ rest_pattern_accessible_field
+        E::C {} => (),
+    }
+
+    proc_macros::external! {
+        let s1 = S { a: 1, b: 2, c: 3 };
+        let S { a, b, .. } = s1;
+    }
+
+    proc_macros::with_span! {
+        span
+        let s2 = S { a: 1, b: 2, c: 3 };
+        let S { a, b, .. } = s2;
+    }
+
+    let ne = NonExhaustiveStruct::default();
+    let NonExhaustiveStruct { field1: _, .. } = ne;
+    //~^ rest_pattern_accessible_field
+
+    let ne = NonExhaustiveStruct::default();
+    let NonExhaustiveStruct {
+        field1: _, field2: _, ..
+    } = ne;
+
+    let ne = NonExhaustiveStructNoPrivateFields::default();
+    let NonExhaustiveStructNoPrivateFields { .. } = ne;
+    //~^ rest_pattern_accessible_field
+
+    let ne = NonExhaustiveStructNoPrivateFields::default();
+    let NonExhaustiveStructNoPrivateFields { field: _, .. } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _ } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _, .. } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { .. } = ne;
+    //~^ rest_pattern_accessible_field
+
+    use m::Sm;
+
+    let Sm { .. } = Sm::default();
+    //~^ rest_pattern_accessible_field
+
+    let Sm { a: _, b: _, .. } = Sm::default();
+}

--- a/tests/ui/rest_pattern_accessible_field.stderr
+++ b/tests/ui/rest_pattern_accessible_field.stderr
@@ -1,0 +1,109 @@
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:38:9
+   |
+LL |     let S { a, b, .. } = s;
+   |         ^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::rest-pattern-accessible-field` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::rest_pattern_accessible_field)]`
+help: consider explicitly ignoring remaining fields with wildcard patterns (`x: _`)
+   |
+LL -     let S { a, b, .. } = s;
+LL +     let S { a, b, c: _ } = s;
+   |
+
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:41:9
+   |
+LL |     let S { c, .. } = s;
+   |         ^^^^^^^^^^^
+   |
+help: consider explicitly ignoring remaining fields with wildcard patterns (`x: _`)
+   |
+LL -     let S { c, .. } = s;
+LL +     let S { c, a: _, b: _ } = s;
+   |
+
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:46:5
+   |
+LL |     S { a: _, b: _, .. } = S { a: 1, b: 2, c: 3 };
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider explicitly ignoring remaining fields with wildcard patterns (`x: _`)
+   |
+LL -     S { a: _, b: _, .. } = S { a: 1, b: 2, c: 3 };
+LL +     S { a: _, b: _, c: _ } = S { a: 1, b: 2, c: 3 };
+   |
+
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:53:9
+   |
+LL |         E::B { .. } => (),
+   |         ^^^^^^^^^^^
+   |
+help: consider explicitly ignoring fields with wildcard patterns (`x: _`)
+   |
+LL -         E::B { .. } => (),
+LL +         E::B { b1: _, b2: _ } => (),
+   |
+
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:60:9
+   |
+LL |         E::B { b1: _, .. } => (),
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+help: consider explicitly ignoring remaining fields with wildcard patterns (`x: _`)
+   |
+LL -         E::B { b1: _, .. } => (),
+LL +         E::B { b1: _, b2: _ } => (),
+   |
+
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:77:9
+   |
+LL |     let NonExhaustiveStruct { field1: _, .. } = ne;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider explicitly ignoring remaining fields with wildcard patterns (`x: _`)
+   |
+LL |     let NonExhaustiveStruct { field1: _, field2: _, .. } = ne;
+   |                                          ++++++++++
+
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:86:9
+   |
+LL |     let NonExhaustiveStructNoPrivateFields { .. } = ne;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider explicitly ignoring fields with wildcard patterns (`x: _`)
+   |
+LL |     let NonExhaustiveStructNoPrivateFields { field: _, .. } = ne;
+   |                                              +++++++++
+
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:99:9
+   |
+LL |     let LocalNonExhaustive { .. } = ne;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider explicitly ignoring fields with wildcard patterns (`x: _`)
+   |
+LL -     let LocalNonExhaustive { .. } = ne;
+LL +     let LocalNonExhaustive { field: _ } = ne;
+   |
+
+error: struct destructuring with rest (`..`)
+  --> tests/ui/rest_pattern_accessible_field.rs:104:9
+   |
+LL |     let Sm { .. } = Sm::default();
+   |         ^^^^^^^^^
+   |
+help: consider explicitly ignoring fields with wildcard patterns (`x: _`)
+   |
+LL |     let Sm { a: _, b: _, .. } = Sm::default();
+   |              +++++++++++
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/unnecessary_rest_pattern.fixed
+++ b/tests/ui/unnecessary_rest_pattern.fixed
@@ -1,0 +1,90 @@
+//@aux-build:proc_macros.rs
+//@aux-build:non-exhaustive-struct.rs
+#![warn(clippy::unnecessary_rest_pattern)]
+#![allow(clippy::unneeded_wildcard_pattern)]
+
+use non_exhaustive_struct::{NonExhaustiveStruct, NonExhaustiveStructNoPrivateFields};
+
+struct S {
+    a: u8,
+    b: u8,
+    c: u8,
+}
+
+#[derive(Default)]
+#[non_exhaustive]
+struct LocalNonExhaustive {
+    field: i32,
+}
+
+enum E {
+    A { a1: u8, a2: u8 },
+    B { b1: u8, b2: u8 },
+    C {},
+}
+
+mod m {
+    #[derive(Default)]
+    pub struct Sm {
+        pub a: u8,
+        pub(crate) b: u8,
+        c: u8,
+    }
+}
+
+fn main() {
+    let s = S { a: 1, b: 2, c: 3 };
+
+    let S { a, b, c,  } = s;
+    //~^ unnecessary_rest_pattern
+
+    let e = E::A { a1: 1, a2: 2 };
+
+    match e {
+        E::A { a1, a2 } => (),
+        E::B { b1, b2,  } => (),
+        //~^ unnecessary_rest_pattern
+        E::C {  } => (),
+        //~^ unnecessary_rest_pattern
+    }
+
+    proc_macros::external! {
+        let s1 = S { a: 1, b: 2, c: 3 };
+        let S { a, b, c, .. } = s1;
+    }
+
+    proc_macros::with_span! {
+        span
+        let s2 = S { a: 1, b: 2, c: 3 };
+        let S { a, b, c, .. } = s2;
+    }
+
+    let ne = NonExhaustiveStruct::default();
+    let NonExhaustiveStruct { field1: _, .. } = ne;
+
+    let ne = NonExhaustiveStruct::default();
+    let NonExhaustiveStruct {
+        field1: _, field2: _, ..
+    } = ne;
+
+    let ne = NonExhaustiveStructNoPrivateFields::default();
+    let NonExhaustiveStructNoPrivateFields { .. } = ne;
+
+    let ne = NonExhaustiveStructNoPrivateFields::default();
+    let NonExhaustiveStructNoPrivateFields { field: _, .. } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _ } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _,  } = ne;
+    //~^ unnecessary_rest_pattern
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { .. } = ne;
+
+    use m::Sm;
+
+    let Sm { .. } = Sm::default();
+    let Sm { a: _, b: _, .. } = Sm::default();
+}

--- a/tests/ui/unnecessary_rest_pattern.rs
+++ b/tests/ui/unnecessary_rest_pattern.rs
@@ -1,0 +1,90 @@
+//@aux-build:proc_macros.rs
+//@aux-build:non-exhaustive-struct.rs
+#![warn(clippy::unnecessary_rest_pattern)]
+#![allow(clippy::unneeded_wildcard_pattern)]
+
+use non_exhaustive_struct::{NonExhaustiveStruct, NonExhaustiveStructNoPrivateFields};
+
+struct S {
+    a: u8,
+    b: u8,
+    c: u8,
+}
+
+#[derive(Default)]
+#[non_exhaustive]
+struct LocalNonExhaustive {
+    field: i32,
+}
+
+enum E {
+    A { a1: u8, a2: u8 },
+    B { b1: u8, b2: u8 },
+    C {},
+}
+
+mod m {
+    #[derive(Default)]
+    pub struct Sm {
+        pub a: u8,
+        pub(crate) b: u8,
+        c: u8,
+    }
+}
+
+fn main() {
+    let s = S { a: 1, b: 2, c: 3 };
+
+    let S { a, b, c, .. } = s;
+    //~^ unnecessary_rest_pattern
+
+    let e = E::A { a1: 1, a2: 2 };
+
+    match e {
+        E::A { a1, a2 } => (),
+        E::B { b1, b2, .. } => (),
+        //~^ unnecessary_rest_pattern
+        E::C { .. } => (),
+        //~^ unnecessary_rest_pattern
+    }
+
+    proc_macros::external! {
+        let s1 = S { a: 1, b: 2, c: 3 };
+        let S { a, b, c, .. } = s1;
+    }
+
+    proc_macros::with_span! {
+        span
+        let s2 = S { a: 1, b: 2, c: 3 };
+        let S { a, b, c, .. } = s2;
+    }
+
+    let ne = NonExhaustiveStruct::default();
+    let NonExhaustiveStruct { field1: _, .. } = ne;
+
+    let ne = NonExhaustiveStruct::default();
+    let NonExhaustiveStruct {
+        field1: _, field2: _, ..
+    } = ne;
+
+    let ne = NonExhaustiveStructNoPrivateFields::default();
+    let NonExhaustiveStructNoPrivateFields { .. } = ne;
+
+    let ne = NonExhaustiveStructNoPrivateFields::default();
+    let NonExhaustiveStructNoPrivateFields { field: _, .. } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _ } = ne;
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { field: _, .. } = ne;
+    //~^ unnecessary_rest_pattern
+
+    let ne = LocalNonExhaustive::default();
+    let LocalNonExhaustive { .. } = ne;
+
+    use m::Sm;
+
+    let Sm { .. } = Sm::default();
+    let Sm { a: _, b: _, .. } = Sm::default();
+}

--- a/tests/ui/unnecessary_rest_pattern.stderr
+++ b/tests/ui/unnecessary_rest_pattern.stderr
@@ -1,0 +1,52 @@
+error: unnecessary rest pattern (`..`)
+  --> tests/ui/unnecessary_rest_pattern.rs:38:9
+   |
+LL |     let S { a, b, c, .. } = s;
+   |         ^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::unnecessary-rest-pattern` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_rest_pattern)]`
+help: consider removing the unnecessary rest pattern (`..`)
+   |
+LL -     let S { a, b, c, .. } = s;
+LL +     let S { a, b, c,  } = s;
+   |
+
+error: unnecessary rest pattern (`..`)
+  --> tests/ui/unnecessary_rest_pattern.rs:45:9
+   |
+LL |         E::B { b1, b2, .. } => (),
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the unnecessary rest pattern (`..`)
+   |
+LL -         E::B { b1, b2, .. } => (),
+LL +         E::B { b1, b2,  } => (),
+   |
+
+error: unnecessary rest pattern (`..`)
+  --> tests/ui/unnecessary_rest_pattern.rs:47:9
+   |
+LL |         E::C { .. } => (),
+   |         ^^^^^^^^^^^
+   |
+help: consider removing the unnecessary rest pattern (`..`)
+   |
+LL -         E::C { .. } => (),
+LL +         E::C {  } => (),
+   |
+
+error: unnecessary rest pattern (`..`)
+  --> tests/ui/unnecessary_rest_pattern.rs:80:9
+   |
+LL |     let LocalNonExhaustive { field: _, .. } = ne;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the unnecessary rest pattern (`..`)
+   |
+LL -     let LocalNonExhaustive { field: _, .. } = ne;
+LL +     let LocalNonExhaustive { field: _,  } = ne;
+   |
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/15000)*

Add a new lint that warns when using a rest pattern when destructuring a struct. This lint was requested in this comment https://github.com/rust-lang/rust-clippy/issues/10666#issuecomment-1572061535 by @xxchan.

changelog: [`rest_pattern_accessible_field`] new lint
changelog: [`unnecessary_rest_pattern`] new lint
