### PR TITLE
fix `legacy_numeric_constants` suggestion when call is wrapped in parens

### DIFF
--- a/clippy_lints/src/legacy_numeric_constants.rs
+++ b/clippy_lints/src/legacy_numeric_constants.rs
@@ -1,5 +1,5 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::{get_parent_expr, is_from_proc_macro};
 use hir::def_id::DefId;
@@ -143,7 +143,7 @@ impl<'tcx> LateLintPass<'tcx> for LegacyNumericConstants {
             && self.msrv.meets(cx, msrvs::NUMERIC_ASSOCIATED_CONSTANTS)
             && !is_from_proc_macro(cx, expr)
         {
-            span_lint_hir_and_then(cx, LEGACY_NUMERIC_CONSTANTS, expr.hir_id, span, msg, |diag| {
+            span_lint_and_then(cx, LEGACY_NUMERIC_CONSTANTS, span, msg, |diag| {
                 diag.span_suggestion_verbose(
                     span,
                     "use the associated constant instead",

--- a/clippy_lints/src/legacy_numeric_constants.rs
+++ b/clippy_lints/src/legacy_numeric_constants.rs
@@ -122,17 +122,17 @@ impl<'tcx> LateLintPass<'tcx> for LegacyNumericConstants {
                 "usage of a legacy numeric constant",
             )
         // `<integer>::xxx_value` check
-        } else if let QPath::TypeRelative(_, last_segment) = qpath
+        } else if let QPath::TypeRelative(mod_path, last_segment) = qpath
             && let Some(def_id) = cx.qpath_res(qpath, expr.hir_id).opt_def_id()
             && let Some(par_expr) = get_parent_expr(cx, expr)
             && let ExprKind::Call(_, []) = par_expr.kind
             && is_integer_method(cx, def_id)
         {
             let name = last_segment.ident.name.as_str();
-
+            let mod_name = clippy_utils::source::snippet(cx, mod_path.span, "_");
             (
-                last_segment.ident.span.with_hi(par_expr.span.hi()),
-                name[..=2].to_ascii_uppercase(),
+                par_expr.span,
+                format!("{}::{}", mod_name, name[..=2].to_ascii_uppercase()),
                 "usage of a legacy numeric method",
             )
         } else {

--- a/tests/ui/legacy_numeric_constants.fixed
+++ b/tests/ui/legacy_numeric_constants.fixed
@@ -97,6 +97,13 @@ fn main() {
     u32::MAX;
     //~^ ERROR: usage of a legacy numeric method
     //~| HELP: use the associated constant instead
+    i32::MAX;
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
+    type Ω = i32;
+    Ω::MAX;
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
 }
 
 #[warn(clippy::legacy_numeric_constants)]

--- a/tests/ui/legacy_numeric_constants.fixed
+++ b/tests/ui/legacy_numeric_constants.fixed
@@ -79,8 +79,23 @@ fn main() {
     f64::consts::E;
     b!();
 
+    std::primitive::i32::MAX;
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
     [(0, "", i128::MAX)];
     //~^ ERROR: usage of a legacy numeric constant
+    //~| HELP: use the associated constant instead
+    i32::MAX;
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
+    assert_eq!(0, -i32::MAX);
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
+    i128::MAX;
+    //~^ ERROR: usage of a legacy numeric constant
+    //~| HELP: use the associated constant instead
+    u32::MAX;
+    //~^ ERROR: usage of a legacy numeric method
     //~| HELP: use the associated constant instead
 }
 

--- a/tests/ui/legacy_numeric_constants.rs
+++ b/tests/ui/legacy_numeric_constants.rs
@@ -79,8 +79,23 @@ fn main() {
     f64::consts::E;
     b!();
 
+    <std::primitive::i32>::max_value();
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
     [(0, "", std::i128::MAX)];
     //~^ ERROR: usage of a legacy numeric constant
+    //~| HELP: use the associated constant instead
+    (i32::max_value());
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
+    assert_eq!(0, -(i32::max_value()));
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
+    (std::i128::MAX);
+    //~^ ERROR: usage of a legacy numeric constant
+    //~| HELP: use the associated constant instead
+    (<u32>::max_value());
+    //~^ ERROR: usage of a legacy numeric method
     //~| HELP: use the associated constant instead
 }
 

--- a/tests/ui/legacy_numeric_constants.rs
+++ b/tests/ui/legacy_numeric_constants.rs
@@ -97,6 +97,13 @@ fn main() {
     (<u32>::max_value());
     //~^ ERROR: usage of a legacy numeric method
     //~| HELP: use the associated constant instead
+    ((i32::max_value)());
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
+    type Ω = i32;
+    Ω::max_value();
+    //~^ ERROR: usage of a legacy numeric method
+    //~| HELP: use the associated constant instead
 }
 
 #[warn(clippy::legacy_numeric_constants)]

--- a/tests/ui/legacy_numeric_constants.stderr
+++ b/tests/ui/legacy_numeric_constants.stderr
@@ -72,10 +72,10 @@ LL |     u32::MAX;
    |     +++++
 
 error: usage of a legacy numeric method
-  --> tests/ui/legacy_numeric_constants.rs:50:10
+  --> tests/ui/legacy_numeric_constants.rs:50:5
    |
 LL |     i32::max_value();
-   |          ^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    |
 help: use the associated constant instead
    |
@@ -84,10 +84,10 @@ LL +     i32::MAX;
    |
 
 error: usage of a legacy numeric method
-  --> tests/ui/legacy_numeric_constants.rs:53:9
+  --> tests/ui/legacy_numeric_constants.rs:53:5
    |
 LL |     u8::max_value();
-   |         ^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
    |
 help: use the associated constant instead
    |
@@ -96,10 +96,10 @@ LL +     u8::MAX;
    |
 
 error: usage of a legacy numeric method
-  --> tests/ui/legacy_numeric_constants.rs:56:9
+  --> tests/ui/legacy_numeric_constants.rs:56:5
    |
 LL |     u8::min_value();
-   |         ^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
    |
 help: use the associated constant instead
    |
@@ -120,10 +120,10 @@ LL +     u8::MIN;
    |
 
 error: usage of a legacy numeric method
-  --> tests/ui/legacy_numeric_constants.rs:62:27
+  --> tests/ui/legacy_numeric_constants.rs:62:5
    |
 LL |     ::std::primitive::u8::min_value();
-   |                           ^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: use the associated constant instead
    |
@@ -132,10 +132,10 @@ LL +     ::std::primitive::u8::MIN;
    |
 
 error: usage of a legacy numeric method
-  --> tests/ui/legacy_numeric_constants.rs:65:26
+  --> tests/ui/legacy_numeric_constants.rs:65:5
    |
 LL |     std::primitive::i32::max_value();
-   |                          ^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: use the associated constant instead
    |
@@ -171,8 +171,20 @@ LL -                 let x = std::u64::MAX;
 LL +                 let x = u64::MAX;
    |
 
+error: usage of a legacy numeric method
+  --> tests/ui/legacy_numeric_constants.rs:82:5
+   |
+LL |     <std::primitive::i32>::max_value();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use the associated constant instead
+   |
+LL -     <std::primitive::i32>::max_value();
+LL +     std::primitive::i32::MAX;
+   |
+
 error: usage of a legacy numeric constant
-  --> tests/ui/legacy_numeric_constants.rs:82:14
+  --> tests/ui/legacy_numeric_constants.rs:85:14
    |
 LL |     [(0, "", std::i128::MAX)];
    |              ^^^^^^^^^^^^^^
@@ -183,8 +195,56 @@ LL -     [(0, "", std::i128::MAX)];
 LL +     [(0, "", i128::MAX)];
    |
 
+error: usage of a legacy numeric method
+  --> tests/ui/legacy_numeric_constants.rs:88:5
+   |
+LL |     (i32::max_value());
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+help: use the associated constant instead
+   |
+LL -     (i32::max_value());
+LL +     i32::MAX;
+   |
+
+error: usage of a legacy numeric method
+  --> tests/ui/legacy_numeric_constants.rs:91:20
+   |
+LL |     assert_eq!(0, -(i32::max_value()));
+   |                    ^^^^^^^^^^^^^^^^^^
+   |
+help: use the associated constant instead
+   |
+LL -     assert_eq!(0, -(i32::max_value()));
+LL +     assert_eq!(0, -i32::MAX);
+   |
+
 error: usage of a legacy numeric constant
-  --> tests/ui/legacy_numeric_constants.rs:116:5
+  --> tests/ui/legacy_numeric_constants.rs:94:5
+   |
+LL |     (std::i128::MAX);
+   |     ^^^^^^^^^^^^^^^^
+   |
+help: use the associated constant instead
+   |
+LL -     (std::i128::MAX);
+LL +     i128::MAX;
+   |
+
+error: usage of a legacy numeric method
+  --> tests/ui/legacy_numeric_constants.rs:97:5
+   |
+LL |     (<u32>::max_value());
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: use the associated constant instead
+   |
+LL -     (<u32>::max_value());
+LL +     u32::MAX;
+   |
+
+error: usage of a legacy numeric constant
+  --> tests/ui/legacy_numeric_constants.rs:131:5
    |
 LL |     std::u32::MAX;
    |     ^^^^^^^^^^^^^
@@ -195,5 +255,5 @@ LL -     std::u32::MAX;
 LL +     u32::MAX;
    |
 
-error: aborting due to 16 previous errors
+error: aborting due to 21 previous errors
 

--- a/tests/ui/legacy_numeric_constants.stderr
+++ b/tests/ui/legacy_numeric_constants.stderr
@@ -243,8 +243,32 @@ LL -     (<u32>::max_value());
 LL +     u32::MAX;
    |
 
+error: usage of a legacy numeric method
+  --> tests/ui/legacy_numeric_constants.rs:100:5
+   |
+LL |     ((i32::max_value)());
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: use the associated constant instead
+   |
+LL -     ((i32::max_value)());
+LL +     i32::MAX;
+   |
+
+error: usage of a legacy numeric method
+  --> tests/ui/legacy_numeric_constants.rs:104:5
+   |
+LL |     Ω::max_value();
+   |     ^^^^^^^^^^^^^^
+   |
+help: use the associated constant instead
+   |
+LL -     Ω::max_value();
+LL +     Ω::MAX;
+   |
+
 error: usage of a legacy numeric constant
-  --> tests/ui/legacy_numeric_constants.rs:131:5
+  --> tests/ui/legacy_numeric_constants.rs:138:5
    |
 LL |     std::u32::MAX;
    |     ^^^^^^^^^^^^^
@@ -255,5 +279,5 @@ LL -     std::u32::MAX;
 LL +     u32::MAX;
    |
 
-error: aborting due to 21 previous errors
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#15008

changelog: [`legacy_numeric_constants`]: fix suggestion when call is inside parentheses like `(i32::max_value())`
