### PR TITLE
Update manual_is_variant_and documentation to include equality comparison

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3859,6 +3859,7 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     /// ### What it does
     /// Checks for usage of `option.map(f).unwrap_or_default()` and `result.map(f).unwrap_or_default()` where f is a function or closure that returns the `bool` type.
+    /// Also checks for equality comparisons like `option.map(f) == Some(true)` and `result.map(f) == Ok(true)`.
     ///
     /// ### Why is this bad?
     /// Readability. These can be written more concisely as `option.is_some_and(f)` and `result.is_ok_and(f)`.
@@ -3869,6 +3870,11 @@ declare_clippy_lint! {
     /// # let result: Result<usize, ()> = Ok(1);
     /// option.map(|a| a > 10).unwrap_or_default();
     /// result.map(|a| a > 10).unwrap_or_default();
+    ///
+    /// option.map(|a| a > 10) == Some(true);
+    /// result.map(|a| a > 10) == Ok(true);
+    /// option.map(|a| a > 10) != Some(true);
+    /// result.map(|a| a > 10) != Ok(true);
     /// ```
     /// Use instead:
     /// ```no_run
@@ -3876,11 +3882,16 @@ declare_clippy_lint! {
     /// # let result: Result<usize, ()> = Ok(1);
     /// option.is_some_and(|a| a > 10);
     /// result.is_ok_and(|a| a > 10);
+    ///
+    /// option.is_some_and(|a| a > 10);
+    /// result.is_ok_and(|a| a > 10);
+    /// option.is_none_or(|a| a > 10);
+    /// !result.is_ok_and(|a| a > 10);
     /// ```
     #[clippy::version = "1.77.0"]
     pub MANUAL_IS_VARIANT_AND,
     pedantic,
-    "using `.map(f).unwrap_or_default()`, which is more succinctly expressed as `is_some_and(f)` or `is_ok_and(f)`"
+    "using `.map(f).unwrap_or_default()` or `.map(f) == Some/Ok(true)`, which are more succinctly expressed as `is_some_and(f)` or `is_ok_and(f)`"
 }
 
 declare_clippy_lint! {


### PR DESCRIPTION
Update `manual_is_variant_and` documentation to include equality comparison patterns

This commit updates the documentation for the `manual_is_variant_and` lint to include all linted cases. Previously, the documentation only mentioned the `.map(f).unwrap_or_default()` pattern, but the lint also catches equality comparison patterns like `option.map(f) == Some(true)` and `result.map(f) == Ok(true)`.

changelog: [`manual_is_variant_and`]: Update documentation to include equality comparison patterns

fixes rust-lang/rust-clippy#15217 