### PR TITLE
Fix `disallowed_script_idents` FP on identifiers with `_`

### DIFF
--- a/clippy_lints/src/disallowed_script_idents.rs
+++ b/clippy_lints/src/disallowed_script_idents.rs
@@ -89,6 +89,10 @@ impl EarlyLintPass for DisallowedScriptIdents {
             // Fast path for ascii-only idents.
             if !symbol_str.is_ascii()
                 && let Some(script) = symbol_str.chars().find_map(|c| {
+                    if c.is_ascii() {
+                        return None;
+                    }
+
                     c.script_extension()
                         .iter()
                         .find(|script| !self.whitelist.contains(script))

--- a/tests/ui/disallowed_script_idents.rs
+++ b/tests/ui/disallowed_script_idents.rs
@@ -15,3 +15,17 @@ fn main() {
     let カウンタ = 10;
     //~^ disallowed_script_idents
 }
+
+fn issue15116() {
+    const ÄÖÜ: u8 = 0;
+    const _ÄÖÜ: u8 = 0;
+    const Ä_ÖÜ: u8 = 0;
+    const ÄÖ_Ü: u8 = 0;
+    const ÄÖÜ_: u8 = 0;
+    let äöüß = 1;
+    let _äöüß = 1;
+    let ä_öüß = 1;
+    let äö_üß = 1;
+    let äöü_ß = 1;
+    let äöüß_ = 1;
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15116

The cause for this issue is that `_` belongs to the `Common` catagory in unicode instead of `Latin` like other ASCII alphabets. Since ASCII characters are always allowed, I just added an extra `is_ascii()` check to ensure this.

changelog: [`disallowed_script_idents`] fix FP on identifiers with `_`
