### PR TITLE
Clarify `strlen_on_c_strings` documentation

### DIFF
--- a/clippy_lints/src/strlen_on_c_strings.rs
+++ b/clippy_lints/src/strlen_on_c_strings.rs
@@ -14,8 +14,8 @@ declare_clippy_lint! {
     /// and suggest calling `as_bytes().len()` or `to_bytes().len()` respectively instead.
     ///
     /// ### Why is this bad?
-    /// This avoids calling an unsafe `libc` function.
-    /// Currently, it also avoids calculating the length.
+    /// libc::strlen is an unsafe function, which we don't need to call
+    /// if all we want to know is the length of the c-string.
     ///
     /// ### Example
     /// ```rust, ignore


### PR DESCRIPTION
The original documentation had me confused for a couple of minutes. Now it should be more or less unambiguous. 

changelog: none