### PR TITLE
Remove "Known problems" section for `clippy::redundant_closure`

### DIFF
--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -29,12 +29,6 @@ declare_clippy_lint! {
     /// Needlessly creating a closure adds code for no benefit
     /// and gives the optimizer more work.
     ///
-    /// ### Known problems
-    /// If creating the closure inside the closure has a side-
-    /// effect then moving the closure creation out will change when that side-
-    /// effect runs.
-    /// See [#1439](https://github.com/rust-lang/rust-clippy/issues/1439) for more details.
-    ///
     /// ### Example
     /// ```rust,ignore
     /// xs.map(|x| foo(x))


### PR DESCRIPTION
Remove "Known problems" section for `clippy::redundant_closure` since it was fixed by [this PR](https://github.com/rust-lang/rust-clippy/pull/4008)
We can see this by running examples from [the issue](https://github.com/rust-lang/rust-clippy/issues/1439), for ex. [this one](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=6562527b4c3f6dcebb3c43718341af98) 

changelog: none
