### PR TITLE
Add MSRV test for `unnecessary_debug_formatting` with `OsStr`

### DIFF
--- a/tests/ui/unnecessary_os_str_debug_formatting.rs
+++ b/tests/ui/unnecessary_os_str_debug_formatting.rs
@@ -21,3 +21,16 @@ fn main() {
     let _: String = format!("{:?}", os_str); //~ unnecessary_debug_formatting
     let _: String = format!("{:?}", os_string); //~ unnecessary_debug_formatting
 }
+
+#[clippy::msrv = "1.86"]
+fn msrv_1_86() {
+    let os_str = OsStr::new("test");
+    println!("{:?}", os_str);
+}
+
+#[clippy::msrv = "1.87"]
+fn msrv_1_87() {
+    let os_str = OsStr::new("test");
+    println!("{:?}", os_str);
+    //~^ unnecessary_debug_formatting
+}

--- a/tests/ui/unnecessary_os_str_debug_formatting.stderr
+++ b/tests/ui/unnecessary_os_str_debug_formatting.stderr
@@ -54,5 +54,14 @@ LL |     let _: String = format!("{:?}", os_string);
    = help: use `Display` formatting and change this to `os_string.display()`
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
-error: aborting due to 6 previous errors
+error: unnecessary `Debug` formatting in `println!` args
+  --> tests/ui/unnecessary_os_str_debug_formatting.rs:34:22
+   |
+LL |     println!("{:?}", os_str);
+   |                      ^^^^^^
+   |
+   = help: use `Display` formatting and change this to `os_str.display()`
+   = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
`unnecessary_debug_formatting` suggests display() respected for
MSRV but lacking of tests. This adds tests to check MSRV for OsStr.

changelog: none