### PR TITLE
Allow `--print=crate-root-lint-levels`

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -330,7 +330,8 @@ pub fn main() {
 
         // Do not run Clippy for Cargo's info queries so that invalid CLIPPY_ARGS are not cached
         // https://github.com/rust-lang/cargo/issues/14385
-        let info_query = has_arg(&orig_args, "-vV") || has_arg(&orig_args, "--print");
+        let info_query = has_arg(&orig_args, "-vV")
+            || arg_value(&orig_args, "--print", |val| val != "crate-root-lint-levels").is_some();
 
         let clippy_enabled = !cap_lints_allow && relevant_package && !info_query;
         if clippy_enabled {


### PR DESCRIPTION
rust-lang/rust-clippy#13468 delegated all `--print` requests to `rustc`; this PR adds an exception to `crate-root-lint-levels` (rust-lang/rust#139180), i.e.:
```
$ rustc -Zunstable-options --print=crate-root-lint-levels /dev/null | wc -l
230
$ clippy-driver -Zunstable-options --print=crate-root-lint-levels /dev/null | wc -l
230
$ cargo run --bin clippy-driver -- -Zunstable-options --print=crate-root-lint-levels /dev/null | wc -l
1020
```
So as to have a way to print all Clippy lint levels in a machine-readable format.

----

changelog: none
