### PR TITLE
New lint: `concealed_obvious_default`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6506,6 +6506,7 @@ Released 2018-09-13
 [`collection_is_never_read`]: https://rust-lang.github.io/rust-clippy/master/index.html#collection_is_never_read
 [`comparison_chain`]: https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain
 [`comparison_to_empty`]: https://rust-lang.github.io/rust-clippy/master/index.html#comparison_to_empty
+[`concealed_obvious_default`]: https://rust-lang.github.io/rust-clippy/master/index.html#concealed_obvious_default
 [`confusing_method_to_numeric_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#confusing_method_to_numeric_cast
 [`const_is_empty`]: https://rust-lang.github.io/rust-clippy/master/index.html#const_is_empty
 [`const_static_lifetime`]: https://rust-lang.github.io/rust-clippy/master/index.html#const_static_lifetime

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -1159,7 +1159,7 @@ impl serde::de::Error for FieldError {
             writeln!(msg).unwrap();
             for (column, column_width) in column_widths.iter().copied().enumerate() {
                 let index = column * rows + row;
-                let field = expected.get(index).copied().unwrap_or_default();
+                let field = expected.get(index).copied().unwrap_or("");
                 write!(msg, "{:SEPARATOR_WIDTH$}{field:column_width$}", " ").unwrap();
             }
         }
@@ -1190,7 +1190,7 @@ fn calculate_dimensions(fields: &[&str]) -> (usize, Vec<usize>) {
                 (0..rows)
                     .map(|row| {
                         let index = column * rows + row;
-                        let field = fields.get(index).copied().unwrap_or_default();
+                        let field = fields.get(index).copied().unwrap_or("");
                         field.len()
                     })
                     .max()

--- a/clippy_lints/src/arbitrary_source_item_ordering.rs
+++ b/clippy_lints/src/arbitrary_source_item_ordering.rs
@@ -420,7 +420,7 @@ impl<'tcx> LateLintPass<'tcx> for ArbitrarySourceItemOrdering {
             let module_level_order = self
                 .module_item_order_groupings
                 .module_level_order_of(&item_kind)
-                .unwrap_or_default();
+                .unwrap_or(0);
 
             if let Some(cur_t) = cur_t.as_ref() {
                 use std::cmp::Ordering; // Better legibility.

--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -49,7 +49,7 @@ fn apply_reductions(cx: &LateContext<'_>, nbits: u64, expr: &Expr<'_>, signed: b
                 .min(apply_reductions(cx, nbits, right, signed))
                 .min(apply_reductions(cx, nbits, left, signed)),
             BinOpKind::Shr => apply_reductions(cx, nbits, left, signed)
-                .saturating_sub(constant_int(cx, right).map_or(0, |s| u64::try_from(s).unwrap_or_default())),
+                .saturating_sub(constant_int(cx, right).map_or(0, |s| u64::try_from(s).unwrap_or(0))),
             _ => nbits,
         },
         ExprKind::MethodCall(method, left, [right], _) => {

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -367,6 +367,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::CLONE_ON_REF_PTR_INFO,
     crate::methods::CLONED_INSTEAD_OF_COPIED_INFO,
     crate::methods::COLLAPSIBLE_STR_REPLACE_INFO,
+    crate::methods::CONCEALED_OBVIOUS_DEFAULT_INFO,
     crate::methods::CONST_IS_EMPTY_INFO,
     crate::methods::DOUBLE_ENDED_ITERATOR_LAST_INFO,
     crate::methods::DRAIN_COLLECT_INFO,

--- a/clippy_lints/src/empty_line_after.rs
+++ b/clippy_lints/src/empty_line_after.rs
@@ -456,7 +456,7 @@ impl EmptyLineAfter {
             .filter(|attr| attr.style == AttrStyle::Outer && !attr.span.from_expansion())
             .map(|attr| Stop::from_attr(cx, attr))
             .collect::<Option<Vec<_>>>()
-            .unwrap_or_default();
+            .unwrap_or(vec![]);
 
         if outer.is_empty() {
             return;

--- a/clippy_lints/src/manual_strip.rs
+++ b/clippy_lints/src/manual_strip.rs
@@ -272,7 +272,7 @@ fn find_stripping<'tcx>(
 
         fn visit_pat(&mut self, pat: &'tcx rustc_hir::Pat<'tcx>) -> Self::Result {
             if let PatKind::Binding(_, _, ident, _) = pat.kind {
-                *self.bindings.entry(ident.name).or_default() += 1;
+                *self.bindings.entry(ident.name).or_insert(0) += 1;
             }
             walk_pat(self, pat);
         }

--- a/clippy_lints/src/methods/concealed_obvious_default.rs
+++ b/clippy_lints/src/methods/concealed_obvious_default.rs
@@ -4,7 +4,7 @@ use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::sym;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
-use rustc_lint::LateContext;
+use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::Span;
 
@@ -23,7 +23,7 @@ pub(super) fn check(
     // Option::<bool>::unwrap_or_default()
     //                 ^^^^^^^^^^^^^^^^^^^
     // if the call comes from expansion, bail
-    if call_span.from_expansion() {
+    if call_span.in_external_macro(cx.sess().source_map()) {
         return;
     }
 

--- a/clippy_lints/src/methods/concealed_obvious_default.rs
+++ b/clippy_lints/src/methods/concealed_obvious_default.rs
@@ -1,0 +1,255 @@
+use rustc_span::Symbol;
+
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::sym;
+use rustc_errors::Applicability;
+use rustc_hir as hir;
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, Ty};
+use rustc_span::Span;
+
+use super::CONCEALED_OBVIOUS_DEFAULT;
+
+pub(super) fn check(
+    cx: &LateContext<'_>,
+    recv: &hir::Expr<'_>,
+    method_name: Symbol,
+    call_span: Span,
+    method_args: &[rustc_hir::Expr<'_>],
+) {
+    // Type of the expression which invoked the method
+    let recv_ty = cx.typeck_results().expr_ty(recv);
+
+    // Option::<bool>::unwrap_or_default()
+    //                 ^^^^^^^^^^^^^^^^^^^
+    // if the call comes from expansion, bail
+    if call_span.from_expansion() {
+        return;
+    }
+
+    // Only consider algebraic data types e.g. an `Option`.
+    // Their generics are represented by `generic_args`
+    if let ty::Adt(recv_adt, recv_generics) = recv_ty.kind()
+        // `name_of_generic`, is e.g. a `sym::Option`
+        && let Some(recv_symbol) = cx.tcx.get_diagnostic_name(recv_adt.did())
+        && let Some((suggestion, ty, applicability)) = resolve_obvious_default(cx, recv_symbol,
+            recv_generics.as_slice(), method_name, method_args)
+    {
+        let message = format!("method `{ty}` conceals the underlying type");
+
+        span_lint_and_sugg(
+            cx,
+            CONCEALED_OBVIOUS_DEFAULT,
+            call_span,
+            message,
+            "write the default value explicitly".to_string(),
+            suggestion,
+            applicability,
+        );
+    }
+}
+
+/// Resolve obvious default on the given method call.
+///
+/// Returns (suggestion, type, applicability)
+fn resolve_obvious_default(
+    cx: &LateContext<'_>,
+    symbol: Symbol,
+    generics: &[ty::GenericArg<'_>],
+    method: Symbol,
+    args: &[rustc_hir::Expr<'_>],
+) -> Option<(String, String, Applicability)> {
+    Some(match (symbol, generics, method, args) {
+        (sym::Result, [ok, _err], sym::unwrap_or_default, []) => {
+            let ObviousDefaultReplacement {
+                applicability,
+                insert,
+                ty,
+            } = extract_obvious_default(cx, ok.expect_ty())?;
+
+            (
+                format!("unwrap_or({insert})"),
+                format!("Result::<{ty}, _>::unwrap_or_default"),
+                applicability,
+            )
+        },
+        (sym::Result, [ok, _err], sym::map_or_default, [f]) => {
+            let ObviousDefaultReplacement {
+                mut applicability,
+                insert,
+                ty,
+            } = extract_obvious_default(cx, ok.expect_ty())?;
+
+            let f = clippy_utils::source::snippet_with_applicability(cx.tcx.sess, f.span, "..", &mut applicability);
+
+            (
+                format!("map_or({insert}, {f})"),
+                format!("Result::<{ty}, _>::map_or_default"),
+                applicability,
+            )
+        },
+        (sym::Option, [some], sym::unwrap_or_default, []) => {
+            let ObviousDefaultReplacement {
+                applicability,
+                insert,
+                ty,
+            } = extract_obvious_default(cx, some.expect_ty())?;
+
+            (
+                format!("unwrap_or({insert})"),
+                format!("Option::<{ty}>::unwrap_or_default"),
+                applicability,
+            )
+        },
+        (sym::Option, [some], sym::map_or_default, [f]) => {
+            let ObviousDefaultReplacement {
+                mut applicability,
+                insert,
+                ty,
+            } = extract_obvious_default(cx, some.expect_ty())?;
+
+            let f = clippy_utils::source::snippet_with_applicability(cx.tcx.sess, f.span, "..", &mut applicability);
+
+            (
+                format!("map_or({insert}, {f})"),
+                format!("Option::<{ty}>::map_or_default"),
+                applicability,
+            )
+        },
+        (sym::HashMapEntry, [_lifetime, _key, value, _allocator], sym::or_default, []) => {
+            let ObviousDefaultReplacement {
+                applicability,
+                insert,
+                ty,
+            } = extract_obvious_default(cx, value.expect_ty())?;
+
+            (
+                format!("or_insert({insert})"),
+                format!("hash_map::Entry::<'_, _, {ty}>::or_default"),
+                applicability,
+            )
+        },
+        (sym::BTreeEntry, [_lifetime, _key, value, _allocator], sym::or_default, []) => {
+            let ObviousDefaultReplacement {
+                applicability,
+                insert,
+                ty,
+            } = extract_obvious_default(cx, value.expect_ty())?;
+
+            (
+                format!("or_insert({insert})"),
+                format!("btree_map::Entry::<'_, _, {ty}>::or_default"),
+                applicability,
+            )
+        },
+        _ => return None,
+    })
+}
+
+/// An "obvious default"
+struct ObviousDefaultReplacement {
+    applicability: Applicability,
+    /// What to replace this default with
+    insert: &'static str,
+    /// Type of this default
+    ty: &'static str,
+}
+
+/// Get default value of a type with an obvious default.
+///
+/// # Returns
+///
+/// If the type has an obvious default:
+///
+/// - Default for the type
+/// - The type as it should be displayed in the lint message
+///
+/// If the type is not considered to have an obvious default, return `None`.
+fn extract_obvious_default(cx: &LateContext<'_>, ty: Ty<'_>) -> Option<ObviousDefaultReplacement> {
+    match ty.peel_refs().kind() {
+        ty::Int(ty) => Some(ObviousDefaultReplacement {
+            applicability: Applicability::MachineApplicable,
+            insert: "0",
+            ty: ty.name_str(),
+        }),
+        ty::Uint(ty) => Some(ObviousDefaultReplacement {
+            applicability: Applicability::MachineApplicable,
+            insert: "0",
+            ty: ty.name_str(),
+        }),
+        ty::Float(ty) => Some(ObviousDefaultReplacement {
+            applicability: Applicability::MachineApplicable,
+            insert: "0.0",
+            ty: ty.name_str(),
+        }),
+        ty::Char => Some(ObviousDefaultReplacement {
+            applicability: Applicability::MachineApplicable,
+            insert: r"'\0'",
+            ty: "char",
+        }),
+        ty::Str => Some(ObviousDefaultReplacement {
+            applicability: Applicability::MachineApplicable,
+            insert: r#""""#,
+            ty: "&str",
+        }),
+        ty::Bool => Some(ObviousDefaultReplacement {
+            applicability: Applicability::MachineApplicable,
+            insert: "false",
+            ty: "bool",
+        }),
+        ty::Tuple(tys) if tys.is_empty() => Some(ObviousDefaultReplacement {
+            applicability: Applicability::MachineApplicable,
+            insert: "()",
+            ty: "()",
+        }),
+        ty::Array(_, len)
+            if matches!(len.kind(), ty::ConstKind::Value(value) if
+            value.to_leaf().size() == rustc_abi::Size::ZERO) =>
+        {
+            Some(ObviousDefaultReplacement {
+                applicability: Applicability::MachineApplicable,
+                insert: "[]",
+                ty: "[_; 0]",
+            })
+        },
+        // &[u8]
+        ty::Ref(_, ty, _)
+            if matches!(ty.peel_refs().kind(), ty::Slice(ty) if matches!(ty.peel_refs().kind(),
+            ty::Uint(rustc_ast::UintTy::U8))) =>
+        {
+            Some(ObviousDefaultReplacement {
+                applicability: Applicability::MachineApplicable,
+                insert: r#"b"""#,
+                ty: "&[u8]",
+            })
+        },
+        // &[_]
+        ty::Ref(_, ty, _) if matches!(ty.peel_refs().kind(), ty::Slice(_)) => Some(ObviousDefaultReplacement {
+            applicability: Applicability::MachineApplicable,
+            insert: "&[]",
+            ty: "&[_]",
+        }),
+        ty::Adt(def, _) if cx.tcx.get_diagnostic_name(def.did()) == Some(sym::Vec) => Some(ObviousDefaultReplacement {
+            // `vec![]` might be shadowed
+            applicability: Applicability::MaybeIncorrect,
+            insert: "vec![]",
+            ty: "Vec<_>",
+        }),
+        ty::Adt(def, _) if cx.tcx.get_diagnostic_name(def.did()) == Some(sym::CStr) => {
+            Some(ObviousDefaultReplacement {
+                applicability: Applicability::MachineApplicable,
+                insert: r#"c"""#,
+                ty: "&core::ffi::CStr",
+            })
+        },
+        ty::Adt(def, _) if cx.tcx.get_diagnostic_name(def.did()) == Some(sym::Option) => {
+            Some(ObviousDefaultReplacement {
+                // `None` might be shadowed
+                applicability: Applicability::MaybeIncorrect,
+                insert: "None",
+                ty: "Option<_>",
+            })
+        },
+        _ => None,
+    }
+}

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -14,6 +14,7 @@ mod clone_on_copy;
 mod clone_on_ref_ptr;
 mod cloned_instead_of_copied;
 mod collapsible_str_replace;
+mod concealed_obvious_default;
 mod double_ended_iterator_last;
 mod drain_collect;
 mod err_expect;
@@ -444,6 +445,48 @@ declare_clippy_lint! {
     pub COLLAPSIBLE_STR_REPLACE,
     perf,
     "collapse consecutive calls to str::replace (2 or more) into a single call"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for usages of methods like `Option::unwrap_or_default`,
+    /// for types where the `Default` implementation is obvious and can be written literally
+    ///
+    /// ### Why is this bad?
+    ///
+    /// You have to know what the underlying type is, instead of it being obvious from a glance
+    ///
+    /// ### Example
+    /// ```no_run
+    /// fn f(
+    ///     a: Option<&str>,
+    ///     b: Option<usize>,
+    ///     c: Option<Option<bool>>
+    /// ) {
+    ///     let a = a.unwrap_or_default();
+    ///     let b = b.unwrap_or_default();
+    ///     let c = c.unwrap_or_default();
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```no_run
+    /// fn f(
+    ///     a: Option<&str>,
+    ///     b: Option<usize>,
+    ///     c: Option<Option<bool>>
+    /// ) {
+    ///     let a = a.unwrap_or("");
+    ///     let b = b.unwrap_or(0);
+    ///     let c = c.unwrap_or(None);
+    /// }
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub CONCEALED_OBVIOUS_DEFAULT,
+    complexity,
+    ".*or_default() obscures the underlying type"
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4791,6 +4791,7 @@ impl_lint_pass!(Methods => [
     CLONE_ON_COPY,
     CLONE_ON_REF_PTR,
     COLLAPSIBLE_STR_REPLACE,
+    CONCEALED_OBVIOUS_DEFAULT,
     CONST_IS_EMPTY,
     DOUBLE_ENDED_ITERATOR_LAST,
     DRAIN_COLLECT,
@@ -5758,7 +5759,7 @@ impl Methods {
             }
         }
         // Handle method calls whose receiver and arguments may come from expansion
-        if let ExprKind::MethodCall(path, recv, args, _call_span) = expr.kind {
+        if let ExprKind::MethodCall(path, recv, args, call_span) = expr.kind {
             let method_span = path.ident.span;
 
             // Those methods do their own method name checking as they deal with multiple methods.
@@ -5818,6 +5819,9 @@ impl Methods {
                         &self.unwrap_allowed_aliases,
                         unwrap_expect_used::Variant::Unwrap,
                     );
+                },
+                (sym::map_or_default | sym::or_default | sym::unwrap_or_default, args) => {
+                    concealed_obvious_default::check(cx, recv, path.ident.name, call_span, args);
                 },
                 (sym::unwrap_err, []) => {
                     unwrap_expect_used::check(

--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -68,9 +68,9 @@ impl ArithmeticSideEffects {
     /// "multiplication" are present in the inner set of allowed types.
     fn has_allowed_binary(&self, lhs_ty: Ty<'_>, rhs_ty: Ty<'_>) -> bool {
         let lhs_ty_string = lhs_ty.to_string();
-        let lhs_ty_string_elem = lhs_ty_string.split('<').next().unwrap_or_default();
+        let lhs_ty_string_elem = lhs_ty_string.split('<').next().unwrap_or("");
         let rhs_ty_string = rhs_ty.to_string();
-        let rhs_ty_string_elem = rhs_ty_string.split('<').next().unwrap_or_default();
+        let rhs_ty_string_elem = rhs_ty_string.split('<').next().unwrap_or("");
         if let Some(rhs_from_specific) = self.allowed_binary.get(lhs_ty_string_elem)
             && {
                 let rhs_has_allowed_ty = rhs_from_specific.contains(rhs_ty_string_elem);
@@ -89,7 +89,7 @@ impl ArithmeticSideEffects {
     /// allowed types.
     fn has_allowed_unary(&self, ty: Ty<'_>) -> bool {
         let ty_string = ty.to_string();
-        let ty_string_elem = ty_string.split('<').next().unwrap_or_default();
+        let ty_string_elem = ty_string.split('<').next().unwrap_or("");
         self.allowed_unary.contains(ty_string_elem)
     }
 

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -141,7 +141,7 @@ impl<'tcx> LateLintPass<'tcx> for Shadow {
         let HirId { owner, local_id } = id;
         // get (or insert) the list of items for this owner and symbol
         let (ref mut data, scope_owner) = *self.bindings.last_mut().unwrap();
-        let items_with_name = data.entry(ident.name).or_default();
+        let items_with_name = data.entry(ident.name).or_insert(vec![]);
 
         // check other bindings with the same name, most recently seen first
         for &prev in items_with_name.iter().rev() {

--- a/clippy_lints/src/single_component_path_imports.rs
+++ b/clippy_lints/src/single_component_path_imports.rs
@@ -156,7 +156,7 @@ impl SingleComponentPathImports {
             if !imports_reused_with_self.contains(&usage.name)
                 && !import_usage_visitor.imports_referenced_with_self.contains(&usage.name)
             {
-                self.found.entry(usage.item_id).or_default().push(usage);
+                self.found.entry(usage.item_id).or_insert(vec![]).push(usage);
             }
         }
     }

--- a/clippy_lints/src/useless_vec.rs
+++ b/clippy_lints/src/useless_vec.rs
@@ -286,7 +286,7 @@ impl SuggestedType {
         assert!(len_span.is_none_or(|s| !s.from_expansion()));
 
         let maybe_args = args_span.map(|sp| sp.get_source_text(cx).expect("spans are always crate-local"));
-        let maybe_args = maybe_args.as_deref().unwrap_or_default();
+        let maybe_args = maybe_args.as_deref().unwrap_or("");
         let maybe_len = len_span
             .map(|sp| sp.get_source_text(cx).expect("spans are always crate-local"))
             .map(|st| format!("; {st}"))

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -217,7 +217,7 @@ impl<'a, 'tcx> PrintVisitor<'a, 'tcx> {
 
     fn next(&self, s: &'static str) -> String {
         let mut ids = self.ids.take();
-        let out = match *ids.entry(s).and_modify(|n| *n += 1).or_default() {
+        let out = match *ids.entry(s).and_modify(|n| *n += 1).or_insert(0) {
             // first usage of the name, use it as is
             0 => s.to_string(),
             // append a number starting with 1

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2819,7 +2819,7 @@ pub fn tokenize_with_text(s: &str) -> impl Iterator<Item = (TokenKind, &str, Inn
         let range = pos as usize..end as usize;
         let inner = InnerSpan::new(range.start, range.end);
         pos = end;
-        (t.kind, s.get(range).unwrap_or_default(), inner)
+        (t.kind, s.get(range).unwrap_or(""), inner)
     })
 }
 
@@ -2866,7 +2866,7 @@ pub fn span_extract_comments(cx: &impl source::HasSession, span: Span) -> Vec<St
             .map(|(_, s, _)| s.to_string())
             .collect::<Vec<_>>()
     })
-    .unwrap_or_default()
+    .unwrap_or(vec![])
 }
 
 pub fn span_find_starting_semi(sm: &SourceMap, span: Span) -> Span {

--- a/clippy_utils/src/mir/transitive_relation.rs
+++ b/clippy_utils/src/mir/transitive_relation.rs
@@ -9,7 +9,7 @@ pub(super) struct TransitiveRelation {
 
 impl TransitiveRelation {
     pub fn add(&mut self, a: mir::Local, b: mir::Local) {
-        self.relations.entry(a).or_default().push(b);
+        self.relations.entry(a).or_insert(vec![]).push(b);
     }
 
     pub fn reachable_from(&self, a: mir::Local, domain_size: usize) -> DenseBitSet<mir::Local> {

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -203,7 +203,7 @@ pub fn find_crates(tcx: TyCtxt<'_>, name: Symbol) -> &'static [DefId] {
         let mut map = FxHashMap::default();
         map.insert(tcx.crate_name(LOCAL_CRATE), vec![LOCAL_CRATE.as_def_id()]);
         for &num in tcx.crates(()) {
-            map.entry(tcx.crate_name(num)).or_default().push(num.as_def_id());
+            map.entry(tcx.crate_name(num)).or_insert(vec![]).push(num.as_def_id());
         }
         map
     });

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -409,6 +409,7 @@ generate! {
     map_break,
     map_continue,
     map_or,
+    map_or_default,
     map_or_else,
     map_while,
     match_indices,

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -884,7 +884,7 @@ pub fn approx_ty_size<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> u64 {
     match (cx.layout_of(ty).map(|layout| layout.size.bytes()), ty.kind()) {
         (Ok(size), _) => size,
         (Err(_), ty::Tuple(list)) => list.iter().map(|t| approx_ty_size(cx, t)).sum(),
-        (Err(_), ty::Array(t, n)) => n.try_to_target_usize(cx.tcx).unwrap_or_default() * approx_ty_size(cx, *t),
+        (Err(_), ty::Array(t, n)) => n.try_to_target_usize(cx.tcx).unwrap_or(0) * approx_ty_size(cx, *t),
         (Err(_), ty::Adt(def, subst)) if def.is_struct() => def
             .variants()
             .iter()
@@ -905,7 +905,7 @@ pub fn approx_ty_size<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> u64 {
                     .sum::<u64>()
             })
             .max()
-            .unwrap_or_default(),
+            .unwrap_or(0),
         (Err(_), ty::Adt(def, subst)) if def.is_union() => def
             .variants()
             .iter()
@@ -914,10 +914,10 @@ pub fn approx_ty_size<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> u64 {
                     .iter()
                     .map(|field| approx_ty_size(cx, field.ty(cx.tcx, subst)))
                     .max()
-                    .unwrap_or_default()
+                    .unwrap_or(0)
             })
             .max()
-            .unwrap_or_default(),
+            .unwrap_or(0),
         (Err(_), _) => 0,
     }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -279,7 +279,7 @@ fn main() -> ExitCode {
         let clippy_args_var = env::var("CLIPPY_ARGS").ok();
         let clippy_args = clippy_args_var
             .as_deref()
-            .unwrap_or_default()
+            .unwrap_or("")
             .split("__CLIPPY_HACKERY__")
             .filter_map(|s| match s {
                 "" => None,

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -135,7 +135,7 @@ impl TestContext {
                         .map(str::to_string)
                         .collect()
                 })
-                .unwrap_or_default(),
+                .unwrap_or(vec![]),
             target: None,
             bless_command: Some(if IS_RUSTC_TEST_SUITE {
                 "./x test src/tools/clippy --bless".into()

--- a/tests/ui/concealed_obvious_default.fixed
+++ b/tests/ui/concealed_obvious_default.fixed
@@ -1,0 +1,99 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::concealed_obvious_default)]
+#![feature(result_option_map_or_default)]
+#![allow(dead_code)]
+#![allow(clippy::too_many_arguments)]
+
+extern crate proc_macros;
+
+use std::collections::{btree_map, hash_map};
+
+fn test<'e, 'f, 'g, 'h>(
+    a: Option<bool>,
+    b: Option<Option<bool>>,
+    c: Result<&str, ()>,
+    d: Result<usize, ()>,
+    e: btree_map::Entry<'e, (), f32>,
+    e2: btree_map::Entry<'e, (), f32>,
+    f: btree_map::Entry<'f, (), char>,
+    f2: btree_map::Entry<'f, (), char>,
+    g: hash_map::Entry<'g, (), ()>,
+    g2: hash_map::Entry<'g, (), ()>,
+    h: hash_map::Entry<'h, (), u8>,
+    h2: hash_map::Entry<'h, (), u8>,
+    i: Option<Vec<i32>>,
+    i2: Option<Vec<i32>>,
+    j: Result<Vec<i32>, ()>,
+    j2: Result<Vec<i32>, ()>,
+) {
+    _ = a.unwrap_or(false);
+    //~^ concealed_obvious_default
+    _ = a.unwrap_or(false);
+
+    _ = b.unwrap_or(None);
+    //~^ concealed_obvious_default
+    _ = b.unwrap_or(None);
+
+    _ = c.unwrap_or("");
+    //~^ concealed_obvious_default
+    _ = c.unwrap_or("");
+
+    _ = d.unwrap_or(0);
+    //~^ concealed_obvious_default
+    _ = d.unwrap_or(0);
+
+    _ = e.or_insert(0.0);
+    //~^ concealed_obvious_default
+    _ = e2.or_insert(0.0);
+
+    _ = f.or_insert('\0');
+    //~^ concealed_obvious_default
+    _ = f2.or_insert('\0');
+
+    _ = g.or_insert(());
+    //~^ concealed_obvious_default
+    _ = g2.or_insert(());
+
+    _ = h.or_insert(0);
+    //~^ concealed_obvious_default
+    _ = h2.or_insert(0);
+
+    _ = i.map_or(vec![], |_| Vec::from([1]));
+    //~^ concealed_obvious_default
+    _ = i2.map_or(vec![], |_| Vec::from([1]));
+
+    _ = j.map_or(vec![], |_| Vec::from([1]));
+    //~^ concealed_obvious_default
+    _ = j2.map_or(vec![], |_| Vec::from([1]));
+
+    //
+    // If the receiver comes from macro expansion,
+    // that's fine and we lint that.
+    //
+
+    _ = proc_macros::external! {
+        Some(false)
+    }
+    .unwrap_or(false);
+    //~^ concealed_obvious_default
+
+    _ = proc_macros::external! {
+        Some(false)
+    }
+    .unwrap_or(false);
+
+    //
+    // However, if the method itself comes from
+    // macro expansion, it should not be linted.
+    //
+
+    _ = proc_macros::external! {
+        Some(false).unwrap_or_default()
+    };
+
+    _ = proc_macros::external! {
+        Some(false).unwrap_or(false)
+    };
+}
+
+fn main() {}

--- a/tests/ui/concealed_obvious_default.rs
+++ b/tests/ui/concealed_obvious_default.rs
@@ -1,0 +1,99 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::concealed_obvious_default)]
+#![feature(result_option_map_or_default)]
+#![allow(dead_code)]
+#![allow(clippy::too_many_arguments)]
+
+extern crate proc_macros;
+
+use std::collections::{btree_map, hash_map};
+
+fn test<'e, 'f, 'g, 'h>(
+    a: Option<bool>,
+    b: Option<Option<bool>>,
+    c: Result<&str, ()>,
+    d: Result<usize, ()>,
+    e: btree_map::Entry<'e, (), f32>,
+    e2: btree_map::Entry<'e, (), f32>,
+    f: btree_map::Entry<'f, (), char>,
+    f2: btree_map::Entry<'f, (), char>,
+    g: hash_map::Entry<'g, (), ()>,
+    g2: hash_map::Entry<'g, (), ()>,
+    h: hash_map::Entry<'h, (), u8>,
+    h2: hash_map::Entry<'h, (), u8>,
+    i: Option<Vec<i32>>,
+    i2: Option<Vec<i32>>,
+    j: Result<Vec<i32>, ()>,
+    j2: Result<Vec<i32>, ()>,
+) {
+    _ = a.unwrap_or_default();
+    //~^ concealed_obvious_default
+    _ = a.unwrap_or(false);
+
+    _ = b.unwrap_or_default();
+    //~^ concealed_obvious_default
+    _ = b.unwrap_or(None);
+
+    _ = c.unwrap_or_default();
+    //~^ concealed_obvious_default
+    _ = c.unwrap_or("");
+
+    _ = d.unwrap_or_default();
+    //~^ concealed_obvious_default
+    _ = d.unwrap_or(0);
+
+    _ = e.or_default();
+    //~^ concealed_obvious_default
+    _ = e2.or_insert(0.0);
+
+    _ = f.or_default();
+    //~^ concealed_obvious_default
+    _ = f2.or_insert('\0');
+
+    _ = g.or_default();
+    //~^ concealed_obvious_default
+    _ = g2.or_insert(());
+
+    _ = h.or_default();
+    //~^ concealed_obvious_default
+    _ = h2.or_insert(0);
+
+    _ = i.map_or_default(|_| Vec::from([1]));
+    //~^ concealed_obvious_default
+    _ = i2.map_or(vec![], |_| Vec::from([1]));
+
+    _ = j.map_or_default(|_| Vec::from([1]));
+    //~^ concealed_obvious_default
+    _ = j2.map_or(vec![], |_| Vec::from([1]));
+
+    //
+    // If the receiver comes from macro expansion,
+    // that's fine and we lint that.
+    //
+
+    _ = proc_macros::external! {
+        Some(false)
+    }
+    .unwrap_or_default();
+    //~^ concealed_obvious_default
+
+    _ = proc_macros::external! {
+        Some(false)
+    }
+    .unwrap_or(false);
+
+    //
+    // However, if the method itself comes from
+    // macro expansion, it should not be linted.
+    //
+
+    _ = proc_macros::external! {
+        Some(false).unwrap_or_default()
+    };
+
+    _ = proc_macros::external! {
+        Some(false).unwrap_or(false)
+    };
+}
+
+fn main() {}

--- a/tests/ui/concealed_obvious_default.stderr
+++ b/tests/ui/concealed_obvious_default.stderr
@@ -1,0 +1,71 @@
+error: method `Option::<bool>::unwrap_or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:29:11
+   |
+LL |     _ = a.unwrap_or_default();
+   |           ^^^^^^^^^^^^^^^^^^^ help: write the default value explicitly: `unwrap_or(false)`
+   |
+   = note: `-D clippy::concealed-obvious-default` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::concealed_obvious_default)]`
+
+error: method `Option::<Option<_>>::unwrap_or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:33:11
+   |
+LL |     _ = b.unwrap_or_default();
+   |           ^^^^^^^^^^^^^^^^^^^ help: write the default value explicitly: `unwrap_or(None)`
+
+error: method `Result::<&str, _>::unwrap_or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:37:11
+   |
+LL |     _ = c.unwrap_or_default();
+   |           ^^^^^^^^^^^^^^^^^^^ help: write the default value explicitly: `unwrap_or("")`
+
+error: method `Result::<usize, _>::unwrap_or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:41:11
+   |
+LL |     _ = d.unwrap_or_default();
+   |           ^^^^^^^^^^^^^^^^^^^ help: write the default value explicitly: `unwrap_or(0)`
+
+error: method `btree_map::Entry::<'_, _, f32>::or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:45:11
+   |
+LL |     _ = e.or_default();
+   |           ^^^^^^^^^^^^ help: write the default value explicitly: `or_insert(0.0)`
+
+error: method `btree_map::Entry::<'_, _, char>::or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:49:11
+   |
+LL |     _ = f.or_default();
+   |           ^^^^^^^^^^^^ help: write the default value explicitly: `or_insert('\0')`
+
+error: method `hash_map::Entry::<'_, _, ()>::or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:53:11
+   |
+LL |     _ = g.or_default();
+   |           ^^^^^^^^^^^^ help: write the default value explicitly: `or_insert(())`
+
+error: method `hash_map::Entry::<'_, _, u8>::or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:57:11
+   |
+LL |     _ = h.or_default();
+   |           ^^^^^^^^^^^^ help: write the default value explicitly: `or_insert(0)`
+
+error: method `Option::<Vec<_>>::map_or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:61:11
+   |
+LL |     _ = i.map_or_default(|_| Vec::from([1]));
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: write the default value explicitly: `map_or(vec![], |_| Vec::from([1]))`
+
+error: method `Result::<Vec<_>, _>::map_or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:65:11
+   |
+LL |     _ = j.map_or_default(|_| Vec::from([1]));
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: write the default value explicitly: `map_or(vec![], |_| Vec::from([1]))`
+
+error: method `Option::<bool>::unwrap_or_default` conceals the underlying type
+  --> tests/ui/concealed_obvious_default.rs:77:6
+   |
+LL |     .unwrap_or_default();
+   |      ^^^^^^^^^^^^^^^^^^^ help: write the default value explicitly: `unwrap_or(false)`
+
+error: aborting due to 11 previous errors
+

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -1,5 +1,6 @@
 //@aux-build:option_helpers.rs
 #![warn(clippy::manual_is_variant_and)]
