### PR TITLE
or_fun_call: also lint `and` method for Option/Result

### DIFF
--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -136,7 +136,7 @@ pub(super) fn check<'tcx>(
         fun_span: Option<Span>,
     ) -> bool {
         // (path, fn_has_argument, methods, suffix)
-        const KNOW_TYPES: [(Symbol, bool, &[Symbol], &str); 5] = [
+        const KNOW_TYPES: [(Symbol, bool, &[Symbol], &str); 7] = [
             (sym::BTreeEntry, false, &[sym::or_insert], "with"),
             (sym::HashMapEntry, false, &[sym::or_insert], "with"),
             (
@@ -146,7 +146,9 @@ pub(super) fn check<'tcx>(
                 "else",
             ),
             (sym::Option, false, &[sym::get_or_insert], "with"),
+            (sym::Option, true, &[sym::and], "then"),
             (sym::Result, true, &[sym::map_or, sym::or, sym::unwrap_or], "else"),
+            (sym::Result, true, &[sym::and], "then"),
         ];
 
         if KNOW_TYPES.iter().any(|k| k.2.contains(&name))

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -439,4 +439,22 @@ fn test_option_get_or_insert() {
     //~^ or_fun_call
 }
 
+fn test_option_and() {
+    // assume that this is slow call
+    fn g() -> Option<u8> {
+        Some(99)
+    }
+    let mut x = Some(42_u8);
+    let _ = x.and(g());
+}
+
+fn test_result_and() {
+    // assume that this is slow call
+    fn g() -> Result<u8, ()> {
+        Ok(99)
+    }
+    let mut x: Result<u8, ()> = Ok(42);
+    let _ = x.and(g());
+}
+
 fn main() {}

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -445,7 +445,8 @@ fn test_option_and() {
         Some(99)
     }
     let mut x = Some(42_u8);
-    let _ = x.and(g());
+    let _ = x.and_then(|_| g());
+    //~^ or_fun_call
 }
 
 fn test_result_and() {
@@ -454,7 +455,8 @@ fn test_result_and() {
         Ok(99)
     }
     let mut x: Result<u8, ()> = Ok(42);
-    let _ = x.and(g());
+    let _ = x.and_then(|_| g());
+    //~^ or_fun_call
 }
 
 fn main() {}

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -446,6 +446,7 @@ fn test_option_and() {
     }
     let mut x = Some(42_u8);
     let _ = x.and(g());
+    //~^ or_fun_call
 }
 
 fn test_result_and() {
@@ -455,6 +456,7 @@ fn test_result_and() {
     }
     let mut x: Result<u8, ()> = Ok(42);
     let _ = x.and(g());
+    //~^ or_fun_call
 }
 
 fn main() {}

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -439,4 +439,22 @@ fn test_option_get_or_insert() {
     //~^ or_fun_call
 }
 
+fn test_option_and() {
+    // assume that this is slow call
+    fn g() -> Option<u8> {
+        Some(99)
+    }
+    let mut x = Some(42_u8);
+    let _ = x.and(g());
+}
+
+fn test_result_and() {
+    // assume that this is slow call
+    fn g() -> Result<u8, ()> {
+        Ok(99)
+    }
+    let mut x: Result<u8, ()> = Ok(42);
+    let _ = x.and(g());
+}
+
 fn main() {}

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -264,5 +264,17 @@ error: function call inside of `get_or_insert`
 LL |     let _ = x.get_or_insert(g());
    |               ^^^^^^^^^^^^^^^^^^ help: try: `get_or_insert_with(g)`
 
-error: aborting due to 41 previous errors
+error: function call inside of `and`
+  --> tests/ui/or_fun_call.rs:448:15
+   |
+LL |     let _ = x.and(g());
+   |               ^^^^^^^^ help: try: `and_then(|_| g())`
+
+error: function call inside of `and`
+  --> tests/ui/or_fun_call.rs:458:15
+   |
+LL |     let _ = x.and(g());
+   |               ^^^^^^^^ help: try: `and_then(|_| g())`
+
+error: aborting due to 43 previous errors
 


### PR DESCRIPTION
<strike>build on top of rust-lang/rust-clippy#15071</strike>

This also adds ability to lint Option/Result::and method. Yes, this is not `or` method, but uses the same eager/lazy linting logic. Should i update lint description to list all checked structs/methods?

changelog: [`or_fun_call`]: lint Option/Result::and
