### PR TITLE
Fix capacity overflow in `single_match` with deref patterns

### DIFF
--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -161,7 +161,7 @@ fn report_single_pattern(
             // Try to remove address of expressions first.
             let (ex, removed) = peel_n_hir_expr_refs(ex, ref_count_diff);
 
-            (ex, "&".repeat(ref_count_diff - removed))
+            (ex, String::from(if ref_count_diff == removed { "" } else { "&" }))
         } else {
             (ex, "*".repeat(pat_ref_count - ty_ref_count))
         };

--- a/tests/ui/single_match_else_deref_patterns.fixed
+++ b/tests/ui/single_match_else_deref_patterns.fixed
@@ -1,0 +1,7 @@
+#![feature(deref_patterns)]
+#![allow(incomplete_features, clippy::eq_op)]
+#![warn(clippy::single_match_else)]
+
+fn string() {
+    if *"" == *"" {}
+}

--- a/tests/ui/single_match_else_deref_patterns.fixed
+++ b/tests/ui/single_match_else_deref_patterns.fixed
@@ -1,7 +1,53 @@
 #![feature(deref_patterns)]
-#![allow(incomplete_features, clippy::eq_op)]
-#![warn(clippy::single_match_else)]
+#![allow(
+    incomplete_features,
+    clippy::eq_op,
+    clippy::op_ref,
+    clippy::deref_addrof,
+    clippy::borrow_deref_ref,
+    clippy::needless_if
+)]
+#![deny(clippy::single_match_else)]
 
 fn string() {
     if *"" == *"" {}
+
+    if *&*&*&*"" == *"" {}
+
+    if ***&&"" == *"" {}
+
+    if *&*&*"" == *"" {}
+
+    if **&&*"" == *"" {}
+}
+
+fn int() {
+    if &&&1 == &&&2 { unreachable!() } else {
+        // ok
+    }
+    //~^^^^^^ single_match_else
+    if &&1 == &&2 { unreachable!() } else {
+        // ok
+    }
+    //~^^^^^^ single_match_else
+    if &&1 == &&2 { unreachable!() } else {
+        // ok
+    }
+    //~^^^^^^ single_match_else
+    if &1 == &2 { unreachable!() } else {
+        // ok
+    }
+    //~^^^^^^ single_match_else
+    if &1 == &2 { unreachable!() } else {
+        // ok
+    }
+    //~^^^^^^ single_match_else
+    if 1 == 2 { unreachable!() } else {
+        // ok
+    }
+    //~^^^^^^ single_match_else
+    if 1 == 2 { unreachable!() } else {
+        // ok
+    }
+    //~^^^^^^ single_match_else
 }

--- a/tests/ui/single_match_else_deref_patterns.rs
+++ b/tests/ui/single_match_else_deref_patterns.rs
@@ -1,0 +1,11 @@
+#![feature(deref_patterns)]
+#![allow(incomplete_features, clippy::eq_op)]
+#![warn(clippy::single_match_else)]
+
+fn string() {
+    match *"" {
+        //~^ single_match
+        "" => {},
+        _ => {},
+    }
+}

--- a/tests/ui/single_match_else_deref_patterns.rs
+++ b/tests/ui/single_match_else_deref_patterns.rs
@@ -1,6 +1,13 @@
 #![feature(deref_patterns)]
