### PR TITLE
WIP: `mut_mut`: generalize the from-expansion check

### DIFF
--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -53,18 +53,25 @@ fn main() {
     }
 
     let mut z = inline!(&mut $(&mut 3u32));
-    //~^ mut_mut
 }
 
 fn issue939() {
     let array = [5, 6, 7, 8, 9];
     let mut args = array.iter().skip(2);
     for &arg in &mut args {
+        // make sure that we still check inside the block, even if we skip `&mut args` because of
+        // it coming from the expansion of `for-in` syntax
+        let a = &mut &mut 2;
+        //~^ mut_mut
         println!("{}", arg);
     }
 
     let args = &mut args;
     for arg in args {
+        // make sure that we still check inside the block, even if we skip `&mut args` because of
+        // it coming from the expansion of `for-in` syntax
+        let a = &mut &mut 2;
+        //~^ mut_mut
         println!(":{}", arg);
     }
 }

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -13,14 +13,6 @@ error: generally you want to avoid `&mut &mut _` if possible
 LL |     let mut x = &mut &mut 1u32;
    |                 ^^^^^^^^^^^^^^
 
-error: generally you want to avoid `&mut &mut _` if possible
-  --> tests/ui/mut_mut.rs:55:25
-   |
-LL |     let mut z = inline!(&mut $(&mut 3u32));
-   |                         ^
-   |
-   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: this expression mutably borrows a mutable reference. Consider reborrowing
   --> tests/ui/mut_mut.rs:36:21
    |
@@ -57,5 +49,17 @@ error: generally you want to avoid `&mut &mut _` if possible
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                     ^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: generally you want to avoid `&mut &mut _` if possible
+  --> tests/ui/mut_mut.rs:64:17
+   |
+LL |         let a = &mut &mut 2;
+   |                 ^^^^^^^^^^^
+
+error: generally you want to avoid `&mut &mut _` if possible
+  --> tests/ui/mut_mut.rs:73:17
+   |
+LL |         let a = &mut &mut 2;
+   |                 ^^^^^^^^^^^
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
The check was added in https://github.com/rust-lang/rust-clippy/pull/1032, which addressed https://github.com/rust-lang/rust-clippy/issues/939, which did complain about the particular case of a for-loop. But for some reason, the fix also concentrated on for-loops only. I'm pretty sure `Span::from_expansion` is more generally helpful.

WIP because this apparently also stops the lint from firing on the `inline!` proc-macro thing, which I'm not quite sure is correct?.. That would resolve https://github.com/rust-lang/rust-clippy/pull/15417#discussion_r2254232688 though I guess

changelog: none