### PR TITLE
overhaul `mut_mut`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -482,7 +482,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     store.register_late_pass(|_| Box::new(needless_for_each::NeedlessForEach));
     store.register_late_pass(|_| Box::new(misc::LintPass));
     store.register_late_pass(|_| Box::new(eta_reduction::EtaReduction));
-    store.register_late_pass(|_| Box::new(mut_mut::MutMut));
+    store.register_late_pass(|_| Box::new(mut_mut::MutMut::default()));
     store.register_late_pass(|_| Box::new(unnecessary_mut_passed::UnnecessaryMutPassed));
     store.register_late_pass(|_| Box::<significant_drop_tightening::SignificantDropTightening<'_>>::default());
     store.register_late_pass(|_| Box::new(len_zero::LenZero));

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -54,13 +54,15 @@ impl<'tcx> LateLintPass<'tcx> for MutMut {
                 // so don't flag the inner `&mut &mut (x)`
                 return;
             }
-            self.seen_tys.insert(mty.ty.hir_id);
 
             // if there is an even longer chain, like `&mut &mut &mut x`, suggest peeling off
             // all extra ones at once
             let (mut t, mut t2) = (mty.ty, mty2.ty);
             let mut many_muts = false;
             loop {
+                // this should allow us to remember all the nested types, so that the `contains`
+                // above fails faster
+                self.seen_tys.insert(t.hir_id);
                 if let TyKind::Ref(_, next) = t2.kind
                     && next.mutbl == Mutability::Mut
                 {

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -14,19 +14,30 @@ declare_clippy_lint! {
     /// Checks for instances of `mut mut` references.
     ///
     /// ### Why is this bad?
-    /// Multiple `mut`s don't add anything meaningful to the
-    /// source. This is either a copy'n'paste error, or it shows a fundamental
-    /// misunderstanding of references.
+    /// This is usually just a typo or a misunderstanding of how references work.
     ///
     /// ### Example
     /// ```no_run
-    /// # let mut y = 1;
-    /// let x = &mut &mut y;
+    /// let x = &mut &mut 1;
+    ///
+    /// let mut x = &mut 1;
+    /// let y = &mut x;
+    ///
+    /// fn foo(x: &mut &mut u32) {}
+    /// ```
+    /// Use instead
+    /// ```no_run
+    /// let x = &mut 1;
+    ///
+    /// let mut x = &mut 1;
+    /// let y = &mut *x; // reborrow
+    ///
+    /// fn foo(x: &mut u32) {}
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub MUT_MUT,
     pedantic,
-    "usage of double-mut refs, e.g., `&mut &mut ...`"
+    "usage of double mut-refs, e.g., `&mut &mut ...`"
 }
 
 impl_lint_pass!(MutMut => [MUT_MUT]);

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -72,6 +72,9 @@ impl<'tcx> intravisit::Visitor<'tcx> for MutVisitor<'_, 'tcx> {
             intravisit::walk_expr(self, body);
         } else if let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Mut, e) = expr.kind {
             if let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Mut, _) = e.kind {
+                if !expr.span.eq_ctxt(e.span) {
+                    return;
+                }
                 let mut applicability = Applicability::MaybeIncorrect;
                 let sugg = Sugg::hir_with_applicability(self.cx, e, "..", &mut applicability);
                 span_lint_hir_and_then(

--- a/tests/ui/mut_mut.fixed
+++ b/tests/ui/mut_mut.fixed
@@ -1,0 +1,94 @@
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::mut_mut)]
+#![allow(unused)]
+#![allow(
+    clippy::no_effect,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_operation,
+    clippy::needless_pass_by_ref_mut
+)]
+
+extern crate proc_macros;
+use proc_macros::{external, inline_macros};
+
+fn fun(x: &mut &mut u32) {
+    //~^ mut_mut
+}
+
+fn less_fun(x: *mut *mut u32) {
+    let y = x;
+}
+
+macro_rules! mut_ptr {
+    ($p:expr) => {
+        &mut $p
+    };
+}
+
+#[allow(unused_mut, unused_variables)]
+#[inline_macros]
+fn main() {
+    let mut x = &mut &mut 1u32;
+    //~^ mut_mut
+    {
+        let mut y = &mut *x;
+        //~^ mut_mut
+    }
+
+    {
+        let y: &mut &mut u32 = &mut &mut 2;
+        //~^ mut_mut
+        //~| mut_mut
+    }
+
+    {
+        let y: &mut &mut &mut u32 = &mut &mut &mut 2;
+        //~^ mut_mut
+        //~| mut_mut
+        //~| mut_mut
+    }
+
+    let mut z = inline!(&mut $(&mut 3u32));
+    //~^ mut_mut
+}
+
+fn issue939() {
+    let array = [5, 6, 7, 8, 9];
+    let mut args = array.iter().skip(2);
+    for &arg in &mut args {
+        println!("{}", arg);
+    }
+
+    let args = &mut args;
+    for arg in args {
+        println!(":{}", arg);
+    }
+}
+
+fn issue6922() {
+    // do not lint from an external macro
+    external!(let mut_mut_ty: &mut &mut u32 = &mut &mut 1u32;);
+}
+
+mod issue9035 {
+    use std::fmt::Display;
+
+    struct Foo<'a> {
+        inner: &'a mut dyn Display,
+    }
+
+    impl Foo<'_> {
+        fn foo(&mut self) {
+            let hlp = &mut self.inner;
+            bar(hlp);
+        }
+    }
+
+    fn bar(_: &mut impl Display) {}
+}
+
+fn allow_works() {
+    #[allow(clippy::mut_mut)]
+    let _ = &mut &mut 1;
+}

