### PR TITLE
feat: `manual_rotate` also recognize non-consts

### DIFF
--- a/tests/ui/manual_rotate.fixed
+++ b/tests/ui/manual_rotate.fixed
@@ -44,3 +44,20 @@ fn main() {
     let mut l = vec![12_u8, 34];
     let y = (l.pop().unwrap() << 3) + (l.pop().unwrap() >> 5);
 }
+
+fn issue13028() {
+    let s = 5;
+    let u = 5;
+    let x: u32 = 123456;
+
+    let _ = x.rotate_left(s);
+    //~^ manual_rotate
+    let _ = x.rotate_left(s);
+    //~^ manual_rotate
+    // still works with consts
+    let _ = x.rotate_right(9);
+    //~^ manual_rotate
+
+    // don't lint, because `s` and `u` are different variables, albeit with the same value
+    let _ = (x << s) | (x >> (32 - u));
+}

--- a/tests/ui/manual_rotate.rs
+++ b/tests/ui/manual_rotate.rs
@@ -44,3 +44,20 @@ fn main() {
     let mut l = vec![12_u8, 34];
     let y = (l.pop().unwrap() << 3) + (l.pop().unwrap() >> 5);
 }
+
+fn issue13028() {
+    let s = 5;
+    let u = 5;
+    let x: u32 = 123456;
+
+    let _ = (x << s) | (x >> (32 - s));
+    //~^ manual_rotate
+    let _ = (x << s) | (x >> (31 ^ s));
+    //~^ manual_rotate
+    // still works with consts
+    let _ = (x >> 9) | (x << (32 - 9));
+    //~^ manual_rotate
+
+    // don't lint, because `s` and `u` are different variables, albeit with the same value
+    let _ = (x << s) | (x >> (32 - u));
+}

--- a/tests/ui/manual_rotate.stderr
+++ b/tests/ui/manual_rotate.stderr
@@ -73,5 +73,23 @@ error: there is no need to manually implement bit rotation
 LL |     let _ = (x_i64 >> N) | (x_i64 << (64 - N));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `x_i64.rotate_right(N)`
 
-error: aborting due to 12 previous errors
+error: there is no need to manually implement bit rotation
+  --> tests/ui/manual_rotate.rs:53:13
+   |
+LL |     let _ = (x << s) | (x >> (32 - s));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `x.rotate_left(s)`
+
+error: there is no need to manually implement bit rotation
+  --> tests/ui/manual_rotate.rs:55:13
+   |
+LL |     let _ = (x << s) | (x >> (31 ^ s));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `x.rotate_left(s)`
+
+error: there is no need to manually implement bit rotation
+  --> tests/ui/manual_rotate.rs:58:13
+   |
+LL |     let _ = (x >> 9) | (x << (32 - 9));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `x.rotate_right(9)`
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
changelog: [`manual_rotate`]: also recognize non-consts

fixes https://github.com/rust-lang/rust-clippy/issues/13028

r? @llogiq