### PR TITLE
Update actions/download-artifact to v5

### DIFF
--- a/.github/workflows/clippy_mq.yml
+++ b/.github/workflows/clippy_mq.yml
@@ -181,7 +181,7 @@ jobs:
 
     # Download
     - name: Download target dir
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: binaries
         path: target/debug

--- a/.github/workflows/lintcheck.yml
+++ b/.github/workflows/lintcheck.yml
@@ -126,7 +126,7 @@ jobs:
         fail-on-cache-miss: true
 
     - name: Download JSON
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
 
     - name: Store PR number
       run: echo ${{ github.event.pull_request.number }} > pr.txt

--- a/.github/workflows/lintcheck_summary.yml
+++ b/.github/workflows/lintcheck_summary.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: summary
           path: untrusted


### PR DESCRIPTION
Update actions/download-artifact to v5 as per [this](https://github.com/actions/download-artifact?tab=readme-ov-file#usage)

changelog: none
