### PR TITLE
Fix `manual_assert` suggests wrongly for macros

### DIFF
--- a/clippy_lints/src/manual_assert.rs
+++ b/clippy_lints/src/manual_assert.rs
@@ -60,7 +60,8 @@ impl<'tcx> LateLintPass<'tcx> for ManualAssert {
                 ExprKind::Unary(UnOp::Not, e) => (e, ""),
                 _ => (cond, "!"),
             };
-            let cond_sugg = sugg::Sugg::hir_with_applicability(cx, cond, "..", &mut applicability).maybe_paren();
+            let cond_sugg =
+                sugg::Sugg::hir_with_context(cx, cond, expr.span.ctxt(), "..", &mut applicability).maybe_paren();
             let semicolon = if is_parent_stmt(cx, expr.hir_id) { ";" } else { "" };
             let sugg = format!("assert!({not}{cond_sugg}, {format_args_snip}){semicolon}");
             // we show to the user the suggestion without the comments, but when applying the fix, include the

--- a/tests/ui/manual_assert.edition2018.stderr
+++ b/tests/ui/manual_assert.edition2018.stderr
@@ -189,5 +189,23 @@ LL -         };
 LL +         const BAR: () = assert!(!(N == 0), );
    |
 
-error: aborting due to 10 previous errors
+error: only a `panic!` in `if`-then statement
+  --> tests/ui/manual_assert.rs:116:5
+   |
+LL | /     if !is_x86_feature_detected!("ssse3") {
+LL | |
+LL | |         panic!("SSSE3 is not supported");
+LL | |     }
+   | |_____^
+   |
+help: try instead
+   |
+LL -     if !is_x86_feature_detected!("ssse3") {
+LL -
+LL -         panic!("SSSE3 is not supported");
+LL -     }
+LL +     assert!(is_x86_feature_detected!("ssse3"), "SSSE3 is not supported");
+   |
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/manual_assert.edition2021.stderr
+++ b/tests/ui/manual_assert.edition2021.stderr
@@ -189,5 +189,23 @@ LL -         };
 LL +         const BAR: () = assert!(!(N == 0), );
    |
 
-error: aborting due to 10 previous errors
+error: only a `panic!` in `if`-then statement
+  --> tests/ui/manual_assert.rs:116:5
+   |
+LL | /     if !is_x86_feature_detected!("ssse3") {
+LL | |
+LL | |         panic!("SSSE3 is not supported");
+LL | |     }
+   | |_____^
+   |
+help: try instead
+   |
+LL -     if !is_x86_feature_detected!("ssse3") {
+LL -
+LL -         panic!("SSSE3 is not supported");
+LL -     }
+LL +     assert!(is_x86_feature_detected!("ssse3"), "SSSE3 is not supported");
+   |
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/manual_assert.rs
+++ b/tests/ui/manual_assert.rs
@@ -105,3 +105,17 @@ fn issue12505() {
         };
     }
 }
+
+fn issue15227(left: u64, right: u64) -> u64 {
+    macro_rules! is_x86_feature_detected {
+        ($feature:literal) => {
+            $feature.len() > 0 && $feature.starts_with("ss")
+        };
+    }
+
+    if !is_x86_feature_detected!("ssse3") {
+        //~^ manual_assert
+        panic!("SSSE3 is not supported");
+    }
+    unsafe { todo!() }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15227 

changelog: [`manual_assert`] fix wrong suggestions for macros
