### PR TITLE
fix `ignored_unit_patterns`: include refs in the suggestion

### DIFF
--- a/clippy_lints/src/ignored_unit_patterns.rs
+++ b/clippy_lints/src/ignored_unit_patterns.rs
@@ -45,7 +45,7 @@ impl<'tcx> LateLintPass<'tcx> for IgnoredUnitPatterns {
             && let (pat_ty, refs) = peel_refs_with_mutabilities(pat_ty)
             && pat_ty.is_unit()
         {
-            match cx.tcx.parent_hir_node(pat.hir_id) {
+            let should_add_refs = match cx.tcx.parent_hir_node(pat.hir_id) {
                 Node::Param(param) if matches!(cx.tcx.parent_hir_node(param.hir_id), Node::Item(_)) => {
                     // Ignore function parameters
                     return;
@@ -54,10 +54,18 @@ impl<'tcx> LateLintPass<'tcx> for IgnoredUnitPatterns {
                     // Ignore let bindings with explicit type
                     return;
                 },
-                _ => {},
-            }
+                // Node::Arm(_) | Node::Pat(_) | Node::PatField(_) => {
+                //     // The pattern `()` does match (arbitrarily nested) references to `()`
+                //     false
+                // },
+                _ => false,
+            };
 
-            let sugg = refs.into_iter().map(Mutability::ref_prefix_str).chain(["()"]).collect();
+            let sugg = if should_add_refs {
+                refs.into_iter().map(Mutability::ref_prefix_str).chain(["()"]).collect()
+            } else {
+                "()".to_string()
+            };
             span_lint_and_sugg(
                 cx,
                 IGNORED_UNIT_PATTERNS,

--- a/tests/ui/ignored_unit_patterns.fixed
+++ b/tests/ui/ignored_unit_patterns.fixed
@@ -47,7 +47,7 @@ pub fn moo(_: ()) {
 fn test_unit_ref_1() {
     let x: (usize, &&&&&()) = (1, &&&&&&());
     match x {
-        (1, ()) => unimplemented!(),
+        (1, &&&&&()) => unimplemented!(),
         //~^ ERROR: matching over `()` is more explicit
         _ => unimplemented!(),
     };
@@ -57,5 +57,22 @@ fn test_unit_ref_2(v: &[(usize, ())]) {
     for (x, ()) in v {
         //~^ ERROR: matching over `()` is more explicit
         let _ = x;
+    }
+}
+
+fn issue15187() {
+    let func: fn(&()) = |&()| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&mut ()) = |&mut ()| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&&mut ()) = |&&mut ()| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&&mut &()) = |&&mut &()| {};
+    //~^ ERROR: matching over `()` is more explicit
+
+    #[allow(clippy::match_single_binding)]
+    match &() {
+        &() => todo!(),
+        //~^ ERROR: matching over `()` is more explicit
     }
 }

--- a/tests/ui/ignored_unit_patterns.fixed
+++ b/tests/ui/ignored_unit_patterns.fixed
@@ -4,6 +4,7 @@
     clippy::let_unit_value,
     clippy::redundant_pattern_matching,
     clippy::single_match,
+    clippy::match_single_binding,
     clippy::needless_borrow
 )]
 
@@ -47,7 +48,7 @@ pub fn moo(_: ()) {
 fn test_unit_ref_1() {
     let x: (usize, &&&&&()) = (1, &&&&&&());
     match x {
-        (1, &&&&&()) => unimplemented!(),
+        (1, ()) => unimplemented!(),
         //~^ ERROR: matching over `()` is more explicit
         _ => unimplemented!(),
     };
@@ -61,18 +62,62 @@ fn test_unit_ref_2(v: &[(usize, ())]) {
 }
 
 fn issue15187() {
-    let func: fn(&()) = |&()| {};
+    type LifetimeBound<'r> = &'r fn(&'r ());
+
+    fn main() {
+        let func = move |()| {};
+        //~^ ERROR: matching over `()` is more explicit
+        let func_ref_bound: LifetimeBound = &(&(func as fn(_)));
+    }
+
+    let func: fn(&()) = |()| {};
     //~^ ERROR: matching over `()` is more explicit
-    let func: fn(&mut ()) = |&mut ()| {};
+    let func: fn(&mut ()) = |()| {};
     //~^ ERROR: matching over `()` is more explicit
-    let func: fn(&&mut ()) = |&&mut ()| {};
+    let func: fn(&&mut ()) = |()| {};
     //~^ ERROR: matching over `()` is more explicit
-    let func: fn(&&mut &()) = |&&mut &()| {};
+    let func: fn(&&mut &()) = |()| {};
+    //~^ ERROR: matching over `()` is more explicit
+    fn foo1() -> fn(&()) {
+        |()| {}
+    }
+    //~^^ ERROR: matching over `()` is more explicit
+    fn foo2() -> impl Fn(&()) {
+        |()| {}
+    }
+    //~^^ ERROR: matching over `()` is more explicit
+    fn foo3() -> &'static dyn Fn(&'static ()) {
+        &|()| {}
+    }
+    //~^^ ERROR: matching over `()` is more explicit
+    let func: fn(&mut ()) = |()| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&&mut ()) = |()| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&&mut &()) = |()| {};
     //~^ ERROR: matching over `()` is more explicit
 
-    #[allow(clippy::match_single_binding)]
     match &() {
-        &() => todo!(),
+        () => todo!(),
         //~^ ERROR: matching over `()` is more explicit
+    }
+
+    struct S {
+        foo: &'static &'static &'static mut (),
+        bar: u8,
+    }
+    let s = S { foo: &&&mut (), bar: 1 };
+    match s {
+        S { foo: (), bar: 1 } => todo!(),
+        //~^ ERROR: matching over `()` is more explicit
+        _ => todo!(),
+    }
+
+    struct T(&'static &'static &'static mut (), u8);
+    let f = T(&&&mut (), 1);
+    match f {
+        T((), 1) => todo!(),
+        //~^ ERROR: matching over `()` is more explicit
+        _ => todo!(),
     }
 }

--- a/tests/ui/ignored_unit_patterns.rs
+++ b/tests/ui/ignored_unit_patterns.rs
@@ -59,3 +59,20 @@ fn test_unit_ref_2(v: &[(usize, ())]) {
         let _ = x;
     }
 }
+
+fn issue15187() {
+    let func: fn(&()) = |_| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&mut ()) = |_| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&&mut ()) = |_| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&&mut &()) = |_| {};
+    //~^ ERROR: matching over `()` is more explicit
+
+    #[allow(clippy::match_single_binding)]
+    match &() {
+        _ => todo!(),
+        //~^ ERROR: matching over `()` is more explicit
+    }
+}

