### PR TITLE
Add missing space when expanding a struct-like variant

### DIFF
--- a/clippy_lints/src/matches/match_wild_enum.rs
+++ b/clippy_lints/src/matches/match_wild_enum.rs
@@ -140,7 +140,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>]) {
                 Some(CtorKind::Fn) if variant.fields.len() == 1 => "(_)",
                 Some(CtorKind::Fn) => "(..)",
                 Some(CtorKind::Const) => "",
-                None => "{ .. }",
+                None => " { .. }",
             }
         )
     };

--- a/tests/ui/wildcard_enum_match_arm.fixed
+++ b/tests/ui/wildcard_enum_match_arm.fixed
@@ -91,6 +91,21 @@ fn main() {
     }
 
     {
+        pub enum Enum {
+            A,
+            B,
+            C(u8),
+            D(u8, u8),
+            E { e: u8 },
+        };
+        match Enum::A {
+            Enum::A => (),
+            Enum::B | Enum::C(_) | Enum::D(..) | Enum::E { .. } => (),
+            //~^ wildcard_enum_match_arm
+        }
+    }
+
+    {
         #![allow(clippy::manual_non_exhaustive)]
         pub enum Enum {
             A,

--- a/tests/ui/wildcard_enum_match_arm.rs
+++ b/tests/ui/wildcard_enum_match_arm.rs
@@ -91,6 +91,21 @@ fn main() {
     }
 
     {
+        pub enum Enum {
+            A,
+            B,
+            C(u8),
+            D(u8, u8),
+            E { e: u8 },
+        };
+        match Enum::A {
+            Enum::A => (),
+            _ => (),
+            //~^ wildcard_enum_match_arm
+        }
+    }
+
+    {
         #![allow(clippy::manual_non_exhaustive)]
         pub enum Enum {
             A,

--- a/tests/ui/wildcard_enum_match_arm.stderr
+++ b/tests/ui/wildcard_enum_match_arm.stderr
@@ -38,13 +38,19 @@ error: wildcard match will also match any future added variants
   --> tests/ui/wildcard_enum_match_arm.rs:103:13
    |
 LL |             _ => (),
+   |             ^ help: try: `Enum::B | Enum::C(_) | Enum::D(..) | Enum::E { .. }`
+
+error: wildcard match will also match any future added variants
+  --> tests/ui/wildcard_enum_match_arm.rs:118:13
+   |
+LL |             _ => (),
    |             ^ help: try: `Enum::B | Enum::__Private`
 
 error: wildcard match will also match any future added variants
-  --> tests/ui/wildcard_enum_match_arm.rs:118:9
+  --> tests/ui/wildcard_enum_match_arm.rs:133:9
    |
 LL |         r#type => {},
    |         ^^^^^^ help: try: `r#type @ Foo::B | r#type @ Foo::C`
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
In `wildcard_enum_match_arm`, expanding a variant with struct-like fields was missing a space between the variant name and the opening bracket.

Also, add a test for tuple-like variants with only one field, as those are expanded as `VariantName(_)` instead of `VariantName(..)`.

changelog: none