### PR TITLE
Fix `create_dir` ignores paths in suggestions

### DIFF
--- a/tests/ui/create_dir.fixed
+++ b/tests/ui/create_dir.fixed
@@ -7,12 +7,31 @@ fn create_dir() {}
 
 fn main() {
     // Should be warned
-    create_dir_all("foo");
+    std::fs::create_dir_all("foo");
     //~^ create_dir
-    create_dir_all("bar").unwrap();
+    std::fs::create_dir_all("bar").unwrap();
     //~^ create_dir
 
     // Shouldn't be warned
     create_dir();
     std::fs::create_dir_all("foobar");
+}
+
+mod issue14994 {
+    fn with_no_prefix() {
+        use std::fs::create_dir;
+        std::fs::create_dir_all("some/dir").unwrap();
+        //~^ create_dir
+    }
+
+    fn with_fs_prefix() {
+        use std::fs;
+        fs::create_dir_all("/some/dir").unwrap();
+        //~^ create_dir
+    }
+
+    fn with_full_prefix() {
+        std::fs::create_dir_all("/some/dir").unwrap();
+        //~^ create_dir
+    }
 }

--- a/tests/ui/create_dir.rs
+++ b/tests/ui/create_dir.rs
@@ -16,3 +16,22 @@ fn main() {
     create_dir();
     std::fs::create_dir_all("foobar");
 }
+
+mod issue14994 {
+    fn with_no_prefix() {
+        use std::fs::create_dir;
+        create_dir("some/dir").unwrap();
+        //~^ create_dir
+    }
+
+    fn with_fs_prefix() {
+        use std::fs;
+        fs::create_dir("/some/dir").unwrap();
+        //~^ create_dir
+    }
+
+    fn with_full_prefix() {
+        std::fs::create_dir("/some/dir").unwrap();
+        //~^ create_dir
+    }
+}

--- a/tests/ui/create_dir.stderr
+++ b/tests/ui/create_dir.stderr
@@ -8,9 +8,8 @@ LL |     std::fs::create_dir("foo");
    = help: to override `-D warnings` add `#[allow(clippy::create_dir)]`
 help: consider calling `std::fs::create_dir_all` instead
    |
-LL -     std::fs::create_dir("foo");
-LL +     create_dir_all("foo");
-   |
+LL |     std::fs::create_dir_all("foo");
+   |                        ++++
 
 error: calling `std::fs::create_dir` where there may be a better way
   --> tests/ui/create_dir.rs:12:5
@@ -20,9 +19,41 @@ LL |     std::fs::create_dir("bar").unwrap();
    |
 help: consider calling `std::fs::create_dir_all` instead
    |
-LL -     std::fs::create_dir("bar").unwrap();
-LL +     create_dir_all("bar").unwrap();
-   |
+LL |     std::fs::create_dir_all("bar").unwrap();
+   |                        ++++
 
-error: aborting due to 2 previous errors
+error: calling `std::fs::create_dir` where there may be a better way
+  --> tests/ui/create_dir.rs:23:9
+   |
+LL |         create_dir("some/dir").unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider calling `std::fs::create_dir_all` instead
+   |
+LL |         std::fs::create_dir_all("some/dir").unwrap();
+   |         +++++++++          ++++
+
+error: calling `std::fs::create_dir` where there may be a better way
+  --> tests/ui/create_dir.rs:29:9
+   |
+LL |         fs::create_dir("/some/dir").unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider calling `std::fs::create_dir_all` instead
+   |
+LL |         fs::create_dir_all("/some/dir").unwrap();
+   |                       ++++
+
+error: calling `std::fs::create_dir` where there may be a better way
+  --> tests/ui/create_dir.rs:34:9
+   |
+LL |         std::fs::create_dir("/some/dir").unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider calling `std::fs::create_dir_all` instead
+   |
+LL |         std::fs::create_dir_all("/some/dir").unwrap();
+   |                            ++++
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14994

changelog: [`create_dir`] fix missing paths in suggestions
