### PR TITLE
expand the issue template for new lints

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_lint.yml
+++ b/.github/ISSUE_TEMPLATE/new_lint.yml
@@ -48,3 +48,24 @@ body:
         ```
     validations:
       required: true
+  - type: textarea
+    id: comparison
+    attributes:
+      label: Comparision with existing lints
+      description: |
+        What makes this lint different from any existing lints that are similar, and how are those differences useful?
+
+        You can [use this playground template to see what existing lints are triggered by the bad code][playground]
+        (make sure to use "Tools > Clippy" and not "Build").
+        You can also look through the list of [rustc's allowed-by-default lints][allowed-by-default],
+        as those won't show up in the playground above.
+
+        [allowed-by-default](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html)
+
+        [playground]: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&code=%23%21%5Bwarn%28clippy%3A%3Apedantic%29%5D%0A%23%21%5Bwarn%28clippy%3A%3Anursery%29%5D%0A%23%21%5Bwarn%28clippy%3A%3Arestriction%29%5D%0A%23%21%5Bwarn%28clippy%3A%3Aall%29%5D%0A%23%21%5Ballow%28clippy%3A%3Ablanket_clippy_restriction_lints%2C+reason+%3D+%22testing+to+see+if+any+restriction+lints+match+given+code%22%29%5D%0A%0A%2F%2F%21+Template+that+can+be+used+to+see+what+clippy+lints+a+given+piece+of+code+would+trigger
+      placeholder: Unlike `clippy::...`, the proposed lint would...
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any additional context that you believe may be relevant.

--- a/.github/ISSUE_TEMPLATE/new_lint.yml
+++ b/.github/ISSUE_TEMPLATE/new_lint.yml
@@ -60,7 +60,7 @@ body:
         You can also look through the list of [rustc's allowed-by-default lints][allowed-by-default],
         as those won't show up in the playground above.
 
-        [allowed-by-default](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html)
+        [allowed-by-default]: https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
 
         [playground]: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&code=%23%21%5Bwarn%28clippy%3A%3Apedantic%29%5D%0A%23%21%5Bwarn%28clippy%3A%3Anursery%29%5D%0A%23%21%5Bwarn%28clippy%3A%3Arestriction%29%5D%0A%23%21%5Bwarn%28clippy%3A%3Aall%29%5D%0A%23%21%5Ballow%28clippy%3A%3Ablanket_clippy_restriction_lints%2C+reason+%3D+%22testing+to+see+if+any+restriction+lints+match+given+code%22%29%5D%0A%0A%2F%2F%21+Template+that+can+be+used+to+see+what+clippy+lints+a+given+piece+of+code+would+trigger
       placeholder: Unlike `clippy::...`, the proposed lint would...


### PR DESCRIPTION
When I first tried contributing to clippy,
I encountered the problem that a lot of lint suggestions overlapped with existing lints, so I would spend a bunch of time implementing something only to figure out it wasn't actually needed.

The "comparison with existing lints" field should hopefully reduce this somewhat, while not incresing the burden of
requesting a new lint too much due to not being mandatory.

changelog: none
