### PR TITLE
Fix `map_entry` suggests wrongly for insert with cfg-ed out code

### DIFF
--- a/tests/ui/entry.fixed
+++ b/tests/ui/entry.fixed
@@ -273,3 +273,13 @@ mod issue_16173 {
 }
 
 fn main() {}
+
+fn issue15781(m: &mut std::collections::HashMap<i32, i32>, k: i32, v: i32) {
+    fn very_important_fn() {}
+    m.entry(k).or_insert_with(|| {
+        //~^ map_entry
+        #[cfg(test)]
+        very_important_fn();
+        v
+    });
+}

--- a/tests/ui/entry.rs
+++ b/tests/ui/entry.rs
@@ -279,3 +279,13 @@ mod issue_16173 {
 }
 
 fn main() {}
+
+fn issue15781(m: &mut std::collections::HashMap<i32, i32>, k: i32, v: i32) {
+    fn very_important_fn() {}
+    if !m.contains_key(&k) {
+        //~^ map_entry
+        #[cfg(test)]
+        very_important_fn();
+        m.insert(k, v);
+    }
+}

--- a/tests/ui/entry.stderr
+++ b/tests/ui/entry.stderr
@@ -246,5 +246,26 @@ LL +         e.insert(42);
 LL +     }
    |
 
-error: aborting due to 11 previous errors
+error: usage of `contains_key` followed by `insert` on a `HashMap`
+  --> tests/ui/entry.rs:285:5
+   |
+LL | /     if !m.contains_key(&k) {
+LL | |
+LL | |         #[cfg(test)]
+LL | |         very_important_fn();
+LL | |         m.insert(k, v);
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     m.entry(k).or_insert_with(|| {
+LL +
+LL +         #[cfg(test)]
+LL +         very_important_fn();
+LL +         v
+LL +     });
+   |
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15781 

changelog: [`map_entry`] fix wrong suggestions for insert with cfg-ed out code
