### PR TITLE
Add `large-error-ignored` config-knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6871,6 +6871,7 @@ Released 2018-09-13
 [`excessive-nesting-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#excessive-nesting-threshold
 [`future-size-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#future-size-threshold
 [`ignore-interior-mutability`]: https://doc.rust-lang.org/clippy/lint_configuration.html#ignore-interior-mutability
+[`large-error-ignored`]: https://doc.rust-lang.org/clippy/lint_configuration.html#large-error-ignored
 [`large-error-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#large-error-threshold
 [`lint-commented-code`]: https://doc.rust-lang.org/clippy/lint_configuration.html#lint-commented-code
 [`literal-representation-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#literal-representation-threshold

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -671,6 +671,17 @@ A list of paths to types that should be treated as if they do not contain interi
 * [`mutable_key_type`](https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type)
 
 
+## `large-error-ignored`
+A list of paths to types that should be ignored as overly large `Err`-variants in a
+`Result` returned from a function
+
+**Default Value:** `[]`
+
+---
+**Affected lints:**
+* [`result_large_err`](https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err)
+
+
 ## `large-error-threshold`
 The maximum size of the `Err`-variant in a `Result` returned from a function
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -663,6 +663,10 @@ define_Conf! {
     /// A list of paths to types that should be treated as if they do not contain interior mutability
     #[lints(borrow_interior_mutable_const, declare_interior_mutable_const, ifs_same_cond, mutable_key_type)]
     ignore_interior_mutability: Vec<String> = Vec::from(["bytes::Bytes".into()]),
+    /// A list of paths to types that should be ignored as overly large `Err`-variants in a
+    /// `Result` returned from a function
+    #[lints(result_large_err)]
+    large_error_ignored: Vec<String> = Vec::default(),
     /// The maximum size of the `Err`-variant in a `Result` returned from a function
     #[lints(result_large_err)]
     large_error_threshold: u64 = 128,

--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -485,6 +485,7 @@ pub struct Functions {
     too_many_arguments_threshold: u64,
     too_many_lines_threshold: u64,
     large_error_threshold: u64,
+    large_error_ignored: DefIdSet,
     avoid_breaking_exported_api: bool,
     /// A set of resolved `def_id` of traits that are configured to allow
     /// function params renaming.
@@ -498,6 +499,11 @@ impl Functions {
             too_many_arguments_threshold: conf.too_many_arguments_threshold,
             too_many_lines_threshold: conf.too_many_lines_threshold,
             large_error_threshold: conf.large_error_threshold,
+            large_error_ignored: conf
+                .large_error_ignored
+                .iter()
+                .flat_map(|ignored_ty| lookup_path_str(tcx, PathNS::Type, ignored_ty))
+                .collect(),
             avoid_breaking_exported_api: conf.avoid_breaking_exported_api,
             trait_ids: conf
                 .allow_renamed_params_for
@@ -554,12 +560,24 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
 
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
         must_use::check_item(cx, item);
-        result::check_item(cx, item, self.large_error_threshold, self.msrv);
+        result::check_item(
+            cx,
+            item,
+            self.large_error_threshold,
+            &self.large_error_ignored,
+            self.msrv,
+        );
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::ImplItem<'_>) {
         must_use::check_impl_item(cx, item);
-        result::check_impl_item(cx, item, self.large_error_threshold, self.msrv);
+        result::check_impl_item(
+            cx,
+            item,
+            self.large_error_threshold,
+            &self.large_error_ignored,
+            self.msrv,
+        );
         impl_trait_in_params::check_impl_item(cx, item);
         renamed_function_params::check_impl_item(cx, item, &self.trait_ids);
     }
@@ -568,7 +586,13 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
         too_many_arguments::check_trait_item(cx, item, self.too_many_arguments_threshold);
         not_unsafe_ptr_arg_deref::check_trait_item(cx, item);
         must_use::check_trait_item(cx, item);
-        result::check_trait_item(cx, item, self.large_error_threshold, self.msrv);
+        result::check_trait_item(
+            cx,
+            item,
+            self.large_error_threshold,
+            &self.large_error_ignored,
+            self.msrv,
+        );
         impl_trait_in_params::check_trait_item(cx, item, self.avoid_breaking_exported_api);
         ref_option::check_trait_item(cx, item, self.avoid_breaking_exported_api);
     }

--- a/clippy_lints/src/functions/result.rs
+++ b/clippy_lints/src/functions/result.rs
@@ -3,6 +3,7 @@ use rustc_errors::Diag;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::{self, Ty};
+use rustc_span::def_id::DefIdSet;
 use rustc_span::{Span, sym};
 
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
@@ -34,7 +35,13 @@ fn result_err_ty<'tcx>(
     }
 }
 
-pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &hir::Item<'tcx>, large_err_threshold: u64, msrv: Msrv) {
+pub(super) fn check_item<'tcx>(
+    cx: &LateContext<'tcx>,
+    item: &hir::Item<'tcx>,
+    large_err_threshold: u64,
+    large_err_ignored: &DefIdSet,
+    msrv: Msrv,
+) {
     if let hir::ItemKind::Fn { ref sig, .. } = item.kind
         && let Some((hir_ty, err_ty)) = result_err_ty(cx, sig.decl, item.owner_id.def_id, item.span)
     {
@@ -42,7 +49,7 @@ pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &hir::Item<'tcx>, l
             let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
             check_result_unit_err(cx, err_ty, fn_header_span, msrv);
         }
-        check_result_large_err(cx, err_ty, hir_ty.span, large_err_threshold);
+        check_result_large_err(cx, err_ty, hir_ty.span, large_err_threshold, large_err_ignored);
     }
 }
 
