### PR TITLE
`unnecessary_safety_comment`: check for impl items as well

### DIFF
--- a/tests/ui/unnecessary_safety_comment.rs
+++ b/tests/ui/unnecessary_safety_comment.rs
@@ -99,4 +99,30 @@ mod issue_12048 {
     }
 }
 
+mod issue_15034 {
+    struct Foo;
+    trait Baz {
+        fn baz() {}
+    }
+
+    impl Baz for Foo {
+        // Safety: unnecessary
+        fn baz() {}
+        //~^ unnecessary_safety_comment
+    }
+
+    impl Foo {
+        // SAFETY: unnecessary
+        const BAR: usize = 0;
+        //~^ unnecessary_safety_comment
+
+        // Safety: unnecessary
+        fn foo() {}
+        //~^ unnecessary_safety_comment
+
+        // Safety: necessary
+        unsafe fn bar() {}
+    }
+}
+
 fn main() {}

--- a/tests/ui/unnecessary_safety_comment.stderr
+++ b/tests/ui/unnecessary_safety_comment.stderr
@@ -112,5 +112,41 @@ help: consider removing the safety comment
 LL |     // SAFETY: unnecessary
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: associated function has unnecessary safety comment
+  --> tests/ui/unnecessary_safety_comment.rs:110:9
+   |
+LL |         fn baz() {}
+   |         ^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> tests/ui/unnecessary_safety_comment.rs:109:9
+   |
+LL |         // Safety: unnecessary
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: associated constant has unnecessary safety comment
+  --> tests/ui/unnecessary_safety_comment.rs:116:9
+   |
+LL |         const BAR: usize = 0;
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> tests/ui/unnecessary_safety_comment.rs:115:9
+   |
+LL |         // SAFETY: unnecessary
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: associated function has unnecessary safety comment
+  --> tests/ui/unnecessary_safety_comment.rs:120:9
+   |
+LL |         fn foo() {}
+   |         ^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> tests/ui/unnecessary_safety_comment.rs:119:9
+   |
+LL |         // Safety: unnecessary
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#15034 

changelog: [`unnecessary_safety_comment`]: check for impl items as well

