### PR TITLE
add `ptr_offset_by_literal` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6376,6 +6376,7 @@ Released 2018-09-13
 [`ptr_as_ptr`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_as_ptr
 [`ptr_cast_constness`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_cast_constness
 [`ptr_eq`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_eq
+[`ptr_offset_by_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_offset_by_literal
 [`ptr_offset_with_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_offset_with_cast
 [`pub_enum_variant_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#pub_enum_variant_names
 [`pub_underscore_fields`]: https://rust-lang.github.io/rust-clippy/master/index.html#pub_underscore_fields

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -625,6 +625,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::ptr::MUT_FROM_REF_INFO,
     crate::ptr::PTR_ARG_INFO,
     crate::ptr::PTR_EQ_INFO,
+    crate::ptr_offset_by_literal::PTR_OFFSET_BY_LITERAL_INFO,
     crate::ptr_offset_with_cast::PTR_OFFSET_WITH_CAST_INFO,
     crate::pub_underscore_fields::PUB_UNDERSCORE_FIELDS_INFO,
     crate::pub_use::PUB_USE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -302,6 +302,7 @@ mod permissions_set_readonly_false;
 mod pointers_in_nomem_asm_block;
 mod precedence;
 mod ptr;
+mod ptr_offset_by_literal;
 mod ptr_offset_with_cast;
 mod pub_underscore_fields;
 mod pub_use;
@@ -592,6 +593,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     store.register_late_pass(|_| Box::new(unwrap::Unwrap));
     store.register_late_pass(move |_| Box::new(indexing_slicing::IndexingSlicing::new(conf)));
     store.register_late_pass(move |tcx| Box::new(non_copy_const::NonCopyConst::new(tcx, conf)));
+    store.register_late_pass(|_| Box::new(ptr_offset_by_literal::PtrOffsetByLiteral));
     store.register_late_pass(|_| Box::new(ptr_offset_with_cast::PtrOffsetWithCast));
     store.register_late_pass(|_| Box::new(redundant_clone::RedundantClone));
     store.register_late_pass(|_| Box::new(slow_vector_initialization::SlowVectorInit));

--- a/clippy_lints/src/ptr_offset_by_literal.rs
+++ b/clippy_lints/src/ptr_offset_by_literal.rs
@@ -1,0 +1,156 @@
+use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg};
+use clippy_utils::source::SpanRangeExt;
+use clippy_utils::sym;
+use rustc_ast::LitKind;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, UnOp};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+use std::cmp::Ordering;
+use std::fmt;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for usage of the `offset` pointer method with an integer
+    /// literal.
+    ///
+    /// ### Why is this bad?
+    /// The `add` and `sub` methods more accurately express the intent.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let vec = vec![b'a', b'b', b'c'];
+    /// let ptr = vec.as_ptr();
+    ///
+    /// unsafe {
+    ///     ptr.offset(-8);
+    /// }
+    /// ```
+    ///
+    /// Could be written:
+    ///
+    /// ```no_run
+    /// let vec = vec![b'a', b'b', b'c'];
+    /// let ptr = vec.as_ptr();
+    ///
+    /// unsafe {
+    ///     ptr.sub(8);
+    /// }
+    /// ```
+    #[clippy::version = "CURRENT_RUSTC_VERSION"]
+    pub PTR_OFFSET_BY_LITERAL,
+    complexity,
+    "unneeded pointer offset"
+}
+
+declare_lint_pass!(PtrOffsetByLiteral => [PTR_OFFSET_BY_LITERAL]);
+
+impl<'tcx> LateLintPass<'tcx> for PtrOffsetByLiteral {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        // Check if the expressions is a ptr.offset or ptr.wrapping_offset method call
+        let Some((receiver_expr, arg_expr, method)) = expr_as_ptr_offset_call(cx, expr) else {
+            return;
+        };
+
+        // Check if the argument to the method call is a (negated) literal.
+        let Some(literal) = expr_as_literal(arg_expr) else {
+            return;
+        };
+
+        let msg = format!("use of `{method}` with a literal");
+        if let Some(sugg) = build_suggestion(cx, method, receiver_expr, literal) {
+            span_lint_and_sugg(
+                cx,
+                PTR_OFFSET_BY_LITERAL,
+                expr.span,
+                msg,
+                "try",
+                sugg,
+                Applicability::MachineApplicable,
+            );
+        } else {
+            span_lint(cx, PTR_OFFSET_BY_LITERAL, expr.span, msg);
+        }
+    }
+}
+
+fn get_literal_bits<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<u128> {
+    let ExprKind::Lit(lit) = expr.kind else {
+        return None;
+    };
+
+    let LitKind::Int(packed_u128, _) = lit.node else {
+        return None;
+    };
+
+    Some(packed_u128.get())
+}
+
+// If the given expression is a (negated) literal, return its value.
+fn expr_as_literal<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<i128> {
+    if let Some(literal_bits) = get_literal_bits(expr) {
+        // The value must fit in a isize, so we can't have overflow here.
+        return Some(literal_bits as i128);
+    }
+
+    if let ExprKind::Unary(UnOp::Neg, inner) = expr.kind {
+        if let Some(literal_bits) = get_literal_bits(inner) {
+            return Some(-1 * literal_bits as i128);
+        }
+    }
+
+    None
+}
+
+// If the given expression is a ptr::offset  or ptr::wrapping_offset method call, return the
+// receiver, the arg of the method call, and the method.
+fn expr_as_ptr_offset_call<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+) -> Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>, Method)> {
+    if let ExprKind::MethodCall(path_segment, arg_0, [arg_1], _) = &expr.kind
+        && cx.typeck_results().expr_ty(arg_0).is_raw_ptr()
+    {
+        if path_segment.ident.name == sym::offset {
+            return Some((arg_0, arg_1, Method::Offset));
+        }
+        if path_segment.ident.name == sym::wrapping_offset {
+            return Some((arg_0, arg_1, Method::WrappingOffset));
+        }
+    }
+    None
+}
+
+fn build_suggestion(cx: &LateContext<'_>, method: Method, receiver_expr: &Expr<'_>, literal: i128) -> Option<String> {
+    let receiver = receiver_expr.span.get_source_text(cx)?;
+
+    let new_method = match Ord::cmp(&literal, &0) {
+        Ordering::Greater => match method {
+            Method::Offset => "add",
+            Method::WrappingOffset => "wrapping_add",
+        },
+        Ordering::Equal => return Some(format!("{receiver}")),
+        Ordering::Less => match method {
+            Method::Offset => "sub",
+            Method::WrappingOffset => "wrapping_sub",
+        },
+    };
+
+    let literal = literal.unsigned_abs();
+    Some(format!("{receiver}.{new_method}({literal})"))
+}
+
+#[derive(Copy, Clone)]
+enum Method {
+    Offset,
+    WrappingOffset,
+}
+
+impl fmt::Display for Method {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Offset => write!(f, "offset"),
+            Self::WrappingOffset => write!(f, "wrapping_offset"),
+        }
+    }
+}

