### PR TITLE
Use `$RUSTC` instead of `rustc` to get version if var is available

### DIFF
--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -157,7 +157,8 @@ pub fn get_commit_date() -> Option<String> {
 
 #[must_use]
 pub fn get_compiler_version() -> Option<String> {
-    get_output("rustc", &["-V"])
+    let compiler = std::option_env!("RUSTC").unwrap_or("rustc");
+    get_output(compiler, &["-V"])
 }
 
 #[must_use]
@@ -172,6 +173,8 @@ pub fn get_channel(compiler_version: Option<String>) -> String {
             return String::from("beta");
         } else if rustc_output.contains("nightly") {
             return String::from("nightly");
+        } else if rustc_output.contains("dev") {
+            return String::from("dev");
         }
     }
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#15249

For the builtin rustc, it should return "dev" as the release channel. Clippy tests pass with this patch in both the Clippy standalone repository and from within the compiler repository.

changelog: none