### PR TITLE
Cleanup feature_freeze workflow

### DIFF
--- a/.github/workflows/feature_freeze.yml
+++ b/.github/workflows/feature_freeze.yml
@@ -20,16 +20,26 @@ jobs:
     # of the pull request, as malicious code would be able to access the private
     # GitHub token.
     steps:
-    - name: Check PR Changes
-      id: pr-changes
-      run: echo "::set-output name=changes::${{ toJson(github.event.pull_request.changed_files) }}"
-
-    - name: Create Comment
-      if: steps.pr-changes.outputs.changes != '[]'
-      run: |
-        # Use GitHub API to create a comment on the PR
-        PR_NUMBER=${{ github.event.pull_request.number }}
-        COMMENT="**Seems that you are trying to add a new lint!**\nWe are currently in a [feature freeze](https://doc.rust-lang.org/nightly/clippy/development/feature_freeze.html), so we are delaying all lint-adding PRs to September 18 and focusing on bugfixes.\nThanks a lot for your contribution, and sorry for the inconvenience.\nWith ❤ from the Clippy team\n\n@rustbot note Feature-freeze\n@rustbot blocked\n@rustbot label +A-lint\n"
-        GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-        COMMENT_URL="https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
-        curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST $COMMENT_URL -d "{\"body\":\"$COMMENT\"}"
+      - name: Add freeze warning comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          COMMENT=$(echo "**Seems that you are trying to add a new lint!**\n\
+          \n\
+          We are currently in a [feature freeze](https://doc.rust-lang.org/nightly/clippy/development/feature_freeze.html), so we are delaying all lint-adding PRs to September 18 and [focusing on bugfixes](https://github.com/rust-lang/rust-clippy/issues/15086).\n\
+          \n\
+          Thanks a lot for your contribution, and sorry for the inconvenience.\n\
+          \n\
+          With ❤ from the Clippy team.\n\
+          \n\
+          @rustbot note Feature-freeze\n\
+          @rustbot blocked\n\
+          @rustbot label +A-lint"
+          )
+          curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+             -H "Content-Type: application/vnd.github.raw+json" \
+             -X POST \
+             --data "{\"body\":\"${COMMENT}\"}" \
+             "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments"


### PR DESCRIPTION
Delete the step and the conditional that checks `changes != '[]'` (`github.event.pull_request.changed_file`s returns the number of files changed in the pull request - not the list of changed files)
Escape newlines in the comment body safely
Use Bearer instead of deprecated token

changelog: none 
