### PR TITLE
Use `Ty::is_fn` instead of manually matching on `TyKind`

### DIFF
--- a/clippy_lints/src/casts/confusing_method_to_numeric_cast.rs
+++ b/clippy_lints/src/casts/confusing_method_to_numeric_cast.rs
@@ -59,9 +59,8 @@ fn get_const_name_and_ty_name(
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>) {
     // We allow casts from any function type to any function type.
-    match cast_to.kind() {
-        ty::FnDef(..) | ty::FnPtr(..) => return,
-        _ => { /* continue to checks */ },
+    if cast_to.is_fn() {
+        return;
     }
 
     if let ty::FnDef(def_id, generics) = cast_from.kind()

--- a/clippy_lints/src/casts/fn_to_numeric_cast.rs
+++ b/clippy_lints/src/casts/fn_to_numeric_cast.rs
@@ -3,7 +3,7 @@ use clippy_utils::source::snippet_with_applicability;
 use rustc_errors::Applicability;
 use rustc_hir::Expr;
 use rustc_lint::LateContext;
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::Ty;
 
 use super::{FN_TO_NUMERIC_CAST, utils};
 
@@ -13,23 +13,20 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>,
         return;
     };
 
-    match cast_from.kind() {
-        ty::FnDef(..) | ty::FnPtr(..) => {
-            let mut applicability = Applicability::MaybeIncorrect;
+    if cast_from.is_fn() {
+        let mut applicability = Applicability::MaybeIncorrect;
 
-            if to_nbits >= cx.tcx.data_layout.pointer_size().bits() && !cast_to.is_usize() {
-                let from_snippet = snippet_with_applicability(cx, cast_expr.span, "x", &mut applicability);
-                span_lint_and_sugg(
-                    cx,
-                    FN_TO_NUMERIC_CAST,
-                    expr.span,
-                    format!("casting function pointer `{from_snippet}` to `{cast_to}`"),
-                    "try",
-                    format!("{from_snippet} as usize"),
-                    applicability,
-                );
-            }
-        },
-        _ => {},
+        if to_nbits >= cx.tcx.data_layout.pointer_size().bits() && !cast_to.is_usize() {
+            let from_snippet = snippet_with_applicability(cx, cast_expr.span, "x", &mut applicability);
+            span_lint_and_sugg(
+                cx,
+                FN_TO_NUMERIC_CAST,
+                expr.span,
+                format!("casting function pointer `{from_snippet}` to `{cast_to}`"),
+                "try",
+                format!("{from_snippet} as usize"),
+                applicability,
+            );
+        }
     }
 }

--- a/clippy_lints/src/casts/fn_to_numeric_cast_any.rs
+++ b/clippy_lints/src/casts/fn_to_numeric_cast_any.rs
@@ -3,18 +3,17 @@ use clippy_utils::source::snippet_with_applicability;
 use rustc_errors::Applicability;
 use rustc_hir::Expr;
 use rustc_lint::LateContext;
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::Ty;
 
 use super::FN_TO_NUMERIC_CAST_ANY;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>) {
     // We allow casts from any function type to any function type.
-    match cast_to.kind() {
-        ty::FnDef(..) | ty::FnPtr(..) => return,
-        _ => { /* continue to checks */ },
+    if cast_to.is_fn() {
+        return;
     }
 
-    if let ty::FnDef(..) | ty::FnPtr(..) = cast_from.kind() {
+    if cast_from.is_fn() {
         let mut applicability = Applicability::MaybeIncorrect;
         let from_snippet = snippet_with_applicability(cx, cast_expr.span, "..", &mut applicability);
 

--- a/clippy_lints/src/casts/fn_to_numeric_cast_with_truncation.rs
+++ b/clippy_lints/src/casts/fn_to_numeric_cast_with_truncation.rs
@@ -3,7 +3,7 @@ use clippy_utils::source::snippet_with_applicability;
 use rustc_errors::Applicability;
 use rustc_hir::Expr;
 use rustc_lint::LateContext;
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::Ty;
 
 use super::{FN_TO_NUMERIC_CAST_WITH_TRUNCATION, utils};
 
@@ -12,23 +12,20 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>,
     let Some(to_nbits) = utils::int_ty_to_nbits(cx.tcx, cast_to) else {
         return;
     };
-    match cast_from.kind() {
-        ty::FnDef(..) | ty::FnPtr(..) => {
-            let mut applicability = Applicability::MaybeIncorrect;
-            let from_snippet = snippet_with_applicability(cx, cast_expr.span, "x", &mut applicability);
+    if cast_from.is_fn() {
+        let mut applicability = Applicability::MaybeIncorrect;
+        let from_snippet = snippet_with_applicability(cx, cast_expr.span, "x", &mut applicability);
 
-            if to_nbits < cx.tcx.data_layout.pointer_size().bits() {
-                span_lint_and_sugg(
-                    cx,
-                    FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
-                    expr.span,
-                    format!("casting function pointer `{from_snippet}` to `{cast_to}`, which truncates the value"),
-                    "try",
-                    format!("{from_snippet} as usize"),
-                    applicability,
-                );
-            }
-        },
-        _ => {},
+        if to_nbits < cx.tcx.data_layout.pointer_size().bits() {
+            span_lint_and_sugg(
+                cx,
+                FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
+                expr.span,
+                format!("casting function pointer `{from_snippet}` to `{cast_to}`, which truncates the value"),
+                "try",
+                format!("{from_snippet} as usize"),
+                applicability,
+            );
+        }
     }
 }

--- a/clippy_lints/src/mixed_read_write_in_expression.rs
+++ b/clippy_lints/src/mixed_read_write_in_expression.rs
@@ -171,14 +171,11 @@ impl<'tcx> Visitor<'tcx> for DivergenceVisitor<'_, 'tcx> {
             ExprKind::Continue(_) | ExprKind::Break(_, _) | ExprKind::Ret(_) => self.report_diverging_sub_expr(e),
             ExprKind::Call(func, _) => {
                 let typ = self.cx.typeck_results().expr_ty(func);
-                match typ.kind() {
-                    ty::FnDef(..) | ty::FnPtr(..) => {
-                        let sig = typ.fn_sig(self.cx.tcx);
-                        if self.cx.tcx.instantiate_bound_regions_with_erased(sig).output().kind() == &ty::Never {
-                            self.report_diverging_sub_expr(e);
-                        }
-                    },
-                    _ => {},
+                if typ.is_fn() {
+                    let sig = typ.fn_sig(self.cx.tcx);
+                    if self.cx.tcx.instantiate_bound_regions_with_erased(sig).output().kind() == &ty::Never {
+                        self.report_diverging_sub_expr(e);
+                    }
                 }
             },
             ExprKind::MethodCall(..) => {

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -79,7 +79,7 @@ fn check_arguments<'tcx>(
     name: &str,
     fn_kind: &str,
 ) {
-    if let ty::FnDef(..) | ty::FnPtr(..) = type_definition.kind() {
+    if type_definition.is_fn() {
         let parameters = type_definition.fn_sig(cx.tcx).skip_binder().inputs();
         for (argument, parameter) in iter::zip(arguments, parameters) {
             if let ty::Ref(_, _, Mutability::Not) | ty::RawPtr(_, Mutability::Not) = parameter.kind()

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -492,10 +492,7 @@ pub fn peel_mid_ty_refs_is_mutable(ty: Ty<'_>) -> (Ty<'_>, usize, Mutability) {
 
 /// Returns `true` if the given type is an `unsafe` function.
 pub fn type_is_unsafe_function<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-    match ty.kind() {
-        ty::FnDef(..) | ty::FnPtr(..) => ty.fn_sig(cx.tcx).safety().is_unsafe(),
-        _ => false,
-    }
+    ty.is_fn() && ty.fn_sig(cx.tcx).safety().is_unsafe()
 }
 
 /// Returns the base type for HIR references and pointers.


### PR DESCRIPTION
just makes the code a bit more concise

changelog: none