### PR TITLE
Add `uninlined_format_args` example for `{:?}`

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -128,6 +128,7 @@ declare_clippy_lint! {
     /// # let width = 1;
     /// # let prec = 2;
     /// format!("{}", var);
+    /// format!("{:?}", var);
     /// format!("{v:?}", v = var);
     /// format!("{0} {0}", var);
     /// format!("{0:1$}", var, width);
@@ -139,6 +140,7 @@ declare_clippy_lint! {
     /// # let width = 1;
     /// # let prec = 2;
     /// format!("{var}");
+    /// format!("{var:?}");
     /// format!("{var:?}");
     /// format!("{var} {var}");
     /// format!("{var:width$}");


### PR DESCRIPTION
Before this, you had to guess how to fix a `{:?}` formatting argument. I have happened to guess `{:?var}` in the past, got frustrated, and disabled the lint. This additional example would have saved me a bit of trouble.

changelog: [`uninlined_format_args`]: added an example of how to fix a `{:?}` parameter.