### PR TITLE
fix: `semicolon_inside_block` don't fire if block is surrounded by parens

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -733,7 +733,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     store.register_late_pass(|_| Box::new(from_raw_with_void_ptr::FromRawWithVoidPtr));
     store.register_late_pass(|_| Box::new(suspicious_xor_used_as_pow::ConfusingXorAndPow));
     store.register_late_pass(move |_| Box::new(manual_is_ascii_check::ManualIsAsciiCheck::new(conf)));
-    store.register_late_pass(move |_| Box::new(semicolon_block::SemicolonBlock::new(conf)));
+    store.register_early_pass(move || Box::new(semicolon_block::SemicolonBlock::new(conf)));
     store.register_late_pass(|_| Box::new(permissions_set_readonly_false::PermissionsSetReadonlyFalse));
     store.register_late_pass(|_| Box::new(size_of_ref::SizeOfRef));
     store.register_late_pass(|_| Box::new(multiple_unsafe_ops_per_block::MultipleUnsafeOpsPerBlock));

--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -140,10 +140,11 @@ impl SemicolonBlock {
 impl LateLintPass<'_> for SemicolonBlock {
     fn check_stmt(&mut self, cx: &LateContext<'_>, stmt: &Stmt<'_>) {
         match stmt.kind {
-            StmtKind::Expr(Expr {
-                kind: ExprKind::Block(block, _),
-                ..
-            }) if !block.span.from_expansion() && stmt.span.contains(block.span) => {
+            StmtKind::Expr(expr)
+                if let ExprKind::Block(block, _) = expr.kind
+                    && !block.span.from_expansion()
+                    && stmt.span.contains(block.span) =>
+            {
                 if block.expr.is_none()
                     && let [.., stmt] = block.stmts
                     && let StmtKind::Semi(expr) = stmt.kind
@@ -151,10 +152,10 @@ impl LateLintPass<'_> for SemicolonBlock {
                     self.semicolon_outside_block(cx, block, expr);
                 }
             },
-            StmtKind::Semi(Expr {
-                kind: ExprKind::Block(block, _),
-                ..
-            }) if !block.span.from_expansion() => {
+            StmtKind::Semi(expr)
+                if let ExprKind::Block(block, _) = expr.kind
+                    && !block.span.from_expansion() =>
+            {
                 if let Some(tail) = block.expr {
                     self.semicolon_inside_block(cx, block, tail, stmt.span);
                 }

--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -78,7 +78,7 @@ impl SemicolonBlock {
         }
     }
 
-    fn semicolon_inside_block(&self, cx: &LateContext<'_>, block: &Block<'_>, tail: &Expr<'_>, semi_span: Span) {
+    fn semicolon_inside_block(&self, cx: &impl LintContext, block: &Block<'_>, tail: &Expr<'_>, semi_span: Span) {
         let insert_span = tail.span.source_callsite().shrink_to_hi();
         let remove_span = semi_span.with_lo(block.span.hi());
 
@@ -101,7 +101,7 @@ impl SemicolonBlock {
         );
     }
 
-    fn semicolon_outside_block(&self, cx: &LateContext<'_>, block: &Block<'_>, tail_stmt_expr: &Expr<'_>) {
+    fn semicolon_outside_block(&self, cx: &impl LintContext, block: &Block<'_>, tail_stmt_expr: &Expr<'_>) {
         let insert_span = block.span.shrink_to_hi();
 
         // For macro call semicolon statements (`mac!();`), the statement's span does not actually
@@ -164,6 +164,6 @@ impl LateLintPass<'_> for SemicolonBlock {
     }
 }
 
-fn get_line(cx: &LateContext<'_>, span: Span) -> Option<usize> {
+fn get_line(cx: &impl LintContext, span: Span) -> Option<usize> {
     cx.sess().source_map().lookup_line(span.lo()).ok().map(|line| line.line)
 }

--- a/tests/ui/semicolon_inside_block.fixed
+++ b/tests/ui/semicolon_inside_block.fixed
@@ -3,7 +3,8 @@
     clippy::unused_unit,
     clippy::unnecessary_operation,
     clippy::no_effect,
-    clippy::single_element_loop
+    clippy::single_element_loop,
+    clippy::double_parens
 )]
 #![warn(clippy::semicolon_inside_block)]
 
@@ -85,4 +86,20 @@ fn main() {
     { unit_fn_block(); };
 
     unit_fn_block()
+}
+
+fn issue15380() {
+    #[rustfmt::skip]
+    ( {0;0;}
+    //~^ semicolon_inside_block
+
+    ({
+        //~^ semicolon_inside_block
+        0;
+        0;
+    }
+
+    #[rustfmt::skip]
+    (({0;}
+    //~^ semicolon_inside_block
 }

--- a/tests/ui/semicolon_inside_block.fixed
+++ b/tests/ui/semicolon_inside_block.fixed
@@ -90,16 +90,13 @@ fn main() {
 
 fn issue15380() {
     #[rustfmt::skip]
-    ( {0;0;}
-    //~^ semicolon_inside_block
+    ( {0;0});
 
     ({
-        //~^ semicolon_inside_block
         0;
-        0;
-    }
+        0
+    });
 
     #[rustfmt::skip]
-    (({0;}
-    //~^ semicolon_inside_block
+    (({0}))    ;
 }

--- a/tests/ui/semicolon_inside_block.rs
+++ b/tests/ui/semicolon_inside_block.rs
@@ -91,15 +91,12 @@ fn main() {
 fn issue15380() {
     #[rustfmt::skip]
     ( {0;0});
-    //~^ semicolon_inside_block
 
     ({
-        //~^ semicolon_inside_block
         0;
         0
     });
 
     #[rustfmt::skip]
     (({0}))    ;
-    //~^ semicolon_inside_block
 }

--- a/tests/ui/semicolon_inside_block.rs
+++ b/tests/ui/semicolon_inside_block.rs
@@ -3,7 +3,8 @@
     clippy::unused_unit,
     clippy::unnecessary_operation,
     clippy::no_effect,
-    clippy::single_element_loop
+    clippy::single_element_loop,
+    clippy::double_parens
 )]
 #![warn(clippy::semicolon_inside_block)]
 
@@ -85,4 +86,20 @@ fn main() {
     { unit_fn_block(); };
 
     unit_fn_block()
+}
+
+fn issue15380() {
+    #[rustfmt::skip]
+    ( {0;0});
+    //~^ semicolon_inside_block
+
+    ({
+        //~^ semicolon_inside_block
+        0;
+        0
+    });
+
+    #[rustfmt::skip]
+    (({0}))    ;
+    //~^ semicolon_inside_block
 }

--- a/tests/ui/semicolon_inside_block.stderr
+++ b/tests/ui/semicolon_inside_block.stderr
@@ -1,5 +1,5 @@
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:38:5
+  --> tests/ui/semicolon_inside_block.rs:39:5
    |
 LL |     { unit_fn_block() };
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     { unit_fn_block(); }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:40:5
+  --> tests/ui/semicolon_inside_block.rs:41:5
    |
 LL |     unsafe { unit_fn_block() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     unsafe { unit_fn_block(); }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:49:5
+  --> tests/ui/semicolon_inside_block.rs:50:5
    |
 LL | /     {
 LL | |
@@ -41,7 +41,7 @@ LL ~     }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:63:5
+  --> tests/ui/semicolon_inside_block.rs:64:5
    |
 LL |     { m!(()) };
    |     ^^^^^^^^^^^
@@ -52,5 +52,45 @@ LL -     { m!(()) };
 LL +     { m!(()); }
    |
 
-error: aborting due to 4 previous errors
+error: consider moving the `;` inside the block for consistent formatting
+  --> tests/ui/semicolon_inside_block.rs:93:5
+   |
+LL |     ( {0;0});
+   |     ^^^^^^^^^
+   |
+help: put the `;` here
+   |
+LL -     ( {0;0});
+LL +     ( {0;0;}
+   |
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> tests/ui/semicolon_inside_block.rs:96:5
+   |
+LL | /     ({
+LL | |
+LL | |         0;
+LL | |         0
+LL | |     });
+   | |_______^
+   |
+help: put the `;` here
+   |
+LL ~         0;
+LL ~     }
+   |
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> tests/ui/semicolon_inside_block.rs:103:5
+   |
+LL |     (({0}))    ;
+   |     ^^^^^^^^^^^^
+   |
+help: put the `;` here
+   |
+LL -     (({0}))    ;
+LL +     (({0;}
+   |
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/semicolon_inside_block.stderr
+++ b/tests/ui/semicolon_inside_block.stderr
@@ -52,45 +52,5 @@ LL -     { m!(()) };
 LL +     { m!(()); }
    |
 
-error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:93:5
-   |
-LL |     ( {0;0});
-   |     ^^^^^^^^^
-   |
-help: put the `;` here
-   |
-LL -     ( {0;0});
-LL +     ( {0;0;}
-   |
-
-error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:96:5
-   |
-LL | /     ({
-LL | |
-LL | |         0;
-LL | |         0
-LL | |     });
-   | |_______^
-   |
-help: put the `;` here
-   |
-LL ~         0;
-LL ~     }
-   |
-
-error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:103:5
-   |
-LL |     (({0}))    ;
-   |     ^^^^^^^^^^^^
-   |
-help: put the `;` here
-   |
-LL -     (({0}))    ;
-LL +     (({0;}
-   |
-
-error: aborting due to 7 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/semicolon_outside_block.fixed
+++ b/tests/ui/semicolon_outside_block.fixed
@@ -121,3 +121,16 @@ fn issue14926() {
         },
     }
 }
+
+fn f() {
+    struct Vec;
+    impl Vec {
+        unsafe fn set_len(&mut self, _len: usize) {}
+        fn clear(&mut self) {
+            unsafe {
+                //~^ semicolon_outside_block
+                self.set_len(0)
+            };
+        }
+    }
+}

--- a/tests/ui/semicolon_outside_block.rs
+++ b/tests/ui/semicolon_outside_block.rs
@@ -128,6 +128,7 @@ fn f() {
         unsafe fn set_len(&mut self, _len: usize) {}
         fn clear(&mut self) {
             unsafe {
+                //~^ semicolon_outside_block
                 self.set_len(0);
             }
         }

--- a/tests/ui/semicolon_outside_block.rs
+++ b/tests/ui/semicolon_outside_block.rs
@@ -121,3 +121,15 @@ fn issue14926() {
         },
     }
 }
+
+fn f() {
+    struct Vec;
+    impl Vec {
+        unsafe fn set_len(&mut self, _len: usize) {}
+        fn clear(&mut self) {
+            unsafe {
+                self.set_len(0);
+            }
+        }
+    }
+}

--- a/tests/ui/semicolon_outside_block.stderr
+++ b/tests/ui/semicolon_outside_block.stderr
@@ -82,5 +82,20 @@ LL ~         line!()
 LL ~     };
    |
 
-error: aborting due to 6 previous errors
+error: consider moving the `;` outside the block for consistent formatting
+  --> tests/ui/semicolon_outside_block.rs:130:13
+   |
+LL | /             unsafe {
+LL | |
+LL | |                 self.set_len(0);
+LL | |             }
+   | |_____________^
+   |
+help: put the `;` here
+   |
+LL ~                 self.set_len(0)
+LL ~             };
+   |
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
changelog: [`semicolon_inside_block`]: don't fire if block is surrounded by parens

supersedes https://github.com/rust-lang/rust-clippy/pull/15391, fixes https://github.com/rust-lang/rust-clippy/issues/15380, fixes https://github.com/rust-lang/rust-clippy/issues/15389

I changed to approach to ignore blocks surrounded by parens, as suggested in https://github.com/rust-lang/rust-clippy/pull/15391#issuecomment-3146878801.

To do that, I took inspiration from https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/attempted.20fix.20for.20disallowed_macros/near/532461016 and realized that this lint would benefit from being early-pass rather than late-pass, since that surfaces `ExprKind::Paren` which we now can explicitly ignore. Well, implicitly rather -- the lint now matches _only_ on a `StmtKind::Semi` that contains a `ExprKind::Block`, without a `ExprKind::Paren` layer inbetween.