### PR TITLE
Fix `non_copy_const` ICE

### DIFF
--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -617,7 +617,7 @@ impl<'tcx> NonCopyConst<'tcx> {
 
             // Then a type check. Note we only check the type here as the result
             // gets cached.
-            let ty = EarlyBinder::bind(typeck.expr_ty(src_expr)).instantiate(tcx, init_args);
+            let ty = typeck.expr_ty(src_expr);
             // Normalized as we need to check if this is an array later.
             let ty = tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
             if self.is_ty_freeze(tcx, typing_env, ty).is_freeze() {

--- a/tests/ui/borrow_interior_mutable_const.rs
+++ b/tests/ui/borrow_interior_mutable_const.rs
@@ -218,4 +218,20 @@ fn main() {
         let _ = &S::VALUE.1; //~ borrow_interior_mutable_const
         let _ = &S::VALUE.2;
     }
+    {
+        pub struct Foo<T, const N: usize>(pub Entry<N>, pub T);
+
+        pub struct Entry<const N: usize>(pub Cell<[u32; N]>);
+
+        impl<const N: usize> Entry<N> {
+            const INIT: Self = Self(Cell::new([42; N]));
+        }
+
+        impl<T, const N: usize> Foo<T, N> {
+            pub fn make_foo(v: T) -> Self {
+                // Used to ICE due to incorrect instantiation.
+                Foo(Entry::INIT, v)
+            }
+        }
+    }
 }


### PR DESCRIPTION
fixes rust-lang/rust-clippy#15069

----

changelog: none
