### PR TITLE
Fix `mem_replace_with_default` wrongly unmangled macros

### DIFF
--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -1,7 +1,7 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::source::{snippet, snippet_with_applicability};
+use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::is_non_aggregate_primitive_type;
 use clippy_utils::{
@@ -269,14 +269,11 @@ fn check_replace_with_default(
             ),
             |diag| {
                 if !expr.span.from_expansion() {
-                    let suggestion = format!("{top_crate}::mem::take({})", snippet(cx, dest.span, ""));
+                    let mut applicability = Applicability::MachineApplicable;
+                    let (dest_snip, _) = snippet_with_context(cx, dest.span, expr.span.ctxt(), "", &mut applicability);
+                    let suggestion = format!("{top_crate}::mem::take({dest_snip})");
 
-                    diag.span_suggestion(
-                        expr.span,
-                        "consider using",
-                        suggestion,
-                        Applicability::MachineApplicable,
-                    );
+                    diag.span_suggestion(expr.span, "consider using", suggestion, applicability);
                 }
             },
         );

--- a/tests/ui/mem_replace.fixed
+++ b/tests/ui/mem_replace.fixed
@@ -179,3 +179,9 @@ fn mem_replace_option_with_some_bad_msrv() {
     let mut an_option = Some(0);
     let replaced = mem::replace(&mut an_option, Some(1));
 }
+
+fn issue15785() {
+    let mut text = String::from("foo");
+    let replaced = std::mem::take(dbg!(&mut text));
+    //~^ mem_replace_with_default
+}

--- a/tests/ui/mem_replace.rs
+++ b/tests/ui/mem_replace.rs
@@ -179,3 +179,9 @@ fn mem_replace_option_with_some_bad_msrv() {
     let mut an_option = Some(0);
     let replaced = mem::replace(&mut an_option, Some(1));
 }
+
+fn issue15785() {
+    let mut text = String::from("foo");
+    let replaced = std::mem::replace(dbg!(&mut text), String::default());
+    //~^ mem_replace_with_default
+}

--- a/tests/ui/mem_replace.stderr
+++ b/tests/ui/mem_replace.stderr
@@ -181,5 +181,11 @@ error: replacing an `Option` with `Some(..)`
 LL |     let replaced = mem::replace(if b { &mut opt1 } else { &mut opt2 }, Some(1));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::replace()` instead: `(if b { &mut opt1 } else { &mut opt2 }).replace(1)`
 
-error: aborting due to 29 previous errors
+error: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
+  --> tests/ui/mem_replace.rs:185:20
+   |
+LL |     let replaced = std::mem::replace(dbg!(&mut text), String::default());
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(dbg!(&mut text))`
+
+error: aborting due to 30 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15785 

changelog: [`mem_replace_with_default`] fix wrongly unmangled macros
