### PR TITLE
Do not run lintcheck summary on feature-freezed PRs

### DIFF
--- a/.github/workflows/lintcheck_summary.yml
+++ b/.github/workflows/lintcheck_summary.yml
@@ -24,7 +24,8 @@ permissions:
 jobs:
   download:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # FIXME(feature freeze): Make sure to remove that last part after the feature freeze is over
+    if: ${{ github.event.workflow_run.conclusion == 'success' && ! contains(github.event.pull_request.labels.*.name, 'A-lint') }}
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -68,7 +69,7 @@ jobs:
             }
 
             let summary = `Lintcheck changes for ${context.payload.workflow_run.head_sha}
-            
+
             | Lint | Added | Removed | Changed |
             | ---- | ----: | ------: | ------: |
             `;


### PR DESCRIPTION
Make sure that lintcheck summary comment do not overwrite PRs with the `A-new-lint` label that is applied on freezed PRs. As the lintcheck summary action runs after conclusion and after lintcheck, it's impossible that it gets executed before applying the label.

(Also, those spaces I added are not an accident, GHA treats empty lines very weirdly) 

r? @flip1995
changelog: none
