### PR TITLE
gh-pages: reduce page size by skipping spaces

### DIFF
--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -148,7 +148,7 @@ Otherwise, have a great day =^.^=
                 <label for="label-{{lint.id}}"> {# #}
                     <h2 class="lint-title"> {# #}
                         <div class="panel-title-name" id="lint-{{lint.id}}"> {# #}
-                            {{lint.id +}}
+                            {{lint.id ~}}
                             <a href="#{{lint.id}}" class="anchor label label-default">&para;</a> {#+ #}
                             <a href="" class="copy-to-clipboard anchor label label-default"> {# #}
                                 &#128203; {# #}


### PR DESCRIPTION
This removes preserved spaces after lint name, marginally reducing page size.
Changing `~}}` into `-}}` will break things: lint name will touch copy buttons on it's right side.

cc @GuillaumeGomez as one who touched this last time

changelog: none