### PR TITLE
`legacy_numeric_constants`: add ctxt check for internal macro

### DIFF
--- a/tests/ui/legacy_numeric_constants_unfixable.rs
+++ b/tests/ui/legacy_numeric_constants_unfixable.rs
@@ -77,3 +77,14 @@ fn msrv_juust_right() {
     use std::u32::MAX;
     //~^ ERROR: importing a legacy numeric constant
 }
+
+macro_rules! foo {
+    ($a: ty) => {
+        let _ = <$a>::max_value();
+        let _ = (<$a>::max_value)();
+    };
+}
+
+fn issue15805() {
+    foo!(u8);
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#15805

ICE bisects to 9457d640b7, which handles the span incorrectly when part of the path originates from internal declarative macro. 

changelog: none