+#![allow(clippy::concealed_obvious_default)]
 #![allow(clippy::redundant_closure)]
 
 #[macro_use]

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -1,5 +1,6 @@
 //@aux-build:option_helpers.rs
 #![warn(clippy::manual_is_variant_and)]
+#![allow(clippy::concealed_obvious_default)]
 #![allow(clippy::redundant_closure)]
 
 #[macro_use]

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -1,5 +1,5 @@
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:52:17
+  --> tests/ui/manual_is_variant_and.rs:53:17
    |
 LL |       let _ = opt.map(|x| x > 1)
    |  _________________^
@@ -11,7 +11,7 @@ LL | |         .unwrap_or_default();
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:57:17
+  --> tests/ui/manual_is_variant_and.rs:58:17
    |
 LL |       let _ = opt.map(|x| {
    |  _________________^
@@ -30,13 +30,13 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:62:17
+  --> tests/ui/manual_is_variant_and.rs:63:17
    |
 LL |     let _ = opt.map(|x| x > 1).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:65:10
+  --> tests/ui/manual_is_variant_and.rs:66:10
    |
 LL |           .map(|x| x > 1)
    |  __________^
@@ -45,37 +45,37 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:69:13
+  --> tests/ui/manual_is_variant_and.rs:70:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:71:13
+  --> tests/ui/manual_is_variant_and.rs:72:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 != 0)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:73:13
+  --> tests/ui/manual_is_variant_and.rs:74:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == some_true!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:75:13
+  --> tests/ui/manual_is_variant_and.rs:76:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != some_false!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:82:18
+  --> tests/ui/manual_is_variant_and.rs:83:18
    |
 LL |     let _ = opt2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(char::is_alphanumeric)`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:100:17
+  --> tests/ui/manual_is_variant_and.rs:101:17
    |
 LL |       let _ = res.map(|x| {
    |  _________________^
@@ -94,7 +94,7 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:105:17
+  --> tests/ui/manual_is_variant_and.rs:106:17
    |
 LL |       let _ = res.map(|x| x > 1)
    |  _________________^
@@ -103,145 +103,145 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_ok_and(|x| x > 1)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:109:13
+  --> tests/ui/manual_is_variant_and.rs:110:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) == Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:111:13
+  --> tests/ui/manual_is_variant_and.rs:112:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:113:13
+  --> tests/ui/manual_is_variant_and.rs:114:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:120:18
+  --> tests/ui/manual_is_variant_and.rs:121:18
    |
 LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:130:18
+  --> tests/ui/manual_is_variant_and.rs:131:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:137:18
+  --> tests/ui/manual_is_variant_and.rs:138:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:144:18
+  --> tests/ui/manual_is_variant_and.rs:145:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:151:18
+  --> tests/ui/manual_is_variant_and.rs:152:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:159:18
+  --> tests/ui/manual_is_variant_and.rs:160:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:166:18
+  --> tests/ui/manual_is_variant_and.rs:167:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:173:18
+  --> tests/ui/manual_is_variant_and.rs:174:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:180:18
+  --> tests/ui/manual_is_variant_and.rs:181:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:193:18
+  --> tests/ui/manual_is_variant_and.rs:194:18
    |
 LL |         let a1 = b.map(iad) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(iad)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:198:18
+  --> tests/ui/manual_is_variant_and.rs:199:18
    |
 LL |         let a1 = b.map(iad) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:203:18
+  --> tests/ui/manual_is_variant_and.rs:204:18
    |
 LL |         let a1 = b.map(iad) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:208:18
+  --> tests/ui/manual_is_variant_and.rs:209:18
    |
 LL |         let a1 = b.map(iad) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(iad)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:215:18
+  --> tests/ui/manual_is_variant_and.rs:216:18
    |
 LL |         let a1 = b.map(iad) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(iad)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:220:18
+  --> tests/ui/manual_is_variant_and.rs:221:18
    |
 LL |         let a1 = b.map(iad) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(|x| !iad(x))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:225:18
+  --> tests/ui/manual_is_variant_and.rs:226:18
    |
 LL |         let a1 = b.map(iad) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(iad)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:230:18
+  --> tests/ui/manual_is_variant_and.rs:231:18
    |
 LL |         let a1 = b.map(iad) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:240:13
+  --> tests/ui/manual_is_variant_and.rs:241:13
    |
 LL |     let _ = opt.is_none() || opt.is_some_and(then_fn);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:243:13
+  --> tests/ui/manual_is_variant_and.rs:244:13
    |
 LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_some_and`
-  --> tests/ui/manual_is_variant_and.rs:259:5
+  --> tests/ui/manual_is_variant_and.rs:260:5
    |
 LL |     opt.filter(|x| condition(x)).is_some();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_some_and(|x| condition(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:261:5
+  --> tests/ui/manual_is_variant_and.rs:262:5
    |
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`

--- a/tests/ui/manual_saturating_arithmetic.fixed
+++ b/tests/ui/manual_saturating_arithmetic.fixed
@@ -1,4 +1,4 @@
-#![allow(clippy::legacy_numeric_constants, unused_imports)]
+#![allow(clippy::legacy_numeric_constants, unused_imports, clippy::concealed_obvious_default)]
 
 fn main() {
     let _ = 1u32.saturating_add(1);

--- a/tests/ui/manual_saturating_arithmetic.rs
+++ b/tests/ui/manual_saturating_arithmetic.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::legacy_numeric_constants, unused_imports)]
+#![allow(clippy::legacy_numeric_constants, unused_imports, clippy::concealed_obvious_default)]
 
 fn main() {
     let _ = 1u32.checked_add(1).unwrap_or(u32::max_value());

--- a/tests/ui/manual_unwrap_or_default.fixed
+++ b/tests/ui/manual_unwrap_or_default.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_unwrap_or_default)]
-#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::concealed_obvious_default)]
 
 fn main() {
     let x: Option<Vec<String>> = None;

--- a/tests/ui/manual_unwrap_or_default.rs
+++ b/tests/ui/manual_unwrap_or_default.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_unwrap_or_default)]
-#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::concealed_obvious_default)]
 
 fn main() {
     let x: Option<Vec<String>> = None;

--- a/tests/ui/obfuscated_if_else.fixed
+++ b/tests/ui/obfuscated_if_else.fixed
@@ -3,7 +3,8 @@
     clippy::unnecessary_lazy_evaluations,
     clippy::unit_arg,
     clippy::unused_unit,
-    clippy::unwrap_or_default
+    clippy::unwrap_or_default,
+    clippy::concealed_obvious_default
 )]
 
 fn main() {

--- a/tests/ui/obfuscated_if_else.rs
+++ b/tests/ui/obfuscated_if_else.rs
@@ -3,7 +3,8 @@
     clippy::unnecessary_lazy_evaluations,
     clippy::unit_arg,
     clippy::unused_unit,
-    clippy::unwrap_or_default
+    clippy::unwrap_or_default,
+    clippy::concealed_obvious_default
 )]
 
 fn main() {

--- a/tests/ui/obfuscated_if_else.stderr
+++ b/tests/ui/obfuscated_if_else.stderr
@@ -1,5 +1,5 @@
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:10:5
+  --> tests/ui/obfuscated_if_else.rs:11:5
    |
 LL |     true.then_some("a").unwrap_or("b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { "a" } else { "b" }`
@@ -8,139 +8,139 @@ LL |     true.then_some("a").unwrap_or("b");
    = help: to override `-D warnings` add `#[allow(clippy::obfuscated_if_else)]`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:13:5
+  --> tests/ui/obfuscated_if_else.rs:14:5
    |
 LL |     true.then(|| "a").unwrap_or("b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { "a" } else { "b" }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:17:5
+  --> tests/ui/obfuscated_if_else.rs:18:5
    |
 LL |     (a == 1).then_some("a").unwrap_or("b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if a == 1 { "a" } else { "b" }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:20:5
+  --> tests/ui/obfuscated_if_else.rs:21:5
    |
 LL |     (a == 1).then(|| "a").unwrap_or("b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if a == 1 { "a" } else { "b" }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:27:5
+  --> tests/ui/obfuscated_if_else.rs:28:5
    |
 LL |     true.then_some(a += 1).unwrap_or(());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { a += 1 } else { () }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:30:5
+  --> tests/ui/obfuscated_if_else.rs:31:5
    |
 LL |     true.then_some(()).unwrap_or(a += 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { () } else { a += 2 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:34:5
+  --> tests/ui/obfuscated_if_else.rs:35:5
    |
 LL |     true.then(|| n = 1).unwrap_or_else(|| n = 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { n = 1 } else { n = 2 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:36:5
+  --> tests/ui/obfuscated_if_else.rs:37:5
    |
 LL |     true.then_some(1).unwrap_or_else(|| n * 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 1 } else { n * 2 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:38:5
+  --> tests/ui/obfuscated_if_else.rs:39:5
    |
 LL |     true.then_some(n += 1).unwrap_or_else(|| ());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { n += 1 } else { () }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:41:13
+  --> tests/ui/obfuscated_if_else.rs:42:13
    |
 LL |     let _ = true.then_some(1).unwrap_or_else(|| n * 2);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 1 } else { n * 2 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:44:5
+  --> tests/ui/obfuscated_if_else.rs:45:5
    |
 LL |     true.then_some(1).unwrap_or_else(Default::default);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 1 } else { Default::default() }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:50:5
+  --> tests/ui/obfuscated_if_else.rs:51:5
    |
 LL |     true.then_some(()).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { () } else { Default::default() }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:53:5
+  --> tests/ui/obfuscated_if_else.rs:54:5
    |
 LL |     true.then(|| ()).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { () } else { Default::default() }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:56:5
+  --> tests/ui/obfuscated_if_else.rs:57:5
    |
 LL |     true.then_some(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 1 } else { Default::default() }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:59:5
+  --> tests/ui/obfuscated_if_else.rs:60:5
    |
 LL |     true.then(|| 1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 1 } else { Default::default() }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:65:13
+  --> tests/ui/obfuscated_if_else.rs:66:13
    |
 LL |     let _ = true.then_some(40).unwrap_or(17) | 2;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(if true { 40 } else { 17 })`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:69:13
+  --> tests/ui/obfuscated_if_else.rs:70:13
    |
 LL |     let _ = true.then_some(30).unwrap_or(17) | true.then_some(2).unwrap_or(3) | true.then_some(10).unwrap_or(1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(if true { 30 } else { 17 })`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:69:48
+  --> tests/ui/obfuscated_if_else.rs:70:48
    |
 LL |     let _ = true.then_some(30).unwrap_or(17) | true.then_some(2).unwrap_or(3) | true.then_some(10).unwrap_or(1);
    |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 2 } else { 3 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:69:81
+  --> tests/ui/obfuscated_if_else.rs:70:81
    |
 LL |     let _ = true.then_some(30).unwrap_or(17) | true.then_some(2).unwrap_or(3) | true.then_some(10).unwrap_or(1);
    |                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 10 } else { 1 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:75:17
+  --> tests/ui/obfuscated_if_else.rs:76:17
    |
 LL |     let _ = 2 | true.then_some(40).unwrap_or(17);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 40 } else { 17 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:79:13
+  --> tests/ui/obfuscated_if_else.rs:80:13
    |
 LL |     let _ = true.then_some(42).unwrap_or(17) as u8;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 42 } else { 17 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:83:14
+  --> tests/ui/obfuscated_if_else.rs:84:14
    |
 LL |     let _ = *true.then_some(&42).unwrap_or(&17);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { &42 } else { &17 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:87:14
+  --> tests/ui/obfuscated_if_else.rs:88:14
    |
 LL |     let _ = *true.then_some(&42).unwrap_or(&17) as u8;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { &42 } else { &17 }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:93:5
+  --> tests/ui/obfuscated_if_else.rs:94:5
    |
 LL |     true.then(|| format!("this is a test")).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { format!("this is a test") } else { Default::default() }`

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -6,7 +6,8 @@
     clippy::unnecessary_literal_unwrap,
     clippy::unnecessary_result_map_or_else,
     clippy::unnecessary_option_map_or_else,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::concealed_obvious_default
 )]
 
 use std::collections::{BTreeMap, HashMap};

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -6,7 +6,8 @@
     clippy::unnecessary_literal_unwrap,
     clippy::unnecessary_result_map_or_else,
     clippy::unnecessary_option_map_or_else,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::concealed_obvious_default
 )]
 
 use std::collections::{BTreeMap, HashMap};

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -1,5 +1,5 @@
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:53:22
+  --> tests/ui/or_fun_call.rs:54:22
    |
 LL |     with_constructor.unwrap_or(make());
    |                      ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(make)`
@@ -8,7 +8,7 @@ LL |     with_constructor.unwrap_or(make());
    = help: to override `-D warnings` add `#[allow(clippy::or_fun_call)]`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:57:14
+  --> tests/ui/or_fun_call.rs:58:14
    |
 LL |     with_new.unwrap_or(Vec::new());
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
@@ -17,205 +17,205 @@ LL |     with_new.unwrap_or(Vec::new());
    = help: to override `-D warnings` add `#[allow(clippy::unwrap_or_default)]`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:61:21
+  --> tests/ui/or_fun_call.rs:62:21
    |
 LL |     with_const_args.unwrap_or(Vec::with_capacity(12));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Vec::with_capacity(12))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:65:14
+  --> tests/ui/or_fun_call.rs:66:14
    |
 LL |     with_err.unwrap_or(make());
    |              ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| make())`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:69:19
+  --> tests/ui/or_fun_call.rs:70:19
    |
 LL |     with_err_args.unwrap_or(Vec::with_capacity(12));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:73:24
+  --> tests/ui/or_fun_call.rs:74:24
    |
 LL |     with_default_trait.unwrap_or(Default::default());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:77:23
+  --> tests/ui/or_fun_call.rs:78:23
    |
 LL |     with_default_type.unwrap_or(u64::default());
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:97:18
+  --> tests/ui/or_fun_call.rs:98:18
    |
 LL |     self_default.unwrap_or(<FakeDefault>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(<FakeDefault>::default)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:101:18
+  --> tests/ui/or_fun_call.rs:102:18
    |
 LL |     real_default.unwrap_or(<FakeDefault as Default>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:105:14
+  --> tests/ui/or_fun_call.rs:106:14
    |
 LL |     with_vec.unwrap_or(Vec::new());
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:109:21
+  --> tests/ui/or_fun_call.rs:110:21
    |
 LL |     without_default.unwrap_or(Foo::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(Foo::new)`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:113:19
+  --> tests/ui/or_fun_call.rs:114:19
    |
 LL |     map.entry(42).or_insert(String::new());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:117:23
+  --> tests/ui/or_fun_call.rs:118:23
    |
 LL |     map_vec.entry(42).or_insert(Vec::new());
    |                       ^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:121:21
+  --> tests/ui/or_fun_call.rs:122:21
    |
 LL |     btree.entry(42).or_insert(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:125:25
+  --> tests/ui/or_fun_call.rs:126:25
    |
 LL |     btree_vec.entry(42).or_insert(Vec::new());
    |                         ^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:129:21
+  --> tests/ui/or_fun_call.rs:130:21
    |
 LL |     let _ = stringy.unwrap_or(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `ok_or`
-  --> tests/ui/or_fun_call.rs:134:17
+  --> tests/ui/or_fun_call.rs:135:17
    |
 LL |     let _ = opt.ok_or(format!("{} world.", hello));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ok_or_else(|| format!("{} world.", hello))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:139:21
+  --> tests/ui/or_fun_call.rs:140:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:142:21
+  --> tests/ui/or_fun_call.rs:143:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: function call inside of `or`
-  --> tests/ui/or_fun_call.rs:167:35
+  --> tests/ui/or_fun_call.rs:168:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_else(|| Some("b".to_string()))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:210:18
+  --> tests/ui/or_fun_call.rs:211:18
    |
 LL |             None.unwrap_or(ptr_to_ref(s));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:218:14
+  --> tests/ui/or_fun_call.rs:219:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:221:14
+  --> tests/ui/or_fun_call.rs:222:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:297:25
+  --> tests/ui/or_fun_call.rs:298:25
    |
 LL |         let _ = Some(4).map_or(g(), |v| v);
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(g, |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:299:25
+  --> tests/ui/or_fun_call.rs:300:25
    |
 LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:302:25
+  --> tests/ui/or_fun_call.rs:303:25
    |
 LL |         let _ = Some(4).map_or("asd".to_string().len() as i32, f);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| "asd".to_string().len() as i32, f)`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:333:18
+  --> tests/ui/or_fun_call.rs:334:18
    |
 LL |         with_new.unwrap_or_else(Vec::new);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:337:28
+  --> tests/ui/or_fun_call.rs:338:28
    |
 LL |         with_default_trait.unwrap_or_else(Default::default);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:341:27
+  --> tests/ui/or_fun_call.rs:342:27
    |
 LL |         with_default_type.unwrap_or_else(u64::default);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:345:22
+  --> tests/ui/or_fun_call.rs:346:22
    |
 LL |         real_default.unwrap_or_else(<FakeDefault as Default>::default);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:349:23
+  --> tests/ui/or_fun_call.rs:350:23
    |
 LL |         map.entry(42).or_insert_with(String::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:353:25
+  --> tests/ui/or_fun_call.rs:354:25
    |
 LL |         btree.entry(42).or_insert_with(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:357:25
+  --> tests/ui/or_fun_call.rs:358:25
    |
 LL |         let _ = stringy.unwrap_or_else(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:399:17
+  --> tests/ui/or_fun_call.rs:400:17
    |
 LL |     let _ = opt.unwrap_or({ f() }); // suggest `.unwrap_or_else(f)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(f)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:404:17
+  --> tests/ui/or_fun_call.rs:405:17
    |
 LL |     let _ = opt.unwrap_or(f() + 1); // suggest `.unwrap_or_else(|| f() + 1)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| f() + 1)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:409:17
+  --> tests/ui/or_fun_call.rs:410:17
    |
 LL |       let _ = opt.unwrap_or({
    |  _________________^
@@ -235,79 +235,79 @@ LL ~     });
    |
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:415:17
+  --> tests/ui/or_fun_call.rs:416:17
    |
 LL |     let _ = opt.map_or(f() + 1, |v| v); // suggest `.map_or_else(|| f() + 1, |v| v)`
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| f() + 1, |v| v)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:420:17
+  --> tests/ui/or_fun_call.rs:421:17
    |
 LL |     let _ = opt.unwrap_or({ i32::default() });
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:427:21
+  --> tests/ui/or_fun_call.rs:428:21
    |
 LL |     let _ = opt_foo.unwrap_or(Foo { val: String::default() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Foo { val: String::default() })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:442:19
+  --> tests/ui/or_fun_call.rs:443:19
    |
 LL |         let _ = x.map_or(g(), |v| v);
    |                   ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|_| g(), |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:444:19
+  --> tests/ui/or_fun_call.rs:445:19
    |
 LL |         let _ = x.map_or(g(), f);
    |                   ^^^^^^^^^^^^^^ help: try: `map_or_else(|_| g(), f)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:447:19
+  --> tests/ui/or_fun_call.rs:448:19
    |
 LL |         let _ = x.map_or("asd".to_string().len() as i32, f);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|_| "asd".to_string().len() as i32, f)`
 
 error: function call inside of `get_or_insert`
-  --> tests/ui/or_fun_call.rs:458:15
+  --> tests/ui/or_fun_call.rs:459:15
    |
 LL |     let _ = x.get_or_insert(g());
    |               ^^^^^^^^^^^^^^^^^^ help: try: `get_or_insert_with(g)`
 
 error: function call inside of `and`
-  --> tests/ui/or_fun_call.rs:468:15
+  --> tests/ui/or_fun_call.rs:469:15
    |
 LL |     let _ = x.and(g());
    |               ^^^^^^^^ help: try: `and_then(|_| g())`
 
 error: function call inside of `and`
-  --> tests/ui/or_fun_call.rs:478:15
+  --> tests/ui/or_fun_call.rs:479:15
    |
 LL |     let _ = x.and(g());
    |               ^^^^^^^^ help: try: `and_then(|_| g())`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:484:17
+  --> tests/ui/or_fun_call.rs:485:17
    |
 LL |     let _ = opt.unwrap_or(Default::default());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:486:17
+  --> tests/ui/or_fun_call.rs:487:17
    |
 LL |     let _ = res.unwrap_or(Default::default());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| Default::default())`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:492:17
+  --> tests/ui/or_fun_call.rs:493:17
    |
 LL |     let _ = opt.unwrap_or(Default::default());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:494:17
+  --> tests/ui/or_fun_call.rs:495:17
    |
 LL |     let _ = res.unwrap_or(Default::default());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`

--- a/tests/ui/significant_drop_tightening.fixed
+++ b/tests/ui/significant_drop_tightening.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::significant_drop_tightening)]
+#![allow(clippy::concealed_obvious_default)]
 
 use std::sync::Mutex;
 

--- a/tests/ui/significant_drop_tightening.rs
+++ b/tests/ui/significant_drop_tightening.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::significant_drop_tightening)]
+#![allow(clippy::concealed_obvious_default)]
 
 use std::sync::Mutex;
 

--- a/tests/ui/significant_drop_tightening.stderr
+++ b/tests/ui/significant_drop_tightening.stderr
@@ -1,5 +1,5 @@
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:10:9
+  --> tests/ui/significant_drop_tightening.rs:11:9
    |
 LL |   pub fn complex_return_triggers_the_lint() -> i32 {
    |  __________________________________________________-
@@ -23,7 +23,7 @@ LL +     drop(lock);
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:105:13
+  --> tests/ui/significant_drop_tightening.rs:106:13
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(1i32);
@@ -42,7 +42,7 @@ LL +         drop(lock);
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:127:13
+  --> tests/ui/significant_drop_tightening.rs:128:13
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(1i32);
@@ -63,7 +63,7 @@ LL ~
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:134:17
+  --> tests/ui/significant_drop_tightening.rs:135:17
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(vec![1i32]);
@@ -84,7 +84,7 @@ LL ~
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:151:9
+  --> tests/ui/significant_drop_tightening.rs:152:9
    |
 LL |   fn issue15574() {
    |  _________________-
@@ -110,7 +110,7 @@ LL ~
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:155:13
+  --> tests/ui/significant_drop_tightening.rs:156:13
    |
 LL |   fn issue15574() {
    |  _________________-
@@ -132,7 +132,7 @@ LL +     drop(stdin);
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:171:9
+  --> tests/ui/significant_drop_tightening.rs:172:9
    |
 LL |   fn issue16343() {
    |  _________________-

--- a/tests/ui/unnecessary_literal_unwrap.fixed
+++ b/tests/ui/unnecessary_literal_unwrap.fixed
@@ -4,7 +4,8 @@
     clippy::unnecessary_lazy_evaluations,
     clippy::diverging_sub_expression,
     clippy::let_unit_value,
-    clippy::no_effect
+    clippy::no_effect,
+    clippy::concealed_obvious_default
 )]
 
 fn unwrap_option_some() {

--- a/tests/ui/unnecessary_literal_unwrap.rs
+++ b/tests/ui/unnecessary_literal_unwrap.rs
@@ -4,7 +4,8 @@
     clippy::unnecessary_lazy_evaluations,
     clippy::diverging_sub_expression,
     clippy::let_unit_value,
-    clippy::no_effect
+    clippy::no_effect,
+    clippy::concealed_obvious_default
 )]
 
 fn unwrap_option_some() {

--- a/tests/ui/unnecessary_literal_unwrap.stderr
+++ b/tests/ui/unnecessary_literal_unwrap.stderr
@@ -1,5 +1,5 @@
 error: used `unwrap()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:11:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:12:16
    |
 LL |     let _val = Some(1).unwrap();
    |                ^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:13:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:14:16
    |
 LL |     let _val = Some(1).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:16:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:17:5
    |
 LL |     Some(1).unwrap();
    |     ^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL +     1;
    |
 
 error: used `expect()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:18:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:19:5
    |
 LL |     Some(1).expect("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +     1;
    |
 
 error: used `unwrap()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:24:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:25:16
    |
 LL |     let _val = None::<()>.unwrap();
    |                ^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL +     let _val = panic!();
    |
 
 error: used `expect()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:26:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:27:16
    |
 LL |     let _val = None::<()>.expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +     let _val = panic!("this always happens");
    |
 
 error: used `unwrap_or_default()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:28:24
+  --> tests/ui/unnecessary_literal_unwrap.rs:29:24
    |
 LL |     let _val: String = None.unwrap_or_default();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +     let _val: String = String::default();
    |
 
 error: used `unwrap_or()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:30:21
+  --> tests/ui/unnecessary_literal_unwrap.rs:31:21
    |
 LL |     let _val: u16 = None.unwrap_or(234);
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL +     let _val: u16 = 234;
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:32:21
+  --> tests/ui/unnecessary_literal_unwrap.rs:33:21
    |
 LL |     let _val: u16 = None.unwrap_or_else(|| 234);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL +     let _val: u16 = 234;
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:34:21
+  --> tests/ui/unnecessary_literal_unwrap.rs:35:21
    |
 LL |     let _val: u16 = None.unwrap_or_else(|| { 234 });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL +     let _val: u16 = { 234 };
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:36:21
+  --> tests/ui/unnecessary_literal_unwrap.rs:37:21
    |
 LL |     let _val: u16 = None.unwrap_or_else(|| -> u16 { 234 });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL +     let _val: u16 = { 234 };
    |
 
 error: used `unwrap()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:39:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:40:5
    |
 LL |     None::<()>.unwrap();
    |     ^^^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL +     panic!();
    |
 
 error: used `expect()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:41:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:42:5
    |
 LL |     None::<()>.expect("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     panic!("this always happens");
    |
 
 error: used `unwrap_or_default()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:43:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:44:5
    |
 LL |     None::<String>.unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL +     String::default();
    |
 
 error: used `unwrap_or()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:45:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:46:5
    |
 LL |     None::<u16>.unwrap_or(234);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     234;
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:47:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:48:5
    |
 LL |     None::<u16>.unwrap_or_else(|| 234);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL +     234;
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:49:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:50:5
    |
 LL |     None::<u16>.unwrap_or_else(|| { 234 });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +205,7 @@ LL +     { 234 };
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:51:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:52:5
    |
 LL |     None::<u16>.unwrap_or_else(|| -> u16 { 234 });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +217,7 @@ LL +     { 234 };
    |
 
 error: used `unwrap()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:56:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:57:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:58:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:59:16
    |
 LL |     let _val = Ok::<_, ()>(1).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +241,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:60:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:61:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -253,7 +253,7 @@ LL +     let _val = panic!("{:?}", 1);
    |
 
 error: used `expect_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:62:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:63:16
    |
 LL |     let _val = Ok::<_, ()>(1).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -265,7 +265,7 @@ LL +     let _val = panic!("{1}: {:?}", 1, "this always happens");
    |
 
 error: used `unwrap()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:65:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:66:5
    |
 LL |     Ok::<_, ()>(1).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,7 +277,7 @@ LL +     1;
    |
 
 error: used `expect()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:67:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:68:5
    |
 LL |     Ok::<_, ()>(1).expect("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -289,7 +289,7 @@ LL +     1;
    |
 
 error: used `unwrap_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:69:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:70:5
    |
 LL |     Ok::<_, ()>(1).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -301,7 +301,7 @@ LL +     panic!("{:?}", 1);
    |
 
 error: used `expect_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:71:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:72:5
    |
 LL |     Ok::<_, ()>(1).expect_err("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -313,7 +313,7 @@ LL +     panic!("{1}: {:?}", 1, "this always happens");
    |
 
 error: used `unwrap_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:76:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:77:16
    |
 LL |     let _val = Err::<(), _>(1).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -325,7 +325,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:78:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:79:16
    |
 LL |     let _val = Err::<(), _>(1).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -337,7 +337,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:80:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:81:16
    |
 LL |     let _val = Err::<(), _>(1).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -349,7 +349,7 @@ LL +     let _val = panic!("{:?}", 1);
    |
 
 error: used `expect()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:82:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:83:16
    |
 LL |     let _val = Err::<(), _>(1).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -361,7 +361,7 @@ LL +     let _val = panic!("{1}: {:?}", 1, "this always happens");
    |
 
 error: used `unwrap_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:85:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:86:5
    |
 LL |     Err::<(), _>(1).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -373,7 +373,7 @@ LL +     1;
    |
 
 error: used `expect_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:87:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:88:5
    |
 LL |     Err::<(), _>(1).expect_err("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -385,7 +385,7 @@ LL +     1;
    |
 
 error: used `unwrap()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:89:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:90:5
    |
 LL |     Err::<(), _>(1).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -397,7 +397,7 @@ LL +     panic!("{:?}", 1);
    |
 
 error: used `expect()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:91:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:92:5
    |
 LL |     Err::<(), _>(1).expect("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -409,7 +409,7 @@ LL +     panic!("{1}: {:?}", 1, "this always happens");
    |
 
 error: used `unwrap_or()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:96:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:97:16
    |
 LL |     let _val = Some(1).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^
@@ -421,7 +421,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_default()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:98:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:99:16
    |
 LL |     let _val = Some(1).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -433,7 +433,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_else()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:100:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:101:16
    |
 LL |     let _val = Some(1).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -445,7 +445,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:103:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:104:5
    |
 LL |     Some(1).unwrap_or(2);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -457,7 +457,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_default()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:105:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:106:5
    |
 LL |     Some(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -469,7 +469,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_else()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:107:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:108:5
    |
 LL |     Some(1).unwrap_or_else(|| 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -481,7 +481,7 @@ LL +     1;
    |
 
 error: used `unwrap_or()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:112:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:113:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -493,7 +493,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:114:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:115:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -505,7 +505,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:116:16
+  --> tests/ui/unnecessary_literal_unwrap.rs:117:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -517,7 +517,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:119:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:120:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or(2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -529,7 +529,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:121:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:122:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -541,7 +541,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:123:5
+  --> tests/ui/unnecessary_literal_unwrap.rs:124:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or_else(|_| 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -553,7 +553,7 @@ LL +     1;
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:138:22
+  --> tests/ui/unnecessary_literal_unwrap.rs:139:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -565,7 +565,7 @@ LL +     let _ = 1;
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:140:22
+  --> tests/ui/unnecessary_literal_unwrap.rs:141:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() + *(&1 as *const i32) }; // needs to keep the unsafe block
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -577,7 +577,7 @@ LL +     let _ = unsafe { 1 + *(&1 as *const i32) }; // needs to keep the unsafe
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:143:22
+  --> tests/ui/unnecessary_literal_unwrap.rs:144:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() } + 1;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -589,7 +589,7 @@ LL +     let _ = 1 + 1;
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:145:22
+  --> tests/ui/unnecessary_literal_unwrap.rs:146:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -601,7 +601,7 @@ LL +     let _ = 1;
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:147:22
+  --> tests/ui/unnecessary_literal_unwrap.rs:148:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() + *(&1 as *const i32) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -613,7 +613,7 @@ LL +     let _ = unsafe { 1 + *(&1 as *const i32) };
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:149:22
+  --> tests/ui/unnecessary_literal_unwrap.rs:150:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() } + 1;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -625,7 +625,7 @@ LL +     let _ = 1 + 1;
    |
 
 error: used `unwrap_err_unchecked()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap.rs:151:22
+  --> tests/ui/unnecessary_literal_unwrap.rs:152:22
    |
 LL |     let _ = unsafe { Err::<(), i32>(123).unwrap_err_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unnecessary_literal_unwrap_unfixable.rs
+++ b/tests/ui/unnecessary_literal_unwrap_unfixable.rs
@@ -1,6 +1,10 @@
 #![warn(clippy::unnecessary_literal_unwrap)]
 #![allow(unreachable_code)]
-#![allow(clippy::unnecessary_lazy_evaluations, clippy::let_unit_value)]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    clippy::let_unit_value,
+    clippy::concealed_obvious_default
+)]
 //@no-rustfix
 fn unwrap_option_some() {
     let val = Some(1);

--- a/tests/ui/unnecessary_literal_unwrap_unfixable.stderr
+++ b/tests/ui/unnecessary_literal_unwrap_unfixable.stderr
@@ -1,11 +1,11 @@
 error: used `unwrap()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:7:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:11:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:6:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:10:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
@@ -13,91 +13,91 @@ LL |     let val = Some(1);
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_literal_unwrap)]`
 
 error: used `expect()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:10:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:14:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:6:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:10:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:15:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:19:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:15:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:19:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:18:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:22:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:18:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:22:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:22:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:26:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:21:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:25:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:25:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:29:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:21:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:25:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:31:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:35:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `None` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:30:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:34:15
    |
 LL |     let val = None::<()>;
    |               ^^^^^^^^^^
 
 error: used `expect()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:34:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:38:17
    |
 LL |     let _val2 = val.expect("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `None` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:30:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:34:15
    |
 LL |     let val = None::<()>;
    |               ^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:37:21
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:41:21
    |
 LL |     let _val3: u8 = None.unwrap_or_default();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL +     let _val3: u8 = Default::default();
    |
 
 error: used `unwrap_or_default()` on `None` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:40:5
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:44:5
    |
 LL |     None::<()>.unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,505 +121,505 @@ LL +     Default::default();
    |
 
 error: used `unwrap()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:46:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:50:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:45:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:49:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:49:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:53:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:45:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:49:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:52:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:56:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:45:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:49:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:55:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:59:17
    |
 LL |     let _val2 = val.expect_err("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:45:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:49:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:60:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:64:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:60:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:64:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:63:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:67:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:63:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:67:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:66:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:70:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:66:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:70:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:69:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:73:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:69:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:73:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:73:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:77:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:72:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:76:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:76:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:80:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:72:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:76:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:79:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:83:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:72:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:76:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:82:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:86:17
    |
 LL |     let _val2 = val.expect_err("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:72:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:76:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:88:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:92:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:87:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:91:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:91:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:95:17
    |
 LL |     let _val2 = val.expect_err("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:87:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:91:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:94:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:98:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:87:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:91:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:97:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:101:17
    |
 LL |     let _val2 = val.expect("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:87:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:91:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:102:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:106:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:102:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:106:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:105:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:109:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:105:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:109:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:108:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:112:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:108:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:112:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:111:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:115:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:111:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:115:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:115:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:119:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:114:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:118:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:118:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:122:17
    |
 LL |     let _val2 = val.expect_err("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:114:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:118:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:121:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:125:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:114:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:118:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:124:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:128:17
    |
 LL |     let _val2 = val.expect("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:114:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:118:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:130:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:134:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:129:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:133:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:133:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:137:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:129:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:133:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:136:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:140:17
    |
 LL |     let _val2 = val.unwrap_or_else(|| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:129:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:133:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:141:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:145:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:141:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:145:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:144:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:148:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:144:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:148:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:147:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:151:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:147:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:151:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:151:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:155:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:150:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:154:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:154:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:158:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:150:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:154:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:157:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:161:17
    |
 LL |     let _val2 = val.unwrap_or_else(|| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:150:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:154:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:163:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:167:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:162:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:166:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:166:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:170:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:162:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:166:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:169:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:173:17
    |
 LL |     let _val2 = val.unwrap_or_else(|_| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:162:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:166:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:174:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:178:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:174:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:178:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:177:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:181:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:177:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:181:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:180:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:184:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:180:16
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:184:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:184:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:188:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:183:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:187:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:187:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:191:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:183:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:187:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:190:17
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:194:17
    |
 LL |     let _val2 = val.unwrap_or_else(|_| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:183:15
+  --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:187:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unwrap_or_else_default.fixed
+++ b/tests/ui/unwrap_or_else_default.fixed
@@ -1,6 +1,10 @@
 #![warn(clippy::unwrap_or_default)]
 #![allow(dead_code)]
-#![allow(clippy::unnecessary_wraps, clippy::unnecessary_literal_unwrap)]
+#![allow(
+    clippy::unnecessary_wraps,
+    clippy::unnecessary_literal_unwrap,
+    clippy::concealed_obvious_default
+)]
 
 /// Checks implementation of the `UNWRAP_OR_DEFAULT` lint.
 fn unwrap_or_else_default() {

--- a/tests/ui/unwrap_or_else_default.rs
+++ b/tests/ui/unwrap_or_else_default.rs
@@ -1,6 +1,10 @@
 #![warn(clippy::unwrap_or_default)]
 #![allow(dead_code)]
-#![allow(clippy::unnecessary_wraps, clippy::unnecessary_literal_unwrap)]
+#![allow(
+    clippy::unnecessary_wraps,
+    clippy::unnecessary_literal_unwrap,
+    clippy::concealed_obvious_default
+)]
 
 /// Checks implementation of the `UNWRAP_OR_DEFAULT` lint.
 fn unwrap_or_else_default() {

--- a/tests/ui/unwrap_or_else_default.stderr
+++ b/tests/ui/unwrap_or_else_default.stderr
@@ -1,5 +1,5 @@
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:60:23
+  --> tests/ui/unwrap_or_else_default.rs:64:23
    |
 LL |     with_real_default.unwrap_or_else(<HasDefaultAndDuplicate as Default>::default);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
@@ -8,34 +8,28 @@ LL |     with_real_default.unwrap_or_else(<HasDefaultAndDuplicate as Default>::d
    = help: to override `-D warnings` add `#[allow(clippy::unwrap_or_default)]`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:64:24
+  --> tests/ui/unwrap_or_else_default.rs:68:24
    |
 LL |     with_default_trait.unwrap_or_else(Default::default);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:68:23
+  --> tests/ui/unwrap_or_else_default.rs:72:23
    |
 LL |     with_default_type.unwrap_or_else(u64::default);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:72:23
+  --> tests/ui/unwrap_or_else_default.rs:76:23
    |
 LL |     with_default_type.unwrap_or_else(Vec::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:76:18
+  --> tests/ui/unwrap_or_else_default.rs:80:18
    |
 LL |     empty_string.unwrap_or_else(|| "".to_string());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
-
-error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:81:12
-   |
-LL |     option.unwrap_or_else(Vec::new).push(1);
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
   --> tests/ui/unwrap_or_else_default.rs:85:12
@@ -80,13 +74,19 @@ LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:126:12
+  --> tests/ui/unwrap_or_else_default.rs:113:12
+   |
+LL |     option.unwrap_or_else(Vec::new).push(1);
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
+
+error: use of `unwrap_or_else` to construct default value
+  --> tests/ui/unwrap_or_else_default.rs:130:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:144:32
+  --> tests/ui/unwrap_or_else_default.rs:148:32
    |
 LL |     let _ = inner_map.entry(0).or_insert_with(Default::default);
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`


### PR DESCRIPTION
This PR introduces a `complexity` lint `concealed_obvious_default` which checks usages of `Option::<T>::unwrap_or_default()` on a type with an obvious default and suggests using `Option::<T>::unwrap_or(<default>)` instead. It checks similar methods on `Result` and `Entry`

for example, it suggests to replace `x.unwrap_or_default()` with `x.unwrap_or(0)` where `x: Option<u8>`.

Closes rust-lang/rust-clippy#14779

changelog: add [`concealed_obvious_default`] lint
