### PR TITLE
docs(clippy_utils): Add documentation for ast_utils

### DIFF
--- a/clippy_utils/src/ast_utils/ident_iter.rs
+++ b/clippy_utils/src/ast_utils/ident_iter.rs
@@ -3,6 +3,7 @@ use rustc_ast::visit::{Visitor, walk_attribute, walk_expr};
 use rustc_ast::{Attribute, Expr};
 use rustc_span::symbol::Ident;
 
+/// An iterator over identifiers.
 pub struct IdentIter(std::vec::IntoIter<Ident>);
 
 impl Iterator for IdentIter {


### PR DESCRIPTION
Part of rust-lang/rust-clippy#15569

changelog: none

This PR adds documentation for the `clippy_utils::ast_utils` module.

Enabled the `#![warn(missing_docs)]` lint on the module.
Added concise documentation for all public functions, structs, and the `ident_iter` submodule.