### PR TITLE
Fix `if_then_some_else_none` FP when return exists in block expr

### DIFF
--- a/clippy_lints/src/if_then_some_else_none.rs
+++ b/clippy_lints/src/if_then_some_else_none.rs
@@ -79,6 +79,7 @@ impl<'tcx> LateLintPass<'tcx> for IfThenSomeElseNone {
             && !is_in_const_context(cx)
             && self.msrv.meets(cx, msrvs::BOOL_THEN)
             && !contains_return(then_block.stmts)
+            && then_block.expr.is_none_or(|expr| !contains_return(expr))
         {
             let method_name = if switch_to_eager_eval(cx, expr) && self.msrv.meets(cx, msrvs::BOOL_THEN_SOME) {
                 sym::then_some

--- a/tests/ui/if_then_some_else_none.fixed
+++ b/tests/ui/if_then_some_else_none.fixed
@@ -206,3 +206,15 @@ fn dont_lint_inside_macros() {
     }
     let _: Option<u32> = mac!(true, 42);
 }
+
+mod issue15770 {
+    fn maybe_error() -> Result<u32, &'static str> {
+        Err("error!")
+    }
+
+    pub fn trying(b: bool) -> Result<(), &'static str> {
+        let _x: Option<u32> = if b { Some(maybe_error()?) } else { None };
+        // Process _x locally
+        Ok(())
+    }
+}

--- a/tests/ui/if_then_some_else_none.rs
+++ b/tests/ui/if_then_some_else_none.rs
@@ -262,3 +262,15 @@ fn dont_lint_inside_macros() {
     }
     let _: Option<u32> = mac!(true, 42);
 }
+
+mod issue15770 {
+    fn maybe_error() -> Result<u32, &'static str> {
+        Err("error!")
+    }
+
+    pub fn trying(b: bool) -> Result<(), &'static str> {
+        let _x: Option<u32> = if b { Some(maybe_error()?) } else { None };
+        // Process _x locally
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15770

changelog: [`if_then_some_else_none`] fix FP when return exists in block expr
