### PR TITLE
Fix `eq_op` FP on literal of different form

### DIFF
--- a/clippy_lints/src/operators/eq_op.rs
+++ b/clippy_lints/src/operators/eq_op.rs
@@ -2,10 +2,26 @@ use clippy_utils::ast_utils::is_useless_with_eq_exprs;
 use clippy_utils::diagnostics::{span_lint, span_lint_and_then};
 use clippy_utils::macros::{find_assert_eq_args, first_node_macro_backtrace};
 use clippy_utils::{eq_expr_value, is_in_test_function, sym};
-use rustc_hir::{BinOpKind, Expr};
+use rustc_ast::LitKind;
+use rustc_hir::{BinOpKind, Expr, ExprKind, Lit};
 use rustc_lint::LateContext;
 
 use super::EQ_OP;
+
+/// Checks if `l` and `r` are two literals using different forms (e.g., `b' '` vs. `0x20u8`)
+fn are_different_form_literals(l: &Lit, r: &Lit) -> bool {
+    match (l.node, r.node) {
+        (LitKind::Str(_, l_style), LitKind::Str(_, r_style))
+        | (LitKind::ByteStr(_, l_style), LitKind::ByteStr(_, r_style))
+        | (LitKind::CStr(_, l_style), LitKind::CStr(_, r_style)) => l_style != r_style,
+        (LitKind::Int(_, l_int_type), LitKind::Int(_, r_int_type)) => l_int_type != r_int_type,
+        (LitKind::Float(_, l_float_type), LitKind::Float(_, r_float_type)) => l_float_type != r_float_type,
+        (LitKind::Byte(_), LitKind::Byte(_))
+        | (LitKind::Char(_), LitKind::Char(_))
+        | (LitKind::Bool(_), LitKind::Bool(_)) => false,
+        _ => true,
+    }
+}
 
 pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
     if let Some(macro_call) = first_node_macro_backtrace(cx, e).find(|macro_call| {
@@ -17,6 +33,7 @@ pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
         && eq_expr_value(cx, lhs, rhs)
         && macro_call.is_local()
         && !is_in_test_function(cx.tcx, e.hir_id)
+        && !matches!((lhs.kind, rhs.kind), (ExprKind::Lit(l), ExprKind::Lit(r)) if are_different_form_literals(&l, &r))
     {
         span_lint(
             cx,
@@ -37,7 +54,11 @@ pub(crate) fn check<'tcx>(
     left: &'tcx Expr<'_>,
     right: &'tcx Expr<'_>,
 ) {
-    if is_useless_with_eq_exprs(op) && eq_expr_value(cx, left, right) && !is_in_test_function(cx.tcx, e.hir_id) {
+    if is_useless_with_eq_exprs(op)
+        && eq_expr_value(cx, left, right)
+        && !is_in_test_function(cx.tcx, e.hir_id)
+        && !matches!((left.kind, right.kind), (ExprKind::Lit(l), ExprKind::Lit(r)) if are_different_form_literals(&l, &r))
+    {
         span_lint_and_then(
             cx,
             EQ_OP,

--- a/tests/ui/eq_op.rs
+++ b/tests/ui/eq_op.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::eq_op)]
 #![allow(clippy::double_parens, clippy::identity_op, clippy::nonminimal_bool)]
-#![allow(clippy::suspicious_xor_used_as_pow)]
+#![allow(clippy::suspicious_xor_used_as_pow, clippy::assertions_on_constants)]
 
 fn main() {
     // simple values and comparisons
@@ -153,4 +153,11 @@ fn eq_op_macros_shouldnt_trigger_in_tests() {
     let b = 2;
     assert_eq!(a, a);
     assert_eq!(a + b, b + a);
+}
+
+fn issue15609() {
+    const {
+        assert!(0x20 == b' ');
+    }
+    assert_eq!(0x20, b' ');
 }


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15609 

changelog: [`eq_op`] fix FP on literal of different form
