### PR TITLE
Fixed issue #15192

### DIFF
--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -1,5 +1,6 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::is_no_std_crate;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::{AdtVariantInfo, approx_ty_size, is_copy};
 use rustc_errors::Applicability;
@@ -83,7 +84,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeEnumVariant {
 
             let mut difference = variants_size[0].size - variants_size[1].size;
             if difference > self.maximum_size_difference_allowed {
-                let help_text = "consider boxing the large fields to reduce the total size of the enum";
+                let help_text = "consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum";
                 span_lint_and_then(
                     cx,
                     LARGE_ENUM_VARIANT,
@@ -117,7 +118,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeEnumVariant {
                                 ident.span,
                                 "boxing a variant would require the type no longer be `Copy`",
                             );
-                        } else {
+                        } else if !is_no_std_crate(cx) {
                             let sugg: Vec<(Span, String)> = variants_size[0]
                                 .fields_size
                                 .iter()

--- a/tests/ui-toml/enum_variant_size/enum_variant_size.stderr
+++ b/tests/ui-toml/enum_variant_size/enum_variant_size.stderr
@@ -12,7 +12,7 @@ LL | | }
    |
    = note: `-D clippy::large-enum-variant` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B([u8; 501]),
 LL +     B(Box<[u8; 501]>),

--- a/tests/ui/large_enum_variant.32bit.stderr
+++ b/tests/ui/large_enum_variant.32bit.stderr
@@ -12,7 +12,7 @@ LL | | }
    |
    = note: `-D clippy::large-enum-variant` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B([i32; 8000]),
 LL +     B(Box<[i32; 8000]>),
@@ -30,7 +30,7 @@ LL | |     ContainingLargeEnum(LargeEnum),
 LL | | }
    | |_^ the entire enum is at least 32004 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     ContainingLargeEnum(LargeEnum),
 LL +     ContainingLargeEnum(Box<LargeEnum>),
@@ -49,7 +49,7 @@ LL | |     StructLikeLittle { x: i32, y: i32 },
 LL | | }
    | |_^ the entire enum is at least 70008 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]),
 LL +     ContainingMoreThanOneField(i32, Box<[i32; 8000]>, Box<[i32; 9500]>),
@@ -67,7 +67,7 @@ LL | |     StructLikeLarge { x: [i32; 8000], y: i32 },
 LL | | }
    | |_^ the entire enum is at least 32008 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     StructLikeLarge { x: [i32; 8000], y: i32 },
 LL +     StructLikeLarge { x: Box<[i32; 8000]>, y: i32 },
@@ -85,7 +85,7 @@ LL | |     StructLikeLarge2 { x: [i32; 8000] },
 LL | | }
    | |_^ the entire enum is at least 32004 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     StructLikeLarge2 { x: [i32; 8000] },
 LL +     StructLikeLarge2 { x: Box<[i32; 8000]> },
@@ -104,7 +104,7 @@ LL | |     C([u8; 200]),
 LL | | }
    | |_^ the entire enum is at least 1256 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B([u8; 1255]),
 LL +     B(Box<[u8; 1255]>),
@@ -122,7 +122,7 @@ LL | |     ContainingMoreThanOneField([i32; 8000], [i32; 2], [i32; 9500], [i32; 
 LL | | }
    | |_^ the entire enum is at least 70132 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     ContainingMoreThanOneField([i32; 8000], [i32; 2], [i32; 9500], [i32; 30]),
 LL +     ContainingMoreThanOneField(Box<[i32; 8000]>, [i32; 2], Box<[i32; 9500]>, [i32; 30]),
@@ -140,7 +140,7 @@ LL | |     B(Struct2),
 LL | | }
    | |_^ the entire enum is at least 32004 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B(Struct2),
 LL +     B(Box<Struct2>),
@@ -158,7 +158,7 @@ LL | |     B(Struct2),
 LL | | }
    | |_^ the entire enum is at least 32000 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B(Struct2),
 LL +     B(Box<Struct2>),
@@ -176,7 +176,7 @@ LL | |     B(Struct2),
 LL | | }
    | |_^ the entire enum is at least 32000 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B(Struct2),
 LL +     B(Box<Struct2>),
