### PR TITLE
Fix `needless_doctest_main` panic when doctest is invalid

### DIFF
--- a/clippy_lints/src/doc/needless_doctest_main.rs
+++ b/clippy_lints/src/doc/needless_doctest_main.rs
@@ -105,7 +105,10 @@ pub fn check(
                         },
                         Ok(None) => break,
                         Err(e) => {
-                            e.cancel();
+                            // See issue #15041. When calling `.cancel()` on the `Diag`, Clippy will unexpectedly panic
+                            // when the `Diag` is unwinded. Meanwhile, we can just call `.emit()`, since the `DiagCtxt`
+                            // is just a sink, nothing will be printed.
+                            e.emit();
                             return (false, test_attr_spans);
                         },
                     }

--- a/tests/ui/doc/needless_doctest_main.rs
+++ b/tests/ui/doc/needless_doctest_main.rs
@@ -20,3 +20,19 @@
 fn foo() {}
 
 fn main() {}
+
+fn issue8244() -> Result<(), ()> {
+    //! ```compile_fail
+    //! fn test() -> Result< {}
+    //! ```
+    Ok(())
+}
+
+/// # Examples
+///
+/// ```
+/// use std::error::Error;
+/// fn main() -> Result<(), Box<dyn Error>/* > */ {
+/// }
+/// ```
+fn issue15041() {}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#8244 
Closes rust-lang/rust-clippy#15041

This feels like a bug with the compiler, because the panic happens when `Diag` is getting unwinded. However, `drop()` is already called in `.cancel()` so this should not happen. 

In this PR, I find a workaround to just call `emit()`, since the `DiagCtxt` here is just a `io::sink`, nothing will happen and the panic just goes away.

changelog: [`needless_doctest_main`] fix panic when doctest is invalid