-#![allow(incomplete_features, clippy::eq_op)]
-#![warn(clippy::single_match_else)]
+#![allow(
+    incomplete_features,
+    clippy::eq_op,
+    clippy::op_ref,
+    clippy::deref_addrof,
+    clippy::borrow_deref_ref,
+    clippy::needless_if
+)]
+#![deny(clippy::single_match_else)]
 
 fn string() {
     match *"" {
@@ -8,4 +15,80 @@ fn string() {
         "" => {},
         _ => {},
     }
+
+    match *&*&*&*"" {
+        //~^ single_match
+        "" => {},
+        _ => {},
+    }
+
+    match ***&&"" {
+        //~^ single_match
+        "" => {},
+        _ => {},
+    }
+
+    match *&*&*"" {
+        //~^ single_match
+        "" => {},
+        _ => {},
+    }
+
+    match **&&*"" {
+        //~^ single_match
+        "" => {},
+        _ => {},
+    }
+}
+
+fn int() {
+    match &&&1 {
+        &&&2 => unreachable!(),
+        _ => {
+            // ok
+        },
+    }
+    //~^^^^^^ single_match_else
+    match &&&1 {
+        &&2 => unreachable!(),
+        _ => {
+            // ok
+        },
+    }
+    //~^^^^^^ single_match_else
+    match &&1 {
+        &&2 => unreachable!(),
+        _ => {
+            // ok
+        },
+    }
+    //~^^^^^^ single_match_else
+    match &&&1 {
+        &2 => unreachable!(),
+        _ => {
+            // ok
+        },
+    }
+    //~^^^^^^ single_match_else
+    match &&1 {
+        &2 => unreachable!(),
+        _ => {
+            // ok
+        },
+    }
+    //~^^^^^^ single_match_else
+    match &&&1 {
+        2 => unreachable!(),
+        _ => {
+            // ok
+        },
+    }
+    //~^^^^^^ single_match_else
+    match &&1 {
+        2 => unreachable!(),
+        _ => {
+            // ok
+        },
+    }
+    //~^^^^^^ single_match_else
 }

--- a/tests/ui/single_match_else_deref_patterns.stderr
+++ b/tests/ui/single_match_else_deref_patterns.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match_else_deref_patterns.rs:6:5
+  --> tests/ui/single_match_else_deref_patterns.rs:13:5
    |
 LL | /     match *"" {
 LL | |
@@ -12,5 +12,177 @@ LL | |     }
    = note: `-D clippy::single-match` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::single_match)]`
 
-error: aborting due to 1 previous error
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:19:5
+   |
+LL | /     match *&*&*&*"" {
+LL | |
+LL | |         "" => {},
+LL | |         _ => {},
+LL | |     }
+   | |_____^ help: try: `if *&*&*&*"" == *"" {}`
+   |
+   = note: you might want to preserve the comments from inside the `match`
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:25:5
+   |
+LL | /     match ***&&"" {
+LL | |
+LL | |         "" => {},
+LL | |         _ => {},
+LL | |     }
+   | |_____^ help: try: `if ***&&"" == *"" {}`
+   |
+   = note: you might want to preserve the comments from inside the `match`
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:31:5
+   |
+LL | /     match *&*&*"" {
+LL | |
+LL | |         "" => {},
+LL | |         _ => {},
+LL | |     }
+   | |_____^ help: try: `if *&*&*"" == *"" {}`
+   |
+   = note: you might want to preserve the comments from inside the `match`
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:37:5
+   |
+LL | /     match **&&*"" {
+LL | |
+LL | |         "" => {},
+LL | |         _ => {},
+LL | |     }
+   | |_____^ help: try: `if **&&*"" == *"" {}`
+   |
+   = note: you might want to preserve the comments from inside the `match`
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:45:5
+   |
+LL | /     match &&&1 {
+LL | |         &&&2 => unreachable!(),
+LL | |         _ => {
+...  |
+LL | |     }
+   | |_____^
+   |
+note: the lint level is defined here
+  --> tests/ui/single_match_else_deref_patterns.rs:10:9
+   |
+LL | #![deny(clippy::single_match_else)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: try
+   |
+LL ~     if &&&1 == &&&2 { unreachable!() } else {
+LL +         // ok
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:52:5
+   |
+LL | /     match &&&1 {
+LL | |         &&2 => unreachable!(),
+LL | |         _ => {
+...  |
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if &&1 == &&2 { unreachable!() } else {
+LL +         // ok
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:59:5
+   |
+LL | /     match &&1 {
+LL | |         &&2 => unreachable!(),
+LL | |         _ => {
+...  |
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if &&1 == &&2 { unreachable!() } else {
+LL +         // ok
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:66:5
+   |
+LL | /     match &&&1 {
+LL | |         &2 => unreachable!(),
+LL | |         _ => {
+...  |
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if &1 == &2 { unreachable!() } else {
+LL +         // ok
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:73:5
+   |
+LL | /     match &&1 {
+LL | |         &2 => unreachable!(),
+LL | |         _ => {
+...  |
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if &1 == &2 { unreachable!() } else {
+LL +         // ok
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:80:5
+   |
+LL | /     match &&&1 {
+LL | |         2 => unreachable!(),
+LL | |         _ => {
+...  |
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if 1 == 2 { unreachable!() } else {
+LL +         // ok
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:87:5
+   |
+LL | /     match &&1 {
+LL | |         2 => unreachable!(),
+LL | |         _ => {
+...  |
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if 1 == 2 { unreachable!() } else {
+LL +         // ok
+LL +     }
+   |
+
+error: aborting due to 12 previous errors
 

--- a/tests/ui/single_match_else_deref_patterns.stderr
+++ b/tests/ui/single_match_else_deref_patterns.stderr
@@ -1,0 +1,16 @@
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match_else_deref_patterns.rs:6:5
+   |
+LL | /     match *"" {
+LL | |
+LL | |         "" => {},
+LL | |         _ => {},
+LL | |     }
+   | |_____^ help: try: `if *"" == *"" {}`
+   |
+   = note: you might want to preserve the comments from inside the `match`
+   = note: `-D clippy::single-match` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::single_match)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#14882

changelog: [`single_match`]: fix ICE with deref patterns and string literals