### PR TITLE
fix(new_without_default): if `new` has `#[cfg]`, copy that onto `impl Default`

### DIFF
--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -74,10 +74,8 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
             .filter_by_name_unhygienic(sym::new)
         {
             if let AssocKind::Fn { has_self: false, .. } = assoc_item.kind
-                && let impl_item = cx
-                    .tcx
-                    .hir_node_by_def_id(assoc_item.def_id.expect_local())
-                    .expect_impl_item()
+                && let assoc_item_hir_id = cx.tcx.local_def_id_to_hir_id(assoc_item.def_id.expect_local())
+                && let impl_item = cx.tcx.hir_node(assoc_item_hir_id).expect_impl_item()
                 && !impl_item.span.in_external_macro(cx.sess().source_map())
                 && let hir::ImplItemKind::Fn(ref sig, _) = impl_item.kind
                 && let id = impl_item.owner_id
@@ -120,6 +118,24 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                 }
 
                 let mut appl = Applicability::MachineApplicable;
+                let attrs_sugg = match cx.tcx.hir_attrs(assoc_item_hir_id) {
+                    [] => String::new(),
+                    [attr] if attr.has_name(sym::cfg_trace) => {
+                        format!(
+                            "{}\n",
+                            snippet_with_applicability(cx.sess(), attr.span(), "_", &mut appl)
+                        )
+                    },
+                    _ => {
+                        // There might be some other attributes which the `impl Default` ought to inherit from `fn new`.
+                        // At the same time, there are many attributes that actually can't be put on an impl block --
+                        // like `#[inline]`, for example. And for some attributes we can't even build a suggestion,
+                        // since `Attribute::span` may panic. Because of all this, remain conservative: don't inherit
+                        // any attrs, and just reduce the applicability
+                        appl = Applicability::MaybeIncorrect;
+                        String::new()
+                    },
+                };
                 let generics_sugg = snippet_with_applicability(cx, generics.span, "", &mut appl);
                 let where_clause_sugg = if generics.has_where_clause_predicates {
                     format!(
@@ -143,6 +159,7 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                             item.span,
                             "try adding this",
                             &create_new_without_default_suggest_msg(
+                                &attrs_sugg,
                                 &self_type_snip,
                                 &generics_sugg,
                                 &where_clause_sugg,
@@ -157,13 +174,14 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
 }
 
 fn create_new_without_default_suggest_msg(
+    attrs_sugg: &str,
     self_type_snip: &str,
     generics_sugg: &str,
     where_clause_sugg: &str,
 ) -> String {
     #[rustfmt::skip]
     format!(
-"impl{generics_sugg} Default for {self_type_snip}{where_clause_sugg} {{
+"{attrs_sugg}impl{generics_sugg} Default for {self_type_snip}{where_clause_sugg} {{
     fn default() -> Self {{
         Self::new()
     }}

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::return_ty;
-use clippy_utils::source::snippet;
+use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::sugg::DiagExt;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -58,103 +58,99 @@ impl_lint_pass!(NewWithoutDefault => [NEW_WITHOUT_DEFAULT]);
 
 impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
-        if let hir::ItemKind::Impl(hir::Impl {
+        let hir::ItemKind::Impl(hir::Impl {
             of_trait: None,
             generics,
             self_ty: impl_self_ty,
             ..
         }) = item.kind
+        else {
+            return;
+        };
+
+        for assoc_item in cx
+            .tcx
+            .associated_items(item.owner_id.def_id)
+            .filter_by_name_unhygienic(sym::new)
         {
-            for assoc_item in cx
-                .tcx
-                .associated_items(item.owner_id.def_id)
-                .filter_by_name_unhygienic(sym::new)
+            if let AssocKind::Fn { has_self: false, .. } = assoc_item.kind
+                && let impl_item = cx
+                    .tcx
+                    .hir_node_by_def_id(assoc_item.def_id.expect_local())
+                    .expect_impl_item()
+                && !impl_item.span.in_external_macro(cx.sess().source_map())
+                && let hir::ImplItemKind::Fn(ref sig, _) = impl_item.kind
+                && let id = impl_item.owner_id
+                // can't be implemented for unsafe new
+                && !sig.header.is_unsafe()
+                // shouldn't be implemented when it is hidden in docs
+                && !cx.tcx.is_doc_hidden(impl_item.owner_id.def_id)
+                // when the result of `new()` depends on a parameter we should not require
+                // an impl of `Default`
+                && impl_item.generics.params.is_empty()
+                && sig.decl.inputs.is_empty()
+                && cx.effective_visibilities.is_reachable(impl_item.owner_id.def_id)
+                && let self_ty = cx.tcx.type_of(item.owner_id).instantiate_identity()
+                && self_ty == return_ty(cx, impl_item.owner_id)
+                && let Some(default_trait_id) = cx.tcx.get_diagnostic_item(sym::Default)
             {
-                if let AssocKind::Fn { has_self: false, .. } = assoc_item.kind {
-                    let impl_item = cx
-                        .tcx
-                        .hir_node_by_def_id(assoc_item.def_id.expect_local())
-                        .expect_impl_item();
-                    if impl_item.span.in_external_macro(cx.sess().source_map()) {
-                        return;
-                    }
-                    if let hir::ImplItemKind::Fn(ref sig, _) = impl_item.kind {
-                        let id = impl_item.owner_id;
-                        if sig.header.is_unsafe() {
-                            // can't be implemented for unsafe new
-                            return;
-                        }
-                        if cx.tcx.is_doc_hidden(impl_item.owner_id.def_id) {
-                            // shouldn't be implemented when it is hidden in docs
-                            return;
-                        }
-                        if !impl_item.generics.params.is_empty() {
-                            // when the result of `new()` depends on a parameter we should not require
-                            // an impl of `Default`
-                            return;
-                        }
-                        if sig.decl.inputs.is_empty()
-                            && cx.effective_visibilities.is_reachable(impl_item.owner_id.def_id)
-                            && let self_ty = cx.tcx.type_of(item.owner_id).instantiate_identity()
-                            && self_ty == return_ty(cx, impl_item.owner_id)
-                            && let Some(default_trait_id) = cx.tcx.get_diagnostic_item(sym::Default)
+                if self.impling_types.is_none() {
+                    let mut impls = HirIdSet::default();
+                    for &d in cx.tcx.local_trait_impls(default_trait_id) {
+                        let ty = cx.tcx.type_of(d).instantiate_identity();
+                        if let Some(ty_def) = ty.ty_adt_def()
+                            && let Some(local_def_id) = ty_def.did().as_local()
                         {
-                            if self.impling_types.is_none() {
-                                let mut impls = HirIdSet::default();
-                                for &d in cx.tcx.local_trait_impls(default_trait_id) {
-                                    let ty = cx.tcx.type_of(d).instantiate_identity();
-                                    if let Some(ty_def) = ty.ty_adt_def()
-                                        && let Some(local_def_id) = ty_def.did().as_local()
-                                    {
-                                        impls.insert(cx.tcx.local_def_id_to_hir_id(local_def_id));
-                                    }
-                                }
-                                self.impling_types = Some(impls);
-                            }
-
-                            // Check if a Default implementation exists for the Self type, regardless of
-                            // generics
-                            if let Some(ref impling_types) = self.impling_types
-                                && let self_def = cx.tcx.type_of(item.owner_id).instantiate_identity()
-                                && let Some(self_def) = self_def.ty_adt_def()
-                                && let Some(self_local_did) = self_def.did().as_local()
-                                && let self_id = cx.tcx.local_def_id_to_hir_id(self_local_did)
-                                && impling_types.contains(&self_id)
-                            {
-                                return;
-                            }
-
-                            let generics_sugg = snippet(cx, generics.span, "");
-                            let where_clause_sugg = if generics.has_where_clause_predicates {
-                                format!("\n{}\n", snippet(cx, generics.where_clause_span, ""))
-                            } else {
-                                String::new()
-                            };
-                            let self_ty_fmt = self_ty.to_string();
-                            let self_type_snip = snippet(cx, impl_self_ty.span, &self_ty_fmt);
-                            span_lint_hir_and_then(
-                                cx,
-                                NEW_WITHOUT_DEFAULT,
-                                id.into(),
-                                impl_item.span,
-                                format!("you should consider adding a `Default` implementation for `{self_type_snip}`"),
-                                |diag| {
-                                    diag.suggest_prepend_item(
-                                        cx,
-                                        item.span,
-                                        "try adding this",
-                                        &create_new_without_default_suggest_msg(
-                                            &self_type_snip,
-                                            &generics_sugg,
-                                            &where_clause_sugg,
-                                        ),
-                                        Applicability::MachineApplicable,
-                                    );
-                                },
-                            );
+                            impls.insert(cx.tcx.local_def_id_to_hir_id(local_def_id));
                         }
                     }
+                    self.impling_types = Some(impls);
                 }
+
+                // Check if a Default implementation exists for the Self type, regardless of
+                // generics
+                if let Some(ref impling_types) = self.impling_types
+                    && let self_def = cx.tcx.type_of(item.owner_id).instantiate_identity()
+                    && let Some(self_def) = self_def.ty_adt_def()
+                    && let Some(self_local_did) = self_def.did().as_local()
+                    && let self_id = cx.tcx.local_def_id_to_hir_id(self_local_did)
+                    && impling_types.contains(&self_id)
+                {
+                    return;
+                }
+
+                let mut appl = Applicability::MachineApplicable;
+                let generics_sugg = snippet_with_applicability(cx, generics.span, "", &mut appl);
+                let where_clause_sugg = if generics.has_where_clause_predicates {
+                    format!(
+                        "\n{}\n",
+                        snippet_with_applicability(cx, generics.where_clause_span, "", &mut appl)
+                    )
+                } else {
+                    String::new()
+                };
+                let self_ty_fmt = self_ty.to_string();
+                let self_type_snip = snippet_with_applicability(cx, impl_self_ty.span, &self_ty_fmt, &mut appl);
+                span_lint_hir_and_then(
+                    cx,
+                    NEW_WITHOUT_DEFAULT,
+                    id.into(),
+                    impl_item.span,
+                    format!("you should consider adding a `Default` implementation for `{self_type_snip}`"),
+                    |diag| {
+                        diag.suggest_prepend_item(
+                            cx,
+                            item.span,
+                            "try adding this",
+                            &create_new_without_default_suggest_msg(
+                                &self_type_snip,
+                                &generics_sugg,
+                                &where_clause_sugg,
+                            ),
+                            appl,
+                        );
+                    },
+                );
             }
         }
     }

--- a/tests/ui/new_without_default.fixed
+++ b/tests/ui/new_without_default.fixed
@@ -322,3 +322,22 @@ where
         Self { _kv: None }
     }
 }
+
+// From issue #14552, but with `#[cfg]` condition inverted,
+// otherwise Clippy wouldn't see the code to lint it
+
+pub struct NewWithCfg;
+#[cfg(not(test))]
+impl Default for NewWithCfg {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NewWithCfg {
+    #[cfg(not(test))]
+    pub fn new() -> NewWithCfg {
+        //~^ new_without_default
+        unimplemented!()
+    }
+}

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -265,3 +265,15 @@ where
         Self { _kv: None }
     }
 }
+
+// From issue #14552, but with `#[cfg]` condition inverted,
+// otherwise Clippy wouldn't see the code to lint it
+
+pub struct NewWithCfg;
+impl NewWithCfg {
+    #[cfg(not(test))]
+    pub fn new() -> NewWithCfg {
+        //~^ new_without_default
+        unimplemented!()
+    }
+}

--- a/tests/ui/new_without_default.stderr
+++ b/tests/ui/new_without_default.stderr
@@ -174,5 +174,25 @@ LL +     }
 LL + }
    |
 
-error: aborting due to 9 previous errors
+error: you should consider adding a `Default` implementation for `NewWithCfg`
+  --> tests/ui/new_without_default.rs:275:5
+   |
+LL | /     pub fn new() -> NewWithCfg {
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + #[cfg(not(test))]
+LL + impl Default for NewWithCfg {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+LL | impl NewWithCfg {
+   |
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/14552

changelog: [`new_without_default`]: if `new` has `#[cfg]`, copy that onto `impl Default`