### PR TITLE
`needless_return`: do not lint on proc macros

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -344,6 +344,9 @@ fn check_final_expr<'tcx>(
     replacement: RetReplacement<'tcx>,
     match_ty_opt: Option<Ty<'_>>,
 ) {
+    if is_from_proc_macro(cx, expr) {
+        return;
+    }
     let peeled_drop_expr = expr.peel_drop_temps();
     match &peeled_drop_expr.kind {
         // simple return is always "bad"


### PR DESCRIPTION
Due to the complexity of the issue and the simplicity of the fix, I'm not being able to reproduce it in the tests (I'm not even being able to reproduce to issue to begin with), but testing it on upstream rust, the panic no longer occurs.

fixes https://github.com/rust-lang/rust-clippy/issues/15338

changelog:[`needless_return`]: Do not run in proc macros.
