### PR TITLE
extend `while_let_loop` to `loop { let else }`

### DIFF
--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -861,6 +861,7 @@ impl<'tcx> LateLintPass<'tcx> for Loops {
         // check for `loop { if let {} else break }` that could be `while let`
         // (also matches an explicit "match" instead of "if let")
         // (even if the "match" or "if let" is used for declaration)
+        // (also matches on `let {} else break`)
         if let ExprKind::Loop(block, label, LoopSource::Loop, _) = expr.kind {
             // also check for empty `loop {}` statements, skipping those in #[panic_handler]
             empty_loop::check(cx, expr, block);

--- a/tests/ui/infinite_loops.rs
+++ b/tests/ui/infinite_loops.rs
@@ -1,7 +1,7 @@
 //@no-rustfix: multiple suggestions add `-> !` to the same fn
 //@aux-build:proc_macros.rs
 
-#![allow(clippy::never_loop)]
+#![allow(clippy::never_loop, clippy::while_let_loop)]
 #![warn(clippy::infinite_loop)]
 
 extern crate proc_macros;

--- a/tests/ui/while_let_loop.rs
+++ b/tests/ui/while_let_loop.rs
@@ -24,6 +24,19 @@ fn main() {
 
     loop {
         //~^ while_let_loop
+        let Some(_x) = y else { break };
+    }
+
+    loop {
+        // no error, else branch does something other than break
+        let Some(_x) = y else {
+            let _z = 1;
+            break;
+        };
+    }
+
+    loop {
+        //~^ while_let_loop
 
         match y {
             Some(_x) => true,

--- a/tests/ui/while_let_loop.stderr
+++ b/tests/ui/while_let_loop.stderr
@@ -17,6 +17,15 @@ error: this loop could be written as a `while let` loop
    |
 LL | /     loop {
 LL | |
+LL | |         let Some(_x) = y else { break };
+LL | |     }
+   | |_____^ help: try: `while let Some(_x) = y { .. }`
+
+error: this loop could be written as a `while let` loop
+  --> tests/ui/while_let_loop.rs:38:5
+   |
+LL | /     loop {
+LL | |
 LL | |
 LL | |         match y {
 ...  |
@@ -25,7 +34,7 @@ LL | |     }
    | |_____^ help: try: `while let Some(_x) = y { .. }`
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:34:5
+  --> tests/ui/while_let_loop.rs:47:5
    |
 LL | /     loop {
 LL | |
@@ -37,7 +46,7 @@ LL | |     }
    | |_____^ help: try: `while let Some(x) = y { .. }`
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:45:5
+  --> tests/ui/while_let_loop.rs:58:5
    |
 LL | /     loop {
 LL | |
@@ -48,7 +57,7 @@ LL | |     }
    | |_____^ help: try: `while let Some(x) = y { .. }`
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:77:5
+  --> tests/ui/while_let_loop.rs:90:5
    |
 LL | /     loop {
 LL | |
@@ -68,7 +77,7 @@ LL +     }
    |
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:167:9
+  --> tests/ui/while_let_loop.rs:180:9
    |
 LL | /         loop {
 LL | |
@@ -88,7 +97,7 @@ LL +         }
    |
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:182:5
+  --> tests/ui/while_let_loop.rs:195:5
    |
 LL | /     loop {
 LL | |
@@ -107,7 +116,7 @@ LL +     }
    |
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:194:5
+  --> tests/ui/while_let_loop.rs:207:5
    |
 LL | /     loop {
 LL | |
@@ -126,7 +135,7 @@ LL +     }
    |
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:206:5
+  --> tests/ui/while_let_loop.rs:219:5
    |
 LL | /     loop {
 LL | |
@@ -137,7 +146,7 @@ LL | |     }
    | |_____^ help: try: `while let Some(x) = Some(3) { .. }`
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:218:5
+  --> tests/ui/while_let_loop.rs:231:5
    |
 LL | /     loop {
 LL | |
@@ -156,7 +165,7 @@ LL +     }
    |
 
 error: this loop could be written as a `while let` loop
-  --> tests/ui/while_let_loop.rs:230:5
+  --> tests/ui/while_let_loop.rs:243:5
    |
 LL | /     loop {
 LL | |
@@ -177,5 +186,5 @@ LL +         ..
 LL +     }
    |
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
now lints on
```rs
let mut x = [1,2,3].into_iter();
loop {
   let Some(x) = x.next() else { break };
   dbg!(x);
}
```
```
changelog: [`while_let_loop`]: extend to lint on `let else`
```
