### PR TITLE
Fix `module_name_repetitions` FP on exported macros

### DIFF
--- a/clippy_lints/src/item_name_repetitions.rs
+++ b/clippy_lints/src/item_name_repetitions.rs
@@ -8,6 +8,7 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::{EnumDef, FieldDef, Item, ItemKind, OwnerId, QPath, TyKind, Variant, VariantData};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
+use rustc_span::MacroKind;
 use rustc_span::symbol::Symbol;
 
 declare_clippy_lint! {
@@ -502,7 +503,8 @@ impl LateLintPass<'_> for ItemNameRepetitions {
                 );
             }
 
-            if both_are_public && item_camel.len() > mod_camel.len() {
+            let is_macro_rule = matches!(item.kind, ItemKind::Macro(_, _, MacroKind::Bang));
+            if both_are_public && item_camel.len() > mod_camel.len() && !is_macro_rule {
                 let matching = count_match_start(mod_camel, &item_camel);
                 let rmatching = count_match_end(mod_camel, &item_camel);
                 let nchars = mod_camel.chars().count();

--- a/tests/ui/module_name_repetitions.rs
+++ b/tests/ui/module_name_repetitions.rs
@@ -55,3 +55,21 @@ pub mod foo {
 }
 
 fn main() {}
+
+pub mod issue14095 {
+    pub mod widget {
+        #[macro_export]
+        macro_rules! define_widget {
+            ($id:ident) => {
+                /* ... */
+            };
+        }
+
+        #[macro_export]
+        macro_rules! widget_impl {
+            ($id:ident) => {
+                /* ... */
+            };
+        }
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14095 

changelog: [`module_name_repetitions`] fix FP on exported macros
