### PR TITLE
Fix `ptr_as_ptr` suggests wrongly with turbo fish

### DIFF
--- a/tests/ui/ptr_as_ptr.fixed
+++ b/tests/ui/ptr_as_ptr.fixed
@@ -219,3 +219,11 @@ mod null_entire_infer {
         //~^ ptr_as_ptr
     }
 }
+
+#[allow(clippy::transmute_null_to_fn)]
+fn issue15283() {
+    unsafe {
+        let _: fn() = std::mem::transmute(std::ptr::null::<u8>());
+        //~^ ptr_as_ptr
+    }
+}

--- a/tests/ui/ptr_as_ptr.rs
+++ b/tests/ui/ptr_as_ptr.rs
@@ -219,3 +219,11 @@ mod null_entire_infer {
         //~^ ptr_as_ptr
     }
 }
+
+#[allow(clippy::transmute_null_to_fn)]
+fn issue15283() {
+    unsafe {
+        let _: fn() = std::mem::transmute(std::ptr::null::<()>() as *const u8);
+        //~^ ptr_as_ptr
+    }
+}

--- a/tests/ui/ptr_as_ptr.stderr
+++ b/tests/ui/ptr_as_ptr.stderr
@@ -201,5 +201,11 @@ error: `as` casting between raw pointers without changing their constness
 LL |         core::ptr::null() as _
    |         ^^^^^^^^^^^^^^^^^^^^^^ help: try call directly: `core::ptr::null()`
 
-error: aborting due to 33 previous errors
+error: `as` casting between raw pointers without changing their constness
+  --> tests/ui/ptr_as_ptr.rs:226:43
+   |
+LL |         let _: fn() = std::mem::transmute(std::ptr::null::<()>() as *const u8);
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try call directly: `std::ptr::null::<u8>()`
+
+error: aborting due to 34 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15283 

----

changelog: [`ptr_as_ptr`]: fix wrong suggestions with turbo fish
