### PR TITLE
Fix false positive in useless_attribute with redundant_imports

### DIFF
--- a/clippy_lints/src/attrs/useless_attribute.rs
+++ b/clippy_lints/src/attrs/useless_attribute.rs
@@ -36,6 +36,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, item: &Item, attrs: &[Attribute]) {
                                     | sym::unused_braces
                                     | sym::unused_import_braces
                                     | sym::unused_imports
+                                    | sym::redundant_imports
                             )
                         {
                             return;

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -261,6 +261,7 @@ generate! {
     read_to_end,
     read_to_string,
     read_unaligned,
+    redundant_imports,
     redundant_pub_crate,
     regex,
     rem_euclid,

--- a/tests/ui/useless_attribute.fixed
+++ b/tests/ui/useless_attribute.fixed
@@ -146,3 +146,15 @@ pub mod unknown_namespace {
     #[allow(rustc::non_glob_import_of_type_ir_inherent)]
     use some_module::SomeType;
 }
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/15316
+pub mod redundant_imports_issue {
+    macro_rules! empty {
+        () => {};
+    }
+
+    #[expect(redundant_imports)]
+    pub(crate) use empty;
+
+    empty!();
+}

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -146,3 +146,15 @@ pub mod unknown_namespace {
     #[allow(rustc::non_glob_import_of_type_ir_inherent)]
     use some_module::SomeType;
 }
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/15316
+pub mod redundant_imports_issue {
+    macro_rules! empty {
+        () => {};
+    }
+
+    #[expect(redundant_imports)]
+    pub(crate) use empty;
+
+    empty!();
+}


### PR DESCRIPTION
Fix false positive in `useless_attribute` with `redundant_imports`

Add `redundant_imports` to the list of allowed lints on use items to prevent
`useless_attribute` from triggering false positives when `#[expect(redundant_imports)]`
or similar attributes are used on use statements.

fixes rust-lang/rust-clippy#15316

---

changelog: [`useless_attribute`]: fix false positive when using `#[expect(redundant_imports)]` and similar lint attributes on `use` statements