### PR TITLE
Do not suggest using a `if let` chain if it is not supported

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -898,6 +898,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`unchecked_duration_subtraction`](https://rust-lang.github.io/rust-clippy/master/index.html#unchecked_duration_subtraction)
 * [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)
 * [`unnecessary_lazy_evaluations`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations)
+* [`unnecessary_unwrap`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap)
 * [`unnested_or_patterns`](https://rust-lang.github.io/rust-clippy/master/index.html#unnested_or_patterns)
 * [`unused_trait_names`](https://rust-lang.github.io/rust-clippy/master/index.html#unused_trait_names)
 * [`use_self`](https://rust-lang.github.io/rust-clippy/master/index.html#use_self)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -794,6 +794,7 @@ define_Conf! {
         unchecked_duration_subtraction,
         uninlined_format_args,
         unnecessary_lazy_evaluations,
+        unnecessary_unwrap,
         unnested_or_patterns,
         unused_trait_names,
         use_self,

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -1,8 +1,8 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_hir_and_then;
-use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::msrvs::Msrv;
 use clippy_utils::source::{IntoSpan as _, SpanRangeExt, snippet, snippet_block_with_applicability};
-use clippy_utils::{span_contains_non_whitespace, sym, tokenize_with_text};
+use clippy_utils::{can_use_if_let_chains, span_contains_non_whitespace, sym, tokenize_with_text};
 use rustc_ast::{BinOpKind, MetaItemInner};
 use rustc_errors::Applicability;
 use rustc_hir::{Block, Expr, ExprKind, StmtKind};
@@ -216,8 +216,7 @@ impl CollapsibleIf {
     }
 
     fn eligible_condition(&self, cx: &LateContext<'_>, cond: &Expr<'_>) -> bool {
-        !matches!(cond.kind, ExprKind::Let(..))
-            || (cx.tcx.sess.edition().at_least_rust_2024() && self.msrv.meets(cx, msrvs::LET_CHAINS))
+        !matches!(cond.kind, ExprKind::Let(..)) || can_use_if_let_chains(cx, self.msrv)
     }
 
     // Check that nothing significant can be found between the initial `{` of `inner_if` and

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -589,7 +589,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     store.register_late_pass(|_| Box::new(map_unit_fn::MapUnit));
     store.register_late_pass(|_| Box::new(inherent_impl::MultipleInherentImpl));
     store.register_late_pass(|_| Box::new(neg_cmp_op_on_partial_ord::NoNegCompOpForPartialOrd));
-    store.register_late_pass(|_| Box::new(unwrap::Unwrap));
+    store.register_late_pass(move |_| Box::new(unwrap::Unwrap::new(conf)));
     store.register_late_pass(move |_| Box::new(indexing_slicing::IndexingSlicing::new(conf)));
     store.register_late_pass(move |tcx| Box::new(non_copy_const::NonCopyConst::new(tcx, conf)));
     store.register_late_pass(|_| Box::new(redundant_clone::RedundantClone));

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -129,6 +129,7 @@ use visitors::{Visitable, for_each_unconsumed_temporary};
 use crate::ast_utils::unordered_over;
 use crate::consts::{ConstEvalCtxt, Constant, mir_to_const};
 use crate::higher::Range;
+use crate::msrvs::Msrv;
 use crate::ty::{adt_and_variant_of_res, can_partially_move_ty, expr_sig, is_copy, is_recursively_primitive_type};
 use crate::visitors::for_each_expr_without_closures;
 
@@ -3658,4 +3659,9 @@ pub fn is_expr_async_block(expr: &Expr<'_>) -> bool {
             ..
         })
     )
+}
+
+/// Checks if the chosen edition and `msrv` allows using `if let` chains.
+pub fn can_use_if_let_chains(cx: &LateContext<'_>, msrv: Msrv) -> bool {
+    cx.tcx.sess.edition().at_least_rust_2024() && msrv.meets(cx, msrvs::LET_CHAINS)
 }

--- a/tests/ui/checked_unwrap/if_let_chains.rs
+++ b/tests/ui/checked_unwrap/if_let_chains.rs
@@ -1,0 +1,24 @@
+//@require-annotations-for-level: ERROR
+#![deny(clippy::unnecessary_unwrap)]
+
+#[clippy::msrv = "1.85"]
+fn if_let_chains_unsupported(a: Option<u32>, b: Option<u32>) {
+    if a.is_none() || b.is_none() {
+        println!("a or b is not set");
+    } else {
+        println!("the value of a is {}", a.unwrap());
+        //~^ unnecessary_unwrap
+        //~| HELP: try using `match`
+    }
+}
+
+#[clippy::msrv = "1.88"]
+fn if_let_chains_supported(a: Option<u32>, b: Option<u32>) {
+    if a.is_none() || b.is_none() {
+        println!("a or b is not set");
+    } else {
+        println!("the value of a is {}", a.unwrap());
+        //~^ unnecessary_unwrap
+        //~| HELP: try using `if let` or `match`
+    }
+}

--- a/tests/ui/checked_unwrap/if_let_chains.stderr
+++ b/tests/ui/checked_unwrap/if_let_chains.stderr
@@ -1,0 +1,29 @@
+error: called `unwrap` on `a` after checking its variant with `is_none`
+  --> tests/ui/checked_unwrap/if_let_chains.rs:9:42
+   |
+LL |     if a.is_none() || b.is_none() {
+   |        ----------- the check is happening here
+...
+LL |         println!("the value of a is {}", a.unwrap());
+   |                                          ^^^^^^^^^^
+   |
+   = help: try using `match`
+note: the lint level is defined here
+  --> tests/ui/checked_unwrap/if_let_chains.rs:2:9
+   |
+LL | #![deny(clippy::unnecessary_unwrap)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: called `unwrap` on `a` after checking its variant with `is_none`
+  --> tests/ui/checked_unwrap/if_let_chains.rs:20:42
+   |
+LL |     if a.is_none() || b.is_none() {
+   |        ----------- the check is happening here
+...
+LL |         println!("the value of a is {}", a.unwrap());
+   |                                          ^^^^^^^^^^
+   |
+   = help: try using `if let` or `match`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This might be due to a low edition (< 2024) or too low a MSRV. In this case, we will suggest only `match`.

Fixes rust-lang/rust-clippy#15744 

changelog: [`unnecessary_unwrap`]: do not suggest using `if let` chains if this is not supported with the current edition or MSRV
changelog:[`collapsible_if`]: Do not suggest using `if let` if this is not supported with the current edition or MSRV