### PR TITLE
Add missing word to `cloned_ref_to_slice_refs` docs

### DIFF
--- a/clippy_lints/src/cloned_ref_to_slice_refs.rs
+++ b/clippy_lints/src/cloned_ref_to_slice_refs.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad
     ///
-    /// A reference does not need to be owned in order to used as a slice.
+    /// A reference does not need to be owned in order to be used as a slice.
     ///
     /// ### Known problems
     ///


### PR DESCRIPTION
changelog: none