### PR TITLE
Fix`unnecessary_safety_comment` does not lint for the first line

### DIFF
--- a/tests/ui-cargo/undocumented_unsafe_blocks/fail/Cargo.stderr
+++ b/tests/ui-cargo/undocumented_unsafe_blocks/fail/Cargo.stderr
@@ -1,0 +1,26 @@
+error: module has unnecessary safety comment
+ --> src/main.rs:2:1
+  |
+2 | mod x {}
+  | ^^^^^^^^
+  |
+help: consider removing the safety comment
+ --> src/main.rs:1:1
+  |
+1 | // SAFETY: ...
+  | ^^^^^^^^^^^^^^
+  = note: requested on the command line with `-D clippy::unnecessary-safety-comment`
+
+error: module has unnecessary safety comment
+ --> src/main.rs:5:1
+  |
+5 | mod y {}
+  | ^^^^^^^^
+  |
+help: consider removing the safety comment
+ --> src/main.rs:4:1
+  |
+4 | // SAFETY: ...
+  | ^^^^^^^^^^^^^^
+
+error: could not compile `undocumented_unsafe_blocks` (bin "undocumented_unsafe_blocks") due to 2 previous errors

--- a/tests/ui-cargo/undocumented_unsafe_blocks/fail/Cargo.toml
+++ b/tests/ui-cargo/undocumented_unsafe_blocks/fail/Cargo.toml
@@ -1,0 +1,12 @@
+# Reproducing #14553 requires the `# Safety` comment to be in the first line of 
+# the file. Since `unnecessary_safety_comment` is not enabled by default, we
+# will set it up here.
+
+[package]
+name = "undocumented_unsafe_blocks"
+edition = "2024"
+publish = false
+version = "0.1.0"
+
+[lints.clippy]
+unnecessary_safety_comment = "deny"

--- a/tests/ui-cargo/undocumented_unsafe_blocks/fail/src/main.rs
+++ b/tests/ui-cargo/undocumented_unsafe_blocks/fail/src/main.rs
@@ -1,0 +1,7 @@
+// SAFETY: ...
+mod x {}
+
+// SAFETY: ...
+mod y {}
+
+fn main() {}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14553
Closes rust-lang/rust-clippy#14554

changelog: [`unnecessary_safety_comment`] fix FN for the first line in file
