### PR TITLE
Fix `needless_range_loop` FP and FN on multidimensional array

### DIFF
--- a/tests/ui/needless_range_loop.rs
+++ b/tests/ui/needless_range_loop.rs
@@ -185,3 +185,23 @@ mod issue_2496 {
         unimplemented!()
     }
 }
+
+fn issue_15068() {
+    let a = vec![vec![0u8; MAX_LEN]; MAX_LEN];
+    let b = vec![0u8; MAX_LEN];
+
+    for i in 0..MAX_LEN {
+        // no error
+        let _ = a[0][i];
+        let _ = b[i];
+    }
+
+    // Could be rewrited to:
+    // ```no_run
+    // for <item> in a[0].take(MAX_LEN) {
+    // ```
+    for i in 0..MAX_LEN {
+        //~^ needless_range_loop
+        let _ = a[0][i];
+    }
+}

--- a/tests/ui/needless_range_loop.stderr
+++ b/tests/ui/needless_range_loop.stderr
@@ -168,5 +168,17 @@ LL -     for i in 0..vec.len() {
 LL +     for (i, <item>) in vec.iter_mut().enumerate() {
    |
 
-error: aborting due to 14 previous errors
+error: the loop variable `i` is only used to index `a`
+  --> tests/ui/needless_range_loop.rs:203:14
+   |
+LL |     for i in 0..MAX_LEN {
+   |              ^^^^^^^^^^
+   |
+help: consider using an iterator
+   |
+LL -     for i in 0..MAX_LEN {
+LL +     for <item> in a.iter().take(MAX_LEN) {
+   |
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Fixes: #15068

changelog: Fix [`needless_range_loop`]'s FP and FN when metting multidimensional array