### PR TITLE
Warn about types not meeting MSRV

### DIFF
--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -26,6 +26,18 @@ fn foo() {
     //~^ incompatible_msrv
 }
 
+#[clippy::msrv = "1.2.0"]
+static NO_BODY_BAD_MSRV: Option<Duration> = None;
+//~^ incompatible_msrv
+
+static NO_BODY_GOOD_MSRV: Option<Duration> = None;
+
+#[clippy::msrv = "1.2.0"]
+fn bad_type_msrv() {
+    let _: Option<Duration> = None;
+    //~^ incompatible_msrv
+}
+
 #[test]
 fn test() {
     sleep(Duration::new(1, 0));
@@ -75,6 +87,12 @@ fn lang_items() {
 fn issue14212() {
     let _ = std::iter::repeat_n((), 5);
     //~^ incompatible_msrv
+}
+
+#[clippy::msrv = "1.0.0"]
+fn cstr_and_cstring_ok() {
+    let _: Option<&'static std::ffi::CStr> = None;
+    let _: Option<std::ffi::CString> = None;
 }
 
 fn local_msrv_change_suggestion() {

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -19,14 +19,26 @@ error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^
 
+error: current MSRV (Minimum Supported Rust Version) is `1.2.0` but this item is stable since `1.3.0`
+  --> tests/ui/incompatible_msrv.rs:30:33
+   |
+LL | static NO_BODY_BAD_MSRV: Option<Duration> = None;
+   |                                 ^^^^^^^^
+
+error: current MSRV (Minimum Supported Rust Version) is `1.2.0` but this item is stable since `1.3.0`
+  --> tests/ui/incompatible_msrv.rs:37:19
+   |
+LL |     let _: Option<Duration> = None;
+   |                   ^^^^^^^^
+
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:49:17
+  --> tests/ui/incompatible_msrv.rs:61:17
    |
 LL |         let _ = core::iter::once_with(|| 0);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:56:21
+  --> tests/ui/incompatible_msrv.rs:68:21
    |
 LL |             let _ = core::iter::once_with(|| $msg);
    |                     ^^^^^^^^^^^^^^^^^^^^^
@@ -37,25 +49,25 @@ LL |     my_panic!("foo");
    = note: this error originates in the macro `my_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:63:13
+  --> tests/ui/incompatible_msrv.rs:75:13
    |
 LL |     assert!(core::iter::once_with(|| 0).next().is_some());
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.80.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:76:13
+  --> tests/ui/incompatible_msrv.rs:88:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:81:13
+  --> tests/ui/incompatible_msrv.rs:99:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:86:17
+  --> tests/ui/incompatible_msrv.rs:104:17
    |
 LL |         let _ = std::iter::repeat_n((), 5);
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -63,22 +75,22 @@ LL |         let _ = std::iter::repeat_n((), 5);
    = note: you may want to conditionally increase the MSRV considered by Clippy using the `clippy::msrv` attribute
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:91:17
+  --> tests/ui/incompatible_msrv.rs:109:17
    |
 LL |         let _ = std::iter::repeat_n((), 5);
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.78.0` but this item is stable since `1.84.0`
-  --> tests/ui/incompatible_msrv.rs:104:7
+  --> tests/ui/incompatible_msrv.rs:122:7
    |
 LL |     r.isqrt()
    |       ^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.85.0`
-  --> tests/ui/incompatible_msrv.rs:109:13
+  --> tests/ui/incompatible_msrv.rs:127:13
    |
 LL |     let _ = std::io::ErrorKind::CrossesDevices;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
For example, the `Duration` type from the standard library was only introduced in Rust 1.3.0.

changelog: [`incompatible_msrv`]: recognize types exceeding MSRV as well

r? Jarcho @rustbot label +C-bug +I-false-negative
