### PR TITLE
or_fun_call: lint method calls inside map_or first arg

### DIFF
--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -246,8 +246,10 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                         for (span, suggestion) in clone_spans {
                             diag.span_suggestion(
                                 span,
-                                span.get_source_text(cx)
-                                    .map_or("change the call to".to_owned(), |src| format!("change `{src}` to")),
+                                span.get_source_text(cx).map_or_else(
+                                    || "change the call to".to_owned(),
+                                    |src| format!("change `{src}` to"),
+                                ),
                                 suggestion,
                                 Applicability::Unspecified,
                             );
@@ -275,8 +277,10 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                         for (span, suggestion) in clone_spans {
                             diag.span_suggestion(
                                 span,
-                                span.get_source_text(cx)
-                                    .map_or("change the call to".to_owned(), |src| format!("change `{src}` to")),
+                                span.get_source_text(cx).map_or_else(
+                                    || "change the call to".to_owned(),
+                                    |src| format!("change `{src}` to"),
+                                ),
                                 suggestion,
                                 Applicability::Unspecified,
                             );

--- a/clippy_utils/src/diagnostics.rs
+++ b/clippy_utils/src/diagnostics.rs
@@ -22,10 +22,13 @@ fn docs_link(diag: &mut Diag<'_, ()>, lint: &'static Lint) {
     {
         diag.help(format!(
             "for further information visit https://rust-lang.github.io/rust-clippy/{}/index.html#{lint}",
-            &option_env!("RUST_RELEASE_NUM").map_or("master".to_string(), |n| {
-                // extract just major + minor version and ignore patch versions
-                format!("rust-{}", n.rsplit_once('.').unwrap().1)
-            })
+            &option_env!("RUST_RELEASE_NUM").map_or_else(
+                || "master".to_string(),
+                |n| {
+                    // extract just major + minor version and ignore patch versions
+                    format!("rust-{}", n.rsplit_once('.').unwrap().1)
+                }
+            )
         ));
     }
 }

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -283,6 +283,7 @@ mod issue8993 {
         let _ = Some(4).map_or_else(g, f);
         //~^ or_fun_call
         let _ = Some(4).map_or(0, f);
+        let _ = Some(4).map_or("asd".to_string().len() as i32, f);
     }
 }
 
@@ -426,6 +427,7 @@ mod result_map_or {
         let _ = x.map_or_else(|_| g(), f);
         //~^ or_fun_call
         let _ = x.map_or(0, f);
+        let _ = x.map_or("asd".to_string().len() as i32, f);
     }
 }
 

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -283,7 +283,8 @@ mod issue8993 {
         let _ = Some(4).map_or_else(g, f);
         //~^ or_fun_call
         let _ = Some(4).map_or(0, f);
-        let _ = Some(4).map_or("asd".to_string().len() as i32, f);
+        let _ = Some(4).map_or_else(|| "asd".to_string().len() as i32, f);
+        //~^ or_fun_call
     }
 }
 
@@ -427,7 +428,8 @@ mod result_map_or {
         let _ = x.map_or_else(|_| g(), f);
         //~^ or_fun_call
         let _ = x.map_or(0, f);
-        let _ = x.map_or("asd".to_string().len() as i32, f);
+        let _ = x.map_or_else(|_| "asd".to_string().len() as i32, f);
+        //~^ or_fun_call
     }
 }
 

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -283,6 +283,7 @@ mod issue8993 {
         let _ = Some(4).map_or(g(), f);
         //~^ or_fun_call
         let _ = Some(4).map_or(0, f);
+        let _ = Some(4).map_or("asd".to_string().len() as i32, f);
     }
 }
 
@@ -426,6 +427,7 @@ mod result_map_or {
         let _ = x.map_or(g(), f);
         //~^ or_fun_call
         let _ = x.map_or(0, f);
+        let _ = x.map_or("asd".to_string().len() as i32, f);
     }
 }
 

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -284,6 +284,7 @@ mod issue8993 {
         //~^ or_fun_call
         let _ = Some(4).map_or(0, f);
         let _ = Some(4).map_or("asd".to_string().len() as i32, f);
+        //~^ or_fun_call
     }
 }
 
