### PR TITLE
Activate `range-diff` feature of triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -49,6 +49,9 @@ new_pr = true
 # These labels are set when there are unresolved concerns, removed otherwise
 labels = ["S-waiting-on-concerns"]
 
+# Show differences when a PR is rebased
+[range-diff]
+
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
 users_on_vacation = [


### PR DESCRIPTION
This [feature](https://forge.rust-lang.org/triagebot/range-diff.html) shows the changes when a PR is rebased, while the GitHub UI would mix the actual changes with the ones coming from the rebase.

changelog: none

r? @flip1995 