### PR TITLE
Fix `as_ptr_cast_mut` FP when `self` is not mutable

### DIFF
--- a/clippy_lints/src/casts/as_ptr_cast_mut.rs
+++ b/clippy_lints/src/casts/as_ptr_cast_mut.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_mutable;
 use clippy_utils::source::SpanRangeExt;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
@@ -20,6 +21,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>,
         && let Some(first_param_ty) = as_ptr_sig.skip_binder().inputs().iter().next()
         && let ty::Ref(_, _, Mutability::Not) = first_param_ty.kind()
         && let Some(recv) = receiver.span.get_source_text(cx)
+        && is_mutable(cx, receiver)
     {
         // `as_mut_ptr` might not exist
         let applicability = Applicability::MaybeIncorrect;

--- a/tests/ui/as_ptr_cast_mut.rs
+++ b/tests/ui/as_ptr_cast_mut.rs
@@ -40,3 +40,12 @@ fn main() {
     let ref_with_write_perm = Covariant(std::ptr::addr_of_mut!(local) as *const _);
     let _ = ref_with_write_perm.as_ptr() as *mut u8;
 }
+
+mod issue15259 {
+    use std::slice::from_raw_parts_mut;
+
+    #[allow(clippy::ptr_arg, clippy::mut_from_ref)]
+    pub fn as_mut_slice<T>(self_: &Vec<T>) -> &mut [T] {
+        unsafe { from_raw_parts_mut(self_.as_ptr() as *mut T, self_.len()) }
+    }
+}


### PR DESCRIPTION
Closes #15259 

changelog: [`as_ptr_cast_mut`] fix FP when `self` is not mutable
