### PR TITLE
Add configuration option to allow `unreachable!` in test functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6692,6 +6692,7 @@ Released 2018-09-13
 [`allow-print-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-print-in-tests
 [`allow-private-module-inception`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-private-module-inception
 [`allow-renamed-params-for`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-renamed-params-for
+[`allow-unreachable-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-unreachable-in-tests
 [`allow-unwrap-in-consts`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-unwrap-in-consts
 [`allow-unwrap-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-unwrap-in-tests
 [`allow-useless-vec-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-useless-vec-in-tests

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -184,6 +184,16 @@ default configuration of Clippy. By default, any configuration will replace the 
 * [`renamed_function_params`](https://rust-lang.github.io/rust-clippy/master/index.html#renamed_function_params)
 
 
+## `allow-unreachable-in-tests`
+Whether `unreachable` should be allowed in test functions or `#[cfg(test)]`
+
+**Default Value:** `false`
+
+---
+**Affected lints:**
+* [`unreachable`](https://rust-lang.github.io/rust-clippy/master/index.html#unreachable)
+
+
 ## `allow-unwrap-in-consts`
 Whether `unwrap` should be allowed in code always evaluated at compile time
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -403,6 +403,9 @@ define_Conf! {
     #[lints(renamed_function_params)]
     allow_renamed_params_for: Vec<String> =
         DEFAULT_ALLOWED_TRAITS_WITH_RENAMED_PARAMS.iter().map(ToString::to_string).collect(),
+    /// Whether `unreachable` should be allowed in test functions or `#[cfg(test)]`
+    #[lints(unreachable)]
+    allow_unreachable_in_tests: bool = false,
     /// Whether `unwrap` should be allowed in code always evaluated at compile time
     #[lints(unwrap_used)]
     allow_unwrap_in_consts: bool = true,

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -10,12 +10,14 @@ use rustc_span::sym;
 
 pub struct PanicUnimplemented {
     allow_panic_in_tests: bool,
+    allow_unreachable_in_tests: bool,
 }
 
 impl PanicUnimplemented {
     pub fn new(conf: &'static Conf) -> Self {
         Self {
             allow_panic_in_tests: conf.allow_panic_in_tests,
+            allow_unreachable_in_tests: conf.allow_unreachable_in_tests,
         }
     }
 }
@@ -131,6 +133,10 @@ impl<'tcx> LateLintPass<'tcx> for PanicUnimplemented {
                     );
                 },
                 Some(sym::unreachable_macro) => {
+                    if self.allow_unreachable_in_tests && is_in_test(cx.tcx, expr.hir_id) {
+                        return;
+                    }
+
                     span_lint(cx, UNREACHABLE, macro_call.span, "usage of the `unreachable!` macro");
                 },
                 _ => {},

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -15,6 +15,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            allow-print-in-tests
            allow-private-module-inception
            allow-renamed-params-for
+           allow-unreachable-in-tests
            allow-unwrap-in-consts
            allow-unwrap-in-tests
            allow-useless-vec-in-tests
@@ -109,6 +110,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            allow-print-in-tests
            allow-private-module-inception
            allow-renamed-params-for
+           allow-unreachable-in-tests
            allow-unwrap-in-consts
            allow-unwrap-in-tests
            allow-useless-vec-in-tests
@@ -203,6 +205,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            allow-print-in-tests
            allow-private-module-inception
            allow-renamed-params-for
+           allow-unreachable-in-tests
            allow-unwrap-in-consts
            allow-unwrap-in-tests
            allow-useless-vec-in-tests

--- a/tests/ui-toml/unreachable/clippy.toml
+++ b/tests/ui-toml/unreachable/clippy.toml
@@ -1,0 +1,1 @@
+allow-unreachable-in-tests = true

--- a/tests/ui-toml/unreachable/unreachable.rs
+++ b/tests/ui-toml/unreachable/unreachable.rs
@@ -1,0 +1,25 @@
+//@compile-flags: --test
+#![warn(clippy::unreachable)]
+
+fn main() {
+    unreachable!();
+    //~^ unreachable
+}
+
+#[test]
+fn allowed_in_test_fn() {
+    unreachable!();
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn nested_test() {
+        unreachable!();
+    }
+
+    fn helper() {
+        // still test context should be allowed
+        unreachable!();
+    }
+}

--- a/tests/ui-toml/unreachable/unreachable.stderr
+++ b/tests/ui-toml/unreachable/unreachable.stderr
@@ -1,0 +1,11 @@
+error: usage of the `unreachable!` macro
+  --> tests/ui-toml/unreachable/unreachable.rs:5:5
+   |
+LL |     unreachable!();
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::unreachable` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unreachable)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
changelog: [`unreachable`]: Add configuration option to allow usage in test functions


<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [Feature-freeze](https://github.com/rust-lang/rust-clippy/pull/15517#issuecomment-3227314618) by [samueltardieu](https://github.com/samueltardieu)

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->