--- a/tests/ui/mut_mut.fixed
+++ b/tests/ui/mut_mut.fixed
@@ -49,8 +49,7 @@ fn main() {
         //~| mut_mut
     }
 
-    let mut z = inline!(&mut 3u32mut $(&mut 3u32));
-    //~^ mut_mut
+    let mut z = inline!(&mut $(&mut 3u32));
 }
 
 fn issue939() {

--- a/tests/ui/mut_mut.fixed
+++ b/tests/ui/mut_mut.fixed
@@ -12,7 +12,7 @@
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};
 
-fn fun(x: &mut &mut u32) {
+fn fun(x: &mut u32) {
     //~^ mut_mut
 }
 
@@ -37,15 +37,14 @@ fn main() {
     }
 
     {
-        let y: &mut &mut u32 = &mut 2;
+        let y: &mut u32 = &mut 2;
         //~^ mut_mut
         //~| mut_mut
     }
 
     {
-        let y: &mut &mut &mut u32 = &mut &mut 2;
+        let y: &mut &mut u32 = &mut &mut 2;
         //~^ mut_mut
-        //~| mut_mut
         //~| mut_mut
     }
 

--- a/tests/ui/mut_mut.fixed
+++ b/tests/ui/mut_mut.fixed
@@ -43,7 +43,7 @@ fn main() {
     }
 
     {
-        let y: &mut &mut u32 = &mut &mut 2;
+        let y: &mut u32 = &mut 2;
         //~^ mut_mut
         //~| mut_mut
     }

--- a/tests/ui/mut_mut.fixed
+++ b/tests/ui/mut_mut.fixed
@@ -29,7 +29,7 @@ macro_rules! mut_ptr {
 #[allow(unused_mut, unused_variables)]
 #[inline_macros]
 fn main() {
-    let mut x = &mut &mut 1u32;
+    let mut x = &mut 1u32;
     //~^ mut_mut
     {
         let mut y = &mut *x;
@@ -37,19 +37,19 @@ fn main() {
     }
 
     {
-        let y: &mut &mut u32 = &mut &mut 2;
+        let y: &mut &mut u32 = &mut 2;
         //~^ mut_mut
         //~| mut_mut
     }
 
     {
-        let y: &mut &mut &mut u32 = &mut &mut &mut 2;
+        let y: &mut &mut &mut u32 = &mut &mut 2;
         //~^ mut_mut
         //~| mut_mut
         //~| mut_mut
     }
 
-    let mut z = inline!(&mut $(&mut 3u32));
+    let mut z = inline!(&mut 3u32mut $(&mut 3u32));
     //~^ mut_mut
 }
 

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -50,7 +50,6 @@ fn main() {
     }
 
     let mut z = inline!(&mut $(&mut 3u32));
-    //~^ mut_mut
 }
 
 fn issue939() {

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -12,9 +12,8 @@
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};
 
-fn fun(x: &mut &mut u32) -> bool {
+fn fun(x: &mut &mut u32) {
     //~^ mut_mut
-    **x > 0
 }
 
 fn less_fun(x: *mut *mut u32) {
@@ -37,19 +36,17 @@ fn main() {
         //~^ mut_mut
     }
 
-    if fun(x) {
+    {
         let y: &mut &mut u32 = &mut &mut 2;
         //~^ mut_mut
         //~| mut_mut
-        **y + **x;
     }
 
-    if fun(x) {
+    {
         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
         //~^ mut_mut
         //~| mut_mut
         //~| mut_mut
-        ***y + **x;
     }
 
     let mut z = inline!(&mut $(&mut 3u32));

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -46,7 +46,6 @@ fn main() {
         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
         //~^ mut_mut
         //~| mut_mut
-        //~| mut_mut
     }
 
     let mut z = inline!(&mut $(&mut 3u32));

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -7,17 +7,17 @@ LL | fn fun(x: &mut &mut u32) {
    = note: `-D clippy::mut-mut` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mut_mut)]`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:32:17
    |
 LL |     let mut x = &mut &mut 1u32;
-   |                 ^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut 1u32`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:52:25
    |
 LL |     let mut z = inline!(&mut $(&mut 3u32));
-   |                         ^
+   |                         ^ help: remove the extra `&mut`: `&mut 3u32`
    |
    = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,11 +27,11 @@ error: this expression mutably borrows a mutable reference
 LL |         let mut y = &mut x;
    |                     ^^^^^^ help: reborrow instead: `&mut *x`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:40:32
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
-   |                                ^^^^^^^^^^^
+   |                                ^^^^^^^^^^^ help: remove the extra `&mut`: `&mut 2`
 
 error: generally you want to avoid `&mut &mut _` if possible
   --> tests/ui/mut_mut.rs:40:16
@@ -39,11 +39,11 @@ error: generally you want to avoid `&mut &mut _` if possible
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                ^^^^^^^^^^^^^
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:46:37
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
-   |                                     ^^^^^^^^^^^^^^^^
+   |                                     ^^^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut &mut 2`
 
 error: generally you want to avoid `&mut &mut _` if possible
   --> tests/ui/mut_mut.rs:46:16

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -43,11 +43,5 @@ error: a type of form `&mut &mut _`
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                ^^^^^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut &mut u32`
 
-error: a type of form `&mut &mut _`
-  --> tests/ui/mut_mut.rs:46:21
-   |
-LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
-   |                     ^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut u32`
-
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -1,8 +1,8 @@
-error: generally you want to avoid `&mut &mut _` if possible
+error: a type of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:15:11
    |
 LL | fn fun(x: &mut &mut u32) {
-   |           ^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut u32`
    |
    = note: `-D clippy::mut-mut` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mut_mut)]`
@@ -25,11 +25,11 @@ error: an expression of form `&mut &mut _`
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                                ^^^^^^^^^^^ help: remove the extra `&mut`: `&mut 2`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: a type of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:40:16
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
-   |                ^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut u32`
 
 error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:46:37
@@ -37,17 +37,17 @@ error: an expression of form `&mut &mut _`
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                                     ^^^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut &mut 2`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: a type of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:46:16
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
-   |                ^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut &mut u32`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: a type of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:46:21
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
-   |                     ^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut u32`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -35,13 +35,13 @@ error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:46:37
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
-   |                                     ^^^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut &mut 2`
+   |                                     ^^^^^^^^^^^^^^^^ help: remove the extra `&mut`s: `&mut 2`
 
 error: a type of form `&mut &mut _`
   --> tests/ui/mut_mut.rs:46:16
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
-   |                ^^^^^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut &mut u32`
+   |                ^^^^^^^^^^^^^^^^^^ help: remove the extra `&mut`s: `&mut u32`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -13,14 +13,6 @@ error: an expression of form `&mut &mut _`
 LL |     let mut x = &mut &mut 1u32;
    |                 ^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut 1u32`
 
-error: an expression of form `&mut &mut _`
-  --> tests/ui/mut_mut.rs:52:25
-   |
-LL |     let mut z = inline!(&mut $(&mut 3u32));
-   |                         ^ help: remove the extra `&mut`: `&mut 3u32`
-   |
-   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: this expression mutably borrows a mutable reference
   --> tests/ui/mut_mut.rs:35:21
    |
@@ -57,5 +49,5 @@ error: generally you want to avoid `&mut &mut _` if possible
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                     ^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -1,20 +1,20 @@
 error: generally you want to avoid `&mut &mut _` if possible
   --> tests/ui/mut_mut.rs:15:11
    |
-LL | fn fun(x: &mut &mut u32) -> bool {
+LL | fn fun(x: &mut &mut u32) {
    |           ^^^^^^^^^^^^^
    |
    = note: `-D clippy::mut-mut` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mut_mut)]`
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:33:17
+  --> tests/ui/mut_mut.rs:32:17
    |
 LL |     let mut x = &mut &mut 1u32;
    |                 ^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:55:25
+  --> tests/ui/mut_mut.rs:52:25
    |
 LL |     let mut z = inline!(&mut $(&mut 3u32));
    |                         ^
@@ -22,37 +22,37 @@ LL |     let mut z = inline!(&mut $(&mut 3u32));
    = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this expression mutably borrows a mutable reference. Consider reborrowing
-  --> tests/ui/mut_mut.rs:36:21
+  --> tests/ui/mut_mut.rs:35:21
    |
 LL |         let mut y = &mut x;
    |                     ^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:41:32
+  --> tests/ui/mut_mut.rs:40:32
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                                ^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:41:16
+  --> tests/ui/mut_mut.rs:40:16
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                ^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:48:37
+  --> tests/ui/mut_mut.rs:46:37
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                                     ^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:48:16
+  --> tests/ui/mut_mut.rs:46:16
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                ^^^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:48:21
+  --> tests/ui/mut_mut.rs:46:21
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                     ^^^^^^^^^^^^^

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -21,11 +21,11 @@ LL |     let mut z = inline!(&mut $(&mut 3u32));
    |
    = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: this expression mutably borrows a mutable reference. Consider reborrowing
+error: this expression mutably borrows a mutable reference
   --> tests/ui/mut_mut.rs:35:21
    |
 LL |         let mut y = &mut x;
-   |                     ^^^^^^
+   |                     ^^^^^^ help: reborrow instead: `&mut *x`
 
 error: generally you want to avoid `&mut &mut _` if possible
   --> tests/ui/mut_mut.rs:40:32

--- a/tests/ui/mut_mut_unfixable.rs
+++ b/tests/ui/mut_mut_unfixable.rs
@@ -31,4 +31,12 @@ fn main() {
         //~^ mut_mut
         ***y + **x;
     }
+
+    if fun(x) {
+        // The lint will remove the extra `&mut`, but the result will still be a `&mut` of an expr
+        // of type `&mut _` (x), so the lint will fire again. That's because we've decided that
+        // doing both fixes in one run is not worth it, given how improbable code like this is.
+        let y = &mut &mut x;
+        //~^ mut_mut
+    }
 }

--- a/tests/ui/mut_mut_unfixable.rs
+++ b/tests/ui/mut_mut_unfixable.rs
@@ -1,0 +1,34 @@
+//@no-rustfix
+
+#![warn(clippy::mut_mut)]
+#![allow(unused)]
+#![expect(clippy::no_effect)]
+
+//! removing the extra `&mut`s will break the derefs
+
+fn fun(x: &mut &mut u32) -> bool {
+    //~^ mut_mut
+    **x > 0
+}
+
+fn main() {
+    let mut x = &mut &mut 1u32;
+    //~^ mut_mut
+    {
+        let mut y = &mut x;
+        //~^ mut_mut
+        ***y + **x;
+    }
+
+    if fun(x) {
+        let y = &mut &mut 2;
+        //~^ mut_mut
+        **y + **x;
+    }
+
+    if fun(x) {
+        let y = &mut &mut &mut 2;
+        //~^ mut_mut
+        ***y + **x;
+    }
+}

--- a/tests/ui/mut_mut_unfixable.stderr
+++ b/tests/ui/mut_mut_unfixable.stderr
@@ -1,8 +1,8 @@
-error: generally you want to avoid `&mut &mut _` if possible
+error: a type of form `&mut &mut _`
   --> tests/ui/mut_mut_unfixable.rs:9:11
    |
 LL | fn fun(x: &mut &mut u32) -> bool {
-   |           ^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut u32`
    |
    = note: `-D clippy::mut-mut` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mut_mut)]`

--- a/tests/ui/mut_mut_unfixable.stderr
+++ b/tests/ui/mut_mut_unfixable.stderr
@@ -7,11 +7,11 @@ LL | fn fun(x: &mut &mut u32) -> bool {
    = note: `-D clippy::mut-mut` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mut_mut)]`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut_unfixable.rs:15:17
    |
 LL |     let mut x = &mut &mut 1u32;
-   |                 ^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut 1u32`
 
 error: this expression mutably borrows a mutable reference
   --> tests/ui/mut_mut_unfixable.rs:18:21
@@ -19,17 +19,17 @@ error: this expression mutably borrows a mutable reference
 LL |         let mut y = &mut x;
    |                     ^^^^^^ help: reborrow instead: `&mut *x`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut_unfixable.rs:24:17
    |
 LL |         let y = &mut &mut 2;
-   |                 ^^^^^^^^^^^
+   |                 ^^^^^^^^^^^ help: remove the extra `&mut`: `&mut 2`
 
-error: generally you want to avoid `&mut &mut _` if possible
+error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut_unfixable.rs:30:17
    |
 LL |         let y = &mut &mut &mut 2;
-   |                 ^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut &mut 2`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/mut_mut_unfixable.stderr
+++ b/tests/ui/mut_mut_unfixable.stderr
@@ -29,7 +29,7 @@ error: an expression of form `&mut &mut _`
   --> tests/ui/mut_mut_unfixable.rs:30:17
    |
 LL |         let y = &mut &mut &mut 2;
-   |                 ^^^^^^^^^^^^^^^^ help: remove the extra `&mut`: `&mut &mut 2`
+   |                 ^^^^^^^^^^^^^^^^ help: remove the extra `&mut`s: `&mut 2`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/mut_mut_unfixable.stderr
+++ b/tests/ui/mut_mut_unfixable.stderr
@@ -13,11 +13,11 @@ error: generally you want to avoid `&mut &mut _` if possible
 LL |     let mut x = &mut &mut 1u32;
    |                 ^^^^^^^^^^^^^^
 
-error: this expression mutably borrows a mutable reference. Consider reborrowing
+error: this expression mutably borrows a mutable reference
   --> tests/ui/mut_mut_unfixable.rs:18:21
    |
 LL |         let mut y = &mut x;
-   |                     ^^^^^^
+   |                     ^^^^^^ help: reborrow instead: `&mut *x`
 
 error: generally you want to avoid `&mut &mut _` if possible
   --> tests/ui/mut_mut_unfixable.rs:24:17

--- a/tests/ui/mut_mut_unfixable.stderr
+++ b/tests/ui/mut_mut_unfixable.stderr
@@ -1,0 +1,35 @@
+error: generally you want to avoid `&mut &mut _` if possible
+  --> tests/ui/mut_mut_unfixable.rs:9:11
+   |
+LL | fn fun(x: &mut &mut u32) -> bool {
+   |           ^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::mut-mut` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::mut_mut)]`
+
+error: generally you want to avoid `&mut &mut _` if possible
+  --> tests/ui/mut_mut_unfixable.rs:15:17
+   |
+LL |     let mut x = &mut &mut 1u32;
+   |                 ^^^^^^^^^^^^^^
+
+error: this expression mutably borrows a mutable reference. Consider reborrowing
+  --> tests/ui/mut_mut_unfixable.rs:18:21
+   |
+LL |         let mut y = &mut x;
+   |                     ^^^^^^
+
+error: generally you want to avoid `&mut &mut _` if possible
+  --> tests/ui/mut_mut_unfixable.rs:24:17
+   |
+LL |         let y = &mut &mut 2;
+   |                 ^^^^^^^^^^^
+
+error: generally you want to avoid `&mut &mut _` if possible
+  --> tests/ui/mut_mut_unfixable.rs:30:17
+   |
+LL |         let y = &mut &mut &mut 2;
+   |                 ^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/mut_mut_unfixable.stderr
+++ b/tests/ui/mut_mut_unfixable.stderr
@@ -31,5 +31,11 @@ error: an expression of form `&mut &mut _`
 LL |         let y = &mut &mut &mut 2;
    |                 ^^^^^^^^^^^^^^^^ help: remove the extra `&mut`s: `&mut 2`
 
-error: aborting due to 5 previous errors
+error: an expression of form `&mut &mut _`
+  --> tests/ui/mut_mut_unfixable.rs:39:17
+   |
+LL |         let y = &mut &mut x;
+   |                 ^^^^^^^^^^^ help: remove the extra `&mut`: `&mut x`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
This PR:
- adds structured suggestions to all 3 lint scenarios
- adds more examples of linted patterns, and recommended fixes
- moves some test cases to `_unfixable.rs`, to allow running rustfix on the main file
- stops the lint from firing multiple times on types like `&mut &mut &mut T`

Open questions:
- I'd like to add a note explaining why chained `&mut` are useless.. but can't really come up with something consice. I very much don't like the one in the docs -- it's a bit too condescending imo.
- see comments in the diff for more

I do realize that the PR ended up being quite wide-scoped, but that's primarily because once I added structured suggestions to one of the lint cases, `ui_test` started complaining about warnings remaining after the rustfix run, which of course had to with the fact that the other two lint cases didn't actually fix the code they linted, only warned. I _guess_ `ui_test` could be smarter about this, by understanding that if a warning was created without a suggestion, then that warning will still remain in the fixed file. But oh well.

changelog: [`mut_mut`]: add structured suggestions, improve docs

fixes rust-lang/rust-clippy#13021