### PR TITLE
fix(should_implement_trait): only suggest traits that are in the prelude

### DIFF
--- a/clippy_lints/src/methods/lib.rs
+++ b/clippy_lints/src/methods/lib.rs
@@ -1,0 +1,70 @@
+use clippy_utils::sym;
+use clippy_utils::ty::{implements_trait, is_copy};
+use rustc_hir::Mutability;
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, Ty};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum SelfKind {
+    Value,
+    Ref,
+    RefMut,
+    No, // When we want the first argument type to be different than `Self`
+}
+
+impl SelfKind {
+    pub(super) fn matches<'a>(self, cx: &LateContext<'a>, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
+        fn matches_value<'a>(cx: &LateContext<'a>, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
+            if ty == parent_ty {
+                true
+            } else if let Some(boxed_ty) = ty.boxed_ty() {
+                boxed_ty == parent_ty
+            } else if let ty::Adt(adt_def, args) = ty.kind()
+                && matches!(cx.tcx.get_diagnostic_name(adt_def.did()), Some(sym::Rc | sym::Arc))
+            {
+                args.types().next() == Some(parent_ty)
+            } else {
+                false
+            }
+        }
+
+        fn matches_ref<'a>(cx: &LateContext<'a>, mutability: Mutability, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
+            if let ty::Ref(_, t, m) = *ty.kind() {
+                return m == mutability && t == parent_ty;
+            }
+
+            let trait_sym = match mutability {
+                Mutability::Not => sym::AsRef,
+                Mutability::Mut => sym::AsMut,
+            };
+
+            let Some(trait_def_id) = cx.tcx.get_diagnostic_item(trait_sym) else {
+                return false;
+            };
+            implements_trait(cx, ty, trait_def_id, &[parent_ty.into()])
+        }
+
+        fn matches_none<'a>(cx: &LateContext<'a>, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
+            !matches_value(cx, parent_ty, ty)
+                && !matches_ref(cx, Mutability::Not, parent_ty, ty)
+                && !matches_ref(cx, Mutability::Mut, parent_ty, ty)
+        }
+
+        match self {
+            Self::Value => matches_value(cx, parent_ty, ty),
+            Self::Ref => matches_ref(cx, Mutability::Not, parent_ty, ty) || ty == parent_ty && is_copy(cx, ty),
+            Self::RefMut => matches_ref(cx, Mutability::Mut, parent_ty, ty),
+            Self::No => matches_none(cx, parent_ty, ty),
+        }
+    }
+
+    #[must_use]
+    pub(super) fn description(self) -> &'static str {
+        match self {
+            Self::Value => "`self` by value",
+            Self::Ref => "`self` by reference",
+            Self::RefMut => "`self` by mutable reference",
+            Self::No => "no `self`",
+        }
+    }
+}

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -55,6 +55,7 @@ mod iter_skip_zero;
 mod iter_with_drain;
 mod iterator_step_by_zero;
 mod join_absolute_paths;
+mod lib;
 mod manual_c_str_literals;
 mod manual_contains;
 mod manual_inspect;
@@ -102,6 +103,7 @@ mod return_and_then;
 mod search_is_some;
 mod seek_from_current;
 mod seek_to_start_instead_of_rewind;
+mod should_implement_trait;
 mod single_char_add_str;
 mod skip_while_next;
 mod sliced_string_as_bytes;
@@ -146,19 +148,18 @@ mod zst_offset;
 
 use clippy_config::Conf;
 use clippy_utils::consts::{ConstEvalCtxt, Constant};
-use clippy_utils::diagnostics::{span_lint, span_lint_and_help};
+use clippy_utils::diagnostics::span_lint;
 use clippy_utils::macros::FormatArgsStorage;
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::ty::{contains_ty_adt_constructor_opaque, implements_trait, is_copy};
-use clippy_utils::{contains_return, is_bool, is_trait_method, iter_input_pats, peel_blocks, return_ty, sym};
+use clippy_utils::ty::contains_ty_adt_constructor_opaque;
+use clippy_utils::{contains_return, is_trait_method, iter_input_pats, peel_blocks, return_ty, sym};
 pub use path_ends_with_ext::DEFAULT_ALLOWED_DOTFILES;
