### PR TITLE
Remove rogue comma from infallible_try_from lint message

### DIFF
--- a/clippy_lints/src/infallible_try_from.rs
+++ b/clippy_lints/src/infallible_try_from.rs
@@ -71,7 +71,7 @@ impl<'tcx> LateLintPass<'tcx> for InfallibleTryFrom {
                     cx,
                     INFALLIBLE_TRY_FROM,
                     span,
-                    "infallible TryFrom impl; consider implementing From, instead",
+                    "infallible TryFrom impl; consider implementing From instead",
                 );
             }
         }

--- a/tests/ui/infallible_try_from.stderr
+++ b/tests/ui/infallible_try_from.stderr
@@ -1,4 +1,4 @@
-error: infallible TryFrom impl; consider implementing From, instead
+error: infallible TryFrom impl; consider implementing From instead
   --> tests/ui/infallible_try_from.rs:8:1
    |
 LL | impl TryFrom<i8> for MyStruct {
@@ -10,7 +10,7 @@ LL |     type Error = !;
    = note: `-D clippy::infallible-try-from` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::infallible_try_from)]`
 
-error: infallible TryFrom impl; consider implementing From, instead
+error: infallible TryFrom impl; consider implementing From instead
   --> tests/ui/infallible_try_from.rs:16:1
    |
 LL | impl TryFrom<i16> for MyStruct {


### PR DESCRIPTION
Spotted while reading through the new lints in the changelog for Clippy 1.89:

```
 1 | error: infallible TryFrom impl; consider implementing From, instead
   |                                                           ^ this comma looks out of place
```


---

changelog: [`infallible_try_from`]: Fix a typo in the lint message
