### PR TITLE
Fix `string_to_string` wrongly suggests `cloned` inside `map`

### DIFF
--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -495,7 +495,9 @@ impl<'tcx> LateLintPass<'tcx> for StringToString {
                     && let ty = cx.typeck_results().expr_ty(self_arg)
                     && is_type_lang_item(cx, ty.peel_refs(), LangItem::String)
                 {
-                    if let Some(parent_span) = is_called_from_map_like(cx, expr) {
+                    if let Some(parent_span) = is_called_from_map_like(cx, expr)
+                        && let ExprKind::Path(_) = self_arg.kind
+                    {
                         suggest_cloned_string_to_string(cx, parent_span);
                     } else {
                         #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]

--- a/tests/ui/string_to_string.rs
+++ b/tests/ui/string_to_string.rs
@@ -19,3 +19,22 @@ fn main() {
     let _ = x.unwrap_or_else(|| v.to_string());
     //~^ string_to_string
 }
+
+mod issue15300 {
+    use std::collections::{BTreeMap, HashSet};
+
+    struct SourceFile {
+        url: String,
+        ty: u32,
+    }
+
+    fn wrong_cloned(sources: BTreeMap<String, SourceFile>) {
+        let _ = sources
+            .iter()
+            .map(|x| x.1)
+            .filter(|x| x.ty == 0)
+            .map(|x| x.url.to_string())
+            //~^ string_to_string
+            .collect::<HashSet<_>>();
+    }
+}

--- a/tests/ui/string_to_string.stderr
+++ b/tests/ui/string_to_string.stderr
@@ -24,5 +24,13 @@ LL |     let _ = x.unwrap_or_else(|| v.to_string());
    |
    = help: consider using `.clone()`
 
-error: aborting due to 3 previous errors
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string.rs:36:22
+   |
+LL |             .map(|x| x.url.to_string())
+   |                      ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `.clone()`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15300 

changelog: [`string_to_string`] fix wrong suggestion of `cloned` inside `map`
