### PR TITLE
Output lintcheck summary HTML markdown in order

### DIFF
--- a/lintcheck/src/json.rs
+++ b/lintcheck/src/json.rs
@@ -66,7 +66,7 @@ impl fmt::Display for Summary {
         } in &self.0
         {
             let html_id = to_html_id(name);
-            writeln!(f, "| [`{name}`](#{html_id}) | {added} | {changed} | {removed} |")?;
+            writeln!(f, "| [`{name}`](#{html_id}) | {added} | {removed} | {changed} |")?;
         }
 
         Ok(())


### PR DESCRIPTION
The data in the table needs to be in the same order as the headings.

changelog: none

Fixes rust-lang/rust-clippy#15370 