### PR TITLE
Split `possible_missing_else` from `suspicious_else_formatting`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6260,6 +6260,7 @@ Released 2018-09-13
 [`pointers_in_nomem_asm_block`]: https://rust-lang.github.io/rust-clippy/master/index.html#pointers_in_nomem_asm_block
 [`positional_named_format_parameters`]: https://rust-lang.github.io/rust-clippy/master/index.html#positional_named_format_parameters
 [`possible_missing_comma`]: https://rust-lang.github.io/rust-clippy/master/index.html#possible_missing_comma
+[`possible_missing_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#possible_missing_else
 [`precedence`]: https://rust-lang.github.io/rust-clippy/master/index.html#precedence
 [`precedence_bits`]: https://rust-lang.github.io/rust-clippy/master/index.html#precedence_bits
 [`print_in_format_impl`]: https://rust-lang.github.io/rust-clippy/master/index.html#print_in_format_impl

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -178,6 +178,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::format_impl::RECURSIVE_FORMAT_IMPL_INFO,
     crate::format_push_string::FORMAT_PUSH_STRING_INFO,
     crate::formatting::POSSIBLE_MISSING_COMMA_INFO,
+    crate::formatting::POSSIBLE_MISSING_ELSE_INFO,
     crate::formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING_INFO,
     crate::formatting::SUSPICIOUS_ELSE_FORMATTING_INFO,
     crate::formatting::SUSPICIOUS_UNARY_OP_FORMATTING_INFO,

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -93,6 +93,31 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for an `if` expression followed by either a block or another `if` that
+    /// looks like it should have an `else` between them.
+    ///
+    /// ### Why is this bad?
+    /// This is probably some refactoring remnant, even if the code is correct, it
+    /// might look confusing.
+    ///
+    /// ### Example
+    /// ```rust,ignore
+    /// if foo {
+    /// } { // looks like an `else` is missing here
+    /// }
+    ///
+    /// if foo {
+    /// } if bar { // looks like an `else` is missing here
+    /// }
+    /// ```
+    #[clippy::version = "1.90.0"]
+    pub POSSIBLE_MISSING_ELSE,
+    suspicious,
+    "possibly missing `else`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for possible missing comma in an array. It lints if
     /// an array element is a binary operator expression and it lies on two lines.
     ///
@@ -116,6 +141,7 @@ declare_lint_pass!(Formatting => [
     SUSPICIOUS_ASSIGNMENT_FORMATTING,
     SUSPICIOUS_UNARY_OP_FORMATTING,
     SUSPICIOUS_ELSE_FORMATTING,
+    POSSIBLE_MISSING_ELSE,
     POSSIBLE_MISSING_COMMA
 ]);
 
@@ -307,7 +333,7 @@ fn check_missing_else(cx: &EarlyContext<'_>, first: &Expr, second: &Expr) {
 
         span_lint_and_note(
             cx,
-            SUSPICIOUS_ELSE_FORMATTING,
+            POSSIBLE_MISSING_ELSE,
             else_span,
             format!("this looks like {looks_like} but the `else` is missing"),
             None,

--- a/tests/ui/suspicious_else_formatting.rs
+++ b/tests/ui/suspicious_else_formatting.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macro_suspicious_else_formatting.rs
 
-#![warn(clippy::suspicious_else_formatting)]
+#![warn(clippy::suspicious_else_formatting, clippy::possible_missing_else)]
 #![allow(
     clippy::if_same_then_else,
     clippy::let_unit_value,
@@ -20,12 +20,12 @@ fn main() {
     // weird `else` formatting:
     if foo() {
     } {
-    //~^ suspicious_else_formatting
+    //~^ possible_missing_else
     }
 
     if foo() {
     } if foo() {
-    //~^ suspicious_else_formatting
+    //~^ possible_missing_else
     }
 
     let _ = { // if as the last expression
@@ -33,7 +33,7 @@ fn main() {
 
         if foo() {
         } if foo() {
-        //~^ suspicious_else_formatting
+        //~^ possible_missing_else
         }
         else {
         }
@@ -42,7 +42,7 @@ fn main() {
     let _ = { // if in the middle of a block
         if foo() {
         } if foo() {
-        //~^ suspicious_else_formatting
+        //~^ possible_missing_else
         }
         else {
         }

--- a/tests/ui/suspicious_else_formatting.stderr
+++ b/tests/ui/suspicious_else_formatting.stderr
@@ -5,8 +5,8 @@ LL |     } {
    |      ^
    |
    = note: to remove this lint, add the missing `else` or add a new line before the next block
-   = note: `-D clippy::suspicious-else-formatting` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::suspicious_else_formatting)]`
+   = note: `-D clippy::possible-missing-else` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::possible_missing_else)]`
 
 error: this looks like an `else if` but the `else` is missing
   --> tests/ui/suspicious_else_formatting.rs:27:6
@@ -41,6 +41,8 @@ LL | |     {
    | |____^
    |
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
+   = note: `-D clippy::suspicious-else-formatting` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::suspicious_else_formatting)]`
 
 error: this is an `else if` but the formatting might hide it
   --> tests/ui/suspicious_else_formatting.rs:67:6


### PR DESCRIPTION
This has always been one lint (added in rust-lang/rust-clippy#720), but the two cases are also quite distinct.

changelog: Split `possible_missing_else` from `suspicious_else_formatting`


<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [Feature-freeze](https://github.com/rust-lang/rust-clippy/pull/15317#issuecomment-3094592022) by [github-actions[bot]](https://github.com/github-actions[bot])

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->