### PR TITLE
Adjust `declare_interior_mutable_const` lint's category

### DIFF
--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -92,7 +92,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub DECLARE_INTERIOR_MUTABLE_CONST,
-    style,
+    suspicious,
     "declaring `const` with interior mutability"
 }
 


### PR DESCRIPTION
Per the root readme, `clippy::style` is a category with

> code that should be written in a more idiomatic way

description.

The code this lint guards from may be much worse than badly styled:

```rs
use std::sync::LazyLock;

// `const` instead of `static` causes `dbg!` to be printed 10 times
// instead of one.
const LICENSE_FILE_NAME_REGEX: LazyLock<String> = LazyLock::new(|| {
    dbg!("I am a large regex initialized in a lazy lock!");
    format!("Hello {}", "World".to_string())
});

fn main() {
    for _ in 0..10 {
        let _ = LICENSE_FILE_NAME_REGEX.split(" ");
    }
}
```

In large projects, it's unfortunate but sometimes possible to see style lints suppressed with

```toml
[workspace.lints.clippy]
style = { level = "allow", priority = -1 }
```

effectively turning off crucial checks for the code like above.

To keep them, promote this lint to `clippy::suspicious`:

> code that is most likely wrong or useless

category that has the same, `warn` default level, thus not failing on false-positives which lead to https://github.com/rust-lang/rust-clippy/issues/5863


---

changelog: [`declare_interior_mutable_const`]: promote lint's category to `clippy::suspicious`