### PR TITLE
fix ip_constant when call wrapped in extra parens

### DIFF
--- a/clippy_lints/src/methods/ip_constant.rs
+++ b/clippy_lints/src/methods/ip_constant.rs
@@ -1,7 +1,7 @@
 use clippy_utils::consts::{ConstEvalCtxt, Constant};
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, QPath, Ty, TyKind};
+use rustc_hir::{Expr, ExprKind, QPath, TyKind};
 use rustc_lint::LateContext;
 use rustc_span::sym;
 use smallvec::SmallVec;
@@ -9,13 +9,8 @@ use smallvec::SmallVec;
 use super::IP_CONSTANT;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, func: &Expr<'_>, args: &[Expr<'_>]) {
-    if let ExprKind::Path(QPath::TypeRelative(
-        Ty {
-            kind: TyKind::Path(QPath::Resolved(_, func_path)),
-            ..
-        },
-        p,
-    )) = func.kind
+    if let ExprKind::Path(QPath::TypeRelative(ty, p)) = func.kind
+        && let TyKind::Path(QPath::Resolved(_, func_path)) = ty.kind
         && p.ident.name == sym::new
         && let Some(func_def_id) = func_path.res.opt_def_id()
         && matches!(
@@ -40,13 +35,15 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, func: &Expr<'_>, args
             _ => return,
         };
 
+        let mut sugg = vec![(expr.span.with_lo(p.ident.span.lo()), constant_name.to_owned())];
+        let before_span = expr.span.shrink_to_lo().until(ty.span);
+        if !before_span.is_empty() {
+            // Remove everything before the type name
+            sugg.push((before_span, String::new()));
+        }
+
         span_lint_and_then(cx, IP_CONSTANT, expr.span, "hand-coded well-known IP address", |diag| {
-            diag.span_suggestion_verbose(
-                expr.span.with_lo(p.ident.span.lo()),
-                "use",
-                constant_name,
-                Applicability::MachineApplicable,
-            );
+            diag.multipart_suggestion_verbose("use", sugg, Applicability::MachineApplicable);
         });
     }
 }

--- a/tests/ui/ip_constant.fixed
+++ b/tests/ui/ip_constant.fixed
@@ -48,6 +48,20 @@ fn literal_test3() {
     //~^ ip_constant
 }
 
+fn wrapped_in_parens() {
+    let _ = std::net::Ipv4Addr::LOCALHOST;
+    //~^ ip_constant
+    let _ = std::net::Ipv4Addr::BROADCAST;
+    //~^ ip_constant
+    let _ = std::net::Ipv4Addr::UNSPECIFIED;
+    //~^ ip_constant
+
+    let _ = std::net::Ipv6Addr::LOCALHOST;
+    //~^ ip_constant
+    let _ = std::net::Ipv6Addr::UNSPECIFIED;
+    //~^ ip_constant
+}
+
 const CONST_U8_0: u8 = 0;
 const CONST_U8_1: u8 = 1;
 const CONST_U8_127: u8 = 127;

--- a/tests/ui/ip_constant.rs
+++ b/tests/ui/ip_constant.rs
@@ -48,6 +48,20 @@ fn literal_test3() {
     //~^ ip_constant
 }
 
