### PR TITLE
Do not look for `Cargo.toml` inside `target`

### DIFF
--- a/tests/no-profile-in-cargo-toml.rs
+++ b/tests/no-profile-in-cargo-toml.rs
@@ -17,6 +17,9 @@ fn no_profile_in_cargo_toml() {
     // keep it fast and simple.
     for entry in WalkDir::new(".")
         .into_iter()
+        // Do not recurse into `target` as lintcheck might put some sources (and their
+        //  `Cargo.toml`) there.
+        .filter_entry(|e| e.file_name() != "target")
         .filter_map(Result::ok)
         .filter(|e| e.file_name().to_str() == Some("Cargo.toml"))
     {


### PR DESCRIPTION
This test, which checks that we do not define new profiles directly in Clippy's multiple `Cargo.toml` files, must not look inside `target` as `lintcheck` might place some third-party sources there. Of course those third-party sources are allowed to define profiles in their `Cargo.toml`.

changelog: none