### PR TITLE
Fix `as_underscore` to only suggest when it's suggestable

### DIFF
--- a/clippy_lints/src/casts/as_underscore.rs
+++ b/clippy_lints/src/casts/as_underscore.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, Ty, TyKind};
 use rustc_lint::LateContext;
-use rustc_middle::ty;
+use rustc_middle::ty::IsSuggestable;
 
 use super::AS_UNDERSCORE;
 
@@ -10,15 +10,15 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, ty: &'tc
     if matches!(ty.kind, TyKind::Infer(())) {
         span_lint_and_then(cx, AS_UNDERSCORE, expr.span, "using `as _` conversion", |diag| {
             let ty_resolved = cx.typeck_results().expr_ty(expr);
-            if let ty::Error(_) = ty_resolved.kind() {
-                diag.help("consider giving the type explicitly");
-            } else {
+            if ty_resolved.is_suggestable(cx.tcx, true) {
                 diag.span_suggestion(
                     ty.span,
                     "consider giving the type explicitly",
                     ty_resolved,
                     Applicability::MachineApplicable,
                 );
+            } else {
+                diag.help("consider giving the type explicitly");
             }
         });
     }

--- a/tests/ui/as_underscore_unfixable.rs
+++ b/tests/ui/as_underscore_unfixable.rs
@@ -1,0 +1,14 @@
+//@no-rustfix
+
+#![warn(clippy::as_underscore)]
+
+fn main() {
+    // From issue #15282
+    let f = async || ();
+    let _: Box<dyn FnOnce() -> _> = Box::new(f) as _;
+    //~^ as_underscore
+
+    let barr = || (|| ());
+    let _: Box<dyn Fn() -> _> = Box::new(barr) as _;
+    //~^ as_underscore
+}

--- a/tests/ui/as_underscore_unfixable.stderr
+++ b/tests/ui/as_underscore_unfixable.stderr
@@ -1,0 +1,20 @@
+error: using `as _` conversion
+  --> tests/ui/as_underscore_unfixable.rs:8:37
+   |
+LL |     let _: Box<dyn FnOnce() -> _> = Box::new(f) as _;
+   |                                     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider giving the type explicitly
+   = note: `-D clippy::as-underscore` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::as_underscore)]`
+
+error: using `as _` conversion
+  --> tests/ui/as_underscore_unfixable.rs:12:33
+   |
+LL |     let _: Box<dyn Fn() -> _> = Box::new(barr) as _;
+   |                                 ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider giving the type explicitly
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Have `as_underscore` only make a suggestion when the type is suggestable.

changelog: [`as_underscore`]: Don't suggest a fix if the type is not suggestable

Fixes rust-lang/rust-clippy#15282 
