### PR TITLE
Fix `empty_structs_with_brackets` suggests wrongly on generics

### DIFF
--- a/clippy_lints/src/empty_with_brackets.rs
+++ b/clippy_lints/src/empty_with_brackets.rs
@@ -93,11 +93,11 @@ impl_lint_pass!(EmptyWithBrackets => [EMPTY_STRUCTS_WITH_BRACKETS, EMPTY_ENUM_VA
 impl LateLintPass<'_> for EmptyWithBrackets {
     fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
         // FIXME: handle `struct $name {}`
-        if let ItemKind::Struct(ident, _, var_data) = &item.kind
+        if let ItemKind::Struct(ident, generics, var_data) = &item.kind
             && !item.span.from_expansion()
             && !ident.span.from_expansion()
             && has_brackets(var_data)
-            && let span_after_ident = item.span.with_lo(ident.span.hi())
+            && let span_after_ident = item.span.with_lo(generics.span.hi())
             && has_no_fields(cx, var_data, span_after_ident)
         {
             span_lint_and_then(

--- a/tests/ui/empty_structs_with_brackets.fixed
+++ b/tests/ui/empty_structs_with_brackets.fixed
@@ -32,3 +32,17 @@ macro_rules! empty_struct {
 empty_struct!(FromMacro);
 
 fn main() {}
+
+mod issue15349 {
+    trait Bar<T> {}
+    impl<T> Bar<T> for [u8; 7] {}
+
+    struct Foo<const N: usize>;
+    //~^ empty_structs_with_brackets
+    impl<const N: usize> Foo<N>
+    where
+        [u8; N]: Bar<[(); N]>,
+    {
+        fn foo() {}
+    }
+}

--- a/tests/ui/empty_structs_with_brackets.rs
+++ b/tests/ui/empty_structs_with_brackets.rs
@@ -32,3 +32,17 @@ macro_rules! empty_struct {
 empty_struct!(FromMacro);
 
 fn main() {}
+
+mod issue15349 {
+    trait Bar<T> {}
+    impl<T> Bar<T> for [u8; 7] {}
+
+    struct Foo<const N: usize> {}
+    //~^ empty_structs_with_brackets
+    impl<const N: usize> Foo<N>
+    where
+        [u8; N]: Bar<[(); N]>,
+    {
+        fn foo() {}
+    }
+}

--- a/tests/ui/empty_structs_with_brackets.stderr
+++ b/tests/ui/empty_structs_with_brackets.stderr
@@ -16,5 +16,13 @@ LL | struct MyEmptyTupleStruct(); // should trigger lint
    |
    = help: remove the brackets
 
-error: aborting due to 2 previous errors
+error: found empty brackets on struct declaration
+  --> tests/ui/empty_structs_with_brackets.rs:40:31
+   |
+LL |     struct Foo<const N: usize> {}
+   |                               ^^^
+   |
+   = help: remove the brackets
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15349

changelog: [`empty_structs_with_brackets`] fix wrong suggestions on generics
