### PR TITLE
feat(lints): add `unsigned_subtraction_gt_zero` lint for comparisons against zero after subtraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7155,6 +7155,7 @@ Released 2018-09-13
 [`unsafe_removed_from_name`]: https://rust-lang.github.io/rust-clippy/master/index.html#unsafe_removed_from_name
 [`unsafe_vector_initialization`]: https://rust-lang.github.io/rust-clippy/master/index.html#unsafe_vector_initialization
 [`unseparated_literal_suffix`]: https://rust-lang.github.io/rust-clippy/master/index.html#unseparated_literal_suffix
+[`unsigned_subtraction_gt_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#unsigned_subtraction_gt_zero
 [`unsound_collection_transmute`]: https://rust-lang.github.io/rust-clippy/master/index.html#unsound_collection_transmute
 [`unstable_as_mut_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#unstable_as_mut_slice
 [`unstable_as_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#unstable_as_slice

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -611,6 +611,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::operators::OP_REF_INFO,
     crate::operators::REDUNDANT_COMPARISONS_INFO,
     crate::operators::SELF_ASSIGNMENT_INFO,
+    crate::operators::UNSIGNED_SUBTRACTION_GT_ZERO_INFO,
     crate::operators::VERBOSE_BIT_MASK_INFO,
     crate::option_env_unwrap::OPTION_ENV_UNWRAP_INFO,
     crate::option_if_let_else::OPTION_IF_LET_ELSE_INFO,

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -24,6 +24,7 @@ mod needless_bitwise_bool;
 mod numeric_arithmetic;
 mod op_ref;
 mod self_assignment;
+mod unsigned_subtraction_gt_zero;
 mod verbose_bit_mask;
 
 pub(crate) mod arithmetic_side_effects;
@@ -933,6 +934,34 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Lints comparisons of an unsigned integer subtraction against zero, like `(a - b) > 0`.
+    ///
+    /// ### Why is this bad?
+    /// If `a < b`, `a - b` will panic in debug builds and wrap in release builds, making the
+    /// comparison effectively behave like `a != b`. This is likely unintended; `a > b` is clearer
+    /// and avoids potential panics and wraparound.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let (a, b): (u32, u32) = (1, 2);
+    /// if a - b > 0 {}
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// let (a, b): (u32, u32) = (1, 2);
+    /// if a > b {}
+    /// // Or, if you meant inequality:
+    /// if a != b {}
+    /// ```
+    #[clippy::version = "1.95.0"]
+    pub UNSIGNED_SUBTRACTION_GT_ZERO,
+    suspicious,
+    "suspicious comparison of unsigned subtraction to zero"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for bit masks that can be replaced by a call
     /// to `trailing_zeros`
     ///
@@ -989,6 +1018,7 @@ impl_lint_pass!(Operators => [
     OP_REF,
     REDUNDANT_COMPARISONS,
     SELF_ASSIGNMENT,
+    UNSIGNED_SUBTRACTION_GT_ZERO,
     VERBOSE_BIT_MASK,
 ]);
 
@@ -1036,6 +1066,7 @@ impl<'tcx> LateLintPass<'tcx> for Operators {
                 const_comparisons::check(cx, op, lhs, rhs, e.span);
                 duration_subsec::check(cx, e, op.node, lhs, rhs);
                 float_equality_without_abs::check(cx, e, op.node, lhs, rhs);
+                unsigned_subtraction_gt_zero::check(cx, e, op.node, lhs, rhs);
                 integer_division::check(cx, e, op.node, lhs, rhs);
                 integer_division_remainder_used::check(cx, op.node, lhs, rhs, e.span);
                 cmp_owned::check(cx, e, op.node, lhs, rhs);

--- a/clippy_lints/src/operators/unsigned_subtraction_gt_zero.rs
+++ b/clippy_lints/src/operators/unsigned_subtraction_gt_zero.rs
@@ -1,0 +1,73 @@
+use clippy_utils::consts::is_zero_integer_const;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::sugg::{Sugg, make_binop};
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Expr, ExprKind};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+
+use super::UNSIGNED_SUBTRACTION_GT_ZERO;
+
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    op: BinOpKind,
+    lhs_expr: &'tcx Expr<'tcx>,
+    rhs_expr: &'tcx Expr<'tcx>,
+) {
+    // Avoid linting macro-generated code to reduce noise
+    if expr.span.from_expansion() {
+        return;
+    }
+
+    // Only consider strict relational comparisons where one side is zero and the other is a subtraction
+    let sub_expr = match op {
+        // x > 0
+        BinOpKind::Gt if is_zero_integer_const(cx, rhs_expr, expr.span.ctxt()) => lhs_expr,
+        // 0 < x
+        BinOpKind::Lt if is_zero_integer_const(cx, lhs_expr, expr.span.ctxt()) => rhs_expr,
+
+        _ => return,
+    };
+
+    // Ensure the compared expression is a subtraction
+    let (lhs, rhs) = match sub_expr.kind {
+        ExprKind::Binary(sub_op, lhs, rhs) if sub_op.node == BinOpKind::Sub => (lhs, rhs),
+        _ => return,
+    };
+
+    // Subtraction result type must be an unsigned primitive
+    if !matches!(cx.typeck_results().expr_ty(sub_expr).peel_refs().kind(), ty::Uint(_)) {
+        return;
+    }
+
+    span_lint_and_then(
+        cx,
+        UNSIGNED_SUBTRACTION_GT_ZERO,
+        expr.span,
+        "suspicious comparison of unsigned subtraction to zero",
+        |diag| {
+            // Build suggestions
+            let mut app = Applicability::MaybeIncorrect;
+            let left_sugg = Sugg::hir_with_applicability(cx, lhs, "_", &mut app);
+            let right_sugg = Sugg::hir_with_applicability(cx, rhs, "_", &mut app);
+
+            let replacement = make_binop(BinOpKind::Gt, &left_sugg, &right_sugg);
+            let neq_suggestion = make_binop(BinOpKind::Ne, &left_sugg, &right_sugg);
+
+            diag.help("`lhs - rhs > 0` will panic in debug mode when `lhs < rhs` and wrap in release mode");
+            diag.span_suggestion_verbose(
+                expr.span,
+                "`lhs > rhs` is cleaner and will never panic",
+                replacement,
+                app,
+            );
+            diag.span_suggestion_verbose(
+                expr.span,
+                "if you meant inequality, use `lhs != rhs`",
+                neq_suggestion,
+                app,
+            );
+        },
+    );
+}

--- a/tests/ui/unsigned_subtraction_gt_zero.1.fixed
+++ b/tests/ui/unsigned_subtraction_gt_zero.1.fixed
@@ -1,0 +1,29 @@
+#![warn(clippy::unsigned_subtraction_gt_zero)]
+#![allow(clippy::needless_ifs)]
+
+fn main() {
+    let (a, b): (u32, u32) = (1, 2);
+    if a > b {}
+    //~^ unsigned_subtraction_gt_zero
+
+    if a > b {}
+    //~^ unsigned_subtraction_gt_zero
+
+    let (x, y): (usize, usize) = (10, 3);
+    if x > y {}
+    //~^ unsigned_subtraction_gt_zero
+
+    if x > y {}
+    //~^ unsigned_subtraction_gt_zero
+
+    // signed: should not lint
+    let (i, j): (i32, i32) = (1, 2);
+    if i - j > 0 {}
+
+    // float: should not lint
+    let (f, g): (f32, f32) = (1.0, 2.0);
+    if f - g > 0.0 {}
+
+    // using saturating_sub: should not lint
+    if a.saturating_sub(b) > 0 {}
+}

--- a/tests/ui/unsigned_subtraction_gt_zero.2.fixed
+++ b/tests/ui/unsigned_subtraction_gt_zero.2.fixed
@@ -1,0 +1,29 @@
+#![warn(clippy::unsigned_subtraction_gt_zero)]
+#![allow(clippy::needless_ifs)]
+
+fn main() {
+    let (a, b): (u32, u32) = (1, 2);
+    if a != b {}
+    //~^ unsigned_subtraction_gt_zero
+
+    if a != b {}
+    //~^ unsigned_subtraction_gt_zero
+
+    let (x, y): (usize, usize) = (10, 3);
+    if x != y {}
+    //~^ unsigned_subtraction_gt_zero
+
+    if x != y {}
+    //~^ unsigned_subtraction_gt_zero
+
+    // signed: should not lint
+    let (i, j): (i32, i32) = (1, 2);
+    if i - j > 0 {}
+
+    // float: should not lint
+    let (f, g): (f32, f32) = (1.0, 2.0);
+    if f - g > 0.0 {}
+
+    // using saturating_sub: should not lint
+    if a.saturating_sub(b) > 0 {}
+}

--- a/tests/ui/unsigned_subtraction_gt_zero.rs
+++ b/tests/ui/unsigned_subtraction_gt_zero.rs
@@ -1,0 +1,29 @@
+#![warn(clippy::unsigned_subtraction_gt_zero)]
+#![allow(clippy::needless_ifs)]
+
+fn main() {
+    let (a, b): (u32, u32) = (1, 2);
+    if a - b > 0 {}
+    //~^ unsigned_subtraction_gt_zero
+
+    if 0 < a - b {}
+    //~^ unsigned_subtraction_gt_zero
+
+    let (x, y): (usize, usize) = (10, 3);
+    if x - y > 0 {}
+    //~^ unsigned_subtraction_gt_zero
+
+    if 0 < x - y {}
+    //~^ unsigned_subtraction_gt_zero
+
+    // signed: should not lint
+    let (i, j): (i32, i32) = (1, 2);
+    if i - j > 0 {}
+
+    // float: should not lint
+    let (f, g): (f32, f32) = (1.0, 2.0);
+    if f - g > 0.0 {}
+
+    // using saturating_sub: should not lint
+    if a.saturating_sub(b) > 0 {}
+}

--- a/tests/ui/unsigned_subtraction_gt_zero.stderr
+++ b/tests/ui/unsigned_subtraction_gt_zero.stderr
@@ -1,0 +1,76 @@
+error: suspicious comparison of unsigned subtraction to zero
+  --> tests/ui/unsigned_subtraction_gt_zero.rs:6:8
+   |
+LL |     if a - b > 0 {}
+   |        ^^^^^^^^^
+   |
+   = help: `lhs - rhs > 0` will panic in debug mode when `lhs < rhs` and wrap in release mode
+   = note: `-D clippy::unsigned-subtraction-gt-zero` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unsigned_subtraction_gt_zero)]`
+help: `lhs > rhs` is cleaner and will never panic
+   |
+LL -     if a - b > 0 {}
+LL +     if a > b {}
+   |
+help: if you meant inequality, use `lhs != rhs`
+   |
+LL -     if a - b > 0 {}
+LL +     if a != b {}
+   |
+
+error: suspicious comparison of unsigned subtraction to zero
+  --> tests/ui/unsigned_subtraction_gt_zero.rs:9:8
+   |
+LL |     if 0 < a - b {}
+   |        ^^^^^^^^^
+   |
+   = help: `lhs - rhs > 0` will panic in debug mode when `lhs < rhs` and wrap in release mode
+help: `lhs > rhs` is cleaner and will never panic
+   |
+LL -     if 0 < a - b {}
+LL +     if a > b {}
+   |
+help: if you meant inequality, use `lhs != rhs`
+   |
+LL -     if 0 < a - b {}
+LL +     if a != b {}
+   |
+
+error: suspicious comparison of unsigned subtraction to zero
+  --> tests/ui/unsigned_subtraction_gt_zero.rs:13:8
+   |
+LL |     if x - y > 0 {}
+   |        ^^^^^^^^^
+   |
+   = help: `lhs - rhs > 0` will panic in debug mode when `lhs < rhs` and wrap in release mode
+help: `lhs > rhs` is cleaner and will never panic
+   |
+LL -     if x - y > 0 {}
+LL +     if x > y {}
+   |
+help: if you meant inequality, use `lhs != rhs`
+   |
+LL -     if x - y > 0 {}
+LL +     if x != y {}
+   |
+
+error: suspicious comparison of unsigned subtraction to zero
+  --> tests/ui/unsigned_subtraction_gt_zero.rs:16:8
+   |
+LL |     if 0 < x - y {}
+   |        ^^^^^^^^^
+   |
+   = help: `lhs - rhs > 0` will panic in debug mode when `lhs < rhs` and wrap in release mode
+help: `lhs > rhs` is cleaner and will never panic
+   |
+LL -     if 0 < x - y {}
+LL +     if x > y {}
+   |
+help: if you meant inequality, use `lhs != rhs`
+   |
+LL -     if 0 < x - y {}
+LL +     if x != y {}
+   |
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
changelog: new lint: [`unsigned_subtraction_gt_zero`] Lints comparisons of an unsigned integer subtraction against zero, like `(a - b) > 0`.


If `a < b`, `a - b` will panic in debug builds and wrap in release builds, making the effectively behave like `a != b`. This is likely unintended; `a > b` is clearer and avoids potential panics and wraparound.

Fixes rust-lang/rust-clippy#588