### PR TITLE
cast_possible_truncation: Support `size_of`, `align_of`, and `size_of_val`

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -867,7 +867,7 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
     fn align_of_call(&self, callee: &Expr<'_>) -> Option<Constant<'tcx>> {
         let ty = self.typeck.node_args(callee.hir_id).types().next()?;
         if let Ok(layout) = self.tcx.layout_of(self.typing_env.as_query_input(ty)) {
-            Some(Constant::Int(layout.align.bytes() as u128))
+            Some(Constant::Int(u128::from(layout.align.bytes())))
         } else {
             None
         }
@@ -877,7 +877,7 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
         if let Ok(layout) = self.tcx.layout_of(self.typing_env.as_query_input(ty))
             && layout.is_sized()
         {
-            Some(Constant::Int(layout.size.bytes() as u128))
+            Some(Constant::Int(u128::from(layout.size.bytes())))
         } else {
             None
         }

--- a/tests/ui-toml/min_rust_version/min_rust_version.fixed
+++ b/tests/ui-toml/min_rust_version/min_rust_version.fixed
@@ -1,4 +1,9 @@
-#![allow(clippy::redundant_clone, clippy::unnecessary_operation, clippy::incompatible_msrv)]
+#![allow(
+    clippy::redundant_clone,
+    clippy::unnecessary_operation,
+    clippy::incompatible_msrv,
+    clippy::identity_op
+)]
 #![warn(clippy::manual_non_exhaustive, clippy::borrow_as_ptr, clippy::manual_bits)]
 
 use std::mem::{size_of, size_of_val};

--- a/tests/ui-toml/min_rust_version/min_rust_version.rs
+++ b/tests/ui-toml/min_rust_version/min_rust_version.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::redundant_clone, clippy::unnecessary_operation, clippy::incompatible_msrv)]
+#![allow(
+    clippy::redundant_clone,
+    clippy::unnecessary_operation,
+    clippy::incompatible_msrv,
+    clippy::identity_op
+)]
 #![warn(clippy::manual_non_exhaustive, clippy::borrow_as_ptr, clippy::manual_bits)]
 
 use std::mem::{size_of, size_of_val};

--- a/tests/ui-toml/min_rust_version/min_rust_version.stderr
+++ b/tests/ui-toml/min_rust_version/min_rust_version.stderr
@@ -1,5 +1,5 @@
 error: you are using an explicit closure for cloning elements
