### PR TITLE
Fix not showing deprecated lints

### DIFF
--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -208,6 +208,7 @@ const LEVEL_FILTERS_DEFAULT = {
     allow: true,
     warn: true,
     deny: true,
+    none: true,
 };
 const APPLICABILITIES_FILTER_DEFAULT = {
     Unspecified: true,


### PR DESCRIPTION
As discussed at rust-lang/rust-clippy#15387 revert changes https://github.com/rust-lang/rust-clippy/pull/15315 to show deprecated. 

changelog: none
