### PR TITLE
fix false negative of `expect_used`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5546,7 +5546,7 @@ impl Methods {
         // Handle method calls whose receiver and arguments may come from expansion
         if let ExprKind::MethodCall(path, recv, args, _call_span) = expr.kind {
             match (path.ident.name, args) {
-                (sym::expect, [_]) if !matches!(method_call(recv), Some((sym::ok | sym::err, _, [], _, _))) => {
+                (sym::expect, [_]) => {
                     unwrap_expect_used::check(
                         cx,
                         expr,

--- a/tests/ui/expect.rs
+++ b/tests/ui/expect.rs
@@ -16,7 +16,26 @@ fn expect_result() {
     //~^ expect_used
 }
 
+#[allow(clippy::ok_expect)]
+#[allow(clippy::err_expect)]
+fn issue_15247() {
+    let x: Result<u8, u8> = Err(0);
+    x.ok().expect("Huh");
+    //~^ expect_used
+
+    { x.ok() }.expect("...");
+    //~^ expect_used
+
+    let y: Result<u8, u8> = Ok(0);
+    y.err().expect("Huh");
+    //~^ expect_used
+
+    { y.err() }.expect("...");
+    //~^ expect_used
+}
+
 fn main() {
     expect_option();
     expect_result();
+    issue_15247();
 }

--- a/tests/ui/expect.stderr
+++ b/tests/ui/expect.stderr
@@ -24,5 +24,37 @@ LL |     let _ = res.expect_err("");
    |
    = note: if this value is an `Ok`, it will panic
 
-error: aborting due to 3 previous errors
+error: used `expect()` on an `Option` value
+  --> tests/ui/expect.rs:23:5
+   |
+LL |     x.ok().expect("Huh");
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+
+error: used `expect()` on an `Option` value
+  --> tests/ui/expect.rs:26:5
+   |
+LL |     { x.ok() }.expect("...");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+
+error: used `expect()` on an `Option` value
+  --> tests/ui/expect.rs:30:5
+   |
+LL |     y.err().expect("Huh");
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+
+error: used `expect()` on an `Option` value
+  --> tests/ui/expect.rs:33:5
+   |
+LL |     { y.err() }.expect("...");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fixes: #15247

changelog: Fix the false negative of [`expect_used`] when metting `Option::ok().expect`.