@@ -50,6 +57,7 @@ pub(super) fn check_impl_item<'tcx>(
     cx: &LateContext<'tcx>,
     item: &hir::ImplItem<'tcx>,
     large_err_threshold: u64,
+    large_err_ignored: &DefIdSet,
     msrv: Msrv,
 ) {
     // Don't lint if method is a trait's implementation, we can't do anything about those
@@ -61,7 +69,7 @@ pub(super) fn check_impl_item<'tcx>(
             let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
             check_result_unit_err(cx, err_ty, fn_header_span, msrv);
         }
-        check_result_large_err(cx, err_ty, hir_ty.span, large_err_threshold);
+        check_result_large_err(cx, err_ty, hir_ty.span, large_err_threshold, large_err_ignored);
     }
 }
 
@@ -69,6 +77,7 @@ pub(super) fn check_trait_item<'tcx>(
     cx: &LateContext<'tcx>,
     item: &hir::TraitItem<'tcx>,
     large_err_threshold: u64,
+    large_err_ignored: &DefIdSet,
     msrv: Msrv,
 ) {
     if let hir::TraitItemKind::Fn(ref sig, _) = item.kind {
@@ -77,7 +86,7 @@ pub(super) fn check_trait_item<'tcx>(
             if cx.effective_visibilities.is_exported(item.owner_id.def_id) {
                 check_result_unit_err(cx, err_ty, fn_header_span, msrv);
             }
-            check_result_large_err(cx, err_ty, hir_ty.span, large_err_threshold);
+            check_result_large_err(cx, err_ty, hir_ty.span, large_err_threshold, large_err_ignored);
         }
     }
 }
@@ -95,7 +104,18 @@ fn check_result_unit_err(cx: &LateContext<'_>, err_ty: Ty<'_>, fn_header_span: S
     }
 }
 
-fn check_result_large_err<'tcx>(cx: &LateContext<'tcx>, err_ty: Ty<'tcx>, hir_ty_span: Span, large_err_threshold: u64) {
+fn check_result_large_err<'tcx>(
+    cx: &LateContext<'tcx>,
+    err_ty: Ty<'tcx>,
+    hir_ty_span: Span,
+    large_err_threshold: u64,
+    large_err_ignored: &DefIdSet,
+) {
+    if let ty::Adt(adt, _) = err_ty.kind()
+        && large_err_ignored.contains(&adt.did())
+    {
+        return;
+    }
     if let ty::Adt(adt, subst) = err_ty.kind()
         && let Some(local_def_id) = adt.did().as_local()
         && let hir::Node::Item(item) = cx.tcx.hir_node_by_def_id(local_def_id)

--- a/tests/ui-toml/result_large_err/clippy.toml
+++ b/tests/ui-toml/result_large_err/clippy.toml
@@ -1,1 +1,2 @@
 large-error-threshold = 512
+large-error-ignored = ["result_large_err::IgnoredError", "result_large_err::IgnoredErrorEnum"]

--- a/tests/ui-toml/result_large_err/result_large_err.rs
+++ b/tests/ui-toml/result_large_err/result_large_err.rs
@@ -1,4 +1,6 @@
+//@compile-flags: --crate-name result_large_err
 #![warn(clippy::result_large_err)]
+#![allow(clippy::large_enum_variant)]
 
 fn f() -> Result<(), [u8; 511]> {
     todo!()
@@ -7,4 +9,22 @@ fn f2() -> Result<(), [u8; 512]> {
     //~^ ERROR: the `Err`-variant returned from this function is very large
     todo!()
 }
+
+struct IgnoredError {
+    inner: [u8; 512],
+}
+
+fn f3() -> Result<(), IgnoredError> {
+    todo!()
+}
+
+enum IgnoredErrorEnum {
+    V1,
+    V2 { inner: [u8; 512] },
+}
+
+fn f4() -> Result<(), IgnoredErrorEnum> {
+    todo!()
+}
+
 fn main() {}

--- a/tests/ui-toml/result_large_err/result_large_err.stderr
+++ b/tests/ui-toml/result_large_err/result_large_err.stderr
@@ -1,5 +1,5 @@
 error: the `Err`-variant returned from this function is very large
-  --> tests/ui-toml/result_large_err/result_large_err.rs:6:12
+  --> tests/ui-toml/result_large_err/result_large_err.rs:8:12
    |
 LL | fn f2() -> Result<(), [u8; 512]> {
    |            ^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 512 bytes

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -49,6 +49,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           large-error-ignored
            large-error-threshold
            lint-commented-code
            literal-representation-threshold
@@ -144,6 +145,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           large-error-ignored
            large-error-threshold
            lint-commented-code
            literal-representation-threshold
@@ -239,6 +241,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           large-error-ignored
            large-error-threshold
            lint-commented-code
            literal-representation-threshold


### PR DESCRIPTION
Fixes #15404

changelog: [`result_large_err`]: Add `large_error_ignored` configuration
