### PR TITLE
fix(transmute_ptr_to_ptr): add parens if `transmute` is receiver of a projection

### DIFF
--- a/tests/ui/transmute_ptr_to_ptr.fixed
+++ b/tests/ui/transmute_ptr_to_ptr.fixed
@@ -139,4 +139,24 @@ fn msrv_1_65(ptr: *const u8, mut_ptr: *mut u8) {
     }
 }
 
+fn issue15003(bs: &mut [u8]) {
+    unsafe {
+        (&mut *(bs as *mut [u8] as *mut [i8]))[4] = 42;
+        //~^ transmute_ptr_to_ptr
+        let _ = (&*(bs as *mut [u8] as *const [u8])).len();
+        //~^ transmute_ptr_to_ptr
+        // NOTE: need to transmute into something we can then index into
+        let _ = (&mut *(bs as *mut [u8] as *mut (u8, [u8]))).0;
+        //~^ transmute_ptr_to_ptr
+
+        // Don't add parens if the expression is not the receiver
+        struct S;
+        impl S {
+            fn foo(self, _: &mut [i8]) {}
+        }
+        S.foo(&mut *(bs as *mut [u8] as *mut [i8]));
+        //~^ transmute_ptr_to_ptr
+    }
+}
+
 fn main() {}

--- a/tests/ui/transmute_ptr_to_ptr.rs
+++ b/tests/ui/transmute_ptr_to_ptr.rs
@@ -139,4 +139,24 @@ fn msrv_1_65(ptr: *const u8, mut_ptr: *mut u8) {
     }
 }
 
+fn issue15003(bs: &mut [u8]) {
+    unsafe {
+        transmute::<&mut [u8], &mut [i8]>(bs)[4] = 42;
+        //~^ transmute_ptr_to_ptr
+        let _ = transmute::<&mut [u8], &[u8]>(bs).len();
+        //~^ transmute_ptr_to_ptr
+        // NOTE: need to transmute into something we can then index into
+        let _ = transmute::<&mut [u8], &mut (u8, [u8])>(bs).0;
+        //~^ transmute_ptr_to_ptr
+
+        // Don't add parens if the expression is not the receiver
+        struct S;
+        impl S {
+            fn foo(self, _: &mut [i8]) {}
+        }
+        S.foo(transmute::<&mut [u8], &mut [i8]>(bs));
+        //~^ transmute_ptr_to_ptr
+    }
+}
+
 fn main() {}

--- a/tests/ui/transmute_ptr_to_ptr.stderr
+++ b/tests/ui/transmute_ptr_to_ptr.stderr
@@ -210,5 +210,29 @@ LL -         let _: *const u8 = transmute(mut_ptr);
 LL +         let _: *const u8 = mut_ptr.cast_const();
    |
 
-error: aborting due to 20 previous errors
+error: transmute from a reference to a reference
+  --> tests/ui/transmute_ptr_to_ptr.rs:144:9
+   |
+LL |         transmute::<&mut [u8], &mut [i8]>(bs)[4] = 42;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&mut *(bs as *mut [u8] as *mut [i8]))`
+
+error: transmute from a reference to a reference
+  --> tests/ui/transmute_ptr_to_ptr.rs:146:17
+   |
+LL |         let _ = transmute::<&mut [u8], &[u8]>(bs).len();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&*(bs as *mut [u8] as *const [u8]))`
+
+error: transmute from a reference to a reference
+  --> tests/ui/transmute_ptr_to_ptr.rs:149:17
+   |
+LL |         let _ = transmute::<&mut [u8], &mut (u8, [u8])>(bs).0;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&mut *(bs as *mut [u8] as *mut (u8, [u8])))`
+
+error: transmute from a reference to a reference
+  --> tests/ui/transmute_ptr_to_ptr.rs:157:15
+   |
+LL |         S.foo(transmute::<&mut [u8], &mut [i8]>(bs));
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(bs as *mut [u8] as *mut [i8])`
+
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15003

changelog: [`transmute_ptr_to_ptr`]: add parens if `transmute` is receiver of a projection