### PR TITLE
Remove jujutsu directory from search tools.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ helper.txt
 
 # mdbook generated output
 /book/book
+
+# Remove jujutsu directory from search tools
+.jj


### PR DESCRIPTION
This prevents ripgrep from searching the directory by default.

changelog: none