@@ -428,6 +429,7 @@ mod result_map_or {
         //~^ or_fun_call
         let _ = x.map_or(0, f);
         let _ = x.map_or("asd".to_string().len() as i32, f);
+        //~^ or_fun_call
     }
 }
 

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -154,62 +154,68 @@ error: function call inside of `map_or`
 LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
+error: function call inside of `map_or`
+  --> tests/ui/or_fun_call.rs:286:25
+   |
+LL |         let _ = Some(4).map_or("asd".to_string().len() as i32, f);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| "asd".to_string().len() as i32, f)`
+
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:316:18
+  --> tests/ui/or_fun_call.rs:317:18
    |
 LL |         with_new.unwrap_or_else(Vec::new);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:320:28
+  --> tests/ui/or_fun_call.rs:321:28
    |
 LL |         with_default_trait.unwrap_or_else(Default::default);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:324:27
+  --> tests/ui/or_fun_call.rs:325:27
    |
 LL |         with_default_type.unwrap_or_else(u64::default);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:328:22
+  --> tests/ui/or_fun_call.rs:329:22
    |
 LL |         real_default.unwrap_or_else(<FakeDefault as Default>::default);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:332:23
+  --> tests/ui/or_fun_call.rs:333:23
    |
 LL |         map.entry(42).or_insert_with(String::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:336:25
+  --> tests/ui/or_fun_call.rs:337:25
    |
 LL |         btree.entry(42).or_insert_with(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:340:25
+  --> tests/ui/or_fun_call.rs:341:25
    |
 LL |         let _ = stringy.unwrap_or_else(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:382:17
+  --> tests/ui/or_fun_call.rs:383:17
    |
 LL |     let _ = opt.unwrap_or({ f() }); // suggest `.unwrap_or_else(f)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(f)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:387:17
+  --> tests/ui/or_fun_call.rs:388:17
    |
 LL |     let _ = opt.unwrap_or(f() + 1); // suggest `.unwrap_or_else(|| f() + 1)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| f() + 1)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:392:17
+  --> tests/ui/or_fun_call.rs:393:17
    |
 LL |       let _ = opt.unwrap_or({
    |  _________________^
@@ -229,52 +235,58 @@ LL ~     });
    |
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:398:17
+  --> tests/ui/or_fun_call.rs:399:17
    |
 LL |     let _ = opt.map_or(f() + 1, |v| v); // suggest `.map_or_else(|| f() + 1, |v| v)`
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| f() + 1, |v| v)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:403:17
+  --> tests/ui/or_fun_call.rs:404:17
    |
 LL |     let _ = opt.unwrap_or({ i32::default() });
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:410:21
+  --> tests/ui/or_fun_call.rs:411:21
    |
 LL |     let _ = opt_foo.unwrap_or(Foo { val: String::default() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Foo { val: String::default() })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:425:19
+  --> tests/ui/or_fun_call.rs:426:19
    |
 LL |         let _ = x.map_or(g(), |v| v);
    |                   ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|_| g(), |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:427:19
+  --> tests/ui/or_fun_call.rs:428:19
    |
 LL |         let _ = x.map_or(g(), f);
    |                   ^^^^^^^^^^^^^^ help: try: `map_or_else(|_| g(), f)`
 
+error: function call inside of `map_or`
+  --> tests/ui/or_fun_call.rs:431:19
+   |
+LL |         let _ = x.map_or("asd".to_string().len() as i32, f);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|_| "asd".to_string().len() as i32, f)`
+
 error: function call inside of `get_or_insert`
-  --> tests/ui/or_fun_call.rs:440:15
+  --> tests/ui/or_fun_call.rs:442:15
    |
 LL |     let _ = x.get_or_insert(g());
    |               ^^^^^^^^^^^^^^^^^^ help: try: `get_or_insert_with(g)`
 
 error: function call inside of `and`
-  --> tests/ui/or_fun_call.rs:450:15
+  --> tests/ui/or_fun_call.rs:452:15
    |
 LL |     let _ = x.and(g());
    |               ^^^^^^^^ help: try: `and_then(|_| g())`
 
 error: function call inside of `and`
-  --> tests/ui/or_fun_call.rs:460:15
+  --> tests/ui/or_fun_call.rs:462:15
    |
 LL |     let _ = x.and(g());
    |               ^^^^^^^^ help: try: `and_then(|_| g())`
 
-error: aborting due to 43 previous errors
+error: aborting due to 45 previous errors
 

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -155,61 +155,61 @@ LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:315:18
+  --> tests/ui/or_fun_call.rs:316:18
    |
 LL |         with_new.unwrap_or_else(Vec::new);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:319:28
+  --> tests/ui/or_fun_call.rs:320:28
    |
 LL |         with_default_trait.unwrap_or_else(Default::default);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:323:27
+  --> tests/ui/or_fun_call.rs:324:27
    |
 LL |         with_default_type.unwrap_or_else(u64::default);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:327:22
+  --> tests/ui/or_fun_call.rs:328:22
    |
 LL |         real_default.unwrap_or_else(<FakeDefault as Default>::default);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:331:23
+  --> tests/ui/or_fun_call.rs:332:23
    |
 LL |         map.entry(42).or_insert_with(String::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:335:25
+  --> tests/ui/or_fun_call.rs:336:25
    |
 LL |         btree.entry(42).or_insert_with(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:339:25
+  --> tests/ui/or_fun_call.rs:340:25
    |
 LL |         let _ = stringy.unwrap_or_else(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:381:17
+  --> tests/ui/or_fun_call.rs:382:17
    |
 LL |     let _ = opt.unwrap_or({ f() }); // suggest `.unwrap_or_else(f)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(f)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:386:17