@@ -199,7 +199,7 @@ note: boxing a variant would require the type no longer be `Copy`
    |
 LL | enum CopyableLargeEnum {
    |      ^^^^^^^^^^^^^^^^^
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   --> tests/ui/large_enum_variant.rs:118:5
    |
 LL |     B([u64; 8000]),
@@ -222,7 +222,7 @@ note: boxing a variant would require the type no longer be `Copy`
    |
 LL | enum ManuallyCopyLargeEnum {
    |      ^^^^^^^^^^^^^^^^^^^^^
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   --> tests/ui/large_enum_variant.rs:124:5
    |
 LL |     B([u64; 8000]),
@@ -245,7 +245,7 @@ note: boxing a variant would require the type no longer be `Copy`
    |
 LL | enum SomeGenericPossiblyCopyEnum<T> {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   --> tests/ui/large_enum_variant.rs:138:5
    |
 LL |     B([u64; 4000]),
@@ -263,7 +263,7 @@ LL | |     Large((T, [u8; 512])),
 LL | | }
    | |_^ the entire enum is at least 512 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Large((T, [u8; 512])),
 LL +     Large(Box<(T, [u8; 512])>),
@@ -281,7 +281,7 @@ LL | |     Small(u8),
 LL | | }
    | |_^ the entire enum is at least 516 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Large([Foo<u64>; 64]),
 LL +     Large(Box<[Foo<u64>; 64]>),
@@ -299,7 +299,7 @@ LL | |     Error(PossiblyLargeEnumWithConst<256>),
 LL | | }
    | |_^ the entire enum is at least 514 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Error(PossiblyLargeEnumWithConst<256>),
 LL +     Error(Box<PossiblyLargeEnumWithConst<256>>),
@@ -317,7 +317,7 @@ LL | |     Recursive(Box<WithRecursion>),
 LL | | }
    | |_^ the entire enum is at least 516 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Large([u64; 64]),
 LL +     Large(Box<[u64; 64]>),
@@ -335,7 +335,7 @@ LL | |     Error(WithRecursionAndGenerics<u64>),
 LL | | }
    | |_^ the entire enum is at least 516 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Error(WithRecursionAndGenerics<u64>),
 LL +     Error(Box<WithRecursionAndGenerics<u64>>),

--- a/tests/ui/large_enum_variant.64bit.stderr
+++ b/tests/ui/large_enum_variant.64bit.stderr
@@ -12,7 +12,7 @@ LL | | }
    |
    = note: `-D clippy::large-enum-variant` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B([i32; 8000]),
 LL +     B(Box<[i32; 8000]>),
@@ -30,7 +30,7 @@ LL | |     ContainingLargeEnum(LargeEnum),
 LL | | }
    | |_^ the entire enum is at least 32004 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     ContainingLargeEnum(LargeEnum),
 LL +     ContainingLargeEnum(Box<LargeEnum>),
@@ -49,7 +49,7 @@ LL | |     StructLikeLittle { x: i32, y: i32 },
 LL | | }
    | |_^ the entire enum is at least 70008 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]),
 LL +     ContainingMoreThanOneField(i32, Box<[i32; 8000]>, Box<[i32; 9500]>),
@@ -67,7 +67,7 @@ LL | |     StructLikeLarge { x: [i32; 8000], y: i32 },
 LL | | }
    | |_^ the entire enum is at least 32008 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     StructLikeLarge { x: [i32; 8000], y: i32 },
 LL +     StructLikeLarge { x: Box<[i32; 8000]>, y: i32 },
@@ -85,7 +85,7 @@ LL | |     StructLikeLarge2 { x: [i32; 8000] },
 LL | | }
    | |_^ the entire enum is at least 32004 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     StructLikeLarge2 { x: [i32; 8000] },
 LL +     StructLikeLarge2 { x: Box<[i32; 8000]> },
@@ -104,7 +104,7 @@ LL | |     C([u8; 200]),
 LL | | }
    | |_^ the entire enum is at least 1256 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B([u8; 1255]),
 LL +     B(Box<[u8; 1255]>),
@@ -122,7 +122,7 @@ LL | |     ContainingMoreThanOneField([i32; 8000], [i32; 2], [i32; 9500], [i32; 
 LL | | }
    | |_^ the entire enum is at least 70132 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     ContainingMoreThanOneField([i32; 8000], [i32; 2], [i32; 9500], [i32; 30]),
 LL +     ContainingMoreThanOneField(Box<[i32; 8000]>, [i32; 2], Box<[i32; 9500]>, [i32; 30]),
@@ -140,7 +140,7 @@ LL | |     B(Struct2),
 LL | | }
    | |_^ the entire enum is at least 32004 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B(Struct2),
 LL +     B(Box<Struct2>),
@@ -158,7 +158,7 @@ LL | |     B(Struct2),
 LL | | }
    | |_^ the entire enum is at least 32000 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B(Struct2),
 LL +     B(Box<Struct2>),
