### PR TITLE
`is_else_cause`: don't use `hir_parent_iter` just to go one level up

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1349,16 +1349,13 @@ pub fn peel_blocks_with_stmt<'a>(mut expr: &'a Expr<'a>) -> &'a Expr<'a> {
 
 /// Checks if the given expression is the else clause of either an `if` or `if let` expression.
 pub fn is_else_clause(tcx: TyCtxt<'_>, expr: &Expr<'_>) -> bool {
-    let mut iter = tcx.hir_parent_iter(expr.hir_id);
-    match iter.next() {
-        Some((
-            _,
-            Node::Expr(Expr {
-                kind: ExprKind::If(_, _, Some(else_expr)),
-                ..
-            }),
-        )) => else_expr.hir_id == expr.hir_id,
-        _ => false,
+    if let Node::Expr(expr) = tcx.parent_hir_node(expr.hir_id)
+        && let ExprKind::If(_, _, Some(else_expr)) = expr.kind
+        && else_expr.hir_id == expr.hir_id
+    {
+        true
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
changelog: none