### PR TITLE
Remove unused option `None` for `LEVEL_FILTERS_DEFAULT`

### DIFF
--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -208,7 +208,6 @@ const LEVEL_FILTERS_DEFAULT = {
     allow: true,
     warn: true,
     deny: true,
-    none: true,
 };
 const APPLICABILITIES_FILTER_DEFAULT = {
     Unspecified: true,


### PR DESCRIPTION
Take to account that we don't have lints under under `None` for `LEVEL_FILTERS_DEFAULT` so far https://rust-lang.github.io/rust-clippy/master/index.html?levels=none, we can remove it. 

changelog: none