--- a/tests/ui/borrow_as_ptr.fixed
+++ b/tests/ui/borrow_as_ptr.fixed
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::borrow_as_ptr)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::useless_vec, clippy::ptr_offset_by_literal)]
 
 extern crate proc_macros;
 

--- a/tests/ui/borrow_as_ptr.rs
+++ b/tests/ui/borrow_as_ptr.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::borrow_as_ptr)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::useless_vec, clippy::ptr_offset_by_literal)]
 
 extern crate proc_macros;
 

--- a/tests/ui/crashes/ice-4579.rs
+++ b/tests/ui/crashes/ice-4579.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![allow(clippy::single_match)]
+#![allow(clippy::single_match, clippy::ptr_offset_by_literal)]
 
 use std::ptr;
 

--- a/tests/ui/ptr_offset_by_literal.fixed
+++ b/tests/ui/ptr_offset_by_literal.fixed
@@ -1,0 +1,38 @@
+fn main() {
+    let arr = [b'a', b'b', b'c'];
+    let ptr = arr.as_ptr();
+
+    let var = 32;
+    const CONST: isize = 42;
+
+    unsafe {
+        let _ = ptr;
+        //~^ ptr_offset_by_literal
+        let _ = ptr;
+        //~^ ptr_offset_by_literal
+
+        let _ = ptr.add(5);
+        //~^ ptr_offset_by_literal
+        let _ = ptr.sub(5);
+        //~^ ptr_offset_by_literal
+
+        let _ = ptr.offset(var);
+        let _ = ptr.offset(CONST);
+
+        let _ = ptr.wrapping_add(5);
+        //~^ ptr_offset_by_literal
+        let _ = ptr.wrapping_sub(5);
+        //~^ ptr_offset_by_literal
+
+        let _ = ptr.sub(5);
+        //~^ ptr_offset_by_literal
+        let _ = ptr.wrapping_sub(5);
+        //~^ ptr_offset_by_literal
+
+        // isize::MAX and isize::MIN on 64-bit systems.
+        let _ = ptr.add(9223372036854775807);
+        //~^ ptr_offset_by_literal
+        let _ = ptr.sub(9223372036854775808);
+        //~^ ptr_offset_by_literal
+    }
+}

