### PR TITLE
fix suggestion causes error of `needless_for_each`

### DIFF
--- a/clippy_lints/src/needless_for_each.rs
+++ b/clippy_lints/src/needless_for_each.rs
@@ -101,18 +101,23 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessForEach {
 
             let body_param_sugg = snippet_with_applicability(cx, body.params[0].pat.span, "..", &mut applicability);
             let for_each_rev_sugg = snippet_with_applicability(cx, for_each_recv.span, "..", &mut applicability);
-            let body_value_sugg = snippet_with_applicability(cx, body.value.span, "..", &mut applicability);
+            let body_value_sugg =
+                snippet_with_applicability(cx, get_user_code_span(body.value.span), "..", &mut applicability);
 
             let sugg = format!(
                 "for {} in {} {}",
                 body_param_sugg,
                 for_each_rev_sugg,
-                match body.value.kind {
-                    ExprKind::Block(block, _) if is_let_desugar(block) => {
-                        format!("{{ {body_value_sugg} }}")
-                    },
-                    ExprKind::Block(_, _) => body_value_sugg.to_string(),
-                    _ => format!("{{ {body_value_sugg}; }}"),
+                if body.value.span.from_expansion() {
+                    format!("{{ {body_value_sugg}; }}")
+                } else {
+                    match body.value.kind {
+                        ExprKind::Block(block, _) if is_let_desugar(block) => {
+                            format!("{{ {body_value_sugg} }}")
+                        },
+                        ExprKind::Block(_, _) => body_value_sugg.to_string(),
+                        _ => format!("{{ {body_value_sugg}; }}"),
+                    }
                 }
             );
 
@@ -123,6 +128,22 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessForEach {
                 }
             });
         }
+    }
+}
+
+/// Get user code span from macro expansion span if it is a macro expansion span
+/// or return the original span
+fn get_user_code_span(span: Span) -> Span {
+    if span.from_expansion() {
+        // Recursively get the original call site
+        let mut current_span = span;
+        while current_span.from_expansion() {
+            let expn_data = current_span.ctxt().outer_expn_data();
+            current_span = expn_data.call_site;
+        }
+        current_span
+    } else {
+        span
     }
 }
 

--- a/tests/ui/needless_for_each_fixable.fixed
+++ b/tests/ui/needless_for_each_fixable.fixed
@@ -143,3 +143,9 @@ mod issue14734 {
         //~^ needless_for_each
     }
 }
+
+fn issue15256() {
+    let vec: Vec<i32> = Vec::new();
+    for v in vec.iter() { println!("{v}"); }
+    //~^ needless_for_each
+}

--- a/tests/ui/needless_for_each_fixable.rs
+++ b/tests/ui/needless_for_each_fixable.rs
@@ -143,3 +143,9 @@ mod issue14734 {
         //~^ needless_for_each
     }
 }
+
+fn issue15256() {
+    let vec: Vec<i32> = Vec::new();
+    vec.iter().for_each(|v| println!("{v}"));
+    //~^ needless_for_each
+}

--- a/tests/ui/needless_for_each_fixable.stderr
+++ b/tests/ui/needless_for_each_fixable.stderr
@@ -148,5 +148,11 @@ error: needless use of `for_each`
 LL |         rows.iter().for_each(|x| do_something(x, 1u8));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in rows.iter() { do_something(x, 1u8); }`
 
-error: aborting due to 10 previous errors
+error: needless use of `for_each`
+  --> tests/ui/needless_for_each_fixable.rs:149:5
+   |
+LL |     vec.iter().for_each(|v| println!("{v}"));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for v in vec.iter() { println!("{v}"); }`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fixes: #15256

changelog: fix suggestion causes error of [`needless_for_each`] when the `body.value` comes from macro expansion.
