### PR TITLE
docs(cognitive_complexity): Correct lint group

### DIFF
--- a/clippy_lints/src/cognitive_complexity.rs
+++ b/clippy_lints/src/cognitive_complexity.rs
@@ -23,8 +23,8 @@ declare_clippy_lint! {
     ///
     /// ### Known problems
     /// The true Cognitive Complexity of a method is not something we can
-    /// calculate using modern technology. This lint has been left in the
-    /// `nursery` so as to not mislead users into using this lint as a
+    /// calculate using modern technology. This lint has been left in
+    /// `restriction` so as to not mislead users into using this lint as a
     /// measurement tool.
     ///
     /// For more detailed information, see [rust-clippy#3793](https://github.com/rust-lang/rust-clippy/issues/3793)


### PR DESCRIPTION
The docs say this lint is included in `nursery`, but it is now in `restriction`.

changelog:[`cognitive_complexity`]: Fixed documentation comment to state that the lint is in `restriction`, not `nursery`