### PR TITLE
Fix `exhaustive_structs` FP on structs with default valued field

### DIFF
--- a/clippy_lints/src/exhaustive_items.rs
+++ b/clippy_lints/src/exhaustive_items.rs
@@ -76,7 +76,7 @@ impl LateLintPass<'_> for ExhaustiveItems {
                 "exported enums should not be exhaustive",
                 [].as_slice(),
             ),
-            ItemKind::Struct(_, _, v) => (
+            ItemKind::Struct(_, _, v) if v.fields().iter().all(|f| f.default.is_none()) => (
                 EXHAUSTIVE_STRUCTS,
                 "exported structs should not be exhaustive",
                 v.fields(),

--- a/tests/ui/exhaustive_items.fixed
+++ b/tests/ui/exhaustive_items.fixed
@@ -1,3 +1,4 @@
+#![feature(default_field_values)]
 #![deny(clippy::exhaustive_enums, clippy::exhaustive_structs)]
 #![allow(unused)]
 
@@ -88,5 +89,11 @@ pub mod structs {
     struct NonExhaustivePrivate {
         pub foo: u8,
         pub bar: String,
+    }
+}
+
+pub mod issue14992 {
+    pub struct A {
+        pub a: isize = 42,
     }
 }

--- a/tests/ui/exhaustive_items.rs
+++ b/tests/ui/exhaustive_items.rs
@@ -1,3 +1,4 @@
+#![feature(default_field_values)]
 #![deny(clippy::exhaustive_enums, clippy::exhaustive_structs)]
 #![allow(unused)]
 
@@ -85,5 +86,11 @@ pub mod structs {
     struct NonExhaustivePrivate {
         pub foo: u8,
         pub bar: String,
+    }
+}
+
+pub mod issue14992 {
+    pub struct A {
+        pub a: isize = 42,
     }
 }

--- a/tests/ui/exhaustive_items.stderr
+++ b/tests/ui/exhaustive_items.stderr
@@ -1,5 +1,5 @@
 error: exported enums should not be exhaustive
-  --> tests/ui/exhaustive_items.rs:9:5
+  --> tests/ui/exhaustive_items.rs:10:5
    |
 LL | /     pub enum Exhaustive {
 LL | |
@@ -11,7 +11,7 @@ LL | |     }
    | |_____^
    |
 note: the lint level is defined here
-  --> tests/ui/exhaustive_items.rs:1:9
+  --> tests/ui/exhaustive_items.rs:2:9
    |
 LL | #![deny(clippy::exhaustive_enums, clippy::exhaustive_structs)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL ~     pub enum Exhaustive {
    |
 
 error: exported enums should not be exhaustive
-  --> tests/ui/exhaustive_items.rs:19:5
+  --> tests/ui/exhaustive_items.rs:20:5
    |
 LL | /     pub enum ExhaustiveWithAttrs {
 LL | |
@@ -40,7 +40,7 @@ LL ~     pub enum ExhaustiveWithAttrs {
    |
 
 error: exported structs should not be exhaustive
-  --> tests/ui/exhaustive_items.rs:55:5
+  --> tests/ui/exhaustive_items.rs:56:5
    |
 LL | /     pub struct Exhaustive {
 LL | |
@@ -50,7 +50,7 @@ LL | |     }
    | |_____^
    |
 note: the lint level is defined here
-  --> tests/ui/exhaustive_items.rs:1:35
+  --> tests/ui/exhaustive_items.rs:2:35
    |
 LL | #![deny(clippy::exhaustive_enums, clippy::exhaustive_structs)]
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14992 

changelog: [`exhaustive_structs`] fix FP on structs with default valued field
