### PR TITLE
Lint docs: Sort versions, so that stable comes first

### DIFF
--- a/util/versions.py
+++ b/util/versions.py
@@ -6,11 +6,11 @@ import os
 import sys
 
 def key(v):
-    if v == "master":
-        return sys.maxsize
     if v == "stable":
-        return sys.maxsize - 1
+        return sys.maxsize 
     if v == "beta":
+        return sys.maxsize - 1
+    if v == "master":
         return sys.maxsize - 2
     if v == "pre-1.29.0":
         return -1


### PR DESCRIPTION
I expect that most people use stable Clippy. So having `master` be the first documentation link in the list is weird. Now the versions are sorted stable->beta->master.

changelog: none
