### PR TITLE
Make `transmute_ptr_to_ref` suggestion work correctly with some outer expression types

### DIFF
--- a/clippy_lints/src/transmute/transmute_ptr_to_ref.rs
+++ b/clippy_lints/src/transmute/transmute_ptr_to_ref.rs
@@ -4,7 +4,7 @@ use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::sugg;
 use rustc_errors::Applicability;
-use rustc_hir::{self as hir, Expr, GenericArg, Mutability, Path, TyKind};
+use rustc_hir::{self as hir, Expr, ExprKind, GenericArg, Mutability, Path, TyKind, Node};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, Ty, TypeVisitableExt};
 
@@ -59,7 +59,22 @@ pub(super) fn check<'tcx>(
                         sugg::make_unop(deref, arg.as_ty(format!("{cast} {to_ref_ty}"))).to_string()
                     };
 
-                    diag.span_suggestion(e.span, "try", sugg, app);
+                    if let Node::Expr(
+                        Expr {
+                            kind: ExprKind::Call(
+                                Expr {
+                                    kind: ExprKind::Call(..),
+                                    ..
+                                },
+                                ..
+                            ),
+                            ..
+                        }
+                    ) = cx.tcx.parent_hir_node(e.hir_id) {
+                        diag.span_suggestion(e.span, "try", format!("({sugg})"), app);
+                    } else {
+                        diag.span_suggestion(e.span, "try", sugg, app);
+                    }
                 },
             );
             true

--- a/tests/ui/transmute_ptr_to_ref.fixed
+++ b/tests/ui/transmute_ptr_to_ref.fixed
@@ -106,4 +106,54 @@ unsafe fn _under_msrv<'a, 'b, 'c>(x: *const &'a u32) -> &'c &'b u32 {
     }
 }
 
+unsafe fn _issue1754() {
+    let mut_num_func_ptr: *mut std::ffi::c_void = std::ptr::null_mut();
+
+    let num: u32 = 0;
+
+    // If pointer cast is supported by MSRV.
+    unsafe {
+        // Not recommended.
+        (&mut *mut_num_func_ptr.cast::<Box<dyn FnMut(&u32)>>())(&num);
+        //~^ transmute_ptr_to_ref
+
+        // Recommended.
+        (&mut *mut_num_func_ptr.cast::<Box<dyn FnMut(&u32)>>())(&num);
+    }
+
+    // If pointer cast is not supported by MSRV.
+    #[clippy::msrv = "1.37"]
+    unsafe {
+        // Not recommended.
+        (&mut *(mut_num_func_ptr as *mut Box<dyn FnMut(&u32)>))(&num);
+        //~^ transmute_ptr_to_ref
+
+        // Recommended.
+        (&mut *(mut_num_func_ptr as *mut Box<dyn FnMut(&u32)>))(&num);
+    };
+
+    let num_func_ptr: *const std::ffi::c_void = std::ptr::null_mut();
+
+    // If pointer cast is supported by MSRV.
+    unsafe {
+        // Not recommended.
+        (&*num_func_ptr.cast::<Box<dyn Fn(&u32)>>())(&num);
+        //~^ transmute_ptr_to_ref
+
+        // Recommended.
+        (&*num_func_ptr.cast::<Box<dyn Fn(&u32)>>())(&num);
+    }
+
+    // If pointer cast is not supported by MSRV.
+    #[clippy::msrv = "1.37"]
+    unsafe {
+        // Not recommended.
+        (&*(num_func_ptr as *const Box<dyn Fn(&u32)>))(&num);
+        //~^ transmute_ptr_to_ref
+
+        // Recommended.
+        (&*(num_func_ptr as *const Box<dyn Fn(&u32)>))(&num);
+    };
+}
+
 fn main() {}

--- a/tests/ui/transmute_ptr_to_ref.rs
+++ b/tests/ui/transmute_ptr_to_ref.rs
@@ -106,4 +106,54 @@ unsafe fn _under_msrv<'a, 'b, 'c>(x: *const &'a u32) -> &'c &'b u32 {
     }
 }
 
