### PR TITLE
Add env var to override clippy-driver location

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,10 @@ impl ClippyCmd {
     }
 
     fn path() -> PathBuf {
+        if let Ok(driver) = env::var("CLIPPY_DRIVER") {
+            return PathBuf::from(driver);
+        }
+
         let mut path = env::current_exe()
             .expect("current executable path invalid")
             .with_file_name("clippy-driver");


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none

Hi!
I'm currently working on a problem with our rust support in NixOS/nixpkgs.
We need a way to point `cargo-clippy` to a wrapper of `clippy-driver` which provides it with a correct sysroot.
I've came up with this patch to solve it, but we would want to upstream it, so here I am :)
Feel free to let me know what you think of this or if you have a better idea.

Relevant: https://github.com/NixOS/nixpkgs/pull/434028