### PR TITLE
`ptr_cast_constness`: check for implicit mut to const pointer coercion

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -919,5 +919,6 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
         cast_ptr_alignment::check_cast_method(cx, expr);
         cast_slice_different_sizes::check(cx, expr, self.msrv);
         ptr_cast_constness::check_null_ptr_cast_method(cx, expr);
+        ptr_cast_constness::check_implicit_cast_from_mut(cx, expr, self.msrv);
     }
 }

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -112,3 +112,16 @@ fn issue11317() {
     let _ptr: *mut u32 = (r as *const u32).cast_mut();
     //~^ ptr_cast_constness
 }
+
+/// Checks for implicit mut pointer to const pointer coercion
+fn issue13667() {
+    fn expect_const_ptr<T>(_: *const T) {}
+
+    let p = &mut 0 as *mut i32;
+    let _: *const i32 = p.cast_const();
+    //~^ ptr_cast_constness
+    expect_const_ptr(p.cast_const());
+    //~^ ptr_cast_constness
+    let _: *const u8 = (p as *mut u8).cast_const();
+    //~^ ptr_cast_constness
+}

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -112,3 +112,16 @@ fn issue11317() {
     let _ptr: *mut u32 = r as *const _ as *mut _;
     //~^ ptr_cast_constness
 }
+
+/// Checks for implicit mut pointer to const pointer coercion
+fn issue13667() {
+    fn expect_const_ptr<T>(_: *const T) {}
+
+    let p = &mut 0 as *mut i32;
+    let _: *const i32 = p;
+    //~^ ptr_cast_constness
+    expect_const_ptr(p);
+    //~^ ptr_cast_constness
+    let _: *const u8 = p as *mut u8;
+    //~^ ptr_cast_constness
+}

--- a/tests/ui/ptr_cast_constness.stderr
+++ b/tests/ui/ptr_cast_constness.stderr
@@ -95,5 +95,23 @@ error: `as` casting between raw pointers while changing only its constness
 LL |     let _ptr: *mut u32 = r as *const _ as *mut _;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `(r as *const u32).cast_mut()`
 
-error: aborting due to 15 previous errors
+error: implicit casting from mut pointer to const pointer
+  --> tests/ui/ptr_cast_constness.rs:121:25
+   |
+LL |     let _: *const i32 = p;
+   |                         ^ help: try `pointer::cast_const`, a safer alternative: `p.cast_const()`
+
+error: implicit casting from mut pointer to const pointer
+  --> tests/ui/ptr_cast_constness.rs:123:22
+   |
+LL |     expect_const_ptr(p);
+   |                      ^ help: try `pointer::cast_const`, a safer alternative: `p.cast_const()`
+
+error: implicit casting from mut pointer to const pointer
+  --> tests/ui/ptr_cast_constness.rs:125:24
+   |
+LL |     let _: *const u8 = p as *mut u8;
+   |                        ^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `(p as *mut u8).cast_const()`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#13667

changelog: [`ptr_cast_constness`]: check for implicit mut to const pointer coercion