### PR TITLE
fix(clone_on_ref_ptr): only name the generic type if possible

### DIFF
--- a/tests/ui/clone_on_ref_ptr.fixed
+++ b/tests/ui/clone_on_ref_ptr.fixed
@@ -49,3 +49,33 @@ mod issue2076 {
         //~^ clone_on_ref_ptr
     }
 }
+
+#[allow(
+    clippy::needless_borrow,
+    reason = "the suggestion creates `Weak::clone(&rec)`, but `rec` is already a reference"
+)]
+mod issue15009 {
+    use std::rc::{Rc, Weak};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn main() {
+        let counter = AtomicU32::new(0);
+        let counter_ref = &counter;
+        let factorial = Rc::new_cyclic(move |rec| {
+            let rec = std::rc::Weak::</* generic */>::clone(&rec) as Weak<dyn Fn(u32) -> u32>;
+            //~^ clone_on_ref_ptr
+            move |x| {
+                // can capture env
+                counter_ref.fetch_add(1, Ordering::Relaxed);
+                match x {
+                    0 => 1,
+                    x => x * rec.upgrade().unwrap()(x - 1),
+                }
+            }
+        });
+        println!("{}", factorial(5)); // 120
+        println!("{}", counter.load(Ordering::Relaxed)); // 6
+        println!("{}", factorial(7)); // 5040
+        println!("{}", counter.load(Ordering::Relaxed)); // 14
+    }
+}

--- a/tests/ui/clone_on_ref_ptr.stderr
+++ b/tests/ui/clone_on_ref_ptr.stderr
@@ -37,5 +37,11 @@ error: using `.clone()` on a ref-counted pointer
 LL |         Some(try_opt!(Some(rc)).clone())
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::rc::Rc::<u8>::clone(&try_opt!(Some(rc)))`
 
-error: aborting due to 6 previous errors
+error: using `.clone()` on a ref-counted pointer
+  --> tests/ui/clone_on_ref_ptr.rs:65:23
+   |
+LL |             let rec = rec.clone() as Weak<dyn Fn(u32) -> u32>;
+   |                       ^^^^^^^^^^^ help: try: `std::rc::Weak::</* generic */>::clone(&rec)`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15009

changelog: [clone_on_ref_ptr]: only name the generic type if possible