### PR TITLE
fix(`collapsible{,_else}_if`): respect `#[expect]` on inner `if`

### DIFF
--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -1,5 +1,5 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::{IntoSpan as _, SpanRangeExt, snippet, snippet_block_with_applicability};
 use clippy_utils::{span_contains_non_whitespace, sym, tokenize_with_text};
@@ -102,7 +102,7 @@ impl CollapsibleIf {
             // we need to actually fulfill its expectation (#13365)
             match cx.tcx.hir_attrs(else_.hir_id) {
                 [] if !block_starts_with_significant_tokens(cx, else_block, else_, self.lint_commented_code) => {},
-                // This is an expectation of the `collapsible_else_if` lint
+                // The attribute is present
                 [attr]
                     if matches!(Level::from_attr(attr), Some((Level::Expect, _)))
                         && let Some(metas) = attr.meta_item_list()
@@ -187,15 +187,36 @@ impl CollapsibleIf {
 
     fn check_collapsible_if_if(&self, cx: &LateContext<'_>, expr: &Expr<'_>, check: &Expr<'_>, then: &Block<'_>) {
         if let Some(inner) = expr_block(then)
-            && cx.tcx.hir_attrs(inner.hir_id).is_empty()
             && let ExprKind::If(check_inner, _, None) = &inner.kind
             && self.eligible_condition(cx, check_inner)
             && expr.span.eq_ctxt(inner.span)
-            && !block_starts_with_significant_tokens(cx, then, inner, self.lint_commented_code)
         {
-            span_lint_and_then(
+            // if the inner `if` has a `#[expect(clippy::collapsible_if)]` attribute,
+            // we need to actually fulfill its expectation (#13365)
+            match cx.tcx.hir_attrs(inner.hir_id) {
+                [] if !block_starts_with_significant_tokens(cx, then, inner, self.lint_commented_code) => {},
+                // The attribute is present
+                [attr]
+                    if matches!(Level::from_attr(attr), Some((Level::Expect, _)))
+                        && let Some(metas) = attr.meta_item_list()
+                        && let Some(MetaItemInner::MetaItem(meta_item)) = metas.first()
+                        && let [tool, lint_name] = meta_item.path.segments.as_slice()
+                        && tool.ident.name == sym::clippy
+                        && matches!(
+                            lint_name.ident.name,
+                            sym::collapsible_if | sym::style | sym::all
+                        )
+                        // There isn't significant text apart from the attr
+                        && let span_before_attr = then.span.split_at(1).1.until(attr.span())
+                        && !span_contains_non_whitespace(cx, span_before_attr, self.lint_commented_code)
+                        && let span_after_attr = attr.span().between(inner.span)
+                        && !span_contains_non_whitespace(cx, span_after_attr, self.lint_commented_code) => {},
+                _ => return,
+            }
+            span_lint_hir_and_then(
                 cx,
                 COLLAPSIBLE_IF,
+                inner.hir_id,
                 expr.span,
                 "this `if` statement can be collapsed",
                 |diag| {

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -1,13 +1,13 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::{IntoSpan as _, SpanRangeExt, snippet, snippet_block_with_applicability};
-use clippy_utils::{span_contains_non_whitespace, tokenize_with_text};
-use rustc_ast::BinOpKind;
+use clippy_utils::{span_contains_non_whitespace, sym, tokenize_with_text};
+use rustc_ast::{BinOpKind, MetaItemInner};
 use rustc_errors::Applicability;
 use rustc_hir::{Block, Expr, ExprKind, StmtKind};
 use rustc_lexer::TokenKind;
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, Level};
 use rustc_session::impl_lint_pass;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span};
@@ -95,14 +95,35 @@ impl CollapsibleIf {
 
     fn check_collapsible_else_if(&self, cx: &LateContext<'_>, then_span: Span, else_block: &Block<'_>) {
         if let Some(else_) = expr_block(else_block)
-            && cx.tcx.hir_attrs(else_.hir_id).is_empty()
             && !else_.span.from_expansion()
             && let ExprKind::If(else_if_cond, ..) = else_.kind
-            && !block_starts_with_significant_tokens(cx, else_block, else_, self.lint_commented_code)
         {
-            span_lint_and_then(
+            // if the inner `if` has a `#[expect(clippy::collapsible_else_if)]` attribute,
+            // we need to actually fulfill its expectation (#13365)
+            match cx.tcx.hir_attrs(else_.hir_id) {
+                [] if !block_starts_with_significant_tokens(cx, else_block, else_, self.lint_commented_code) => {},
+                // This is an expectation of the `collapsible_else_if` lint
+                [attr]
+                    if matches!(Level::from_attr(attr), Some((Level::Expect, _)))
+                        && let Some(metas) = attr.meta_item_list()
+                        && let Some(MetaItemInner::MetaItem(meta_item)) = metas.first()
+                        && let [tool, lint_name] = meta_item.path.segments.as_slice()
+                        && tool.ident.name == sym::clippy
+                        && matches!(
+                            lint_name.ident.name,
+                            sym::collapsible_else_if | sym::style | sym::all
+                        )
+                        // There isn't significant text apart from the attr
+                        && let span_before_attr = else_block.span.split_at(1).1.until(attr.span())
+                        && !span_contains_non_whitespace(cx, span_before_attr, self.lint_commented_code)
+                        && let span_after_attr = attr.span().between(else_.span)
+                        && !span_contains_non_whitespace(cx, span_after_attr, self.lint_commented_code) => {},
+                _ => return,
+            }
+            span_lint_hir_and_then(
                 cx,
                 COLLAPSIBLE_ELSE_IF,
+                else_.hir_id,
                 else_block.span,
                 "this `else { if .. }` block can be collapsed",
                 |diag| {

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -112,6 +112,7 @@ generate! {
     cloned,
     cognitive_complexity,
     collapsible_else_if,
+    collapsible_if,
     collect,
     const_ptr,
     contains,

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -111,6 +111,7 @@ generate! {
     clone_into,
     cloned,
     cognitive_complexity,
+    collapsible_else_if,
     collect,
     const_ptr,
     contains,

--- a/tests/ui-toml/collapsible_if/collapsible_else_if.fixed
+++ b/tests/ui-toml/collapsible_if/collapsible_else_if.fixed
@@ -1,7 +1,7 @@
 #![allow(clippy::eq_op, clippy::nonminimal_bool)]
+#![warn(clippy::collapsible_if)]
 
 #[rustfmt::skip]
-#[warn(clippy::collapsible_if)]
 fn main() {
     let (x, y) = ("hello", "world");
 
@@ -47,4 +47,21 @@ fn main() {
             println!("Hello world!");
         }
     //~^^^^^^ collapsible_else_if
+}
+
+fn issue_13365() {
+    // the comments don't stop us from linting, so the the `expect` *will* be fulfilled
+    if true {
+    } else {
+        // some other text before
+        #[expect(clippy::collapsible_else_if)]
+        if false {}
+    }
+
+    if true {
+    } else {
+        #[expect(clippy::collapsible_else_if)]
+        // some other text after
+        if false {}
+    }
 }

--- a/tests/ui-toml/collapsible_if/collapsible_else_if.rs
+++ b/tests/ui-toml/collapsible_if/collapsible_else_if.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::eq_op, clippy::nonminimal_bool)]
+#![warn(clippy::collapsible_if)]
 
 #[rustfmt::skip]
-#[warn(clippy::collapsible_if)]
 fn main() {
     let (x, y) = ("hello", "world");
 
@@ -52,4 +52,21 @@ fn main() {
         }
     }
     //~^^^^^^ collapsible_else_if
+}
+
+fn issue_13365() {
+    // the comments don't stop us from linting, so the the `expect` *will* be fulfilled
+    if true {
+    } else {
+        // some other text before
+        #[expect(clippy::collapsible_else_if)]
+        if false {}
+    }
+
+    if true {
+    } else {
+        #[expect(clippy::collapsible_else_if)]
+        // some other text after
+        if false {}
+    }
 }

--- a/tests/ui/collapsible_else_if.fixed
+++ b/tests/ui/collapsible_else_if.fixed
@@ -87,6 +87,33 @@ fn issue_7318() {
     //~^^^ collapsible_else_if
 }
 
+fn issue_13365() {
+    // all the `expect`s that we should fulfill
+    if true {
+    } else {
+        #[expect(clippy::collapsible_else_if)]
+        if false {}
+    }
+
+    if true {
+    } else {
+        #[expect(clippy::style)]
+        if false {}
+    }
+
+    if true {
+    } else {
+        #[expect(clippy::all)]
+        if false {}
+    }
+
+    if true {
+    } else {
+        #[expect(warnings)]
+        if false {}
+    }
+}
+
 fn issue14799() {
     use std::ops::ControlFlow;
 

--- a/tests/ui/collapsible_else_if.rs
+++ b/tests/ui/collapsible_else_if.rs
@@ -103,6 +103,33 @@ fn issue_7318() {
     //~^^^ collapsible_else_if
 }
 
+fn issue_13365() {
+    // all the `expect`s that we should fulfill
+    if true {
+    } else {
+        #[expect(clippy::collapsible_else_if)]
+        if false {}
+    }
+
+    if true {
+    } else {
+        #[expect(clippy::style)]
+        if false {}
+    }
+
+    if true {
+    } else {
+        #[expect(clippy::all)]
+        if false {}
+    }
+
+    if true {
+    } else {
+        #[expect(warnings)]
+        if false {}
+    }
+}
+
 fn issue14799() {
     use std::ops::ControlFlow;
 

--- a/tests/ui/collapsible_else_if.stderr
+++ b/tests/ui/collapsible_else_if.stderr
@@ -151,7 +151,7 @@ LL | |     }
    | |_____^ help: collapse nested if block: `if false {}`
 
 error: this `else { if .. }` block can be collapsed
-  --> tests/ui/collapsible_else_if.rs:130:12
+  --> tests/ui/collapsible_else_if.rs:157:12
    |
 LL |       } else {
    |  ____________^

--- a/tests/ui/collapsible_else_if_unfixable.rs
+++ b/tests/ui/collapsible_else_if_unfixable.rs
@@ -1,0 +1,22 @@
+//@no-rustfix
+#![warn(clippy::collapsible_else_if)]
+
+fn issue_13365() {
+    // in the following examples, we won't lint because of the comments,
+    // so the the `expect` will be unfulfilled
+    if true {
+    } else {
+        // some other text before
+        #[expect(clippy::collapsible_else_if)]
+        if false {}
+    }
+    //~^^^ ERROR: this lint expectation is unfulfilled
+
+    if true {
+    } else {
+        #[expect(clippy::collapsible_else_if)]
+        // some other text after
+        if false {}
+    }
+    //~^^^^ ERROR: this lint expectation is unfulfilled
+}

--- a/tests/ui/collapsible_else_if_unfixable.stderr
+++ b/tests/ui/collapsible_else_if_unfixable.stderr
@@ -1,0 +1,17 @@
+error: this lint expectation is unfulfilled
+  --> tests/ui/collapsible_else_if_unfixable.rs:10:18
+   |
+LL |         #[expect(clippy::collapsible_else_if)]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unfulfilled_lint_expectations)]`
+
+error: this lint expectation is unfulfilled
+  --> tests/ui/collapsible_else_if_unfixable.rs:17:18
+   |
+LL |         #[expect(clippy::collapsible_else_if)]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/collapsible_if.fixed
+++ b/tests/ui/collapsible_if.fixed
@@ -144,6 +144,24 @@ fn layout_check() -> u32 {
     //~^^^^^ collapsible_if
 }
 
+fn issue13365() {
+    // all the `expect`s that we should fulfill
+    if true {
+        #[expect(clippy::collapsible_if)]
+        if true {}
+    }
+
+    if true {
+        #[expect(clippy::style)]
+        if true {}
+    }
+
+    if true {
+        #[expect(clippy::all)]
+        if true {}
+    }
+}
+
 fn issue14722() {
     let x = if true {
         Some(1)

--- a/tests/ui/collapsible_if.rs
+++ b/tests/ui/collapsible_if.rs
@@ -154,6 +154,24 @@ fn layout_check() -> u32 {
     //~^^^^^ collapsible_if
 }
 
+fn issue13365() {
+    // all the `expect`s that we should fulfill
+    if true {
+        #[expect(clippy::collapsible_if)]
+        if true {}
+    }
+
+    if true {
+        #[expect(clippy::style)]
+        if true {}
+    }
+
+    if true {
+        #[expect(clippy::all)]
+        if true {}
+    }
+}
+
 fn issue14722() {
     let x = if true {
         Some(1)

--- a/tests/ui/collapsible_if.stderr
+++ b/tests/ui/collapsible_if.stderr
@@ -191,7 +191,7 @@ LL ~     ; 3
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:178:5
+  --> tests/ui/collapsible_if.rs:196:5
    |
 LL | /     if true {
 LL | |         (if true {

--- a/tests/ui/collapsible_if_unfixable.rs
+++ b/tests/ui/collapsible_if_unfixable.rs
@@ -1,0 +1,20 @@
+//@ no-rustfix
+#![warn(clippy::collapsible_if)]
+
+fn issue13365() {
+    // in the following examples, we won't lint because of the comments,
+    // so the the `expect` will be unfulfilled
+    if true {
+        // don't collapsible because of this comment
+        #[expect(clippy::collapsible_if)]
+        if true {}
+    }
+    //~^^^ ERROR: this lint expectation is unfulfilled
+
+    if true {
+        #[expect(clippy::collapsible_if)]
+        // don't collapsible because of this comment
+        if true {}
+    }
+    //~^^^^ ERROR: this lint expectation is unfulfilled
+}

--- a/tests/ui/collapsible_if_unfixable.stderr
+++ b/tests/ui/collapsible_if_unfixable.stderr
@@ -1,0 +1,17 @@
+error: this lint expectation is unfulfilled
+  --> tests/ui/collapsible_if_unfixable.rs:9:18
+   |
+LL |         #[expect(clippy::collapsible_if)]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unfulfilled_lint_expectations)]`
+
+error: this lint expectation is unfulfilled
+  --> tests/ui/collapsible_if_unfixable.rs:15:18
+   |
+LL |         #[expect(clippy::collapsible_if)]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/13365

Pretty much the exact approach described in https://github.com/rust-lang/rust-clippy/issues/13365#issuecomment-2344850167, thank you @Jarcho!
r? @Jarcho

changelog: [`collapsible_if`]: respect `#[expect]` on inner `if`
changelog: [`collapsible_else_if`]: respect `#[expect]` on inner `if`
