### PR TITLE
Fix `missing_inline_in_public_items` fail to fulfill `expect` in `--test` build

### DIFF
--- a/tests/ui/missing_inline_executable.rs
+++ b/tests/ui/missing_inline_executable.rs
@@ -1,7 +1,6 @@
-//@ check-pass
-
 #![warn(clippy::missing_inline_in_public_items)]
 
 pub fn foo() {}
+//~^ missing_inline_in_public_items
 
 fn main() {}

--- a/tests/ui/missing_inline_executable.stderr
+++ b/tests/ui/missing_inline_executable.stderr
@@ -1,0 +1,11 @@
+error: missing `#[inline]` for a function
+  --> tests/ui/missing_inline_executable.rs:3:1
+   |
+LL | pub fn foo() {}
+   | ^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::missing-inline-in-public-items` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_inline_in_public_items)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/missing_inline_test_crate.rs
+++ b/tests/ui/missing_inline_test_crate.rs
@@ -6,3 +6,5 @@
 pub fn foo() -> u32 {
     0
 }
+
+fn private_function() {}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#13394

changelog: [`missing_inline_in_public_items`] fix failure to fulfill `expect` in `--test` build
