### PR TITLE
Changelog: fix heading level in 1.90 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Current stable, released 2025-09-18
 Note: This Clippy release does not introduce many new lints and is focused entirely on bug fixes — see
 [#15086](https://github.com/rust-lang/rust-clippy/issues/15086) for more details.
 
-## New Lints
+### New Lints
 
 * Added [`manual_is_multiple_of`] to `complexity` [#14292](https://github.com/rust-lang/rust-clippy/pull/14292)
 * Added [`doc_broken_link`] to `pedantic` [#13696](https://github.com/rust-lang/rust-clippy/pull/13696)


### PR DESCRIPTION
changelog: none
