### PR TITLE
fix: `let_with_type_underscore` don't eat closing paren in `let (i): _ = 0;`

### DIFF
--- a/clippy_lints/src/let_with_type_underscore.rs
+++ b/clippy_lints/src/let_with_type_underscore.rs
@@ -1,5 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_from_proc_macro;
+use clippy_utils::source::{IntoSpan, SpanRangeExt};
 use rustc_errors::Applicability;
 use rustc_hir::{LetStmt, TyKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -30,9 +31,15 @@ impl<'tcx> LateLintPass<'tcx> for UnderscoreTyped {
         if let Some(ty) = local.ty // Ensure that it has a type defined
             && let TyKind::Infer(()) = &ty.kind // that type is '_'
             && local.span.eq_ctxt(ty.span)
-            && !local.span.in_external_macro(cx.tcx.sess.source_map())
+            && let sm = cx.tcx.sess.source_map()
+            && !local.span.in_external_macro(sm)
             && !is_from_proc_macro(cx, ty)
         {
+            let span_to_remove = sm
+                .span_extend_to_prev_char_before(ty.span, ':', true)
+                .with_leading_whitespace(cx)
+                .into_span();
+
             span_lint_and_then(
                 cx,
                 LET_WITH_TYPE_UNDERSCORE,
@@ -40,7 +47,7 @@ impl<'tcx> LateLintPass<'tcx> for UnderscoreTyped {
                 "variable declared with type underscore",
                 |diag| {
                     diag.span_suggestion_verbose(
-                        ty.span.with_lo(local.pat.span.hi()),
+                        span_to_remove,
                         "remove the explicit type `_` declaration",
                         "",
                         Applicability::MachineApplicable,

--- a/tests/ui/let_with_type_underscore.fixed
+++ b/tests/ui/let_with_type_underscore.fixed
@@ -45,3 +45,15 @@ fn main() {
         x = ();
     };
 }
+
+fn issue15377() {
+    let (a) = 0;
+    //~^ let_with_type_underscore
+    let ((a)) = 0;
+    //~^ let_with_type_underscore
+    let ((a,)) = (0,);
+    //~^ let_with_type_underscore
+    #[rustfmt::skip]
+    let (   (a   )   ) = 0;
+    //~^ let_with_type_underscore
+}

--- a/tests/ui/let_with_type_underscore.rs
+++ b/tests/ui/let_with_type_underscore.rs
@@ -45,3 +45,15 @@ fn main() {
         x = ();
     };
 }
+
+fn issue15377() {
+    let (a): _ = 0;
+    //~^ let_with_type_underscore
+    let ((a)): _ = 0;
+    //~^ let_with_type_underscore
+    let ((a,)): _ = (0,);
+    //~^ let_with_type_underscore
+    #[rustfmt::skip]
+    let (   (a   )   ):  _ = 0;
+    //~^ let_with_type_underscore
+}

--- a/tests/ui/let_with_type_underscore.stderr
+++ b/tests/ui/let_with_type_underscore.stderr
@@ -60,5 +60,53 @@ LL -     let x : _ = 1;
 LL +     let x = 1;
    |
 
-error: aborting due to 5 previous errors
+error: variable declared with type underscore
+  --> tests/ui/let_with_type_underscore.rs:50:5
+   |
+LL |     let (a): _ = 0;
+   |     ^^^^^^^^^^^^^^^
+   |
+help: remove the explicit type `_` declaration
+   |
+LL -     let (a): _ = 0;
+LL +     let (a) = 0;
+   |
+
+error: variable declared with type underscore
+  --> tests/ui/let_with_type_underscore.rs:52:5
+   |
+LL |     let ((a)): _ = 0;
+   |     ^^^^^^^^^^^^^^^^^
+   |
+help: remove the explicit type `_` declaration
+   |
+LL -     let ((a)): _ = 0;
+LL +     let ((a)) = 0;
+   |
+
+error: variable declared with type underscore
+  --> tests/ui/let_with_type_underscore.rs:54:5
+   |
+LL |     let ((a,)): _ = (0,);
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the explicit type `_` declaration
+   |
+LL -     let ((a,)): _ = (0,);
+LL +     let ((a,)) = (0,);
+   |
+
+error: variable declared with type underscore
+  --> tests/ui/let_with_type_underscore.rs:57:5
+   |
+LL |     let (   (a   )   ):  _ = 0;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the explicit type `_` declaration
+   |
+LL -     let (   (a   )   ):  _ = 0;
+LL +     let (   (a   )   ) = 0;
+   |
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Apparently, one can surround a pattern with an arbitrary number of parens, and the resulting `Pat` won't include the span of those parens. And the previous approach extended the to-be-deleted span all the way to the end of `Pat`'s span, so it included the closing paren.

I think the new approach is more robust anyway, since all we care to remove (besides the `_`) is the `:`, so we search just for that.

~This does leave one extra whitespace in one of the test cases, but I'd say let rustfmt handle that.~ fixed in the third commit

changelog: [`let_with_type_underscore`]: don't eat closing paren in `let (i): _ = 0;`

fixes https://github.com/rust-lang/rust-clippy/issues/15377