### PR TITLE
Do not specialize for `if_chain` any longer

### DIFF
--- a/clippy_lints/src/index_refutable_slice.rs
+++ b/clippy_lints/src/index_refutable_slice.rs
@@ -4,7 +4,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::higher::IfLet;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::ty::is_copy;
-use clippy_utils::{is_expn_of, is_lint_allowed, path_to_local, sym};
+use clippy_utils::{is_lint_allowed, path_to_local};
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -71,7 +71,7 @@ impl_lint_pass!(IndexRefutableSlice => [INDEX_REFUTABLE_SLICE]);
 impl<'tcx> LateLintPass<'tcx> for IndexRefutableSlice {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) {
         if let Some(IfLet { let_pat, if_then, .. }) = IfLet::hir(cx, expr)
-            && (!expr.span.from_expansion() || is_expn_of(expr.span, sym::if_chain).is_some())
+            && !expr.span.from_expansion()
             && !is_lint_allowed(cx, INDEX_REFUTABLE_SLICE, expr.hir_id)
             && let found_slices = find_slice_values(cx, let_pat)
             && !found_slices.is_empty()

--- a/clippy_test_deps/Cargo.lock
+++ b/clippy_test_deps/Cargo.lock
@@ -70,7 +70,6 @@ name = "clippy_test_deps"
 version = "0.1.0"
 dependencies = [
  "futures",
- "if_chain",
  "itertools",
  "libc",
  "parking_lot",
@@ -181,12 +180,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "if_chain"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "io-uring"

--- a/clippy_test_deps/Cargo.toml
+++ b/clippy_test_deps/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 libc = "0.2"
 regex = "1.5.5"
 serde = { version = "1.0.145", features = ["derive"] }
-if_chain = "1.0"
 quote = "1.0.25"
 syn = { version = "2.0", features = ["full"] }
 futures = "0.3"

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -171,7 +171,6 @@ generate! {
     has_significant_drop,
     hidden_glob_reexports,
     hygiene,
-    if_chain,
     insert,
     inspect,
     int_roundings,

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -73,8 +73,7 @@ fn internal_extern_flags() -> Vec<String> {
             && INTERNAL_TEST_DEPENDENCIES.contains(&name)
         {
             // A dependency may be listed twice if it is available in sysroot,
-            // and the sysroot dependencies are listed first. As of the writing,
-            // this only seems to apply to if_chain.
+            // and the sysroot dependencies are listed first.
             crates.insert(name, path);
         }
     }

--- a/tests/ui/index_refutable_slice/slice_indexing_in_macro.fixed
+++ b/tests/ui/index_refutable_slice/slice_indexing_in_macro.fixed
@@ -1,8 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
 
-extern crate if_chain;
-use if_chain::if_chain;
-
 macro_rules! if_let_slice_macro {
     () => {
         // This would normally be linted
@@ -18,12 +15,9 @@ fn main() {
     if_let_slice_macro!();
 
     // Do lint this
-    if_chain! {
-        let slice: Option<&[u32]> = Some(&[1, 2, 3]);
-        if let Some([slice_0, ..]) = slice;
+    let slice: Option<&[u32]> = Some(&[1, 2, 3]);
+    if let Some([slice_0, ..]) = slice {
         //~^ ERROR: this binding can be a slice pattern to avoid indexing
-        then {
-            println!("{}", slice_0);
-        }
+        println!("{}", slice_0);
     }
 }

--- a/tests/ui/index_refutable_slice/slice_indexing_in_macro.rs
+++ b/tests/ui/index_refutable_slice/slice_indexing_in_macro.rs
@@ -1,8 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
 
-extern crate if_chain;
-use if_chain::if_chain;
-
 macro_rules! if_let_slice_macro {
     () => {
         // This would normally be linted
@@ -18,12 +15,9 @@ fn main() {
     if_let_slice_macro!();
 
     // Do lint this
-    if_chain! {
-        let slice: Option<&[u32]> = Some(&[1, 2, 3]);
-        if let Some(slice) = slice;
+    let slice: Option<&[u32]> = Some(&[1, 2, 3]);
+    if let Some(slice) = slice {
         //~^ ERROR: this binding can be a slice pattern to avoid indexing
-        then {
-            println!("{}", slice[0]);
-        }
+        println!("{}", slice[0]);
     }
 }

--- a/tests/ui/index_refutable_slice/slice_indexing_in_macro.stderr
+++ b/tests/ui/index_refutable_slice/slice_indexing_in_macro.stderr
@@ -1,8 +1,8 @@
 error: this binding can be a slice pattern to avoid indexing
-  --> tests/ui/index_refutable_slice/slice_indexing_in_macro.rs:23:21
+  --> tests/ui/index_refutable_slice/slice_indexing_in_macro.rs:19:17
    |
-LL |         if let Some(slice) = slice;
-   |                     ^^^^^
+LL |     if let Some(slice) = slice {
+   |                 ^^^^^
    |
 note: the lint level is defined here
   --> tests/ui/index_refutable_slice/slice_indexing_in_macro.rs:1:9
@@ -11,10 +11,9 @@ LL | #![deny(clippy::index_refutable_slice)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: replace the binding and indexed access with a slice pattern
    |
-LL ~         if let Some([slice_0, ..]) = slice;
+LL ~     if let Some([slice_0, ..]) = slice {
 LL |
-LL |         then {
-LL ~             println!("{}", slice_0);
+LL ~         println!("{}", slice_0);
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
Now that `if let` chains have been introduced, the `if_chain` external crate is no longer necessary. Dropping special support for it also alleviates the need to keep the crate as a dependency in tests.

This is a cleanup PR.

changelog: none