+unsafe fn _issue1754() {
+    let mut_num_func_ptr: *mut std::ffi::c_void = std::ptr::null_mut();
+
+    let num: u32 = 0;
+
+    // If pointer cast is supported by MSRV.
+    unsafe {
+        // Not recommended.
+        std::mem::transmute::<*mut std::ffi::c_void, &mut Box<dyn FnMut(&u32)>>(mut_num_func_ptr)(&num);
+        //~^ transmute_ptr_to_ref
+
+        // Recommended.
+        (&mut *mut_num_func_ptr.cast::<Box<dyn FnMut(&u32)>>())(&num);
+    }
+
+    // If pointer cast is not supported by MSRV.
+    #[clippy::msrv = "1.37"]
+    unsafe {
+        // Not recommended.
+        std::mem::transmute::<*mut std::ffi::c_void, &mut Box<dyn FnMut(&u32)>>(mut_num_func_ptr)(&num);
+        //~^ transmute_ptr_to_ref
+
+        // Recommended.
+        (&mut *(mut_num_func_ptr as *mut Box<dyn FnMut(&u32)>))(&num);
+    };
+
+    let num_func_ptr: *const std::ffi::c_void = std::ptr::null_mut();
+
+    // If pointer cast is supported by MSRV.
+    unsafe {
+        // Not recommended.
+        std::mem::transmute::<*const std::ffi::c_void, &Box<dyn Fn(&u32)>>(num_func_ptr)(&num);
+        //~^ transmute_ptr_to_ref
+
+        // Recommended.
+        (&*num_func_ptr.cast::<Box<dyn Fn(&u32)>>())(&num);
+    }
+
+    // If pointer cast is not supported by MSRV.
+    #[clippy::msrv = "1.37"]
+    unsafe {
+        // Not recommended.
+        std::mem::transmute::<*const std::ffi::c_void, &Box<dyn Fn(&u32)>>(num_func_ptr)(&num);
+        //~^ transmute_ptr_to_ref
+
+        // Recommended.
+        (&*(num_func_ptr as *const Box<dyn Fn(&u32)>))(&num);
+    };
+}
+
 fn main() {}

--- a/tests/ui/transmute_ptr_to_ref.stderr
+++ b/tests/ui/transmute_ptr_to_ref.stderr
@@ -133,5 +133,29 @@ error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32
 LL |             _ => std::mem::transmute::<_, &&'b u32>(x),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &'b u32)`
 
-error: aborting due to 22 previous errors
+error: transmute from a pointer type (`*mut std::ffi::c_void`) to a reference type (`&mut std::boxed::Box<dyn for<'a> std::ops::FnMut(&'a u32)>`)
+  --> tests/ui/transmute_ptr_to_ref.rs:117:9
+   |
+LL |         std::mem::transmute::<*mut std::ffi::c_void, &mut Box<dyn FnMut(&u32)>>(mut_num_func_ptr)(&num);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&mut *mut_num_func_ptr.cast::<Box<dyn FnMut(&u32)>>())`
+
+error: transmute from a pointer type (`*mut std::ffi::c_void`) to a reference type (`&mut std::boxed::Box<dyn for<'a> std::ops::FnMut(&'a u32)>`)
+  --> tests/ui/transmute_ptr_to_ref.rs:128:9
+   |
+LL |         std::mem::transmute::<*mut std::ffi::c_void, &mut Box<dyn FnMut(&u32)>>(mut_num_func_ptr)(&num);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&mut *(mut_num_func_ptr as *mut Box<dyn FnMut(&u32)>))`
+
+error: transmute from a pointer type (`*const std::ffi::c_void`) to a reference type (`&std::boxed::Box<dyn for<'a> std::ops::Fn(&'a u32)>`)
+  --> tests/ui/transmute_ptr_to_ref.rs:140:9
+   |
+LL |         std::mem::transmute::<*const std::ffi::c_void, &Box<dyn Fn(&u32)>>(num_func_ptr)(&num);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&*num_func_ptr.cast::<Box<dyn Fn(&u32)>>())`
+
+error: transmute from a pointer type (`*const std::ffi::c_void`) to a reference type (`&std::boxed::Box<dyn for<'a> std::ops::Fn(&'a u32)>`)
+  --> tests/ui/transmute_ptr_to_ref.rs:151:9
+   |
+LL |         std::mem::transmute::<*const std::ffi::c_void, &Box<dyn Fn(&u32)>>(num_func_ptr)(&num);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&*(num_func_ptr as *const Box<dyn Fn(&u32)>))`
+
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
fixes #1754

changelog: [`transmute_ptr_to_ref`]: provide correct suggestions for some outer expression types