### PR TITLE
Fix `nonstandard_macro_braces` FN on macros with empty args

### DIFF
--- a/clippy_lints/src/nonstandard_macro_braces.rs
+++ b/clippy_lints/src/nonstandard_macro_braces.rs
@@ -83,30 +83,40 @@ impl EarlyLintPass for MacroBraces {
 }
 
 fn is_offending_macro(cx: &EarlyContext<'_>, span: Span, mac_braces: &MacroBraces) -> Option<MacroInfo> {
-    let unnested_or_local = || {
-        !span.ctxt().outer_expn_data().call_site.from_expansion()
+    let unnested_or_local = |span: Span| {
+        !span.from_expansion()
             || span
                 .macro_backtrace()
                 .last()
                 .is_some_and(|e| e.macro_def_id.is_some_and(DefId::is_local))
     };
-    let span_call_site = span.ctxt().outer_expn_data().call_site;
-    if let ExpnKind::Macro(MacroKind::Bang, mac_name) = span.ctxt().outer_expn_data().kind
+    let mut span_expn = span.ctxt().outer_expn_data();
+    loop {
+        if let ExpnKind::Macro(MacroKind::Bang, mac_name) = span_expn.kind
         && let name = mac_name.as_str()
+
         && let Some(&braces) = mac_braces.macro_braces.get(name)
-        && let Some(snip) = span_call_site.get_source_text(cx)
+
+        && let Some(snip) = span_expn.call_site.get_source_text(cx)
         // we must check only invocation sites
         // https://github.com/rust-lang/rust-clippy/issues/7422
         && snip.starts_with(&format!("{name}!"))
-        && unnested_or_local()
+
+        && unnested_or_local(span_expn.call_site)
+
         // make formatting consistent
         && let c = snip.replace(' ', "")
         && !c.starts_with(&format!("{name}!{}", braces.0))
-        && !mac_braces.done.contains(&span_call_site)
-    {
-        Some((span_call_site, braces, snip))
-    } else {
-        None
+        && !mac_braces.done.contains(&span_expn.call_site)
+        {
+            return Some((span_expn.call_site, braces, snip));
+        }
+
+        if span_expn.call_site.ctxt().is_root() {
+            return None;
+        }
+
+        span_expn = span_expn.call_site.ctxt().outer_expn_data();
     }
 }
 

--- a/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.fixed
+++ b/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.fixed
@@ -1,6 +1,7 @@
 //@aux-build:proc_macro_derive.rs
 
 #![warn(clippy::nonstandard_macro_braces)]
+#![allow(clippy::println_empty_string)]
 
 extern crate proc_macro_derive;
 extern crate quote;
@@ -66,4 +67,17 @@ fn main() {
     //~^ nonstandard_macro_braces
 
     printlnfoo!["test if printlnfoo is triggered by println"];
+}
+
+fn issue15594() {
+    println!();
+    println!("");
+    println!();
+    //~^ nonstandard_macro_braces
+    println!("");
+    //~^ nonstandard_macro_braces
+    println!();
+    //~^ nonstandard_macro_braces
+    println!("");
+    //~^ nonstandard_macro_braces
 }

--- a/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs
+++ b/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs
@@ -1,6 +1,7 @@
 //@aux-build:proc_macro_derive.rs
 
 #![warn(clippy::nonstandard_macro_braces)]
+#![allow(clippy::println_empty_string)]
 
 extern crate proc_macro_derive;
 extern crate quote;
@@ -66,4 +67,17 @@ fn main() {
     //~^ nonstandard_macro_braces
 
     printlnfoo!["test if printlnfoo is triggered by println"];
+}
+
+fn issue15594() {
+    println!();
+    println!("");
+    println![];
+    //~^ nonstandard_macro_braces
+    println![""];
+    //~^ nonstandard_macro_braces
+    println! {};
+    //~^ nonstandard_macro_braces
+    println! {""};
+    //~^ nonstandard_macro_braces
 }

--- a/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.stderr
+++ b/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.stderr
@@ -1,5 +1,5 @@
 error: use of irregular braces for `vec!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:44:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:45:13
    |
 LL |     let _ = vec! {1, 2, 3};
    |             ^^^^^^^^^^^^^^ help: consider writing: `vec![1, 2, 3]`
@@ -8,31 +8,31 @@ LL |     let _ = vec! {1, 2, 3};
    = help: to override `-D warnings` add `#[allow(clippy::nonstandard_macro_braces)]`
 
 error: use of irregular braces for `format!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:46:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:47:13
    |
 LL |     let _ = format!["ugh {} stop being such a good compiler", "hello"];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `format!("ugh {} stop being such a good compiler", "hello")`
 
 error: use of irregular braces for `matches!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:48:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:49:13
    |
 LL |     let _ = matches!{{}, ()};
    |             ^^^^^^^^^^^^^^^^ help: consider writing: `matches!({}, ())`
 
 error: use of irregular braces for `quote!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:50:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:51:13
    |
 LL |     let _ = quote!(let x = 1;);
    |             ^^^^^^^^^^^^^^^^^^ help: consider writing: `quote!{let x = 1;}`
 
 error: use of irregular braces for `quote::quote!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:52:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:53:13
    |
 LL |     let _ = quote::quote!(match match match);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `quote::quote!{match match match}`
 
 error: use of irregular braces for `vec!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:18:9
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:19:9
    |
 LL |         vec!{0, 0, 0}
    |         ^^^^^^^^^^^^^ help: consider writing: `vec![0, 0, 0]`
@@ -43,16 +43,40 @@ LL |     let _ = test!(); // trigger when macro def is inside our own crate
    = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: use of irregular braces for `type_pos!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:62:12
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:63:12
    |
 LL |     let _: type_pos!(usize) = vec![];
    |            ^^^^^^^^^^^^^^^^ help: consider writing: `type_pos![usize]`
 
 error: use of irregular braces for `eprint!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:65:5
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:66:5
    |
 LL |     eprint!("test if user config overrides defaults");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `eprint!["test if user config overrides defaults"]`
 
-error: aborting due to 8 previous errors
+error: use of irregular braces for `println!` macro
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:75:5
+   |
+LL |     println![];
+   |     ^^^^^^^^^^ help: consider writing: `println!()`
+
+error: use of irregular braces for `println!` macro
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:77:5
+   |
+LL |     println![""];
+   |     ^^^^^^^^^^^^ help: consider writing: `println!("")`
+
+error: use of irregular braces for `println!` macro
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:79:5
+   |
+LL |     println! {};
+   |     ^^^^^^^^^^^ help: consider writing: `println!()`
+
+error: use of irregular braces for `println!` macro
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:81:5
+   |
+LL |     println! {""};
+   |     ^^^^^^^^^^^^^ help: consider writing: `println!("")`
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Closes #15594 

changelog: [`nonstandard_macro_braces`] fix FN on macros with empty args