--- a/tests/ui/ptr_offset_by_literal.rs
+++ b/tests/ui/ptr_offset_by_literal.rs
@@ -1,0 +1,38 @@
+fn main() {
+    let arr = [b'a', b'b', b'c'];
+    let ptr = arr.as_ptr();
+
+    let var = 32;
+    const CONST: isize = 42;
+
+    unsafe {
+        let _ = ptr.offset(0);
+        //~^ ptr_offset_by_literal
+        let _ = ptr.offset(-0);
+        //~^ ptr_offset_by_literal
+
+        let _ = ptr.offset(5);
+        //~^ ptr_offset_by_literal
+        let _ = ptr.offset(-5);
+        //~^ ptr_offset_by_literal
+
+        let _ = ptr.offset(var);
+        let _ = ptr.offset(CONST);
+
+        let _ = ptr.wrapping_offset(5isize);
+        //~^ ptr_offset_by_literal
+        let _ = ptr.wrapping_offset(-5isize);
+        //~^ ptr_offset_by_literal
+
+        let _ = ptr.offset(-(5));
+        //~^ ptr_offset_by_literal
+        let _ = ptr.wrapping_offset(-(5));
+        //~^ ptr_offset_by_literal
+
+        // isize::MAX and isize::MIN on 64-bit systems.
+        let _ = ptr.offset(9_223_372_036_854_775_807isize);
+        //~^ ptr_offset_by_literal
+        let _ = ptr.offset(-9_223_372_036_854_775_808isize);
+        //~^ ptr_offset_by_literal
+    }
+}

--- a/tests/ui/ptr_offset_by_literal.stderr
+++ b/tests/ui/ptr_offset_by_literal.stderr
@@ -1,0 +1,65 @@
+error: use of `offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:9:17
+   |
+LL |         let _ = ptr.offset(0);
+   |                 ^^^^^^^^^^^^^ help: try: `ptr`
+   |
+   = note: `-D clippy::ptr-offset-by-literal` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::ptr_offset_by_literal)]`
+
+error: use of `offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:11:17
+   |
+LL |         let _ = ptr.offset(-0);
+   |                 ^^^^^^^^^^^^^^ help: try: `ptr`
+
+error: use of `offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:14:17
+   |
+LL |         let _ = ptr.offset(5);
+   |                 ^^^^^^^^^^^^^ help: try: `ptr.add(5)`
+
+error: use of `offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:16:17
+   |
+LL |         let _ = ptr.offset(-5);
+   |                 ^^^^^^^^^^^^^^ help: try: `ptr.sub(5)`
+
+error: use of `wrapping_offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:22:17
+   |
+LL |         let _ = ptr.wrapping_offset(5isize);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ptr.wrapping_add(5)`
+
+error: use of `wrapping_offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:24:17
+   |
+LL |         let _ = ptr.wrapping_offset(-5isize);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ptr.wrapping_sub(5)`
+
+error: use of `offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:27:17
+   |
+LL |         let _ = ptr.offset(-(5));
+   |                 ^^^^^^^^^^^^^^^^ help: try: `ptr.sub(5)`
+
+error: use of `wrapping_offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:29:17
+   |
+LL |         let _ = ptr.wrapping_offset(-(5));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ptr.wrapping_sub(5)`
+
+error: use of `offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:33:17
+   |
+LL |         let _ = ptr.offset(9_223_372_036_854_775_807isize);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ptr.add(9223372036854775807)`
+
+error: use of `offset` with a literal
+  --> tests/ui/ptr_offset_by_literal.rs:35:17
+   |
+LL |         let _ = ptr.offset(-9_223_372_036_854_775_808isize);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ptr.sub(9223372036854775808)`
+
+error: aborting due to 10 previous errors
+

--- a/tests/ui/zero_offset.rs
+++ b/tests/ui/zero_offset.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::borrow_as_ptr)]
+#[allow(clippy::borrow_as_ptr, clippy::ptr_offset_by_literal)]
 fn main() {
     unsafe {
         let m = &mut () as *mut ();


### PR DESCRIPTION
Related to https://rust-lang.github.io/rust-clippy/master/index.html#ptr_offset_with_cast (and very much modelled off of its implementation).

This lint is motivated by cleaning up the output of [c2rust](https://c2rust.com/), which contains many `.offset` calls with by literal. The lint also nicely handles offsets by zero, which are unnecessary.

I'm aware that the feature freeze is still in place, but this was top-of-mind now. I'll patiently wait until the freeze is lifted.

changelog: [`ptr_offset_by_literal`]: add `ptr_offset_by_literal` lint
