### PR TITLE
fix(map_entry): provide explicit type when suggesting `None`

### DIFF
--- a/tests/ui/entry.fixed
+++ b/tests/ui/entry.fixed
@@ -248,4 +248,11 @@ mod issue14449 {
     }
 }
 
+fn issue15307<K: Eq + Hash, V>(mut m: HashMap<K, V>, k: K, v: V) {
+    if let std::collections::hash_map::Entry::Vacant(e) = m.entry(k) {
+        //~^ map_entry
+        assert!({ e.insert(v); None::<V> }.is_none());
+    }
+}
+
 fn main() {}

--- a/tests/ui/entry.rs
+++ b/tests/ui/entry.rs
@@ -254,4 +254,11 @@ mod issue14449 {
     }
 }
 
+fn issue15307<K: Eq + Hash, V>(mut m: HashMap<K, V>, k: K, v: V) {
+    if !m.contains_key(&k) {
+        //~^ map_entry
+        assert!(m.insert(k, v).is_none());
+    }
+}
+
 fn main() {}

--- a/tests/ui/entry.stderr
+++ b/tests/ui/entry.stderr
@@ -246,5 +246,22 @@ LL +         e.insert(42);
 LL +     }
    |
 
-error: aborting due to 11 previous errors
+error: usage of `contains_key` followed by `insert` on a `HashMap`
+  --> tests/ui/entry.rs:258:5
+   |
+LL | /     if !m.contains_key(&k) {
+LL | |
+LL | |         assert!(m.insert(k, v).is_none());
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if let std::collections::hash_map::Entry::Vacant(e) = m.entry(k) {
+LL +
+LL +         assert!({ e.insert(v); None::<V> }.is_none());
+LL +     }
+   |
+
+error: aborting due to 12 previous errors
 

--- a/tests/ui/entry_with_else.fixed
+++ b/tests/ui/entry_with_else.fixed
@@ -62,7 +62,7 @@ fn insert_if_absent0<K: Eq + Hash + Copy, V: Copy>(m: &mut HashMap<K, V>, k: K, 
         }
         std::collections::hash_map::Entry::Vacant(e) => {
             e.insert(v);
-            None
+            None::<V>
         }
     };
 
@@ -70,6 +70,15 @@ fn insert_if_absent0<K: Eq + Hash + Copy, V: Copy>(m: &mut HashMap<K, V>, k: K, 
         //~^ map_entry
         foo();
         Some(e.insert(v))
+    } else {
+        None
+    };
+
+    // used to result in type ambiguity before #15759
+    let _ = if let std::collections::hash_map::Entry::Vacant(e) = m.entry(k) {
+        //~^ map_entry
+        e.insert(v);
+        None::<V>
     } else {
         None
     };

--- a/tests/ui/entry_with_else.rs
+++ b/tests/ui/entry_with_else.rs
@@ -60,6 +60,14 @@ fn insert_if_absent0<K: Eq + Hash + Copy, V: Copy>(m: &mut HashMap<K, V>, k: K, 
     } else {
         None
     };
+
+    // used to result in type ambiguity before #15759
+    let _ = if !m.contains_key(&k) {
+        //~^ map_entry
+        m.insert(k, v)
+    } else {
+        None
+    };
 }
 
 fn main() {}

--- a/tests/ui/entry_with_else.stderr
+++ b/tests/ui/entry_with_else.stderr
@@ -134,7 +134,7 @@ LL +             if true { Some(e.insert(v)) } else { Some(e.insert(v2)) }
 LL +         }
 LL +         std::collections::hash_map::Entry::Vacant(e) => {
 LL +             e.insert(v);
-LL +             None
+LL +             None::<V>
 LL +         }
 LL ~     };
    |
@@ -162,5 +162,28 @@ LL +         None
 LL ~     };
    |
 
-error: aborting due to 7 previous errors
+error: usage of `contains_key` followed by `insert` on a `HashMap`
+  --> tests/ui/entry_with_else.rs:65:13
+   |
+LL |       let _ = if !m.contains_key(&k) {
+   |  _____________^
+LL | |
+LL | |         m.insert(k, v)
+LL | |     } else {
+LL | |         None
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     let _ = if let std::collections::hash_map::Entry::Vacant(e) = m.entry(k) {
+LL +
+LL +         e.insert(v);
+LL +         None::<V>
+LL +     } else {
+LL +         None
+LL ~     };
+   |
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15307

changelog: [`map_entry`]: provide explicit type when suggesting `None`