### PR TITLE
fix(let_unit_value): create the suggestion "differentially"

### DIFF
--- a/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/clippy_lints/src/unit_types/let_unit_value.rs
@@ -117,11 +117,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, format_args: &FormatArgsStorag
                                 init.span,
                                 format!("();\n{}", reindent_multiline(&snip, false, indent_of(cx, local.span))),
                             ));
-                            diag.multipart_suggestion(
-                                "replace variable usages with `()`",
-                                suggestions,
-                                Applicability::MachineApplicable,
-                            );
+                            diag.multipart_suggestion("replace variable usages with `()`", suggestions, app);
                             return;
                         }
                     }
@@ -132,7 +128,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, format_args: &FormatArgsStorag
                     } else {
                         "omit the `let` binding and replace variable usages with `()`"
                     };
-                    diag.multipart_suggestion(message, suggestions, Applicability::MachineApplicable);
+                    diag.multipart_suggestion(message, suggestions, app);
                 },
             );
         }

--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -1,5 +1,10 @@
 #![warn(clippy::let_unit_value)]
-#![allow(clippy::no_effect, clippy::needless_late_init, path_statements)]
+#![allow(
+    clippy::no_effect,
+    clippy::needless_late_init,
+    path_statements,
+    clippy::match_single_binding
+)]
 
 macro_rules! let_and_return {
     ($n:expr) => {{
@@ -197,12 +202,30 @@ pub fn issue12594() {
     }
 }
 
-fn issue15061() {
-    fn do_something(x: ()) {}
+fn takes_unit(x: ()) {}
 
+fn issue15061() {
     let res = ();
     returns_unit();
     //~^ let_unit_value
-    do_something(());
+    takes_unit(());
+    println!("{res:?}");
+}
+
+fn issue15771() {
+    match "Example String" {
+        _ => returns_unit(),
+        //~^ let_unit_value
+    }
+
+    if true {}
+    //~^ let_unit_value
+}
+
+fn issue_15784() {
+    let res = ();
+    eprintln!("I return unit");
+    //~^ let_unit_value
+    takes_unit(());
     println!("{res:?}");
 }

--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::let_unit_value)]
-#![allow(unused, clippy::no_effect, clippy::needless_late_init, path_statements)]
+#![allow(clippy::no_effect, clippy::needless_late_init, path_statements)]
 
 macro_rules! let_and_return {
     ($n:expr) => {{
@@ -15,12 +15,12 @@ fn main() {
     if true {
         // do not lint this, since () is explicit
         let _a = ();
-        let () = dummy();
+        let () = returns_unit();
         let () = ();
-        () = dummy();
+        () = returns_unit();
         () = ();
         let _a: () = ();
-        let _a: () = dummy();
+        let _a: () = returns_unit();
     }
 
     consume_units_with_for_loop(); // should be fine as well
@@ -30,7 +30,7 @@ fn main() {
     let_and_return!(()) // should be fine
 }
 
-fn dummy() {}
+fn returns_unit() {}
 
 // Related to issue #1964
 fn consume_units_with_for_loop() {
@@ -181,8 +181,6 @@ async fn issue10433() {
 pub async fn issue11502(a: ()) {}
 
 pub fn issue12594() {
-    fn returns_unit() {}
-
     fn returns_result<T>(res: T) -> Result<T, ()> {
         Ok(res)
     }
@@ -200,11 +198,10 @@ pub fn issue12594() {
 }
 
 fn issue15061() {
-    fn return_unit() {}
     fn do_something(x: ()) {}
 
     let res = ();
-    return_unit();
+    returns_unit();
     //~^ let_unit_value
     do_something(());
     println!("{res:?}");

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::let_unit_value)]
-#![allow(clippy::no_effect, clippy::needless_late_init, path_statements)]
+#![allow(
+    clippy::no_effect,
+    clippy::needless_late_init,
+    path_statements,
+    clippy::match_single_binding
+)]
 
 macro_rules! let_and_return {
     ($n:expr) => {{
@@ -197,11 +202,28 @@ pub fn issue12594() {
     }
 }
 
-fn issue15061() {
-    fn do_something(x: ()) {}
+fn takes_unit(x: ()) {}
 
+fn issue15061() {
     let res = returns_unit();
     //~^ let_unit_value
-    do_something(res);
+    takes_unit(res);
+    println!("{res:?}");
+}
+
+fn issue15771() {
+    match "Example String" {
+        _ => _ = returns_unit(),
+        //~^ let_unit_value
+    }
+
+    _ = if true {}
+    //~^ let_unit_value
+}
+
+fn issue_15784() {
+    let res = eprintln!("I return unit");
+    //~^ let_unit_value
+    takes_unit(res);
     println!("{res:?}");
 }

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::let_unit_value)]
-#![allow(unused, clippy::no_effect, clippy::needless_late_init, path_statements)]
+#![allow(clippy::no_effect, clippy::needless_late_init, path_statements)]
 
 macro_rules! let_and_return {
     ($n:expr) => {{
@@ -15,12 +15,12 @@ fn main() {
     if true {
         // do not lint this, since () is explicit
         let _a = ();
-        let () = dummy();
+        let () = returns_unit();
         let () = ();
-        () = dummy();
+        () = returns_unit();
         () = ();
         let _a: () = ();
-        let _a: () = dummy();
+        let _a: () = returns_unit();
     }
 
     consume_units_with_for_loop(); // should be fine as well
@@ -30,7 +30,7 @@ fn main() {
     let_and_return!(()) // should be fine
 }
 
-fn dummy() {}
+fn returns_unit() {}
 
 // Related to issue #1964
 fn consume_units_with_for_loop() {
@@ -181,8 +181,6 @@ async fn issue10433() {
 pub async fn issue11502(a: ()) {}
 
 pub fn issue12594() {
-    fn returns_unit() {}
-
     fn returns_result<T>(res: T) -> Result<T, ()> {
         Ok(res)
     }
@@ -200,10 +198,9 @@ pub fn issue12594() {
 }
 
 fn issue15061() {
-    fn return_unit() {}
     fn do_something(x: ()) {}
 
-    let res = return_unit();
+    let res = returns_unit();
     //~^ let_unit_value
     do_something(res);
     println!("{res:?}");

--- a/tests/ui/let_unit.stderr
+++ b/tests/ui/let_unit.stderr
@@ -1,14 +1,19 @@
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:11:5
+  --> tests/ui/let_unit.rs:16:5
    |
 LL |     let _x = println!("x");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `println!("x");`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::let-unit-value` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::let_unit_value)]`
+help: omit the `let` binding
+   |
+LL -     let _x = println!("x");
+LL +     println!("x");
+   |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:60:5
+  --> tests/ui/let_unit.rs:65:5
    |
 LL | /     let _ = v
 LL | |
@@ -21,18 +26,12 @@ LL | |         .unwrap();
    |
 help: omit the `let` binding
    |
-LL ~     v
-LL +
-LL +         .into_iter()
-LL +         .map(|i| i * 2)
-LL +         .filter(|i| i.is_multiple_of(2))
-LL +         .map(|_| ())
-LL +         .next()
-LL +         .unwrap();
+LL -     let _ = v
+LL +     v
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:110:5
+  --> tests/ui/let_unit.rs:115:5
    |
 LL | /     let x = match Some(0) {
 LL | |
@@ -45,17 +44,12 @@ LL | |     };
    |
 help: omit the `let` binding
    |
-LL ~     match Some(0) {
-LL +
-LL +         None => f2(1),
-LL +         Some(0) => f(),
-LL +         Some(1) => f2(3),
-LL +         Some(_) => (),
-LL +     };
+LL -     let x = match Some(0) {
+LL +     match Some(0) {
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:190:9
+  --> tests/ui/let_unit.rs:195:9
    |
 LL |         let res = returns_unit();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +63,7 @@ LL ~         returns_result(()).unwrap();
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:203:5
+  --> tests/ui/let_unit.rs:208:5
    |
 LL |     let res = returns_unit();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,8 +73,46 @@ help: replace variable usages with `()`
 LL ~     let res = ();
 LL ~     returns_unit();
 LL |
-LL ~     do_something(());
+LL ~     takes_unit(());
    |
 
-error: aborting due to 5 previous errors
+error: this let-binding has unit value
+  --> tests/ui/let_unit.rs:216:14
+   |
+LL |         _ => _ = returns_unit(),
+   |              ^^^^^^^^^^^^^^^^^^
+   |
+help: omit the `let` binding
+   |
+LL -         _ => _ = returns_unit(),
+LL +         _ => returns_unit(),
+   |
+
+error: this let-binding has unit value
+  --> tests/ui/let_unit.rs:220:5
+   |
+LL |     _ = if true {}
+   |     ^^^^^^^^^^^^^^
+   |
+help: omit the `let` binding
+   |
+LL -     _ = if true {}
+LL +     if true {}
+   |
+
+error: this let-binding has unit value
+  --> tests/ui/let_unit.rs:225:5
+   |
+LL |     let res = eprintln!("I return unit");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace variable usages with `()`
+   |
+LL ~     let res = ();
+LL ~     eprintln!("I return unit");
+LL |
+LL ~     takes_unit(());
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/let_unit.stderr
+++ b/tests/ui/let_unit.stderr
@@ -55,7 +55,7 @@ LL +     };
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:192:9
+  --> tests/ui/let_unit.rs:190:9
    |
 LL |         let res = returns_unit();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,15 +69,15 @@ LL ~         returns_result(()).unwrap();
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:206:5
+  --> tests/ui/let_unit.rs:203:5
    |
-LL |     let res = return_unit();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let res = returns_unit();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: replace variable usages with `()`
    |
 LL ~     let res = ();
-LL ~     return_unit();
+LL ~     returns_unit();
 LL |
 LL ~     do_something(());
    |


### PR DESCRIPTION
I.e, instead of constructing a whole new `LetStmt` to replace the old one, suggest to only change the part of the `LetStmt` that we don't like. This makes the suggestion less likely to introduce spurious changes, but also makes the diagnostic much nicer imo.

Fixes #15771 by not adding a semicolon that the initial `LetStmt` didn't have
Fixes #15784 by using the `init.span` with the correct `SyntaxContext`

changelog: [`let_unit_value`]: don't add spurious semicolon
changelog: [`let_unit_value`]: don't mangle macro calls