### PR TITLE
Post lint on the type HIR node

### DIFF
--- a/clippy_lints/src/derive/derive_ord_xor_partial_ord.rs
+++ b/clippy_lints/src/derive/derive_ord_xor_partial_ord.rs
@@ -1,5 +1,5 @@
-use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_hir as hir;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
+use rustc_hir::{self as hir, HirId};
 use rustc_lint::LateContext;
 use rustc_middle::ty::Ty;
 use rustc_span::{Span, sym};
@@ -12,6 +12,7 @@ pub(super) fn check<'tcx>(
     span: Span,
     trait_ref: &hir::TraitRef<'_>,
     ty: Ty<'tcx>,
+    adt_hir_id: HirId,
     ord_is_automatically_derived: bool,
 ) {
     if let Some(ord_trait_def_id) = cx.tcx.get_diagnostic_item(sym::Ord)
@@ -38,7 +39,7 @@ pub(super) fn check<'tcx>(
                     "you are deriving `Ord` but have implemented `PartialOrd` explicitly"
                 };
 
-                span_lint_and_then(cx, DERIVE_ORD_XOR_PARTIAL_ORD, span, mess, |diag| {
+                span_lint_hir_and_then(cx, DERIVE_ORD_XOR_PARTIAL_ORD, adt_hir_id, span, mess, |diag| {
                     if let Some(local_def_id) = impl_id.as_local() {
                         let hir_id = cx.tcx.local_def_id_to_hir_id(local_def_id);
                         diag.span_note(cx.tcx.hir_span(hir_id), "`PartialOrd` implemented here");

--- a/tests/ui/derive.rs
+++ b/tests/ui/derive.rs
@@ -130,3 +130,16 @@ fn issue14558() {
 }
 
 fn main() {}
+
+mod issue15708 {
+    // Check that the lint posts on the type definition node
+    #[expect(clippy::expl_impl_clone_on_copy)]
+    #[derive(Copy)]
+    struct S;
+
+    impl Clone for S {
+        fn clone(&self) -> Self {
+            S
+        }
+    }
+}

--- a/tests/ui/derive.stderr
+++ b/tests/ui/derive.stderr
@@ -9,7 +9,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-note: consider deriving `Clone` or removing `Copy`
+help: consider deriving `Clone` or removing `Copy`
   --> tests/ui/derive.rs:15:1
    |
 LL | / impl Clone for Qux {
@@ -33,7 +33,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-note: consider deriving `Clone` or removing `Copy`
+help: consider deriving `Clone` or removing `Copy`
   --> tests/ui/derive.rs:41:1
    |
 LL | / impl<'a> Clone for Lt<'a> {
@@ -55,7 +55,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-note: consider deriving `Clone` or removing `Copy`
+help: consider deriving `Clone` or removing `Copy`
   --> tests/ui/derive.rs:54:1
    |
 LL | / impl Clone for BigArray {
@@ -77,7 +77,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-note: consider deriving `Clone` or removing `Copy`
+help: consider deriving `Clone` or removing `Copy`
   --> tests/ui/derive.rs:67:1
    |
 LL | / impl Clone for FnPtr {
@@ -99,7 +99,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-note: consider deriving `Clone` or removing `Copy`
+help: consider deriving `Clone` or removing `Copy`
   --> tests/ui/derive.rs:89:1
    |
 LL | / impl<T: Clone> Clone for Generic2<T> {

--- a/tests/ui/derive_ord_xor_partial_ord.rs
+++ b/tests/ui/derive_ord_xor_partial_ord.rs
@@ -76,3 +76,18 @@ mod use_ord {
 }
 
 fn main() {}
+
+mod issue15708 {
+    use std::cmp::{Ord, Ordering};
+
+    // Check that the lint posts on the type definition node
+    #[expect(clippy::derive_ord_xor_partial_ord)]
+    #[derive(PartialOrd, PartialEq, Eq)]
+    struct DerivePartialOrdInUseOrd;
+
+    impl Ord for DerivePartialOrdInUseOrd {
+        fn cmp(&self, other: &Self) -> Ordering {
+            Ordering::Less
+        }
+    }
+}

--- a/tests/ui/derived_hash_with_manual_eq.rs
+++ b/tests/ui/derived_hash_with_manual_eq.rs
@@ -41,3 +41,19 @@ impl std::hash::Hash for Bah {
 }
 
 fn main() {}
+
+mod issue15708 {
+    // Check that the lint posts on the type definition node
+    #[expect(clippy::derived_hash_with_manual_eq)]
+    #[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord, Hash)]
+    pub struct Span {
+        start: usize,
+        end: usize,
+    }
+
+    impl PartialEq for Span {
+        fn eq(&self, other: &Self) -> bool {
+            self.start.cmp(&other.start).then(self.end.cmp(&other.end)).is_eq()
+        }
+    }
+}


### PR DESCRIPTION
Out of the 5 lints in the `derive` directory, only two of them (`unsafe_derive_deserialize` and `derive_partial_eq_without_eq`) posted the lint on the ADT node. This fixes the situation for the three other lints:

- `derived_hash_with_manual_eq`
- `derive_ord_xor_partial_ord`
- `expl_impl_clone_on_copy`

This allows `#[expect]` to be used on the ADT to silence the lint.

Also, this makes `expl_impl_clone_on_copy` properly use an "help" message instead of a "note" one when suggesting a fix.

Fixes rust-lang/rust-clippy#15708
Fixes rust-lang/rust-clippy#13356

changelog: [`derived_hash_with_manual_eq`]: honor the use of `#[expect]` on the type to which the lint applies
changelog: [`derive_ord_xor_partial_ord`]: honor the use of `#[expect]` on the type to which the lint applies
changelog: [`expl_impl_clone_on_copy`]: honor the use of `#[expect]` on the type to which the lint applies