+fn wrapped_in_parens() {
+    let _ = (std::net::Ipv4Addr::new(127, 0, 0, 1));
+    //~^ ip_constant
+    let _ = (std::net::Ipv4Addr::new(255, 255, 255, 255));
+    //~^ ip_constant
+    let _ = (std::net::Ipv4Addr::new(0, 0, 0, 0));
+    //~^ ip_constant
+
+    let _ = (std::net::Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    //~^ ip_constant
+    let _ = (std::net::Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
+    //~^ ip_constant
+}
+
 const CONST_U8_0: u8 = 0;
 const CONST_U8_1: u8 = 1;
 const CONST_U8_127: u8 = 127;

--- a/tests/ui/ip_constant.stderr
+++ b/tests/ui/ip_constant.stderr
@@ -181,7 +181,67 @@ LL +     let _ = std::net::Ipv6Addr::UNSPECIFIED;
    |
 
 error: hand-coded well-known IP address
+  --> tests/ui/ip_constant.rs:52:13
+   |
+LL |     let _ = (std::net::Ipv4Addr::new(127, 0, 0, 1));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use
+   |
+LL -     let _ = (std::net::Ipv4Addr::new(127, 0, 0, 1));
+LL +     let _ = std::net::Ipv4Addr::LOCALHOST;
+   |
+
+error: hand-coded well-known IP address
+  --> tests/ui/ip_constant.rs:54:13
+   |
+LL |     let _ = (std::net::Ipv4Addr::new(255, 255, 255, 255));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use
+   |
+LL -     let _ = (std::net::Ipv4Addr::new(255, 255, 255, 255));
+LL +     let _ = std::net::Ipv4Addr::BROADCAST;
+   |
+
+error: hand-coded well-known IP address
+  --> tests/ui/ip_constant.rs:56:13
+   |
+LL |     let _ = (std::net::Ipv4Addr::new(0, 0, 0, 0));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use
+   |
+LL -     let _ = (std::net::Ipv4Addr::new(0, 0, 0, 0));
+LL +     let _ = std::net::Ipv4Addr::UNSPECIFIED;
+   |
+
+error: hand-coded well-known IP address
+  --> tests/ui/ip_constant.rs:59:13
+   |
+LL |     let _ = (std::net::Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use
+   |
+LL -     let _ = (std::net::Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+LL +     let _ = std::net::Ipv6Addr::LOCALHOST;
+   |
+
+error: hand-coded well-known IP address
   --> tests/ui/ip_constant.rs:61:13
+   |
+LL |     let _ = (std::net::Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use
+   |
+LL -     let _ = (std::net::Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
+LL +     let _ = std::net::Ipv6Addr::UNSPECIFIED;
+   |
+
+error: hand-coded well-known IP address
+  --> tests/ui/ip_constant.rs:75:13
    |
 LL |     let _ = Ipv4Addr::new(CONST_U8_127, CONST_U8_0, CONST_U8_0, CONST_U8_1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +253,7 @@ LL +     let _ = Ipv4Addr::LOCALHOST;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:63:13
+  --> tests/ui/ip_constant.rs:77:13
    |
 LL |     let _ = Ipv4Addr::new(CONST_U8_255, CONST_U8_255, CONST_U8_255, CONST_U8_255);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +265,7 @@ LL +     let _ = Ipv4Addr::BROADCAST;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:65:13
+  --> tests/ui/ip_constant.rs:79:13
    |
 LL |     let _ = Ipv4Addr::new(CONST_U8_0, CONST_U8_0, CONST_U8_0, CONST_U8_0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +277,7 @@ LL +     let _ = Ipv4Addr::UNSPECIFIED;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:69:13
+  --> tests/ui/ip_constant.rs:83:13
    |
 LL |       let _ = Ipv6Addr::new(
    |  _____________^
@@ -246,7 +306,7 @@ LL +     let _ = Ipv6Addr::LOCALHOST;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:81:13
+  --> tests/ui/ip_constant.rs:95:13
    |
 LL |       let _ = Ipv6Addr::new(
    |  _____________^
@@ -275,7 +335,7 @@ LL +     let _ = Ipv6Addr::UNSPECIFIED;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:96:13
+  --> tests/ui/ip_constant.rs:110:13
    |
 LL |     let _ = Ipv4Addr::new(126 + 1, 0, 0, 1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -287,7 +347,7 @@ LL +     let _ = Ipv4Addr::LOCALHOST;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:98:13
+  --> tests/ui/ip_constant.rs:112:13
    |
 LL |     let _ = Ipv4Addr::new(254 + CONST_U8_1, 255, { 255 - CONST_U8_0 }, CONST_U8_255);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -299,7 +359,7 @@ LL +     let _ = Ipv4Addr::BROADCAST;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:100:13
+  --> tests/ui/ip_constant.rs:114:13
    |
 LL |     let _ = Ipv4Addr::new(0, CONST_U8_255 - 255, 0, { 1 + 0 - 1 });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -311,7 +371,7 @@ LL +     let _ = Ipv4Addr::UNSPECIFIED;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:104:13
+  --> tests/ui/ip_constant.rs:118:13
    |
 LL |     let _ = Ipv6Addr::new(0 + CONST_U16_0, 0, 0, 0, 0, 0, 0, 1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -323,7 +383,7 @@ LL +     let _ = Ipv6Addr::LOCALHOST;
    |
 
 error: hand-coded well-known IP address
-  --> tests/ui/ip_constant.rs:106:13
+  --> tests/ui/ip_constant.rs:120:13
    |
 LL |     let _ = Ipv6Addr::new(0 + 0, 0, 0, 0, 0, { 2 - 1 - CONST_U16_1 }, 0, 1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -334,5 +394,5 @@ LL -     let _ = Ipv6Addr::new(0 + 0, 0, 0, 0, 0, { 2 - 1 - CONST_U16_1 }, 0, 1)
 LL +     let _ = Ipv6Addr::LOCALHOST;
    |
 
-error: aborting due to 25 previous errors
+error: aborting due to 30 previous errors
 


### PR DESCRIPTION
changelog: [`ip_constant`]: fix suggestion when call is inside parentheses like `(Ipv4Addr::new(127, 0, 0, 1))`

Very similar to the fix in https://github.com/rust-lang/rust-clippy/pull/15191

