### PR TITLE
Add `disabled-in-tests` configuration to disable arbitrary lints in tests

### DIFF
--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -590,6 +590,8 @@ define_Conf! {
     /// Use the Cognitive Complexity lint instead.
     #[conf_deprecated("Please use `cognitive-complexity-threshold` instead", cognitive_complexity_threshold)]
     cyclomatic_complexity_threshold: u64 = 25,
+    /// Lints to disable in tests.
+    disabled_in_tests: Vec<String> = Vec::new(),
     /// The list of disallowed fields, written as fully qualified paths.
     ///
     /// **Fields:**

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -6,7 +6,9 @@
 
 // FIXME: switch to something more ergonomic here, once available.
 // (Currently there is no way to opt into sysroot crates without `extern crate`.)
+extern crate rustc_data_structures;
 extern crate rustc_driver;
+extern crate rustc_errors;
 extern crate rustc_interface;
 extern crate rustc_session;
 extern crate rustc_span;
@@ -20,14 +22,18 @@ extern crate rustc_span;
 #[cfg(feature = "jemalloc")]
 extern crate tikv_jemalloc_sys as _;
 
+use clippy_config::Conf;
 use clippy_utils::sym;
 use declare_clippy_lint::LintListBuilder;
+use rustc_data_structures::fx::FxHashSet;
+use rustc_errors::DiagInner;
 use rustc_interface::interface;
 use rustc_session::config::ErrorOutputType;
 use rustc_session::{EarlyDiagCtxt, Session};
 use rustc_span::symbol::Symbol;
 
 use std::env;
+use std::fmt::Write;
 use std::fs::read_to_string;
 use std::io::Write as _;
 use std::path::Path;
@@ -156,11 +162,14 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
                 (previous)(sess, lint_store);
             }
 
+            let conf = clippy_config::Conf::read(sess, &conf_path);
+            let disabled = build_disabled_set(sess, conf);
+            set_post_expect_filter(sess, disabled);
+
             let mut list_builder = LintListBuilder::default();
             list_builder.insert(clippy_lints::declared_lints::LINTS);
             list_builder.register(lint_store);
 
-            let conf = clippy_config::Conf::read(sess, &conf_path);
             clippy_lints::register_lint_passes(lint_store, conf);
 
             #[cfg(feature = "internal")]
@@ -178,6 +187,45 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
 
         // Disable flattening and inlining of format_args!(), so the HIR matches with the AST.
         config.opts.unstable_opts.flatten_format_args = false;
