### PR TITLE
Fix versions lints for 1.90.0

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -315,7 +315,7 @@ declare_clippy_lint! {
     /// /// [example of a good link](https://github.com/rust-lang/rust-clippy/)
     /// pub fn do_something() {}
     /// ```
-    #[clippy::version = "1.84.0"]
+    #[clippy::version = "1.90.0"]
     pub DOC_BROKEN_LINK,
     pedantic,
     "broken document link"

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -854,7 +854,7 @@ declare_clippy_lint! {
     ///     println!("{a} is divisible by {b}");
     /// }
     /// ```
-    #[clippy::version = "1.89.0"]
+    #[clippy::version = "1.90.0"]
     pub MANUAL_IS_MULTIPLE_OF,
     complexity,
     "manual implementation of `.is_multiple_of()`"


### PR DESCRIPTION
Missed update lints versions for 1.90 at #15670 so doing this

changelog: none

r? @flip1995 