-  --> tests/ui-toml/min_rust_version/min_rust_version.rs:74:26
+  --> tests/ui-toml/min_rust_version/min_rust_version.rs:79:26
    |
 LL |     let _: Option<u64> = Some(&16).map(|b| *b);
    |                          ^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `Some(&16).cloned()`

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -251,6 +251,26 @@ fn main() {
     999999u64.clamp(0, 256) as u8;
     //~^ cast_possible_truncation
 
+    std::mem::size_of::<u64>() as u8;
+    std::mem::size_of_val(&1_u64) as u8;
+    std::mem::align_of::<u64>() as u8;
+    std::mem::align_of_val(&1_u64) as u8; // currently not supported by const eval
+    //~^ cast_possible_truncation
+
+    std::mem::size_of::<[u8; 256]>() as u8;
+    //~^ cast_possible_truncation
+    std::mem::size_of_val(&[0_u8; 256]) as u8;
+    //~^ cast_possible_truncation
+    std::mem::size_of_val("foo") as u8;
+    //~^ cast_possible_truncation
+
+    #[repr(C, align(256))]
+    struct HighAlign([u8; 256]);
+    std::mem::size_of::<HighAlign>() as u8;
+    //~^ cast_possible_truncation
+    std::mem::align_of::<HighAlign>() as u8;
+    //~^ cast_possible_truncation
+
     #[derive(Clone, Copy)]
     enum E1 {
         A,

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -254,7 +254,8 @@ fn main() {
     std::mem::size_of::<u64>() as u8;
     std::mem::size_of_val(&1_u64) as u8;
     std::mem::align_of::<u64>() as u8;
-    std::mem::align_of_val(&1_u64) as u8; // currently not supported by const eval
+    // currently not supported by const eval
+    std::mem::align_of_val(&1_u64) as u8;
     //~^ cast_possible_truncation
 
     std::mem::size_of::<[u8; 256]>() as u8;

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -386,20 +386,20 @@ LL +     u8::try_from(999999u64.clamp(0, 256));
    |
 
 error: casting `usize` to `u8` may truncate the value
-  --> tests/ui/cast.rs:257:5
+  --> tests/ui/cast.rs:258:5
    |
-LL |     std::mem::align_of_val(&1_u64) as u8; // currently not supported by const eval
+LL |     std::mem::align_of_val(&1_u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
-LL -     std::mem::align_of_val(&1_u64) as u8; // currently not supported by const eval
-LL +     u8::try_from(std::mem::align_of_val(&1_u64)); // currently not supported by const eval
+LL -     std::mem::align_of_val(&1_u64) as u8;
+LL +     u8::try_from(std::mem::align_of_val(&1_u64));
    |
 
 error: casting `usize` to `u8` may truncate the value
-  --> tests/ui/cast.rs:260:5
+  --> tests/ui/cast.rs:261:5
    |
 LL |     std::mem::size_of::<[u8; 256]>() as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -412,7 +412,7 @@ LL +     u8::try_from(std::mem::size_of::<[u8; 256]>());
    |
 
 error: casting `usize` to `u8` may truncate the value
-  --> tests/ui/cast.rs:262:5
+  --> tests/ui/cast.rs:263:5
    |
 LL |     std::mem::size_of_val(&[0_u8; 256]) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -425,7 +425,7 @@ LL +     u8::try_from(std::mem::size_of_val(&[0_u8; 256]));
    |
 
 error: casting `usize` to `u8` may truncate the value
-  --> tests/ui/cast.rs:264:5
+  --> tests/ui/cast.rs:265:5
    |
 LL |     std::mem::size_of_val("foo") as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -438,7 +438,7 @@ LL +     u8::try_from(std::mem::size_of_val("foo"));
    |
 
 error: casting `usize` to `u8` may truncate the value
-  --> tests/ui/cast.rs:269:5
+  --> tests/ui/cast.rs:270:5
    |
 LL |     std::mem::size_of::<HighAlign>() as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -451,7 +451,7 @@ LL +     u8::try_from(std::mem::size_of::<HighAlign>());
    |
 
 error: casting `usize` to `u8` may truncate the value
-  --> tests/ui/cast.rs:271:5
+  --> tests/ui/cast.rs:272:5
    |
 LL |     std::mem::align_of::<HighAlign>() as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -464,7 +464,7 @@ LL +     u8::try_from(std::mem::align_of::<HighAlign>());
    |
 
 error: casting `main::E2` to `u8` may truncate the value
-  --> tests/ui/cast.rs:294:21
+  --> tests/ui/cast.rs:295:21
    |
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
@@ -477,7 +477,7 @@ LL +             let _ = u8::try_from(self);
    |
 
 error: casting `main::E2::B` to `u8` will truncate the value
-  --> tests/ui/cast.rs:297:21
+  --> tests/ui/cast.rs:298:21
    |
 LL |             let _ = Self::B as u8;
    |                     ^^^^^^^^^^^^^
@@ -486,7 +486,7 @@ LL |             let _ = Self::B as u8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_enum_truncation)]`
 
 error: casting `main::E5` to `i8` may truncate the value
-  --> tests/ui/cast.rs:339:21
+  --> tests/ui/cast.rs:340:21
    |
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
@@ -499,13 +499,13 @@ LL +             let _ = i8::try_from(self);
    |
 
 error: casting `main::E5::A` to `i8` will truncate the value
-  --> tests/ui/cast.rs:342:21
+  --> tests/ui/cast.rs:343:21
    |
 LL |             let _ = Self::A as i8;
    |                     ^^^^^^^^^^^^^
 
 error: casting `main::E6` to `i16` may truncate the value
-  --> tests/ui/cast.rs:360:21
+  --> tests/ui/cast.rs:361:21
    |
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
@@ -518,7 +518,7 @@ LL +             let _ = i16::try_from(self);
    |
 
 error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:380:21
+  --> tests/ui/cast.rs:381:21
    |
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
@@ -531,7 +531,7 @@ LL +             let _ = usize::try_from(self);
    |
 
 error: casting `main::E10` to `u16` may truncate the value
-  --> tests/ui/cast.rs:428:21
+  --> tests/ui/cast.rs:429:21
    |
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
@@ -544,7 +544,7 @@ LL +             let _ = u16::try_from(self);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:440:13
+  --> tests/ui/cast.rs:441:13
    |
 LL |     let c = (q >> 16) as u8;
    |             ^^^^^^^^^^^^^^^
@@ -557,7 +557,7 @@ LL +     let c = u8::try_from(q >> 16);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:445:13
+  --> tests/ui/cast.rs:446:13
    |
 LL |     let c = (q / 1000) as u8;
    |             ^^^^^^^^^^^^^^^^
@@ -570,85 +570,85 @@ LL +     let c = u8::try_from(q / 1000);
    |
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:458:9
+  --> tests/ui/cast.rs:459:9
    |
 LL |         (x * x) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:464:32
+  --> tests/ui/cast.rs:465:32
    |
 LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
    |                                ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:467:5
+  --> tests/ui/cast.rs:468:5
    |
 LL |     (2_i32).checked_pow(3).unwrap() as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:469:5
+  --> tests/ui/cast.rs:470:5
    |
 LL |     (-2_i32).pow(3) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:474:5
+  --> tests/ui/cast.rs:475:5
    |
 LL |     (-5_i32 % 2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:477:5
+  --> tests/ui/cast.rs:478:5
    |
 LL |     (-5_i32 % -2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:481:5
+  --> tests/ui/cast.rs:482:5
    |
 LL |     (-2_i32 >> 1) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:485:5
+  --> tests/ui/cast.rs:486:5
    |
 LL |     (x * x) as u32;
    |     ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:487:5
+  --> tests/ui/cast.rs:488:5
    |
 LL |     (x * x * x) as u32;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:491:5
+  --> tests/ui/cast.rs:492:5
    |
 LL |     (y * y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:494:5
+  --> tests/ui/cast.rs:495:5
    |
 LL |     (y * y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:496:5
+  --> tests/ui/cast.rs:497:5
    |
 LL |     (y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:499:5
+  --> tests/ui/cast.rs:500:5
    |
 LL |     (y / y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `/`
-  --> tests/ui/cast.rs:499:6
+  --> tests/ui/cast.rs:500:6
    |
 LL |     (y / y * y * -2) as u16;
    |      ^^^^^
@@ -656,97 +656,97 @@ LL |     (y / y * y * -2) as u16;
    = note: `#[deny(clippy::eq_op)]` on by default
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:503:5
+  --> tests/ui/cast.rs:504:5
    |
 LL |     (y + y + y + -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:506:5
+  --> tests/ui/cast.rs:507:5
    |
 LL |     (y + y + y + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:510:5
+  --> tests/ui/cast.rs:511:5
    |
 LL |     (z + -2) as u16;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:513:5
+  --> tests/ui/cast.rs:514:5
    |
 LL |     (z + z + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:517:9
+  --> tests/ui/cast.rs:518:9
    |
 LL |         (a * a * b * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:519:9
+  --> tests/ui/cast.rs:520:9
    |
 LL |         (a * b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:522:9
+  --> tests/ui/cast.rs:523:9
    |
 LL |         (a * -b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:525:9
+  --> tests/ui/cast.rs:526:9
    |
 LL |         (a * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:527:9
+  --> tests/ui/cast.rs:528:9
    |
 LL |         (a * -2) as u32;
    |         ^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:530:9
+  --> tests/ui/cast.rs:531:9
    |
 LL |         (a * b * c * -2) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:533:9
+  --> tests/ui/cast.rs:534:9
    |
 LL |         (a / b) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:535:9
+  --> tests/ui/cast.rs:536:9
    |
 LL |         (a / b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:538:9
+  --> tests/ui/cast.rs:539:9
    |
 LL |         (a / b + b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:541:9
+  --> tests/ui/cast.rs:542:9
    |
 LL |         a.saturating_pow(3) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:544:9
+  --> tests/ui/cast.rs:545:9
    |
 LL |         (a.abs() * b.pow(2) / c.abs()) as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:552:21
+  --> tests/ui/cast.rs:553:21
    |
 LL |             let _ = i32::MIN as u32; // cast_sign_loss
    |                     ^^^^^^^^^^^^^^^
@@ -757,7 +757,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:555:21
+  --> tests/ui/cast.rs:556:21
    |
 LL |             let _ = u32::MAX as u8; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^
@@ -774,7 +774,7 @@ LL +             let _ = u8::try_from(u32::MAX); // cast_possible_truncation
    |
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:558:21
+  --> tests/ui/cast.rs:559:21
    |
 LL |             let _ = std::f64::consts::PI as f32; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -786,7 +786,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `i64` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:569:5
+  --> tests/ui/cast.rs:570:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -799,13 +799,13 @@ LL +     usize::try_from(bar.unwrap().unwrap())
    |
 
 error: casting `i64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:569:5
+  --> tests/ui/cast.rs:570:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:586:5
+  --> tests/ui/cast.rs:587:5
    |
 LL |     (256 & 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -818,7 +818,7 @@ LL +     u8::try_from(256 & 999999u64);
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:589:5
+  --> tests/ui/cast.rs:590:5
    |
 LL |     (255 % 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -385,8 +385,86 @@ LL -     999999u64.clamp(0, 256) as u8;
 LL +     u8::try_from(999999u64.clamp(0, 256));
    |
 
+error: casting `usize` to `u8` may truncate the value
+  --> tests/ui/cast.rs:257:5
+   |
+LL |     std::mem::align_of_val(&1_u64) as u8; // currently not supported by const eval
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL -     std::mem::align_of_val(&1_u64) as u8; // currently not supported by const eval
+LL +     u8::try_from(std::mem::align_of_val(&1_u64)); // currently not supported by const eval
+   |
+
+error: casting `usize` to `u8` may truncate the value
+  --> tests/ui/cast.rs:260:5
+   |
+LL |     std::mem::size_of::<[u8; 256]>() as u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL -     std::mem::size_of::<[u8; 256]>() as u8;
+LL +     u8::try_from(std::mem::size_of::<[u8; 256]>());
+   |
+
+error: casting `usize` to `u8` may truncate the value
+  --> tests/ui/cast.rs:262:5
+   |
+LL |     std::mem::size_of_val(&[0_u8; 256]) as u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL -     std::mem::size_of_val(&[0_u8; 256]) as u8;
+LL +     u8::try_from(std::mem::size_of_val(&[0_u8; 256]));
+   |
+
+error: casting `usize` to `u8` may truncate the value
+  --> tests/ui/cast.rs:264:5
+   |
+LL |     std::mem::size_of_val("foo") as u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL -     std::mem::size_of_val("foo") as u8;
+LL +     u8::try_from(std::mem::size_of_val("foo"));
+   |
+
+error: casting `usize` to `u8` may truncate the value
+  --> tests/ui/cast.rs:269:5
+   |
+LL |     std::mem::size_of::<HighAlign>() as u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL -     std::mem::size_of::<HighAlign>() as u8;
+LL +     u8::try_from(std::mem::size_of::<HighAlign>());
+   |
+
+error: casting `usize` to `u8` may truncate the value
+  --> tests/ui/cast.rs:271:5
+   |
+LL |     std::mem::align_of::<HighAlign>() as u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL -     std::mem::align_of::<HighAlign>() as u8;
+LL +     u8::try_from(std::mem::align_of::<HighAlign>());
+   |
+
 error: casting `main::E2` to `u8` may truncate the value
-  --> tests/ui/cast.rs:274:21
+  --> tests/ui/cast.rs:294:21
    |
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
@@ -399,7 +477,7 @@ LL +             let _ = u8::try_from(self);
    |
 
 error: casting `main::E2::B` to `u8` will truncate the value
-  --> tests/ui/cast.rs:277:21
+  --> tests/ui/cast.rs:297:21
    |
 LL |             let _ = Self::B as u8;
    |                     ^^^^^^^^^^^^^
@@ -408,7 +486,7 @@ LL |             let _ = Self::B as u8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_enum_truncation)]`
 
 error: casting `main::E5` to `i8` may truncate the value
-  --> tests/ui/cast.rs:319:21
+  --> tests/ui/cast.rs:339:21
    |
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
@@ -421,13 +499,13 @@ LL +             let _ = i8::try_from(self);
    |
 
 error: casting `main::E5::A` to `i8` will truncate the value
-  --> tests/ui/cast.rs:322:21
+  --> tests/ui/cast.rs:342:21
    |
 LL |             let _ = Self::A as i8;
    |                     ^^^^^^^^^^^^^
 
 error: casting `main::E6` to `i16` may truncate the value
-  --> tests/ui/cast.rs:340:21
+  --> tests/ui/cast.rs:360:21
    |
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
@@ -440,7 +518,7 @@ LL +             let _ = i16::try_from(self);
    |
 
 error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:360:21
+  --> tests/ui/cast.rs:380:21
    |
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
@@ -453,7 +531,7 @@ LL +             let _ = usize::try_from(self);
    |
 
 error: casting `main::E10` to `u16` may truncate the value
-  --> tests/ui/cast.rs:408:21
+  --> tests/ui/cast.rs:428:21
    |
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
@@ -466,7 +544,7 @@ LL +             let _ = u16::try_from(self);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:420:13
+  --> tests/ui/cast.rs:440:13
    |
 LL |     let c = (q >> 16) as u8;
    |             ^^^^^^^^^^^^^^^
@@ -479,7 +557,7 @@ LL +     let c = u8::try_from(q >> 16);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:425:13
+  --> tests/ui/cast.rs:445:13
    |
 LL |     let c = (q / 1000) as u8;
    |             ^^^^^^^^^^^^^^^^
@@ -492,85 +570,85 @@ LL +     let c = u8::try_from(q / 1000);
    |
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:438:9
+  --> tests/ui/cast.rs:458:9
    |
 LL |         (x * x) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:444:32
+  --> tests/ui/cast.rs:464:32
    |
 LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
    |                                ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:447:5
+  --> tests/ui/cast.rs:467:5
    |
 LL |     (2_i32).checked_pow(3).unwrap() as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:449:5
+  --> tests/ui/cast.rs:469:5
    |
 LL |     (-2_i32).pow(3) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:454:5
+  --> tests/ui/cast.rs:474:5
    |
 LL |     (-5_i32 % 2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:457:5
+  --> tests/ui/cast.rs:477:5
    |
 LL |     (-5_i32 % -2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:461:5
+  --> tests/ui/cast.rs:481:5
    |
 LL |     (-2_i32 >> 1) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:465:5
+  --> tests/ui/cast.rs:485:5
    |
 LL |     (x * x) as u32;
    |     ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:467:5
+  --> tests/ui/cast.rs:487:5
    |
 LL |     (x * x * x) as u32;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:471:5
+  --> tests/ui/cast.rs:491:5
    |
 LL |     (y * y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:474:5
+  --> tests/ui/cast.rs:494:5
    |
 LL |     (y * y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:476:5
+  --> tests/ui/cast.rs:496:5
    |
 LL |     (y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:479:5
+  --> tests/ui/cast.rs:499:5
    |
 LL |     (y / y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `/`
-  --> tests/ui/cast.rs:479:6
+  --> tests/ui/cast.rs:499:6
    |
 LL |     (y / y * y * -2) as u16;
    |      ^^^^^
@@ -578,97 +656,97 @@ LL |     (y / y * y * -2) as u16;
    = note: `#[deny(clippy::eq_op)]` on by default
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:483:5
+  --> tests/ui/cast.rs:503:5
    |
 LL |     (y + y + y + -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:486:5
+  --> tests/ui/cast.rs:506:5
    |
 LL |     (y + y + y + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:490:5
+  --> tests/ui/cast.rs:510:5
    |
 LL |     (z + -2) as u16;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:493:5
+  --> tests/ui/cast.rs:513:5
    |
 LL |     (z + z + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:497:9
+  --> tests/ui/cast.rs:517:9
    |
 LL |         (a * a * b * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:499:9
+  --> tests/ui/cast.rs:519:9
    |
 LL |         (a * b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:502:9
+  --> tests/ui/cast.rs:522:9
    |
 LL |         (a * -b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:505:9
+  --> tests/ui/cast.rs:525:9
    |
 LL |         (a * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:507:9
+  --> tests/ui/cast.rs:527:9
    |
 LL |         (a * -2) as u32;
    |         ^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:510:9
+  --> tests/ui/cast.rs:530:9
    |
 LL |         (a * b * c * -2) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:513:9
+  --> tests/ui/cast.rs:533:9
    |
 LL |         (a / b) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:515:9
+  --> tests/ui/cast.rs:535:9
    |
 LL |         (a / b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:518:9
+  --> tests/ui/cast.rs:538:9
    |
 LL |         (a / b + b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:521:9
+  --> tests/ui/cast.rs:541:9
    |
 LL |         a.saturating_pow(3) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:524:9
+  --> tests/ui/cast.rs:544:9
    |
 LL |         (a.abs() * b.pow(2) / c.abs()) as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:532:21
+  --> tests/ui/cast.rs:552:21
    |
 LL |             let _ = i32::MIN as u32; // cast_sign_loss
    |                     ^^^^^^^^^^^^^^^
@@ -679,7 +757,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:535:21
+  --> tests/ui/cast.rs:555:21
    |
 LL |             let _ = u32::MAX as u8; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^
@@ -696,7 +774,7 @@ LL +             let _ = u8::try_from(u32::MAX); // cast_possible_truncation
    |
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:538:21
+  --> tests/ui/cast.rs:558:21
    |
 LL |             let _ = std::f64::consts::PI as f32; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -708,7 +786,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `i64` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:549:5
+  --> tests/ui/cast.rs:569:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -721,13 +799,13 @@ LL +     usize::try_from(bar.unwrap().unwrap())
    |
 
 error: casting `i64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:549:5
+  --> tests/ui/cast.rs:569:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:566:5
+  --> tests/ui/cast.rs:586:5
    |
 LL |     (256 & 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -740,7 +818,7 @@ LL +     u8::try_from(256 & 999999u64);
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:569:5
+  --> tests/ui/cast.rs:589:5
    |
 LL |     (255 % 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -752,5 +830,5 @@ LL -     (255 % 999999u64) as u8;
 LL +     u8::try_from(255 % 999999u64);
    |
 
-error: aborting due to 92 previous errors
+error: aborting due to 98 previous errors
 

--- a/tests/ui/manual_bits.fixed
+++ b/tests/ui/manual_bits.fixed
@@ -1,5 +1,6 @@
 #![warn(clippy::manual_bits)]
 #![allow(
+    clippy::identity_op,
     clippy::no_effect,
     clippy::useless_conversion,
     path_statements,

--- a/tests/ui/manual_bits.rs
+++ b/tests/ui/manual_bits.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::manual_bits)]
 #![allow(
+    clippy::identity_op,
     clippy::no_effect,
     clippy::useless_conversion,
     path_statements,

--- a/tests/ui/manual_bits.stderr
+++ b/tests/ui/manual_bits.stderr
@@ -1,5 +1,5 @@
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:14:5
+  --> tests/ui/manual_bits.rs:15:5
    |
 LL |     size_of::<i8>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `i8::BITS as usize`
@@ -8,169 +8,169 @@ LL |     size_of::<i8>() * 8;
    = help: to override `-D warnings` add `#[allow(clippy::manual_bits)]`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:16:5
+  --> tests/ui/manual_bits.rs:17:5
    |
 LL |     size_of::<i16>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i16::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:18:5
+  --> tests/ui/manual_bits.rs:19:5
    |
 LL |     size_of::<i32>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i32::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:20:5
+  --> tests/ui/manual_bits.rs:21:5
    |
 LL |     size_of::<i64>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i64::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:22:5
+  --> tests/ui/manual_bits.rs:23:5
    |
 LL |     size_of::<i128>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `i128::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:24:5
+  --> tests/ui/manual_bits.rs:25:5
    |
 LL |     size_of::<isize>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `isize::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:27:5
+  --> tests/ui/manual_bits.rs:28:5
    |
 LL |     size_of::<u8>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `u8::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:29:5
+  --> tests/ui/manual_bits.rs:30:5
    |
 LL |     size_of::<u16>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u16::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:31:5
+  --> tests/ui/manual_bits.rs:32:5
    |
 LL |     size_of::<u32>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u32::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:33:5
+  --> tests/ui/manual_bits.rs:34:5
    |
 LL |     size_of::<u64>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u64::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:35:5
+  --> tests/ui/manual_bits.rs:36:5
    |
 LL |     size_of::<u128>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:37:5
+  --> tests/ui/manual_bits.rs:38:5
    |
 LL |     size_of::<usize>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `usize::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:40:5
+  --> tests/ui/manual_bits.rs:41:5
    |
 LL |     8 * size_of::<i8>();
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `i8::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:42:5
+  --> tests/ui/manual_bits.rs:43:5
    |
 LL |     8 * size_of::<i16>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i16::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:44:5
+  --> tests/ui/manual_bits.rs:45:5
    |
 LL |     8 * size_of::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i32::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:46:5
+  --> tests/ui/manual_bits.rs:47:5
    |
 LL |     8 * size_of::<i64>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i64::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:48:5
+  --> tests/ui/manual_bits.rs:49:5
    |
 LL |     8 * size_of::<i128>();
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `i128::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:50:5
+  --> tests/ui/manual_bits.rs:51:5
    |
 LL |     8 * size_of::<isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `isize::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:53:5
+  --> tests/ui/manual_bits.rs:54:5
    |
 LL |     8 * size_of::<u8>();
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `u8::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:55:5
+  --> tests/ui/manual_bits.rs:56:5
    |
 LL |     8 * size_of::<u16>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u16::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:57:5
+  --> tests/ui/manual_bits.rs:58:5
    |
 LL |     8 * size_of::<u32>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u32::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:59:5
+  --> tests/ui/manual_bits.rs:60:5
    |
 LL |     8 * size_of::<u64>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u64::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:61:5
+  --> tests/ui/manual_bits.rs:62:5
    |
 LL |     8 * size_of::<u128>();
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:63:5
+  --> tests/ui/manual_bits.rs:64:5
    |
 LL |     8 * size_of::<usize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `usize::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:74:5
+  --> tests/ui/manual_bits.rs:75:5
    |
 LL |     size_of::<Word>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `Word::BITS as usize`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:79:18
+  --> tests/ui/manual_bits.rs:80:18
    |
 LL |     let _: u32 = (size_of::<u128>() * 8) as u32;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:81:18
+  --> tests/ui/manual_bits.rs:82:18
    |
 LL |     let _: u32 = (size_of::<u128>() * 8).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:83:13
+  --> tests/ui/manual_bits.rs:84:13
    |
 LL |     let _ = (size_of::<u128>() * 8).pow(5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(u128::BITS as usize)`
 
 error: usage of `size_of::<T>()` to obtain the size of `T` in bits
-  --> tests/ui/manual_bits.rs:85:14
+  --> tests/ui/manual_bits.rs:86:14
    |
 LL |     let _ = &(size_of::<u128>() * 8);
    |              ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(u128::BITS as usize)`

--- a/tests/ui/manual_slice_size_calculation.fixed
+++ b/tests/ui/manual_slice_size_calculation.fixed
@@ -77,6 +77,7 @@ fn issue_14802() {
     }
 
     impl IcedSlice {
+        #[allow(clippy::identity_op)]
         fn get_len(&self) -> usize {
             std::mem::size_of_val(&self.dst)
             //~^ manual_slice_size_calculation

--- a/tests/ui/manual_slice_size_calculation.rs
+++ b/tests/ui/manual_slice_size_calculation.rs
@@ -77,6 +77,7 @@ fn issue_14802() {
     }
 
     impl IcedSlice {
+        #[allow(clippy::identity_op)]
         fn get_len(&self) -> usize {
             self.dst.len() * size_of::<u8>()
             //~^ manual_slice_size_calculation

--- a/tests/ui/manual_slice_size_calculation.stderr
+++ b/tests/ui/manual_slice_size_calculation.stderr
@@ -62,7 +62,7 @@ LL |     let _ = s_i32.len() * size_of::<i32>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> tests/ui/manual_slice_size_calculation.rs:81:13
+  --> tests/ui/manual_slice_size_calculation.rs:82:13
    |
 LL |             self.dst.len() * size_of::<u8>()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(&self.dst)`

--- a/tests/ui/size_of_in_element_count/expressions.rs
+++ b/tests/ui/size_of_in_element_count/expressions.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::size_of_in_element_count)]
-#![allow(clippy::ptr_offset_with_cast)]
+#![allow(clippy::ptr_offset_with_cast, clippy::identity_op, clippy::eq_op)]
 
 use std::mem::{size_of, size_of_val};
 use std::ptr::{copy, copy_nonoverlapping, write_bytes};

--- a/tests/ui/size_of_ref.rs
+++ b/tests/ui/size_of_ref.rs
@@ -24,6 +24,7 @@ struct S {
 
 impl S {
     /// Get size of object including `self`, in bytes.
+    #[allow(clippy::identity_op)]
     pub fn size(&self) -> usize {
         std::mem::size_of_val(&self) + (std::mem::size_of::<u8>() * self.data.capacity())
         //~^ size_of_ref

--- a/tests/ui/size_of_ref.stderr
+++ b/tests/ui/size_of_ref.stderr
@@ -17,7 +17,7 @@ LL |     size_of_val(&y);
    = help: dereference the argument to `size_of_val()` to get the size of the value instead of the size of the reference-type
 
 error: argument to `size_of_val()` is a reference to a reference
-  --> tests/ui/size_of_ref.rs:28:9
+  --> tests/ui/size_of_ref.rs:29:9
    |
 LL |         std::mem::size_of_val(&self) + (std::mem::size_of::<u8>() * self.data.capacity())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/transmutes_expressible_as_ptr_casts.fixed
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.fixed
@@ -80,6 +80,7 @@ struct Single(u64);
 #[repr(C)]
 struct Pair(u32, u32);
 
+#[allow(clippy::eq_op)]
 fn cannot_be_expressed_as_pointer_cast(in_param: Single) -> Pair {
     assert_eq!(size_of::<Single>(), size_of::<Pair>());
 

--- a/tests/ui/transmutes_expressible_as_ptr_casts.rs
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.rs
@@ -80,6 +80,7 @@ struct Single(u64);
 #[repr(C)]
 struct Pair(u32, u32);
 
+#[allow(clippy::eq_op)]
 fn cannot_be_expressed_as_pointer_cast(in_param: Single) -> Pair {
     assert_eq!(size_of::<Single>(), size_of::<Pair>());
 

--- a/tests/ui/transmutes_expressible_as_ptr_casts.stderr
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.stderr
@@ -73,7 +73,7 @@ LL |     unsafe { transmute::<&[i32; 1], *const u8>(in_param) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `in_param as *const [i32; 1] as *const u8`
 
 error: transmute from `fn()` to `*const u8` which could be expressed as a pointer cast instead
-  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:92:28
+  --> tests/ui/transmutes_expressible_as_ptr_casts.rs:93:28
    |
 LL |     let _x: u8 = unsafe { *std::mem::transmute::<fn(), *const u8>(f) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(f as *const u8)`


### PR DESCRIPTION
fixes parts of rust-lang/rust-clippy#9613, related to rust-lang/rust-clippy#12962

Unlike rust-lang/rust-clippy#12962, I added support for `size_of`, `align_of`, and `size_of_val` to `ConstEval`, so all lints using it benefit from this change. 

`cast_possible_truncation` itself changed relatively little. Functions calls are now delegated to const eval and ptr-sized to fixed-sized casts now consider `from_nbits`.

changelog: [`cast_possible_truncation`]: support `size_of`, `align_of`, and `size_of_val`

---

My intention with this PR is not to superceed rust-lang/rust-clippy#12962, but to get in a simple improvement while I work on rust-lang/rust-clippy#15342.