### PR TITLE
Do not autofix comments containing bare CR

### DIFF
--- a/tests/ui/four_forward_slashes_bare_cr.rs
+++ b/tests/ui/four_forward_slashes_bare_cr.rs
@@ -1,0 +1,6 @@
+//@no-rustfix
+#![warn(clippy::four_forward_slashes)]
+
+//~v four_forward_slashes
+//// nondoc comment with bare CR: ''
+fn main() {}

--- a/tests/ui/four_forward_slashes_bare_cr.stderr
+++ b/tests/ui/four_forward_slashes_bare_cr.stderr
@@ -1,0 +1,14 @@
+error: this item has comments with 4 forward slashes (`////`). These look like doc comments, but they aren't
+  --> tests/ui/four_forward_slashes_bare_cr.rs:5:1
+   |
+LL | / //// nondoc comment with bare CR: '␍'
+LL | | fn main() {}
+   | |_^
+   |
+   = help: make this a doc comment by removing one `/`
+   = note: bare CR characters are not allowed in doc comments
+   = note: `-D clippy::four-forward-slashes` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::four_forward_slashes)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
When a bare CR is present in a four slashes comment, keep triggering the lint but do not issue a fix suggestion as bare CRs are not supported in doc comments. An extra note is added to the diagnostic to warn the user about it. 

I have put the test in a separate file to make it clear that the bare CR is not a formatting error.

Fixes rust-lang/rust-clippy#15174 

changelog: [`four_forward_slashes`]: warn about bare CR in comment, and do not propose invalid autofix