### PR TITLE
test: remove extraneous `#[allow(clippy::uninlined_format_args)]`

### DIFF
--- a/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs
+++ b/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::uninlined_format_args)]
-
 fn main() {}
 
 #[warn(clippy::cognitive_complexity)]
@@ -8,7 +6,7 @@ fn cognitive_complexity() {
     let x = vec![1, 2, 3];
     for i in x {
         if i == 1 {
-            println!("{}", i);
+            println!("{i}");
         }
     }
 }

--- a/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.stderr
+++ b/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.stderr
@@ -11,7 +11,7 @@ LL | blacklisted-names = [ "..", "wibble" ]
    | ^^^^^^^^^^^^^^^^^
 
 error: the function has a cognitive complexity of (3/2)
-  --> tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs:6:4
+  --> tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs:4:4
    |
 LL | fn cognitive_complexity() {
    |    ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.fixed
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.fixed
@@ -1,4 +1,3 @@
-#![allow(clippy::uninlined_format_args)]
 #![deny(clippy::index_refutable_slice)]
 
 fn below_limit() {

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::uninlined_format_args)]
 #![deny(clippy::index_refutable_slice)]
 
 fn below_limit() {

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.stderr
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.stderr
@@ -1,11 +1,11 @@
 error: this binding can be a slice pattern to avoid indexing
-  --> tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs:6:17
+  --> tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs:5:17
    |
 LL |     if let Some(slice) = slice {
    |                 ^^^^^
    |
 note: the lint level is defined here
-  --> tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs:2:9
+  --> tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs:1:9
    |
 LL | #![deny(clippy::index_refutable_slice)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/bind_instead_of_map.fixed
+++ b/tests/ui/bind_instead_of_map.fixed
@@ -1,5 +1,4 @@
 #![deny(clippy::bind_instead_of_map)]
-#![allow(clippy::uninlined_format_args)]
 
 // need a main anyway, use it get rid of unused warnings too
 pub fn main() {

--- a/tests/ui/bind_instead_of_map.rs
+++ b/tests/ui/bind_instead_of_map.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::bind_instead_of_map)]
-#![allow(clippy::uninlined_format_args)]
 
 // need a main anyway, use it get rid of unused warnings too
 pub fn main() {

--- a/tests/ui/bind_instead_of_map.stderr
+++ b/tests/ui/bind_instead_of_map.stderr
@@ -1,5 +1,5 @@
 error: using `Option.and_then(Some)`, which is a no-op
-  --> tests/ui/bind_instead_of_map.rs:8:13
+  --> tests/ui/bind_instead_of_map.rs:7:13
    |
 LL |     let _ = x.and_then(Some);
    |             ^^^^^^^^^^^^^^^^ help: use the expression directly: `x`
@@ -11,13 +11,13 @@ LL | #![deny(clippy::bind_instead_of_map)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
-  --> tests/ui/bind_instead_of_map.rs:10:13
+  --> tests/ui/bind_instead_of_map.rs:9:13
    |
 LL |     let _ = x.and_then(|o| Some(o + 1));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.map(|o| o + 1)`
 
 error: using `Result.and_then(Ok)`, which is a no-op
-  --> tests/ui/bind_instead_of_map.rs:17:13
+  --> tests/ui/bind_instead_of_map.rs:16:13
    |
 LL |     let _ = x.and_then(Ok);
    |             ^^^^^^^^^^^^^^ help: use the expression directly: `x`

--- a/tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs
+++ b/tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
 #![allow(dead_code)]
-#![allow(clippy::uninlined_format_args)]
 //@no-rustfix
 // branches_sharing_code at the top and bottom of the if blocks
 
@@ -70,7 +69,7 @@ fn complexer_example() {
         let b = 0xffff00ff;
         let e_id = gen_id(a, b);
 
-        println!("From the a `{}` to the b `{}`", a, b);
+        println!("From the a `{a}` to the b `{b}`");
 
         let pack = DataPack {
             id: e_id,
@@ -83,7 +82,7 @@ fn complexer_example() {
         let b = 0xffff00ff;
         let e_id = gen_id(a, b);
 
-        println!("The new ID is '{}'", e_id);
+        println!("The new ID is '{e_id}'");
 
         let pack = DataPack {
             id: e_id,

--- a/tests/ui/branches_sharing_code/shared_at_top_and_bottom.stderr
+++ b/tests/ui/branches_sharing_code/shared_at_top_and_bottom.stderr
@@ -1,5 +1,5 @@
 error: all if blocks contain the same code at both the start and the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:17:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:16:5
    |
 LL | /     if x == 7 {
 LL | |
@@ -10,7 +10,7 @@ LL | |         let _overlap_end = 2 * t;
    | |_________________________________^
    |
 note: this code is shared at the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:31:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:30:5
    |
 LL | /         let _u = 9;
 LL | |     }
@@ -34,7 +34,7 @@ LL +     let _u = 9;
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:35:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:34:5
    |
 LL | /     if x == 99 {
 LL | |
@@ -45,7 +45,7 @@ LL | |         let _overlap_middle = r * r;
    | |____________________________________^
    |
 note: this code is shared at the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:48:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:47:5
    |
 LL | /         let _overlap_end = r * r * r;
 LL | |         let z = "end";
@@ -67,7 +67,7 @@ LL +     let z = "end";
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:66:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:65:5
    |
 LL | /     if (x > 7 && y < 13) || (x + y) % 2 == 1 {
 LL | |
@@ -78,7 +78,7 @@ LL | |         let e_id = gen_id(a, b);
    | |________________________________^
    |
 note: this code is shared at the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:88:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:87:5
    |
 LL | /         let pack = DataPack {
 LL | |             id: e_id,
@@ -108,7 +108,7 @@ LL +     process_data(pack);
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:101:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:100:5
    |
 LL | /     let _ = if x == 7 {
 ...  |
@@ -116,7 +116,7 @@ LL | |         let _ = 19;
    | |___________________^
    |
 note: this code is shared at the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:112:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:111:5
    |
 LL | /         x << 2
 LL | |     };
@@ -134,7 +134,7 @@ LL ~     x << 2;
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:115:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:114:5
    |
 LL | /     if x == 9 {
 ...  |
@@ -142,7 +142,7 @@ LL | |         let _ = 17;
    | |___________________^
    |
 note: this code is shared at the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:126:5
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:125:5
    |
 LL | /         x * 4
 LL | |     }
@@ -160,7 +160,7 @@ LL +     x * 4
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:158:9
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:157:9
    |
 LL | /         if false {
 LL | |
@@ -168,7 +168,7 @@ LL | |             let x = 1;
    | |______________________^
    |
 note: this code is shared at the end
-  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:166:9
+  --> tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs:165:9
    |
 LL | /             let y = 1;
 LL | |         }

--- a/tests/ui/cast_abs_to_unsigned.fixed
+++ b/tests/ui/cast_abs_to_unsigned.fixed
@@ -1,11 +1,11 @@
 #![warn(clippy::cast_abs_to_unsigned)]
-#![allow(clippy::uninlined_format_args, unused)]
+#![allow(unused)]
 
 fn main() {
     let x: i32 = -42;
     let y: u32 = x.unsigned_abs();
     //~^ cast_abs_to_unsigned
-    println!("The absolute value of {} is {}", x, y);
+    println!("The absolute value of {x} is {y}");
 
     let a: i32 = -3;
     let _: usize = a.unsigned_abs() as usize;

--- a/tests/ui/cast_abs_to_unsigned.rs
+++ b/tests/ui/cast_abs_to_unsigned.rs
@@ -1,11 +1,11 @@
 #![warn(clippy::cast_abs_to_unsigned)]
-#![allow(clippy::uninlined_format_args, unused)]
+#![allow(unused)]
 
 fn main() {
     let x: i32 = -42;
     let y: u32 = x.abs() as u32;
     //~^ cast_abs_to_unsigned
-    println!("The absolute value of {} is {}", x, y);
+    println!("The absolute value of {x} is {y}");
 
     let a: i32 = -3;
     let _: usize = a.abs() as usize;

--- a/tests/ui/crashes/ice-4775.rs
+++ b/tests/ui/crashes/ice-4775.rs
@@ -7,7 +7,7 @@ pub struct ArrayWrapper<const N: usize>([usize; N]);
 impl<const N: usize> ArrayWrapper<{ N }> {
     pub fn ice(&self) {
         for i in self.0.iter() {
-            println!("{}", i);
+            println!("{i}");
         }
     }
 }

--- a/tests/ui/default_trait_access.fixed
+++ b/tests/ui/default_trait_access.fixed
@@ -1,7 +1,6 @@
 //@aux-build: proc_macros.rs
 #![deny(clippy::default_trait_access)]
 #![allow(dead_code, unused_imports)]
-#![allow(clippy::uninlined_format_args)]
 
 extern crate proc_macros;
 
@@ -63,6 +62,7 @@ fn main() {
 
     let _s21: String = with_span!(s Default::default());
 
+    #[expect(clippy::uninlined_format_args)]
     println!(
         "[{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}]",
         s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20,

--- a/tests/ui/default_trait_access.rs
+++ b/tests/ui/default_trait_access.rs
@@ -1,7 +1,6 @@
 //@aux-build: proc_macros.rs
 #![deny(clippy::default_trait_access)]
 #![allow(dead_code, unused_imports)]
-#![allow(clippy::uninlined_format_args)]
 
 extern crate proc_macros;
 
@@ -63,6 +62,7 @@ fn main() {
 
     let _s21: String = with_span!(s Default::default());
 
+    #[expect(clippy::uninlined_format_args)]
     println!(
         "[{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}]",
         s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20,

--- a/tests/ui/default_trait_access.stderr
+++ b/tests/ui/default_trait_access.stderr
@@ -1,5 +1,5 @@
 error: calling `String::default()` is more clear than this expression
-  --> tests/ui/default_trait_access.rs:13:22
+  --> tests/ui/default_trait_access.rs:12:22
    |
 LL |     let s1: String = Default::default();
    |                      ^^^^^^^^^^^^^^^^^^ help: try: `String::default()`
@@ -11,43 +11,43 @@ LL | #![deny(clippy::default_trait_access)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: calling `String::default()` is more clear than this expression
-  --> tests/ui/default_trait_access.rs:18:22
+  --> tests/ui/default_trait_access.rs:17:22
    |
 LL |     let s3: String = D2::default();
    |                      ^^^^^^^^^^^^^ help: try: `String::default()`
 
 error: calling `String::default()` is more clear than this expression
-  --> tests/ui/default_trait_access.rs:21:22
+  --> tests/ui/default_trait_access.rs:20:22
    |
 LL |     let s4: String = std::default::Default::default();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `String::default()`
 
 error: calling `String::default()` is more clear than this expression
-  --> tests/ui/default_trait_access.rs:26:22
+  --> tests/ui/default_trait_access.rs:25:22
    |
 LL |     let s6: String = default::Default::default();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `String::default()`
 
 error: calling `GenericDerivedDefault::default()` is more clear than this expression
-  --> tests/ui/default_trait_access.rs:37:46
+  --> tests/ui/default_trait_access.rs:36:46
    |
 LL |     let s11: GenericDerivedDefault<String> = Default::default();
    |                                              ^^^^^^^^^^^^^^^^^^ help: try: `GenericDerivedDefault::default()`
 
 error: calling `TupleDerivedDefault::default()` is more clear than this expression
-  --> tests/ui/default_trait_access.rs:44:36
+  --> tests/ui/default_trait_access.rs:43:36
    |
 LL |     let s14: TupleDerivedDefault = Default::default();
    |                                    ^^^^^^^^^^^^^^^^^^ help: try: `TupleDerivedDefault::default()`
 
 error: calling `ArrayDerivedDefault::default()` is more clear than this expression
-  --> tests/ui/default_trait_access.rs:47:36
+  --> tests/ui/default_trait_access.rs:46:36
    |
 LL |     let s15: ArrayDerivedDefault = Default::default();
    |                                    ^^^^^^^^^^^^^^^^^^ help: try: `ArrayDerivedDefault::default()`
 
 error: calling `TupleStructDerivedDefault::default()` is more clear than this expression
-  --> tests/ui/default_trait_access.rs:52:42
+  --> tests/ui/default_trait_access.rs:51:42
    |
 LL |     let s17: TupleStructDerivedDefault = Default::default();
    |                                          ^^^^^^^^^^^^^^^^^^ help: try: `TupleStructDerivedDefault::default()`

--- a/tests/ui/explicit_counter_loop.rs
+++ b/tests/ui/explicit_counter_loop.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::explicit_counter_loop)]
-#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
+#![allow(clippy::useless_vec)]
 //@no-rustfix: suggestion does not remove the `+= 1`
 fn main() {
     let mut vec = vec![1, 2, 3, 4];
@@ -89,13 +89,13 @@ mod issue_1219 {
         for _v in &vec {
             index += 1
         }
-        println!("index: {}", index);
+        println!("index: {index}");
 
         // should not trigger the lint because the count is conditional #1219
         let text = "banana";
         let mut count = 0;
         for ch in text.chars() {
-            println!("{}", count);
+            println!("{count}");
             if ch == 'a' {
                 continue;
             }
@@ -106,7 +106,7 @@ mod issue_1219 {
         let text = "banana";
         let mut count = 0;
         for ch in text.chars() {
-            println!("{}", count);
+            println!("{count}");
             if ch == 'a' {
                 count += 1;
             }
@@ -118,7 +118,7 @@ mod issue_1219 {
         for ch in text.chars() {
             //~^ explicit_counter_loop
 
-            println!("{}", count);
+            println!("{count}");
             count += 1;
             if ch == 'a' {
                 continue;
@@ -131,7 +131,7 @@ mod issue_1219 {
         for ch in text.chars() {
             //~^ explicit_counter_loop
 
-            println!("{}", count);
+            println!("{count}");
             count += 1;
             for i in 0..2 {
                 let _ = 123;
@@ -142,7 +142,7 @@ mod issue_1219 {
         let text = "banana";
         let mut count = 0;
         for ch in text.chars() {
-            println!("{}", count);
+            println!("{count}");
             count += 1;
             for i in 0..2 {
                 count += 1;
@@ -157,7 +157,7 @@ mod issue_3308 {
         let mut skips = 0;
         let erasures = vec![];
         for i in 0..10 {
-            println!("{}", skips);
+            println!("{skips}");
             while erasures.contains(&(i + skips)) {
                 skips += 1;
             }
@@ -166,7 +166,7 @@ mod issue_3308 {
         // should not trigger the lint because the count is incremented multiple times
         let mut skips = 0;
         for i in 0..10 {
-            println!("{}", skips);
+            println!("{skips}");
             let mut j = 0;
             while j < 5 {
                 skips += 1;
@@ -177,7 +177,7 @@ mod issue_3308 {
         // should not trigger the lint because the count is incremented multiple times
         let mut skips = 0;
         for i in 0..10 {
-            println!("{}", skips);
+            println!("{skips}");
             for j in 0..5 {
                 skips += 1;
             }
@@ -205,7 +205,7 @@ mod issue_4732 {
         for _v in slice {
             index += 1
         }
-        let _closure = || println!("index: {}", index);
+        let _closure = || println!("index: {index}");
     }
 }
 
@@ -217,7 +217,7 @@ mod issue_4677 {
         let mut count = 0;
         for _i in slice {
             count += 1;
-            println!("{}", count);
+            println!("{count}");
         }
     }
 }

--- a/tests/ui/explicit_write.fixed
+++ b/tests/ui/explicit_write.fixed
@@ -1,6 +1,5 @@
 #![warn(clippy::explicit_write)]
 #![allow(unused_imports)]
-#![allow(clippy::uninlined_format_args)]
 
 fn stdout() -> String {
     String::new()
@@ -40,7 +39,7 @@ fn main() {
         //~^ explicit_write
 
         let value = 1;
-        eprintln!("with {}", value);
+        eprintln!("with {value}");
         //~^ explicit_write
         eprintln!("with {} {}", 2, value);
         //~^ explicit_write
@@ -49,7 +48,7 @@ fn main() {
         eprintln!("macro arg {}", one!());
         //~^ explicit_write
         let width = 2;
-        eprintln!("{:w$}", value, w = width);
+        eprintln!("{value:w$}", w = width);
         //~^ explicit_write
     }
     // these should not warn, different destination

--- a/tests/ui/explicit_write.rs
+++ b/tests/ui/explicit_write.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::explicit_write)]
 #![allow(unused_imports)]
-#![allow(clippy::uninlined_format_args)]
 
 fn stdout() -> String {
     String::new()
@@ -40,7 +39,7 @@ fn main() {
         //~^ explicit_write
 
         let value = 1;
-        writeln!(std::io::stderr(), "with {}", value).unwrap();
+        writeln!(std::io::stderr(), "with {value}").unwrap();
         //~^ explicit_write
         writeln!(std::io::stderr(), "with {} {}", 2, value).unwrap();
         //~^ explicit_write
@@ -49,7 +48,7 @@ fn main() {
         writeln!(std::io::stderr(), "macro arg {}", one!()).unwrap();
         //~^ explicit_write
         let width = 2;
-        writeln!(std::io::stderr(), "{:w$}", value, w = width).unwrap();
+        writeln!(std::io::stderr(), "{value:w$}", w = width).unwrap();
         //~^ explicit_write
     }
     // these should not warn, different destination

--- a/tests/ui/explicit_write.stderr
+++ b/tests/ui/explicit_write.stderr
@@ -1,5 +1,5 @@
 error: use of `write!(stdout(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:23:9
+  --> tests/ui/explicit_write.rs:22:9
    |
 LL |         write!(std::io::stdout(), "test").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `print!("test")`
@@ -8,76 +8,76 @@ LL |         write!(std::io::stdout(), "test").unwrap();
    = help: to override `-D warnings` add `#[allow(clippy::explicit_write)]`
 
 error: use of `write!(stderr(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:25:9
+  --> tests/ui/explicit_write.rs:24:9
    |
 LL |         write!(std::io::stderr(), "test").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprint!("test")`
 
 error: use of `writeln!(stdout(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:27:9
+  --> tests/ui/explicit_write.rs:26:9
    |
 LL |         writeln!(std::io::stdout(), "test").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `println!("test")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:29:9
+  --> tests/ui/explicit_write.rs:28:9
    |
 LL |         writeln!(std::io::stderr(), "test").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("test")`
 
 error: use of `stdout().write_fmt(...).unwrap()`
-  --> tests/ui/explicit_write.rs:31:9
+  --> tests/ui/explicit_write.rs:30:9
    |
 LL |         std::io::stdout().write_fmt(format_args!("test")).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `print!("test")`
 
 error: use of `stderr().write_fmt(...).unwrap()`
-  --> tests/ui/explicit_write.rs:33:9
+  --> tests/ui/explicit_write.rs:32:9
    |
 LL |         std::io::stderr().write_fmt(format_args!("test")).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprint!("test")`
 
 error: use of `writeln!(stdout(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:37:9
+  --> tests/ui/explicit_write.rs:36:9
    |
 LL |         writeln!(std::io::stdout(), "test\ntest").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `println!("test\ntest")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:39:9
+  --> tests/ui/explicit_write.rs:38:9
    |
 LL |         writeln!(std::io::stderr(), "test\ntest").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("test\ntest")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:43:9
-   |
-LL |         writeln!(std::io::stderr(), "with {}", value).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("with {}", value)`
-
-error: use of `writeln!(stderr(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:45:9
-   |
-LL |         writeln!(std::io::stderr(), "with {} {}", 2, value).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("with {} {}", 2, value)`
-
-error: use of `writeln!(stderr(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:47:9
+  --> tests/ui/explicit_write.rs:42:9
    |
 LL |         writeln!(std::io::stderr(), "with {value}").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("with {value}")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:49:9
+  --> tests/ui/explicit_write.rs:44:9
+   |
+LL |         writeln!(std::io::stderr(), "with {} {}", 2, value).unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("with {} {}", 2, value)`
+
+error: use of `writeln!(stderr(), ...).unwrap()`
+  --> tests/ui/explicit_write.rs:46:9
+   |
+LL |         writeln!(std::io::stderr(), "with {value}").unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("with {value}")`
+
+error: use of `writeln!(stderr(), ...).unwrap()`
+  --> tests/ui/explicit_write.rs:48:9
    |
 LL |         writeln!(std::io::stderr(), "macro arg {}", one!()).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("macro arg {}", one!())`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> tests/ui/explicit_write.rs:52:9
+  --> tests/ui/explicit_write.rs:51:9
    |
-LL |         writeln!(std::io::stderr(), "{:w$}", value, w = width).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("{:w$}", value, w = width)`
+LL |         writeln!(std::io::stderr(), "{value:w$}", w = width).unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("{value:w$}", w = width)`
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/fallible_impl_from.rs
+++ b/tests/ui/fallible_impl_from.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::fallible_impl_from)]
-#![allow(clippy::uninlined_format_args)]
 
 // docs example
 struct Foo(i32);
@@ -62,7 +61,7 @@ impl<'a> From<&'a mut <Box<u32> as ProjStrTrait>::ProjString> for Invalid {
 
     fn from(s: &'a mut <Box<u32> as ProjStrTrait>::ProjString) -> Invalid {
         if s.parse::<u32>().ok().unwrap() != 42 {
-            panic!("{:?}", s);
+            panic!("{s:?}");
         }
         Invalid
     }

--- a/tests/ui/fallible_impl_from.stderr
+++ b/tests/ui/fallible_impl_from.stderr
@@ -1,5 +1,5 @@
 error: consider implementing `TryFrom` instead
-  --> tests/ui/fallible_impl_from.rs:6:1
+  --> tests/ui/fallible_impl_from.rs:5:1
    |
 LL | / impl From<String> for Foo {
 LL | |
@@ -11,7 +11,7 @@ LL | | }
    |
    = help: `From` is intended for infallible conversions only. Use `TryFrom` if there's a possibility for the conversion to fail
 note: potential failure(s)
-  --> tests/ui/fallible_impl_from.rs:10:13
+  --> tests/ui/fallible_impl_from.rs:9:13
    |
 LL |         Foo(s.parse().unwrap())
    |             ^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL | #![deny(clippy::fallible_impl_from)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider implementing `TryFrom` instead
-  --> tests/ui/fallible_impl_from.rs:29:1
+  --> tests/ui/fallible_impl_from.rs:28:1
    |
 LL | / impl From<usize> for Invalid {
 LL | |
@@ -34,13 +34,13 @@ LL | | }
    |
    = help: `From` is intended for infallible conversions only. Use `TryFrom` if there's a possibility for the conversion to fail
 note: potential failure(s)
-  --> tests/ui/fallible_impl_from.rs:34:13
+  --> tests/ui/fallible_impl_from.rs:33:13
    |
 LL |             panic!();
    |             ^^^^^^^^
 
 error: consider implementing `TryFrom` instead
-  --> tests/ui/fallible_impl_from.rs:40:1
+  --> tests/ui/fallible_impl_from.rs:39:1
    |
 LL | / impl From<Option<String>> for Invalid {
 LL | |
@@ -52,7 +52,7 @@ LL | | }
    |
    = help: `From` is intended for infallible conversions only. Use `TryFrom` if there's a possibility for the conversion to fail
 note: potential failure(s)
-  --> tests/ui/fallible_impl_from.rs:44:17
+  --> tests/ui/fallible_impl_from.rs:43:17
    |
 LL |         let s = s.unwrap();
    |                 ^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |             panic!("{:?}", s);
    |             ^^^^^^^^^^^^^^^^^
 
 error: consider implementing `TryFrom` instead
-  --> tests/ui/fallible_impl_from.rs:60:1
+  --> tests/ui/fallible_impl_from.rs:59:1
    |
 LL | / impl<'a> From<&'a mut <Box<u32> as ProjStrTrait>::ProjString> for Invalid {
 LL | |
@@ -77,12 +77,12 @@ LL | | }
    |
    = help: `From` is intended for infallible conversions only. Use `TryFrom` if there's a possibility for the conversion to fail
 note: potential failure(s)
-  --> tests/ui/fallible_impl_from.rs:64:12
+  --> tests/ui/fallible_impl_from.rs:63:12
    |
 LL |         if s.parse::<u32>().ok().unwrap() != 42 {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |             panic!("{:?}", s);
-   |             ^^^^^^^^^^^^^^^^^
+LL |             panic!("{s:?}");
+   |             ^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/index_refutable_slice/if_let_slice_binding.fixed
+++ b/tests/ui/index_refutable_slice/if_let_slice_binding.fixed
@@ -1,5 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
-#![allow(clippy::uninlined_format_args, clippy::needless_lifetimes, clippy::collapsible_if)]
+#![allow(clippy::needless_lifetimes, clippy::collapsible_if)]
 
 enum SomeEnum<T> {
     One(T),
@@ -60,7 +60,7 @@ fn lintable_examples() {
 
         println!("{:?}", slice_1);
     }
-    println!("{:?}", slice);
+    println!("{slice:?}");
 
     // This should not suggest using the `ref` keyword as the scrutinee is already
     // a reference
@@ -70,7 +70,7 @@ fn lintable_examples() {
 
         println!("{:?}", slice_0);
     }
-    println!("{:?}", slice);
+    println!("{slice:?}");
 }
 
 fn slice_index_above_limit() {
@@ -113,7 +113,7 @@ fn check_slice_as_arg() {
             println!("This is interesting {}", slice[0]);
         }
     }
-    println!("{:?}", slice_wrapped);
+    println!("{slice_wrapped:?}");
 }
 
 fn check_slice_in_struct() {
@@ -152,7 +152,7 @@ fn check_slice_in_struct() {
             println!("This is super awesome! {}", slice_0);
         }
     }
-    println!("Complete wrap: {:?}", wrap);
+    println!("Complete wrap: {wrap:?}");
 }
 
 /// This would be a nice additional feature to have in the future, but adding it
@@ -164,14 +164,14 @@ fn mutable_slice_index() {
     if let Some(ref mut slice) = slice {
         slice[0] = String::from("Mr. Penguin");
     }
-    println!("Use after modification: {:?}", slice);
+    println!("Use after modification: {slice:?}");
 
     // Mut access on reference
     let mut slice: Option<[String; 1]> = Some([String::from("Cat")]);
     if let Some(slice) = &mut slice {
         slice[0] = String::from("Lord Meow Meow");
     }
-    println!("Use after modification: {:?}", slice);
+    println!("Use after modification: {slice:?}");
 }
 
 /// The lint will ignore bindings with sub patterns as it would be hard

--- a/tests/ui/index_refutable_slice/if_let_slice_binding.rs
+++ b/tests/ui/index_refutable_slice/if_let_slice_binding.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
-#![allow(clippy::uninlined_format_args, clippy::needless_lifetimes, clippy::collapsible_if)]
+#![allow(clippy::needless_lifetimes, clippy::collapsible_if)]
 
 enum SomeEnum<T> {
     One(T),
@@ -60,7 +60,7 @@ fn lintable_examples() {
 
         println!("{:?}", slice[1]);
     }
-    println!("{:?}", slice);
+    println!("{slice:?}");
 
     // This should not suggest using the `ref` keyword as the scrutinee is already
     // a reference
@@ -70,7 +70,7 @@ fn lintable_examples() {
 
         println!("{:?}", slice[0]);
     }
-    println!("{:?}", slice);
+    println!("{slice:?}");
 }
 
 fn slice_index_above_limit() {
@@ -113,7 +113,7 @@ fn check_slice_as_arg() {
             println!("This is interesting {}", slice[0]);
         }
     }
-    println!("{:?}", slice_wrapped);
+    println!("{slice_wrapped:?}");
 }
 
 fn check_slice_in_struct() {
@@ -152,7 +152,7 @@ fn check_slice_in_struct() {
             println!("This is super awesome! {}", slice[0]);
         }
     }
-    println!("Complete wrap: {:?}", wrap);
+    println!("Complete wrap: {wrap:?}");
 }
 
 /// This would be a nice additional feature to have in the future, but adding it
@@ -164,14 +164,14 @@ fn mutable_slice_index() {
     if let Some(ref mut slice) = slice {
         slice[0] = String::from("Mr. Penguin");
     }
-    println!("Use after modification: {:?}", slice);
+    println!("Use after modification: {slice:?}");
 
     // Mut access on reference
     let mut slice: Option<[String; 1]> = Some([String::from("Cat")]);
     if let Some(slice) = &mut slice {
         slice[0] = String::from("Lord Meow Meow");
     }
-    println!("Use after modification: {:?}", slice);
+    println!("Use after modification: {slice:?}");
 }
 
 /// The lint will ignore bindings with sub patterns as it would be hard

--- a/tests/ui/infinite_iter.rs
+++ b/tests/ui/infinite_iter.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::uninlined_format_args, clippy::double_ended_iterator_last)]
+#![allow(clippy::double_ended_iterator_last)]
 
 use std::iter::repeat;
 fn square_is_lower_64(x: &u32) -> bool {
@@ -30,7 +30,7 @@ fn infinite_iters() {
         .rev()
         .cycle()
         .map(|x| x + 1_u32)
-        .for_each(|x| println!("{}", x));
+        .for_each(|x| println!("{x}"));
     // infinite iter
     (0..3_u32).flat_map(|x| x..).sum::<u32>();
     // infinite iter

--- a/tests/ui/infinite_iter.stderr
+++ b/tests/ui/infinite_iter.stderr
@@ -30,8 +30,8 @@ LL | |
 LL | |         .rev()
 LL | |         .cycle()
 LL | |         .map(|x| x + 1_u32)
-LL | |         .for_each(|x| println!("{}", x));
-   | |________________________________________^
+LL | |         .for_each(|x| println!("{x}"));
+   | |______________________________________^
 
 error: infinite iteration detected
   --> tests/ui/infinite_iter.rs:37:5

--- a/tests/ui/issue_2356.fixed
+++ b/tests/ui/issue_2356.fixed
@@ -1,6 +1,5 @@
 #![deny(clippy::while_let_on_iterator)]
 #![allow(unused_mut)]
-#![allow(clippy::uninlined_format_args)]
 
 use std::iter::Iterator;
 
@@ -16,7 +15,7 @@ impl Foo {
     fn foo2<I: Iterator<Item = usize>>(mut it: I) {
         for e in it {
             //~^ while_let_on_iterator
-            println!("{:?}", e);
+            println!("{e:?}");
         }
     }
 }

--- a/tests/ui/issue_2356.rs
+++ b/tests/ui/issue_2356.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::while_let_on_iterator)]
 #![allow(unused_mut)]
-#![allow(clippy::uninlined_format_args)]
 
 use std::iter::Iterator;
 
@@ -16,7 +15,7 @@ impl Foo {
     fn foo2<I: Iterator<Item = usize>>(mut it: I) {
         while let Some(e) = it.next() {
             //~^ while_let_on_iterator
-            println!("{:?}", e);
+            println!("{e:?}");
         }
     }
 }

--- a/tests/ui/issue_2356.stderr
+++ b/tests/ui/issue_2356.stderr
@@ -1,5 +1,5 @@
 error: this loop could be written as a `for` loop
-  --> tests/ui/issue_2356.rs:17:9
+  --> tests/ui/issue_2356.rs:16:9
    |
 LL |         while let Some(e) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for e in it`

--- a/tests/ui/issue_4266.rs
+++ b/tests/ui/issue_4266.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![allow(clippy::uninlined_format_args)]
 
 async fn sink1<'a>(_: &'a str) {} // lint
 //~^ needless_lifetimes
@@ -39,7 +38,7 @@ impl Foo {
 // rust-lang/rust#61115
 // ok
 async fn print(s: &str) {
-    println!("{}", s);
+    println!("{s}");
 }
 
 fn main() {}

--- a/tests/ui/issue_4266.stderr
+++ b/tests/ui/issue_4266.stderr
@@ -1,5 +1,5 @@
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/issue_4266.rs:4:16
+  --> tests/ui/issue_4266.rs:3:16
    |
 LL | async fn sink1<'a>(_: &'a str) {} // lint
    |                ^^      ^^
@@ -8,13 +8,13 @@ LL | async fn sink1<'a>(_: &'a str) {} // lint
    = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/issue_4266.rs:10:21
+  --> tests/ui/issue_4266.rs:9:21
    |
 LL | async fn one_to_one<'a>(s: &'a str) -> &'a str {
    |                     ^^      ^^          ^^
 
 error: methods called `new` usually take no `self`
-  --> tests/ui/issue_4266.rs:32:22
+  --> tests/ui/issue_4266.rs:31:22
    |
 LL |     pub async fn new(&mut self) -> Self {
    |                      ^^^^^^^^^

--- a/tests/ui/match_single_binding.fixed
+++ b/tests/ui/match_single_binding.fixed
@@ -4,7 +4,6 @@
     clippy::let_unit_value,
     clippy::no_effect,
     clippy::toplevel_ref_arg,
-    clippy::uninlined_format_args,
     clippy::useless_vec
 )]
 
@@ -32,11 +31,11 @@ fn main() {
     // Lint
     let (x, y, z) = (a, b, c);
     {
-        println!("{} {} {}", x, y, z);
+        println!("{x} {y} {z}");
     }
     // Lint
     let (x, y, z) = (a, b, c);
-    println!("{} {} {}", x, y, z);
+    println!("{x} {y} {z}");
     // Ok
     foo!(a);
     // Ok
@@ -47,7 +46,7 @@ fn main() {
     // Ok
     let d = Some(5);
     match d {
-        Some(d) => println!("{}", d),
+        Some(d) => println!("{d}"),
         _ => println!("None"),
     }
     // Lint
@@ -55,7 +54,7 @@ fn main() {
     // Lint
     {
         let x = 29;
-        println!("x has a value of {}", x);
+        println!("x has a value of {x}");
     }
     // Lint
     {
@@ -67,18 +66,18 @@ fn main() {
     // Lint
     let p = Point { x: 0, y: 7 };
     let Point { x, y } = p;
-    println!("Coords: ({}, {})", x, y);
+    println!("Coords: ({x}, {y})");
     // Lint
     let Point { x: x1, y: y1 } = p;
-    println!("Coords: ({}, {})", x1, y1);
+    println!("Coords: ({x1}, {y1})");
     // Lint
     let x = 5;
     let ref r = x;
-    println!("Got a reference to {}", r);
+    println!("Got a reference to {r}");
     // Lint
     let mut x = 5;
     let ref mut mr = x;
-    println!("Got a mutable reference to {}", mr);
+    println!("Got a mutable reference to {mr}");
     // Lint
     let Point { x, y } = coords();
     let product = x * y;
@@ -122,7 +121,7 @@ fn issue_8723() {
 
     let (pre, suf) = val.split_at(idx);
     val = {
-        println!("{}", pre);
+        println!("{pre}");
         suf
     };
 
@@ -210,20 +209,20 @@ mod issue15018 {
         let x = 1;
         {
             let (x, y, z) = (a, b, c);
-            println!("{} {} {}", x, y, z);
+            println!("{x} {y} {z}");
         }
         println!("x = {x}");
     }
 
     fn not_used_later(a: i32, b: i32, c: i32) {
         let (x, y, z) = (a, b, c);
-        println!("{} {} {}", x, y, z)
+        println!("{x} {y} {z}")
     }
 
     #[allow(irrefutable_let_patterns)]
     fn not_used_later_but_shadowed(a: i32, b: i32, c: i32) {
         let (x, y, z) = (a, b, c);
-        println!("{} {} {}", x, y, z);
+        println!("{x} {y} {z}");
         let x = 1;
         println!("x = {x}");
     }
@@ -231,27 +230,27 @@ mod issue15018 {
     #[allow(irrefutable_let_patterns)]
     fn not_used_later_but_shadowed_nested(a: i32, b: i32, c: i32) {
         let (x, y, z) = (a, b, c);
-        println!("{} {} {}", x, y, z);
+        println!("{x} {x} {y}");
         if let (x, y, z) = (a, b, c) {
-            println!("{} {} {}", x, y, z)
+            println!("{x} {y} {z}")
         }
 
         {
             let x: i32 = 1;
             {
                 let (x, y, z) = (a, b, c);
-                println!("{} {} {}", x, y, z);
+                println!("{x} {y} {z}");
             }
             if let (x, y, z) = (a, x, c) {
-                println!("{} {} {}", x, y, z)
+                println!("{x} {y} {z}")
             }
         }
 
         {
             let (x, y, z) = (a, b, c);
-            println!("{} {} {}", x, y, z);
+            println!("{x} {y} {z}");
             let fn_ = |y| {
-                println!("{} {} {}", a, b, y);
+                println!("{a} {b} {y}");
             };
             fn_(c);
         }

--- a/tests/ui/match_single_binding.rs
+++ b/tests/ui/match_single_binding.rs
@@ -4,7 +4,6 @@
     clippy::let_unit_value,
     clippy::no_effect,
     clippy::toplevel_ref_arg,
-    clippy::uninlined_format_args,
     clippy::useless_vec
 )]
 
@@ -33,13 +32,13 @@ fn main() {
     match (a, b, c) {
         //~^ match_single_binding
         (x, y, z) => {
-            println!("{} {} {}", x, y, z);
+            println!("{x} {y} {z}");
         },
     }
     // Lint
     match (a, b, c) {
         //~^ match_single_binding
-        (x, y, z) => println!("{} {} {}", x, y, z),
+        (x, y, z) => println!("{x} {y} {z}"),
     }
     // Ok
     foo!(a);
@@ -51,7 +50,7 @@ fn main() {
     // Ok
     let d = Some(5);
     match d {
-        Some(d) => println!("{}", d),
+        Some(d) => println!("{d}"),
         _ => println!("None"),
     }
     // Lint
@@ -64,7 +63,7 @@ fn main() {
         //~^ match_single_binding
         _ => {
             let x = 29;
-            println!("x has a value of {}", x);
+            println!("x has a value of {x}");
         },
     }
     // Lint
@@ -81,24 +80,24 @@ fn main() {
     let p = Point { x: 0, y: 7 };
     match p {
         //~^ match_single_binding
-        Point { x, y } => println!("Coords: ({}, {})", x, y),
+        Point { x, y } => println!("Coords: ({x}, {y})"),
     }
     // Lint
     match p {
         //~^ match_single_binding
-        Point { x: x1, y: y1 } => println!("Coords: ({}, {})", x1, y1),
+        Point { x: x1, y: y1 } => println!("Coords: ({x1}, {y1})"),
     }
     // Lint
     let x = 5;
     match x {
         //~^ match_single_binding
-        ref r => println!("Got a reference to {}", r),
+        ref r => println!("Got a reference to {r}"),
     }
     // Lint
     let mut x = 5;
     match x {
         //~^ match_single_binding
-        ref mut mr => println!("Got a mutable reference to {}", mr),
+        ref mut mr => println!("Got a mutable reference to {mr}"),
     }
     // Lint
     let product = match coords() {
@@ -150,7 +149,7 @@ fn issue_8723() {
     val = match val.split_at(idx) {
         //~^ match_single_binding
         (pre, suf) => {
-            println!("{}", pre);
+            println!("{pre}");
             suf
         },
     };
@@ -273,7 +272,7 @@ mod issue15018 {
         let x = 1;
         match (a, b, c) {
             //~^ match_single_binding
-            (x, y, z) => println!("{} {} {}", x, y, z),
+            (x, y, z) => println!("{x} {y} {z}"),
         }
         println!("x = {x}");
     }
@@ -281,7 +280,7 @@ mod issue15018 {
     fn not_used_later(a: i32, b: i32, c: i32) {
         match (a, b, c) {
             //~^ match_single_binding
-            (x, y, z) => println!("{} {} {}", x, y, z),
+            (x, y, z) => println!("{x} {y} {z}"),
         }
     }
 
@@ -289,7 +288,7 @@ mod issue15018 {
     fn not_used_later_but_shadowed(a: i32, b: i32, c: i32) {
         match (a, b, c) {
             //~^ match_single_binding
-            (x, y, z) => println!("{} {} {}", x, y, z),
+            (x, y, z) => println!("{x} {y} {z}"),
         }
         let x = 1;
         println!("x = {x}");
@@ -299,30 +298,30 @@ mod issue15018 {
     fn not_used_later_but_shadowed_nested(a: i32, b: i32, c: i32) {
         match (a, b, c) {
             //~^ match_single_binding
-            (x, y, z) => println!("{} {} {}", x, y, z),
+            (x, y, z) => println!("{x} {x} {y}"),
         }
         if let (x, y, z) = (a, b, c) {
-            println!("{} {} {}", x, y, z)
+            println!("{x} {y} {z}")
         }
 
         {
             let x: i32 = 1;
             match (a, b, c) {
                 //~^ match_single_binding
-                (x, y, z) => println!("{} {} {}", x, y, z),
+                (x, y, z) => println!("{x} {y} {z}"),
             }
             if let (x, y, z) = (a, x, c) {
-                println!("{} {} {}", x, y, z)
+                println!("{x} {y} {z}")
             }
         }
 
         {
             match (a, b, c) {
                 //~^ match_single_binding
-                (x, y, z) => println!("{} {} {}", x, y, z),
+                (x, y, z) => println!("{x} {y} {z}"),
             }
             let fn_ = |y| {
-                println!("{} {} {}", a, b, y);
+                println!("{a} {b} {y}");
             };
             fn_(c);
         }

--- a/tests/ui/match_single_binding.stderr
+++ b/tests/ui/match_single_binding.stderr
@@ -1,10 +1,10 @@
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:33:5
+  --> tests/ui/match_single_binding.rs:32:5
    |
 LL | /     match (a, b, c) {
 LL | |
 LL | |         (x, y, z) => {
-LL | |             println!("{} {} {}", x, y, z);
+LL | |             println!("{x} {y} {z}");
 LL | |         },
 LL | |     }
    | |_____^
@@ -15,27 +15,27 @@ help: consider using a `let` statement
    |
 LL ~     let (x, y, z) = (a, b, c);
 LL +     {
-LL +         println!("{} {} {}", x, y, z);
+LL +         println!("{x} {y} {z}");
 LL +     }
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:40:5
+  --> tests/ui/match_single_binding.rs:39:5
    |
 LL | /     match (a, b, c) {
 LL | |
-LL | |         (x, y, z) => println!("{} {} {}", x, y, z),
+LL | |         (x, y, z) => println!("{x} {y} {z}"),
 LL | |     }
    | |_____^
    |
 help: consider using a `let` statement
    |
 LL ~     let (x, y, z) = (a, b, c);
-LL +     println!("{} {} {}", x, y, z);
+LL +     println!("{x} {y} {z}");
    |
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:58:5
+  --> tests/ui/match_single_binding.rs:57:5
    |
 LL | /     match a {
 LL | |
@@ -44,13 +44,13 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `println!("whatever");`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:63:5
+  --> tests/ui/match_single_binding.rs:62:5
    |
 LL | /     match a {
 LL | |
 LL | |         _ => {
 LL | |             let x = 29;
-LL | |             println!("x has a value of {}", x);
+LL | |             println!("x has a value of {x}");
 LL | |         },
 LL | |     }
    | |_____^
@@ -59,12 +59,12 @@ help: consider using the match body instead
    |
 LL ~     {
 LL +         let x = 29;
-LL +         println!("x has a value of {}", x);
+LL +         println!("x has a value of {x}");
 LL +     }
    |
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:71:5
+  --> tests/ui/match_single_binding.rs:70:5
    |
 LL | /     match a {
 LL | |
@@ -86,67 +86,67 @@ LL +     }
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:82:5
+  --> tests/ui/match_single_binding.rs:81:5
    |
 LL | /     match p {
 LL | |
-LL | |         Point { x, y } => println!("Coords: ({}, {})", x, y),
+LL | |         Point { x, y } => println!("Coords: ({x}, {y})"),
 LL | |     }
    | |_____^
    |
 help: consider using a `let` statement
    |
 LL ~     let Point { x, y } = p;
-LL +     println!("Coords: ({}, {})", x, y);
+LL +     println!("Coords: ({x}, {y})");
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:87:5
+  --> tests/ui/match_single_binding.rs:86:5
    |
 LL | /     match p {
 LL | |
-LL | |         Point { x: x1, y: y1 } => println!("Coords: ({}, {})", x1, y1),
+LL | |         Point { x: x1, y: y1 } => println!("Coords: ({x1}, {y1})"),
 LL | |     }
    | |_____^
    |
 help: consider using a `let` statement
    |
 LL ~     let Point { x: x1, y: y1 } = p;
-LL +     println!("Coords: ({}, {})", x1, y1);
+LL +     println!("Coords: ({x1}, {y1})");
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:93:5
+  --> tests/ui/match_single_binding.rs:92:5
    |
 LL | /     match x {
 LL | |
-LL | |         ref r => println!("Got a reference to {}", r),
+LL | |         ref r => println!("Got a reference to {r}"),
 LL | |     }
    | |_____^
    |
 help: consider using a `let` statement
    |
 LL ~     let ref r = x;
-LL +     println!("Got a reference to {}", r);
+LL +     println!("Got a reference to {r}");
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:99:5
+  --> tests/ui/match_single_binding.rs:98:5
    |
 LL | /     match x {
 LL | |
-LL | |         ref mut mr => println!("Got a mutable reference to {}", mr),
+LL | |         ref mut mr => println!("Got a mutable reference to {mr}"),
 LL | |     }
    | |_____^
    |
 help: consider using a `let` statement
    |
 LL ~     let ref mut mr = x;
-LL +     println!("Got a mutable reference to {}", mr);
+LL +     println!("Got a mutable reference to {mr}");
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:104:5
+  --> tests/ui/match_single_binding.rs:103:5
    |
 LL | /     let product = match coords() {
 LL | |
@@ -161,7 +161,7 @@ LL +     let product = x * y;
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:113:18
+  --> tests/ui/match_single_binding.rs:112:18
    |
 LL |           .map(|i| match i.unwrap() {
    |  __________________^
@@ -179,7 +179,7 @@ LL ~         })
    |
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:140:5
+  --> tests/ui/match_single_binding.rs:139:5
    |
 LL | /     match x {
 LL | |
@@ -189,12 +189,12 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `println!("Not an array index start")`
 
 error: this assignment could be simplified
-  --> tests/ui/match_single_binding.rs:150:5
+  --> tests/ui/match_single_binding.rs:149:5
    |
 LL | /     val = match val.split_at(idx) {
 LL | |
 LL | |         (pre, suf) => {
-LL | |             println!("{}", pre);
+LL | |             println!("{pre}");
 LL | |             suf
 LL | |         },
 LL | |     };
@@ -204,13 +204,13 @@ help: consider removing the `match` expression
    |
 LL ~     let (pre, suf) = val.split_at(idx);
 LL +     val = {
-LL +         println!("{}", pre);
+LL +         println!("{pre}");
 LL +         suf
 LL ~     };
    |
 
 error: this match could be replaced by its scrutinee and body
-  --> tests/ui/match_single_binding.rs:164:16
+  --> tests/ui/match_single_binding.rs:163:16
    |
 LL |       let _ = || match side_effects() {
    |  ________________^
@@ -228,7 +228,7 @@ LL ~     };
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:171:5
+  --> tests/ui/match_single_binding.rs:170:5
    |
 LL | /     match r {
 LL | |
@@ -253,7 +253,7 @@ LL ~     };
    |
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:185:5
+  --> tests/ui/match_single_binding.rs:184:5
    |
 LL | /     match 1 {
 LL | |
@@ -262,7 +262,7 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `();`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:190:13
+  --> tests/ui/match_single_binding.rs:189:13
    |
 LL |       let a = match 1 {
    |  _____________^
@@ -272,7 +272,7 @@ LL | |     };
    | |_____^ help: consider using the match body instead: `()`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:195:5
+  --> tests/ui/match_single_binding.rs:194:5
    |
 LL | /     match 1 {
 LL | |
@@ -281,7 +281,7 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `side_effects();`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:200:13
+  --> tests/ui/match_single_binding.rs:199:13
    |
 LL |       let b = match 1 {
    |  _____________^
@@ -291,7 +291,7 @@ LL | |     };
    | |_____^ help: consider using the match body instead: `side_effects()`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:205:5
+  --> tests/ui/match_single_binding.rs:204:5
    |
 LL | /     match 1 {
 LL | |
@@ -300,7 +300,7 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `println!("1");`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:210:13
+  --> tests/ui/match_single_binding.rs:209:13
    |
 LL |       let c = match 1 {
    |  _____________^
@@ -310,7 +310,7 @@ LL | |     };
    | |_____^ help: consider using the match body instead: `println!("1")`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:216:9
+  --> tests/ui/match_single_binding.rs:215:9
    |
 LL | /         match 1 {
 LL | |
@@ -319,7 +319,7 @@ LL | |         },
    | |_________^ help: consider using the match body instead: `()`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:220:9
+  --> tests/ui/match_single_binding.rs:219:9
    |
 LL | /         match 1 {
 LL | |
@@ -328,7 +328,7 @@ LL | |         },
    | |_________^ help: consider using the match body instead: `side_effects()`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:224:9
+  --> tests/ui/match_single_binding.rs:223:9
    |
 LL | /         match 1 {
 LL | |
@@ -337,7 +337,7 @@ LL | |         },
    | |_________^ help: consider using the match body instead: `println!("1")`
 
 error: this match could be replaced by its scrutinee and body
-  --> tests/ui/match_single_binding.rs:239:5
+  --> tests/ui/match_single_binding.rs:238:5
    |
 LL | /     match dbg!(3) {
 LL | |         _ => println!("here"),
@@ -351,7 +351,7 @@ LL +     println!("here");
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:243:5
+  --> tests/ui/match_single_binding.rs:242:5
    |
 LL | /     match dbg!(3) {
 LL | |         id!(a) => println!("found {a}"),
@@ -365,7 +365,7 @@ LL +     println!("found {a}");
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:247:5
+  --> tests/ui/match_single_binding.rs:246:5
    |
 LL | /     let id!(_a) = match dbg!(3) {
 LL | |         id!(b) => dbg!(b + 1),
@@ -379,7 +379,7 @@ LL +     let id!(_a) = dbg!(b + 1);
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:255:21
+  --> tests/ui/match_single_binding.rs:254:21
    |
 LL |           inner: [(); match 1 {
    |  _____________________^
@@ -397,7 +397,7 @@ LL ~         }],
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:263:13
+  --> tests/ui/match_single_binding.rs:262:13
    |
 LL | /             match 1 {
 LL | |
@@ -412,11 +412,11 @@ LL +             42
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:274:9
+  --> tests/ui/match_single_binding.rs:273:9
    |
 LL | /         match (a, b, c) {
 LL | |
-LL | |             (x, y, z) => println!("{} {} {}", x, y, z),
+LL | |             (x, y, z) => println!("{x} {y} {z}"),
 LL | |         }
    | |_________^
    |
@@ -424,61 +424,61 @@ help: consider using a `let` statement
    |
 LL ~         {
 LL +             let (x, y, z) = (a, b, c);
-LL +             println!("{} {} {}", x, y, z);
+LL +             println!("{x} {y} {z}");
 LL +         }
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:282:9
+  --> tests/ui/match_single_binding.rs:281:9
    |
 LL | /         match (a, b, c) {
 LL | |
-LL | |             (x, y, z) => println!("{} {} {}", x, y, z),
+LL | |             (x, y, z) => println!("{x} {y} {z}"),
 LL | |         }
    | |_________^
    |
 help: consider using a `let` statement
    |
 LL ~         let (x, y, z) = (a, b, c);
-LL +         println!("{} {} {}", x, y, z)
+LL +         println!("{x} {y} {z}")
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:290:9
+  --> tests/ui/match_single_binding.rs:289:9
    |
 LL | /         match (a, b, c) {
 LL | |
-LL | |             (x, y, z) => println!("{} {} {}", x, y, z),
+LL | |             (x, y, z) => println!("{x} {y} {z}"),
 LL | |         }
    | |_________^
    |
 help: consider using a `let` statement
    |
 LL ~         let (x, y, z) = (a, b, c);
-LL +         println!("{} {} {}", x, y, z);
+LL +         println!("{x} {y} {z}");
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:300:9
+  --> tests/ui/match_single_binding.rs:299:9
    |
 LL | /         match (a, b, c) {
 LL | |
-LL | |             (x, y, z) => println!("{} {} {}", x, y, z),
+LL | |             (x, y, z) => println!("{x} {x} {y}"),
 LL | |         }
    | |_________^
    |
 help: consider using a `let` statement
    |
 LL ~         let (x, y, z) = (a, b, c);
-LL +         println!("{} {} {}", x, y, z);
+LL +         println!("{x} {x} {y}");
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:310:13
+  --> tests/ui/match_single_binding.rs:309:13
    |
 LL | /             match (a, b, c) {
 LL | |
-LL | |                 (x, y, z) => println!("{} {} {}", x, y, z),
+LL | |                 (x, y, z) => println!("{x} {y} {z}"),
 LL | |             }
    | |_____________^
    |
@@ -486,27 +486,27 @@ help: consider using a `let` statement
    |
 LL ~             {
 LL +                 let (x, y, z) = (a, b, c);
-LL +                 println!("{} {} {}", x, y, z);
+LL +                 println!("{x} {y} {z}");
 LL +             }
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding.rs:320:13
+  --> tests/ui/match_single_binding.rs:319:13
    |
 LL | /             match (a, b, c) {
 LL | |
-LL | |                 (x, y, z) => println!("{} {} {}", x, y, z),
+LL | |                 (x, y, z) => println!("{x} {y} {z}"),
 LL | |             }
    | |_____________^
    |
 help: consider using a `let` statement
    |
 LL ~             let (x, y, z) = (a, b, c);
-LL +             println!("{} {} {}", x, y, z);
+LL +             println!("{x} {y} {z}");
    |
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:335:12
+  --> tests/ui/match_single_binding.rs:334:12
    |
 LL |           && match b {
    |  ____________^
@@ -516,7 +516,7 @@ LL | |         };
    | |_________^ help: consider using the match body instead: `b < c`
 
 error: this match could be replaced by its body itself
-  --> tests/ui/match_single_binding.rs:341:12
+  --> tests/ui/match_single_binding.rs:340:12
    |
 LL |           && match (a, b) {
    |  ____________^

--- a/tests/ui/match_single_binding2.fixed
+++ b/tests/ui/match_single_binding2.fixed
@@ -1,6 +1,5 @@
 #![warn(clippy::match_single_binding)]
 #![allow(unused_variables)]
-#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     // Lint (additional curly braces needed, see #6572)
@@ -29,7 +28,7 @@ fn main() {
         #[rustfmt::skip]
         Some((first, _second)) => {
             let (a, b) = get_tup();
-            println!("a {:?} and b {:?}", a, b)
+            println!("a {a:?} and b {b:?}")
         },
         None => println!("nothing"),
     }

--- a/tests/ui/match_single_binding2.rs
+++ b/tests/ui/match_single_binding2.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::match_single_binding)]
 #![allow(unused_variables)]
-#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     // Lint (additional curly braces needed, see #6572)
@@ -30,7 +29,7 @@ fn main() {
         Some((first, _second)) => {
             match get_tup() {
             //~^ match_single_binding
-                (a, b) => println!("a {:?} and b {:?}", a, b),
+                (a, b) => println!("a {a:?} and b {b:?}"),
             }
         },
         None => println!("nothing"),

--- a/tests/ui/match_single_binding2.stderr
+++ b/tests/ui/match_single_binding2.stderr
@@ -1,5 +1,5 @@
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding2.rs:17:36
+  --> tests/ui/match_single_binding2.rs:16:36
    |
 LL |               Some((iter, _item)) => match iter.size_hint() {
    |  ____________________________________^
@@ -19,22 +19,22 @@ LL ~             },
    |
 
 error: this match could be written as a `let` statement
-  --> tests/ui/match_single_binding2.rs:31:13
+  --> tests/ui/match_single_binding2.rs:30:13
    |
 LL | /             match get_tup() {
 LL | |
-LL | |                 (a, b) => println!("a {:?} and b {:?}", a, b),
+LL | |                 (a, b) => println!("a {a:?} and b {b:?}"),
 LL | |             }
    | |_____________^
    |
 help: consider using a `let` statement
    |
 LL ~             let (a, b) = get_tup();
-LL +             println!("a {:?} and b {:?}", a, b)
+LL +             println!("a {a:?} and b {b:?}")
    |
 
 error: this match could be replaced by its scrutinee and body
-  --> tests/ui/match_single_binding2.rs:43:5
+  --> tests/ui/match_single_binding2.rs:42:5
    |
 LL | /     match side_effects() {
 LL | |
@@ -49,7 +49,7 @@ LL +     println!("Side effects");
    |
 
 error: this match could be replaced by its scrutinee and body
-  --> tests/ui/match_single_binding2.rs:51:5
+  --> tests/ui/match_single_binding2.rs:50:5
    |
 LL | /     match match x {
 LL | |


### PR DESCRIPTION
These were probably added automatically to avoid code churn. I'd like to get rid of them bit by bit, so here's the first bit

changelog: none