### PR TITLE
Do not lint for `wildcard_imports` in external macro

### DIFF
--- a/clippy_lints/src/wildcard_imports.rs
+++ b/clippy_lints/src/wildcard_imports.rs
@@ -118,7 +118,7 @@ impl_lint_pass!(WildcardImports => [ENUM_GLOB_USE, WILDCARD_IMPORTS]);
 
 impl LateLintPass<'_> for WildcardImports {
     fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
-        if cx.sess().is_test_crate() {
+        if cx.sess().is_test_crate() || item.span.in_external_macro(cx.sess().source_map()) {
             return;
         }
 

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.fixed
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.fixed
@@ -1,3 +1,4 @@
+//@aux-build:../../ui/auxiliary/proc_macros.rs
 #![warn(clippy::wildcard_imports)]
 
 mod prelude {
@@ -13,6 +14,10 @@ mod my_crate {
     pub mod utils {
         pub fn my_util_fn() {}
     }
+
+    pub mod utils2 {
+        pub const SOME_CONST: u32 = 1;
+    }
 }
 
 pub use utils::{BAR, print};
@@ -21,6 +26,12 @@ use my_crate::utils::my_util_fn;
 //~^ ERROR: usage of wildcard import
 use prelude::FOO;
 //~^ ERROR: usage of wildcard import
+
+proc_macros::external! {
+    use my_crate::utils2::*;
+
+    static SOME_STATIC: u32 = SOME_CONST;
+}
 
 fn main() {
     let _ = FOO;

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.rs
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.rs
@@ -1,3 +1,4 @@
+//@aux-build:../../ui/auxiliary/proc_macros.rs
 #![warn(clippy::wildcard_imports)]
 
 mod prelude {
@@ -13,6 +14,10 @@ mod my_crate {
     pub mod utils {
         pub fn my_util_fn() {}
     }
+
+    pub mod utils2 {
+        pub const SOME_CONST: u32 = 1;
+    }
 }
 
 pub use utils::*;
@@ -21,6 +26,12 @@ use my_crate::utils::*;
 //~^ ERROR: usage of wildcard import
 use prelude::*;
 //~^ ERROR: usage of wildcard import
+
+proc_macros::external! {
+    use my_crate::utils2::*;
+
+    static SOME_STATIC: u32 = SOME_CONST;
+}
 
 fn main() {
     let _ = FOO;

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.stderr
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.stderr
@@ -1,5 +1,5 @@
 error: usage of wildcard import
-  --> tests/ui-toml/wildcard_imports/wildcard_imports.rs:18:9
+  --> tests/ui-toml/wildcard_imports/wildcard_imports.rs:23:9
    |
 LL | pub use utils::*;
    |         ^^^^^^^^ help: try: `utils::{BAR, print}`
@@ -8,13 +8,13 @@ LL | pub use utils::*;
    = help: to override `-D warnings` add `#[allow(clippy::wildcard_imports)]`
 
 error: usage of wildcard import
-  --> tests/ui-toml/wildcard_imports/wildcard_imports.rs:20:5
+  --> tests/ui-toml/wildcard_imports/wildcard_imports.rs:25:5
    |
 LL | use my_crate::utils::*;
    |     ^^^^^^^^^^^^^^^^^^ help: try: `my_crate::utils::my_util_fn`
 
 error: usage of wildcard import
-  --> tests/ui-toml/wildcard_imports/wildcard_imports.rs:22:5
+  --> tests/ui-toml/wildcard_imports/wildcard_imports.rs:27:5
    |
 LL | use prelude::*;
    |     ^^^^^^^^^^ help: try: `prelude::FOO`


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#15412 

changelog: [`wildcard_imports`]: do not lint code coming from an external macro