### PR TITLE
fix(map_entry): don't autofix when `{e.insert(_); None }` would be required

### DIFF
--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -696,6 +696,8 @@ impl<'tcx> InsertSearchResults<'tcx> {
                 } else {
                     write!(res, "{{ e.insert({value_str}); None }}")
                 };
+                // This might leave `None`'s type ambiguous, so reduce applicability
+                *app = Applicability::MaybeIncorrect;
             }),
             "Vacant(e)",
         )

--- a/tests/ui/entry.fixed
+++ b/tests/ui/entry.fixed
@@ -1,6 +1,6 @@
 //@needs-asm-support
 
-#![allow(unused, clippy::needless_pass_by_value, clippy::collapsible_if)]
+#![allow(clippy::needless_pass_by_value, clippy::collapsible_if)]
 #![warn(clippy::map_entry)]
 
 use std::arch::asm;

--- a/tests/ui/entry.rs
+++ b/tests/ui/entry.rs
@@ -1,6 +1,6 @@
 //@needs-asm-support
 
-#![allow(unused, clippy::needless_pass_by_value, clippy::collapsible_if)]
+#![allow(clippy::needless_pass_by_value, clippy::collapsible_if)]
 #![warn(clippy::map_entry)]
 
 use std::arch::asm;

--- a/tests/ui/entry_btree.fixed
+++ b/tests/ui/entry_btree.fixed
@@ -1,5 +1,4 @@
 #![warn(clippy::map_entry)]
-#![allow(dead_code)]
 
 use std::collections::BTreeMap;
 

--- a/tests/ui/entry_btree.rs
+++ b/tests/ui/entry_btree.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::map_entry)]
-#![allow(dead_code)]
 
 use std::collections::BTreeMap;
 

--- a/tests/ui/entry_btree.stderr
+++ b/tests/ui/entry_btree.stderr
@@ -1,5 +1,5 @@
 error: usage of `contains_key` followed by `insert` on a `BTreeMap`
-  --> tests/ui/entry_btree.rs:10:5
+  --> tests/ui/entry_btree.rs:9:5
    |
 LL | /     if !m.contains_key(&k) {
 LL | |

--- a/tests/ui/entry_unfixable.rs
+++ b/tests/ui/entry_unfixable.rs
@@ -1,3 +1,4 @@
+//@no-rustfix
 #![allow(clippy::needless_pass_by_value, clippy::collapsible_if)]
 #![warn(clippy::map_entry)]
 
@@ -87,6 +88,13 @@ mod issue13306 {
                 false
             }
         }
+    }
+}
+
+fn issue15307<K: Eq + Hash, V>(mut m: HashMap<K, V>, k: K, v: V) {
+    if !m.contains_key(&k) {
+        //~^ map_entry
+        assert!(m.insert(k, v).is_none());
     }
 }
 

--- a/tests/ui/entry_unfixable.rs
+++ b/tests/ui/entry_unfixable.rs
@@ -14,40 +14,6 @@ macro_rules! insert {
     };
 }
 
-mod issue13306 {
-    use std::collections::HashMap;
-
-    struct Env {
-        enclosing: Option<Box<Env>>,
-        values: HashMap<String, usize>,
-    }
-
-    impl Env {
-        fn assign(&mut self, name: String, value: usize) -> bool {
-            if !self.values.contains_key(&name) {
-                //~^ map_entry
-                self.values.insert(name, value);
-                true
-            } else if let Some(enclosing) = &mut self.enclosing {
-                enclosing.assign(name, value)
-            } else {
-                false
-            }
-        }
-    }
-}
-
-fn issue9925(mut hm: HashMap<String, bool>) {
-    let key = "hello".to_string();
-    if hm.contains_key(&key) {
-        //~^ map_entry
-        let bval = hm.get_mut(&key).unwrap();
-        *bval = false;
-    } else {
-        hm.insert(key, true);
-    }
-}
-
 mod issue9470 {
     use std::collections::HashMap;
     use std::sync::Mutex;
@@ -86,6 +52,40 @@ mod issue9470 {
             }
 
             Ok(())
+        }
+    }
+}
+
+fn issue9925(mut hm: HashMap<String, bool>) {
+    let key = "hello".to_string();
+    if hm.contains_key(&key) {
+        //~^ map_entry
+        let bval = hm.get_mut(&key).unwrap();
+        *bval = false;
+    } else {
+        hm.insert(key, true);
+    }
+}
+
+mod issue13306 {
+    use std::collections::HashMap;
+
+    struct Env {
+        enclosing: Option<Box<Env>>,
+        values: HashMap<String, usize>,
+    }
+
+    impl Env {
+        fn assign(&mut self, name: String, value: usize) -> bool {
+            if !self.values.contains_key(&name) {
+                //~^ map_entry
+                self.values.insert(name, value);
+                true
+            } else if let Some(enclosing) = &mut self.enclosing {
+                enclosing.assign(name, value)
+            } else {
+                false
+            }
         }
     }
 }

