### PR TITLE
[`unnecessary_safety_comment`] Considering comments above attributes for items

### DIFF
--- a/clippy_lints/src/undocumented_unsafe_blocks.rs
+++ b/clippy_lints/src/undocumented_unsafe_blocks.rs
@@ -201,7 +201,7 @@ impl<'tcx> LateLintPass<'tcx> for UndocumentedUnsafeBlocks {
             (span, help_span)
         };
 
-        let item_has_safety_comment = item_has_safety_comment(cx, item);
+        let item_has_safety_comment = item_has_safety_comment(cx, item, self.accept_comment_above_attributes);
         match item_has_safety_comment {
             HasSafetyComment::Yes(pos) => check_has_safety_comment(cx, item, mk_spans(pos)),
             HasSafetyComment::No => check_has_no_safety_comment(cx, item),
@@ -272,6 +272,7 @@ fn check_has_safety_comment(cx: &LateContext<'_>, item: &hir::Item<'_>, (span, h
         },
     }
 }
+
 fn check_has_no_safety_comment(cx: &LateContext<'_>, item: &hir::Item<'_>) {
     if let ItemKind::Impl(Impl {
         of_trait: Some(of_trait),
@@ -482,6 +483,7 @@ fn include_attrs_in_span(cx: &LateContext<'_>, hir_id: HirId, span: Span) -> Spa
     }))
 }
 
+#[derive(Debug)]
 enum HasSafetyComment {
     Yes(BytePos),
     No,
@@ -490,7 +492,11 @@ enum HasSafetyComment {
 
 /// Checks if the lines immediately preceding the item contain a safety comment.
 #[allow(clippy::collapsible_match)]
-fn item_has_safety_comment(cx: &LateContext<'_>, item: &hir::Item<'_>) -> HasSafetyComment {
+fn item_has_safety_comment(
+    cx: &LateContext<'_>,
+    item: &hir::Item<'_>,
+    accept_comment_above_attributes: bool,
+) -> HasSafetyComment {
     match span_from_macro_expansion_has_safety_comment(cx, item.span) {
         HasSafetyComment::Maybe => (),
         has_safety_comment => return has_safety_comment,
@@ -524,10 +530,15 @@ fn item_has_safety_comment(cx: &LateContext<'_>, item: &hir::Item<'_>) -> HasSaf
         },
     };
 
+    let mut span = item.span;
+    if accept_comment_above_attributes {
+        span = include_attrs_in_span(cx, item.hir_id(), span);
+    }
+
     let source_map = cx.sess().source_map();
     // If the comment is in the first line of the file, there is no preceding line
     if let Some(comment_start) = comment_start
-        && let Ok(unsafe_line) = source_map.lookup_line(item.span.lo())
+        && let Ok(unsafe_line) = source_map.lookup_line(span.lo())
         && let Ok(comment_start_line) = source_map.lookup_line(comment_start.into())
         && let include_first_line_of_file = matches!(comment_start, CommentStartBeforeItem::Start)
         && (include_first_line_of_file || Arc::ptr_eq(&unsafe_line.sf, &comment_start_line.sf))
@@ -572,8 +583,6 @@ fn stmt_has_safety_comment(
         _ => return HasSafetyComment::Maybe,
     };
 
-    // if span_with_attrs_has_safety_comment(cx, span, hir_id, accept_comment_above_attrib
-    // }
     let mut span = span;
     if accept_comment_above_attributes {
         span = include_attrs_in_span(cx, hir_id, span);
@@ -586,6 +595,7 @@ fn stmt_has_safety_comment(
         && Arc::ptr_eq(&unsafe_line.sf, &comment_start_line.sf)
         && let Some(src) = unsafe_line.sf.src.as_deref()
     {
+        // dbg!(src);
         return if comment_start_line.line >= unsafe_line.line {
             HasSafetyComment::No
         } else {

--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.default.stderr
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.default.stderr
@@ -342,17 +342,53 @@ LL |         const NO_SAFETY_IN_IMPL: i32 = unsafe { 1 };
    |
    = help: consider adding a safety comment on the preceding line
 
+error: constant has unnecessary safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:701:5
+   |
+LL |     const UNIX_EPOCH_JULIAN_DAY: i32 =
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:699:5
+   |
+LL |     // SAFETY: fail ONLY if `accept-comment-above-attribute = false`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: statement has unnecessary safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:719:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:720:5
    |
 LL |     _ = bar();
    |     ^^^^^^^^^^
    |
 help: consider removing the safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:718:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:719:5
    |
 LL |     // SAFETY: unnecessary_safety_comment triggers here
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 40 previous errors
+error: module has unnecessary safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:740:5
+   |
+LL |     mod x {}
+   |     ^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:739:5
+   |
+LL |     // SAFETY: ...
+   |     ^^^^^^^^^^^^^^
+
+error: module has unnecessary safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:745:5
+   |
+LL |     mod y {}
+   |     ^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:743:5
+   |
+LL |     // SAFETY: ...
+   |     ^^^^^^^^^^^^^^
+
+error: aborting due to 43 previous errors
 

--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.disabled.stderr
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.disabled.stderr
@@ -439,24 +439,48 @@ LL |         unsafe { Date::__from_ordinal_date_unchecked(1970, 1) }.into_julian
    = help: consider adding a safety comment on the preceding line
 
 error: statement has unnecessary safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:719:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:720:5
    |
 LL |     _ = bar();
    |     ^^^^^^^^^^
    |
 help: consider removing the safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:718:5
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:719:5
    |
 LL |     // SAFETY: unnecessary_safety_comment triggers here
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe block missing a safety comment
-  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:733:12
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:734:12
    |
 LL |     return unsafe { h() };
    |            ^^^^^^^^^^^^^^
    |
    = help: consider adding a safety comment on the preceding line
 
-error: aborting due to 53 previous errors
+error: module has unnecessary safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:740:5
+   |
+LL |     mod x {}
+   |     ^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:739:5
+   |
+LL |     // SAFETY: ...
+   |     ^^^^^^^^^^^^^^
+
+error: module has unnecessary safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:750:5
+   |
+LL |     mod z {}
+   |     ^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs:749:5
+   |
+LL |     // SAFETY: ...
+   |     ^^^^^^^^^^^^^^
+
+error: aborting due to 55 previous errors
 

--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs
@@ -701,6 +701,7 @@ mod issue_11709_regression {
     const UNIX_EPOCH_JULIAN_DAY: i32 =
         unsafe { Date::__from_ordinal_date_unchecked(1970, 1) }.into_julian_day_just_make_this_line_longer();
     //~[disabled]^ undocumented_unsafe_blocks
+    //~[default]^^^ unnecessary_safety_comment
 }
 
 fn issue_13039() {
@@ -732,6 +733,22 @@ fn rfl_issue15034() -> i32 {
     #[allow(clippy::unnecessary_cast)]
     return unsafe { h() };
     //~[disabled]^ ERROR: unsafe block missing a safety comment
+}
+
+mod issue_14555 {
+    // SAFETY: ...
+    mod x {}
+    //~^ unnecessary_safety_comment
+
+    // SAFETY: ...
+    #[doc(hidden)]
+    mod y {}
+    //~[default]^ unnecessary_safety_comment
+
+    #[doc(hidden)]
+    // SAFETY: ...
+    mod z {}
+    //~[disabled]^ unnecessary_safety_comment
 }
 
 fn main() {}


### PR DESCRIPTION
This is a draft PR, this bugfix generates other bugs so needs further work.

changelog: [`unnecessary_safety_comment`]: Taking into account comments above attributes for items
