### PR TITLE
`{flat_,}map_identity`: recognize `|[x, y]| [x, y]` as an identity function as well

### DIFF
--- a/tests/ui/flat_map_identity.fixed
+++ b/tests/ui/flat_map_identity.fixed
@@ -16,3 +16,16 @@ fn main() {
     let _ = iterator.flatten();
     //~^ flat_map_identity
 }
+
+fn issue15198() {
+    let x = [[1, 2], [3, 4]];
+    // don't lint: this is an `Iterator<Item = &[i32, i32]>`
+    // match ergonomics makes the binding patterns into references
+    // so that its type changes to `Iterator<Item = [&i32, &i32]>`
+    let _ = x.iter().flat_map(|[x, y]| [x, y]);
+    let _ = x.iter().flat_map(|x| [x[0]]);
+
+    // no match ergonomics for `[i32, i32]`
+    let _ = x.iter().copied().flatten();
+    //~^ flat_map_identity
+}

--- a/tests/ui/flat_map_identity.rs
+++ b/tests/ui/flat_map_identity.rs
@@ -16,3 +16,16 @@ fn main() {
     let _ = iterator.flat_map(|x| return x);
     //~^ flat_map_identity
 }
+
+fn issue15198() {
+    let x = [[1, 2], [3, 4]];
+    // don't lint: this is an `Iterator<Item = &[i32, i32]>`
+    // match ergonomics makes the binding patterns into references
+    // so that its type changes to `Iterator<Item = [&i32, &i32]>`
+    let _ = x.iter().flat_map(|[x, y]| [x, y]);
+    let _ = x.iter().flat_map(|x| [x[0]]);
+
+    // no match ergonomics for `[i32, i32]`
+    let _ = x.iter().copied().flat_map(|[x, y]| [x, y]);
+    //~^ flat_map_identity
+}

--- a/tests/ui/flat_map_identity.stderr
+++ b/tests/ui/flat_map_identity.stderr
@@ -19,5 +19,11 @@ error: use of `flat_map` with an identity function
 LL |     let _ = iterator.flat_map(|x| return x);
    |                      ^^^^^^^^^^^^^^^^^^^^^^ help: try: `flatten()`
 
-error: aborting due to 3 previous errors
+error: use of `flat_map` with an identity function
+  --> tests/ui/flat_map_identity.rs:29:31
+   |
+LL |     let _ = x.iter().copied().flat_map(|[x, y]| [x, y]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `flatten()`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/map_identity.fixed
+++ b/tests/ui/map_identity.fixed
@@ -87,3 +87,15 @@ fn issue13904() {
     let _ = { it }.next();
     //~^ map_identity
 }
+
+// same as `issue11764`, but for arrays
+fn issue15198() {
+    let x = [[1, 2], [3, 4]];
+    // don't lint: `&[i32; 2]` becomes `[&i32; 2]`
+    let _ = x.iter().map(|[x, y]| [x, y]);
+    let _ = x.iter().map(|x| [x[0]]).map(|[x]| x);
+
+    // no match ergonomics for `[i32, i32]`
+    let _ = x.iter().copied();
+    //~^ map_identity
+}

--- a/tests/ui/map_identity.rs
+++ b/tests/ui/map_identity.rs
@@ -93,3 +93,15 @@ fn issue13904() {
     let _ = { it }.map(|x| x).next();
     //~^ map_identity
 }
+
+// same as `issue11764`, but for arrays
+fn issue15198() {
+    let x = [[1, 2], [3, 4]];
+    // don't lint: `&[i32; 2]` becomes `[&i32; 2]`
+    let _ = x.iter().map(|[x, y]| [x, y]);
+    let _ = x.iter().map(|x| [x[0]]).map(|[x]| x);
+
+    // no match ergonomics for `[i32, i32]`
+    let _ = x.iter().copied().map(|[x, y]| [x, y]);
+    //~^ map_identity
+}

--- a/tests/ui/map_identity.stderr
+++ b/tests/ui/map_identity.stderr
@@ -87,5 +87,11 @@ error: unnecessary map of the identity function
 LL |     let _ = { it }.map(|x| x).next();
    |                   ^^^^^^^^^^^ help: remove the call to `map`
 
-error: aborting due to 13 previous errors
+error: unnecessary map of the identity function
+  --> tests/ui/map_identity.rs:105:30
+   |
+LL |     let _ = x.iter().copied().map(|[x, y]| [x, y]);
+   |                              ^^^^^^^^^^^^^^^^^^^^^ help: remove the call to `map`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
changelog: [`map_identity`,`flat_map_identity`]: also recognize `|[x, y]| [x, y]`

fixes rust-lang/rust-clippy#15198