### PR TITLE
Not on vacation, again!

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -52,7 +52,6 @@ contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIB
 users_on_vacation = [
     "matthiaskrgr",
     "Manishearth",
-    "blyxyas",
 ]
 
 [assign.owners]


### PR DESCRIPTION
As I said in my on-vacation PR (a little bit late) I'm getting reincorporated into the review queue. Something that I'd like to do is implement the reviewer capacity system into Clippy, but seems that it's not supported yet. https://github.com/rust-lang/triagebot/issues/2007

r? @ghost
changelog:none
