### PR TITLE
Use `.cargo/config.toml` for local compilation options

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,3 +23,10 @@ split-debuginfo = "unpacked"
 rustflags = ["--remap-path-prefix", "=clippy_dev"]
 [profile.dev.package.lintcheck]
 rustflags = ["--remap-path-prefix", "=lintcheck"]
+
+# quine-mc_cluskey makes up a significant part of the runtime in dogfood
+# due to the number of conditions in the clippy_lints crate
+# and enabling optimizations for that specific dependency helps a bit
+# without increasing total build times.
+[profile.dev.package.quine-mc_cluskey]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,13 +65,6 @@ harness = false
 name = "dogfood"
 harness = false
 
-# quine-mc_cluskey makes up a significant part of the runtime in dogfood
-# due to the number of conditions in the clippy_lints crate
-# and enabling optimizations for that specific dependency helps a bit
-# without increasing total build times.
-[profile.dev.package.quine-mc_cluskey]
-opt-level = 3
-
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(bootstrap)']


### PR DESCRIPTION
This will be ignored when Clippy is part of the compiler workspace. Using `Cargo.toml` would complain about profiles defined outside the top-level when run from the compiler repository.

Suggested by Jakub Beránek.

changelog: none

r? flip1995