### PR TITLE
Remove profile from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,13 +65,6 @@ harness = false
 name = "dogfood"
 harness = false
 
-# quine-mc_cluskey makes up a significant part of the runtime in dogfood
-# due to the number of conditions in the clippy_lints crate
-# and enabling optimizations for that specific dependency helps a bit
-# without increasing total build times.
-[profile.dev.package.quine-mc_cluskey]
-opt-level = 3
-
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(bootstrap)']


### PR DESCRIPTION
To avoid warnings in rust-lang/rust.

[This](https://github.com/rust-lang/rust/pull/145749) subtree sync started causing warnings in Rust builds (https://github.com/rust-lang/rust/issues/145777) because of the `profile` section in Clippy's `Cargo.toml` file. This profile section was added in https://github.com/rust-lang/rust-clippy/pull/13408 last year, and since it also caused issues then, it was later reverted. However, this change recently reappeared in [this commit](https://github.com/rust-lang/rust-clippy/commit/90364dd178b074db391649eed504564ac26f77c1), so it is again causing issues for rust-lang/rust.

This PR removes the profile section again.

changelog:

<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_CONCERN-ISSUE_START -->

> [!CAUTION]
> # Concerns (1 active)
>
> - [Large performance issue in lintcheck](https://github.com/rust-lang/rust-clippy/pull/15542#issuecomment-3216564663)
>
> *Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/concern.html) for details.*

<!-- TRIAGEBOT_CONCERN-ISSUE_END -->
<!-- TRIAGEBOT_END -->