### PR TITLE
fix: `semicolon_inside_block` don't eat closing paren in `({0});`

### DIFF
--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -144,18 +144,15 @@ impl LateLintPass<'_> for SemicolonBlock {
                 kind: ExprKind::Block(block, _),
                 ..
             }) if !block.span.from_expansion() && stmt.span.contains(block.span) => {
-                let Block {
+                if let Block {
                     expr: None,
                     stmts: [.., stmt],
                     ..
                 } = block
-                else {
-                    return;
-                };
-                let StmtKind::Semi(expr) = stmt.kind else {
-                    return;
-                };
-                self.semicolon_outside_block(cx, block, expr);
+                    && let StmtKind::Semi(expr) = stmt.kind
+                {
+                    self.semicolon_outside_block(cx, block, expr);
+                }
             },
             StmtKind::Semi(Expr {
                 kind: ExprKind::Block(block @ Block { expr: Some(tail), .. }, _),

--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -102,7 +102,7 @@ impl SemicolonBlock {
     }
 
     fn semicolon_outside_block(&self, cx: &LateContext<'_>, block: &Block<'_>, tail_stmt_expr: &Expr<'_>) {
-        let insert_span = block.span.with_lo(block.span.hi());
+        let insert_span = block.span.shrink_to_hi();
 
         // For macro call semicolon statements (`mac!();`), the statement's span does not actually
         // include the semicolon itself, so use `mac_call_stmt_semi_span`, which finds the semicolon

--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -152,11 +152,7 @@ impl LateLintPass<'_> for SemicolonBlock {
                 else {
                     return;
                 };
-                let &Stmt {
-                    kind: StmtKind::Semi(expr),
-                    ..
-                } = stmt
-                else {
+                let StmtKind::Semi(expr) = stmt.kind else {
                     return;
                 };
                 self.semicolon_outside_block(cx, block, expr);

--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -163,9 +163,5 @@ impl LateLintPass<'_> for SemicolonBlock {
 }
 
 fn get_line(cx: &LateContext<'_>, span: Span) -> Option<usize> {
-    if let Ok(line) = cx.sess().source_map().lookup_line(span.lo()) {
-        return Some(line.line);
-    }
-
-    None
+    cx.sess().source_map().lookup_line(span.lo()).ok().map(|line| line.line)
 }

--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -152,10 +152,12 @@ impl LateLintPass<'_> for SemicolonBlock {
                 }
             },
             StmtKind::Semi(Expr {
-                kind: ExprKind::Block(block @ Block { expr: Some(tail), .. }, _),
+                kind: ExprKind::Block(block, _),
                 ..
             }) if !block.span.from_expansion() => {
-                self.semicolon_inside_block(cx, block, tail, stmt.span);
+                if let Some(tail) = block.expr {
+                    self.semicolon_inside_block(cx, block, tail, stmt.span);
+                }
             },
             _ => (),
         }

--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -144,11 +144,8 @@ impl LateLintPass<'_> for SemicolonBlock {
                 kind: ExprKind::Block(block, _),
                 ..
             }) if !block.span.from_expansion() && stmt.span.contains(block.span) => {
-                if let Block {
-                    expr: None,
-                    stmts: [.., stmt],
-                    ..
-                } = block
+                if let None = block.expr
+                    && let [.., stmt] = block.stmts
                     && let StmtKind::Semi(expr) = stmt.kind
                 {
                     self.semicolon_outside_block(cx, block, expr);

--- a/tests/ui/semicolon_inside_block.fixed
+++ b/tests/ui/semicolon_inside_block.fixed
@@ -3,7 +3,8 @@
     clippy::unused_unit,
     clippy::unnecessary_operation,
     clippy::no_effect,
-    clippy::single_element_loop
+    clippy::single_element_loop,
+    clippy::double_parens
 )]
 #![warn(clippy::semicolon_inside_block)]
 