-use rustc_abi::ExternAbi;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::{self as hir, Expr, ExprKind, Node, Stmt, StmtKind, TraitItem, TraitItemKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
-use rustc_middle::ty::{self, TraitRef, Ty};
+use rustc_middle::ty::TraitRef;
 use rustc_session::impl_lint_pass;
-use rustc_span::{Span, Symbol, kw};
+use rustc_span::{Span, Symbol};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -4888,47 +4889,17 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
         if impl_item.span.in_external_macro(cx.sess().source_map()) {
             return;
         }
+
         if let hir::ImplItemKind::Fn(ref sig, id) = impl_item.kind {
-            let name = impl_item.ident.name;
             let parent = cx.tcx.hir_get_parent_item(impl_item.hir_id()).def_id;
             let item = cx.tcx.hir_expect_item(parent);
             let self_ty = cx.tcx.type_of(item.owner_id).instantiate_identity();
-
             let implements_trait = matches!(item.kind, hir::ItemKind::Impl(hir::Impl { of_trait: Some(_), .. }));
+
             let method_sig = cx.tcx.fn_sig(impl_item.owner_id).instantiate_identity();
             let method_sig = cx.tcx.instantiate_bound_regions_with_erased(method_sig);
             let first_arg_ty_opt = method_sig.inputs().iter().next().copied();
-            // if this impl block implements a trait, lint in trait definition instead
-            if !implements_trait && cx.effective_visibilities.is_exported(impl_item.owner_id.def_id) {
-                // check missing trait implementations
-                for method_config in &TRAIT_METHODS {
-                    if name == method_config.method_name
-                        && sig.decl.inputs.len() == method_config.param_count
-                        && method_config.output_type.matches(&sig.decl.output)
-                        // in case there is no first arg, since we already have checked the number of arguments
-                        // it's should be always true
-                        && first_arg_ty_opt
-                            .is_none_or(|first_arg_ty| method_config.self_kind.matches(cx, self_ty, first_arg_ty))
-                        && fn_header_equals(method_config.fn_header, sig.header)
-                        && method_config.lifetime_param_cond(impl_item)
-                    {
-                        span_lint_and_help(
-                            cx,
-                            SHOULD_IMPLEMENT_TRAIT,
-                            impl_item.span,
-                            format!(
-                                "method `{}` can be confused for the standard trait method `{}::{}`",
-                                method_config.method_name, method_config.trait_name, method_config.method_name
-                            ),
-                            None,
-                            format!(
-                                "consider implementing the trait `{}` or choosing a less ambiguous method name",
-                                method_config.trait_name
-                            ),
-                        );
-                    }
-                }
-            }
+            should_implement_trait::check_impl_item(cx, impl_item, self_ty, implements_trait, first_arg_ty_opt, sig);
 
             if sig.decl.implicit_self.has_implicit_self()
                 && !(self.avoid_breaking_exported_api
@@ -4938,7 +4909,7 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
             {
                 wrong_self_convention::check(
                     cx,
-                    name,
+                    impl_item.ident.name,
                     self_ty,
                     first_arg_ty,
                     first_arg.pat.span,
@@ -5710,182 +5681,4 @@ fn lint_binary_expr_with_method_call(cx: &LateContext<'_>, info: &mut BinaryExpr
     lint_with_both_lhs_and_rhs!(chars_last_cmp::check, cx, info);
     lint_with_both_lhs_and_rhs!(chars_next_cmp_with_unwrap::check, cx, info);
     lint_with_both_lhs_and_rhs!(chars_last_cmp_with_unwrap::check, cx, info);
-}
-
-const FN_HEADER: hir::FnHeader = hir::FnHeader {
-    safety: hir::HeaderSafety::Normal(hir::Safety::Safe),
-    constness: hir::Constness::NotConst,
-    asyncness: hir::IsAsync::NotAsync,
-    abi: ExternAbi::Rust,
-};
-
-struct ShouldImplTraitCase {
-    trait_name: &'static str,
-    method_name: Symbol,
-    param_count: usize,
-    fn_header: hir::FnHeader,
-    // implicit self kind expected (none, self, &self, ...)
-    self_kind: SelfKind,
-    // checks against the output type
-    output_type: OutType,
-    // certain methods with explicit lifetimes can't implement the equivalent trait method
-    lint_explicit_lifetime: bool,
-}
-impl ShouldImplTraitCase {
-    const fn new(
-        trait_name: &'static str,
-        method_name: Symbol,
-        param_count: usize,
-        fn_header: hir::FnHeader,
-        self_kind: SelfKind,
-        output_type: OutType,
-        lint_explicit_lifetime: bool,
-    ) -> ShouldImplTraitCase {
-        ShouldImplTraitCase {
-            trait_name,
-            method_name,
-            param_count,
-            fn_header,
-            self_kind,
-            output_type,
-            lint_explicit_lifetime,
-        }
-    }
-
-    fn lifetime_param_cond(&self, impl_item: &hir::ImplItem<'_>) -> bool {
-        self.lint_explicit_lifetime
-            || !impl_item.generics.params.iter().any(|p| {
-                matches!(
-                    p.kind,
-                    hir::GenericParamKind::Lifetime {
-                        kind: hir::LifetimeParamKind::Explicit
-                    }
-                )
-            })
-    }
-}
-
-#[rustfmt::skip]
-const TRAIT_METHODS: [ShouldImplTraitCase; 30] = [
-    ShouldImplTraitCase::new("std::ops::Add",           sym::add,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::convert::AsMut",     sym::as_mut,     1,  FN_HEADER, SelfKind::RefMut, OutType::Ref,  true ),
-    ShouldImplTraitCase::new("std::convert::AsRef",     sym::as_ref,     1,  FN_HEADER, SelfKind::Ref,    OutType::Ref,  true ),
-    ShouldImplTraitCase::new("std::ops::BitAnd",        sym::bitand,     2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::BitOr",         sym::bitor,      2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::BitXor",        sym::bitxor,     2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::borrow::Borrow",     sym::borrow,     1,  FN_HEADER, SelfKind::Ref,    OutType::Ref,  true ),
-    ShouldImplTraitCase::new("std::borrow::BorrowMut",  sym::borrow_mut, 1,  FN_HEADER, SelfKind::RefMut, OutType::Ref,  true ),
-    ShouldImplTraitCase::new("std::clone::Clone",       sym::clone,      1,  FN_HEADER, SelfKind::Ref,    OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::cmp::Ord",           sym::cmp,        2,  FN_HEADER, SelfKind::Ref,    OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::default::Default",   kw::Default,     0,  FN_HEADER, SelfKind::No,     OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::Deref",         sym::deref,      1,  FN_HEADER, SelfKind::Ref,    OutType::Ref,  true ),
-    ShouldImplTraitCase::new("std::ops::DerefMut",      sym::deref_mut,  1,  FN_HEADER, SelfKind::RefMut, OutType::Ref,  true ),
-    ShouldImplTraitCase::new("std::ops::Div",           sym::div,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::Drop",          sym::drop,       1,  FN_HEADER, SelfKind::RefMut, OutType::Unit, true ),
-    ShouldImplTraitCase::new("std::cmp::PartialEq",     sym::eq,         2,  FN_HEADER, SelfKind::Ref,    OutType::Bool, true ),
-    ShouldImplTraitCase::new("std::iter::FromIterator", sym::from_iter,  1,  FN_HEADER, SelfKind::No,     OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::str::FromStr",       sym::from_str,   1,  FN_HEADER, SelfKind::No,     OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::hash::Hash",         sym::hash,       2,  FN_HEADER, SelfKind::Ref,    OutType::Unit, true ),
-    ShouldImplTraitCase::new("std::ops::Index",         sym::index,      2,  FN_HEADER, SelfKind::Ref,    OutType::Ref,  true ),
-    ShouldImplTraitCase::new("std::ops::IndexMut",      sym::index_mut,  2,  FN_HEADER, SelfKind::RefMut, OutType::Ref,  true ),
-    ShouldImplTraitCase::new("std::iter::IntoIterator", sym::into_iter,  1,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::Mul",           sym::mul,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::Neg",           sym::neg,        1,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::iter::Iterator",     sym::next,       1,  FN_HEADER, SelfKind::RefMut, OutType::Any,  false),
-    ShouldImplTraitCase::new("std::ops::Not",           sym::not,        1,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::Rem",           sym::rem,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::Shl",           sym::shl,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::Shr",           sym::shr,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-    ShouldImplTraitCase::new("std::ops::Sub",           sym::sub,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
-];
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum SelfKind {
-    Value,
-    Ref,
-    RefMut,
-    No, // When we want the first argument type to be different than `Self`
-}
-
-impl SelfKind {
-    fn matches<'a>(self, cx: &LateContext<'a>, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
-        fn matches_value<'a>(cx: &LateContext<'a>, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
-            if ty == parent_ty {
-                true
-            } else if let Some(boxed_ty) = ty.boxed_ty() {
-                boxed_ty == parent_ty
-            } else if let ty::Adt(adt, args) = ty.kind()
-                && matches!(cx.tcx.get_diagnostic_name(adt.did()), Some(sym::Rc | sym::Arc))
-            {
-                args.types().next() == Some(parent_ty)
-            } else {
-                false
-            }
-        }
-
-        fn matches_ref<'a>(cx: &LateContext<'a>, mutability: hir::Mutability, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
-            if let ty::Ref(_, t, m) = *ty.kind() {
-                return m == mutability && t == parent_ty;
-            }
-
-            let trait_sym = match mutability {
-                hir::Mutability::Not => sym::AsRef,
-                hir::Mutability::Mut => sym::AsMut,
-            };
-
-            let Some(trait_def_id) = cx.tcx.get_diagnostic_item(trait_sym) else {
-                return false;
-            };
-            implements_trait(cx, ty, trait_def_id, &[parent_ty.into()])
-        }
-
-        fn matches_none<'a>(cx: &LateContext<'a>, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
-            !matches_value(cx, parent_ty, ty)
-                && !matches_ref(cx, hir::Mutability::Not, parent_ty, ty)
-                && !matches_ref(cx, hir::Mutability::Mut, parent_ty, ty)
-        }
-
-        match self {
-            Self::Value => matches_value(cx, parent_ty, ty),
-            Self::Ref => matches_ref(cx, hir::Mutability::Not, parent_ty, ty) || ty == parent_ty && is_copy(cx, ty),
-            Self::RefMut => matches_ref(cx, hir::Mutability::Mut, parent_ty, ty),
-            Self::No => matches_none(cx, parent_ty, ty),
-        }
-    }
-
-    #[must_use]
-    fn description(self) -> &'static str {
-        match self {
-            Self::Value => "`self` by value",
-            Self::Ref => "`self` by reference",
-            Self::RefMut => "`self` by mutable reference",
-            Self::No => "no `self`",
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-enum OutType {
-    Unit,
-    Bool,
-    Any,
-    Ref,
-}
-
-impl OutType {
-    fn matches(self, ty: &hir::FnRetTy<'_>) -> bool {
-        let is_unit = |ty: &hir::Ty<'_>| matches!(ty.kind, hir::TyKind::Tup(&[]));
-        match (self, ty) {
-            (Self::Unit, &hir::FnRetTy::DefaultReturn(_)) => true,
-            (Self::Unit, &hir::FnRetTy::Return(ty)) if is_unit(ty) => true,
-            (Self::Bool, &hir::FnRetTy::Return(ty)) if is_bool(ty) => true,
-            (Self::Any, &hir::FnRetTy::Return(ty)) if !is_unit(ty) => true,
-            (Self::Ref, &hir::FnRetTy::Return(ty)) => matches!(ty.kind, hir::TyKind::Ref(_, _)),
-            _ => false,
-        }
-    }
-}
-
-fn fn_header_equals(expected: hir::FnHeader, actual: hir::FnHeader) -> bool {
-    expected.constness == actual.constness && expected.safety == actual.safety && expected.asyncness == actual.asyncness
 }

--- a/clippy_lints/src/methods/should_implement_trait.rs
+++ b/clippy_lints/src/methods/should_implement_trait.rs
@@ -1,0 +1,165 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::{is_bool, sym};
+use rustc_abi::ExternAbi;
+use rustc_hir as hir;
+use rustc_hir::{FnSig, ImplItem};
+use rustc_lint::LateContext;
+use rustc_middle::ty::Ty;
+use rustc_span::{Symbol, kw};
+
+use super::SHOULD_IMPLEMENT_TRAIT;
+use super::lib::SelfKind;
+
+pub(super) fn check_impl_item<'tcx>(
+    cx: &LateContext<'tcx>,
+    impl_item: &'tcx ImplItem<'_>,
+    self_ty: Ty<'tcx>,
+    impl_implements_trait: bool,
+    first_arg_ty_opt: Option<Ty<'tcx>>,
+    sig: &FnSig<'_>,
+) {
+    // if this impl block implements a trait, lint in trait definition instead
+    if !impl_implements_trait && cx.effective_visibilities.is_exported(impl_item.owner_id.def_id) {
+        // check missing trait implementations
+        for method_config in &TRAIT_METHODS {
+            if impl_item.ident.name == method_config.method_name
+                && sig.decl.inputs.len() == method_config.param_count
+                && method_config.output_type.matches(&sig.decl.output)
+                // in case there is no first arg, since we already have checked the number of arguments
+                // it's should be always true
+                && first_arg_ty_opt
+                    .is_none_or(|first_arg_ty| method_config.self_kind.matches(cx, self_ty, first_arg_ty))
+                && fn_header_equals(method_config.fn_header, sig.header)
+                && method_config.lifetime_param_cond(impl_item)
+            {
+                span_lint_and_help(
+                    cx,
+                    SHOULD_IMPLEMENT_TRAIT,
+                    impl_item.span,
+                    format!(
+                        "method `{}` can be confused for the standard trait method `{}::{}`",
+                        method_config.method_name, method_config.trait_name, method_config.method_name
+                    ),
+                    None,
+                    format!(
+                        "consider implementing the trait `{}` or choosing a less ambiguous method name",
+                        method_config.trait_name
+                    ),
+                );
+            }
+        }
+    }
+}
+
+const FN_HEADER: hir::FnHeader = hir::FnHeader {
+    safety: hir::HeaderSafety::Normal(hir::Safety::Safe),
+    constness: hir::Constness::NotConst,
+    asyncness: hir::IsAsync::NotAsync,
+    abi: ExternAbi::Rust,
+};
+
+struct ShouldImplTraitCase {
+    trait_name: &'static str,
+    method_name: Symbol,
+    param_count: usize,
+    fn_header: hir::FnHeader,
+    // implicit self kind expected (none, self, &self, ...)
+    self_kind: SelfKind,
+    // checks against the output type
+    output_type: OutType,
+    // certain methods with explicit lifetimes can't implement the equivalent trait method
+    lint_explicit_lifetime: bool,
+}
+impl ShouldImplTraitCase {
+    const fn new(
+        trait_name: &'static str,
+        method_name: Symbol,
+        param_count: usize,
+        fn_header: hir::FnHeader,
+        self_kind: SelfKind,
+        output_type: OutType,
+        lint_explicit_lifetime: bool,
+    ) -> ShouldImplTraitCase {
+        ShouldImplTraitCase {
+            trait_name,
+            method_name,
+            param_count,
+            fn_header,
+            self_kind,
+            output_type,
+            lint_explicit_lifetime,
+        }
+    }
+
+    fn lifetime_param_cond(&self, impl_item: &ImplItem<'_>) -> bool {
+        self.lint_explicit_lifetime
+            || !impl_item.generics.params.iter().any(|p| {
+                matches!(
+                    p.kind,
+                    hir::GenericParamKind::Lifetime {
+                        kind: hir::LifetimeParamKind::Explicit
+                    }
+                )
+            })
+    }
+}
+
+#[rustfmt::skip]
+const TRAIT_METHODS: [ShouldImplTraitCase; 30] = [
+    ShouldImplTraitCase::new("std::ops::Add",           sym::add,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::convert::AsMut",     sym::as_mut,     1,  FN_HEADER, SelfKind::RefMut, OutType::Ref,  true ),
+    ShouldImplTraitCase::new("std::convert::AsRef",     sym::as_ref,     1,  FN_HEADER, SelfKind::Ref,    OutType::Ref,  true ),
+    ShouldImplTraitCase::new("std::ops::BitAnd",        sym::bitand,     2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::BitOr",         sym::bitor,      2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::BitXor",        sym::bitxor,     2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::borrow::Borrow",     sym::borrow,     1,  FN_HEADER, SelfKind::Ref,    OutType::Ref,  true ),
+    ShouldImplTraitCase::new("std::borrow::BorrowMut",  sym::borrow_mut, 1,  FN_HEADER, SelfKind::RefMut, OutType::Ref,  true ),
+    ShouldImplTraitCase::new("std::clone::Clone",       sym::clone,      1,  FN_HEADER, SelfKind::Ref,    OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::cmp::Ord",           sym::cmp,        2,  FN_HEADER, SelfKind::Ref,    OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::default::Default",   kw::Default,     0,  FN_HEADER, SelfKind::No,     OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::Deref",         sym::deref,      1,  FN_HEADER, SelfKind::Ref,    OutType::Ref,  true ),
+    ShouldImplTraitCase::new("std::ops::DerefMut",      sym::deref_mut,  1,  FN_HEADER, SelfKind::RefMut, OutType::Ref,  true ),
+    ShouldImplTraitCase::new("std::ops::Div",           sym::div,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::Drop",          sym::drop,       1,  FN_HEADER, SelfKind::RefMut, OutType::Unit, true ),
+    ShouldImplTraitCase::new("std::cmp::PartialEq",     sym::eq,         2,  FN_HEADER, SelfKind::Ref,    OutType::Bool, true ),
+    ShouldImplTraitCase::new("std::iter::FromIterator", sym::from_iter,  1,  FN_HEADER, SelfKind::No,     OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::str::FromStr",       sym::from_str,   1,  FN_HEADER, SelfKind::No,     OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::hash::Hash",         sym::hash,       2,  FN_HEADER, SelfKind::Ref,    OutType::Unit, true ),
+    ShouldImplTraitCase::new("std::ops::Index",         sym::index,      2,  FN_HEADER, SelfKind::Ref,    OutType::Ref,  true ),
+    ShouldImplTraitCase::new("std::ops::IndexMut",      sym::index_mut,  2,  FN_HEADER, SelfKind::RefMut, OutType::Ref,  true ),
+    ShouldImplTraitCase::new("std::iter::IntoIterator", sym::into_iter,  1,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::Mul",           sym::mul,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::Neg",           sym::neg,        1,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::iter::Iterator",     sym::next,       1,  FN_HEADER, SelfKind::RefMut, OutType::Any,  false),
+    ShouldImplTraitCase::new("std::ops::Not",           sym::not,        1,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::Rem",           sym::rem,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::Shl",           sym::shl,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::Shr",           sym::shr,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+    ShouldImplTraitCase::new("std::ops::Sub",           sym::sub,        2,  FN_HEADER, SelfKind::Value,  OutType::Any,  true ),
+];
+
+#[derive(Clone, Copy)]
+enum OutType {
+    Unit,
+    Bool,
+    Any,
+    Ref,
+}
+
+impl OutType {
+    fn matches(self, ty: &hir::FnRetTy<'_>) -> bool {
+        let is_unit = |ty: &hir::Ty<'_>| matches!(ty.kind, hir::TyKind::Tup(&[]));
+        match (self, ty) {
+            (Self::Unit, &hir::FnRetTy::DefaultReturn(_)) => true,
+            (Self::Unit, &hir::FnRetTy::Return(ty)) if is_unit(ty) => true,
+            (Self::Bool, &hir::FnRetTy::Return(ty)) if is_bool(ty) => true,
+            (Self::Any, &hir::FnRetTy::Return(ty)) if !is_unit(ty) => true,
+            (Self::Ref, &hir::FnRetTy::Return(ty)) => matches!(ty.kind, hir::TyKind::Ref(_, _)),
+            _ => false,
+        }
+    }
+}
+
+fn fn_header_equals(expected: hir::FnHeader, actual: hir::FnHeader) -> bool {
+    expected.constness == actual.constness && expected.safety == actual.safety && expected.asyncness == actual.asyncness
+}

--- a/clippy_lints/src/methods/wrong_self_convention.rs
+++ b/clippy_lints/src/methods/wrong_self_convention.rs
@@ -1,4 +1,3 @@
-use crate::methods::SelfKind;
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::ty::is_copy;
 use itertools::Itertools;
@@ -8,6 +7,7 @@ use rustc_span::{Span, Symbol};
 use std::fmt;
 
 use super::WRONG_SELF_CONVENTION;
+use super::lib::SelfKind;
 
 #[rustfmt::skip]
 const CONVENTIONS: [(&[Convention], &[SelfKind]); 9] = [

--- a/tests/ui/should_impl_trait/method_list_1.edition2015.stderr
+++ b/tests/ui/should_impl_trait/method_list_1.edition2015.stderr
@@ -1,5 +1,5 @@
 error: method `add` can be confused for the standard trait method `std::ops::Add::add`
-  --> tests/ui/should_impl_trait/method_list_1.rs:24:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:27:5
    |
 LL | /     pub fn add(self, other: T) -> T {
 LL | |
@@ -13,7 +13,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::should_implement_trait)]`
 
 error: method `as_mut` can be confused for the standard trait method `std::convert::AsMut::as_mut`
-  --> tests/ui/should_impl_trait/method_list_1.rs:30:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:33:5
    |
 LL | /     pub fn as_mut(&mut self) -> &mut T {
 LL | |
@@ -25,7 +25,7 @@ LL | |     }
    = help: consider implementing the trait `std::convert::AsMut` or choosing a less ambiguous method name
 
 error: method `as_ref` can be confused for the standard trait method `std::convert::AsRef::as_ref`
-  --> tests/ui/should_impl_trait/method_list_1.rs:36:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:39:5
    |
 LL | /     pub fn as_ref(&self) -> &T {
 LL | |
@@ -37,7 +37,7 @@ LL | |     }
    = help: consider implementing the trait `std::convert::AsRef` or choosing a less ambiguous method name
 
 error: method `bitand` can be confused for the standard trait method `std::ops::BitAnd::bitand`
-  --> tests/ui/should_impl_trait/method_list_1.rs:42:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:45:5
    |
 LL | /     pub fn bitand(self, rhs: T) -> T {
 LL | |
@@ -49,7 +49,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::BitAnd` or choosing a less ambiguous method name
 
 error: method `bitor` can be confused for the standard trait method `std::ops::BitOr::bitor`
-  --> tests/ui/should_impl_trait/method_list_1.rs:48:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:51:5
    |
 LL | /     pub fn bitor(self, rhs: Self) -> Self {
 LL | |
@@ -61,7 +61,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::BitOr` or choosing a less ambiguous method name
 
 error: method `bitxor` can be confused for the standard trait method `std::ops::BitXor::bitxor`
-  --> tests/ui/should_impl_trait/method_list_1.rs:54:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:57:5
    |
 LL | /     pub fn bitxor(self, rhs: Self) -> Self {
 LL | |
@@ -73,7 +73,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::BitXor` or choosing a less ambiguous method name
 
 error: method `borrow` can be confused for the standard trait method `std::borrow::Borrow::borrow`
-  --> tests/ui/should_impl_trait/method_list_1.rs:60:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:63:5
    |
 LL | /     pub fn borrow(&self) -> &str {
 LL | |
@@ -85,7 +85,7 @@ LL | |     }
    = help: consider implementing the trait `std::borrow::Borrow` or choosing a less ambiguous method name
 
 error: method `borrow_mut` can be confused for the standard trait method `std::borrow::BorrowMut::borrow_mut`
-  --> tests/ui/should_impl_trait/method_list_1.rs:66:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:69:5
    |
 LL | /     pub fn borrow_mut(&mut self) -> &mut str {
 LL | |
@@ -97,7 +97,7 @@ LL | |     }
    = help: consider implementing the trait `std::borrow::BorrowMut` or choosing a less ambiguous method name
 
 error: method `clone` can be confused for the standard trait method `std::clone::Clone::clone`
-  --> tests/ui/should_impl_trait/method_list_1.rs:72:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:75:5
    |
 LL | /     pub fn clone(&self) -> Self {
 LL | |
@@ -109,7 +109,7 @@ LL | |     }
    = help: consider implementing the trait `std::clone::Clone` or choosing a less ambiguous method name
 
 error: method `cmp` can be confused for the standard trait method `std::cmp::Ord::cmp`
-  --> tests/ui/should_impl_trait/method_list_1.rs:78:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:81:5
    |
 LL | /     pub fn cmp(&self, other: &Self) -> Self {
 LL | |
@@ -121,7 +121,7 @@ LL | |     }
    = help: consider implementing the trait `std::cmp::Ord` or choosing a less ambiguous method name
 
 error: method `default` can be confused for the standard trait method `std::default::Default::default`
-  --> tests/ui/should_impl_trait/method_list_1.rs:84:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:87:5
    |
 LL | /     pub fn default() -> Self {
 LL | |
@@ -133,7 +133,7 @@ LL | |     }
    = help: consider implementing the trait `std::default::Default` or choosing a less ambiguous method name
 
 error: method `deref` can be confused for the standard trait method `std::ops::Deref::deref`
-  --> tests/ui/should_impl_trait/method_list_1.rs:90:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:93:5
    |
 LL | /     pub fn deref(&self) -> &Self {
 LL | |
@@ -145,7 +145,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Deref` or choosing a less ambiguous method name
 
 error: method `deref_mut` can be confused for the standard trait method `std::ops::DerefMut::deref_mut`
-  --> tests/ui/should_impl_trait/method_list_1.rs:96:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:99:5
    |
 LL | /     pub fn deref_mut(&mut self) -> &mut Self {
 LL | |
@@ -157,7 +157,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::DerefMut` or choosing a less ambiguous method name
 
 error: method `div` can be confused for the standard trait method `std::ops::Div::div`
-  --> tests/ui/should_impl_trait/method_list_1.rs:102:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:105:5
    |
 LL | /     pub fn div(self, rhs: Self) -> Self {
 LL | |
@@ -169,7 +169,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Div` or choosing a less ambiguous method name
 
 error: method `drop` can be confused for the standard trait method `std::ops::Drop::drop`
-  --> tests/ui/should_impl_trait/method_list_1.rs:108:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:111:5
    |
 LL | /     pub fn drop(&mut self) {
 LL | |

--- a/tests/ui/should_impl_trait/method_list_1.edition2021.stderr
+++ b/tests/ui/should_impl_trait/method_list_1.edition2021.stderr
@@ -1,0 +1,184 @@
+error: method `add` can be confused for the standard trait method `std::ops::Add::add`
+  --> tests/ui/should_impl_trait/method_list_1.rs:27:5
+   |
+LL | /     pub fn add(self, other: T) -> T {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Add` or choosing a less ambiguous method name
+   = note: `-D clippy::should-implement-trait` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::should_implement_trait)]`
+
+error: method `as_mut` can be confused for the standard trait method `std::convert::AsMut::as_mut`
+  --> tests/ui/should_impl_trait/method_list_1.rs:33:5
+   |
+LL | /     pub fn as_mut(&mut self) -> &mut T {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::convert::AsMut` or choosing a less ambiguous method name
+
+error: method `as_ref` can be confused for the standard trait method `std::convert::AsRef::as_ref`
+  --> tests/ui/should_impl_trait/method_list_1.rs:39:5
+   |
+LL | /     pub fn as_ref(&self) -> &T {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::convert::AsRef` or choosing a less ambiguous method name
+
+error: method `bitand` can be confused for the standard trait method `std::ops::BitAnd::bitand`
+  --> tests/ui/should_impl_trait/method_list_1.rs:45:5
+   |
+LL | /     pub fn bitand(self, rhs: T) -> T {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::BitAnd` or choosing a less ambiguous method name
+
+error: method `bitor` can be confused for the standard trait method `std::ops::BitOr::bitor`
+  --> tests/ui/should_impl_trait/method_list_1.rs:51:5
+   |
+LL | /     pub fn bitor(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::BitOr` or choosing a less ambiguous method name
+
+error: method `bitxor` can be confused for the standard trait method `std::ops::BitXor::bitxor`
+  --> tests/ui/should_impl_trait/method_list_1.rs:57:5
+   |
+LL | /     pub fn bitxor(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::BitXor` or choosing a less ambiguous method name
+
+error: method `borrow` can be confused for the standard trait method `std::borrow::Borrow::borrow`
+  --> tests/ui/should_impl_trait/method_list_1.rs:63:5
+   |
+LL | /     pub fn borrow(&self) -> &str {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::borrow::Borrow` or choosing a less ambiguous method name
+
+error: method `borrow_mut` can be confused for the standard trait method `std::borrow::BorrowMut::borrow_mut`
+  --> tests/ui/should_impl_trait/method_list_1.rs:69:5
+   |
+LL | /     pub fn borrow_mut(&mut self) -> &mut str {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::borrow::BorrowMut` or choosing a less ambiguous method name
+
+error: method `clone` can be confused for the standard trait method `std::clone::Clone::clone`
+  --> tests/ui/should_impl_trait/method_list_1.rs:75:5
+   |
+LL | /     pub fn clone(&self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::clone::Clone` or choosing a less ambiguous method name
+
+error: method `cmp` can be confused for the standard trait method `std::cmp::Ord::cmp`
+  --> tests/ui/should_impl_trait/method_list_1.rs:81:5
+   |
+LL | /     pub fn cmp(&self, other: &Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::cmp::Ord` or choosing a less ambiguous method name
+
+error: method `default` can be confused for the standard trait method `std::default::Default::default`
+  --> tests/ui/should_impl_trait/method_list_1.rs:87:5
+   |
+LL | /     pub fn default() -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::default::Default` or choosing a less ambiguous method name
+
+error: method `deref` can be confused for the standard trait method `std::ops::Deref::deref`
+  --> tests/ui/should_impl_trait/method_list_1.rs:93:5
+   |
+LL | /     pub fn deref(&self) -> &Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Deref` or choosing a less ambiguous method name
+
+error: method `deref_mut` can be confused for the standard trait method `std::ops::DerefMut::deref_mut`
+  --> tests/ui/should_impl_trait/method_list_1.rs:99:5
+   |
+LL | /     pub fn deref_mut(&mut self) -> &mut Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::DerefMut` or choosing a less ambiguous method name
+
+error: method `div` can be confused for the standard trait method `std::ops::Div::div`
+  --> tests/ui/should_impl_trait/method_list_1.rs:105:5
+   |
+LL | /     pub fn div(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Div` or choosing a less ambiguous method name
+
+error: method `drop` can be confused for the standard trait method `std::ops::Drop::drop`
+  --> tests/ui/should_impl_trait/method_list_1.rs:111:5
+   |
+LL | /     pub fn drop(&mut self) {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Drop` or choosing a less ambiguous method name
+
+error: aborting due to 15 previous errors
+

--- a/tests/ui/should_impl_trait/method_list_1.rs
+++ b/tests/ui/should_impl_trait/method_list_1.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2021
+//@[edition2015] edition:2015
+//@[edition2021] edition:2021
 #![allow(
     clippy::missing_errors_doc,
     clippy::needless_pass_by_value,

--- a/tests/ui/should_impl_trait/method_list_2.edition2015.stderr
+++ b/tests/ui/should_impl_trait/method_list_2.edition2015.stderr
@@ -1,0 +1,172 @@
+error: method `eq` can be confused for the standard trait method `std::cmp::PartialEq::eq`
+  --> tests/ui/should_impl_trait/method_list_2.rs:28:5
+   |
+LL | /     pub fn eq(&self, other: &Self) -> bool {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::cmp::PartialEq` or choosing a less ambiguous method name
+   = note: `-D clippy::should-implement-trait` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::should_implement_trait)]`
+
+error: method `from_str` can be confused for the standard trait method `std::str::FromStr::from_str`
+  --> tests/ui/should_impl_trait/method_list_2.rs:40:5
+   |
+LL | /     pub fn from_str(s: &str) -> Result<Self, Self> {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::str::FromStr` or choosing a less ambiguous method name
+
+error: method `hash` can be confused for the standard trait method `std::hash::Hash::hash`
+  --> tests/ui/should_impl_trait/method_list_2.rs:46:5
+   |
+LL | /     pub fn hash(&self, state: &mut T) {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::hash::Hash` or choosing a less ambiguous method name
+
+error: method `index` can be confused for the standard trait method `std::ops::Index::index`
+  --> tests/ui/should_impl_trait/method_list_2.rs:52:5
+   |
+LL | /     pub fn index(&self, index: usize) -> &Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Index` or choosing a less ambiguous method name
+
+error: method `index_mut` can be confused for the standard trait method `std::ops::IndexMut::index_mut`
+  --> tests/ui/should_impl_trait/method_list_2.rs:58:5
+   |
+LL | /     pub fn index_mut(&mut self, index: usize) -> &mut Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::IndexMut` or choosing a less ambiguous method name
+
+error: method `into_iter` can be confused for the standard trait method `std::iter::IntoIterator::into_iter`
+  --> tests/ui/should_impl_trait/method_list_2.rs:64:5
+   |
+LL | /     pub fn into_iter(self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::iter::IntoIterator` or choosing a less ambiguous method name
+
+error: method `mul` can be confused for the standard trait method `std::ops::Mul::mul`
+  --> tests/ui/should_impl_trait/method_list_2.rs:70:5
+   |
+LL | /     pub fn mul(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Mul` or choosing a less ambiguous method name
+
+error: method `neg` can be confused for the standard trait method `std::ops::Neg::neg`
+  --> tests/ui/should_impl_trait/method_list_2.rs:76:5
+   |
+LL | /     pub fn neg(self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Neg` or choosing a less ambiguous method name
+
+error: method `next` can be confused for the standard trait method `std::iter::Iterator::next`
+  --> tests/ui/should_impl_trait/method_list_2.rs:82:5
+   |
+LL | /     pub fn next(&mut self) -> Option<Self> {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::iter::Iterator` or choosing a less ambiguous method name
+
+error: method `not` can be confused for the standard trait method `std::ops::Not::not`
+  --> tests/ui/should_impl_trait/method_list_2.rs:88:5
+   |
+LL | /     pub fn not(self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Not` or choosing a less ambiguous method name
+
+error: method `rem` can be confused for the standard trait method `std::ops::Rem::rem`
+  --> tests/ui/should_impl_trait/method_list_2.rs:94:5
+   |
+LL | /     pub fn rem(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Rem` or choosing a less ambiguous method name
+
+error: method `shl` can be confused for the standard trait method `std::ops::Shl::shl`
+  --> tests/ui/should_impl_trait/method_list_2.rs:100:5
+   |
+LL | /     pub fn shl(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Shl` or choosing a less ambiguous method name
+
+error: method `shr` can be confused for the standard trait method `std::ops::Shr::shr`
+  --> tests/ui/should_impl_trait/method_list_2.rs:106:5
+   |
+LL | /     pub fn shr(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Shr` or choosing a less ambiguous method name
+
+error: method `sub` can be confused for the standard trait method `std::ops::Sub::sub`
+  --> tests/ui/should_impl_trait/method_list_2.rs:112:5
+   |
+LL | /     pub fn sub(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Sub` or choosing a less ambiguous method name
+
+error: aborting due to 14 previous errors
+

--- a/tests/ui/should_impl_trait/method_list_2.edition2021.stderr
+++ b/tests/ui/should_impl_trait/method_list_2.edition2021.stderr
@@ -1,0 +1,184 @@
+error: method `eq` can be confused for the standard trait method `std::cmp::PartialEq::eq`
+  --> tests/ui/should_impl_trait/method_list_2.rs:28:5
+   |
+LL | /     pub fn eq(&self, other: &Self) -> bool {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::cmp::PartialEq` or choosing a less ambiguous method name
+   = note: `-D clippy::should-implement-trait` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::should_implement_trait)]`
+
+error: method `from_iter` can be confused for the standard trait method `std::iter::FromIterator::from_iter`
+  --> tests/ui/should_impl_trait/method_list_2.rs:34:5
+   |
+LL | /     pub fn from_iter<T>(iter: T) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::iter::FromIterator` or choosing a less ambiguous method name
+
+error: method `from_str` can be confused for the standard trait method `std::str::FromStr::from_str`
+  --> tests/ui/should_impl_trait/method_list_2.rs:40:5
+   |
+LL | /     pub fn from_str(s: &str) -> Result<Self, Self> {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::str::FromStr` or choosing a less ambiguous method name
+
+error: method `hash` can be confused for the standard trait method `std::hash::Hash::hash`
+  --> tests/ui/should_impl_trait/method_list_2.rs:46:5
+   |
+LL | /     pub fn hash(&self, state: &mut T) {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::hash::Hash` or choosing a less ambiguous method name
+
+error: method `index` can be confused for the standard trait method `std::ops::Index::index`
+  --> tests/ui/should_impl_trait/method_list_2.rs:52:5
+   |
+LL | /     pub fn index(&self, index: usize) -> &Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Index` or choosing a less ambiguous method name
+
+error: method `index_mut` can be confused for the standard trait method `std::ops::IndexMut::index_mut`
+  --> tests/ui/should_impl_trait/method_list_2.rs:58:5
+   |
+LL | /     pub fn index_mut(&mut self, index: usize) -> &mut Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::IndexMut` or choosing a less ambiguous method name
+
+error: method `into_iter` can be confused for the standard trait method `std::iter::IntoIterator::into_iter`
+  --> tests/ui/should_impl_trait/method_list_2.rs:64:5
+   |
+LL | /     pub fn into_iter(self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::iter::IntoIterator` or choosing a less ambiguous method name
+
+error: method `mul` can be confused for the standard trait method `std::ops::Mul::mul`
+  --> tests/ui/should_impl_trait/method_list_2.rs:70:5
+   |
+LL | /     pub fn mul(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Mul` or choosing a less ambiguous method name
+
+error: method `neg` can be confused for the standard trait method `std::ops::Neg::neg`
+  --> tests/ui/should_impl_trait/method_list_2.rs:76:5
+   |
+LL | /     pub fn neg(self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Neg` or choosing a less ambiguous method name
+
+error: method `next` can be confused for the standard trait method `std::iter::Iterator::next`
+  --> tests/ui/should_impl_trait/method_list_2.rs:82:5
+   |
+LL | /     pub fn next(&mut self) -> Option<Self> {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::iter::Iterator` or choosing a less ambiguous method name
+
+error: method `not` can be confused for the standard trait method `std::ops::Not::not`
+  --> tests/ui/should_impl_trait/method_list_2.rs:88:5
+   |
+LL | /     pub fn not(self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Not` or choosing a less ambiguous method name
+
+error: method `rem` can be confused for the standard trait method `std::ops::Rem::rem`
+  --> tests/ui/should_impl_trait/method_list_2.rs:94:5
+   |
+LL | /     pub fn rem(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Rem` or choosing a less ambiguous method name
+
+error: method `shl` can be confused for the standard trait method `std::ops::Shl::shl`
+  --> tests/ui/should_impl_trait/method_list_2.rs:100:5
+   |
+LL | /     pub fn shl(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Shl` or choosing a less ambiguous method name
+
+error: method `shr` can be confused for the standard trait method `std::ops::Shr::shr`
+  --> tests/ui/should_impl_trait/method_list_2.rs:106:5
+   |
+LL | /     pub fn shr(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Shr` or choosing a less ambiguous method name
+
+error: method `sub` can be confused for the standard trait method `std::ops::Sub::sub`
+  --> tests/ui/should_impl_trait/method_list_2.rs:112:5
+   |
+LL | /     pub fn sub(self, rhs: Self) -> Self {
+LL | |
+LL | |
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = help: consider implementing the trait `std::ops::Sub` or choosing a less ambiguous method name
+
+error: aborting due to 15 previous errors
+

--- a/tests/ui/should_impl_trait/method_list_2.rs
+++ b/tests/ui/should_impl_trait/method_list_2.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2021
+//@[edition2015] edition:2015
+//@[edition2021] edition:2021
 #![allow(
     clippy::missing_errors_doc,
     clippy::needless_pass_by_value,
@@ -29,7 +32,7 @@ impl T {
     }
 
     pub fn from_iter<T>(iter: T) -> Self {
-        //~^ should_implement_trait
+        //~[edition2021]^ should_implement_trait
 
         unimplemented!()
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/6752

changelog: [should_implement_trait]: only suggest traits that are in the prelude