### PR TITLE
Fix `cast-lossless` should not suggest when casting type is from macro input

### DIFF
--- a/clippy_lints/src/casts/cast_lossless.rs
+++ b/clippy_lints/src/casts/cast_lossless.rs
@@ -25,6 +25,12 @@ pub(super) fn check(
         return;
     }
 
+    // If the `as` is from a macro and the casting type is from macro input, whether it is lossless is
+    // dependent on the input
+    if expr.span.from_expansion() && !cast_to_hir.span.eq_ctxt(expr.span) {
+        return;
+    }
+
     span_lint_and_then(
         cx,
         CAST_LOSSLESS,

--- a/tests/ui/cast_lossless_integer_unfixable.rs
+++ b/tests/ui/cast_lossless_integer_unfixable.rs
@@ -1,0 +1,17 @@
+//@check-pass
+#![warn(clippy::cast_lossless)]
+
+fn issue15348() {
+    macro_rules! zero {
+        ($int:ty) => {{
+            let data: [u8; 3] = [0, 0, 0];
+            data[0] as $int
+        }};
+    }
+
+    let _ = zero!(u8);
+    let _ = zero!(u16);
+    let _ = zero!(u32);
+    let _ = zero!(u64);
+    let _ = zero!(u128);
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15348 

The span of the `as` expr is also incorrect, but I believe it is not a bug from Clippy.

changelog: [`cast-lossless`] fix wrong suggestions when casting type is from macro input
