### PR TITLE
Fix typo in tests/ui/missing_const_for_fn/const_trait.rs

### DIFF
--- a/tests/ui/missing_const_for_fn/const_trait.fixed
+++ b/tests/ui/missing_const_for_fn/const_trait.fixed
@@ -25,7 +25,7 @@ const fn can_be_const() {
     0u64.method();
 }
 
-// False negative, see FIXME comment in `clipy_utils::qualify_min_const`
+// False negative, see FIXME comment in `clippy_utils::qualify_min_const_fn`
 fn could_be_const_but_does_not_trigger<T>(t: T)
 where
     T: const ConstTrait,

--- a/tests/ui/missing_const_for_fn/const_trait.rs
+++ b/tests/ui/missing_const_for_fn/const_trait.rs
@@ -25,7 +25,7 @@ fn can_be_const() {
     0u64.method();
 }
 
-// False negative, see FIXME comment in `clipy_utils::qualify_min_const`
+// False negative, see FIXME comment in `clippy_utils::qualify_min_const_fn`
 fn could_be_const_but_does_not_trigger<T>(t: T)
 where
     T: const ConstTrait,


### PR DESCRIPTION
I think the comment is meant to refer to [clippy_utils::qualify_min_const_fn](https://github.com/rust-lang/rust-clippy/blob/master/clippy_utils/src/qualify_min_const_fn.rs).

changelog: none
