### PR TITLE
List possible values for configuration enums

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -699,7 +699,7 @@ be filtering for common types.
 
 **Default Value:** `"WellKnownTypes"`
 
-**Values:** `"AllTypes"`, `"Never"`, `"WellKnownTypes"`
+**Possible Values:** `"AllTypes"`, `"Never"`, `"WellKnownTypes"`
 
 ---
 **Affected lints:**
@@ -913,7 +913,7 @@ exported visibility, or whether they are marked as "pub".
 
 **Default Value:** `"PubliclyExported"`
 
-**Values:** `"AllPubFields"`, `"PubliclyExported"`
+**Possible Values:** `"AllPubFields"`, `"PubliclyExported"`
 
 ---
 **Affected lints:**

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -699,6 +699,8 @@ be filtering for common types.
 
 **Default Value:** `"WellKnownTypes"`
 
+**Values:** `"AllTypes"`, `"Never"`, `"WellKnownTypes"`
+
 ---
 **Affected lints:**
 * [`manual_let_else`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else)
@@ -910,6 +912,8 @@ Lint "public" fields in a struct that are prefixed with an underscore based on t
 exported visibility, or whether they are marked as "pub".
 
 **Default Value:** `"PubliclyExported"`
+
+**Values:** `"AllPubFields"`, `"PubliclyExported"`
 
 ---
 **Affected lints:**

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -225,6 +225,7 @@ macro_rules! define_Conf {
         $(#[doc = $doc:literal])+
         $(#[conf_deprecated($dep:literal, $new_conf:ident)])?
         $(#[default_text = $default_text:expr])?
+        $(#[possible_values = [$($possible_value:expr),+]])?
         $(#[disallowed_paths_allow_replacements = $replacements_allowed:expr])?
         $(#[lints($($for_lints:ident),* $(,)?)])?
         $name:ident: $ty:ty = $default:expr,
@@ -315,6 +316,7 @@ macro_rules! define_Conf {
                 ClippyConfiguration {
                     name: stringify!($name).replace('_', "-"),
                     default: default_text!(defaults::$name() $(, $default_text)?),
+                    possible_values: &[$($(stringify!($possible_value)),*)?],
                     lints: &[$($(stringify!($for_lints)),*)?],
                     doc: concat!($($doc, '\n',)*),
                     deprecation_reason: wrap_option!($($dep)?)
@@ -677,6 +679,7 @@ define_Conf! {
     literal_representation_threshold: u64 = 16384,
     /// Whether the matches should be considered by the lint, and whether there should
     /// be filtering for common types.
+    #[possible_values = ["AllTypes", "Never", "WellKnownTypes"]]
     #[lints(manual_let_else)]
     matches_for_let_else: MatchLintBehaviour = MatchLintBehaviour::WellKnownTypes,
     /// The maximum number of bool parameters a function can have
@@ -802,6 +805,7 @@ define_Conf! {
     pass_by_value_size_limit: u64 = 256,
     /// Lint "public" fields in a struct that are prefixed with an underscore based on their
     /// exported visibility, or whether they are marked as "pub".
+    #[possible_values = ["AllPubFields", "PubliclyExported"]]
     #[lints(pub_underscore_fields)]
     pub_underscore_fields_behavior: PubUnderscoreFieldsBehaviour = PubUnderscoreFieldsBehaviour::PubliclyExported,
     /// Whether to lint only if it's multiline.

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -316,7 +316,11 @@ macro_rules! define_Conf {
                 ClippyConfiguration {
                     name: stringify!($name).replace('_', "-"),
                     default: default_text!(defaults::$name() $(, $default_text)?),
-                    possible_values: &[$($(stringify!($possible_value)),*)?],
+                    possible_values: {
+                        let possibilities = &[$($(stringify!($possible_value)),*)?];
+                        assert!(possibilities.len() == std::mem::variant_count::<$ty>());
+                        possibilities
+                    },
                     lints: &[$($(stringify!($for_lints)),*)?],
                     doc: concat!($($doc, '\n',)*),
                     deprecation_reason: wrap_option!($($dep)?)

--- a/clippy_config/src/metadata.rs
+++ b/clippy_config/src/metadata.rs
@@ -5,6 +5,7 @@ use std::fmt;
 pub struct ClippyConfiguration {
     pub name: String,
     pub default: String,
+    pub possible_values: &'static [&'static str],
     pub lints: &'static [&'static str],
     pub doc: &'static str,
     pub deprecation_reason: Option<&'static str>,
@@ -23,10 +24,15 @@ impl fmt::Display for ClippyConfiguration {
 impl ClippyConfiguration {
     pub fn to_markdown_paragraph(&self) -> String {
         format!(
-            "## `{}`\n{}\n\n**Default Value:** `{}`\n\n---\n**Affected lints:**\n{}\n\n",
+            "## `{}`\n{}\n\n**Default Value:** `{}`{}\n\n---\n**Affected lints:**\n{}\n\n",
             self.name,
             self.doc.lines().map(|x| x.strip_prefix(' ').unwrap_or(x)).join("\n"),
             self.default,
+            if self.possible_values.is_empty() {
+                String::new()
+            } else {
+                format!("\n\n**Possible Values:** `{}`", self.possible_values.join("`, `"))
+            },
             self.lints.iter().format_with("\n", |name, f| f(&format_args!(
                 "* [`{name}`](https://rust-lang.github.io/rust-clippy/master/index.html#{name})"
             ))),

--- a/clippy_lints/src/pub_underscore_fields.rs
+++ b/clippy_lints/src/pub_underscore_fields.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad?
     /// Fields prefixed with an `_` are inferred as unused, which suggests it should not be marked
-    /// as `pub`, because marking it as `pub` infers it will be used.
+    /// as `pub`, because marking it as `pub` implies that it will be used.
     ///
     /// ### Example
     /// ```rust


### PR DESCRIPTION
I had to look at clippy's implementation to see what the possible enum values were, so I am making it possible for that information to be more visible with this change.

changelog: Improved lint configuration documentation to show possible enumeration values.
