### PR TITLE
Remove unnecessary `#![allow]` in test

### DIFF
--- a/tests/ui/never_loop_fixable.fixed
+++ b/tests/ui/never_loop_fixable.fixed
@@ -1,4 +1,4 @@
-#![allow(clippy::iter_next_slice, clippy::needless_return, clippy::redundant_pattern_matching)]
+#![allow(clippy::iter_next_slice, clippy::needless_return)]
 
 fn no_break_or_continue_loop() {
     if let Some(i) = [1, 2, 3].iter().next() {

--- a/tests/ui/never_loop_fixable.rs
+++ b/tests/ui/never_loop_fixable.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::iter_next_slice, clippy::needless_return, clippy::redundant_pattern_matching)]
+#![allow(clippy::iter_next_slice, clippy::needless_return)]
 
 fn no_break_or_continue_loop() {
     for i in [1, 2, 3].iter() {


### PR DESCRIPTION
Noticed while working on rust-lang/rust-clippy#15673.

changelog: none
