### PR TITLE
Ping notriddle when a clippy lint in `clippy_lints/doc` is modified

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,6 +17,9 @@ allow-unauthenticated = [
 
 [issue-links]
 
+[mentions."clippy_lints/src/doc"]
+cc = ["@notriddle"]
+
 # Prevents mentions in commits to avoid users being spammed
 [no-mentions]
 


### PR DESCRIPTION
Related to [this Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/Reviewing.20the.20.60doc.60.20lints/with/525943439).

@notriddle Would you want that?

changelog: none

