### PR TITLE
Allow more lazy evaluations

### DIFF
--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -49,7 +49,7 @@ impl ops::BitOrAssign for EagernessSuggestion {
 
 /// Determine the eagerness of the given function call.
 fn fn_eagerness(cx: &LateContext<'_>, fn_id: DefId, name: Symbol, have_one_arg: bool) -> EagernessSuggestion {
-    use EagernessSuggestion::{Eager, Lazy, NoChange};
+    use EagernessSuggestion::{Lazy, NoChange};
 
     let ty = match cx.tcx.impl_of_assoc(fn_id) {
         Some(id) => cx.tcx.type_of(id).instantiate_identity(),
@@ -57,14 +57,7 @@ fn fn_eagerness(cx: &LateContext<'_>, fn_id: DefId, name: Symbol, have_one_arg: 
     };
 
     if (matches!(name, sym::is_empty | sym::len) || name.as_str().starts_with("as_")) && have_one_arg {
-        if matches!(
-            cx.tcx.crate_name(fn_id.krate),
-            sym::std | sym::core | sym::alloc | sym::proc_macro
-        ) {
-            Eager
-        } else {
-            NoChange
-        }
+        NoChange
     } else if let ty::Adt(def, subs) = ty.kind() {
         // Types where the only fields are generic types (or references to) with no trait bounds other
         // than marker traits.

--- a/tests/ui/option_if_let_else.fixed
+++ b/tests/ui/option_if_let_else.fixed
@@ -162,7 +162,7 @@ fn main() {
 
     let s = String::new();
     // Lint, both branches immutably borrow `s`.
-    let _ = Some(0).map_or(s.len(), |x| s.len() + x);
+    let _ = Some(0).map_or_else(|| s.len(), |x| s.len() + x);
     //~^ option_if_let_else
 
     let s = String::new();

--- a/tests/ui/option_if_let_else.stderr
+++ b/tests/ui/option_if_let_else.stderr
@@ -216,11 +216,11 @@ LL +             }
 LL ~         });
    |
 
-error: use Option::map_or instead of an if let/else
+error: use Option::map_or_else instead of an if let/else
   --> tests/ui/option_if_let_else.rs:197:13
    |
 LL |     let _ = if let Some(x) = Some(0) { s.len() + x } else { s.len() };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(0).map_or(s.len(), |x| s.len() + x)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(0).map_or_else(|| s.len(), |x| s.len() + x)`
 
 error: use Option::map_or instead of an if let/else
   --> tests/ui/option_if_let_else.rs:202:13


### PR DESCRIPTION
Update `unnecessary_lazy_evaluations` to allow closures for trivial functions according to the developer's preference.

The current list of trivial functions is `is_empty`, `len`, and `as_*`. This list cannot be updated without causing churn, because e.g., calls to `unwrap_or_else` and `unwrap_or` would need to be swapped for each addition and removal. This list is also undocumented and not based on actual method complexity, but repositories need to follow it to be compliant with this default lint. Leaving these trivial functions up to developer preference allows developers to not need to think about which functions Clippy considers lazy.

A configuration could be added later to re-enable this without any backward-compatibility concern, but it should not be enforced by default.

changelog: [`unnecessary_lazy_evaluations`]: allow optional closure for trivial functions

Fixes: #8109