### PR TITLE
Fix `manual_is_variant_and` condition generation

### DIFF
--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -61,7 +61,7 @@ fn option_methods() {
 
     let _ = Some(2).is_some_and(|x| x % 2 == 0);
     //~^ manual_is_variant_and
-    let _ = Some(2).is_none_or(|x| x % 2 == 0);
+    let _ = Some(2).is_none_or(|x| x % 2 != 0);
     //~^ manual_is_variant_and
     let _ = Some(2).is_some_and(|x| x % 2 == 0);
     //~^ manual_is_variant_and
@@ -115,4 +115,114 @@ fn result_methods() {
 fn main() {
     option_methods();
     result_methods();
+}
+
+fn issue15202() {
+    let xs = [None, Some(b'_'), Some(b'1')];
+    for x in xs {
+        let a1 = x.is_none_or(|b| !b.is_ascii_digit());
+        //~^ manual_is_variant_and
+        let a2 = x.is_none_or(|b| !b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.is_none_or(|b| b.is_ascii_digit());
+        //~^ manual_is_variant_and
+        let a2 = x.is_none_or(|b| b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.is_some_and(|b| b.is_ascii_digit());
+        //~^ manual_is_variant_and
+        let a2 = x.is_some_and(|b| b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.is_some_and(|b| !b.is_ascii_digit());
+        //~^ manual_is_variant_and
+        let a2 = x.is_some_and(|b| !b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    let xs = [Err("foo"), Ok(b'_'), Ok(b'1')];
+    for x in xs {
+        let a1 = !x.is_ok_and(|b| b.is_ascii_digit());
+        //~^ manual_is_variant_and
+        let a2 = !x.is_ok_and(|b| b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = !x.is_ok_and(|b| !b.is_ascii_digit());
+        //~^ manual_is_variant_and
+        let a2 = !x.is_ok_and(|b| !b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.is_ok_and(|b| b.is_ascii_digit());
+        //~^ manual_is_variant_and
+        let a2 = x.is_ok_and(|b| b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.is_ok_and(|b| !b.is_ascii_digit());
+        //~^ manual_is_variant_and
+        let a2 = x.is_ok_and(|b| !b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+}
+
+mod with_func {
+    fn iad(b: u8) -> bool {
+        b.is_ascii_digit()
+    }
+
+    fn check_option(b: Option<u8>) {
+        let a1 = b.is_some_and(iad);
+        //~^ manual_is_variant_and
+        let a2 = b.is_some_and(iad);
+        assert_eq!(a1, a2);
+
+        let a1 = b.is_some_and(|x| !iad(x));
+        //~^ manual_is_variant_and
+        let a2 = b.is_some_and(|x| !iad(x));
+        assert_eq!(a1, a2);
+
+        let a1 = b.is_none_or(|x| !iad(x));
+        //~^ manual_is_variant_and
+        let a2 = b.is_none_or(|x| !iad(x));
+        assert_eq!(a1, a2);
+
+        let a1 = b.is_none_or(iad);
+        //~^ manual_is_variant_and
+        let a2 = b.is_none_or(iad);
+        assert_eq!(a1, a2);
+    }
+
+    fn check_result(b: Result<u8, ()>) {
+        let a1 = b.is_ok_and(iad);
+        //~^ manual_is_variant_and
+        let a2 = b.is_ok_and(iad);
+        assert_eq!(a1, a2);
+
+        let a1 = b.is_ok_and(|x| !iad(x));
+        //~^ manual_is_variant_and
+        let a2 = b.is_ok_and(|x| !iad(x));
+        assert_eq!(a1, a2);
+
+        let a1 = !b.is_ok_and(iad);
+        //~^ manual_is_variant_and
+        let a2 = !b.is_ok_and(iad);
+        assert_eq!(a1, a2);
+
+        let a1 = !b.is_ok_and(|x| !iad(x));
+        //~^ manual_is_variant_and
+        let a2 = !b.is_ok_and(|x| !iad(x));
+        assert_eq!(a1, a2);
+    }
 }

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -125,3 +125,113 @@ fn main() {
     option_methods();
     result_methods();
 }
+
+fn issue15202() {
+    let xs = [None, Some(b'_'), Some(b'1')];
+    for x in xs {
+        let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
+        //~^ manual_is_variant_and
+        let a2 = x.is_none_or(|b| !b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
+        //~^ manual_is_variant_and
+        let a2 = x.is_none_or(|b| b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
+        //~^ manual_is_variant_and
+        let a2 = x.is_some_and(|b| b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
+        //~^ manual_is_variant_and
+        let a2 = x.is_some_and(|b| !b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    let xs = [Err("foo"), Ok(b'_'), Ok(b'1')];
+    for x in xs {
+        let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
+        //~^ manual_is_variant_and
+        let a2 = !x.is_ok_and(|b| b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
+        //~^ manual_is_variant_and
+        let a2 = !x.is_ok_and(|b| !b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
+        //~^ manual_is_variant_and
+        let a2 = x.is_ok_and(|b| b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+
+    for x in xs {
+        let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
+        //~^ manual_is_variant_and
+        let a2 = x.is_ok_and(|b| !b.is_ascii_digit());
+        assert_eq!(a1, a2);
+    }
+}
+
+mod with_func {
+    fn iad(b: u8) -> bool {
+        b.is_ascii_digit()
+    }
+
+    fn check_option(b: Option<u8>) {
+        let a1 = b.map(iad) == Some(true);
+        //~^ manual_is_variant_and
+        let a2 = b.is_some_and(iad);
+        assert_eq!(a1, a2);
+
+        let a1 = b.map(iad) == Some(false);
+        //~^ manual_is_variant_and
+        let a2 = b.is_some_and(|x| !iad(x));
+        assert_eq!(a1, a2);
+
+        let a1 = b.map(iad) != Some(true);
+        //~^ manual_is_variant_and
+        let a2 = b.is_none_or(|x| !iad(x));
+        assert_eq!(a1, a2);
+
+        let a1 = b.map(iad) != Some(false);
+        //~^ manual_is_variant_and
+        let a2 = b.is_none_or(iad);
+        assert_eq!(a1, a2);
+    }
+
+    fn check_result(b: Result<u8, ()>) {
+        let a1 = b.map(iad) == Ok(true);
+        //~^ manual_is_variant_and
+        let a2 = b.is_ok_and(iad);
+        assert_eq!(a1, a2);
+
+        let a1 = b.map(iad) == Ok(false);
+        //~^ manual_is_variant_and
+        let a2 = b.is_ok_and(|x| !iad(x));
+        assert_eq!(a1, a2);
+
+        let a1 = b.map(iad) != Ok(true);
+        //~^ manual_is_variant_and
+        let a2 = !b.is_ok_and(iad);
+        assert_eq!(a1, a2);
+
+        let a1 = b.map(iad) != Ok(false);
+        //~^ manual_is_variant_and
+        let a2 = !b.is_ok_and(|x| !iad(x));
+        assert_eq!(a1, a2);
+    }
+}

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -54,7 +54,7 @@ error: called `.map() != Some()`
   --> tests/ui/manual_is_variant_and.rs:70:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != Some(true);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 != 0)`
 
 error: called `.map() == Some()`
   --> tests/ui/manual_is_variant_and.rs:72:13
@@ -126,5 +126,101 @@ error: called `map(<f>).unwrap_or_default()` on a `Result` value
 LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`
 
-error: aborting due to 15 previous errors
+error: called `.map() != Some()`
+  --> tests/ui/manual_is_variant_and.rs:132:18
+   |
+LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| !b.is_ascii_digit())`
+
+error: called `.map() != Some()`
+  --> tests/ui/manual_is_variant_and.rs:139:18
+   |
+LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| b.is_ascii_digit())`
+
+error: called `.map() == Some()`
+  --> tests/ui/manual_is_variant_and.rs:146:18
+   |
+LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| b.is_ascii_digit())`
+
+error: called `.map() == Some()`
+  --> tests/ui/manual_is_variant_and.rs:153:18
+   |
+LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| !b.is_ascii_digit())`
+
+error: called `.map() != Ok()`
+  --> tests/ui/manual_is_variant_and.rs:161:18
+   |
+LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| b.is_ascii_digit())`
+
+error: called `.map() != Ok()`
+  --> tests/ui/manual_is_variant_and.rs:168:18
+   |
+LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| !b.is_ascii_digit())`
+
+error: called `.map() == Ok()`
+  --> tests/ui/manual_is_variant_and.rs:175:18
+   |
+LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| b.is_ascii_digit())`
+
+error: called `.map() == Ok()`
+  --> tests/ui/manual_is_variant_and.rs:182:18
+   |
+LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| !b.is_ascii_digit())`
+
+error: called `.map() == Some()`
+  --> tests/ui/manual_is_variant_and.rs:195:18
+   |
+LL |         let a1 = b.map(iad) == Some(true);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(iad)`
+
+error: called `.map() == Some()`
+  --> tests/ui/manual_is_variant_and.rs:200:18
+   |
+LL |         let a1 = b.map(iad) == Some(false);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(|x| !iad(x))`
+
+error: called `.map() != Some()`
+  --> tests/ui/manual_is_variant_and.rs:205:18
+   |
+LL |         let a1 = b.map(iad) != Some(true);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(|x| !iad(x))`
+
+error: called `.map() != Some()`
+  --> tests/ui/manual_is_variant_and.rs:210:18
+   |
+LL |         let a1 = b.map(iad) != Some(false);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(iad)`
+
+error: called `.map() == Ok()`
+  --> tests/ui/manual_is_variant_and.rs:217:18
+   |
+LL |         let a1 = b.map(iad) == Ok(true);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(iad)`
+
+error: called `.map() == Ok()`
+  --> tests/ui/manual_is_variant_and.rs:222:18
+   |
+LL |         let a1 = b.map(iad) == Ok(false);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(|x| !iad(x))`
+
+error: called `.map() != Ok()`
+  --> tests/ui/manual_is_variant_and.rs:227:18
+   |
+LL |         let a1 = b.map(iad) != Ok(true);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(iad)`
+
+error: called `.map() != Ok()`
+  --> tests/ui/manual_is_variant_and.rs:232:18
+   |
+LL |         let a1 = b.map(iad) != Ok(false);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
When comparing `x.map(func) == Some(bool_lit)`, the value of `bool_lit` was ignored, despite the fact that its value should determine the value of the proposed expression.

`func` can be either a closure or a path. For the latter, η-expansion will be used if needed to invert the result of the function call.

changelog: [`manual_is_variant_and`]: fix inverted suggestions that could lead to code with different semantics

Fixes rust-lang/rust-clippy#15202 

<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [Beta-nomination](https://github.com/rust-lang/rust-clippy/pull/15206#issuecomment-3034006613) by [samueltardieu](https://github.com/samueltardieu)

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->