### PR TITLE
Warn about `const` instability wrt MSRV

### DIFF
--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -4,6 +4,7 @@
 #![feature(strict_provenance)] // For use in test
 #![clippy::msrv = "1.3.0"]
 
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::future::Future;
@@ -126,6 +127,45 @@ fn feature_enable_14425(ptr: *const u8) -> usize {
 fn non_fn_items() {
     let _ = std::io::ErrorKind::CrossesDevices;
     //~^ incompatible_msrv
+}
+
+#[clippy::msrv = "1.87.0"]
+fn msrv_non_ok_in_const() {
+    {
+        let c = Cell::new(42);
+        _ = c.get();
+    }
+    const {
+        let c = Cell::new(42);
+        _ = c.get();
+        //~^ incompatible_msrv
+    }
+}
+
+#[clippy::msrv = "1.88.0"]
+fn msrv_ok_in_const() {
+    {
+        let c = Cell::new(42);
+        _ = c.get();
+    }
+    const {
+        let c = Cell::new(42);
+        _ = c.get();
+    }
+}
+
+#[clippy::msrv = "1.86.0"]
+fn enum_variant_not_ok() {
+    let _ = std::io::ErrorKind::InvalidFilename;
+    //~^ incompatible_msrv
+    let _ = const { std::io::ErrorKind::InvalidFilename };
+    //~^ incompatible_msrv
+}
+
+#[clippy::msrv = "1.87.0"]
+fn enum_variant_ok() {
+    let _ = std::io::ErrorKind::InvalidFilename;
+    let _ = const { std::io::ErrorKind::InvalidFilename };
 }
 
 fn main() {}

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -1,5 +1,5 @@
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.10.0`
-  --> tests/ui/incompatible_msrv.rs:15:39
+  --> tests/ui/incompatible_msrv.rs:16:39
    |
 LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    |                                       ^^^^^
@@ -8,37 +8,37 @@ LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.12.0`
-  --> tests/ui/incompatible_msrv.rs:21:11
+  --> tests/ui/incompatible_msrv.rs:22:11
    |
 LL |         v.into_key();
    |           ^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.4.0`
-  --> tests/ui/incompatible_msrv.rs:25:5
+  --> tests/ui/incompatible_msrv.rs:26:5
    |
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.2.0` but this item is stable since `1.3.0`
-  --> tests/ui/incompatible_msrv.rs:30:33
+  --> tests/ui/incompatible_msrv.rs:31:33
    |
 LL | static NO_BODY_BAD_MSRV: Option<Duration> = None;
    |                                 ^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.2.0` but this item is stable since `1.3.0`
-  --> tests/ui/incompatible_msrv.rs:37:19
+  --> tests/ui/incompatible_msrv.rs:38:19
    |
 LL |     let _: Option<Duration> = None;
    |                   ^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:61:17
+  --> tests/ui/incompatible_msrv.rs:62:17
    |
 LL |         let _ = core::iter::once_with(|| 0);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:68:21
+  --> tests/ui/incompatible_msrv.rs:69:21
    |
 LL |             let _ = core::iter::once_with(|| $msg);
    |                     ^^^^^^^^^^^^^^^^^^^^^
@@ -49,25 +49,25 @@ LL |     my_panic!("foo");
    = note: this error originates in the macro `my_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:75:13
+  --> tests/ui/incompatible_msrv.rs:76:13
    |
 LL |     assert!(core::iter::once_with(|| 0).next().is_some());
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.80.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:88:13
+  --> tests/ui/incompatible_msrv.rs:89:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:99:13
+  --> tests/ui/incompatible_msrv.rs:100:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:104:17
+  --> tests/ui/incompatible_msrv.rs:105:17
    |
 LL |         let _ = std::iter::repeat_n((), 5);
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -75,22 +75,40 @@ LL |         let _ = std::iter::repeat_n((), 5);
    = note: you may want to conditionally increase the MSRV considered by Clippy using the `clippy::msrv` attribute
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:109:17
+  --> tests/ui/incompatible_msrv.rs:110:17
    |
 LL |         let _ = std::iter::repeat_n((), 5);
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.78.0` but this item is stable since `1.84.0`
-  --> tests/ui/incompatible_msrv.rs:122:7
+  --> tests/ui/incompatible_msrv.rs:123:7
    |
 LL |     r.isqrt()
    |       ^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.85.0`
-  --> tests/ui/incompatible_msrv.rs:127:13
+  --> tests/ui/incompatible_msrv.rs:128:13
    |
 LL |     let _ = std::io::ErrorKind::CrossesDevices;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: current MSRV (Minimum Supported Rust Version) is `1.87.0` but this item is stable in a `const` context since `1.88.0`
+  --> tests/ui/incompatible_msrv.rs:140:15
+   |
+LL |         _ = c.get();
+   |               ^^^^^
+
+error: current MSRV (Minimum Supported Rust Version) is `1.86.0` but this item is stable since `1.87.0`
+  --> tests/ui/incompatible_msrv.rs:159:13
+   |
+LL |     let _ = std::io::ErrorKind::InvalidFilename;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: current MSRV (Minimum Supported Rust Version) is `1.86.0` but this item is stable since `1.87.0`
+  --> tests/ui/incompatible_msrv.rs:161:21
+   |
+LL |     let _ = const { std::io::ErrorKind::InvalidFilename };
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
This makes `const` contexts use the `const`-stability version information instead of the regular stability one, as `const`-stability may happen much later than stability in non-`const` contexts.

~~It includes the content of PR rust-lang/rust-clippy#15296 as its first commit. I separated them because this one is more complex, and rust-lang/rust-clippy#15296 may be merged more rapidly.~~

changelog: [`incompatible_msrv`]: check the right MSRV when in a `const` context

r? Jarcho @rustbot label +C-bug +I-false-negative

