### PR TITLE
fix(disallowed_macros): Fix emitting on attr macros

### DIFF
--- a/clippy_lints/src/disallowed_macros.rs
+++ b/clippy_lints/src/disallowed_macros.rs
@@ -4,18 +4,17 @@ use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::macros::macro_backtrace;
 use clippy_utils::paths::PathNS;
 use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefIdMap;
 use rustc_hir::{
-    AmbigArg, Expr, ExprKind, ForeignItem, HirId, ImplItem, ImplItemImplKind, Item, ItemKind, OwnerId, Pat, Path, Stmt,
-    TraitItem, Ty,
+    AmbigArg, Attribute, Expr, ExprKind, ForeignItem, HirId, ImplItem, ImplItemImplKind, Item,
+    ItemKind, OwnerId, Pat, Path, Stmt, TraitItem, Ty,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::impl_lint_pass;
 use rustc_span::{ExpnId, MacroKind, Span};
-
-use crate::utils::attr_collector::AttrStorage;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -71,14 +70,10 @@ pub struct DisallowedMacros {
     // Track the most recently seen node that can have a `derive` attribute.
     // Needed to use the correct lint level.
     derive_src: Option<OwnerId>,
-
-    // When a macro is disallowed in an early pass, it's stored
-    // and emitted during the late pass. This happens for attributes.
-    early_macro_cache: AttrStorage,
 }
 
 impl DisallowedMacros {
-    pub fn new(tcx: TyCtxt<'_>, conf: &'static Conf, early_macro_cache: AttrStorage) -> Self {
+    pub fn new(tcx: TyCtxt<'_>, conf: &'static Conf) -> Self {
         let (disallowed, _) = create_disallowed_map(
             tcx,
             &conf.disallowed_macros,
@@ -91,7 +86,6 @@ impl DisallowedMacros {
             disallowed,
             seen: FxHashSet::default(),
             derive_src: None,
-            early_macro_cache,
         }
     }
 
@@ -128,13 +122,97 @@ impl DisallowedMacros {
 }
 
 impl LateLintPass<'_> for DisallowedMacros {
-    fn check_crate(&mut self, cx: &LateContext<'_>) {
-        // once we check a crate in the late pass we can emit the early pass lints
-        if let Some(attr_spans) = self.early_macro_cache.clone().0.get() {
-            for span in attr_spans {
-                self.check(cx, *span, None);
-            }
-        }
+    fn check_attribute(&mut self, cx: &LateContext<'_>, attr: &Attribute) {
+        let span = match attr {
+            Attribute::Unparsed(attr_item) => attr_item.span,
+            Attribute::Parsed(kind) => match kind {
+                AttributeKind::AllowInternalUnsafe(span)
+                | AttributeKind::AllowInternalUnstable(_, span)
+                | AttributeKind::AutomaticallyDerived(span)
+                | AttributeKind::Cold(span)
+                | AttributeKind::ConstContinue(span)
+                | AttributeKind::Coroutine(span)
+                | AttributeKind::Coverage(span, _)
+                | AttributeKind::Deprecated { span, .. }
+                | AttributeKind::DocComment { span, .. }
+                | AttributeKind::ExportName { span, .. }
+                | AttributeKind::FfiConst(span)
+                | AttributeKind::FfiPure(span)
+                | AttributeKind::Inline(_, span)
+                | AttributeKind::Lang(_, span)
+                | AttributeKind::LinkName { span, .. }
+                | AttributeKind::LinkOrdinal { span, .. }
+                | AttributeKind::LinkSection { span, .. }
+                | AttributeKind::LoopMatch(span)
+                | AttributeKind::MacroEscape(span)
+                | AttributeKind::MacroExport { span, .. }
+                | AttributeKind::MacroUse { span, .. }
+                | AttributeKind::Marker(span)
+                | AttributeKind::MayDangle(span)
+                | AttributeKind::MustUse { span, .. }
+                | AttributeKind::Naked(span)
+                | AttributeKind::NoCore(span)
+                | AttributeKind::NoImplicitPrelude(span)
+                | AttributeKind::NoMangle(span)
+                | AttributeKind::NoStd(span)
+                | AttributeKind::NonExhaustive(span)
+                | AttributeKind::OnConst { span, .. }
+                | AttributeKind::OnMove { span, .. }
+                | AttributeKind::OnUnimplemented { span, .. }
+                | AttributeKind::OnUnknown { span, .. }
+                | AttributeKind::OnUnmatchArgs { span, .. }
+                | AttributeKind::Optimize(_, span)
+                | AttributeKind::Path(_, span)
+                | AttributeKind::PinV2(span)
+                | AttributeKind::ProcMacro(span)
+                | AttributeKind::ProcMacroAttribute(span)
+                | AttributeKind::ProcMacroDerive { span, .. }
+                | AttributeKind::Repr { first_span: span, .. }
+                | AttributeKind::RustcAlign { span, .. }
+                | AttributeKind::RustcAllowConstFnUnstable(_, span)
+                | AttributeKind::RustcAllowIncoherentImpl(span)
+                | AttributeKind::RustcAsPtr(span)
+                | AttributeKind::RustcBodyStability { span, .. }
+                | AttributeKind::RustcBuiltinMacro { span, .. }
+                | AttributeKind::RustcCoherenceIsCore(span)
+                | AttributeKind::RustcCoinductive(span)
+                | AttributeKind::RustcConstStability { span, .. }
+                | AttributeKind::RustcDenyExplicitImpl(span)
+                | AttributeKind::RustcDocPrimitive(span, _)
+                | AttributeKind::RustcDumpDefPath(span)
+                | AttributeKind::RustcDumpSymbolName(span)
+                | AttributeKind::RustcDumpVtable(span)
+                | AttributeKind::RustcDynIncompatibleTrait(span)
+                | AttributeKind::RustcIfThisChanged(span, _)
+                | AttributeKind::RustcLayoutScalarValidRangeEnd(_, span)
+                | AttributeKind::RustcLayoutScalarValidRangeStart(_, span)
+                | AttributeKind::RustcMustMatchExhaustively(span)
+                | AttributeKind::RustcObjcClass { span, .. }
+                | AttributeKind::RustcObjcSelector { span, .. }
+                | AttributeKind::RustcParenSugar(span)
+                | AttributeKind::RustcPassByValue(span)
+                | AttributeKind::RustcPassIndirectlyInNonRusticAbis(span)
+                | AttributeKind::RustcPubTransparent(span)
+                | AttributeKind::RustcReservationImpl(span, _)
+                | AttributeKind::RustcScalableVector { span, .. }
+                | AttributeKind::RustcShouldNotBeCalledOnConstItems(span)
+                | AttributeKind::RustcSkipDuringMethodDispatch { span, .. }
+                | AttributeKind::RustcSpecializationTrait(span)
+                | AttributeKind::RustcStdInternalSymbol(span)
+                | AttributeKind::RustcThenThisWouldNeed(span, _)
+                | AttributeKind::RustcUnsafeSpecializationMarker(span)
+                | AttributeKind::Sanitize { span, .. }
+                | AttributeKind::ShouldPanic { span, .. }
+                | AttributeKind::Stability { span, .. }
+                | AttributeKind::TargetFeature { attr_span: span, .. }
+                | AttributeKind::TrackCaller(span)
+                | AttributeKind::Used { span, .. }
+                | AttributeKind::WindowsSubsystem(_, span) => *span,
+
+                _ => return,
+            },
+        };
+        self.check(cx, span, self.derive_src);
     }
 
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {

--- a/clippy_lints/src/disallowed_macros.rs
+++ b/clippy_lints/src/disallowed_macros.rs
@@ -8,8 +8,8 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefIdMap;
 use rustc_hir::{
-    AmbigArg, Attribute, Expr, ExprKind, ForeignItem, HirId, ImplItem, ImplItemImplKind, Item,
-    ItemKind, OwnerId, Pat, Path, Stmt, TraitItem, Ty,
+    AmbigArg, Attribute, Expr, ExprKind, ForeignItem, HirId, ImplItem, ImplItemImplKind, Item, ItemKind, OwnerId, Pat,
+    Path, Stmt, TraitItem, Ty,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TyCtxt;

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -703,10 +703,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(|_| Box::<unwrap_in_result::UnwrapInResult>::default()),
         Box::new(|_| Box::new(semicolon_if_nothing_returned::SemicolonIfNothingReturned)),
         Box::new(|_| Box::new(async_yields_async::AsyncYieldsAsync)),
-        {
-            let attrs = attr_storage.clone();
-            Box::new(move |tcx| Box::new(disallowed_macros::DisallowedMacros::new(tcx, conf, attrs.clone())))
-        },
+        Box::new(move |tcx| Box::new(disallowed_macros::DisallowedMacros::new(tcx, conf))),
         Box::new(move |tcx| Box::new(disallowed_methods::DisallowedMethods::new(tcx, conf))),
         Box::new(|_| Box::new(empty_drop::EmptyDrop)),
         Box::new(|_| Box::new(strings::StrToString)),

--- a/tests/ui-toml/disallowed_macros/clippy.toml
+++ b/tests/ui-toml/disallowed_macros/clippy.toml
@@ -1,4 +1,5 @@
 disallowed-macros = [
+    "std::panic",
     "std::println",
     "std::vec",
     { path = "std::cfg" },

--- a/tests/ui-toml/disallowed_macros/disallowed_macros.stderr
+++ b/tests/ui-toml/disallowed_macros/disallowed_macros.stderr
@@ -1,33 +1,11 @@
-error: use of a disallowed macro `serde::Serialize`
-  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:22:14
-   |
-LL |     #[derive(Serialize)]
-   |              ^^^^^^^^^
-   |
-   = note: no serializing
-   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::disallowed_macros)]`
-
-error: use of a disallowed macro `macros::attr`
-  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:42:1
-   |
-LL | / macros::attr! {
-LL | |
-LL | |     struct S;
-LL | | }
-   | |_^
-
-error: use of a disallowed macro `proc_macros::Derive`
-  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:62:10
-   |
-LL | #[derive(Derive)]
-   |          ^^^^^^
-
 error: use of a disallowed macro `std::println`
   --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:13:5
    |
 LL |     println!("one");
    |     ^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::disallowed_macros)]`
 
 error: use of a disallowed macro `std::println`
   --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:15:5
@@ -46,6 +24,14 @@ error: use of a disallowed macro `std::vec`
    |
 LL |     vec![1, 2, 3];
    |     ^^^^^^^^^^^^^
+
+error: use of a disallowed macro `serde::Serialize`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:22:14
+   |
+LL |     #[derive(Serialize)]
+   |              ^^^^^^^^^
+   |
+   = note: no serializing
 
 error: use of a disallowed macro `macros::expr`
   --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:26:13
@@ -83,6 +69,15 @@ error: use of a disallowed macro `macros::binop`
 LL |     let _ = macros::binop!(1);
    |             ^^^^^^^^^^^^^^^^^
 
+error: use of a disallowed macro `macros::attr`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:42:1
+   |
+LL | / macros::attr! {
+LL | |
+LL | |     struct S;
+LL | | }
+   | |_^
+
 error: use of a disallowed macro `macros::item`
   --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:48:5
    |
@@ -100,6 +95,12 @@ error: use of a disallowed macro `macros::item`
    |
 LL |     macros::item!();
    |     ^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `proc_macros::Derive`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:62:10
+   |
+LL | #[derive(Derive)]
+   |          ^^^^^^
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs
+++ b/tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs
@@ -1,0 +1,70 @@
+fn test_allow_on_function() {
+    #![allow(clippy::disallowed_macros)]
+
+    panic!();
+    panic!("message");
+    panic!("{}", 123);
+    panic!("{} {}", 123, 456);
+    println!("test");
+    println!("{}", 123);
+    vec![1, 2, 3];
+}
+
+fn test_expect_on_function() {
+    #![expect(clippy::disallowed_macros)]
+
+    panic!();
+    panic!("message");
+    panic!("{}", 123);
+    panic!("{} {}", 123, 456);
+    println!("test");
+    println!("{}", 123);
+    vec![1, 2, 3];
+}
+
+fn test_no_attributes() {
+    panic!();
+    //~^ disallowed_macros
+    panic!("message");
+    //~^ disallowed_macros
+    panic!("{}", 123);
+    //~^ disallowed_macros
+    panic!("{} {}", 123, 456);
+    //~^ disallowed_macros
+    println!("test");
+    //~^ disallowed_macros
+    println!("{}", 123);
+    //~^ disallowed_macros
+    vec![1, 2, 3];
+    //~^ disallowed_macros
+}
+
+#[allow(clippy::disallowed_macros)]
+mod allowed_module {
+    pub fn test() {
+        panic!();
+        panic!("message");
+        panic!("{}", 123);
+        println!("test");
+        vec![1, 2, 3];
+    }
+}
+
+#[expect(clippy::disallowed_macros)]
+mod expected_module {
+    pub fn test() {
+        panic!();
+        panic!("message");
+        panic!("{}", 123);
+        println!("test");
+        vec![1, 2, 3];
+    }
+}
+
+fn main() {
+    test_allow_on_function();
+    test_expect_on_function();
+    test_no_attributes();
+    allowed_module::test();
+    expected_module::test();
+}

--- a/tests/ui-toml/disallowed_macros/disallowed_macros_regression.stderr
+++ b/tests/ui-toml/disallowed_macros/disallowed_macros_regression.stderr
@@ -1,0 +1,47 @@
+error: use of a disallowed macro `std::panic`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:26:5
+   |
+LL |     panic!();
+   |     ^^^^^^^^
+   |
+   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::disallowed_macros)]`
+
+error: use of a disallowed macro `std::panic`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:28:5
+   |
+LL |     panic!("message");
+   |     ^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::panic`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:30:5
+   |
+LL |     panic!("{}", 123);
+   |     ^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::panic`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:32:5
+   |
+LL |     panic!("{} {}", 123, 456);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::println`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:34:5
+   |
+LL |     println!("test");
+   |     ^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::println`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:36:5
+   |
+LL |     println!("{}", 123);
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::vec`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:38:5
+   |
+LL |     vec![1, 2, 3];
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
changelog: [`disallowed_macros`]: Fix emitting on attr macros. Fixes rust-lang/rust-clippy#14017, rust-lang/rust-clippy#15312 .