--- a/tests/ui/entry_unfixable.stderr
+++ b/tests/ui/entry_unfixable.stderr
@@ -1,12 +1,12 @@
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_unfixable.rs:27:13
+  --> tests/ui/entry_unfixable.rs:46:13
    |
-LL | /             if !self.values.contains_key(&name) {
+LL | /             if self.globals.contains_key(&name) {
 LL | |
-LL | |                 self.values.insert(name, value);
-LL | |                 true
-...  |
-LL | |                 false
+LL | |                 self.globals.insert(name, value);
+LL | |             } else {
+LL | |                 let interner = INTERNER.lock().unwrap();
+LL | |                 return Err(interner.resolve(name).unwrap().to_owned());
 LL | |             }
    | |_____________^
    |
@@ -15,7 +15,7 @@ LL | |             }
    = help: to override `-D warnings` add `#[allow(clippy::map_entry)]`
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_unfixable.rs:42:5
+  --> tests/ui/entry_unfixable.rs:61:5
    |
 LL | /     if hm.contains_key(&key) {
 LL | |
@@ -31,12 +31,12 @@ LL | |     }
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> tests/ui/entry_unfixable.rs:80:13
    |
-LL | /             if self.globals.contains_key(&name) {
+LL | /             if !self.values.contains_key(&name) {
 LL | |
-LL | |                 self.globals.insert(name, value);
-LL | |             } else {
-LL | |                 let interner = INTERNER.lock().unwrap();
-LL | |                 return Err(interner.resolve(name).unwrap().to_owned());
+LL | |                 self.values.insert(name, value);
+LL | |                 true
+...  |
+LL | |                 false
 LL | |             }
    | |_____________^
    |

--- a/tests/ui/entry_unfixable.stderr
+++ b/tests/ui/entry_unfixable.stderr
@@ -1,5 +1,5 @@
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_unfixable.rs:46:13
+  --> tests/ui/entry_unfixable.rs:47:13
    |
 LL | /             if self.globals.contains_key(&name) {
 LL | |
@@ -15,7 +15,7 @@ LL | |             }
    = help: to override `-D warnings` add `#[allow(clippy::map_entry)]`
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_unfixable.rs:61:5
+  --> tests/ui/entry_unfixable.rs:62:5
    |
 LL | /     if hm.contains_key(&key) {
 LL | |
@@ -29,7 +29,7 @@ LL | |     }
    = help: consider using the `Entry` API: https://doc.rust-lang.org/std/collections/struct.HashMap.html#entry-api
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_unfixable.rs:80:13
+  --> tests/ui/entry_unfixable.rs:81:13
    |
 LL | /             if !self.values.contains_key(&name) {
 LL | |
@@ -42,5 +42,22 @@ LL | |             }
    |
    = help: consider using the `Entry` API: https://doc.rust-lang.org/std/collections/struct.HashMap.html#entry-api
 
-error: aborting due to 3 previous errors
+error: usage of `contains_key` followed by `insert` on a `HashMap`
+  --> tests/ui/entry_unfixable.rs:95:5
+   |
+LL | /     if !m.contains_key(&k) {
+LL | |
+LL | |         assert!(m.insert(k, v).is_none());
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if let std::collections::hash_map::Entry::Vacant(e) = m.entry(k) {
+LL +
+LL +         assert!({ e.insert(v); None }.is_none());
+LL +     }
+   |
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/entry_with_else.fixed
+++ b/tests/ui/entry_with_else.fixed
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::needless_pass_by_value, clippy::collapsible_if)]
+#![allow(clippy::needless_pass_by_value, clippy::collapsible_if)]
 #![warn(clippy::map_entry)]
 
 use std::collections::{BTreeMap, HashMap};

--- a/tests/ui/entry_with_else.rs
+++ b/tests/ui/entry_with_else.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::needless_pass_by_value, clippy::collapsible_if)]
+#![allow(clippy::needless_pass_by_value, clippy::collapsible_if)]
 #![warn(clippy::map_entry)]
 
 use std::collections::{BTreeMap, HashMap};


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15307
Alternative to https://github.com/rust-lang/rust-clippy/pull/15808, implements the suggestion in https://github.com/rust-lang/rust-clippy/pull/15808#issuecomment-3365388285

changelog: [`map_entry`]: don't autofix when `{e.insert(_); None }` would be required

r? @Jarcho @samueltardieu 