### PR TITLE
`missing_inline_in_public_items`: fix lint emission source HirId

### DIFF
--- a/tests/ui/missing_inline.rs
+++ b/tests/ui/missing_inline.rs
@@ -97,3 +97,10 @@ pub mod issue15301 {
         println!("Just called a Rust function from Rust!");
     }
 }
+
+pub mod issue15491 {
+    pub trait Foo {
+        #[allow(clippy::missing_inline_in_public_items)]
+        fn foo(&self) {}
+    }
+}


### PR DESCRIPTION
use trait item's HirId when emitting lint at `check_item` level
Fixes #15491

changelog: [`missing_inline_in_public_items`]: fix trait item lint emission