### PR TITLE
Remove Deprecated lints mention

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -8,7 +8,7 @@ use cargo_metadata::Message;
 use cargo_metadata::diagnostic::{Applicability, Diagnostic};
 use clippy_config::ClippyConfiguration;
 use clippy_lints::declared_lints::LINTS;
-use clippy_lints::deprecated_lints::{DEPRECATED, DEPRECATED_VERSION, RENAMED};
+use clippy_lints::deprecated_lints::RENAMED;
 use declare_clippy_lint::LintInfo;
 use pulldown_cmark::{Options, Parser, html};
 use serde::Deserialize;
@@ -27,7 +27,7 @@ use std::ffi::{OsStr, OsString};
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Sender, channel};
-use std::{fs, iter, thread};
+use std::{fs, thread};
 
 mod test_utils;
 
@@ -503,10 +503,6 @@ impl DiagnosticCollector {
             let mut metadata: Vec<LintMetadata> = LINTS
                 .iter()
                 .map(|lint| LintMetadata::new(lint, &applicabilities, &configs))
-                .chain(
-                    iter::zip(DEPRECATED, DEPRECATED_VERSION)
-                        .map(|((lint, reason), version)| LintMetadata::new_deprecated(lint, reason, version)),
-                )
                 .collect();
 
             metadata.sort_unstable_by(|a, b| a.id.cmp(&b.id));
@@ -602,28 +598,6 @@ impl LintMetadata {
             docs,
             version: lint.version,
             applicability,
-        }
-    }
-
-    fn new_deprecated(name: &str, reason: &str, version: &'static str) -> Self {
-        // The reason starts with a lowercase letter and ends without a period.
-        // This needs to be fixed for the website.
-        let mut reason = reason.to_owned();
-        if let Some(reason) = reason.get_mut(0..1) {
-            reason.make_ascii_uppercase();
-        }
-        Self {
-            id: name.strip_prefix("clippy::").unwrap().into(),
-            id_location: None,
-            group: "deprecated",
-            level: "none",
-            docs: format!(
-                "### What it does\n\n\
-                Nothing. This lint has been deprecated\n\n\
-                ### Deprecation reason\n\n{reason}.\n",
-            ),
-            version,
-            applicability: Applicability::Unspecified,
         }
     }
 

--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -83,9 +83,6 @@ Otherwise, have a great day =^.^=
                                 <button onclick="toggleElements('groups_filter', true)">All</button> {# #}
                             </li> {# #}
                             <li class="checkbox"> {# #}
-                                <button onclick="resetGroupsToDefault()">Default</button> {# #}
-                            </li> {# #}
-                            <li class="checkbox"> {# #}
                                 <button onclick="toggleElements('groups_filter', false)">None</button> {# #}
                             </li> {# #}
                             <li role="separator" class="divider"></li> {# #}

--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -202,7 +202,6 @@ const GROUPS_FILTER_DEFAULT = {
     restriction: true,
     style: true,
     suspicious: true,
-    deprecated: false,
 };
 const LEVEL_FILTERS_DEFAULT = {
     allow: true,
@@ -394,28 +393,6 @@ function clearVersionFilters() {
     }
 }
 
-function resetGroupsToDefault() {
-    let needsUpdate = false;
-    let count = 0;
-
-    onEachLazy(document.querySelectorAll("#lint-groups-selector input"), el => {
-        const key = el.getAttribute("data-value");
-        const value = GROUPS_FILTER_DEFAULT[key];
-        if (filters.groups_filter[key] !== value) {
-            filters.groups_filter[key] = value;
-            el.checked = value;
-            needsUpdate = true;
-        }
-        if (value) {
-            count += 1;
-        }
-    });
-    document.querySelector("#lint-groups .badge").innerText = count;
-    if (needsUpdate) {
-        filters.filterLints();
-    }
-}
-
 function generateListOfOptions(list, elementId, filter) {
     let html = '';
     let nbEnabled = 0;
@@ -594,7 +571,7 @@ addListeners();
 highlightLazily();
 
 function updateLintCount() {
-    const allLints = filters.getAllLints().filter(lint => lint.group != "deprecated");
+    const allLints = filters.getAllLints();
     const totalLints = allLints.length;
 
     const countElement = document.getElementById("lint-count");

--- a/util/gh-pages/style.css
+++ b/util/gh-pages/style.css
@@ -137,9 +137,6 @@ article:hover .panel-title-name .anchor { display: inline;}
 .lint-group {
     min-width: 8em;
 }
-.group-deprecated {
-    opacity: 0.5;
-}
 
 .doc-folding {
     color: #000;


### PR DESCRIPTION
Noticed that after https://github.com/rust-lang/rust-clippy/pull/15315 we don't [show deprecated lints at all](https://rust-lang.github.io/rust-clippy/master/index.html?groups=deprecated)
Take to account we don't count them at total after https://github.com/rust-lang/rust-clippy/pull/14948 and we don't show them after https://github.com/rust-lang/rust-clippy/pull/15315 perhaps we don't need to show them as well as filters for them so make a cleanup 
<img width="1374" height="727" alt="Screenshot 2025-08-02 at 14 20 34" src="https://github.com/user-attachments/assets/717296c1-32f3-4c09-a365-d81437feecf8" />

changelog: none
