### PR TITLE
Downgrade known buggy pointer cast suggestions to `MaybeIncorrect`.

### DIFF
--- a/clippy_lints/src/casts/cast_slice_from_raw_parts.rs
+++ b/clippy_lints/src/casts/cast_slice_from_raw_parts.rs
@@ -39,7 +39,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>,
             RawPartsKind::Mutable => "from_raw_parts_mut",
         };
         let span = expr.span;
-        let mut applicability = Applicability::MachineApplicable;
+        let mut applicability = Applicability::MaybeIncorrect;
         let ptr = snippet_with_context(cx, ptr_arg.span, ctxt, "ptr", &mut applicability).0;
         let len = snippet_with_context(cx, len_arg.span, ctxt, "len", &mut applicability).0;
         span_lint_and_sugg(

--- a/clippy_lints/src/casts/ptr_as_ptr.rs
+++ b/clippy_lints/src/casts/ptr_as_ptr.rs
@@ -38,7 +38,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, msrv: Msrv) {
         && to_pointee_ty.is_sized(cx.tcx, cx.typing_env())
         && msrv.meets(cx, msrvs::POINTER_CAST)
     {
-        let mut app = Applicability::MachineApplicable;
+        let mut app = Applicability::MaybeIncorrect;
         let turbofish = match &cast_to_hir_ty.kind {
             TyKind::Infer(()) => String::new(),
             TyKind::Ptr(mut_ty) => {

--- a/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -83,7 +83,7 @@ pub(super) fn check_null_ptr_cast_method(cx: &LateContext<'_>, expr: &Expr<'_>) 
             _ => return,
         }
         && let Some(prefix) = std_or_core(cx)
-        && let mut app = Applicability::MachineApplicable
+        && let mut app = Applicability::MaybeIncorrect
         && let sugg = format!("{}", Sugg::hir_with_applicability(cx, cast_expr, "_", &mut app))
         && let Some((_, after_lt)) = sugg.split_once("::<")
     {

--- a/clippy_lints/src/casts/ref_as_ptr.rs
+++ b/clippy_lints/src/casts/ref_as_ptr.rs
@@ -32,7 +32,7 @@ pub(super) fn check<'tcx>(
             Mutability::Mut => "from_mut",
         };
 
-        let mut app = Applicability::MachineApplicable;
+        let mut app = Applicability::MaybeIncorrect;
         let turbofish = match &cast_to_hir_ty.kind {
             TyKind::Infer(()) => String::new(),
             TyKind::Ptr(mut_ty) => {


### PR DESCRIPTION
See issues rust-lang/rust-clippy#12882 and rust-lang/rust-clippy#13910.

`borrow_as_ptr` was not changed since it does try to detect temporaries and initial testing did not find obvious bugs.

`ptr_cast_constness` was not changed since it isn't doing a reference-to-pointer conversion.

changelog: [`cast_slice_from_raw_parts`]: Disable `--fix` due to known soundness issues with suggestion.
changelog: [`ptr_as_ptr.rs `]: Disable `--fix` due to known soundness issues with suggestion.
changelog: [`ptr_cast_constness`]: Disable `--fix` due to known soundness issues with suggestion.
changelog: [`ref_as_ptr`]: Disable `--fix` due to known soundness issues with suggestion.
