### PR TITLE
triagebot: Amend a review to include a link to what was changed since

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -52,6 +52,9 @@ labels = ["S-waiting-on-concerns"]
 # Show differences when a PR is rebased
 [range-diff]
 
+# Amend a review to include a link to what was changed since the review
+[review-changes-since]
+
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
 users_on_vacation = [


### PR DESCRIPTION
[This feature](https://forge.rust-lang.org/triagebot/review-changes-since.html) adds a handy link to each review message (it doesn't create a new comment) that allows the reviewer or other people to check what has been changed in the PR since the review took place.

changelog: none

r? flip1995 