### PR TITLE
Fix `let_unit_value` suggests wrongly for field init shorthand

### DIFF
--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -229,3 +229,13 @@ fn issue_15784() {
     takes_unit(());
     println!("{res:?}");
 }
+
+fn issue15789() {
+    struct Foo {
+        value: (),
+    }
+    println!();
+    //~^ let_unit_value
+
+    Foo { value: () };
+}

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -227,3 +227,13 @@ fn issue_15784() {
     takes_unit(res);
     println!("{res:?}");
 }
+
+fn issue15789() {
+    struct Foo {
+        value: (),
+    }
+    let value = println!();
+    //~^ let_unit_value
+
+    Foo { value };
+}

--- a/tests/ui/let_unit.stderr
+++ b/tests/ui/let_unit.stderr
@@ -114,5 +114,19 @@ LL |
 LL ~     takes_unit(());
    |
 
-error: aborting due to 8 previous errors
+error: this let-binding has unit value
+  --> tests/ui/let_unit.rs:235:5
+   |
+LL |     let value = println!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: omit the `let` binding and replace variable usages with `()`
+   |
+LL ~     println!();
+LL |
+LL |
+LL ~     Foo { value: () };
+   |
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15789 

changelog: [`let_unit_value`] fix wrong suggestions for field init shorthand