### PR TITLE
Overhaul `needless_parens_on_range_literals`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -617,7 +617,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     store.register_late_pass(move |_| Box::new(collapsible_if::CollapsibleIf::new(conf)));
     store.register_late_pass(|_| Box::new(items_after_statements::ItemsAfterStatements));
     store.register_early_pass(|| Box::new(precedence::Precedence));
-    store.register_late_pass(|_| Box::new(needless_parens_on_range_literals::NeedlessParensOnRangeLiterals));
+    store.register_early_pass(|| Box::new(needless_parens_on_range_literals::NeedlessParensOnRangeLiterals));
     store.register_early_pass(|| Box::new(needless_continue::NeedlessContinue));
     store.register_early_pass(|| Box::new(redundant_else::RedundantElse));
     store.register_late_pass(|_| Box::new(create_dir::CreateDir));

--- a/clippy_lints/src/needless_parens_on_range_literals.rs
+++ b/clippy_lints/src/needless_parens_on_range_literals.rs
@@ -1,11 +1,9 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::higher;
-use clippy_utils::source::{SpanRangeExt, snippet_with_applicability};
+use clippy_utils::source::snippet_with_applicability;
 
-use rustc_ast::ast;
+use rustc_ast::{Expr, ExprKind};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind};
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::declare_lint_pass;
 
 declare_clippy_lint! {
@@ -40,19 +38,11 @@ declare_clippy_lint! {
 
 declare_lint_pass!(NeedlessParensOnRangeLiterals => [NEEDLESS_PARENS_ON_RANGE_LITERALS]);
 
-fn check_for_parens(cx: &LateContext<'_>, e: &Expr<'_>, is_start: bool) {
-    if is_start
-        && let ExprKind::Lit(literal) = e.kind
-        && let ast::LitKind::Float(_sym, ast::LitFloatType::Unsuffixed) = literal.node
-    {
+fn check_for_parens(cx: &EarlyContext<'_>, e: &Expr, is_start: bool) {
+    if let ExprKind::Paren(literal) = &e.kind
+        && let ExprKind::Lit(lit) = &literal.kind
         // don't check floating point literals on the start expression of a range
-        return;
-    }
-    if let ExprKind::Lit(literal) = e.kind
-        // the indicator that parenthesis surround the literal is that the span of the expression and the literal differ
-        && literal.span != e.span
-        // inspect the source code of the expression for parenthesis
-        && e.span.check_source_text(cx, |s| s.starts_with('(') && s.ends_with(')'))
+        && !(is_start && lit.kind == rustc_ast::token::LitKind::Float && lit.suffix.is_none())
     {
         let mut applicability = Applicability::MachineApplicable;
         let suggestion = snippet_with_applicability(cx, literal.span, "_", &mut applicability);
@@ -68,9 +58,9 @@ fn check_for_parens(cx: &LateContext<'_>, e: &Expr<'_>, is_start: bool) {
     }
 }
 
-impl<'tcx> LateLintPass<'tcx> for NeedlessParensOnRangeLiterals {
-    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if let Some(higher::Range { start, end, .. }) = higher::Range::hir(expr) {
+impl EarlyLintPass for NeedlessParensOnRangeLiterals {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        if let ExprKind::Range(start, end, ..) = &expr.kind {
             if let Some(start) = start {
                 check_for_parens(cx, start, true);
             }

--- a/clippy_lints/src/needless_parens_on_range_literals.rs
+++ b/clippy_lints/src/needless_parens_on_range_literals.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::source::{SpanRangeExt, snippet_with_applicability};
+use clippy_utils::source::{SpanRangeExt, snippet_with_context};
 
 use rustc_ast::{Expr, ExprKind};
 use rustc_errors::Applicability;
@@ -39,7 +39,8 @@ declare_clippy_lint! {
 declare_lint_pass!(NeedlessParensOnRangeLiterals => [NEEDLESS_PARENS_ON_RANGE_LITERALS]);
 
 fn check_for_parens(cx: &EarlyContext<'_>, e: &Expr, is_start: bool) {
-    if let ExprKind::Paren(literal) = &e.kind
+    if !e.span.from_expansion()
+        && let ExprKind::Paren(literal) = &e.kind
         && let ExprKind::Lit(lit) = &literal.kind
     {
         if is_start
@@ -52,7 +53,7 @@ fn check_for_parens(cx: &EarlyContext<'_>, e: &Expr, is_start: bool) {
         }
 
         let mut applicability = Applicability::MachineApplicable;
-        let suggestion = snippet_with_applicability(cx, literal.span, "_", &mut applicability);
+        let suggestion = snippet_with_context(cx, literal.span, e.span.ctxt(), "_", &mut applicability).0;
         span_lint_and_sugg(
             cx,
             NEEDLESS_PARENS_ON_RANGE_LITERALS,

--- a/clippy_lints/src/needless_parens_on_range_literals.rs
+++ b/clippy_lints/src/needless_parens_on_range_literals.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::source::{SpanRangeExt, snippet_with_applicability};
 
 use rustc_ast::{Expr, ExprKind};
 use rustc_errors::Applicability;
@@ -41,9 +41,16 @@ declare_lint_pass!(NeedlessParensOnRangeLiterals => [NEEDLESS_PARENS_ON_RANGE_LI
 fn check_for_parens(cx: &EarlyContext<'_>, e: &Expr, is_start: bool) {
     if let ExprKind::Paren(literal) = &e.kind
         && let ExprKind::Lit(lit) = &literal.kind
-        // don't check floating point literals on the start expression of a range
-        && !(is_start && lit.kind == rustc_ast::token::LitKind::Float && lit.suffix.is_none())
     {
+        if is_start
+            && lit.kind == rustc_ast::token::LitKind::Float
+            && lit.suffix.is_none()
+            && literal.span.check_source_text(cx, |s| s.ends_with('.'))
+        {
+            // don't lint `(2.)..end`, since removing the parens would result in invalid syntax
+            return;
+        }
+
         let mut applicability = Applicability::MachineApplicable;
         let suggestion = snippet_with_applicability(cx, literal.span, "_", &mut applicability);
         span_lint_and_sugg(

--- a/tests/ui/needless_parens_on_range_literals.fixed
+++ b/tests/ui/needless_parens_on_range_literals.fixed
@@ -7,9 +7,13 @@ fn main() {
     //~| needless_parens_on_range_literals
     let _ = 'a'..'z';
     //~^ needless_parens_on_range_literals
+
     let _ = (1.)..2.;
     let _ = (1.)..2.;
     //~^ needless_parens_on_range_literals
+    let _ = 1.0..2.;
+    //~^ needless_parens_on_range_literals
+
     let _ = 'a'..;
     //~^ needless_parens_on_range_literals
     let _ = ..'z';

--- a/tests/ui/needless_parens_on_range_literals.fixed
+++ b/tests/ui/needless_parens_on_range_literals.fixed
@@ -18,4 +18,28 @@ fn main() {
     //~^ needless_parens_on_range_literals
     let _ = ..'z';
     //~^ needless_parens_on_range_literals
+
+    macro_rules! verbatim {
+        ($e:expr) => {
+            $e
+        };
+    }
+    macro_rules! add_paren {
+        ($e:expr) => {
+            ($e)
+        };
+    }
+
+    // lint: the paren was added by the user
+    let _ = verbatim!(0)..1;
+    //~^ needless_parens_on_range_literals
+    let _ = 0..verbatim!(1);
+    //~^ needless_parens_on_range_literals
+
+    // lint: the macro doesn't have anything to do with the paren
+    let _ = 0..1;
+    //~^ needless_parens_on_range_literals
+
+    // don't lint: the paren was added by the macro
+    let _ = add_paren!(0)..1;
 }

--- a/tests/ui/needless_parens_on_range_literals.fixed
+++ b/tests/ui/needless_parens_on_range_literals.fixed
@@ -1,5 +1,3 @@
-//@edition:2018
-
 #![warn(clippy::needless_parens_on_range_literals)]
 #![allow(clippy::almost_complete_range)]
 

--- a/tests/ui/needless_parens_on_range_literals.rs
+++ b/tests/ui/needless_parens_on_range_literals.rs
@@ -7,9 +7,13 @@ fn main() {
     //~| needless_parens_on_range_literals
     let _ = 'a'..('z');
     //~^ needless_parens_on_range_literals
+
     let _ = (1.)..2.;
     let _ = (1.)..(2.);
     //~^ needless_parens_on_range_literals
+    let _ = (1.0)..2.;
+    //~^ needless_parens_on_range_literals
+
     let _ = ('a')..;
     //~^ needless_parens_on_range_literals
     let _ = ..('z');

--- a/tests/ui/needless_parens_on_range_literals.rs
+++ b/tests/ui/needless_parens_on_range_literals.rs
@@ -18,4 +18,28 @@ fn main() {
     //~^ needless_parens_on_range_literals
     let _ = ..('z');
     //~^ needless_parens_on_range_literals
+
+    macro_rules! verbatim {
+        ($e:expr) => {
+            $e
+        };
+    }
+    macro_rules! add_paren {
+        ($e:expr) => {
+            ($e)
+        };
+    }
+
+    // lint: the paren was added by the user
+    let _ = verbatim!((0))..1;
+    //~^ needless_parens_on_range_literals
+    let _ = 0..verbatim!((1));
+    //~^ needless_parens_on_range_literals
+
+    // lint: the macro doesn't have anything to do with the paren
+    let _ = (verbatim!(0))..1;
+    //~^ needless_parens_on_range_literals
+
+    // don't lint: the paren was added by the macro
+    let _ = add_paren!(0)..1;
 }

--- a/tests/ui/needless_parens_on_range_literals.rs
+++ b/tests/ui/needless_parens_on_range_literals.rs
@@ -1,5 +1,3 @@
-//@edition:2018
-
 #![warn(clippy::needless_parens_on_range_literals)]
 #![allow(clippy::almost_complete_range)]
 

--- a/tests/ui/needless_parens_on_range_literals.stderr
+++ b/tests/ui/needless_parens_on_range_literals.stderr
@@ -1,5 +1,5 @@
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:7:13
+  --> tests/ui/needless_parens_on_range_literals.rs:5:13
    |
 LL |     let _ = ('a')..=('z');
    |             ^^^^^ help: try: `'a'`
@@ -8,31 +8,31 @@ LL |     let _ = ('a')..=('z');
    = help: to override `-D warnings` add `#[allow(clippy::needless_parens_on_range_literals)]`
 
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:7:21
+  --> tests/ui/needless_parens_on_range_literals.rs:5:21
    |
 LL |     let _ = ('a')..=('z');
    |                     ^^^^^ help: try: `'z'`
 
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:10:18
+  --> tests/ui/needless_parens_on_range_literals.rs:8:18
    |
 LL |     let _ = 'a'..('z');
    |                  ^^^^^ help: try: `'z'`
 
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:13:19
+  --> tests/ui/needless_parens_on_range_literals.rs:11:19
    |
 LL |     let _ = (1.)..(2.);
    |                   ^^^^ help: try: `2.`
 
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:15:13
+  --> tests/ui/needless_parens_on_range_literals.rs:13:13
    |
 LL |     let _ = ('a')..;
    |             ^^^^^ help: try: `'a'`
 
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:17:15
+  --> tests/ui/needless_parens_on_range_literals.rs:15:15
    |
 LL |     let _ = ..('z');
    |               ^^^^^ help: try: `'z'`

--- a/tests/ui/needless_parens_on_range_literals.stderr
+++ b/tests/ui/needless_parens_on_range_literals.stderr
@@ -20,22 +20,28 @@ LL |     let _ = 'a'..('z');
    |                  ^^^^^ help: try: `'z'`
 
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:11:19
+  --> tests/ui/needless_parens_on_range_literals.rs:12:19
    |
 LL |     let _ = (1.)..(2.);
    |                   ^^^^ help: try: `2.`
 
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:13:13
+  --> tests/ui/needless_parens_on_range_literals.rs:14:13
+   |
+LL |     let _ = (1.0)..2.;
+   |             ^^^^^ help: try: `1.0`
+
+error: needless parenthesis on range literals can be removed
+  --> tests/ui/needless_parens_on_range_literals.rs:17:13
    |
 LL |     let _ = ('a')..;
    |             ^^^^^ help: try: `'a'`
 
 error: needless parenthesis on range literals can be removed
-  --> tests/ui/needless_parens_on_range_literals.rs:15:15
+  --> tests/ui/needless_parens_on_range_literals.rs:19:15
    |
 LL |     let _ = ..('z');
    |               ^^^^^ help: try: `'z'`
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/needless_parens_on_range_literals.stderr
+++ b/tests/ui/needless_parens_on_range_literals.stderr
@@ -43,5 +43,23 @@ error: needless parenthesis on range literals can be removed
 LL |     let _ = ..('z');
    |               ^^^^^ help: try: `'z'`
 
-error: aborting due to 7 previous errors
+error: needless parenthesis on range literals can be removed
+  --> tests/ui/needless_parens_on_range_literals.rs:34:23
+   |
+LL |     let _ = verbatim!((0))..1;
+   |                       ^^^ help: try: `0`
+
+error: needless parenthesis on range literals can be removed
+  --> tests/ui/needless_parens_on_range_literals.rs:36:26
+   |
+LL |     let _ = 0..verbatim!((1));
+   |                          ^^^ help: try: `1`
+
+error: needless parenthesis on range literals can be removed
+  --> tests/ui/needless_parens_on_range_literals.rs:40:13
+   |
+LL |     let _ = (verbatim!(0))..1;
+   |             ^^^^^^^^^^^^^^ help: try: `0`
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
This PR makes the lint early-pass, and fixes the following issues:

changelog: [`needless_parens_on_range_literals`]: FN on unsuffixed floats not ending with a `.`
changelog: [`needless_parens_on_range_literals`]: FP on macro-generated code