### PR TITLE
fix(needless_return): FP with `cfg`d code after `return`

### DIFF
--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -517,3 +517,10 @@ mod else_ifs {
         }
     }
 }
+
+fn issue14474() -> u64 {
+    return 456;
+
+    #[cfg(false)]
+    123
+}

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -526,3 +526,10 @@ mod else_ifs {
         }
     }
 }
+
+fn issue14474() -> u64 {
+    return 456;
+
+    #[cfg(false)]
+    123
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/14474

changelog: [`needless_return`]: FP with `cfg`d code after `return`
