### PR TITLE
Fix `question_mark` FP on variables used after

### DIFF
--- a/tests/ui/question_mark.fixed
+++ b/tests/ui/question_mark.fixed
@@ -475,3 +475,28 @@ fn issue_15679() -> Result<i32, String> {
 
     Ok(0)
 }
+
+mod issue14894 {
+    fn use_after_question_mark(do_something_else: impl Fn() -> Result<String, ()>) -> Result<(), ()> {
+        let result = do_something_else();
+        if let Err(reason) = result {
+            return Err(reason);
+        }
+        drop(result);
+
+        let result = do_something_else();
+        let x = result?;
+        drop(x);
+
+        Ok(())
+    }
+
+    #[expect(dropping_copy_types)]
+    fn use_after_question_mark_but_is_copy(do_something_else: impl Fn() -> Result<i32, ()>) -> Result<(), ()> {
+        let result = do_something_else();
+        result?;
+        drop(result);
+
+        Ok(())
+    }
+}

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -583,3 +583,35 @@ fn issue_15679() -> Result<i32, String> {
 
     Ok(0)
 }
+
+mod issue14894 {
+    fn use_after_question_mark(do_something_else: impl Fn() -> Result<String, ()>) -> Result<(), ()> {
+        let result = do_something_else();
+        if let Err(reason) = result {
+            return Err(reason);
+        }
+        drop(result);
+
+        let result = do_something_else();
+        let x = match result {
+            //~^ question_mark
+            Ok(v) => v,
+            Err(e) => return Err(e),
+        };
+        drop(x);
+
+        Ok(())
+    }
+
+    #[expect(dropping_copy_types)]
+    fn use_after_question_mark_but_is_copy(do_something_else: impl Fn() -> Result<i32, ()>) -> Result<(), ()> {
+        let result = do_something_else();
+        if let Err(reason) = result {
+            //~^ question_mark
+            return Err(reason);
+        }
+        drop(result);
+
+        Ok(())
+    }
+}

--- a/tests/ui/question_mark.stderr
+++ b/tests/ui/question_mark.stderr
@@ -313,5 +313,25 @@ LL | |         Err(err) => return Err(<&str as Into<String>>::into(err)),
 LL | |     };
    | |_____^ help: try instead: `some_result?`
 
-error: aborting due to 33 previous errors
+error: this `match` expression can be replaced with `?`
+  --> tests/ui/question_mark.rs:596:17
+   |
+LL |           let x = match result {
+   |  _________________^
+LL | |
+LL | |             Ok(v) => v,
+LL | |             Err(e) => return Err(e),
+LL | |         };
+   | |_________^ help: try instead: `result?`
+
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:609:9
+   |
+LL | /         if let Err(reason) = result {
+LL | |
+LL | |             return Err(reason);
+LL | |         }
+   | |_________^ help: replace it with: `result?;`
+
+error: aborting due to 35 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15635

changelog: [`question_mark`] fix FP on variables used after