+  --> tests/ui/or_fun_call.rs:387:17
    |
 LL |     let _ = opt.unwrap_or(f() + 1); // suggest `.unwrap_or_else(|| f() + 1)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| f() + 1)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:391:17
+  --> tests/ui/or_fun_call.rs:392:17
    |
 LL |       let _ = opt.unwrap_or({
    |  _________________^
@@ -229,49 +229,49 @@ LL ~     });
    |
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:397:17
+  --> tests/ui/or_fun_call.rs:398:17
    |
 LL |     let _ = opt.map_or(f() + 1, |v| v); // suggest `.map_or_else(|| f() + 1, |v| v)`
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| f() + 1, |v| v)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:402:17
+  --> tests/ui/or_fun_call.rs:403:17
    |
 LL |     let _ = opt.unwrap_or({ i32::default() });
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:409:21
+  --> tests/ui/or_fun_call.rs:410:21
    |
 LL |     let _ = opt_foo.unwrap_or(Foo { val: String::default() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Foo { val: String::default() })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:424:19
+  --> tests/ui/or_fun_call.rs:425:19
    |
 LL |         let _ = x.map_or(g(), |v| v);
    |                   ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|_| g(), |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:426:19
+  --> tests/ui/or_fun_call.rs:427:19
    |
 LL |         let _ = x.map_or(g(), f);
    |                   ^^^^^^^^^^^^^^ help: try: `map_or_else(|_| g(), f)`
 
 error: function call inside of `get_or_insert`
-  --> tests/ui/or_fun_call.rs:438:15
+  --> tests/ui/or_fun_call.rs:440:15
    |
 LL |     let _ = x.get_or_insert(g());
    |               ^^^^^^^^^^^^^^^^^^ help: try: `get_or_insert_with(g)`
 
 error: function call inside of `and`
-  --> tests/ui/or_fun_call.rs:448:15
+  --> tests/ui/or_fun_call.rs:450:15
    |
 LL |     let _ = x.and(g());
    |               ^^^^^^^^ help: try: `and_then(|_| g())`
 
 error: function call inside of `and`
-  --> tests/ui/or_fun_call.rs:458:15
+  --> tests/ui/or_fun_call.rs:460:15
    |
 LL |     let _ = x.and(g());
    |               ^^^^^^^^ help: try: `and_then(|_| g())`


### PR DESCRIPTION
<strike>blocked on rust-lang/rust-clippy#15073</strike>

Lint method calls inside `map_or` too, so for this, lint will be showed:
```rust
Some(4).map_or("asd".to_string().len() as i32, f);
```
previously it worked only for:
```rust
Some(4).map_or(slow_fun(), f);
```

https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=bfcda42a6af446e69bc883a8b45eb13c

Sorry for multiple `or_fun_call` PRs.

changelog: [`or_fun_call`]: lint method calls inside map_or first arg
