### PR TITLE
Fix `invalid_upcast_comparisons` wrongly unmangled macros

### DIFF
--- a/tests/ui/invalid_upcast_comparisons.rs
+++ b/tests/ui/invalid_upcast_comparisons.rs
@@ -133,3 +133,15 @@ fn main() {
 
     -5 == (u32 as i32);
 }
+
+fn issue15662() {
+    macro_rules! add_one {
+        ($x:expr) => {
+            $x + 1
+        };
+    }
+
+    let x: u8 = 1;
+    (add_one!(x) as u32) > 300;
+    //~^ invalid_upcast_comparisons
+}

--- a/tests/ui/invalid_upcast_comparisons.stderr
+++ b/tests/ui/invalid_upcast_comparisons.stderr
@@ -163,5 +163,11 @@ error: because of the numeric bounds on `u8` prior to casting, this expression i
 LL |     -5 >= (u8 as i32);
    |     ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 27 previous errors
+error: because of the numeric bounds on `add_one!(x)` prior to casting, this expression is always false
+  --> tests/ui/invalid_upcast_comparisons.rs:145:5
+   |
+LL |     (add_one!(x) as u32) > 300;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 28 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15662 

changelog: [`invalid_upcast_comparisons`] fix wrong unmangle of macros