--- a/tests/ui/ignored_unit_patterns.rs
+++ b/tests/ui/ignored_unit_patterns.rs
@@ -4,6 +4,7 @@
     clippy::let_unit_value,
     clippy::redundant_pattern_matching,
     clippy::single_match,
+    clippy::match_single_binding,
     clippy::needless_borrow
 )]
 
@@ -61,6 +62,14 @@ fn test_unit_ref_2(v: &[(usize, ())]) {
 }
 
 fn issue15187() {
+    type LifetimeBound<'r> = &'r fn(&'r ());
+
+    fn main() {
+        let func = move |_| {};
+        //~^ ERROR: matching over `()` is more explicit
+        let func_ref_bound: LifetimeBound = &(&(func as fn(_)));
+    }
+
     let func: fn(&()) = |_| {};
     //~^ ERROR: matching over `()` is more explicit
     let func: fn(&mut ()) = |_| {};
@@ -69,10 +78,46 @@ fn issue15187() {
     //~^ ERROR: matching over `()` is more explicit
     let func: fn(&&mut &()) = |_| {};
     //~^ ERROR: matching over `()` is more explicit
+    fn foo1() -> fn(&()) {
+        |_| {}
+    }
+    //~^^ ERROR: matching over `()` is more explicit
+    fn foo2() -> impl Fn(&()) {
+        |_| {}
+    }
+    //~^^ ERROR: matching over `()` is more explicit
+    fn foo3() -> &'static dyn Fn(&'static ()) {
+        &|_| {}
+    }
+    //~^^ ERROR: matching over `()` is more explicit
+    let func: fn(&mut ()) = |_| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&&mut ()) = |_| {};
+    //~^ ERROR: matching over `()` is more explicit
+    let func: fn(&&mut &()) = |_| {};
+    //~^ ERROR: matching over `()` is more explicit
 
-    #[allow(clippy::match_single_binding)]
     match &() {
         _ => todo!(),
         //~^ ERROR: matching over `()` is more explicit
+    }
+
+    struct S {
+        foo: &'static &'static &'static mut (),
+        bar: u8,
+    }
+    let s = S { foo: &&&mut (), bar: 1 };
+    match s {
+        S { foo: _, bar: 1 } => todo!(),
+        //~^ ERROR: matching over `()` is more explicit
+        _ => todo!(),
+    }
+
+    struct T(&'static &'static &'static mut (), u8);
+    let f = T(&&&mut (), 1);
+    match f {
+        T(_, 1) => todo!(),
+        //~^ ERROR: matching over `()` is more explicit
+        _ => todo!(),
     }
 }

--- a/tests/ui/ignored_unit_patterns.stderr
+++ b/tests/ui/ignored_unit_patterns.stderr
@@ -47,7 +47,7 @@ error: matching over `()` is more explicit
   --> tests/ui/ignored_unit_patterns.rs:50:13
    |
 LL |         (1, _) => unimplemented!(),
-   |             ^ help: use `()` instead of `_`: `()`
+   |             ^ help: use `()` instead of `_`: `&&&&&()`
 
 error: matching over `()` is more explicit
   --> tests/ui/ignored_unit_patterns.rs:57:13
@@ -55,5 +55,35 @@ error: matching over `()` is more explicit
 LL |     for (x, _) in v {
    |             ^ help: use `()` instead of `_`: `()`
 
-error: aborting due to 9 previous errors
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:64:26
+   |
+LL |     let func: fn(&()) = |_| {};
+   |                          ^ help: use `()` instead of `_`: `&()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:66:30
+   |
+LL |     let func: fn(&mut ()) = |_| {};
+   |                              ^ help: use `()` instead of `_`: `&mut ()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:68:31
+   |
+LL |     let func: fn(&&mut ()) = |_| {};
+   |                               ^ help: use `()` instead of `_`: `&&mut ()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:70:32
+   |
+LL |     let func: fn(&&mut &()) = |_| {};
+   |                                ^ help: use `()` instead of `_`: `&&mut &()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:75:9
+   |
+LL |         _ => todo!(),
+   |         ^ help: use `()` instead of `_`: `&()`
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/ignored_unit_patterns.stderr
+++ b/tests/ui/ignored_unit_patterns.stderr
@@ -1,5 +1,5 @@
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:16:12
+  --> tests/ui/ignored_unit_patterns.rs:17:12
    |
 LL |         Ok(_) => {},
    |            ^ help: use `()` instead of `_`: `()`
@@ -8,82 +8,136 @@ LL |         Ok(_) => {},
    = help: to override `-D warnings` add `#[allow(clippy::ignored_unit_patterns)]`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:17:13
+  --> tests/ui/ignored_unit_patterns.rs:18:13
    |
 LL |         Err(_) => {},
    |             ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:19:15
+  --> tests/ui/ignored_unit_patterns.rs:20:15
    |
 LL |     if let Ok(_) = foo() {}
    |               ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:21:28
+  --> tests/ui/ignored_unit_patterns.rs:22:28
    |
 LL |     let _ = foo().map_err(|_| todo!());
    |                            ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:27:16
+  --> tests/ui/ignored_unit_patterns.rs:28:16
    |
 LL |             Ok(_) => {},
    |                ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:29:17
+  --> tests/ui/ignored_unit_patterns.rs:30:17
    |
 LL |             Err(_) => {},
    |                 ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:41:9
+  --> tests/ui/ignored_unit_patterns.rs:42:9
    |
 LL |     let _ = foo().unwrap();
    |         ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:50:13
+  --> tests/ui/ignored_unit_patterns.rs:51:13
    |
 LL |         (1, _) => unimplemented!(),
-   |             ^ help: use `()` instead of `_`: `&&&&&()`
+   |             ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:57:13
+  --> tests/ui/ignored_unit_patterns.rs:58:13
    |
 LL |     for (x, _) in v {
    |             ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:64:26
+  --> tests/ui/ignored_unit_patterns.rs:68:26
+   |
+LL |         let func = move |_| {};
+   |                          ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:73:26
    |
 LL |     let func: fn(&()) = |_| {};
-   |                          ^ help: use `()` instead of `_`: `&()`
+   |                          ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:66:30
+  --> tests/ui/ignored_unit_patterns.rs:75:30
    |
 LL |     let func: fn(&mut ()) = |_| {};
-   |                              ^ help: use `()` instead of `_`: `&mut ()`
+   |                              ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:68:31
+  --> tests/ui/ignored_unit_patterns.rs:77:31
    |
 LL |     let func: fn(&&mut ()) = |_| {};
-   |                               ^ help: use `()` instead of `_`: `&&mut ()`
+   |                               ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:70:32
+  --> tests/ui/ignored_unit_patterns.rs:79:32
    |
 LL |     let func: fn(&&mut &()) = |_| {};
-   |                                ^ help: use `()` instead of `_`: `&&mut &()`
+   |                                ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> tests/ui/ignored_unit_patterns.rs:75:9
+  --> tests/ui/ignored_unit_patterns.rs:82:10
+   |
+LL |         |_| {}
+   |          ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:86:10
+   |
+LL |         |_| {}
+   |          ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:90:11
+   |
+LL |         &|_| {}
+   |           ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:93:30
+   |
+LL |     let func: fn(&mut ()) = |_| {};
+   |                              ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:95:31
+   |
+LL |     let func: fn(&&mut ()) = |_| {};
+   |                               ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:97:32
+   |
+LL |     let func: fn(&&mut &()) = |_| {};
+   |                                ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:101:9
    |
 LL |         _ => todo!(),
-   |         ^ help: use `()` instead of `_`: `&()`
+   |         ^ help: use `()` instead of `_`: `()`
 
-error: aborting due to 14 previous errors
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:111:18
+   |
+LL |         S { foo: _, bar: 1 } => todo!(),
+   |                  ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> tests/ui/ignored_unit_patterns.rs:119:11
+   |
+LL |         T(_, 1) => todo!(),
+   |           ^ help: use `()` instead of `_`: `()`
+
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15187

changelog: [`ignored_unit_patterns`]: include refs in the suggestion

r? @flip1995 