### PR TITLE
Handle different root contexts in `SpanlessEq`

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -297,8 +297,9 @@ impl<'v> Hir2Qmm<'_, '_, 'v> {
             return Err("contains never type".to_owned());
         }
 
+        let ctxt = e.span.ctxt();
         for (n, expr) in self.terminals.iter().enumerate() {
-            if eq_expr_value(self.cx, e, expr) {
+            if eq_expr_value(self.cx, ctxt, e, expr) {
                 #[expect(clippy::cast_possible_truncation)]
                 return Ok(Bool::Term(n as u8));
             }
@@ -307,8 +308,8 @@ impl<'v> Hir2Qmm<'_, '_, 'v> {
                 && implements_ord(self.cx, e_lhs)
                 && let ExprKind::Binary(expr_binop, expr_lhs, expr_rhs) = &expr.kind
                 && negate(e_binop.node) == Some(expr_binop.node)
-                && eq_expr_value(self.cx, e_lhs, expr_lhs)
-                && eq_expr_value(self.cx, e_rhs, expr_rhs)
+                && eq_expr_value(self.cx, ctxt, e_lhs, expr_lhs)
+                && eq_expr_value(self.cx, ctxt, e_rhs, expr_rhs)
             {
                 #[expect(clippy::cast_possible_truncation)]
                 return Ok(Bool::Not(Box::new(Bool::Term(n as u8))));

--- a/clippy_lints/src/comparison_chain.rs
+++ b/clippy_lints/src/comparison_chain.rs
@@ -6,7 +6,7 @@ use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
-use rustc_span::sym;
+use rustc_span::{SyntaxContext, sym};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -90,8 +90,10 @@ impl<'tcx> LateLintPass<'tcx> for ComparisonChain {
 
                 // Check that both sets of operands are equal
                 let mut spanless_eq = SpanlessEq::new(cx);
-                let same_fixed_operands = spanless_eq.eq_expr(lhs1, lhs2) && spanless_eq.eq_expr(rhs1, rhs2);
-                let same_transposed_operands = spanless_eq.eq_expr(lhs1, rhs2) && spanless_eq.eq_expr(rhs1, lhs2);
+                let same_fixed_operands = spanless_eq.eq_expr(SyntaxContext::root(), lhs1, lhs2)
+                    && spanless_eq.eq_expr(SyntaxContext::root(), rhs1, rhs2);
+                let same_transposed_operands = spanless_eq.eq_expr(SyntaxContext::root(), lhs1, rhs2)
+                    && spanless_eq.eq_expr(SyntaxContext::root(), rhs1, lhs2);
 
                 if !same_fixed_operands && !same_transposed_operands {
                     return;

--- a/clippy_lints/src/floating_point_arithmetic/custom_abs.rs
+++ b/clippy_lints/src/floating_point_arithmetic/custom_abs.rs
@@ -14,11 +14,15 @@ use super::SUBOPTIMAL_FLOPS;
 /// test is positive or an expression which tests whether or not test
 /// is nonnegative.
 /// Used for check-custom-abs function below
-fn is_testing_positive(cx: &LateContext<'_>, expr: &Expr<'_>, test: &Expr<'_>) -> bool {
+fn is_testing_positive(cx: &LateContext<'_>, ctxt: SyntaxContext, expr: &Expr<'_>, test: &Expr<'_>) -> bool {
     if let ExprKind::Binary(Spanned { node: op, .. }, left, right) = expr.kind {
         match op {
-            BinOpKind::Gt | BinOpKind::Ge => is_zero(cx, right, expr.span.ctxt()) && eq_expr_value(cx, left, test),
-            BinOpKind::Lt | BinOpKind::Le => is_zero(cx, left, expr.span.ctxt()) && eq_expr_value(cx, right, test),
+            BinOpKind::Gt | BinOpKind::Ge => {
+                is_zero(cx, right, expr.span.ctxt()) && eq_expr_value(cx, ctxt, left, test)
+            },
+            BinOpKind::Lt | BinOpKind::Le => {
+                is_zero(cx, left, expr.span.ctxt()) && eq_expr_value(cx, ctxt, right, test)
+            },
             _ => false,
         }
     } else {
@@ -27,11 +31,15 @@ fn is_testing_positive(cx: &LateContext<'_>, expr: &Expr<'_>, test: &Expr<'_>) -
 }
 
 /// See [`is_testing_positive`]
-fn is_testing_negative(cx: &LateContext<'_>, expr: &Expr<'_>, test: &Expr<'_>) -> bool {
+fn is_testing_negative(cx: &LateContext<'_>, ctxt: SyntaxContext, expr: &Expr<'_>, test: &Expr<'_>) -> bool {
     if let ExprKind::Binary(Spanned { node: op, .. }, left, right) = expr.kind {
         match op {
-            BinOpKind::Gt | BinOpKind::Ge => is_zero(cx, left, expr.span.ctxt()) && eq_expr_value(cx, right, test),
-            BinOpKind::Lt | BinOpKind::Le => is_zero(cx, right, expr.span.ctxt()) && eq_expr_value(cx, left, test),
+            BinOpKind::Gt | BinOpKind::Ge => {
+                is_zero(cx, left, expr.span.ctxt()) && eq_expr_value(cx, ctxt, right, test)
+            },
+            BinOpKind::Lt | BinOpKind::Le => {
+                is_zero(cx, right, expr.span.ctxt()) && eq_expr_value(cx, ctxt, left, test)
+            },
             _ => false,
         }
     } else {
@@ -55,14 +63,21 @@ fn is_zero(cx: &LateContext<'_>, expr: &Expr<'_>, ctxt: SyntaxContext) -> bool {
 /// one of the two expressions
 /// If the two expressions are not negations of each other, then it
 /// returns None.
-fn are_negated<'a>(cx: &LateContext<'_>, expr1: &'a Expr<'a>, expr2: &'a Expr<'a>) -> Option<(bool, &'a Expr<'a>)> {
+fn are_negated<'a>(
+    cx: &LateContext<'_>,
+    ctxt: SyntaxContext,
+    expr1: &'a Expr<'a>,
+    expr2: &'a Expr<'a>,
+) -> Option<(bool, &'a Expr<'a>)> {
     if let ExprKind::Unary(UnOp::Neg, expr1_negated) = expr1.kind
-        && eq_expr_value(cx, expr1_negated, expr2)
+        && expr1_negated.span.ctxt() == ctxt
+        && eq_expr_value(cx, ctxt, expr1_negated, expr2)
     {
         return Some((false, expr2));
     }
     if let ExprKind::Unary(UnOp::Neg, expr2_negated) = expr2.kind
-        && eq_expr_value(cx, expr1, expr2_negated)
+        && expr2_negated.span.ctxt() == ctxt
+        && eq_expr_value(cx, ctxt, expr1, expr2_negated)
     {
         return Some((true, expr1));
     }
@@ -77,11 +92,12 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
     }) = higher::If::hir(expr)
         && let if_body_expr = peel_blocks(then)
         && let else_body_expr = peel_blocks(r#else)
-        && let Some((if_expr_positive, body)) = are_negated(cx, if_body_expr, else_body_expr)
+        && let ctxt = expr.span.ctxt()
+        && let Some((if_expr_positive, body)) = are_negated(cx, ctxt, if_body_expr, else_body_expr)
     {
-        let sugg_positive_abs = if is_testing_positive(cx, cond, body) {
+        let sugg_positive_abs = if is_testing_positive(cx, ctxt, cond, body) {
             if_expr_positive
-        } else if is_testing_negative(cx, cond, body) {
+        } else if is_testing_negative(cx, ctxt, cond, body) {
             !if_expr_positive
         } else {
             return;

--- a/clippy_lints/src/floating_point_arithmetic/hypot.rs
+++ b/clippy_lints/src/floating_point_arithmetic/hypot.rs
@@ -19,6 +19,7 @@ pub(super) fn detect(cx: &LateContext<'_>, receiver: &Expr<'_>, app: &mut Applic
         add_rhs,
     ) = receiver.kind
     {
+        let ctxt = receiver.span.ctxt();
         // check if expression of the form x * x + y * y
         if let ExprKind::Binary(
             Spanned {
@@ -34,8 +35,8 @@ pub(super) fn detect(cx: &LateContext<'_>, receiver: &Expr<'_>, app: &mut Applic
                 rmul_lhs,
                 rmul_rhs,
             ) = add_rhs.kind
-            && eq_expr_value(cx, lmul_lhs, lmul_rhs)
-            && eq_expr_value(cx, rmul_lhs, rmul_rhs)
+            && eq_expr_value(cx, ctxt, lmul_lhs, lmul_rhs)
+            && eq_expr_value(cx, ctxt, rmul_lhs, rmul_rhs)
         {
             return Some(format!(
                 "{}.hypot({})",

--- a/clippy_lints/src/floating_point_arithmetic/log_division.rs
+++ b/clippy_lints/src/floating_point_arithmetic/log_division.rs
@@ -4,18 +4,18 @@ use clippy_utils::{eq_expr_value, sym};
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, PathSegment};
 use rustc_lint::LateContext;
-use rustc_span::Spanned;
+use rustc_span::{Spanned, SyntaxContext};
 
 use super::SUBOPTIMAL_FLOPS;
 
-fn are_same_base_logs(cx: &LateContext<'_>, expr_a: &Expr<'_>, expr_b: &Expr<'_>) -> bool {
+fn are_same_base_logs(cx: &LateContext<'_>, ctxt: SyntaxContext, expr_a: &Expr<'_>, expr_b: &Expr<'_>) -> bool {
     if let ExprKind::MethodCall(PathSegment { ident: method_a, .. }, _, args_a, _) = expr_a.kind
         && let ExprKind::MethodCall(PathSegment { ident: method_b, .. }, _, args_b, _) = expr_b.kind
     {
         return method_a.name == method_b.name
             && args_a.len() == args_b.len()
             && (matches!(method_a.name, sym::ln | sym::log2 | sym::log10)
-                || method_a.name == sym::log && args_a.len() == 1 && eq_expr_value(cx, &args_a[0], &args_b[0]));
+                || method_a.name == sym::log && args_a.len() == 1 && eq_expr_value(cx, ctxt, &args_a[0], &args_b[0]));
     }
 
     false
@@ -30,7 +30,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
         lhs,
         rhs,
     ) = expr.kind
-        && are_same_base_logs(cx, lhs, rhs)
+        && are_same_base_logs(cx, expr.span.ctxt(), lhs, rhs)
         && let ExprKind::MethodCall(_, largs_self, ..) = lhs.kind
         && let ExprKind::MethodCall(_, rargs_self, ..) = rhs.kind
     {

--- a/clippy_lints/src/ifs/if_same_then_else.rs
+++ b/clippy_lints/src/ifs/if_same_then_else.rs
@@ -3,6 +3,7 @@ use clippy_utils::diagnostics::span_lint_and_note;
 use clippy_utils::higher::has_let_expr;
 use rustc_hir::{Block, Expr};
 use rustc_lint::LateContext;
+use rustc_span::SyntaxContext;
 
 use super::IF_SAME_THEN_ELSE;
 
@@ -12,7 +13,10 @@ pub(super) fn check(cx: &LateContext<'_>, conds: &[&Expr<'_>], blocks: &[&Block<
         .array_windows::<2>()
         .enumerate()
         .fold(true, |all_eq, (i, &[lhs, rhs])| {
-            if eq.eq_block(lhs, rhs) && !has_let_expr(conds[i]) && conds.get(i + 1).is_none_or(|e| !has_let_expr(e)) {
+            if eq.eq_block(SyntaxContext::root(), lhs, rhs)
+                && !has_let_expr(conds[i])
+                && conds.get(i + 1).is_none_or(|e| !has_let_expr(e))
+            {
                 span_lint_and_note(
                     cx,
                     IF_SAME_THEN_ELSE,

--- a/clippy_lints/src/ifs/ifs_same_cond.rs
+++ b/clippy_lints/src/ifs/ifs_same_cond.rs
@@ -4,6 +4,7 @@ use clippy_utils::ty::InteriorMut;
 use clippy_utils::{SpanlessEq, eq_expr_value, find_binding_init, hash_expr, search_same};
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::LateContext;
+use rustc_span::SyntaxContext;
 
 use super::IFS_SAME_COND;
 
@@ -34,10 +35,10 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, conds: &[&Expr<'_>], interior_
                 if method_caller_is_mutable(cx, caller, interior_mut) {
                     false
                 } else {
-                    SpanlessEq::new(cx).eq_expr(lhs, rhs)
+                    SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), lhs, rhs)
                 }
             } else {
-                eq_expr_value(cx, lhs, rhs)
+                eq_expr_value(cx, SyntaxContext::root(), lhs, rhs)
             }
         },
     ) {

--- a/clippy_lints/src/ifs/same_functions_in_if_cond.rs
+++ b/clippy_lints/src/ifs/same_functions_in_if_cond.rs
@@ -2,6 +2,7 @@ use clippy_utils::diagnostics::span_lint;
 use clippy_utils::{SpanlessEq, eq_expr_value, hash_expr, search_same};
 use rustc_hir::Expr;
 use rustc_lint::LateContext;
+use rustc_span::SyntaxContext;
 
 use super::SAME_FUNCTIONS_IN_IF_CONDITION;
 
@@ -13,10 +14,10 @@ pub(super) fn check(cx: &LateContext<'_>, conds: &[&Expr<'_>]) {
             return false;
         }
         // Do not spawn warning if `IFS_SAME_COND` already produced it.
-        if eq_expr_value(cx, lhs, rhs) {
+        if eq_expr_value(cx, SyntaxContext::root(), lhs, rhs) {
             return false;
         }
-        SpanlessEq::new(cx).eq_expr(lhs, rhs)
+        SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), lhs, rhs)
     };
 
     for group in search_same(conds, |e| hash_expr(cx, e), eq) {

--- a/clippy_lints/src/implicit_saturating_add.rs
+++ b/clippy_lints/src/implicit_saturating_add.rs
@@ -67,7 +67,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitSaturatingAdd {
             && let ctxt = expr.span.ctxt()
             && ex.span.ctxt() == ctxt
             && cond.span.ctxt() == ctxt
-            && clippy_utils::SpanlessEq::new(cx).eq_expr(l, target)
+            && clippy_utils::SpanlessEq::new(cx).eq_expr(ctxt, l, target)
             && AssignOpKind::AddAssign == op1.node
             && let ExprKind::Lit(lit) = value.kind
             && let LitKind::Int(Pu128(1), LitIntType::Unsuffixed) = lit.node

--- a/clippy_lints/src/implicit_saturating_sub.rs
+++ b/clippy_lints/src/implicit_saturating_sub.rs
@@ -184,7 +184,7 @@ fn check_gt(
     msrv: Msrv,
     is_composited: bool,
 ) {
-    if is_side_effect_free(cx, big_expr) && is_side_effect_free(cx, little_expr) {
+    if !big_expr.can_have_side_effects() && !little_expr.can_have_side_effects() {
         check_subtraction(
             cx,
             condition_span,
@@ -197,10 +197,6 @@ fn check_gt(
             is_composited,
         );
     }
-}
-
-fn is_side_effect_free(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    eq_expr_value(cx, expr, expr)
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -242,7 +238,8 @@ fn check_subtraction(
         && let ExprKind::Binary(op, left, right) = if_block.kind
         && let BinOpKind::Sub = op.node
     {
-        if eq_expr_value(cx, left, big_expr) && eq_expr_value(cx, right, little_expr) {
+        let ctxt = expr_span.ctxt();
+        if eq_expr_value(cx, ctxt, left, big_expr) && eq_expr_value(cx, ctxt, right, little_expr) {
             // This part of the condition is voluntarily split from the one before to ensure that
             // if `snippet_opt` fails, it won't try the next conditions.
             if !is_in_const_context(cx) || msrv.meets(cx, msrvs::SATURATING_SUB_CONST) {
@@ -277,8 +274,8 @@ fn check_subtraction(
                     },
                 );
             }
-        } else if eq_expr_value(cx, left, little_expr)
-            && eq_expr_value(cx, right, big_expr)
+        } else if eq_expr_value(cx, ctxt, left, little_expr)
+            && eq_expr_value(cx, ctxt, right, big_expr)
             && let Some(big_expr_sugg) = Sugg::hir_opt(cx, big_expr)
             && let Some(little_expr_sugg) = Sugg::hir_opt(cx, little_expr)
         {
@@ -322,14 +319,15 @@ fn check_with_condition<'tcx>(
         // Extracting out the variable name
         && let ExprKind::Path(QPath::Resolved(_, ares_path)) = target.kind
     {
+        let ctxt = expr.span.ctxt();
         // Handle symmetric conditions in the if statement
-        let (cond_var, cond_num_val) = if SpanlessEq::new(cx).eq_expr(cond_left, target) {
+        let (cond_var, cond_num_val) = if SpanlessEq::new(cx).eq_expr(ctxt, cond_left, target) {
             if BinOpKind::Gt == cond_op || BinOpKind::Ne == cond_op {
                 (cond_left, cond_right)
             } else {
                 return;
             }
-        } else if SpanlessEq::new(cx).eq_expr(cond_right, target) {
+        } else if SpanlessEq::new(cx).eq_expr(ctxt, cond_right, target) {
             if BinOpKind::Lt == cond_op || BinOpKind::Ne == cond_op {
                 (cond_right, cond_left)
             } else {
@@ -389,7 +387,7 @@ fn subtracts_one<'a>(cx: &LateContext<'_>, expr: &'a Expr<'a>) -> Option<&'a Exp
         ExprKind::Assign(target, value, _) => {
             if let ExprKind::Binary(ref op1, left1, right1) = value.kind
                 && BinOpKind::Sub == op1.node
-                && SpanlessEq::new(cx).eq_expr(left1, target)
+                && SpanlessEq::new(cx).eq_expr(expr.span.ctxt(), left1, target)
                 && is_integer_literal(right1, 1)
             {
                 Some(target)

--- a/clippy_lints/src/loops/char_indices_as_byte_indices.rs
+++ b/clippy_lints/src/loops/char_indices_as_byte_indices.rs
@@ -89,13 +89,13 @@ fn check_index_usage<'tcx>(
             // `Index` directly and no deref to `str` would happen in that case).
             if cx.typeck_results().expr_ty_adjusted(recv).peel_refs().is_str()
                 && BYTE_INDEX_METHODS.contains(&segment.ident.name)
-                && eq_expr_value(cx, chars_recv, recv) =>
+                && eq_expr_value(cx, expr.span.ctxt(), chars_recv, recv) =>
         {
             "passing a character position to a method that expects a byte index"
         },
         ExprKind::Index(target, ..)
             if is_string_like(cx.typeck_results().expr_ty_adjusted(target).peel_refs())
-                && eq_expr_value(cx, chars_recv, target) =>
+                && eq_expr_value(cx, expr.span.ctxt(), chars_recv, target) =>
         {
             "indexing into a string with a character position where a byte index is expected"
         },

--- a/clippy_lints/src/loops/manual_while_let_some.rs
+++ b/clippy_lints/src/loops/manual_while_let_some.rs
@@ -65,7 +65,7 @@ fn is_vec_pop_unwrap(cx: &LateContext<'_>, expr: &Expr<'_>, is_empty_recv: &Expr
         && let ExprKind::MethodCall(_, pop_recv, ..) = unwrap_recv.kind
     {
         // make sure they're the same `Vec`
-        SpanlessEq::new(cx).eq_expr(pop_recv, is_empty_recv)
+        SpanlessEq::new(cx).eq_expr(expr.span.ctxt(), pop_recv, is_empty_recv)
     } else {
         false
     }

--- a/clippy_lints/src/loops/needless_range_loop.rs
+++ b/clippy_lints/src/loops/needless_range_loop.rs
@@ -101,8 +101,9 @@ pub(super) fn check<'tcx>(
                 if let ExprKind::Binary(ref op, left, right) = end.kind
                     && op.node == BinOpKind::Add
                 {
-                    let start_equal_left = SpanlessEq::new(cx).eq_expr(start, left);
-                    let start_equal_right = SpanlessEq::new(cx).eq_expr(start, right);
+                    let ctxt = start.span.ctxt();
+                    let start_equal_left = SpanlessEq::new(cx).eq_expr(ctxt, start, left);
+                    let start_equal_right = SpanlessEq::new(cx).eq_expr(ctxt, start, right);
 
                     if start_equal_left {
                         take_expr = right;

--- a/clippy_lints/src/manual_abs_diff.rs
+++ b/clippy_lints/src/manual_abs_diff.rs
@@ -121,12 +121,12 @@ fn is_sub_expr(
     expected_b: &Expr<'_>,
     expected_ty: Ty<'_>,
 ) -> bool {
-    let expr = peel_blocks(expr).kind;
+    let expr = peel_blocks(expr);
 
     if let ty::Int(ty) = expected_ty.kind() {
         let unsigned = Ty::new_uint(cx.tcx, ty.to_unsigned());
 
-        return if let ExprKind::Cast(expr, cast_ty) = expr
+        return if let ExprKind::Cast(expr, cast_ty) = expr.kind
             && cx.typeck_results().node_type(cast_ty.hir_id) == unsigned
         {
             is_sub_expr(cx, expr, expected_a, expected_b, unsigned)
@@ -135,10 +135,11 @@ fn is_sub_expr(
         };
     }
 
-    if let ExprKind::Binary(op, a, b) = expr
+    let ctxt = expr.span.ctxt();
+    if let ExprKind::Binary(op, a, b) = expr.kind
         && let BinOpKind::Sub = op.node
-        && eq_expr_value(cx, a, expected_a)
-        && eq_expr_value(cx, b, expected_b)
+        && eq_expr_value(cx, ctxt, a, expected_a)
+        && eq_expr_value(cx, ctxt, b, expected_b)
     {
         true
     } else {

--- a/clippy_lints/src/manual_checked_ops.rs
+++ b/clippy_lints/src/manual_checked_ops.rs
@@ -5,6 +5,7 @@ use rustc_hir::{AssignOpKind, BinOpKind, Block, Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_session::declare_lint_pass;
+use rustc_span::SyntaxContext;
 use std::ops::ControlFlow;
 
 declare_clippy_lint! {
@@ -60,7 +61,7 @@ impl LateLintPass<'_> for ManualCheckedOps {
             && let Some(block) = branch_block(then, r#else, branch)
         {
             let mut eq = SpanlessEq::new(cx).deny_side_effects().paths_by_resolution();
-            if !eq.eq_expr(divisor, divisor) {
+            if !eq.eq_expr(SyntaxContext::root(), divisor, divisor) {
                 return;
             }
 
@@ -70,7 +71,7 @@ impl LateLintPass<'_> for ManualCheckedOps {
             let found_early_use = for_each_expr_without_closures(block, |e| {
                 if let ExprKind::Binary(binop, lhs, rhs) = e.kind
                     && binop.node == BinOpKind::Div
-                    && eq.eq_expr(rhs, divisor)
+                    && eq.eq_expr(SyntaxContext::root(), rhs, divisor)
                     && is_unsigned_integer(cx, lhs)
                 {
                     match first_use {
@@ -84,7 +85,7 @@ impl LateLintPass<'_> for ManualCheckedOps {
                     ControlFlow::<(), _>::Continue(Descend::No)
                 } else if let ExprKind::AssignOp(op, lhs, rhs) = e.kind
                     && op.node == AssignOpKind::DivAssign
-                    && eq.eq_expr(rhs, divisor)
+                    && eq.eq_expr(SyntaxContext::root(), rhs, divisor)
                     && is_unsigned_integer(cx, lhs)
                 {
                     match first_use {
@@ -96,7 +97,7 @@ impl LateLintPass<'_> for ManualCheckedOps {
                     division_spans.push(e.span);
 
                     ControlFlow::<(), _>::Continue(Descend::No)
-                } else if eq.eq_expr(e, divisor) {
+                } else if eq.eq_expr(SyntaxContext::root(), e, divisor) {
                     if first_use.is_none() {
                         first_use = Some(UseKind::Other);
                         return ControlFlow::Break(());

--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -15,7 +15,7 @@ use rustc_hir::{Arm, BinOpKind, Block, Expr, ExprKind, HirId, PatKind, PathSegme
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::Ty;
 use rustc_session::impl_lint_pass;
-use rustc_span::Span;
+use rustc_span::{Span, SyntaxContext};
 use std::cmp::Ordering;
 use std::ops::Deref;
 
@@ -261,6 +261,7 @@ fn is_if_elseif_else_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx
     {
         let params = is_clamp_meta_pattern(
             cx,
+            expr.span.ctxt(),
             &BinaryOp::new(peel_blocks(cond))?,
             &BinaryOp::new(peel_blocks(else_if_cond))?,
             peel_blocks(then),
@@ -268,7 +269,7 @@ fn is_if_elseif_else_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx
             None,
         )?;
         // Contents of the else should be the resolved input.
-        if !eq_expr_value(cx, params.input, peel_blocks(else_body)) {
+        if !eq_expr_value(cx, expr.span.ctxt(), params.input, peel_blocks(else_body)) {
             return None;
         }
         Some(ClampSuggestion {
@@ -445,6 +446,7 @@ fn is_match_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> Opt
         }
         if let Some(params) = is_clamp_meta_pattern(
             cx,
+            expr.span.ctxt(),
             &first,
             &second,
             first_expr,
@@ -496,11 +498,14 @@ fn is_two_if_pattern<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) -> 
                     peel_blocks_with_stmt(first_then).kind
                 && let ExprKind::Assign(maybe_input_second_path, maybe_min_max_second, _) =
                     peel_blocks_with_stmt(second_then).kind
-                && eq_expr_value(cx, maybe_input_first_path, maybe_input_second_path)
+                && let ctxt = first_expr.span.ctxt()
+                && second_expr.span.ctxt() == ctxt
+                && eq_expr_value(cx, ctxt, maybe_input_first_path, maybe_input_second_path)
                 && let Some(first_bin) = BinaryOp::new(first_cond)
                 && let Some(second_bin) = BinaryOp::new(second_cond)
                 && let Some(input_min_max) = is_clamp_meta_pattern(
                     cx,
+                    ctxt,
                     &first_bin,
                     &second_bin,
                     maybe_min_max_first,
@@ -552,15 +557,17 @@ fn is_if_elseif_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) ->
         && let ExprKind::Assign(maybe_input_second_path, maybe_min_max_second, _) =
             peel_blocks_with_stmt(else_if_then).kind
     {
+        let ctxt = expr.span.ctxt();
         let params = is_clamp_meta_pattern(
             cx,
+            ctxt,
             &BinaryOp::new(peel_blocks(cond))?,
             &BinaryOp::new(peel_blocks(else_if_cond))?,
             peel_blocks(maybe_min_max_first),
             peel_blocks(maybe_min_max_second),
             None,
         )?;
-        if !eq_expr_value(cx, maybe_input_first_path, maybe_input_second_path) {
+        if !eq_expr_value(cx, ctxt, maybe_input_first_path, maybe_input_second_path) {
             return None;
         }
         Some(ClampSuggestion {
@@ -631,6 +638,7 @@ impl<'tcx> BinaryOp<'tcx> {
 ///   result can not be the shared argument in either case.
 fn is_clamp_meta_pattern<'tcx>(
     cx: &LateContext<'tcx>,
+    ctxt: SyntaxContext,
     first_bin: &BinaryOp<'tcx>,
     second_bin: &BinaryOp<'tcx>,
     first_expr: &'tcx Expr<'tcx>,
@@ -642,8 +650,10 @@ fn is_clamp_meta_pattern<'tcx>(
     // be the input variable, not the min or max.
     input_hir_ids: Option<(HirId, HirId)>,
 ) -> Option<InputMinMax<'tcx>> {
+    #[expect(clippy::too_many_arguments)]
     fn check<'tcx>(
         cx: &LateContext<'tcx>,
+        ctxt: SyntaxContext,
         first_bin: &BinaryOp<'tcx>,
         second_bin: &BinaryOp<'tcx>,
         first_expr: &'tcx Expr<'tcx>,
@@ -659,11 +669,11 @@ fn is_clamp_meta_pattern<'tcx>(
                         peel_blocks(first_bin.left).res_local_id() == Some(first_hir_id)
                             && peel_blocks(second_bin.left).res_local_id() == Some(second_hir_id)
                     },
-                    None => eq_expr_value(cx, first_bin.left, second_bin.left),
+                    None => eq_expr_value(cx, ctxt, first_bin.left, second_bin.left),
                 };
                 (refers_to_input
-                    && eq_expr_value(cx, first_bin.right, first_expr)
-                    && eq_expr_value(cx, second_bin.right, second_expr))
+                    && eq_expr_value(cx, ctxt, first_bin.right, first_expr)
+                    && eq_expr_value(cx, ctxt, second_bin.right, second_expr))
                 .then_some(InputMinMax {
                     input: first_bin.left,
                     min,
@@ -699,9 +709,20 @@ fn is_clamp_meta_pattern<'tcx>(
     ];
 
     cases.into_iter().find_map(|(first, second)| {
-        check(cx, &first, &second, first_expr, second_expr, input_hir_ids, is_float).or_else(|| {
+        check(
+            cx,
+            ctxt,
+            &first,
+            &second,
+            first_expr,
+            second_expr,
+            input_hir_ids,
+            is_float,
+        )
+        .or_else(|| {
             check(
                 cx,
+                ctxt,
                 &second,
                 &first,
                 second_expr,

--- a/clippy_lints/src/manual_pop_if.rs
+++ b/clippy_lints/src/manual_pop_if.rs
@@ -212,7 +212,7 @@ fn check_is_some_and_pattern<'tcx>(
         && let ExprKind::Closure(closure) = closure_arg.kind
         && let body = cx.tcx.hir_body(closure.body)
         && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
-        && eq_expr_value(cx, collection_expr, pop_collection)
+        && eq_expr_value(cx, if_expr_span.ctxt(), collection_expr, pop_collection)
         && let Some(param) = body.params.first()
         && let Some(ident) = param.pat.simple_ident()
     {
@@ -274,7 +274,7 @@ fn check_if_let_pattern<'tcx>(
             if let ExprKind::If(inner_cond, inner_then, None) = inner_if.kind
                 && is_local_used(cx, inner_cond, binding_id)
                 && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, inner_then, pop_method)
-                && eq_expr_value(cx, collection_expr, pop_collection)
+                && eq_expr_value(cx, if_expr_span.ctxt(), collection_expr, pop_collection)
             {
                 return Some(ManualPopIfPattern {
                     kind,
@@ -327,7 +327,7 @@ fn check_let_chain_pattern<'tcx>(
             && kind.is_diag_item(cx, collection_expr)
             && is_local_used(cx, right, binding_id)
             && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
-            && eq_expr_value(cx, collection_expr, pop_collection)
+            && eq_expr_value(cx, if_expr_span.ctxt(), collection_expr, pop_collection)
         {
             return Some(ManualPopIfPattern {
                 kind,
@@ -372,7 +372,7 @@ fn check_map_unwrap_or_pattern<'tcx>(
         && let body = cx.tcx.hir_body(closure.body)
         && cx.typeck_results().expr_ty(body.value).is_bool()
         && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
-        && eq_expr_value(cx, collection_expr, pop_collection)
+        && eq_expr_value(cx, if_expr_span.ctxt(), collection_expr, pop_collection)
         && let Some(param) = body.params.first()
         && let Some(ident) = param.pat.simple_ident()
     {

--- a/clippy_lints/src/manual_retain.rs
+++ b/clippy_lints/src/manual_retain.rs
@@ -85,7 +85,7 @@ fn check_into_iter(
         && let Some(into_iter_def_id) = cx.typeck_results().type_dependent_def_id(into_iter_expr.hir_id)
         && Some(into_iter_def_id) == cx.tcx.lang_items().into_iter_fn()
         && match_acceptable_type(cx, left_expr, msrv)
-        && SpanlessEq::new(cx).eq_expr(left_expr, struct_expr)
+        && SpanlessEq::new(cx).eq_expr(parent_expr_span.ctxt(), left_expr, struct_expr)
         && let hir::ExprKind::MethodCall(_, _, [closure_expr], _) = target_expr.kind
         && let hir::ExprKind::Closure(closure) = closure_expr.kind
         && let filter_body = cx.tcx.hir_body(closure.body)
@@ -132,7 +132,7 @@ fn check_iter(
         && let Some(iter_expr_def_id) = cx.typeck_results().type_dependent_def_id(iter_expr.hir_id)
         && match_acceptable_sym(cx, iter_expr_def_id)
         && match_acceptable_type(cx, left_expr, msrv)
-        && SpanlessEq::new(cx).eq_expr(left_expr, struct_expr)
+        && SpanlessEq::new(cx).eq_expr(parent_expr_span.ctxt(), left_expr, struct_expr)
         && let hir::ExprKind::MethodCall(_, _, [closure_expr], _) = filter_expr.kind
         && let hir::ExprKind::Closure(closure) = closure_expr.kind
         && let filter_body = cx.tcx.hir_body(closure.body)
@@ -190,7 +190,7 @@ fn check_to_owned(
         && cx.tcx.is_diagnostic_item(sym::str_chars, chars_expr_def_id)
         && let ty = cx.typeck_results().expr_ty(str_expr).peel_refs()
         && ty.is_lang_item(cx, hir::LangItem::String)
-        && SpanlessEq::new(cx).eq_expr(left_expr, str_expr)
+        && SpanlessEq::new(cx).eq_expr(parent_expr_span.ctxt(), left_expr, str_expr)
         && let hir::ExprKind::MethodCall(_, _, [closure_expr], _) = filter_expr.kind
         && let hir::ExprKind::Closure(closure) = closure_expr.kind
         && let filter_body = cx.tcx.hir_body(closure.body)

--- a/clippy_lints/src/manual_strip.rs
+++ b/clippy_lints/src/manual_strip.rs
@@ -188,7 +188,7 @@ fn eq_pattern_length<'tcx>(
     {
         constant_length(cx, pattern, ctxt).is_some_and(|length| n == length)
     } else {
-        len_arg(cx, expr).is_some_and(|arg| eq_expr_value(cx, pattern, arg))
+        len_arg(cx, expr).is_some_and(|arg| eq_expr_value(cx, SyntaxContext::root(), pattern, arg))
     }
 }
 

--- a/clippy_lints/src/manual_take.rs
+++ b/clippy_lints/src/manual_take.rs
@@ -1,4 +1,5 @@
 use clippy_config::Conf;
+use clippy_utils::SpanlessEq;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::msrvs::{MEM_TAKE, Msrv};
 use clippy_utils::source::snippet_with_context;
@@ -74,10 +75,11 @@ impl LateLintPass<'_> for ManualTake {
             && let StmtKind::Semi(assignment) = stmt.kind
             && let ExprKind::Assign(mut_c, possible_false, _) = assignment.kind
             && let ExprKind::Path(_) = mut_c.kind
-            && !expr.span.in_external_macro(cx.sess().source_map())
+            && let ctxt = expr.span.ctxt()
+            && !ctxt.in_external_macro(cx.sess().source_map())
             && let Some(std_or_core) = clippy_utils::std_or_core(cx)
             && self.msrv.meets(cx, MEM_TAKE)
-            && clippy_utils::SpanlessEq::new(cx).eq_expr(cond, mut_c)
+            && SpanlessEq::new(cx).eq_expr(ctxt, cond, mut_c)
             && Some(false) == as_const_bool(possible_false)
             && let Some(then_bool) = as_const_bool(then_expr)
             && let Some(else_bool) = as_const_bool(else_expr)

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -14,12 +14,10 @@ use rustc_hir_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, PlaceBase, Pl
 use rustc_lint::LateContext;
 use rustc_middle::mir::FakeReadCause;
 use rustc_middle::ty;
-use rustc_span::symbol::Ident;
-use rustc_span::{BytePos, Span};
-
-use crate::collapsible_if::{parens_around, peel_parens};
+use rustc_span::{BytePos, Ident, Span, SyntaxContext};
 
 use super::{COLLAPSIBLE_MATCH, pat_contains_disallowed_or};
+use crate::collapsible_if::{parens_around, peel_parens};
 
 pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>], msrv: Msrv) {
     if let Some(els_arm) = arms.iter().rfind(|arm| arm_is_wild_like(cx, arm)) {
@@ -28,6 +26,7 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, ar
             let only_wildcards_after = last_non_wildcard.is_none_or(|lnw| idx >= lnw);
             check_arm(
                 cx,
+                arm.span.ctxt(),
                 true,
                 arm.pat,
                 expr,
@@ -43,18 +42,20 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, ar
 
 pub(super) fn check_if_let<'tcx>(
     cx: &LateContext<'tcx>,
+    ctxt: SyntaxContext,
     pat: &'tcx Pat<'_>,
     body: &'tcx Expr<'_>,
     else_expr: Option<&'tcx Expr<'_>>,
     let_expr: &'tcx Expr<'_>,
     msrv: Msrv,
 ) {
-    check_arm(cx, false, pat, let_expr, body, None, else_expr, msrv, false);
+    check_arm(cx, ctxt, false, pat, let_expr, body, None, else_expr, msrv, false);
 }
 
 #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
 fn check_arm<'tcx>(
     cx: &LateContext<'tcx>,
+    ctxt: SyntaxContext,
     outer_is_match: bool,
     outer_pat: &'tcx Pat<'tcx>,
     outer_cond: &'tcx Expr<'tcx>,
@@ -94,7 +95,7 @@ fn check_arm<'tcx>(
         && match (outer_else_body, inner_else_body) {
             (None, None) => true,
             (None, Some(e)) | (Some(e), None) => is_unit_expr(e),
-            (Some(a), Some(b)) => SpanlessEq::new(cx).eq_expr(a, b),
+            (Some(a), Some(b)) => SpanlessEq::new(cx).eq_expr(ctxt, a, b),
         }
         // the binding must not be used in the if guard
         && outer_guard.is_none_or(|e| !is_local_used(cx, e, binding_id))
@@ -145,7 +146,7 @@ fn check_arm<'tcx>(
         && match (outer_else_body, inner.r#else) {
             (None, None) => true,
             (None, Some(e)) | (Some(e), None) => is_unit_expr(e),
-            (Some(a), Some(b)) => SpanlessEq::new(cx).eq_expr(a, b),
+            (Some(a), Some(b)) => SpanlessEq::new(cx).eq_expr(ctxt, a, b),
         }
         && !pat_bindings_moved_or_mutated(cx, outer_pat, inner.cond)
     {

--- a/clippy_lints/src/matches/match_same_arms.rs
+++ b/clippy_lints/src/matches/match_same_arms.rs
@@ -13,7 +13,7 @@ use rustc_hir::{Arm, Expr, HirId, HirIdMap, HirIdMapEntry, HirIdSet, Pat, PatExp
 use rustc_lint::builtin::NON_EXHAUSTIVE_OMITTED_PATTERNS;
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::{self, TypeckResults};
-use rustc_span::{ByteSymbol, ErrorGuaranteed, Span, Symbol};
+use rustc_span::{ByteSymbol, ErrorGuaranteed, Span, Symbol, SyntaxContext};
 
 use super::MATCH_SAME_ARMS;
 
@@ -87,7 +87,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'_>]) {
 
             SpanlessEq::new(cx)
                 .expr_fallback(eq_fallback)
-                .eq_expr(expr_a, expr_b)
+                .eq_expr(SyntaxContext::root(), expr_a, expr_b)
                 // these checks could be removed to allow unused bindings
                 && bindings_eq(lhs.pat, local_map.keys().copied().collect())
                 && bindings_eq(rhs.pat, local_map.values().copied().collect())

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -1138,6 +1138,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
         } else if let Some(if_let) = higher::IfLet::hir(cx, expr) {
             collapsible_match::check_if_let(
                 cx,
+                if_let.let_span.ctxt(),
                 if_let.let_pat,
                 if_let.if_then,
                 if_let.if_else,

--- a/clippy_lints/src/methods/collapsible_str_replace.rs
+++ b/clippy_lints/src/methods/collapsible_str_replace.rs
@@ -23,7 +23,7 @@ pub(super) fn check<'tcx>(
         // of the last replace call in the current chain, don't lint as it was already linted
         if let Some(parent) = get_parent_expr(cx, expr)
             && let Some((sym::replace, _, [current_from, current_to], _, _)) = method_call(parent)
-            && eq_expr_value(cx, to, current_to)
+            && eq_expr_value(cx, parent.span.ctxt(), to, current_to)
             && from_kind == cx.typeck_results().expr_ty(current_from).peel_refs().kind()
         {
             return;
@@ -46,9 +46,10 @@ fn collect_replace_calls<'tcx>(
     let mut methods = VecDeque::new();
     let mut from_args = VecDeque::new();
 
+    let ctxt = expr.span.ctxt();
     let _: Option<()> = for_each_expr_without_closures(expr, |e| {
         if let Some((sym::replace, _, [from, to], _, _)) = method_call(e) {
-            if eq_expr_value(cx, to_arg, to) && cx.typeck_results().expr_ty(from).peel_refs().is_char() {
+            if eq_expr_value(cx, ctxt, to_arg, to) && cx.typeck_results().expr_ty(from).peel_refs().is_char() {
                 methods.push_front(e);
                 from_args.push_front(from);
                 ControlFlow::Continue(())

--- a/clippy_lints/src/methods/filter_map.rs
+++ b/clippy_lints/src/methods/filter_map.rs
@@ -11,8 +11,8 @@ use rustc_hir::{Closure, Expr, ExprKind, PatKind, PathSegment, QPath, UnOp};
 use rustc_lint::LateContext;
 use rustc_middle::ty::TypeckResults;
 use rustc_middle::ty::adjustment::Adjust;
-use rustc_span::Span;
 use rustc_span::symbol::{Ident, Symbol};
+use rustc_span::{Span, SyntaxContext};
 
 use super::{MANUAL_FILTER_MAP, MANUAL_FIND_MAP, OPTION_FILTER_MAP, RESULT_FILTER_MAP};
 
@@ -109,6 +109,7 @@ impl<'tcx> OffendingFilterExpr<'tcx> {
     pub fn check_map_call(
         &self,
         cx: &LateContext<'tcx>,
+        ctxt: SyntaxContext,
         map_body: &'tcx Body<'tcx>,
         map_param_id: HirId,
         filter_param_id: HirId,
@@ -150,7 +151,7 @@ impl<'tcx> OffendingFilterExpr<'tcx> {
                             && a_typeck_results.expr_ty_adjusted(a) == b_typeck_results.expr_ty_adjusted(b)
                     })
                     && (simple_equal
-                        || SpanlessEq::new(cx).expr_fallback(eq_fallback).eq_expr(receiver, map_arg_peeled))
+                        || SpanlessEq::new(cx).expr_fallback(eq_fallback).eq_expr(ctxt, receiver, map_arg_peeled))
                 {
                     Some(CheckResult::Method {
                         map_arg,
@@ -323,7 +324,9 @@ pub(super) fn check(
         return;
     }
 
-    if let Some((map_param_ident, check_result)) = is_find_or_filter(cx, map_recv, filter_arg, map_arg) {
+    if let Some((map_param_ident, check_result)) =
+        is_find_or_filter(cx, expr.span.ctxt(), map_recv, filter_arg, map_arg)
+    {
         let span = filter_span.with_hi(expr.span.hi());
         let (filter_name, lint) = if is_find {
             ("find", MANUAL_FIND_MAP)
@@ -397,6 +400,7 @@ pub(super) fn check(
 
 fn is_find_or_filter<'a>(
     cx: &LateContext<'a>,
+    ctxt: SyntaxContext,
     map_recv: &Expr<'_>,
     filter_arg: &Expr<'_>,
     map_arg: &Expr<'_>,
@@ -422,7 +426,7 @@ fn is_find_or_filter<'a>(
         && let PatKind::Binding(_, map_param_id, map_param_ident, None) = map_param.pat.kind
 
         && let Some(check_result) =
-            offending_expr.check_map_call(cx, map_body, map_param_id, filter_param_id, is_filter_param_ref)
+            offending_expr.check_map_call(cx, ctxt, map_body, map_param_id, filter_param_id, is_filter_param_ref)
     {
         return Some((map_param_ident, check_result));
     }

--- a/clippy_lints/src/methods/get_last_with_len.rs
+++ b/clippy_lints/src/methods/get_last_with_len.rs
@@ -27,7 +27,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg:
         && is_integer_literal(rhs, 1)
 
         // check that recv == lhs_recv `recv.get(lhs_recv.len() - 1)`
-        && SpanlessEq::new(cx).eq_expr(recv, lhs_recv)
+        && SpanlessEq::new(cx).eq_expr(expr.span.ctxt(), recv, lhs_recv)
         && !recv.can_have_side_effects()
     {
         let method = match cx.typeck_results().expr_ty_adjusted(recv).peel_refs().kind() {

--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -256,7 +256,7 @@ pub(super) fn check_or<'tcx>(
             .expr_ty_adjusted(some_recv)
             .peel_refs()
             .is_diag_item(cx, sym::Option)
-        && SpanlessEq::new(cx).eq_expr(none_recv, some_recv)
+        && SpanlessEq::new(cx).eq_expr(expr.span.ctxt(), none_recv, some_recv)
     {
         (some_recv, some_arg)
     } else {

--- a/clippy_lints/src/methods/no_effect_replace.rs
+++ b/clippy_lints/src/methods/no_effect_replace.rs
@@ -28,7 +28,7 @@ pub(super) fn check<'tcx>(
         return;
     }
 
-    if SpanlessEq::new(cx).eq_expr(arg1, arg2) {
+    if SpanlessEq::new(cx).eq_expr(expr.span.ctxt(), arg1, arg2) {
         span_lint(cx, NO_EFFECT_REPLACE, expr.span, "replacing text with itself");
     }
 }

--- a/clippy_lints/src/methods/range_zip_with_len.rs
+++ b/clippy_lints/src/methods/range_zip_with_len.rs
@@ -19,7 +19,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'
         // `.iter()` and `.len()` called on same `Path`
         && let ExprKind::Path(QPath::Resolved(_, iter_path)) = recv.kind
         && let ExprKind::Path(QPath::Resolved(_, len_path)) = len_recv.kind
-        && SpanlessEq::new(cx).eq_path_segments(iter_path.segments, len_path.segments)
+        && SpanlessEq::new(cx).eq_path_segments(expr.span.ctxt(), iter_path.segments, len_path.segments)
     {
         span_lint_and_then(
             cx,

--- a/clippy_lints/src/methods/unnecessary_iter_cloned.rs
+++ b/clippy_lints/src/methods/unnecessary_iter_cloned.rs
@@ -66,7 +66,7 @@ pub fn check_for_loop_iter(
                 for_each_expr_without_closures(block, |e| {
                     match e.kind {
                         ExprKind::Assign(assignee, _, _) | ExprKind::AssignOp(_, assignee, _) => {
-                            change |= !can_mut_borrow_both(cx, caller, assignee);
+                            change |= !can_mut_borrow_both(cx, body.span.ctxt(), caller, assignee);
                         },
                         _ => {},
                     }

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -238,7 +238,9 @@ fn used_underscore_binding<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
 /// of what it means for an expression to be "used".
 fn is_used(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     get_parent_expr(cx, expr).is_none_or(|parent| match parent.kind {
-        ExprKind::Assign(_, rhs, _) | ExprKind::AssignOp(_, _, rhs) => SpanlessEq::new(cx).eq_expr(rhs, expr),
+        ExprKind::Assign(_, rhs, _) | ExprKind::AssignOp(_, _, rhs) => {
+            SpanlessEq::new(cx).eq_expr(parent.span.ctxt(), rhs, expr)
+        },
         _ => is_used(cx, parent),
     })
 }

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -245,7 +245,10 @@ fn check_index<'hir>(cx: &LateContext<'_>, expr: &'hir Expr<'hir>, map: &mut Uni
         let hash = hash_expr(cx, slice);
 
         let indexes = map.entry(hash).or_default();
-        let entry = indexes.iter_mut().find(|entry| eq_expr_value(cx, entry.slice(), slice));
+        let ctxt = expr.span.ctxt();
+        let entry = indexes
+            .iter_mut()
+            .find(|entry| eq_expr_value(cx, ctxt, entry.slice(), slice));
 
         if let Some(entry) = entry {
             match entry {
@@ -305,7 +308,10 @@ fn check_assert<'hir>(cx: &LateContext<'_>, expr: &'hir Expr<'hir>, map: &mut Un
         let hash = hash_expr(cx, slice);
         let indexes = map.entry(hash).or_default();
 
-        let entry = indexes.iter_mut().find(|entry| eq_expr_value(cx, entry.slice(), slice));
+        let ctxt = expr.span.ctxt();
+        let entry = indexes
+            .iter_mut()
+            .find(|entry| eq_expr_value(cx, ctxt, entry.slice(), slice));
 
         if let Some(entry) = entry {
             if let IndexEntry::IndexWithoutAssert {

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -10,6 +10,7 @@ use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
+use rustc_span::SyntaxContext;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -169,7 +170,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
             }
             if let Some((lhs_a, a)) = fetch_assign(then)
                 && let Some((lhs_b, b)) = fetch_assign(else_expr)
-                && SpanlessEq::new(cx).eq_expr(lhs_a, lhs_b)
+                && SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), lhs_a, lhs_b)
             {
                 let mut applicability = Applicability::MachineApplicable;
                 let cond = Sugg::hir_with_context(cx, cond, e.span.ctxt(), "..", &mut applicability);

--- a/clippy_lints/src/operators/assign_op_pattern.rs
+++ b/clippy_lints/src/operators/assign_op_pattern.rs
@@ -89,9 +89,10 @@ pub(super) fn check<'tcx>(
             }
         };
 
+        let ctxt = expr.span.ctxt();
         let mut found = false;
         let found_multiple = for_each_expr_without_closures(e, |e| {
-            if eq_expr_value(cx, assignee, e) {
+            if eq_expr_value(cx, ctxt, assignee, e) {
                 if found {
                     return ControlFlow::Break(());
                 }
@@ -103,12 +104,12 @@ pub(super) fn check<'tcx>(
 
         if found && !found_multiple {
             // a = a op b
-            if eq_expr_value(cx, assignee, l) {
+            if eq_expr_value(cx, ctxt, assignee, l) {
                 lint(assignee, r);
             }
             // a = b commutative_op a
             // Limited to primitive type as these ops are know to be commutative
-            if eq_expr_value(cx, assignee, r) && cx.typeck_results().expr_ty(assignee).is_primitive_ty() {
+            if eq_expr_value(cx, ctxt, assignee, r) && cx.typeck_results().expr_ty(assignee).is_primitive_ty() {
                 match op.node {
                     hir::BinOpKind::Add
                     | hir::BinOpKind::Mul

--- a/clippy_lints/src/operators/const_comparisons.rs
+++ b/clippy_lints/src/operators/const_comparisons.rs
@@ -63,7 +63,7 @@ pub(super) fn check<'tcx>(
         && left_type == right_type
 
         // Check that the same expression is compared in both comparisons
-        && SpanlessEq::new(cx).eq_expr(left_expr, right_expr)
+        && SpanlessEq::new(cx).eq_expr(span.ctxt(), left_expr, right_expr)
 
         && !left_expr.can_have_side_effects()
 

--- a/clippy_lints/src/operators/double_comparison.rs
+++ b/clippy_lints/src/operators/double_comparison.rs
@@ -11,8 +11,9 @@ use super::DOUBLE_COMPARISONS;
 pub(super) fn check(cx: &LateContext<'_>, op: BinOpKind, lhs: &Expr<'_>, rhs: &Expr<'_>, span: Span) {
     if let ExprKind::Binary(lop, llhs, lrhs) = lhs.kind
         && let ExprKind::Binary(rop, rlhs, rrhs) = rhs.kind
-        && eq_expr_value(cx, llhs, rlhs)
-        && eq_expr_value(cx, lrhs, rrhs)
+        && let ctxt = span.ctxt()
+        && eq_expr_value(cx, ctxt, llhs, rlhs)
+        && eq_expr_value(cx, ctxt, lrhs, rrhs)
     {
         let op = match (op, lop.node, rop.node) {
             // x == y || x < y => x <= y

--- a/clippy_lints/src/operators/eq_op.rs
+++ b/clippy_lints/src/operators/eq_op.rs
@@ -14,7 +14,7 @@ pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
             Some(sym::assert_eq_macro | sym::assert_ne_macro | sym::debug_assert_eq_macro | sym::debug_assert_ne_macro)
         )
     }) && let Some((lhs, rhs, _)) = find_assert_eq_args(cx, e, macro_call.expn)
-        && eq_expr_value(cx, lhs, rhs)
+        && eq_expr_value(cx, macro_call.span.ctxt(), lhs, rhs)
         && macro_call.is_local()
         && !is_in_test_function(cx.tcx, e.hir_id)
     {
@@ -37,7 +37,10 @@ pub(crate) fn check<'tcx>(
     left: &'tcx Expr<'_>,
     right: &'tcx Expr<'_>,
 ) {
-    if is_useless_with_eq_exprs(op) && eq_expr_value(cx, left, right) && !is_in_test_function(cx.tcx, e.hir_id) {
+    if is_useless_with_eq_exprs(op)
+        && eq_expr_value(cx, e.span.ctxt(), left, right)
+        && !is_in_test_function(cx.tcx, e.hir_id)
+    {
         span_lint_and_then(
             cx,
             EQ_OP,

--- a/clippy_lints/src/operators/misrefactored_assign_op.rs
+++ b/clippy_lints/src/operators/misrefactored_assign_op.rs
@@ -19,9 +19,10 @@ pub(super) fn check<'tcx>(
             return;
         }
         // lhs op= l op r
-        if eq_expr_value(cx, lhs, l) {
+        let ctxt = expr.span.ctxt();
+        if eq_expr_value(cx, ctxt, lhs, l) {
             lint_misrefactored_assign_op(cx, expr, op, rhs, lhs, r);
-        } else if is_commutative(op) && eq_expr_value(cx, lhs, r) {
+        } else if is_commutative(op) && eq_expr_value(cx, ctxt, lhs, r) {
             // lhs op= l commutative_op r
             lint_misrefactored_assign_op(cx, expr, op, rhs, lhs, l);
         }

--- a/clippy_lints/src/operators/self_assignment.rs
+++ b/clippy_lints/src/operators/self_assignment.rs
@@ -7,7 +7,7 @@ use rustc_lint::LateContext;
 use super::SELF_ASSIGNMENT;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>, lhs: &'tcx Expr<'_>, rhs: &'tcx Expr<'_>) {
-    if eq_expr_value(cx, lhs, rhs) {
+    if eq_expr_value(cx, e.span.ctxt(), lhs, rhs) {
         let lhs = snippet(cx, lhs.span, "<lhs>");
         let rhs = snippet(cx, rhs.span, "<rhs>");
         span_lint(

--- a/clippy_lints/src/panicking_overflow_checks.rs
+++ b/clippy_lints/src/panicking_overflow_checks.rs
@@ -72,7 +72,7 @@ impl<'tcx> LateLintPass<'tcx> for PanickingOverflowChecks {
             && ty == typeck.expr_ty(op_rhs)
             && ty == typeck.expr_ty(other)
             && !expr.span.in_external_macro(cx.tcx.sess.source_map())
-            && (eq_expr_value(cx, op_lhs, other) || (commutative && eq_expr_value(cx, op_rhs, other)))
+            && (eq_expr_value(cx, ctxt, op_lhs, other) || (commutative && eq_expr_value(cx, ctxt, op_rhs, other)))
         {
             span_lint(
                 cx,

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -299,7 +299,7 @@ fn check_is_none_or_err_and_early_return<'tcx>(cx: &LateContext<'tcx>, expr: &Ex
         let by_ref = !cx.type_is_copy_modulo_regions(caller_ty)
             && !matches!(caller.kind, ExprKind::Call(..) | ExprKind::MethodCall(..));
         let sugg = if let Some(else_inner) = r#else {
-            if eq_expr_value(cx, caller, peel_blocks(else_inner)) {
+            if eq_expr_value(cx, expr.span.ctxt(), caller, peel_blocks(else_inner)) {
                 format!("Some({receiver_str}?)")
             } else {
                 return;
@@ -537,7 +537,7 @@ fn check_if_let_some_or_err_and_early_return<'tcx>(cx: &LateContext<'tcx>, expr:
         && let is_option_early_return = is_early_return(sym::Option, cx, &if_block)
         && (is_option_early_return || is_early_return(sym::Result, cx, &if_block))
         && if_else
-            .map(|e| eq_expr_value(cx, let_expr, peel_blocks(e)))
+            .map(|e| eq_expr_value(cx, expr.span.ctxt(), let_expr, peel_blocks(e)))
             .is_none_or(|e| !e)
     {
         if !is_copy(cx, caller_ty)

--- a/clippy_lints/src/same_length_and_capacity.rs
+++ b/clippy_lints/src/same_length_and_capacity.rs
@@ -79,7 +79,7 @@ impl<'tcx> LateLintPass<'tcx> for SameLengthAndCapacity {
             && let ExprKind::Path(QPath::TypeRelative(ty, fn_path)) = path_expr.kind
             && fn_path.ident.name == sym::from_raw_parts
             && args.len() >= 3
-            && eq_expr_value(cx, &args[1], &args[2])
+            && eq_expr_value(cx, expr.span.ctxt(), &args[1], &args[2])
         {
             let middle_ty = cx.typeck_results().node_type(ty.hir_id);
             if middle_ty.is_diag_item(cx, rustc_sym::Vec) {

--- a/clippy_lints/src/set_contains_or_insert.rs
+++ b/clippy_lints/src/set_contains_or_insert.rs
@@ -7,8 +7,8 @@ use clippy_utils::{SpanlessEq, higher, peel_hir_expr_while, sym};
 use rustc_hir::{Expr, ExprKind, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
-use rustc_span::Span;
 use rustc_span::symbol::Symbol;
+use rustc_span::{Span, SyntaxContext};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -119,7 +119,7 @@ fn is_set_mutated<'tcx>(cx: &LateContext<'tcx>, contains_expr: &OpExpr<'tcx>, ex
             cx.typeck_results().expr_ty(expr).peel_refs().opt_diag_name(cx),
             Some(sym::HashSet | sym::BTreeSet)
         )
-        && SpanlessEq::new(cx).eq_expr(contains_expr.receiver, expr.peel_borrows())
+        && SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), contains_expr.receiver, expr.peel_borrows())
 }
 
 fn find_insert_calls<'tcx>(
@@ -129,8 +129,8 @@ fn find_insert_calls<'tcx>(
 ) -> Option<OpExpr<'tcx>> {
     for_each_expr(cx, expr, |e| {
         if let Some((insert_expr, _)) = try_parse_op_call(cx, e, sym::insert)
-            && SpanlessEq::new(cx).eq_expr(contains_expr.receiver, insert_expr.receiver)
-            && SpanlessEq::new(cx).eq_expr(contains_expr.value, insert_expr.value)
+            && SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), contains_expr.receiver, insert_expr.receiver)
+            && SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), contains_expr.value, insert_expr.value)
         {
             return ControlFlow::Break(Some(insert_expr));
         }

--- a/clippy_lints/src/slow_vector_initialization.rs
+++ b/clippy_lints/src/slow_vector_initialization.rs
@@ -8,6 +8,7 @@ use rustc_hir::intravisit::{Visitor, walk_block, walk_expr, walk_stmt};
 use rustc_hir::{BindingMode, Block, Expr, ExprKind, HirId, PatKind, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
+use rustc_span::SyntaxContext;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -265,7 +266,7 @@ impl<'tcx> VectorInitializationVisitor<'_, 'tcx> {
         {
             let is_matching_resize = if let InitializedSize::Initialized(size_expr) = self.vec_alloc.size_expr {
                 // If we have a size expression, check that it is equal to what's passed to `resize`
-                SpanlessEq::new(self.cx).eq_expr(len_arg, size_expr)
+                SpanlessEq::new(self.cx).eq_expr(SyntaxContext::root(), len_arg, size_expr)
                     || matches!(len_arg.kind, ExprKind::MethodCall(path, ..) if path.ident.name == sym::capacity)
             } else {
                 self.vec_alloc.size_expr = InitializedSize::Initialized(len_arg);
@@ -287,7 +288,7 @@ impl<'tcx> VectorInitializationVisitor<'_, 'tcx> {
         {
             if let InitializedSize::Initialized(size_expr) = self.vec_alloc.size_expr {
                 // Check that len expression is equals to `with_capacity` expression
-                return SpanlessEq::new(self.cx).eq_expr(len_arg, size_expr)
+                return SpanlessEq::new(self.cx).eq_expr(SyntaxContext::root(), len_arg, size_expr)
                     || matches!(len_arg.kind, ExprKind::MethodCall(path, ..) if path.ident.name == sym::capacity);
             }
 

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -11,7 +11,7 @@ use rustc_hir::{BinOpKind, BorrowKind, Expr, ExprKind, LangItem, Node};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty;
 use rustc_session::declare_lint_pass;
-use rustc_span::Spanned;
+use rustc_span::{Spanned, SyntaxContext};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -220,7 +220,8 @@ declare_lint_pass!(TrimSplitWhitespace => [TRIM_SPLIT_WHITESPACE]);
 
 impl<'tcx> LateLintPass<'tcx> for StringAdd {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
-        if e.span.in_external_macro(cx.sess().source_map()) {
+        let ctxt = e.span.ctxt();
+        if ctxt.in_external_macro(cx.sess().source_map()) {
             return;
         }
         match e.kind {
@@ -235,8 +236,8 @@ impl<'tcx> LateLintPass<'tcx> for StringAdd {
                     let parent = get_parent_expr(cx, e);
                     if let Some(p) = parent
                             && let ExprKind::Assign(target, _, _) = p.kind
-                                // avoid duplicate matches
-                                && SpanlessEq::new(cx).eq_expr(target, left)
+                            // avoid duplicate matches
+                            && SpanlessEq::new(cx).eq_expr(ctxt, target, left)
                     {
                         return;
                     }
@@ -248,7 +249,7 @@ impl<'tcx> LateLintPass<'tcx> for StringAdd {
                     "you added something to a string. Consider using `String::push_str()` instead",
                 );
             },
-            ExprKind::Assign(target, src, _) if is_string(cx, target) && is_add(cx, src, target) => {
+            ExprKind::Assign(target, src, _) if is_string(cx, target) && is_add(cx, ctxt, src, target) => {
                 span_lint(
                     cx,
                     STRING_ADD_ASSIGN,
@@ -280,7 +281,7 @@ fn is_string(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
         .is_lang_item(cx, LangItem::String)
 }
 
-fn is_add(cx: &LateContext<'_>, src: &Expr<'_>, target: &Expr<'_>) -> bool {
+fn is_add(cx: &LateContext<'_>, ctxt: SyntaxContext, src: &Expr<'_>, target: &Expr<'_>) -> bool {
     match peel_blocks(src).kind {
         ExprKind::Binary(
             Spanned {
@@ -288,7 +289,7 @@ fn is_add(cx: &LateContext<'_>, src: &Expr<'_>, target: &Expr<'_>) -> bool {
             },
             left,
             _,
-        ) => SpanlessEq::new(cx).eq_expr(target, left),
+        ) => SpanlessEq::new(cx).eq_expr(ctxt, target, left),
         _ => false,
     }
 }

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -98,12 +98,12 @@ fn generate_swap_warning<'tcx>(
     let ctxt = span.ctxt();
     let mut applicability = Applicability::MachineApplicable;
 
-    if !can_mut_borrow_both(cx, e1, e2) {
+    if !can_mut_borrow_both(cx, ctxt, e1, e2) {
         if let ExprKind::Index(lhs1, idx1, _) = e1.kind
             && let ExprKind::Index(lhs2, idx2, _) = e2.kind
-            && eq_expr_value(cx, lhs1, lhs2)
             && e1.span.ctxt() == ctxt
             && e2.span.ctxt() == ctxt
+            && eq_expr_value(cx, ctxt, lhs1, lhs2)
         {
             let ty = cx.typeck_results().expr_ty(lhs1).peel_refs();
 
@@ -189,14 +189,15 @@ fn check_manual_swap<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
             && rhs2_path.segments.len() == 1
 
             && ident.name == rhs2_path.segments[0].ident.name
-            && eq_expr_value(cx, tmp_init, lhs1)
-            && eq_expr_value(cx, rhs1, lhs2)
 
             && let ctxt = s1.span.ctxt()
             && s2.span.ctxt() == ctxt
             && s3.span.ctxt() == ctxt
             && first.span.ctxt() == ctxt
             && second.span.ctxt() == ctxt
+
+            && eq_expr_value(cx, ctxt, tmp_init, lhs1)
+            && eq_expr_value(cx, ctxt, rhs1, lhs2)
         {
             let span = s1.span.to(s3.span);
             generate_swap_warning(block, cx, lhs1, lhs2, rhs1, rhs2, span, false);
@@ -209,11 +210,12 @@ fn check_suspicious_swap(cx: &LateContext<'_>, block: &Block<'_>) {
     for [first, second] in block.stmts.array_windows() {
         if let Some((lhs0, rhs0)) = parse(first)
             && let Some((lhs1, rhs1)) = parse(second)
-            && first.span.eq_ctxt(second.span)
-			&& !first.span.in_external_macro(cx.sess().source_map())
-            && is_same(cx, lhs0, rhs1)
-            && is_same(cx, lhs1, rhs0)
-			&& !is_same(cx, lhs1, rhs1) // Ignore a = b; a = a (#10421)
+            && let ctxt = first.span.ctxt()
+            && ctxt == second.span.ctxt()
+			&& !ctxt.in_external_macro(cx.sess().source_map())
+            && is_same(cx, ctxt, lhs0, rhs1)
+            && is_same(cx, ctxt, lhs1, rhs0)
+			&& !is_same(cx, ctxt, lhs1, rhs1) // Ignore a = b; a = a (#10421)
             && let Some(lhs_sugg) = match &lhs0 {
                 ExprOrIdent::Expr(expr) => Sugg::hir_opt(cx, expr),
                 ExprOrIdent::Ident(ident) => Some(Sugg::NonParen(ident.as_str().into())),
@@ -241,9 +243,9 @@ fn check_suspicious_swap(cx: &LateContext<'_>, block: &Block<'_>) {
     }
 }
 
-fn is_same(cx: &LateContext<'_>, lhs: ExprOrIdent<'_>, rhs: &Expr<'_>) -> bool {
+fn is_same(cx: &LateContext<'_>, ctxt: SyntaxContext, lhs: ExprOrIdent<'_>, rhs: &Expr<'_>) -> bool {
     match lhs {
-        ExprOrIdent::Expr(expr) => eq_expr_value(cx, expr, rhs),
+        ExprOrIdent::Expr(expr) => eq_expr_value(cx, ctxt, expr, rhs),
         ExprOrIdent::Ident(ident) => {
             if let ExprKind::Path(QPath::Resolved(None, path)) = rhs.kind
                 && let [segment] = &path.segments
@@ -284,10 +286,10 @@ fn check_xor_swap<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
         if let Some((lhs0, rhs0)) = extract_sides_of_xor_assign(s1, ctxt)
             && let Some((lhs1, rhs1)) = extract_sides_of_xor_assign(s2, ctxt)
             && let Some((lhs2, rhs2)) = extract_sides_of_xor_assign(s3, ctxt)
-            && eq_expr_value(cx, lhs0, rhs1)
-            && eq_expr_value(cx, lhs2, rhs1)
-            && eq_expr_value(cx, lhs1, rhs0)
-            && eq_expr_value(cx, lhs1, rhs2)
+            && eq_expr_value(cx, ctxt, lhs0, rhs1)
+            && eq_expr_value(cx, ctxt, lhs2, rhs1)
+            && eq_expr_value(cx, ctxt, lhs1, rhs0)
+            && eq_expr_value(cx, ctxt, lhs1, rhs2)
             && s2.span.ctxt() == ctxt
             && s3.span.ctxt() == ctxt
         {

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -15,7 +15,7 @@ use rustc_hir::{
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
-use rustc_span::Span;
+use rustc_span::{Span, SyntaxContext};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -155,9 +155,11 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
                     .filter_map(get_trait_info_from_bound)
                     .for_each(|(trait_item_res, trait_item_segments, span)| {
                         if let Some(self_segments) = self_bounds_map.get(&trait_item_res)
-                            && SpanlessEq::new(cx)
-                                .paths_by_resolution()
-                                .eq_path_segments(self_segments, trait_item_segments)
+                            && SpanlessEq::new(cx).paths_by_resolution().eq_path_segments(
+                                SyntaxContext::root(),
+                                self_segments,
+                                trait_item_segments,
+                            )
                         {
                             span_lint_and_help(
                                 cx,
@@ -250,7 +252,7 @@ impl TraitBounds {
         impl PartialEq for SpanlessTy<'_, '_> {
             fn eq(&self, other: &Self) -> bool {
                 let mut eq = SpanlessEq::new(self.cx);
-                eq.inter_expr().eq_ty(self.ty, other.ty)
+                eq.inter_expr(SyntaxContext::root()).eq_ty(self.ty, other.ty)
             }
         }
         impl Hash for SpanlessTy<'_, '_> {
@@ -380,9 +382,11 @@ struct ComparableTraitRef<'a, 'tcx> {
 impl PartialEq for ComparableTraitRef<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         SpanlessEq::eq_modifiers(self.modifiers, other.modifiers)
-            && SpanlessEq::new(self.cx)
-                .paths_by_resolution()
-                .eq_path(self.trait_ref.path, other.trait_ref.path)
+            && SpanlessEq::new(self.cx).paths_by_resolution().eq_path(
+                SyntaxContext::root(),
+                self.trait_ref.path,
+                other.trait_ref.path,
+            )
     }
 }
 impl Eq for ComparableTraitRef<'_, '_> {}

--- a/clippy_lints/src/transmute/eager_transmute.rs
+++ b/clippy_lints/src/transmute/eager_transmute.rs
@@ -5,6 +5,7 @@ use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, Node};
 use rustc_lint::LateContext;
 use rustc_middle::ty::Ty;
+use rustc_span::SyntaxContext;
 
 use super::EAGER_TRANSMUTE;
 
@@ -54,9 +55,9 @@ fn binops_with_local(cx: &LateContext<'_>, local_expr: &Expr<'_>, expr: &Expr<'_
                     lang_items.range_to_struct()
                 ].into_iter().any(|did| did == Some(receiver_adt.did())) =>
         {
-            eq_expr_value(cx, local_expr, arg.peel_borrows())
+            eq_expr_value(cx, SyntaxContext::root(), local_expr, arg.peel_borrows())
         },
-        _ => eq_expr_value(cx, local_expr, expr),
+        _ => eq_expr_value(cx, SyntaxContext::root(), local_expr, expr),
     }
 }
 

--- a/clippy_lints_internal/src/collapsible_span_lint_calls.rs
+++ b/clippy_lints_internal/src/collapsible_span_lint_calls.rs
@@ -89,10 +89,10 @@ impl<'tcx> LateLintPass<'tcx> for CollapsibleCalls {
             && let ExprKind::Path(..) = recv.kind
         {
             let mut app = Applicability::MachineApplicable;
-            let expr_ctxt = expr.span.ctxt();
+            let ctxt = expr.span.ctxt();
             let and_then_snippets = get_and_then_snippets(
                 cx,
-                expr_ctxt,
+                ctxt,
                 call_cx.span,
                 call_lint.span,
                 call_sp.span,
@@ -101,28 +101,24 @@ impl<'tcx> LateLintPass<'tcx> for CollapsibleCalls {
             );
             let mut sle = SpanlessEq::new(cx).deny_side_effects();
             match ps.ident.name {
-                sym::span_suggestion if sle.eq_expr(call_sp, &span_call_args[0]) => {
-                    let snippets = span_suggestion_snippets(cx, expr_ctxt, span_call_args, &mut app);
+                sym::span_suggestion if sle.eq_expr(ctxt, call_sp, &span_call_args[0]) => {
+                    let snippets = span_suggestion_snippets(cx, ctxt, span_call_args, &mut app);
                     suggest_suggestion(cx, expr, &and_then_snippets, &snippets, app);
                 },
-                sym::span_help if sle.eq_expr(call_sp, &span_call_args[0]) => {
-                    let help_snippet =
-                        snippet_with_context(cx, span_call_args[1].span, expr_ctxt, r#""...""#, &mut app).0;
+                sym::span_help if sle.eq_expr(ctxt, call_sp, &span_call_args[0]) => {
+                    let help_snippet = snippet_with_context(cx, span_call_args[1].span, ctxt, r#""...""#, &mut app).0;
                     suggest_help(cx, expr, &and_then_snippets, help_snippet.borrow(), true, app);
                 },
-                sym::span_note if sle.eq_expr(call_sp, &span_call_args[0]) => {
-                    let note_snippet =
-                        snippet_with_context(cx, span_call_args[1].span, expr_ctxt, r#""...""#, &mut app).0;
+                sym::span_note if sle.eq_expr(ctxt, call_sp, &span_call_args[0]) => {
+                    let note_snippet = snippet_with_context(cx, span_call_args[1].span, ctxt, r#""...""#, &mut app).0;
                     suggest_note(cx, expr, &and_then_snippets, note_snippet.borrow(), true, app);
                 },
                 sym::help => {
-                    let help_snippet =
-                        snippet_with_context(cx, span_call_args[0].span, expr_ctxt, r#""...""#, &mut app).0;
+                    let help_snippet = snippet_with_context(cx, span_call_args[0].span, ctxt, r#""...""#, &mut app).0;
                     suggest_help(cx, expr, &and_then_snippets, help_snippet.borrow(), false, app);
                 },
                 sym::note => {
-                    let note_snippet =
-                        snippet_with_context(cx, span_call_args[0].span, expr_ctxt, r#""...""#, &mut app).0;
+                    let note_snippet = snippet_with_context(cx, span_call_args[0].span, ctxt, r#""...""#, &mut app).0;
                     suggest_note(cx, expr, &and_then_snippets, note_snippet.borrow(), false, app);
                 },
                 _ => (),
@@ -140,7 +136,7 @@ struct AndThenSnippets {
 
 fn get_and_then_snippets(
     cx: &LateContext<'_>,
-    expr_ctxt: SyntaxContext,
+    ctxt: SyntaxContext,
     cx_span: Span,
     lint_span: Span,
     span_span: Span,
@@ -150,7 +146,7 @@ fn get_and_then_snippets(
     let cx_snippet = snippet_with_applicability(cx, cx_span, "cx", app);
     let lint_snippet = snippet_with_applicability(cx, lint_span, "..", app);
     let span_snippet = snippet_with_applicability(cx, span_span, "span", app);
-    let msg_snippet = snippet_with_context(cx, msg_span, expr_ctxt, r#""...""#, app).0;
+    let msg_snippet = snippet_with_context(cx, msg_span, ctxt, r#""...""#, app).0;
 
     AndThenSnippets {
         cx: cx_snippet,
@@ -168,12 +164,12 @@ struct SpanSuggestionSnippets {
 
 fn span_suggestion_snippets<'hir>(
     cx: &LateContext<'_>,
-    expr_ctxt: SyntaxContext,
+    ctxt: SyntaxContext,
     span_call_args: &'hir [Expr<'hir>],
     app: &mut Applicability,
 ) -> SpanSuggestionSnippets {
-    let help_snippet = snippet_with_context(cx, span_call_args[1].span, expr_ctxt, r#""...""#, app).0;
-    let sugg_snippet = snippet_with_context(cx, span_call_args[2].span, expr_ctxt, "..", app).0;
+    let help_snippet = snippet_with_context(cx, span_call_args[1].span, ctxt, r#""...""#, app).0;
+    let sugg_snippet = snippet_with_context(cx, span_call_args[2].span, ctxt, "..", app).0;
     let applicability_snippet =
         snippet_with_applicability(cx, span_call_args[3].span, "Applicability::MachineApplicable", app);
 

--- a/clippy_utils/src/hir_utils.rs
+++ b/clippy_utils/src/hir_utils.rs
@@ -2,6 +2,7 @@ use crate::consts::ConstEvalCtxt;
 use crate::macros::macro_backtrace;
 use crate::source::{SpanRange, SpanRangeExt, walk_span_to_context};
 use crate::{sym, tokenize_with_text};
+use core::mem;
 use rustc_ast::ast;
 use rustc_ast::ast::InlineAsmTemplatePiece;
 use rustc_data_structures::fx::{FxHasher, FxIndexMap};
@@ -107,46 +108,57 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
 
     /// Use this method to wrap comparisons that may involve inter-expression context.
     /// See `self.locals`.
-    pub fn inter_expr(&mut self) -> HirEqInterExpr<'_, 'a, 'tcx> {
+    pub fn inter_expr(&mut self, ctxt: SyntaxContext) -> HirEqInterExpr<'_, 'a, 'tcx> {
         HirEqInterExpr {
             inner: self,
-            left_ctxt: SyntaxContext::root(),
-            right_ctxt: SyntaxContext::root(),
+            eval_ctxt: ctxt,
+            prev_left_ctxt: ctxt,
+            prev_right_ctxt: ctxt,
             locals: HirIdMap::default(),
             local_items: FxIndexMap::default(),
         }
     }
 
-    pub fn eq_block(&mut self, left: &Block<'_>, right: &Block<'_>) -> bool {
-        self.inter_expr().eq_block(left, right)
+    pub fn eq_block(&mut self, ctxt: SyntaxContext, left: &Block<'_>, right: &Block<'_>) -> bool {
+        self.inter_expr(ctxt).eq_block(left, right)
     }
 
-    pub fn eq_expr(&mut self, left: &Expr<'_>, right: &Expr<'_>) -> bool {
-        self.inter_expr().eq_expr(left, right)
+    pub fn eq_expr(&mut self, ctxt: SyntaxContext, left: &Expr<'_>, right: &Expr<'_>) -> bool {
+        self.inter_expr(ctxt).eq_expr(left, right)
     }
 
-    pub fn eq_path(&mut self, left: &Path<'_>, right: &Path<'_>) -> bool {
-        self.inter_expr().eq_path(left, right)
+    pub fn eq_path(&mut self, ctxt: SyntaxContext, left: &Path<'_>, right: &Path<'_>) -> bool {
+        self.inter_expr(ctxt).eq_path(left, right)
     }
 
-    pub fn eq_path_segment(&mut self, left: &PathSegment<'_>, right: &PathSegment<'_>) -> bool {
-        self.inter_expr().eq_path_segment(left, right)
+    pub fn eq_path_segment(&mut self, ctxt: SyntaxContext, left: &PathSegment<'_>, right: &PathSegment<'_>) -> bool {
+        self.inter_expr(ctxt).eq_path_segment(left, right)
     }
 
-    pub fn eq_path_segments(&mut self, left: &[PathSegment<'_>], right: &[PathSegment<'_>]) -> bool {
-        self.inter_expr().eq_path_segments(left, right)
+    pub fn eq_path_segments(
+        &mut self,
+        ctxt: SyntaxContext,
+        left: &[PathSegment<'_>],
+        right: &[PathSegment<'_>],
+    ) -> bool {
+        self.inter_expr(ctxt).eq_path_segments(left, right)
     }
 
     pub fn eq_modifiers(left: TraitBoundModifiers, right: TraitBoundModifiers) -> bool {
-        std::mem::discriminant(&left.constness) == std::mem::discriminant(&right.constness)
-            && std::mem::discriminant(&left.polarity) == std::mem::discriminant(&right.polarity)
+        mem::discriminant(&left.constness) == mem::discriminant(&right.constness)
+            && mem::discriminant(&left.polarity) == mem::discriminant(&right.polarity)
     }
 }
 
 pub struct HirEqInterExpr<'a, 'b, 'tcx> {
     inner: &'a mut SpanlessEq<'b, 'tcx>,
-    left_ctxt: SyntaxContext,
-    right_ctxt: SyntaxContext,
+
+    /// The root context to view each side from.
+    eval_ctxt: SyntaxContext,
+
+    // Optimization to avoid rechecking the context of desugarings.
+    prev_left_ctxt: SyntaxContext,
+    prev_right_ctxt: SyntaxContext,
 
     // When binding are declared, the binding ID in the left expression is mapped to the one on the
     // right. For example, when comparing `{ let x = 1; x + 2 }` and `{ let y = 1; y + 2 }`,
@@ -156,7 +168,17 @@ pub struct HirEqInterExpr<'a, 'b, 'tcx> {
 }
 
 impl HirEqInterExpr<'_, '_, '_> {
+    pub fn set_eval_ctxt(&mut self, ctxt: SyntaxContext) {
+        self.eval_ctxt = ctxt;
+        self.prev_left_ctxt = ctxt;
+        self.prev_right_ctxt = ctxt;
+    }
+
     pub fn eq_stmt(&mut self, left: &Stmt<'_>, right: &Stmt<'_>) -> bool {
+        if self.check_ctxt(left.span.ctxt(), right.span.ctxt()) == Some(false) {
+            return false;
+        }
+
         match (&left.kind, &right.kind) {
             (StmtKind::Let(l), StmtKind::Let(r)) => {
                 // This additional check ensures that the type of the locals are equivalent even if the init
@@ -372,15 +394,16 @@ impl HirEqInterExpr<'_, '_, '_> {
         }
         let lspan = left.span.data();
         let rspan = right.span.data();
-        if lspan.ctxt != SyntaxContext::root() && rspan.ctxt != SyntaxContext::root() {
-            // Don't try to check in between statements inside macros.
-            return over(left.stmts, right.stmts, |left, right| self.eq_stmt(left, right))
-                && both(left.expr.as_ref(), right.expr.as_ref(), |left, right| {
-                    self.eq_expr(left, right)
-                });
-        }
-        if lspan.ctxt != rspan.ctxt {
-            return false;
+        match self.check_ctxt(lspan.ctxt, rspan.ctxt) {
+            Some(false) => return false,
+            None if self.eval_ctxt.is_root() => {},
+            _ => {
+                // Don't try to check in between statements inside macros.
+                return over(left.stmts, right.stmts, |left, right| self.eq_stmt(left, right))
+                    && both(left.expr.as_ref(), right.expr.as_ref(), |left, right| {
+                        self.eq_expr(left, right)
+                    });
+            },
         }
 
         let mut lstart = lspan.lo;
@@ -475,26 +498,28 @@ impl HirEqInterExpr<'_, '_, '_> {
 
     #[expect(clippy::too_many_lines)]
     pub fn eq_expr(&mut self, left: &Expr<'_>, right: &Expr<'_>) -> bool {
-        if !self.check_ctxt(left.span.ctxt(), right.span.ctxt()) {
-            return false;
-        }
-
-        if let Some((typeck_lhs, typeck_rhs)) = self.inner.maybe_typeck_results
-            && typeck_lhs.expr_ty(left) == typeck_rhs.expr_ty(right)
-            && let (Some(l), Some(r)) = (
-                ConstEvalCtxt::with_env(self.inner.cx.tcx, self.inner.cx.typing_env(), typeck_lhs)
-                    .eval_local(left, self.left_ctxt),
-                ConstEvalCtxt::with_env(self.inner.cx.tcx, self.inner.cx.typing_env(), typeck_rhs)
-                    .eval_local(right, self.right_ctxt),
-            )
-            && l == r
-        {
-            return true;
+        match self.check_ctxt(left.span.ctxt(), right.span.ctxt()) {
+            None => {
+                if let Some((typeck_lhs, typeck_rhs)) = self.inner.maybe_typeck_results
+                    && typeck_lhs.expr_ty(left) == typeck_rhs.expr_ty(right)
+                    && let (Some(l), Some(r)) = (
+                        ConstEvalCtxt::with_env(self.inner.cx.tcx, self.inner.cx.typing_env(), typeck_lhs)
+                            .eval_local(left, self.eval_ctxt),
+                        ConstEvalCtxt::with_env(self.inner.cx.tcx, self.inner.cx.typing_env(), typeck_rhs)
+                            .eval_local(right, self.eval_ctxt),
+                    )
+                    && l == r
+                {
+                    return true;
+                }
+            },
+            Some(false) => return false,
+            Some(true) => {},
         }
 
         let is_eq = match (
-            reduce_exprkind(self.inner.cx, &left.kind),
-            reduce_exprkind(self.inner.cx, &right.kind),
+            reduce_exprkind(self.inner.cx, self.eval_ctxt, &left.kind),
+            reduce_exprkind(self.inner.cx, self.eval_ctxt, &right.kind),
         ) {
             (ExprKind::AddrOf(lb, l_mut, le), ExprKind::AddrOf(rb, r_mut, re)) => {
                 lb == rb && l_mut == r_mut && self.eq_expr(le, re)
@@ -542,7 +567,12 @@ impl HirEqInterExpr<'_, '_, '_> {
                     && both(l.ty.as_ref(), r.ty.as_ref(), |l, r| self.eq_ty(l, r))
                     && self.eq_expr(l.init, r.init)
             },
-            (ExprKind::Lit(l), ExprKind::Lit(r)) => l.node == r.node,
+            (ExprKind::Lit(l), ExprKind::Lit(r)) => {
+                if self.check_ctxt(l.span.ctxt(), r.span.ctxt()) == Some(false) {
+                    return false;
+                }
+                l.node == r.node
+            },
             (ExprKind::Loop(lb, ll, lls, _), ExprKind::Loop(rb, rl, rls, _)) => {
                 lls == rls && self.eq_block(lb, rb)
                     && both(ll.as_ref(), rl.as_ref(), |l, r| l.ident.name == r.ident.name)
@@ -673,7 +703,7 @@ impl HirEqInterExpr<'_, '_, '_> {
     }
 
     fn eq_const_arg(&mut self, left: &ConstArg<'_>, right: &ConstArg<'_>) -> bool {
-        if !self.check_ctxt(left.span.ctxt(), right.span.ctxt()) {
+        if self.check_ctxt(left.span.ctxt(), right.span.ctxt()) == Some(false) {
             return false;
         }
 
@@ -892,46 +922,72 @@ impl HirEqInterExpr<'_, '_, '_> {
                 || both_some_and(left.ct(), right.ct(), |l, r| self.eq_const_arg(l, r)))
     }
 
-    fn check_ctxt(&mut self, left: SyntaxContext, right: SyntaxContext) -> bool {
-        if self.left_ctxt == left && self.right_ctxt == right {
-            return true;
-        } else if self.left_ctxt == left || self.right_ctxt == right {
-            // Only one context has changed. This can only happen if the two nodes are written differently.
-            return false;
-        } else if left != SyntaxContext::root() {
+    /// Checks whether either operand is within a macro context, and if so, whether the macro calls
+    /// are equal.
+    fn check_ctxt(&mut self, left: SyntaxContext, right: SyntaxContext) -> Option<bool> {
+        let prev_left = mem::replace(&mut self.prev_left_ctxt, left);
+        let prev_right = mem::replace(&mut self.prev_right_ctxt, right);
+
+        if left == self.eval_ctxt && right == self.eval_ctxt {
+            None
+        } else if left == prev_left && right == prev_right {
+            // Same as the previous context, no need to recheck anything
+            Some(true)
+        } else if left == prev_left
+            || right == prev_right
+            || left == self.eval_ctxt
+            || right == self.eval_ctxt
+            || left.is_root()
+            || right.is_root()
+        {
+            // Either only one context changed, or at least one context is a parent of the
+            // evaluation context.
+            // Unfortunately we can't get a span of a metavariable so we have to treat the
+            // second case as unequal.
+            Some(false)
+        } else {
+            // Walk each context in lockstep up to the evaluation context checking that each
+            // expansion has the same kind.
             let mut left_data = left.outer_expn_data();
             let mut right_data = right.outer_expn_data();
             loop {
                 use TokenKind::{BlockComment, LineComment, Whitespace};
-                if left_data.macro_def_id != right_data.macro_def_id
-                    || (matches!(
-                        left_data.kind,
-                        ExpnKind::Macro(MacroKind::Bang, name)
-                        if name == sym::cfg || name == sym::option_env
-                    ) && !eq_span_tokens(self.inner.cx, left_data.call_site, right_data.call_site, |t| {
-                        !matches!(t, Whitespace | LineComment { .. } | BlockComment { .. })
-                    }))
+                if left_data.macro_def_id != right_data.macro_def_id || left_data.kind != right_data.kind {
+                    return Some(false);
+                }
+                let left = left_data.call_site.ctxt();
+                let right = right_data.call_site.ctxt();
+                if left == self.eval_ctxt && right == self.eval_ctxt {
+                    // Finally if the outermost expansion is a macro call, check if the
+                    // tokens are the same.
+                    if let ExpnKind::Macro(MacroKind::Bang, _) = left_data.kind {
+                        return Some(eq_span_tokens(
+                            self.inner.cx,
+                            left_data.call_site,
+                            right_data.call_site,
+                            |t| !matches!(t, Whitespace | LineComment { .. } | BlockComment { .. }),
+                        ));
+                    }
+                    return Some(true);
+                }
+                if left == prev_left && right == prev_right {
+                    return Some(true);
+                }
+                if left == prev_left
+                    || right == prev_right
+                    || left == self.eval_ctxt
+                    || right == self.eval_ctxt
+                    || left.is_root()
+                    || right.is_root()
                 {
-                    // Either a different chain of macro calls, or different arguments to the `cfg` macro.
-                    return false;
+                    // Either there's a different number of expansions, or at least one context is
+                    // a parent of the evaluation context.
+                    return Some(false);
                 }
-                let left_ctxt = left_data.call_site.ctxt();
-                let right_ctxt = right_data.call_site.ctxt();
-                if left_ctxt == SyntaxContext::root() && right_ctxt == SyntaxContext::root() {
-                    break;
-                }
-                if left_ctxt == SyntaxContext::root() || right_ctxt == SyntaxContext::root() {
-                    // Different lengths for the expansion stack. This can only happen if nodes are written differently,
-                    // or shouldn't be compared to start with.
-                    return false;
-                }
-                left_data = left_ctxt.outer_expn_data();
-                right_data = right_ctxt.outer_expn_data();
+                left_data = left.outer_expn_data();
+                right_data = right.outer_expn_data();
             }
         }
-        self.left_ctxt = left;
-        self.right_ctxt = right;
-        true
     }
 
     fn swap_binop<'a>(
@@ -970,7 +1026,11 @@ impl HirEqInterExpr<'_, '_, '_> {
 }
 
 /// Some simple reductions like `{ return }` => `return`
-fn reduce_exprkind<'hir>(cx: &LateContext<'_>, kind: &'hir ExprKind<'hir>) -> &'hir ExprKind<'hir> {
+fn reduce_exprkind<'hir>(
+    cx: &LateContext<'_>,
+    eval_ctxt: SyntaxContext,
+    kind: &'hir ExprKind<'hir>,
+) -> &'hir ExprKind<'hir> {
     if let ExprKind::Block(block, _) = kind {
         match (block.stmts, block.expr) {
             // From an `if let` expression without an `else` block. The arm for the implicit wild pattern is an empty
@@ -978,17 +1038,20 @@ fn reduce_exprkind<'hir>(cx: &LateContext<'_>, kind: &'hir ExprKind<'hir>) -> &'
             ([], None) if block.span.is_empty() => &ExprKind::Tup(&[]),
             // `{}` => `()`
             ([], None)
-                if block.span.check_source_text(cx, |src| {
-                    tokenize(src, FrontmatterAllowed::No)
-                        .map(|t| t.kind)
-                        .filter(|t| {
-                            !matches!(
-                                t,
-                                TokenKind::LineComment { .. } | TokenKind::BlockComment { .. } | TokenKind::Whitespace
-                            )
-                        })
-                        .eq([TokenKind::OpenBrace, TokenKind::CloseBrace].iter().copied())
-                }) =>
+                if block.span.ctxt() != eval_ctxt
+                    || block.span.check_source_text(cx, |src| {
+                        tokenize(src, FrontmatterAllowed::No)
+                            .map(|t| t.kind)
+                            .filter(|t| {
+                                !matches!(
+                                    t,
+                                    TokenKind::LineComment { .. }
+                                        | TokenKind::BlockComment { .. }
+                                        | TokenKind::Whitespace
+                                )
+                            })
+                            .eq([TokenKind::OpenBrace, TokenKind::CloseBrace].iter().copied())
+                    }) =>
             {
                 &ExprKind::Tup(&[])
             },
@@ -1039,8 +1102,13 @@ pub fn count_eq<X: Sized>(
 }
 
 /// Checks if two expressions evaluate to the same value, and don't contain any side effects.
-pub fn eq_expr_value(cx: &LateContext<'_>, left: &Expr<'_>, right: &Expr<'_>) -> bool {
-    SpanlessEq::new(cx).deny_side_effects().eq_expr(left, right)
+///
+/// The context argument is the context used to view the two expressions. e.g. when comparing the
+/// two arguments in `f(m!(1), m!(2))` the context of the call expression should be used. This is
+/// needed to handle the case where two macros expand to the same thing, but the arguments are
+/// different.
+pub fn eq_expr_value(cx: &LateContext<'_>, ctxt: SyntaxContext, left: &Expr<'_>, right: &Expr<'_>) -> bool {
+    SpanlessEq::new(cx).deny_side_effects().eq_expr(ctxt, left, right)
 }
 
 /// Returns the segments of a path that might have generic parameters.
@@ -1104,7 +1172,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
             self.hash_expr(e);
         }
 
-        std::mem::discriminant(&b.rules).hash(&mut self.s);
+        mem::discriminant(&b.rules).hash(&mut self.s);
     }
 
     #[expect(clippy::too_many_lines)]
@@ -1120,11 +1188,11 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
             return;
         }
 
-        std::mem::discriminant(&e.kind).hash(&mut self.s);
+        mem::discriminant(&e.kind).hash(&mut self.s);
 
         match &e.kind {
             ExprKind::AddrOf(kind, m, e) => {
-                std::mem::discriminant(kind).hash(&mut self.s);
+                mem::discriminant(kind).hash(&mut self.s);
                 m.hash(&mut self.s);
                 self.hash_expr(e);
             },
@@ -1141,7 +1209,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 self.hash_expr(r);
             },
             ExprKind::AssignOp(o, l, r) => {
-                std::mem::discriminant(&o.node).hash(&mut self.s);
+                mem::discriminant(&o.node).hash(&mut self.s);
                 self.hash_expr(l);
                 self.hash_expr(r);
             },
@@ -1152,7 +1220,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 self.hash_block(b);
             },
             ExprKind::Binary(op, l, r) => {
-                std::mem::discriminant(&op.node).hash(&mut self.s);
+                mem::discriminant(&op.node).hash(&mut self.s);
                 self.hash_expr(l);
                 self.hash_expr(r);
             },
@@ -1175,7 +1243,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
             ExprKind::Closure(Closure {
                 capture_clause, body, ..
             }) => {
-                std::mem::discriminant(capture_clause).hash(&mut self.s);
+                mem::discriminant(capture_clause).hash(&mut self.s);
                 // closures inherit TypeckResults
                 self.hash_expr(self.cx.tcx.hir_body(*body).value);
             },
@@ -1326,11 +1394,11 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 self.hash_expr(expr);
             },
             ExprKind::Unary(l_op, le) => {
-                std::mem::discriminant(l_op).hash(&mut self.s);
+                mem::discriminant(l_op).hash(&mut self.s);
                 self.hash_expr(le);
             },
             ExprKind::UnsafeBinderCast(kind, expr, ty) => {
-                std::mem::discriminant(kind).hash(&mut self.s);
+                mem::discriminant(kind).hash(&mut self.s);
                 self.hash_expr(expr);
                 if let Some(ty) = ty {
                     self.hash_ty(ty);
@@ -1363,7 +1431,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
     }
 
     pub fn hash_pat_expr(&mut self, lit: &PatExpr<'_>) {
-        std::mem::discriminant(&lit.kind).hash(&mut self.s);
+        mem::discriminant(&lit.kind).hash(&mut self.s);
         match &lit.kind {
             PatExprKind::Lit { lit, negated } => {
                 lit.node.hash(&mut self.s);
@@ -1374,7 +1442,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
     }
 
     pub fn hash_ty_pat(&mut self, pat: &TyPat<'_>) {
-        std::mem::discriminant(&pat.kind).hash(&mut self.s);
+        mem::discriminant(&pat.kind).hash(&mut self.s);
         match pat.kind {
             TyPatKind::Range(s, e) => {
                 self.hash_const_arg(s);
@@ -1390,16 +1458,16 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
     }
 
     pub fn hash_pat(&mut self, pat: &Pat<'_>) {
-        std::mem::discriminant(&pat.kind).hash(&mut self.s);
+        mem::discriminant(&pat.kind).hash(&mut self.s);
         match &pat.kind {
             PatKind::Missing => unreachable!(),
             PatKind::Binding(BindingMode(by_ref, mutability), _, _, pat) => {
-                std::mem::discriminant(by_ref).hash(&mut self.s);
+                mem::discriminant(by_ref).hash(&mut self.s);
                 if let ByRef::Yes(pi, mu) = by_ref {
-                    std::mem::discriminant(pi).hash(&mut self.s);
-                    std::mem::discriminant(mu).hash(&mut self.s);
+                    mem::discriminant(pi).hash(&mut self.s);
+                    mem::discriminant(mu).hash(&mut self.s);
                 }
-                std::mem::discriminant(mutability).hash(&mut self.s);
+                mem::discriminant(mutability).hash(&mut self.s);
                 if let Some(pat) = pat {
                     self.hash_pat(pat);
                 }
@@ -1418,12 +1486,12 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 if let Some(e) = e {
                     self.hash_pat_expr(e);
                 }
-                std::mem::discriminant(i).hash(&mut self.s);
+                mem::discriminant(i).hash(&mut self.s);
             },
             PatKind::Ref(pat, pi, mu) => {
                 self.hash_pat(pat);
-                std::mem::discriminant(pi).hash(&mut self.s);
-                std::mem::discriminant(mu).hash(&mut self.s);
+                mem::discriminant(pi).hash(&mut self.s);
+                mem::discriminant(mu).hash(&mut self.s);
             },
             PatKind::Guard(pat, guard) => {
                 self.hash_pat(pat);
@@ -1492,12 +1560,12 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
 
     pub fn hash_modifiers(&mut self, modifiers: TraitBoundModifiers) {
         let TraitBoundModifiers { constness, polarity } = modifiers;
-        std::mem::discriminant(&polarity).hash(&mut self.s);
-        std::mem::discriminant(&constness).hash(&mut self.s);
+        mem::discriminant(&polarity).hash(&mut self.s);
+        mem::discriminant(&constness).hash(&mut self.s);
     }
 
     pub fn hash_stmt(&mut self, b: &Stmt<'_>) {
-        std::mem::discriminant(&b.kind).hash(&mut self.s);
+        mem::discriminant(&b.kind).hash(&mut self.s);
 
         match &b.kind {
             StmtKind::Let(local) => {
@@ -1518,14 +1586,14 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
 
     pub fn hash_lifetime(&mut self, lifetime: &Lifetime) {
         lifetime.ident.name.hash(&mut self.s);
-        std::mem::discriminant(&lifetime.kind).hash(&mut self.s);
+        mem::discriminant(&lifetime.kind).hash(&mut self.s);
         if let LifetimeKind::Param(param_id) = lifetime.kind {
             param_id.hash(&mut self.s);
         }
     }
 
     pub fn hash_ty(&mut self, ty: &Ty<'_>) {
-        std::mem::discriminant(&ty.kind).hash(&mut self.s);
+        mem::discriminant(&ty.kind).hash(&mut self.s);
         self.hash_tykind(&ty.kind);
     }
 
@@ -1564,7 +1632,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 for arg in fn_ptr.decl.inputs {
                     self.hash_ty(arg);
                 }
-                std::mem::discriminant(&fn_ptr.decl.output).hash(&mut self.s);
+                mem::discriminant(&fn_ptr.decl.output).hash(&mut self.s);
                 match fn_ptr.decl.output {
                     FnRetTy::DefaultReturn(_) => {},
                     FnRetTy::Return(ty) => {

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -469,19 +469,23 @@ pub fn trait_ref_of_method<'tcx>(cx: &LateContext<'tcx>, owner: OwnerId) -> Opti
 /// this method will return a tuple, composed of a `Vec`
 /// containing the `Expr`s for `v[0], v[0].a, v[0].a.b, v[0].a.b[x]`
 /// and an `Expr` for root of them, `v`
-fn projection_stack<'a, 'hir>(mut e: &'a Expr<'hir>) -> (Vec<&'a Expr<'hir>>, &'a Expr<'hir>) {
+fn projection_stack<'a, 'hir>(
+    mut e: &'a Expr<'hir>,
+    ctxt: SyntaxContext,
+) -> Option<(Vec<&'a Expr<'hir>>, &'a Expr<'hir>)> {
     let mut result = vec![];
     let root = loop {
         match e.kind {
-            ExprKind::Index(ep, _, _) | ExprKind::Field(ep, _) => {
+            ExprKind::Index(ep, _, _) | ExprKind::Field(ep, _) if e.span.ctxt() == ctxt => {
                 result.push(e);
                 e = ep;
             },
+            ExprKind::Index(..) | ExprKind::Field(..) => return None,
             _ => break e,
         }
     };
     result.reverse();
-    (result, root)
+    Some((result, root))
 }
 
 /// Gets the mutability of the custom deref adjustment, if any.
@@ -499,10 +503,14 @@ pub fn expr_custom_deref_adjustment(cx: &LateContext<'_>, e: &Expr<'_>) -> Optio
 
 /// Checks if two expressions can be mutably borrowed simultaneously
 /// and they aren't dependent on borrowing same thing twice
-pub fn can_mut_borrow_both(cx: &LateContext<'_>, e1: &Expr<'_>, e2: &Expr<'_>) -> bool {
-    let (s1, r1) = projection_stack(e1);
-    let (s2, r2) = projection_stack(e2);
-    if !eq_expr_value(cx, r1, r2) {
+pub fn can_mut_borrow_both(cx: &LateContext<'_>, ctxt: SyntaxContext, e1: &Expr<'_>, e2: &Expr<'_>) -> bool {
+    let Some((s1, r1)) = projection_stack(e1, ctxt) else {
+        return false;
+    };
+    let Some((s2, r2)) = projection_stack(e2, ctxt) else {
+        return false;
+    };
+    if !eq_expr_value(cx, ctxt, r1, r2) {
         return true;
     }
     if expr_custom_deref_adjustment(cx, r1).is_some() || expr_custom_deref_adjustment(cx, r2).is_some() {
@@ -518,11 +526,6 @@ pub fn can_mut_borrow_both(cx: &LateContext<'_>, e1: &Expr<'_>, e2: &Expr<'_>) -
             (ExprKind::Field(_, i1), ExprKind::Field(_, i2)) => {
                 if i1 != i2 {
                     return true;
-                }
-            },
-            (ExprKind::Index(_, i1, _), ExprKind::Index(_, i2, _)) => {
-                if !eq_expr_value(cx, i1, i2) {
-                    return false;
                 }
             },
             _ => return false,


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/15793)*

This is needed for `SpanlessEq` to work correctly inside a macro expansion. The context selected for some of the lints may be wrong, but most of them don't handle macros correctly in the first place so this won't really be a regression. Without this change `SpanlessEq` would essentially assume the root context which isn't always correct.

changelog: none
