### PR TITLE
Move `uninlined_format_args` to `pedantic`

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -165,7 +165,7 @@ declare_clippy_lint! {
     /// nothing will be suggested, e.g. `println!("{0}={1}", var, 1+2)`.
     #[clippy::version = "1.66.0"]
     pub UNINLINED_FORMAT_ARGS,
-    style,
+    pedantic,
     "using non-inlined variables in `format!` calls"
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15151

See also https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/uninlined_format_args.20is.20contentious/

changelog: Move [`uninlined_format_args`] to `pedantic`
