### PR TITLE
Use lld on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,3 +30,6 @@ rustflags = ["--remap-path-prefix", "=lintcheck"]
 # without increasing total build times.
 [profile.dev.package.quine-mc_cluskey]
 opt-level = 3
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"


### PR DESCRIPTION
Speeds up windows builds a bit. Should be fine in the rust repo since they ignore our cargo config IIRC.

r? flip1995 

changelog: none