@@ -176,7 +176,7 @@ LL | |     B(Struct2),
 LL | | }
    | |_^ the entire enum is at least 32000 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     B(Struct2),
 LL +     B(Box<Struct2>),
@@ -199,7 +199,7 @@ note: boxing a variant would require the type no longer be `Copy`
    |
 LL | enum CopyableLargeEnum {
    |      ^^^^^^^^^^^^^^^^^
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   --> tests/ui/large_enum_variant.rs:118:5
    |
 LL |     B([u64; 8000]),
@@ -222,7 +222,7 @@ note: boxing a variant would require the type no longer be `Copy`
    |
 LL | enum ManuallyCopyLargeEnum {
    |      ^^^^^^^^^^^^^^^^^^^^^
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   --> tests/ui/large_enum_variant.rs:124:5
    |
 LL |     B([u64; 8000]),
@@ -245,7 +245,7 @@ note: boxing a variant would require the type no longer be `Copy`
    |
 LL | enum SomeGenericPossiblyCopyEnum<T> {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   --> tests/ui/large_enum_variant.rs:138:5
    |
 LL |     B([u64; 4000]),
@@ -263,7 +263,7 @@ LL | |     Large((T, [u8; 512])),
 LL | | }
    | |_^ the entire enum is at least 512 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Large((T, [u8; 512])),
 LL +     Large(Box<(T, [u8; 512])>),
@@ -281,7 +281,7 @@ LL | |     Small(u8),
 LL | | }
    | |_^ the entire enum is at least 520 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Large([Foo<u64>; 64]),
 LL +     Large(Box<[Foo<u64>; 64]>),
@@ -299,7 +299,7 @@ LL | |     Error(PossiblyLargeEnumWithConst<256>),
 LL | | }
    | |_^ the entire enum is at least 514 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Error(PossiblyLargeEnumWithConst<256>),
 LL +     Error(Box<PossiblyLargeEnumWithConst<256>>),
@@ -317,7 +317,7 @@ LL | |     Recursive(Box<WithRecursion>),
 LL | | }
    | |_^ the entire enum is at least 520 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Large([u64; 64]),
 LL +     Large(Box<[u64; 64]>),
@@ -335,7 +335,7 @@ LL | |     Error(WithRecursionAndGenerics<u64>),
 LL | | }
    | |_^ the entire enum is at least 520 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -     Error(WithRecursionAndGenerics<u64>),
 LL +     Error(Box<WithRecursionAndGenerics<u64>>),
@@ -353,7 +353,7 @@ LL | |         _SmallBoi(u8),
 LL | |     }
    | |_____^ the entire enum is at least 296 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -         BigBoi(PublishWithBytes),
 LL +         BigBoi(Box<PublishWithBytes>),
@@ -371,7 +371,7 @@ LL | |         _SmallBoi(u8),
 LL | |     }
    | |_____^ the entire enum is at least 224 bytes
    |
-help: consider boxing the large fields to reduce the total size of the enum
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
 LL -         BigBoi(PublishWithVec),
 LL +         BigBoi(Box<PublishWithVec>),

--- a/tests/ui/large_enum_variant_no_std.rs
+++ b/tests/ui/large_enum_variant_no_std.rs
@@ -1,0 +1,8 @@
+#![no_std]
+#![warn(clippy::large_enum_variant)]
+
+enum Myenum {
+    //~^ ERROR: large size difference between variants
+    Small(u8),
+    Large([u8; 1024]),
+}

--- a/tests/ui/large_enum_variant_no_std.stderr
+++ b/tests/ui/large_enum_variant_no_std.stderr
@@ -1,0 +1,22 @@
+error: large size difference between variants
+  --> tests/ui/large_enum_variant_no_std.rs:4:1
+   |
+LL | / enum Myenum {
+LL | |
+LL | |     Small(u8),
+   | |     --------- the second-largest variant contains at least 1 bytes
+LL | |     Large([u8; 1024]),
+   | |     ----------------- the largest variant contains at least 1024 bytes
+LL | | }
+   | |_^ the entire enum is at least 1025 bytes
+   |
+help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
+  --> tests/ui/large_enum_variant_no_std.rs:7:5
+   |
+LL |     Large([u8; 1024]),
+   |     ^^^^^^^^^^^^^^^^^
+   = note: `-D clippy::large-enum-variant` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#15192 by adding checks for no_std while giving out Box recommendation

```
changelog: [`large_enum_variant`]: Dont suggest `Box` in `no_std` mode
```

