### PR TITLE
fix(`bad_bit_mask`): don't lint on `#[cfg]`-d consts 

### DIFF
--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -203,10 +203,6 @@ declare_clippy_lint! {
     /// set to zero or one by the bit mask, the comparison is constant `true` or
     /// `false` (depending on mask, compared value, and operators).
     ///
-    /// So the code is actively misleading, and the only reason someone would write
-    /// this intentionally is to win an underhanded Rust contest or create a
-    /// test-case for this lint.
-    ///
     /// ### Example
     /// ```no_run
     /// # let x = 1;

--- a/tests/ui/bit_masks.rs
+++ b/tests/ui/bit_masks.rs
@@ -86,3 +86,15 @@ fn ineffective() {
     x | 3 > 4; // not an error (yet), better written as x >= 4
     x | 4 <= 19;
 }
+
+fn issue14167() {
+    #[cfg(test)]
+    const FORCE_DYNAMIC_DETECTION: u8 = 0b00010000;
+
+    #[cfg(not(test))]
+    const FORCE_DYNAMIC_DETECTION: u8 = 0b0000000;
+
+    const CAPS_STATIC: u8 = 0b00001111;
+
+    CAPS_STATIC & FORCE_DYNAMIC_DETECTION == 0;
+}

--- a/tests/ui/bit_masks.rs
+++ b/tests/ui/bit_masks.rs
@@ -1,13 +1,10 @@
+#![allow(clippy::identity_op, clippy::no_effect, clippy::unnecessary_operation)]
+
 const THREE_BITS: i64 = 7;
 const EVEN_MORE_REDIRECTION: i64 = THREE_BITS;
 
 #[warn(clippy::bad_bit_mask)]
-#[allow(
-    clippy::ineffective_bit_mask,
-    clippy::identity_op,
-    clippy::no_effect,
-    clippy::unnecessary_operation
-)]
+#[allow(clippy::ineffective_bit_mask)]
 fn main() {
     let x = 5;
 
@@ -68,7 +65,7 @@ fn main() {
 }
 
 #[warn(clippy::ineffective_bit_mask)]
-#[allow(clippy::bad_bit_mask, clippy::no_effect, clippy::unnecessary_operation)]
+#[allow(clippy::bad_bit_mask)]
 fn ineffective() {
     let x = 5;
 

--- a/tests/ui/bit_masks.stderr
+++ b/tests/ui/bit_masks.stderr
@@ -1,5 +1,5 @@
 error: &-masking with zero
-  --> tests/ui/bit_masks.rs:14:5
+  --> tests/ui/bit_masks.rs:11:5
    |
 LL |     x & 0 == 0;
    |     ^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     x & 0 == 0;
    = help: to override `-D warnings` add `#[allow(clippy::bad_bit_mask)]`
 
 error: this operation will always return zero. This is likely not the intended outcome
-  --> tests/ui/bit_masks.rs:14:5
+  --> tests/ui/bit_masks.rs:11:5
    |
 LL |     x & 0 == 0;
    |     ^^^^^
@@ -16,73 +16,73 @@ LL |     x & 0 == 0;
    = note: `#[deny(clippy::erasing_op)]` on by default
 
 error: incompatible bit mask: `_ & 2` can never be equal to `1`
-  --> tests/ui/bit_masks.rs:20:5
+  --> tests/ui/bit_masks.rs:17:5
    |
 LL |     x & 2 == 1;
    |     ^^^^^^^^^^
 
 error: incompatible bit mask: `_ | 3` can never be equal to `2`
-  --> tests/ui/bit_masks.rs:26:5
+  --> tests/ui/bit_masks.rs:23:5
    |
 LL |     x | 3 == 2;
    |     ^^^^^^^^^^
 
 error: incompatible bit mask: `_ & 1` will never be higher than `1`
-  --> tests/ui/bit_masks.rs:29:5
+  --> tests/ui/bit_masks.rs:26:5
    |
 LL |     x & 1 > 1;
    |     ^^^^^^^^^
 
 error: incompatible bit mask: `_ | 2` will always be higher than `1`
-  --> tests/ui/bit_masks.rs:35:5
+  --> tests/ui/bit_masks.rs:32:5
    |
 LL |     x | 2 > 1;
    |     ^^^^^^^^^
 
 error: incompatible bit mask: `_ & 7` can never be equal to `8`
-  --> tests/ui/bit_masks.rs:44:5
+  --> tests/ui/bit_masks.rs:41:5
    |
 LL |     x & THREE_BITS == 8;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: incompatible bit mask: `_ | 7` will never be lower than `7`
-  --> tests/ui/bit_masks.rs:47:5
+  --> tests/ui/bit_masks.rs:44:5
    |
 LL |     x | EVEN_MORE_REDIRECTION < 7;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: &-masking with zero
-  --> tests/ui/bit_masks.rs:50:5
+  --> tests/ui/bit_masks.rs:47:5
    |
 LL |     0 & x == 0;
    |     ^^^^^^^^^^
 
 error: this operation will always return zero. This is likely not the intended outcome
-  --> tests/ui/bit_masks.rs:50:5
+  --> tests/ui/bit_masks.rs:47:5
    |
 LL |     0 & x == 0;
    |     ^^^^^
 
 error: incompatible bit mask: `_ | 2` will always be higher than `1`
-  --> tests/ui/bit_masks.rs:57:5
+  --> tests/ui/bit_masks.rs:54:5
    |
 LL |     1 < 2 | x;
    |     ^^^^^^^^^
 
 error: incompatible bit mask: `_ | 3` can never be equal to `2`
-  --> tests/ui/bit_masks.rs:60:5
+  --> tests/ui/bit_masks.rs:57:5
    |
 LL |     2 == 3 | x;
    |     ^^^^^^^^^^
 
 error: incompatible bit mask: `_ & 2` can never be equal to `1`
-  --> tests/ui/bit_masks.rs:63:5
+  --> tests/ui/bit_masks.rs:60:5
    |
 LL |     1 == x & 2;
    |     ^^^^^^^^^^
 
 error: ineffective bit mask: `x | 1` compared to `3`, is the same as x compared directly
-  --> tests/ui/bit_masks.rs:75:5
+  --> tests/ui/bit_masks.rs:72:5
    |
 LL |     x | 1 > 3;
    |     ^^^^^^^^^
@@ -91,19 +91,19 @@ LL |     x | 1 > 3;
    = help: to override `-D warnings` add `#[allow(clippy::ineffective_bit_mask)]`
 
 error: ineffective bit mask: `x | 1` compared to `4`, is the same as x compared directly
-  --> tests/ui/bit_masks.rs:78:5
+  --> tests/ui/bit_masks.rs:75:5
    |
 LL |     x | 1 < 4;
    |     ^^^^^^^^^
 
 error: ineffective bit mask: `x | 1` compared to `3`, is the same as x compared directly
-  --> tests/ui/bit_masks.rs:81:5
+  --> tests/ui/bit_masks.rs:78:5
    |
 LL |     x | 1 <= 3;
    |     ^^^^^^^^^^
 
 error: ineffective bit mask: `x | 1` compared to `8`, is the same as x compared directly
-  --> tests/ui/bit_masks.rs:84:5
+  --> tests/ui/bit_masks.rs:81:5
    |
 LL |     x | 1 >= 8;
    |     ^^^^^^^^^^


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/14167

changelog: [`bad_bit_mask`]: don't lint on `#[cfg]`-d consts 