+    }
+}
+
+fn build_disabled_set(sess: &Session, conf: &'static Conf) -> FxHashSet<&'static str> {
+    if !sess.is_test_crate() {
+        return FxHashSet::default();
+    }
+    let disabled = conf
+        .disabled_in_tests
+        .iter()
+        .map(String::as_str)
+        .collect::<FxHashSet<_>>();
+    let declared_lint_names = clippy_lints::declared_lints::LINTS
+        .iter()
+        .map(|lint| lint.name_lower())
+        .collect::<FxHashSet<_>>();
+    #[allow(rustc::potential_query_instability)]
+    for &name in &disabled {
+        if !declared_lint_names.contains(name) {
+            let mut msg = format!("unknown lint `{name}`");
+            let replaced = name.replace('-', "_");
+            if declared_lint_names.contains(&replaced) {
+                writeln!(msg, ". Did you mean `{replaced}`?").unwrap();
+            }
+            sess.dcx().warn(msg);
+        }
+    }
+    disabled
+}
+
+#[allow(clippy::implicit_hasher)]
+pub fn set_post_expect_filter(sess: &Session, disabled: FxHashSet<&'static str>) {
+    if !disabled.is_empty() {
+        sess.dcx().set_post_expect_filter(Box::new(move |diag: &DiagInner| {
+            diag.lint_name().is_some_and(|name| {
+                let name = name.strip_prefix("clippy::").unwrap_or(name);
+                disabled.contains(name)
+            })
+        }));
     }
 }
 

--- a/tests/ui-toml/disabled_in_tests_expect/clippy.toml
+++ b/tests/ui-toml/disabled_in_tests_expect/clippy.toml
@@ -1,0 +1,1 @@
+disabled-in-tests = ["unwrap_used"]

--- a/tests/ui-toml/disabled_in_tests_expect/expect.rs
+++ b/tests/ui-toml/disabled_in_tests_expect/expect.rs
@@ -1,0 +1,17 @@
+//@check-pass
+//@compile-flags: --test
+
+#![allow(clippy::unnecessary_literal_unwrap)]
+#![warn(clippy::unwrap_used)]
+
+fn main() {}
+
+fn foo(opt: Option<i32>) {
+    #[expect(clippy::unwrap_used)]
+    opt.unwrap();
+}
+
+#[test]
+fn unwrap_some() {
+    Some(()).unwrap();
+}

--- a/tests/ui-toml/disabled_in_tests_typo/clippy.toml
+++ b/tests/ui-toml/disabled_in_tests_typo/clippy.toml
@@ -1,0 +1,1 @@
+disabled-in-tests = ["unwrap-used"]

--- a/tests/ui-toml/disabled_in_tests_typo/typo.rs
+++ b/tests/ui-toml/disabled_in_tests_typo/typo.rs
@@ -1,0 +1,4 @@
+//@check-pass
+//@compile-flags: --test
+
+fn main() {}

--- a/tests/ui-toml/disabled_in_tests_typo/typo.stderr
+++ b/tests/ui-toml/disabled_in_tests_typo/typo.stderr
@@ -1,0 +1,4 @@
+warning: unknown lint `unwrap-used`. Did you mean `unwrap_used`?
+
+warning: 1 warning emitted
+

--- a/tests/ui-toml/disabled_in_tests_unwrap_used/clippy.toml
+++ b/tests/ui-toml/disabled_in_tests_unwrap_used/clippy.toml
@@ -1,0 +1,1 @@
+disabled-in-tests = ["unwrap_used"]

--- a/tests/ui-toml/disabled_in_tests_unwrap_used/unwrap_used.fixed
+++ b/tests/ui-toml/disabled_in_tests_unwrap_used/unwrap_used.fixed
@@ -1,0 +1,34 @@
+//@compile-flags: --test
+
+#![warn(clippy::unwrap_used)]
+#![warn(clippy::get_unwrap)]
+
+fn main() {}
+
+#[test]
+fn test() {
+    let boxed_slice: Box<[u8]> = Box::new([0, 1, 2, 3]);
+    let _ = &boxed_slice[1];
+    //~^ get_unwrap
+}
+
+#[cfg(test)]
+mod issue9612 {
+    // should not lint in `#[cfg(test)]` modules
+    #[test]
+    fn test_fn() {
+        let _a: u8 = 2.try_into().unwrap();
+        let _a: u8 = 3.try_into().expect("");
+
+        util();
+    }
+
+    #[allow(unconditional_panic)]
+    fn util() {
+        let _a: u8 = 4.try_into().unwrap();
+        let _a: u8 = 5.try_into().expect("");
+        // should still warn
+        let _ = &Box::new([0])[1];
+        //~^ get_unwrap
+    }
+}

--- a/tests/ui-toml/disabled_in_tests_unwrap_used/unwrap_used.rs
+++ b/tests/ui-toml/disabled_in_tests_unwrap_used/unwrap_used.rs
@@ -1,0 +1,34 @@
+//@compile-flags: --test
+
+#![warn(clippy::unwrap_used)]
+#![warn(clippy::get_unwrap)]
+
+fn main() {}
+
+#[test]
+fn test() {
+    let boxed_slice: Box<[u8]> = Box::new([0, 1, 2, 3]);
+    let _ = boxed_slice.get(1).unwrap();
+    //~^ get_unwrap
+}
+
+#[cfg(test)]
+mod issue9612 {
+    // should not lint in `#[cfg(test)]` modules
+    #[test]
+    fn test_fn() {
+        let _a: u8 = 2.try_into().unwrap();
+        let _a: u8 = 3.try_into().expect("");
+
+        util();
+    }
+
+    #[allow(unconditional_panic)]
+    fn util() {
+        let _a: u8 = 4.try_into().unwrap();
+        let _a: u8 = 5.try_into().expect("");
+        // should still warn
+        let _ = Box::new([0]).get(1).unwrap();
+        //~^ get_unwrap
+    }
+}

--- a/tests/ui-toml/disabled_in_tests_unwrap_used/unwrap_used.stderr
+++ b/tests/ui-toml/disabled_in_tests_unwrap_used/unwrap_used.stderr
@@ -1,0 +1,28 @@
+error: called `.get().unwrap()` on a slice
+  --> tests/ui-toml/disabled_in_tests_unwrap_used/unwrap_used.rs:11:13
+   |
+LL |     let _ = boxed_slice.get(1).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::get-unwrap` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::get_unwrap)]`
+help: using `[]` is clearer and more concise
+   |
+LL -     let _ = boxed_slice.get(1).unwrap();
+LL +     let _ = &boxed_slice[1];
+   |
+
+error: called `.get().unwrap()` on a slice
+  --> tests/ui-toml/disabled_in_tests_unwrap_used/unwrap_used.rs:31:17
+   |
+LL |         let _ = Box::new([0]).get(1).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: using `[]` is clearer and more concise
+   |
+LL -         let _ = Box::new([0]).get(1).unwrap();
+LL +         let _ = &Box::new([0])[1];
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -38,6 +38,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            check-private-items
            cognitive-complexity-threshold
            const-literal-digits-threshold
+           disabled-in-tests
            disallowed-fields
            disallowed-macros
            disallowed-methods
@@ -139,6 +140,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            check-private-items
            cognitive-complexity-threshold
            const-literal-digits-threshold
+           disabled-in-tests
            disallowed-fields
            disallowed-macros
            disallowed-methods
@@ -240,6 +242,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            check-private-items
            cognitive-complexity-threshold
            const-literal-digits-threshold
+           disabled-in-tests
            disallowed-fields
            disallowed-macros
            disallowed-methods


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/15600)*

Adds a catch-all configuration to disable lints in tests, so that one-offs like https://github.com/rust-lang/rust-clippy/pull/8802 are not needed.

To illustrate, the following two clippy.toml files have essentially the same effect:
```toml
allow-unwrap-in-tests = true # existing configuration
```
```toml
disabled-in-tests = ["unwrap_used"] # configuration added by this PR
```
The approach is to store a disabled lints set in `clippy_utils::diagnostics`. When a lint is in the set and `--test` is passed to rustc, diagnostics are not emitted for the lint.

Two other approaches I tried were:
- **Don't register the lint's pass.** This works but disables the other lints in the pass as well. For example, `unwrap_used` is in the `methods::Methods` pass. So not registering that pass causes `expect_used`, `should_implement_trait`, etc. to be disabled as well.
- **Don't register the lint.** E.g., filter the lint from `declared_lints::LINTS`. This works but causes rustc to to produce "unknown lint" warnings on attributes like `#[allow(unwrap_used)]`.

The present PR's approach is also much simpler than the two just described. I could share code for the other approaches if desired, though.

I expect this PR to be subject to the feature freeze.

changelog: Add `disabled-in-tests` configuration to disable arbitrary lints in tests