### PR TITLE
`is_expr_identity_of_pat`: simplify using `(unordered_)over`

### DIFF
--- a/clippy_utils/src/ast_utils/mod.rs
+++ b/clippy_utils/src/ast_utils/mod.rs
@@ -21,7 +21,7 @@ pub fn is_useless_with_eq_exprs(kind: BinOpKind) -> bool {
 }
 
 /// Checks if each element in the first slice is contained within the latter as per `eq_fn`.
-pub fn unordered_over<X>(left: &[X], right: &[X], mut eq_fn: impl FnMut(&X, &X) -> bool) -> bool {
+pub fn unordered_over<X, Y>(left: &[X], right: &[Y], mut eq_fn: impl FnMut(&X, &Y) -> bool) -> bool {
     left.len() == right.len() && left.iter().all(|l| right.iter().any(|r| eq_fn(l, r)))
 }
 

--- a/clippy_utils/src/hir_utils.rs
+++ b/clippy_utils/src/hir_utils.rs
@@ -757,7 +757,7 @@ pub fn both_some_and<X, Y>(l: Option<X>, r: Option<Y>, mut pred: impl FnMut(X, Y
 }
 
 /// Checks if two slices are equal as per `eq_fn`.
-pub fn over<X>(left: &[X], right: &[X], mut eq_fn: impl FnMut(&X, &X) -> bool) -> bool {
+pub fn over<X, Y>(left: &[X], right: &[Y], mut eq_fn: impl FnMut(&X, &Y) -> bool) -> bool {
     left.len() == right.len() && left.iter().zip(right).all(|(x, y)| eq_fn(x, y))
 }
 


### PR DESCRIPTION
This makes the last arm significantly shorter, but marginally shortens the other ones as well

- I first removed the length comparisons from the match guards since they were already present in `(unordered_)over`, but then brought them back since they are quite a helpful "guard clause"
- It's a bit unfortunate that the `Slice`/`Array` arm can't use `over` as well, which creates some asymmetry, but changing the signature of `over` to accept arbitrary iterators felt like too much to me, especially because we'd lose the ability to compare the lengths of the two inputs (which could've been mitigated by `ExactLenIterator::len`, but that method is still unstable AFAIR)

One other option would be to only use `unordered_over` in the last arm, and not `over`, but I think `over` is not that bad..

changelog: none