### PR TITLE
Correct help message for `arc_with_non_send_sync`

### DIFF
--- a/clippy_lints/src/arc_with_non_send_sync.rs
+++ b/clippy_lints/src/arc_with_non_send_sync.rs
@@ -73,7 +73,7 @@ impl<'tcx> LateLintPass<'tcx> for ArcWithNonSendSync {
                         diag.note(format!(
                             "`Arc<{arg_ty}>` is not `Send` and `Sync` as `{arg_ty}` is {reason}"
                         ));
-                        diag.help("if the `Arc` will not used be across threads replace it with an `Rc`");
+                        diag.help("if the `Arc` will not be used across threads replace it with an `Rc`");
                         diag.help(format!(
                             "otherwise make `{arg_ty}` `Send` and `Sync` or consider a wrapper type such as `Mutex`"
                         ));

--- a/tests/ui/arc_with_non_send_sync.stderr
+++ b/tests/ui/arc_with_non_send_sync.stderr
@@ -5,7 +5,7 @@ LL |     let _ = Arc::new(RefCell::new(42));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `Arc<RefCell<i32>>` is not `Send` and `Sync` as `RefCell<i32>` is not `Sync`
-   = help: if the `Arc` will not used be across threads replace it with an `Rc`
+   = help: if the `Arc` will not be used across threads replace it with an `Rc`
    = help: otherwise make `RefCell<i32>` `Send` and `Sync` or consider a wrapper type such as `Mutex`
    = note: `-D clippy::arc-with-non-send-sync` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::arc_with_non_send_sync)]`
@@ -17,7 +17,7 @@ LL |     let _ = Arc::new(mutex.lock().unwrap());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `Arc<MutexGuard<'_, i32>>` is not `Send` and `Sync` as `MutexGuard<'_, i32>` is not `Send`
-   = help: if the `Arc` will not used be across threads replace it with an `Rc`
+   = help: if the `Arc` will not be used across threads replace it with an `Rc`
    = help: otherwise make `MutexGuard<'_, i32>` `Send` and `Sync` or consider a wrapper type such as `Mutex`
 
 error: usage of an `Arc` that is not `Send` and `Sync`
@@ -27,7 +27,7 @@ LL |     let _ = Arc::new(&42 as *const i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `Arc<*const i32>` is not `Send` and `Sync` as `*const i32` is neither `Send` nor `Sync`
-   = help: if the `Arc` will not used be across threads replace it with an `Rc`
+   = help: if the `Arc` will not be used across threads replace it with an `Rc`
    = help: otherwise make `*const i32` `Send` and `Sync` or consider a wrapper type such as `Mutex`
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
Small typo fix for the `arc_with_non_send_sync` lint.

changelog: none