@@ -85,4 +86,20 @@ fn main() {
     { unit_fn_block(); };
 
     unit_fn_block()
+}
+
+fn issue15380() {
+    #[rustfmt::skip]
+    ( {0;0;}
+    //~^ semicolon_inside_block
+
+    ({
+        //~^ semicolon_inside_block
+        0;
+        0;
+    }
+
+    #[rustfmt::skip]
+    (({0;}
+    //~^ semicolon_inside_block
 }

--- a/tests/ui/semicolon_inside_block.fixed
+++ b/tests/ui/semicolon_inside_block.fixed
@@ -88,18 +88,64 @@ fn main() {
     unit_fn_block()
 }
 
-fn issue15380() {
+// TODO: merge the function bodies once https://github.com/rust-lang/rust-clippy/issues/15389 is fixed
+//
+// Right now, if `first` and `second` were to be merged (uitest comments omitted for clarity):
+// ``` fn issue15380() {
+//     ( {0;0});
+//     ({
+//         0;
+//         0
+//     });
+// }
+// ```
+// then the fixed version would look as follows:
+// ```
+// fn issue15380() {
+//     ( {0;0;})
+//     ({
+//         0;
+//         0
+//     });
+// }
+// ```
+// However, that looks like a function call `(f)(x)`, and so we get an error because `{0;0;}` is
+// not a function.
+mod issue15380 {
+    // TODO: apply `[rustfmt::skip]` only to the block once https://github.com/rust-lang/rust-clippy/issues/15388 is fixed
+    //
+    // If we do this right now:
+    // ```
+    // fn issue15380() {
+    //     #[rustfmt::skip]
+    //     ( {0;0});
+    // }
+    // ```
+    // then the fixed version would look as follows:
+    // ```
+    // fn issue15380() {
+    //     #[rustfmt::skip]
+    //     ( {0;0;})
+    // }
+    // ```
+    // But that wouldn't compile because `[rustfmt::skip]` is now placed on an expr
     #[rustfmt::skip]
-    ( {0;0;}
-    //~^ semicolon_inside_block
-
-    ({
+    fn first() {
+        ( {0;0;}
         //~^ semicolon_inside_block
-        0;
-        0;
     }
 
-    #[rustfmt::skip]
-    (({0;}
-    //~^ semicolon_inside_block
+    fn second() {
+        ({
+            //~^ semicolon_inside_block
+            0;
+            0;
+        }
+    }
+
+    #[rustfmt::skip] // TODO: apply onto the block itself, see explanation in `first`
+    fn third() {
+        (({ 0; }
+        //~^ semicolon_inside_block
+    }
 }

--- a/tests/ui/semicolon_inside_block.fixed
+++ b/tests/ui/semicolon_inside_block.fixed
@@ -131,7 +131,7 @@ mod issue15380 {
     // But that wouldn't compile because `[rustfmt::skip]` is now placed on an expr
     #[rustfmt::skip]
     fn first() {
-        ( {0;0;}
+        ( {0;0;})
         //~^ semicolon_inside_block
     }
 
@@ -140,12 +140,12 @@ mod issue15380 {
             //~^ semicolon_inside_block
             0;
             0;
-        }
+        })
     }
 
     #[rustfmt::skip] // TODO: apply onto the block itself, see explanation in `first`
     fn third() {
-        (({ 0; }
+        (({ 0; }))
         //~^ semicolon_inside_block
     }
 }

--- a/tests/ui/semicolon_inside_block.rs
+++ b/tests/ui/semicolon_inside_block.rs
@@ -3,7 +3,8 @@
     clippy::unused_unit,
     clippy::unnecessary_operation,
     clippy::no_effect,
-    clippy::single_element_loop
+    clippy::single_element_loop,
+    clippy::double_parens
 )]
 #![warn(clippy::semicolon_inside_block)]
 
@@ -85,4 +86,20 @@ fn main() {
     { unit_fn_block(); };
 
     unit_fn_block()
+}
+
+fn issue15380() {
+    #[rustfmt::skip]
+    ( {0;0});
+    //~^ semicolon_inside_block
+
+    ({
+        //~^ semicolon_inside_block
+        0;
+        0
+    });
+
+    #[rustfmt::skip]
+    (({0}))    ;
+    //~^ semicolon_inside_block
 }

--- a/tests/ui/semicolon_inside_block.rs
+++ b/tests/ui/semicolon_inside_block.rs
@@ -88,18 +88,64 @@ fn main() {
     unit_fn_block()
 }
 
-fn issue15380() {
+// TODO: merge the function bodies once https://github.com/rust-lang/rust-clippy/issues/15389 is fixed
+//
+// Right now, if `first` and `second` were to be merged (uitest comments omitted for clarity):
+// ``` fn issue15380() {
+//     ( {0;0});
+//     ({
+//         0;
+//         0
+//     });
+// }
+// ```
+// then the fixed version would look as follows:
+// ```
+// fn issue15380() {
+//     ( {0;0;})
+//     ({
+//         0;
+//         0
+//     });
+// }
+// ```
+// However, that looks like a function call `(f)(x)`, and so we get an error because `{0;0;}` is
+// not a function.
+mod issue15380 {
+    // TODO: apply `[rustfmt::skip]` only to the block once https://github.com/rust-lang/rust-clippy/issues/15388 is fixed
+    //
+    // If we do this right now:
+    // ```
+    // fn issue15380() {
+    //     #[rustfmt::skip]
+    //     ( {0;0});
+    // }
+    // ```
+    // then the fixed version would look as follows:
+    // ```
+    // fn issue15380() {
+    //     #[rustfmt::skip]
+    //     ( {0;0;})
+    // }
+    // ```
+    // But that wouldn't compile because `[rustfmt::skip]` is now placed on an expr
     #[rustfmt::skip]
-    ( {0;0});
-    //~^ semicolon_inside_block
-
-    ({
+    fn first() {
+        ( {0;0});
         //~^ semicolon_inside_block
-        0;
-        0
-    });
+    }
 
-    #[rustfmt::skip]
-    (({0}))    ;
-    //~^ semicolon_inside_block
+    fn second() {
+        ({
+            //~^ semicolon_inside_block
+            0;
+            0
+        });
+    }
+
+    #[rustfmt::skip] // TODO: apply onto the block itself, see explanation in `first`
+    fn third() {
+        (({ 0 }))      ;
+        //~^ semicolon_inside_block
+    }
 }

--- a/tests/ui/semicolon_inside_block.stderr
+++ b/tests/ui/semicolon_inside_block.stderr
@@ -61,7 +61,7 @@ LL |         ( {0;0});
 help: put the `;` here
    |
 LL -         ( {0;0});
-LL +         ( {0;0;}
+LL +         ( {0;0;})
    |
 
 error: consider moving the `;` inside the block for consistent formatting
@@ -77,7 +77,7 @@ LL | |         });
 help: put the `;` here
    |
 LL ~             0;
-LL ~         }
+LL ~         })
    |
 
 error: consider moving the `;` inside the block for consistent formatting
@@ -89,7 +89,7 @@ LL |         (({ 0 }))      ;
 help: put the `;` here
    |
 LL -         (({ 0 }))      ;
-LL +         (({ 0; }
+LL +         (({ 0; }))
    |
 
 error: aborting due to 7 previous errors

--- a/tests/ui/semicolon_inside_block.stderr
+++ b/tests/ui/semicolon_inside_block.stderr
@@ -1,5 +1,5 @@
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:38:5
+  --> tests/ui/semicolon_inside_block.rs:39:5
    |
 LL |     { unit_fn_block() };
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     { unit_fn_block(); }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:40:5
+  --> tests/ui/semicolon_inside_block.rs:41:5
    |
 LL |     unsafe { unit_fn_block() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     unsafe { unit_fn_block(); }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:49:5
+  --> tests/ui/semicolon_inside_block.rs:50:5
    |
 LL | /     {
 LL | |
@@ -41,7 +41,7 @@ LL ~     }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:63:5
+  --> tests/ui/semicolon_inside_block.rs:64:5
    |
 LL |     { m!(()) };
    |     ^^^^^^^^^^^
@@ -52,5 +52,45 @@ LL -     { m!(()) };
 LL +     { m!(()); }
    |
 
-error: aborting due to 4 previous errors
+error: consider moving the `;` inside the block for consistent formatting
+  --> tests/ui/semicolon_inside_block.rs:93:5
+   |
+LL |     ( {0;0});
+   |     ^^^^^^^^^
+   |
+help: put the `;` here
+   |
+LL -     ( {0;0});
+LL +     ( {0;0;}
+   |
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> tests/ui/semicolon_inside_block.rs:96:5
+   |
+LL | /     ({
+LL | |
+LL | |         0;
+LL | |         0
+LL | |     });
+   | |_______^
+   |
+help: put the `;` here
+   |
+LL ~         0;
+LL ~     }
+   |
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> tests/ui/semicolon_inside_block.rs:103:5
+   |
+LL |     (({0}))    ;
+   |     ^^^^^^^^^^^^
+   |
+help: put the `;` here
+   |
+LL -     (({0}))    ;
+LL +     (({0;}
+   |
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/semicolon_inside_block.stderr
+++ b/tests/ui/semicolon_inside_block.stderr
@@ -53,43 +53,43 @@ LL +     { m!(()); }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:93:5
+  --> tests/ui/semicolon_inside_block.rs:134:9
    |
-LL |     ( {0;0});
-   |     ^^^^^^^^^
+LL |         ( {0;0});
+   |         ^^^^^^^^^
    |
 help: put the `;` here
    |
-LL -     ( {0;0});
-LL +     ( {0;0;}
+LL -         ( {0;0});
+LL +         ( {0;0;}
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:96:5
+  --> tests/ui/semicolon_inside_block.rs:139:9
    |
-LL | /     ({
+LL | /         ({
 LL | |
-LL | |         0;
-LL | |         0
-LL | |     });
-   | |_______^
+LL | |             0;
+LL | |             0
+LL | |         });
+   | |___________^
    |
 help: put the `;` here
    |
-LL ~         0;
-LL ~     }
+LL ~             0;
+LL ~         }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:103:5
+  --> tests/ui/semicolon_inside_block.rs:148:9
    |
-LL |     (({0}))    ;
-   |     ^^^^^^^^^^^^
+LL |         (({ 0 }))      ;
+   |         ^^^^^^^^^^^^^^^^
    |
 help: put the `;` here
    |
-LL -     (({0}))    ;
-LL +     (({0;}
+LL -         (({ 0 }))      ;
+LL +         (({ 0; }
    |
 
 error: aborting due to 7 previous errors


### PR DESCRIPTION
depends on https://github.com/rust-lang/rust-clippy/pull/15390, but not critically

changelog: [`semicolon_inside_block`] don't eat closing paren in `({0});`

fixes https://github.com/rust-lang/rust-clippy/issues/15380

PS: this is almost identical to https://github.com/rust-lang/rust-clippy/pull/15386 -- I wonder if there's a better way of doing this, given that pretty much anything in Rust can be wrapped in (an arbitrary number of) parens without change of meaning