### PR TITLE
feat: `#[clippy::private_interior_mutability]` attribute

### DIFF
--- a/book/src/attribs.md
+++ b/book/src/attribs.md
@@ -51,3 +51,30 @@ impl<'a> Drop for CounterWrapper<'a> {
     }
 }
 ```
+
+## `#[clippy::private_interior_mutability]`
+
+_Available since Clippy v1.100_
+
+The `clippy::private_interior_mutability` attribute can be added to types which
+internally contain interior-mutable types, but don't expose this fact in their
+API. This is identical to the `ignore-interior-mutability` configuration option,
+but can be placed on the offending type instead of in Clippy's configuration file.
+
+### Example
+
+```rust
+use std::{cell::Cell, collections::HashMap};
+
+#[clippy::private_interior_mutability]
+struct ActuallyFineAsAKey {
+    id: usize,
+    other_data: Cell<i32>,
+}
+
+fn main() {
+    // `mut_key` will not fire here, as `ActuallyFineAsAKey` is considered to
+    // lack interior mutability
+    let _map: HashMap<ActuallyFineAsAKey, String> = HashMap::new();
+}
+```

--- a/clippy_lints/src/mut_key.rs
+++ b/clippy_lints/src/mut_key.rs
@@ -131,17 +131,16 @@ impl<'tcx> MutableKeyType<'tcx> {
                 cx.tcx.get_diagnostic_name(def.did()),
                 Some(sym::HashMap | sym::BTreeMap | sym::HashSet | sym::BTreeSet)
             )
+            && let subst_ty = args.type_at(0)
+            && let Some(chain) = self.interior_mut.interior_mut_ty_chain(cx, subst_ty)
         {
-            let subst_ty = args.type_at(0);
-            if let Some(chain) = self.interior_mut.interior_mut_ty_chain(cx, subst_ty) {
-                span_lint_and_then(cx, MUTABLE_KEY_TYPE, span, "mutable key type", |diag| {
-                    for ty in chain.iter().rev() {
-                        diag.note(with_forced_trimmed_paths!(format!(
-                            "... because it contains `{ty}`, which has interior mutability"
-                        )));
-                    }
-                });
-            }
+            span_lint_and_then(cx, MUTABLE_KEY_TYPE, span, "mutable key type", |diag| {
+                for ty in chain.iter().rev() {
+                    diag.note(with_forced_trimmed_paths!(format!(
+                        "... because it contains `{ty}`, which has interior mutability"
+                    )));
+                }
+            });
         }
     }
 }

--- a/clippy_lints/src/mut_key.rs
+++ b/clippy_lints/src/mut_key.rs
@@ -129,17 +129,16 @@ impl<'tcx> MutableKeyType<'tcx> {
                 cx.tcx.get_diagnostic_name(def.did()),
                 Some(sym::HashMap | sym::BTreeMap | sym::HashSet | sym::BTreeSet)
             )
+            && let subst_ty = args.type_at(0)
+            && let Some(chain) = self.interior_mut.interior_mut_ty_chain(cx, subst_ty)
         {
-            let subst_ty = args.type_at(0);
-            if let Some(chain) = self.interior_mut.interior_mut_ty_chain(cx, subst_ty) {
-                span_lint_and_then(cx, MUTABLE_KEY_TYPE, span, "mutable key type", |diag| {
-                    for ty in chain.iter().rev() {
-                        diag.note(with_forced_trimmed_paths!(format!(
-                            "... because it contains `{ty}`, which has interior mutability"
-                        )));
-                    }
-                });
-            }
+            span_lint_and_then(cx, MUTABLE_KEY_TYPE, span, "mutable key type", |diag| {
+                for ty in chain.iter().rev() {
+                    diag.note(with_forced_trimmed_paths!(format!(
+                        "... because it contains `{ty}`, which has interior mutability"
+                    )));
+                }
+            });
         }
     }
 }

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -71,8 +71,9 @@ declare_clippy_lint! {
     /// no way to both create a value as a constant and modify any mutable field using the
     /// type's public interface (e.g. `bytes::Bytes`). As there is no reasonable way to
     /// scan a crate's interface to see if this is the case, all such types will be linted.
-    /// If this happens use the `ignore-interior-mutability` configuration option to allow
-    /// the type.
+    /// If this happens, use the `ignore-interior-mutability` configuration option or put
+    /// the `#[clippy::ignore_interior_mutability]` attribute onto a type to allow the
+    /// type.
     ///
     /// ### Example
     /// ```no_run
@@ -132,8 +133,9 @@ declare_clippy_lint! {
     /// no way to both create a value as a constant and modify any mutable field using the
     /// type's public interface (e.g. `bytes::Bytes`). As there is no reasonable way to
     /// scan a crate's interface to see if this is the case, all such types will be linted.
-    /// If this happens use the `ignore-interior-mutability` configuration option to allow
-    /// the type.
+    /// If this happens, use the `ignore-interior-mutability` configuration option or put
+    /// the `#[clippy::ignore_interior_mutability]` attribute onto a type to allow the
+    /// type.
     ///
     /// ### Example
     /// ```no_run

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -272,14 +272,14 @@ impl<'tcx> NonCopyConst<'tcx> {
     }
 
     /// Checks if a value of the given type is `Freeze`, or may be depending on the value.
-    fn is_ty_freeze(&mut self, tcx: TyCtxt<'tcx>, typing_env: TypingEnv<'tcx>, ty: Ty<'tcx>) -> IsFreeze {
+    fn is_ty_freeze(&mut self, cx: &LateContext<'tcx>, typing_env: TypingEnv<'tcx>, ty: Ty<'tcx>) -> IsFreeze {
         // FIXME: this should probably be using the trait solver
-        let ty = tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
+        let ty = cx.tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
         match self.freeze_tys.entry(ty) {
             Entry::Occupied(e) => *e.get(),
             Entry::Vacant(e) => {
                 let e = e.insert(IsFreeze::Yes);
-                if ty.is_freeze(tcx, typing_env) {
+                if ty.is_freeze(cx.tcx, typing_env) {
                     return IsFreeze::Yes;
                 }
                 let is_freeze = match *ty.kind() {
@@ -292,14 +292,15 @@ impl<'tcx> NonCopyConst<'tcx> {
                         IsFreeze::from_fields(
                             v.fields
                                 .iter()
-                                .map(|f| self.is_ty_freeze(tcx, typing_env, f.ty(tcx, args))),
+                                .map(|f| self.is_ty_freeze(cx, typing_env, f.ty(cx.tcx, args))),
                         )
                     })),
                     // Workaround for `ManuallyDrop`-like unions.
                     ty::Adt(adt, args)
                         if adt.is_union()
                             && adt.non_enum_variant().fields.iter().any(|f| {
-                                tcx.layout_of(typing_env.as_query_input(f.ty(tcx, args)))
+                                cx.tcx
+                                    .layout_of(typing_env.as_query_input(f.ty(cx.tcx, args)))
                                     .is_ok_and(|l| l.layout.size().bytes() == 0)
                             }) =>
                     {
@@ -311,12 +312,10 @@ impl<'tcx> NonCopyConst<'tcx> {
                         adt.non_enum_variant()
                             .fields
                             .iter()
-                            .map(|f| self.is_ty_freeze(tcx, typing_env, f.ty(tcx, args))),
+                            .map(|f| self.is_ty_freeze(cx, typing_env, f.ty(cx.tcx, args))),
                     ),
-                    ty::Array(ty, _) | ty::Pat(ty, _) => self.is_ty_freeze(tcx, typing_env, ty),
-                    ty::Tuple(tys) => {
-                        IsFreeze::from_fields(tys.iter().map(|ty| self.is_ty_freeze(tcx, typing_env, ty)))
-                    },
+                    ty::Array(ty, _) | ty::Pat(ty, _) => self.is_ty_freeze(cx, typing_env, ty),
+                    ty::Tuple(tys) => IsFreeze::from_fields(tys.iter().map(|ty| self.is_ty_freeze(cx, typing_env, ty))),
                     // Treat type parameters as though they were `Freeze`.
                     ty::Param(_) | ty::Alias(..) => return IsFreeze::Yes,
                     // TODO: check other types.
@@ -337,21 +336,22 @@ impl<'tcx> NonCopyConst<'tcx> {
     /// cannot be read, but the result depends on the value.
     fn is_value_freeze(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         ty: Ty<'tcx>,
         val: ConstValue,
     ) -> Result<bool, ()> {
-        let ty = tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
-        match self.is_ty_freeze(tcx, typing_env, ty) {
+        let ty = cx.tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
+        match self.is_ty_freeze(cx, typing_env, ty) {
             IsFreeze::Yes => Ok(true),
             IsFreeze::Maybe if matches!(ty.kind(), ty::Adt(..) | ty::Array(..) | ty::Tuple(..)) => {
-                for &(val, ty) in tcx
+                for &(val, ty) in cx
+                    .tcx
                     .try_destructure_mir_constant_for_user_output(val, ty)
                     .ok_or(())?
                     .fields
                 {
-                    if !self.is_value_freeze(tcx, typing_env, ty, val)? {
+                    if !self.is_value_freeze(cx, typing_env, ty, val)? {
                         return Ok(false);
                     }
                 }
@@ -370,16 +370,16 @@ impl<'tcx> NonCopyConst<'tcx> {
     /// `typeck` and `e` are from the constant's definition site.
     fn is_init_expr_freeze(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         typeck: &'tcx TypeckResults<'tcx>,
         gen_args: GenericArgsRef<'tcx>,
         e: &'tcx Expr<'tcx>,
     ) -> bool {
         // Make sure to instantiate all types coming from `typeck` with `gen_args`.
-        let ty = EarlyBinder::bind(typeck.expr_ty(e)).instantiate(tcx, gen_args);
-        let ty = tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
-        match self.is_ty_freeze(tcx, typing_env, ty) {
+        let ty = EarlyBinder::bind(typeck.expr_ty(e)).instantiate(cx.tcx, gen_args);
+        let ty = cx.tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
+        match self.is_ty_freeze(cx, typing_env, ty) {
             IsFreeze::Yes => true,
             IsFreeze::No => false,
             IsFreeze::Maybe => match e.kind {
@@ -388,23 +388,25 @@ impl<'tcx> NonCopyConst<'tcx> {
                         && b.stmts.is_empty()
                         && let Some(e) = b.expr =>
                 {
-                    self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, e)
+                    self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, e)
                 },
                 ExprKind::Path(ref p) => {
                     let res = typeck.qpath_res(p, e.hir_id);
-                    let gen_args = EarlyBinder::bind(typeck.node_args(e.hir_id)).instantiate(tcx, gen_args);
+                    let gen_args = EarlyBinder::bind(typeck.node_args(e.hir_id)).instantiate(cx.tcx, gen_args);
                     match res {
                         Res::Def(DefKind::Const | DefKind::AssocConst, did)
-                            if let Ok(val) =
-                                tcx.const_eval_resolve(typing_env, UnevaluatedConst::new(did, gen_args), DUMMY_SP)
-                                && let Ok(is_freeze) = self.is_value_freeze(tcx, typing_env, ty, val) =>
+                            if let Ok(val) = cx.tcx.const_eval_resolve(
+                                typing_env,
+                                UnevaluatedConst::new(did, gen_args),
+                                DUMMY_SP,
+                            ) && let Ok(is_freeze) = self.is_value_freeze(cx, typing_env, ty, val) =>
                         {
                             is_freeze
                         },
                         Res::Def(DefKind::Const | DefKind::AssocConst, did)
-                            if let Some((typeck, init)) = get_const_hir_value(tcx, typing_env, did, gen_args) =>
+                            if let Some((typeck, init)) = get_const_hir_value(cx.tcx, typing_env, did, gen_args) =>
                         {
-                            self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, init)
+                            self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, init)
                         },
                         // Either this is a unit constructor, or some unknown value.
                         // In either case we consider the value to be `Freeze`.
@@ -417,15 +419,15 @@ impl<'tcx> NonCopyConst<'tcx> {
                         && matches!(res, Res::Def(DefKind::Ctor(..), _) | Res::SelfCtor(_)) =>
                 {
                     args.iter()
-                        .all(|e| self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, e))
+                        .all(|e| self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, e))
                 },
                 ExprKind::Struct(_, fields, StructTailExpr::None) => fields
                     .iter()
-                    .all(|f| self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, f.expr)),
+                    .all(|f| self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, f.expr)),
                 ExprKind::Tup(exprs) | ExprKind::Array(exprs) => exprs
                     .iter()
-                    .all(|e| self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, e)),
-                ExprKind::Repeat(e, _) => self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, e),
+                    .all(|e| self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, e)),
+                ExprKind::Repeat(e, _) => self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, e),
                 _ => true,
             },
         }
@@ -435,24 +437,24 @@ impl<'tcx> NonCopyConst<'tcx> {
     /// definitely a non-`Freeze` type.
     fn is_non_freeze_expr_borrowed(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         typeck: &'tcx TypeckResults<'tcx>,
         mut src_expr: &'tcx Expr<'tcx>,
     ) -> Option<BorrowSource<'tcx>> {
-        let mut parents = tcx.hir_parent_iter(src_expr.hir_id);
+        let mut parents = cx.tcx.hir_parent_iter(src_expr.hir_id);
         loop {
             let ty = typeck.expr_ty(src_expr);
             // Normalized as we need to check if this is an array later.
-            let ty = tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
-            let is_freeze = self.is_ty_freeze(tcx, typing_env, ty);
+            let ty = cx.tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
+            let is_freeze = self.is_ty_freeze(cx, typing_env, ty);
             if is_freeze.is_freeze() {
                 return None;
             }
             if let [adjust, ..] = typeck.expr_adjustments(src_expr) {
                 return does_adjust_borrow(adjust)
                     .filter(|_| is_freeze.is_not_freeze())
-                    .map(|cause| BorrowSource::new(tcx, src_expr, cause));
+                    .map(|cause| BorrowSource::new(cx.tcx, src_expr, cause));
             }
             let Some((_, Node::Expr(use_expr))) = parents.next() else {
                 return None;
@@ -461,7 +463,7 @@ impl<'tcx> NonCopyConst<'tcx> {
                 ExprKind::Field(..) => {},
                 ExprKind::Index(..) if ty.is_array() => {},
                 ExprKind::AddrOf(..) if is_freeze.is_not_freeze() => {
-                    return Some(BorrowSource::new(tcx, use_expr, BorrowCause::Borrow));
+                    return Some(BorrowSource::new(cx.tcx, use_expr, BorrowCause::Borrow));
                 },
                 // All other expressions use the value.
                 _ => return None,
@@ -475,29 +477,29 @@ impl<'tcx> NonCopyConst<'tcx> {
     /// result depends on the value.
     fn is_non_freeze_val_borrowed(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         typeck: &'tcx TypeckResults<'tcx>,
         mut src_expr: &'tcx Expr<'tcx>,
         mut val: ConstValue,
     ) -> Result<Option<BorrowSource<'tcx>>, ()> {
-        let mut parents = tcx.hir_parent_iter(src_expr.hir_id);
+        let mut parents = cx.tcx.hir_parent_iter(src_expr.hir_id);
         let mut ty = typeck.expr_ty(src_expr);
         loop {
             // Normalized as we need to check if this is an array later.
-            ty = tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
+            ty = cx.tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
             if let [adjust, ..] = typeck.expr_adjustments(src_expr) {
                 let res = if let Some(cause) = does_adjust_borrow(adjust)
-                    && !self.is_value_freeze(tcx, typing_env, ty, val)?
+                    && !self.is_value_freeze(cx, typing_env, ty, val)?
                 {
-                    Some(BorrowSource::new(tcx, src_expr, cause))
+                    Some(BorrowSource::new(cx.tcx, src_expr, cause))
                 } else {
                     None
                 };
                 return Ok(res);
             }
             // Check only the type here as the result gets cached for each type.
-            if self.is_ty_freeze(tcx, typing_env, ty).is_freeze() {
+            if self.is_ty_freeze(cx, typing_env, ty).is_freeze() {
                 return Ok(None);
             }
             let Some((_, Node::Expr(use_expr))) = parents.next() else {
@@ -506,7 +508,8 @@ impl<'tcx> NonCopyConst<'tcx> {
             let next_val = match use_expr.kind {
                 ExprKind::Field(_, name) => {
                     if let Some(idx) = get_field_idx_by_name(ty, name.name) {
-                        tcx.try_destructure_mir_constant_for_user_output(val, ty)
+                        cx.tcx
+                            .try_destructure_mir_constant_for_user_output(val, ty)
                             .ok_or(())?
                             .fields
                             .get(idx)
@@ -515,23 +518,21 @@ impl<'tcx> NonCopyConst<'tcx> {
                     }
                 },
                 ExprKind::Index(_, idx, _) if ty.is_array() => {
-                    let val = tcx.try_destructure_mir_constant_for_user_output(val, ty).ok_or(())?;
-                    if let Some(Constant::Int(idx)) = ConstEvalCtxt::with_env(tcx, typing_env, typeck).eval(idx) {
+                    let val = cx.tcx.try_destructure_mir_constant_for_user_output(val, ty).ok_or(())?;
+                    if let Some(Constant::Int(idx)) = ConstEvalCtxt::with_env(cx.tcx, typing_env, typeck).eval(idx) {
                         val.fields.get(idx as usize)
                     } else {
                         // It's some value in the array so check all of them.
                         for &(val, _) in val.fields {
-                            if let Some(src) =
-                                self.is_non_freeze_val_borrowed(tcx, typing_env, typeck, use_expr, val)?
-                            {
+                            if let Some(src) = self.is_non_freeze_val_borrowed(cx, typing_env, typeck, use_expr, val)? {
                                 return Ok(Some(src));
                             }
                         }
                         return Ok(None);
                     }
                 },
-                ExprKind::AddrOf(..) if !self.is_value_freeze(tcx, typing_env, ty, val)? => {
-                    return Ok(Some(BorrowSource::new(tcx, use_expr, BorrowCause::Borrow)));
+                ExprKind::AddrOf(..) if !self.is_value_freeze(cx, typing_env, ty, val)? => {
+                    return Ok(Some(BorrowSource::new(cx.tcx, use_expr, BorrowCause::Borrow)));
                 },
                 // All other expressions use the value.
                 _ => return Ok(None),
@@ -554,7 +555,7 @@ impl<'tcx> NonCopyConst<'tcx> {
     #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
     fn is_non_freeze_init_borrowed(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         typeck: &'tcx TypeckResults<'tcx>,
         mut src_expr: &'tcx Expr<'tcx>,
@@ -563,13 +564,13 @@ impl<'tcx> NonCopyConst<'tcx> {
         mut init_expr: &'tcx Expr<'tcx>,
     ) -> Option<BorrowSource<'tcx>> {
         // Make sure to instantiate all types coming from `init_typeck` with `init_args`.
-        let mut parents = tcx.hir_parent_iter(src_expr.hir_id);
+        let mut parents = cx.tcx.hir_parent_iter(src_expr.hir_id);
         loop {
             // First handle any adjustments since they are cheap to check.
             if let [adjust, ..] = typeck.expr_adjustments(src_expr) {
                 return does_adjust_borrow(adjust)
-                    .filter(|_| !self.is_init_expr_freeze(tcx, typing_env, init_typeck, init_args, init_expr))
-                    .map(|cause| BorrowSource::new(tcx, src_expr, cause));
+                    .filter(|_| !self.is_init_expr_freeze(cx, typing_env, init_typeck, init_args, init_expr))
+                    .map(|cause| BorrowSource::new(cx.tcx, src_expr, cause));
             }
 
             // Then read through constants and blocks on the init expression before
@@ -585,22 +586,22 @@ impl<'tcx> NonCopyConst<'tcx> {
                     },
                     ExprKind::Path(ref init_path) => {
                         let next_init_args =
-                            EarlyBinder::bind(init_typeck.node_args(init_expr.hir_id)).instantiate(tcx, init_args);
+                            EarlyBinder::bind(init_typeck.node_args(init_expr.hir_id)).instantiate(cx.tcx, init_args);
                         match init_typeck.qpath_res(init_path, init_expr.hir_id) {
                             Res::Def(DefKind::Ctor(..), _) => return None,
                             Res::Def(DefKind::Const | DefKind::AssocConst, did)
-                                if let Ok(val) = tcx.const_eval_resolve(
+                                if let Ok(val) = cx.tcx.const_eval_resolve(
                                     typing_env,
                                     UnevaluatedConst::new(did, next_init_args),
                                     DUMMY_SP,
                                 ) && let Ok(res) =
-                                    self.is_non_freeze_val_borrowed(tcx, typing_env, init_typeck, src_expr, val) =>
+                                    self.is_non_freeze_val_borrowed(cx, typing_env, init_typeck, src_expr, val) =>
                             {
                                 return res;
                             },
                             Res::Def(DefKind::Const | DefKind::AssocConst, did)
                                 if let Some((next_typeck, value)) =
-                                    get_const_hir_value(tcx, typing_env, did, next_init_args) =>
+                                    get_const_hir_value(cx.tcx, typing_env, did, next_init_args) =>
                             {
                                 init_typeck = next_typeck;
                                 init_args = next_init_args;
@@ -609,7 +610,7 @@ impl<'tcx> NonCopyConst<'tcx> {
                             // There's no more that we can read from the init expression. Switch to a
                             // type based check.
                             _ => {
-                                return self.is_non_freeze_expr_borrowed(tcx, typing_env, typeck, src_expr);
+                                return self.is_non_freeze_expr_borrowed(cx, typing_env, typeck, src_expr);
                             },
                         }
                     },
@@ -621,8 +622,8 @@ impl<'tcx> NonCopyConst<'tcx> {
             // gets cached.
             let ty = typeck.expr_ty(src_expr);
             // Normalized as we need to check if this is an array later.
-            let ty = tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
-            if self.is_ty_freeze(tcx, typing_env, ty).is_freeze() {
+            let ty = cx.tcx.try_normalize_erasing_regions(typing_env, ty).unwrap_or(ty);
+            if self.is_ty_freeze(cx, typing_env, ty).is_freeze() {
                 return None;
             }
 
@@ -655,11 +656,12 @@ impl<'tcx> NonCopyConst<'tcx> {
                         arg
                     },
                     // Revert to a type based check as we don't know the field's value.
-                    _ => return self.is_non_freeze_expr_borrowed(tcx, typing_env, typeck, use_expr),
+                    _ => return self.is_non_freeze_expr_borrowed(cx, typing_env, typeck, use_expr),
                 },
                 ExprKind::Index(_, idx, _) if ty.is_array() => match init_expr.kind {
                     ExprKind::Array(fields) => {
-                        if let Some(Constant::Int(idx)) = ConstEvalCtxt::with_env(tcx, typing_env, typeck).eval(idx) {
+                        if let Some(Constant::Int(idx)) = ConstEvalCtxt::with_env(cx.tcx, typing_env, typeck).eval(idx)
+                        {
                             // If the index is out of bounds it means the code
                             // unconditionally panics. In that case there is no borrow.
                             fields.get(idx as usize)?
@@ -667,7 +669,7 @@ impl<'tcx> NonCopyConst<'tcx> {
                             // Unknown index, just run the check for all values.
                             return fields.iter().find_map(|f| {
                                 self.is_non_freeze_init_borrowed(
-                                    tcx,
+                                    cx,
                                     typing_env,
                                     typeck,
                                     use_expr,
@@ -680,12 +682,12 @@ impl<'tcx> NonCopyConst<'tcx> {
                     },
                     // Just assume the index expression doesn't panic here.
                     ExprKind::Repeat(field, _) => field,
-                    _ => return self.is_non_freeze_expr_borrowed(tcx, typing_env, typeck, use_expr),
+                    _ => return self.is_non_freeze_expr_borrowed(cx, typing_env, typeck, use_expr),
                 },
                 ExprKind::AddrOf(..)
-                    if !self.is_init_expr_freeze(tcx, typing_env, init_typeck, init_args, init_expr) =>
+                    if !self.is_init_expr_freeze(cx, typing_env, init_typeck, init_args, init_expr) =>
                 {
-                    return Some(BorrowSource::new(tcx, use_expr, BorrowCause::Borrow));
+                    return Some(BorrowSource::new(cx.tcx, use_expr, BorrowCause::Borrow));
                 },
                 // All other expressions use the value.
                 _ => return None,
@@ -700,14 +702,14 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
         if let ItemKind::Const(ident, .., ct_rhs) = item.kind
             && !ident.is_special()
             && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity()
-            && match self.is_ty_freeze(cx.tcx, cx.typing_env(), ty) {
+            && match self.is_ty_freeze(cx, cx.typing_env(), ty) {
                 IsFreeze::No => true,
                 IsFreeze::Yes => false,
                 IsFreeze::Maybe => match cx.tcx.const_eval_poly(item.owner_id.to_def_id()) {
-                    Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx.tcx, cx.typing_env(), ty, val) => !is_freeze,
+                    Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx, cx.typing_env(), ty, val) => !is_freeze,
                     // FIXME: we just assume mgca rhs's are freeze
                     _ => const_item_rhs_to_expr(cx.tcx, ct_rhs).is_some_and(|e| !self.is_init_expr_freeze(
-                        cx.tcx,
+                        cx,
                         cx.typing_env(),
                         cx.tcx.typeck(item.owner_id),
                         GenericArgs::identity_for_item(cx.tcx, item.owner_id),
@@ -741,17 +743,15 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
     fn check_trait_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx TraitItem<'_>) {
         if let TraitItemKind::Const(_, ct_rhs_opt, _) = item.kind
             && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity()
-            && match self.is_ty_freeze(cx.tcx, cx.typing_env(), ty) {
+            && match self.is_ty_freeze(cx, cx.typing_env(), ty) {
                 IsFreeze::No => true,
                 IsFreeze::Maybe if let Some(ct_rhs) = ct_rhs_opt => {
                     match cx.tcx.const_eval_poly(item.owner_id.to_def_id()) {
-                        Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx.tcx, cx.typing_env(), ty, val) => {
-                            !is_freeze
-                        },
+                        Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx, cx.typing_env(), ty, val) => !is_freeze,
                         // FIXME: we just assume mgca rhs's are freeze
                         _ => const_item_rhs_to_expr(cx.tcx, ct_rhs).is_some_and(|e| {
                             !self.is_init_expr_freeze(
-                                cx.tcx,
+                                cx,
                                 cx.typing_env(),
                                 cx.tcx.typeck(item.owner_id),
                                 GenericArgs::identity_for_item(cx.tcx, item.owner_id),
@@ -776,7 +776,7 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx ImplItem<'_>) {
         if let ImplItemKind::Const(_, ct_rhs) = item.kind
             && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity()
-            && match self.is_ty_freeze(cx.tcx, cx.typing_env(), ty) {
+            && match self.is_ty_freeze(cx, cx.typing_env(), ty) {
                 IsFreeze::Yes => false,
                 IsFreeze::No => {
                     // If this is a trait impl, check if the trait definition is the source
@@ -796,7 +796,7 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
                         })
                         .fold_ty(cx.tcx.type_of(item.owner_id).instantiate_identity());
                         // `ty` may not be normalizable, but that should be fine.
-                        !self.is_ty_freeze(cx.tcx, cx.typing_env(), ty).is_not_freeze()
+                        !self.is_ty_freeze(cx, cx.typing_env(), ty).is_not_freeze()
                     } else {
                         true
                     }
@@ -804,11 +804,11 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
                 // Even if this is from a trait, there are values which don't have
                 // interior mutability.
                 IsFreeze::Maybe => match cx.tcx.const_eval_poly(item.owner_id.to_def_id()) {
-                    Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx.tcx, cx.typing_env(), ty, val) => !is_freeze,
+                    Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx, cx.typing_env(), ty, val) => !is_freeze,
                     // FIXME: we just assume mgca rhs's are freeze
                     _ => const_item_rhs_to_expr(cx.tcx, ct_rhs).is_some_and(|e| {
                         !self.is_init_expr_freeze(
-                            cx.tcx,
+                            cx,
                             cx.typing_env(),
                             cx.tcx.typeck(item.owner_id),
                             GenericArgs::identity_for_item(cx.tcx, item.owner_id),
@@ -834,22 +834,22 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
             && let Res::Def(DefKind::Const | DefKind::AssocConst, did) = typeck.qpath_res(qpath, e.hir_id)
             // As of `1.80` constant contexts can't borrow any type with interior mutability
             && !is_in_const_context(cx)
-            && !self.is_ty_freeze(cx.tcx, cx.typing_env(), typeck.expr_ty(e)).is_freeze()
+            && !self.is_ty_freeze(cx, cx.typing_env(), typeck.expr_ty(e)).is_freeze()
             && let Some(borrow_src) = {
                 // The extra block helps formatting a lot.
                 if let Ok(val) = cx.tcx.const_eval_resolve(
                     cx.typing_env(),
                     UnevaluatedConst::new(did, typeck.node_args(e.hir_id)),
                     DUMMY_SP,
-                ) && let Ok(src) = self.is_non_freeze_val_borrowed(cx.tcx, cx.typing_env(), typeck, e, val)
+                ) && let Ok(src) = self.is_non_freeze_val_borrowed(cx, cx.typing_env(), typeck, e, val)
                 {
                     src
                 } else if let init_args = typeck.node_args(e.hir_id)
                     && let Some((init_typeck, init)) = get_const_hir_value(cx.tcx, cx.typing_env(), did, init_args)
                 {
-                    self.is_non_freeze_init_borrowed(cx.tcx, cx.typing_env(), typeck, e, init_typeck, init_args, init)
+                    self.is_non_freeze_init_borrowed(cx, cx.typing_env(), typeck, e, init_typeck, init_args, init)
                 } else {
-                    self.is_non_freeze_expr_borrowed(cx.tcx, cx.typing_env(), typeck, e)
+                    self.is_non_freeze_expr_borrowed(cx, cx.typing_env(), typeck, e)
                 }
             }
             && !borrow_src.expr.span.in_external_macro(cx.sess().source_map())

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -22,11 +22,10 @@ use clippy_utils::consts::{ConstEvalCtxt, Constant, const_item_rhs_to_expr};
 use clippy_utils::diagnostics::{span_lint, span_lint_and_then};
 use clippy_utils::is_in_const_context;
 use clippy_utils::macros::macro_backtrace;
-use clippy_utils::paths::{PathNS, lookup_path_str};
-use clippy_utils::ty::{get_field_idx_by_name, implements_trait};
+use clippy_utils::ty::{InteriorMut, get_field_idx_by_name, implements_trait};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{DefId, DefIdSet};
+use rustc_hir::def_id::DefId;
 use rustc_hir::{
     ConstArgKind, ConstItemRhs, Expr, ExprKind, ImplItem, ImplItemKind, Item, ItemKind, Node, StructTailExpr,
     TraitItem, TraitItemKind, UnOp,
@@ -251,7 +250,7 @@ impl<'tcx> BorrowSource<'tcx> {
 }
 
 pub struct NonCopyConst<'tcx> {
-    ignore_tys: DefIdSet,
+    interior_mut: InteriorMut<'tcx>,
     // Cache checked types. We can recurse through a type multiple times so this
     // can be hit quite frequently.
     freeze_tys: FxHashMap<Ty<'tcx>, IsFreeze>,
@@ -262,11 +261,7 @@ impl_lint_pass!(NonCopyConst<'_> => [DECLARE_INTERIOR_MUTABLE_CONST, BORROW_INTE
 impl<'tcx> NonCopyConst<'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>, conf: &'static Conf) -> Self {
         Self {
-            ignore_tys: conf
-                .ignore_interior_mutability
-                .iter()
-                .flat_map(|ignored_ty| lookup_path_str(tcx, PathNS::Type, ignored_ty))
-                .collect(),
+            interior_mut: InteriorMut::new(tcx, &conf.ignore_interior_mutability),
             freeze_tys: FxHashMap::default(),
         }
     }
@@ -287,7 +282,7 @@ impl<'tcx> NonCopyConst<'tcx> {
                         *e = IsFreeze::No;
                         return IsFreeze::No;
                     },
-                    ty::Adt(adt, _) if self.ignore_tys.contains(&adt.did()) => return IsFreeze::Yes,
+                    ty::Adt(_, _) if !self.interior_mut.is_interior_mut_ty(cx, ty) => return IsFreeze::Yes,
                     ty::Adt(adt, args) if adt.is_enum() => IsFreeze::from_variants(adt.variants().iter().map(|v| {
                         IsFreeze::from_fields(
                             v.fields

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -76,8 +76,9 @@ declare_clippy_lint! {
     /// no way to both create a value as a constant and modify any mutable field using the
     /// type's public interface (e.g. `bytes::Bytes`). As there is no reasonable way to
     /// scan a crate's interface to see if this is the case, all such types will be linted.
-    /// If this happens use the `ignore-interior-mutability` configuration option to allow
-    /// the type.
+    /// If this happens, use the `ignore-interior-mutability` configuration option or put
+    /// the `#[clippy::private_interior_mutability]` attribute onto a type to allow the
+    /// type.
     ///
     /// ### Example
     /// ```no_run
@@ -133,8 +134,9 @@ declare_clippy_lint! {
     /// no way to both create a value as a constant and modify any mutable field using the
     /// type's public interface (e.g. `bytes::Bytes`). As there is no reasonable way to
     /// scan a crate's interface to see if this is the case, all such types will be linted.
-    /// If this happens use the `ignore-interior-mutability` configuration option to allow
-    /// the type.
+    /// If this happens, use the `ignore-interior-mutability` configuration option or put
+    /// the `#[clippy::private_interior_mutability]` attribute onto a type to allow the
+    /// type.
     ///
     /// ### Example
     /// ```no_run

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -274,16 +274,17 @@ impl<'tcx> NonCopyConst<'tcx> {
     }
 
     /// Checks if a value of the given type is `Freeze`, or may be depending on the value.
-    fn is_ty_freeze(&mut self, tcx: TyCtxt<'tcx>, typing_env: TypingEnv<'tcx>, ty: Ty<'tcx>) -> IsFreeze {
+    fn is_ty_freeze(&mut self, cx: &LateContext<'tcx>, typing_env: TypingEnv<'tcx>, ty: Ty<'tcx>) -> IsFreeze {
         // FIXME: this should probably be using the trait solver
-        let ty = tcx
+        let ty = cx
+            .tcx
             .try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(ty))
             .unwrap_or(ty);
         match self.freeze_tys.entry(ty) {
             Entry::Occupied(e) => *e.get(),
             Entry::Vacant(e) => {
                 let e = e.insert(IsFreeze::Yes);
-                if ty.is_freeze(tcx, typing_env) {
+                if ty.is_freeze(cx.tcx, typing_env) {
                     return IsFreeze::Yes;
                 }
                 let is_freeze = match *ty.kind() {
@@ -296,14 +297,15 @@ impl<'tcx> NonCopyConst<'tcx> {
                         IsFreeze::from_fields(
                             v.fields
                                 .iter()
-                                .map(|f| self.is_ty_freeze(tcx, typing_env, f.ty(tcx, args).skip_norm_wip())),
+                                .map(|f| self.is_ty_freeze(cx, typing_env, f.ty(cx.tcx, args).skip_norm_wip())),
                         )
                     })),
                     // Workaround for `ManuallyDrop`-like unions.
                     ty::Adt(adt, args)
                         if adt.is_union()
                             && adt.non_enum_variant().fields.iter().any(|f| {
-                                tcx.layout_of(typing_env.as_query_input(f.ty(tcx, args).skip_norm_wip()))
+                                cx.tcx
+                                    .layout_of(typing_env.as_query_input(f.ty(cx.tcx, args).skip_norm_wip()))
                                     .is_ok_and(|l| l.layout.size().bytes() == 0)
                             }) =>
                     {
@@ -315,12 +317,10 @@ impl<'tcx> NonCopyConst<'tcx> {
                         adt.non_enum_variant()
                             .fields
                             .iter()
-                            .map(|f| self.is_ty_freeze(tcx, typing_env, f.ty(tcx, args).skip_norm_wip())),
+                            .map(|f| self.is_ty_freeze(cx, typing_env, f.ty(cx.tcx, args).skip_norm_wip())),
                     ),
-                    ty::Array(ty, _) | ty::Pat(ty, _) => self.is_ty_freeze(tcx, typing_env, ty),
-                    ty::Tuple(tys) => {
-                        IsFreeze::from_fields(tys.iter().map(|ty| self.is_ty_freeze(tcx, typing_env, ty)))
-                    },
+                    ty::Array(ty, _) | ty::Pat(ty, _) => self.is_ty_freeze(cx, typing_env, ty),
+                    ty::Tuple(tys) => IsFreeze::from_fields(tys.iter().map(|ty| self.is_ty_freeze(cx, typing_env, ty))),
                     // Treat type parameters as though they were `Freeze`.
                     ty::Param(_) | ty::Alias(..) => return IsFreeze::Yes,
                     // TODO: check other types.
@@ -341,23 +341,25 @@ impl<'tcx> NonCopyConst<'tcx> {
     /// cannot be read, but the result depends on the value.
     fn is_value_freeze(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         ty: Ty<'tcx>,
         val: ConstValue,
     ) -> Result<bool, ()> {
-        let ty = tcx
+        let ty = cx
+            .tcx
             .try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(ty))
             .unwrap_or(ty);
-        match self.is_ty_freeze(tcx, typing_env, ty) {
+        match self.is_ty_freeze(cx, typing_env, ty) {
             IsFreeze::Yes => Ok(true),
             IsFreeze::Maybe if matches!(ty.kind(), ty::Adt(..) | ty::Array(..) | ty::Tuple(..)) => {
-                for &(val, ty) in tcx
+                for &(val, ty) in cx
+                    .tcx
                     .try_destructure_mir_constant_for_user_output(val, ty)
                     .ok_or(())?
                     .fields
                 {
-                    if !self.is_value_freeze(tcx, typing_env, ty, val)? {
+                    if !self.is_value_freeze(cx, typing_env, ty, val)? {
                         return Ok(false);
                     }
                 }
@@ -376,18 +378,19 @@ impl<'tcx> NonCopyConst<'tcx> {
     /// `typeck` and `e` are from the constant's definition site.
     fn is_init_expr_freeze(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         typeck: &'tcx TypeckResults<'tcx>,
         gen_args: GenericArgsRef<'tcx>,
         e: &'tcx Expr<'tcx>,
     ) -> bool {
         // Make sure to instantiate all types coming from `typeck` with `gen_args`.
-        let ty = EarlyBinder::bind(tcx, typeck.expr_ty(e)).instantiate(tcx, gen_args);
-        let ty = tcx
+        let ty = EarlyBinder::bind(cx.tcx, typeck.expr_ty(e)).instantiate(cx.tcx, gen_args);
+        let ty = cx
+            .tcx
             .try_normalize_erasing_regions(typing_env, ty)
             .unwrap_or(ty.skip_norm_wip());
-        match self.is_ty_freeze(tcx, typing_env, ty) {
+        match self.is_ty_freeze(cx, typing_env, ty) {
             IsFreeze::Yes => true,
             IsFreeze::No => false,
             IsFreeze::Maybe => match e.kind {
@@ -396,25 +399,27 @@ impl<'tcx> NonCopyConst<'tcx> {
                         && b.stmts.is_empty()
                         && let Some(e) = b.expr =>
                 {
-                    self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, e)
+                    self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, e)
                 },
                 ExprKind::Path(ref p) => {
                     let res = typeck.qpath_res(p, e.hir_id);
-                    let gen_args = EarlyBinder::bind(tcx, typeck.node_args(e.hir_id))
-                        .instantiate(tcx, gen_args)
+                    let gen_args = EarlyBinder::bind(cx.tcx, typeck.node_args(e.hir_id))
+                        .instantiate(cx.tcx, gen_args)
                         .skip_norm_wip();
                     match res {
                         Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, did)
-                            if let Ok(val) =
-                                tcx.const_eval_resolve(typing_env, UnevaluatedConst::new(did, gen_args), DUMMY_SP)
-                                && let Ok(is_freeze) = self.is_value_freeze(tcx, typing_env, ty, val) =>
+                            if let Ok(val) = cx.tcx.const_eval_resolve(
+                                typing_env,
+                                UnevaluatedConst::new(did, gen_args),
+                                DUMMY_SP,
+                            ) && let Ok(is_freeze) = self.is_value_freeze(cx, typing_env, ty, val) =>
                         {
                             is_freeze
                         },
                         Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, did)
-                            if let Some((typeck, init)) = get_const_hir_value(tcx, typing_env, did, gen_args) =>
+                            if let Some((typeck, init)) = get_const_hir_value(cx.tcx, typing_env, did, gen_args) =>
                         {
-                            self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, init)
+                            self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, init)
                         },
                         // Either this is a unit constructor, or some unknown value.
                         // In either case we consider the value to be `Freeze`.
@@ -427,15 +432,15 @@ impl<'tcx> NonCopyConst<'tcx> {
                         && matches!(res, Res::Def(DefKind::Ctor(..), _) | Res::SelfCtor(_)) =>
                 {
                     args.iter()
-                        .all(|e| self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, e))
+                        .all(|e| self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, e))
                 },
                 ExprKind::Struct(_, fields, StructTailExpr::None) => fields
                     .iter()
-                    .all(|f| self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, f.expr)),
+                    .all(|f| self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, f.expr)),
                 ExprKind::Tup(exprs) | ExprKind::Array(exprs) => exprs
                     .iter()
-                    .all(|e| self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, e)),
-                ExprKind::Repeat(e, _) => self.is_init_expr_freeze(tcx, typing_env, typeck, gen_args, e),
+                    .all(|e| self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, e)),
+                ExprKind::Repeat(e, _) => self.is_init_expr_freeze(cx, typing_env, typeck, gen_args, e),
                 _ => true,
             },
         }
@@ -445,26 +450,27 @@ impl<'tcx> NonCopyConst<'tcx> {
     /// definitely a non-`Freeze` type.
     fn is_non_freeze_expr_borrowed(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         typeck: &'tcx TypeckResults<'tcx>,
         mut src_expr: &'tcx Expr<'tcx>,
     ) -> Option<BorrowSource<'tcx>> {
-        let mut parents = tcx.hir_parent_iter(src_expr.hir_id);
+        let mut parents = cx.tcx.hir_parent_iter(src_expr.hir_id);
         loop {
             let ty = typeck.expr_ty(src_expr);
             // Normalized as we need to check if this is an array later.
-            let ty = tcx
+            let ty = cx
+                .tcx
                 .try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(ty))
                 .unwrap_or(ty);
-            let is_freeze = self.is_ty_freeze(tcx, typing_env, ty);
+            let is_freeze = self.is_ty_freeze(cx, typing_env, ty);
             if is_freeze.is_freeze() {
                 return None;
             }
             if let [adjust, ..] = typeck.expr_adjustments(src_expr) {
                 return does_adjust_borrow(adjust)
                     .filter(|_| is_freeze.is_not_freeze())
-                    .map(|cause| BorrowSource::new(tcx, src_expr, cause));
+                    .map(|cause| BorrowSource::new(cx.tcx, src_expr, cause));
             }
             let Some((_, Node::Expr(use_expr))) = parents.next() else {
                 return None;
@@ -473,7 +479,7 @@ impl<'tcx> NonCopyConst<'tcx> {
                 ExprKind::Field(..) => {},
                 ExprKind::Index(..) if ty.is_array() => {},
                 ExprKind::AddrOf(..) if is_freeze.is_not_freeze() => {
-                    return Some(BorrowSource::new(tcx, use_expr, BorrowCause::Borrow));
+                    return Some(BorrowSource::new(cx.tcx, use_expr, BorrowCause::Borrow));
                 },
                 // All other expressions use the value.
                 _ => return None,
@@ -487,31 +493,32 @@ impl<'tcx> NonCopyConst<'tcx> {
     /// result depends on the value.
     fn is_non_freeze_val_borrowed(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         typeck: &'tcx TypeckResults<'tcx>,
         mut src_expr: &'tcx Expr<'tcx>,
         mut val: ConstValue,
     ) -> Result<Option<BorrowSource<'tcx>>, ()> {
-        let mut parents = tcx.hir_parent_iter(src_expr.hir_id);
+        let mut parents = cx.tcx.hir_parent_iter(src_expr.hir_id);
         let mut ty = typeck.expr_ty(src_expr);
         loop {
             // Normalized as we need to check if this is an array later.
-            ty = tcx
+            ty = cx
+                .tcx
                 .try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(ty))
                 .unwrap_or(ty);
             if let [adjust, ..] = typeck.expr_adjustments(src_expr) {
                 let res = if let Some(cause) = does_adjust_borrow(adjust)
-                    && !self.is_value_freeze(tcx, typing_env, ty, val)?
+                    && !self.is_value_freeze(cx, typing_env, ty, val)?
                 {
-                    Some(BorrowSource::new(tcx, src_expr, cause))
+                    Some(BorrowSource::new(cx.tcx, src_expr, cause))
                 } else {
                     None
                 };
                 return Ok(res);
             }
             // Check only the type here as the result gets cached for each type.
-            if self.is_ty_freeze(tcx, typing_env, ty).is_freeze() {
+            if self.is_ty_freeze(cx, typing_env, ty).is_freeze() {
                 return Ok(None);
             }
             let Some((_, Node::Expr(use_expr))) = parents.next() else {
@@ -520,7 +527,8 @@ impl<'tcx> NonCopyConst<'tcx> {
             let next_val = match use_expr.kind {
                 ExprKind::Field(_, name) => {
                     if let Some(idx) = get_field_idx_by_name(ty, name.name) {
-                        tcx.try_destructure_mir_constant_for_user_output(val, ty)
+                        cx.tcx
+                            .try_destructure_mir_constant_for_user_output(val, ty)
                             .ok_or(())?
                             .fields
                             .get(idx)
@@ -529,23 +537,21 @@ impl<'tcx> NonCopyConst<'tcx> {
                     }
                 },
                 ExprKind::Index(_, idx, _) if ty.is_array() => {
-                    let val = tcx.try_destructure_mir_constant_for_user_output(val, ty).ok_or(())?;
-                    if let Some(Constant::Int(idx)) = ConstEvalCtxt::with_env(tcx, typing_env, typeck).eval(idx) {
+                    let val = cx.tcx.try_destructure_mir_constant_for_user_output(val, ty).ok_or(())?;
+                    if let Some(Constant::Int(idx)) = ConstEvalCtxt::with_env(cx.tcx, typing_env, typeck).eval(idx) {
                         val.fields.get(idx as usize)
                     } else {
                         // It's some value in the array so check all of them.
                         for &(val, _) in val.fields {
-                            if let Some(src) =
-                                self.is_non_freeze_val_borrowed(tcx, typing_env, typeck, use_expr, val)?
-                            {
+                            if let Some(src) = self.is_non_freeze_val_borrowed(cx, typing_env, typeck, use_expr, val)? {
                                 return Ok(Some(src));
                             }
                         }
                         return Ok(None);
                     }
                 },
-                ExprKind::AddrOf(..) if !self.is_value_freeze(tcx, typing_env, ty, val)? => {
-                    return Ok(Some(BorrowSource::new(tcx, use_expr, BorrowCause::Borrow)));
+                ExprKind::AddrOf(..) if !self.is_value_freeze(cx, typing_env, ty, val)? => {
+                    return Ok(Some(BorrowSource::new(cx.tcx, use_expr, BorrowCause::Borrow)));
                 },
                 // All other expressions use the value.
                 _ => return Ok(None),
@@ -568,7 +574,7 @@ impl<'tcx> NonCopyConst<'tcx> {
     #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
     fn is_non_freeze_init_borrowed(
         &mut self,
-        tcx: TyCtxt<'tcx>,
+        cx: &LateContext<'tcx>,
         typing_env: TypingEnv<'tcx>,
         typeck: &'tcx TypeckResults<'tcx>,
         mut src_expr: &'tcx Expr<'tcx>,
@@ -577,13 +583,13 @@ impl<'tcx> NonCopyConst<'tcx> {
         mut init_expr: &'tcx Expr<'tcx>,
     ) -> Option<BorrowSource<'tcx>> {
         // Make sure to instantiate all types coming from `init_typeck` with `init_args`.
-        let mut parents = tcx.hir_parent_iter(src_expr.hir_id);
+        let mut parents = cx.tcx.hir_parent_iter(src_expr.hir_id);
         loop {
             // First handle any adjustments since they are cheap to check.
             if let [adjust, ..] = typeck.expr_adjustments(src_expr) {
                 return does_adjust_borrow(adjust)
-                    .filter(|_| !self.is_init_expr_freeze(tcx, typing_env, init_typeck, init_args, init_expr))
-                    .map(|cause| BorrowSource::new(tcx, src_expr, cause));
+                    .filter(|_| !self.is_init_expr_freeze(cx, typing_env, init_typeck, init_args, init_expr))
+                    .map(|cause| BorrowSource::new(cx.tcx, src_expr, cause));
             }
 
             // Then read through constants and blocks on the init expression before
@@ -598,24 +604,24 @@ impl<'tcx> NonCopyConst<'tcx> {
                         init_expr = next_init;
                     },
                     ExprKind::Path(ref init_path) => {
-                        let next_init_args = EarlyBinder::bind(tcx, init_typeck.node_args(init_expr.hir_id))
-                            .instantiate(tcx, init_args)
+                        let next_init_args = EarlyBinder::bind(cx.tcx, init_typeck.node_args(init_expr.hir_id))
+                            .instantiate(cx.tcx, init_args)
                             .skip_norm_wip();
                         match init_typeck.qpath_res(init_path, init_expr.hir_id) {
                             Res::Def(DefKind::Ctor(..), _) => return None,
                             Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, did)
-                                if let Ok(val) = tcx.const_eval_resolve(
+                                if let Ok(val) = cx.tcx.const_eval_resolve(
                                     typing_env,
                                     UnevaluatedConst::new(did, next_init_args),
                                     DUMMY_SP,
                                 ) && let Ok(res) =
-                                    self.is_non_freeze_val_borrowed(tcx, typing_env, init_typeck, src_expr, val) =>
+                                    self.is_non_freeze_val_borrowed(cx, typing_env, init_typeck, src_expr, val) =>
                             {
                                 return res;
                             },
                             Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, did)
                                 if let Some((next_typeck, value)) =
-                                    get_const_hir_value(tcx, typing_env, did, next_init_args) =>
+                                    get_const_hir_value(cx.tcx, typing_env, did, next_init_args) =>
                             {
                                 init_typeck = next_typeck;
                                 init_args = next_init_args;
@@ -624,7 +630,7 @@ impl<'tcx> NonCopyConst<'tcx> {
                             // There's no more that we can read from the init expression. Switch to a
                             // type based check.
                             _ => {
-                                return self.is_non_freeze_expr_borrowed(tcx, typing_env, typeck, src_expr);
+                                return self.is_non_freeze_expr_borrowed(cx, typing_env, typeck, src_expr);
                             },
                         }
                     },
@@ -636,10 +642,11 @@ impl<'tcx> NonCopyConst<'tcx> {
             // gets cached.
             let ty = typeck.expr_ty(src_expr);
             // Normalized as we need to check if this is an array later.
-            let ty = tcx
+            let ty = cx
+                .tcx
                 .try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(ty))
                 .unwrap_or(ty);
-            if self.is_ty_freeze(tcx, typing_env, ty).is_freeze() {
+            if self.is_ty_freeze(cx, typing_env, ty).is_freeze() {
                 return None;
             }
 
@@ -672,11 +679,12 @@ impl<'tcx> NonCopyConst<'tcx> {
                         arg
                     },
                     // Revert to a type based check as we don't know the field's value.
-                    _ => return self.is_non_freeze_expr_borrowed(tcx, typing_env, typeck, use_expr),
+                    _ => return self.is_non_freeze_expr_borrowed(cx, typing_env, typeck, use_expr),
                 },
                 ExprKind::Index(_, idx, _) if ty.is_array() => match init_expr.kind {
                     ExprKind::Array(fields) => {
-                        if let Some(Constant::Int(idx)) = ConstEvalCtxt::with_env(tcx, typing_env, typeck).eval(idx) {
+                        if let Some(Constant::Int(idx)) = ConstEvalCtxt::with_env(cx.tcx, typing_env, typeck).eval(idx)
+                        {
                             // If the index is out of bounds it means the code
                             // unconditionally panics. In that case there is no borrow.
                             fields.get(idx as usize)?
@@ -684,7 +692,7 @@ impl<'tcx> NonCopyConst<'tcx> {
                             // Unknown index, just run the check for all values.
                             return fields.iter().find_map(|f| {
                                 self.is_non_freeze_init_borrowed(
-                                    tcx,
+                                    cx,
                                     typing_env,
                                     typeck,
                                     use_expr,
@@ -697,12 +705,12 @@ impl<'tcx> NonCopyConst<'tcx> {
                     },
                     // Just assume the index expression doesn't panic here.
                     ExprKind::Repeat(field, _) => field,
-                    _ => return self.is_non_freeze_expr_borrowed(tcx, typing_env, typeck, use_expr),
+                    _ => return self.is_non_freeze_expr_borrowed(cx, typing_env, typeck, use_expr),
                 },
                 ExprKind::AddrOf(..)
-                    if !self.is_init_expr_freeze(tcx, typing_env, init_typeck, init_args, init_expr) =>
+                    if !self.is_init_expr_freeze(cx, typing_env, init_typeck, init_args, init_expr) =>
                 {
-                    return Some(BorrowSource::new(tcx, use_expr, BorrowCause::Borrow));
+                    return Some(BorrowSource::new(cx.tcx, use_expr, BorrowCause::Borrow));
                 },
                 // All other expressions use the value.
                 _ => return None,
@@ -717,14 +725,14 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
         if let ItemKind::Const(ident, .., ct_rhs) = item.kind
             && !ident.is_special()
             && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip()
-            && match self.is_ty_freeze(cx.tcx, cx.typing_env(), ty) {
+            && match self.is_ty_freeze(cx, cx.typing_env(), ty) {
                 IsFreeze::No => true,
                 IsFreeze::Yes => false,
                 IsFreeze::Maybe => match cx.tcx.const_eval_poly(item.owner_id.to_def_id()) {
-                    Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx.tcx, cx.typing_env(), ty, val) => !is_freeze,
+                    Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx, cx.typing_env(), ty, val) => !is_freeze,
                     // FIXME: we just assume mgca rhs's are freeze
                     _ => const_item_rhs_to_expr(cx.tcx, ct_rhs).is_some_and(|e| !self.is_init_expr_freeze(
-                        cx.tcx,
+                        cx,
                         cx.typing_env(),
                         cx.tcx.typeck(item.owner_id),
                         GenericArgs::identity_for_item(cx.tcx, item.owner_id),
@@ -758,17 +766,15 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
     fn check_trait_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx TraitItem<'_>) {
         if let TraitItemKind::Const(_, ct_rhs_opt) = item.kind
             && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip()
-            && match self.is_ty_freeze(cx.tcx, cx.typing_env(), ty) {
+            && match self.is_ty_freeze(cx, cx.typing_env(), ty) {
                 IsFreeze::No => true,
                 IsFreeze::Maybe if let Some(ct_rhs) = ct_rhs_opt => {
                     match cx.tcx.const_eval_poly(item.owner_id.to_def_id()) {
-                        Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx.tcx, cx.typing_env(), ty, val) => {
-                            !is_freeze
-                        },
+                        Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx, cx.typing_env(), ty, val) => !is_freeze,
                         // FIXME: we just assume mgca rhs's are freeze
                         _ => const_item_rhs_to_expr(cx.tcx, ct_rhs).is_some_and(|e| {
                             !self.is_init_expr_freeze(
-                                cx.tcx,
+                                cx,
                                 cx.typing_env(),
                                 cx.tcx.typeck(item.owner_id),
                                 GenericArgs::identity_for_item(cx.tcx, item.owner_id),
@@ -793,7 +799,7 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx ImplItem<'_>) {
         if let ImplItemKind::Const(_, ct_rhs) = item.kind
             && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip()
-            && match self.is_ty_freeze(cx.tcx, cx.typing_env(), ty) {
+            && match self.is_ty_freeze(cx, cx.typing_env(), ty) {
                 IsFreeze::Yes => false,
                 IsFreeze::No => {
                     // If this is a trait impl, check if the trait definition is the source
@@ -817,7 +823,7 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
                         })
                         .fold_ty(cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip());
                         // `ty` may not be normalizable, but that should be fine.
-                        !self.is_ty_freeze(cx.tcx, cx.typing_env(), ty).is_not_freeze()
+                        !self.is_ty_freeze(cx, cx.typing_env(), ty).is_not_freeze()
                     } else {
                         true
                     }
@@ -825,11 +831,11 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
                 // Even if this is from a trait, there are values which don't have
                 // interior mutability.
                 IsFreeze::Maybe => match cx.tcx.const_eval_poly(item.owner_id.to_def_id()) {
-                    Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx.tcx, cx.typing_env(), ty, val) => !is_freeze,
+                    Ok(val) if let Ok(is_freeze) = self.is_value_freeze(cx, cx.typing_env(), ty, val) => !is_freeze,
                     // FIXME: we just assume mgca rhs's are freeze
                     _ => const_item_rhs_to_expr(cx.tcx, ct_rhs).is_some_and(|e| {
                         !self.is_init_expr_freeze(
-                            cx.tcx,
+                            cx,
                             cx.typing_env(),
                             cx.tcx.typeck(item.owner_id),
                             GenericArgs::identity_for_item(cx.tcx, item.owner_id),
@@ -855,22 +861,22 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
             && let Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, did) = typeck.qpath_res(qpath, e.hir_id)
             // As of `1.80` constant contexts can't borrow any type with interior mutability
             && !is_in_const_context(cx)
-            && !self.is_ty_freeze(cx.tcx, cx.typing_env(), typeck.expr_ty(e)).is_freeze()
+            && !self.is_ty_freeze(cx, cx.typing_env(), typeck.expr_ty(e)).is_freeze()
             && let Some(borrow_src) = {
                 // The extra block helps formatting a lot.
                 if let Ok(val) = cx.tcx.const_eval_resolve(
                     cx.typing_env(),
                     UnevaluatedConst::new(did, typeck.node_args(e.hir_id)),
                     DUMMY_SP,
-                ) && let Ok(src) = self.is_non_freeze_val_borrowed(cx.tcx, cx.typing_env(), typeck, e, val)
+                ) && let Ok(src) = self.is_non_freeze_val_borrowed(cx, cx.typing_env(), typeck, e, val)
                 {
                     src
                 } else if let init_args = typeck.node_args(e.hir_id)
                     && let Some((init_typeck, init)) = get_const_hir_value(cx.tcx, cx.typing_env(), did, init_args)
                 {
-                    self.is_non_freeze_init_borrowed(cx.tcx, cx.typing_env(), typeck, e, init_typeck, init_args, init)
+                    self.is_non_freeze_init_borrowed(cx, cx.typing_env(), typeck, e, init_typeck, init_args, init)
                 } else {
-                    self.is_non_freeze_expr_borrowed(cx.tcx, cx.typing_env(), typeck, e)
+                    self.is_non_freeze_expr_borrowed(cx, cx.typing_env(), typeck, e)
                 }
             }
             && !borrow_src.expr.span.in_external_macro(cx.sess().source_map())

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -21,12 +21,11 @@ use clippy_config::Conf;
 use clippy_utils::consts::{ConstEvalCtxt, Constant, const_item_rhs_to_expr};
 use clippy_utils::diagnostics::{span_lint, span_lint_and_then};
 use clippy_utils::macros::macro_backtrace;
-use clippy_utils::paths::{PathNS, lookup_path_str};
-use clippy_utils::ty::{get_field_idx_by_name, implements_trait};
+use clippy_utils::ty::{InteriorMut, get_field_idx_by_name, implements_trait};
 use clippy_utils::{is_in_const_context, sym};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{DefId, DefIdSet};
+use rustc_hir::def_id::DefId;
 use rustc_hir::{
     ConstArgKind, ConstItemRhs, Expr, ExprKind, ImplItem, ImplItemKind, Item, ItemKind, Node, StructTailExpr,
     TraitItem, TraitItemKind, UnOp,
@@ -255,7 +254,7 @@ impl<'tcx> BorrowSource<'tcx> {
 }
 
 pub struct NonCopyConst<'tcx> {
-    ignore_tys: DefIdSet,
+    interior_mut: InteriorMut<'tcx>,
     // Cache checked types. We can recurse through a type multiple times so this
     // can be hit quite frequently.
     freeze_tys: FxHashMap<Ty<'tcx>, IsFreeze>,
@@ -264,11 +263,7 @@ pub struct NonCopyConst<'tcx> {
 impl<'tcx> NonCopyConst<'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>, conf: &'static Conf) -> Self {
         Self {
-            ignore_tys: conf
-                .ignore_interior_mutability
-                .iter()
-                .flat_map(|ignored_ty| lookup_path_str(tcx, PathNS::Type, ignored_ty))
-                .collect(),
+            interior_mut: InteriorMut::new(tcx, &conf.ignore_interior_mutability),
             freeze_tys: FxHashMap::default(),
         }
     }
@@ -292,7 +287,7 @@ impl<'tcx> NonCopyConst<'tcx> {
                         *e = IsFreeze::No;
                         return IsFreeze::No;
                     },
-                    ty::Adt(adt, _) if self.ignore_tys.contains(&adt.did()) => return IsFreeze::Yes,
+                    ty::Adt(_, _) if !self.interior_mut.is_interior_mut_ty(cx, ty) => return IsFreeze::Yes,
                     ty::Adt(adt, args) if adt.is_enum() => IsFreeze::from_variants(adt.variants().iter().map(|v| {
                         IsFreeze::from_fields(
                             v.fields

--- a/clippy_utils/src/attrs.rs
+++ b/clippy_utils/src/attrs.rs
@@ -30,6 +30,7 @@ pub fn get_builtin_attr<'a, A: AttributeExt + 'a>(
                 sym::cyclomatic_complexity => Some("cognitive_complexity"),
                 sym::author
                 | sym::version
+                | sym::ignore_interior_mutability
                 | sym::cognitive_complexity
                 | sym::dump
                 | sym::msrv

--- a/clippy_utils/src/attrs.rs
+++ b/clippy_utils/src/attrs.rs
@@ -39,7 +39,8 @@ pub fn check_clippy_attr<A: AttributeExt>(sess: &Session, attr: &A) {
             | sym::dump
             | sym::msrv
             | sym::has_significant_drop
-            | sym::format_args => {},
+            | sym::format_args
+            | sym::private_interior_mutability => {},
             _ => {
                 sess.dcx().span_err(path_span, "usage of unknown attribute");
             },

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -196,6 +196,7 @@ generate! {
     help,
     hidden_glob_reexports,
     hygiene,
+    ignore_interior_mutability,
     ilog,
     insert,
     insert_str,

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -484,6 +484,7 @@ generate! {
     powi,
     print_macro,
     println_macro,
+    private_interior_mutability,
     process_abort,
     process_exit,
     product,

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -13,7 +13,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, FnDecl, LangItem, find_attr};
 use rustc_hir_analysis::lower_ty;
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_lint::LateContext;
+use rustc_lint::{LateContext, LintContext};
 use rustc_middle::mir::ConstValue;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::traits::EvaluationResult;
@@ -38,7 +38,7 @@ use std::{iter, mem};
 
 use crate::paths::{PathNS, lookup_path_str};
 use crate::res::{MaybeDef, MaybeQPath};
-use crate::sym;
+use crate::{get_unique_builtin_attr, sym};
 
 mod type_certainty;
 pub use type_certainty::expr_type_is_certain;
@@ -1099,6 +1099,17 @@ impl<'tcx> InteriorMut<'tcx> {
     /// this type to be interior mutable. False negatives may be expected for infinitely recursive
     /// types, and `None` will be returned there.
     pub fn interior_mut_ty_chain(&mut self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<&'tcx ty::List<Ty<'tcx>>> {
+        // Check if given type has a `#[clippy::ignore_interior_mutability]` attribute
+        if let Some(did) = ty.ty_adt_def().map(AdtDef::did)
+            && !self.ignored_def_ids.contains(&did)
+            && let attrs = cx.tcx.get_all_attrs(did)
+            && get_unique_builtin_attr(cx.sess(), attrs, sym::ignore_interior_mutability).is_some()
+        {
+            self.ignored_def_ids.insert(did);
+            // Small optimization: since we know that we're going to ignore interior mutability for
+            // this type anyway, running `self.interior_mut_ty_chain_inner` is unnecessary
+            return None;
+        }
         self.interior_mut_ty_chain_inner(cx, ty, 0)
     }
 

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -25,7 +25,7 @@ use rustc_middle::ty::{
     TypeVisitableExt, TypeVisitor, UintTy, Upcast, VariantDef, VariantDiscr,
 };
 use rustc_span::symbol::Ident;
-use rustc_span::{DUMMY_SP, Span, Symbol, sym};
+use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _;
 use rustc_trait_selection::traits::query::normalize::QueryNormalizeExt;
 use rustc_trait_selection::traits::{Obligation, ObligationCause};
@@ -38,6 +38,7 @@ use std::{iter, mem};
 
 use crate::paths::{PathNS, lookup_path_str};
 use crate::res::{MaybeDef, MaybeQPath};
+use crate::sym;
 
 mod type_certainty;
 pub use type_certainty::expr_type_is_certain;
@@ -1095,7 +1096,7 @@ impl<'tcx> InteriorMut<'tcx> {
 
     /// Check if given type has interior mutability such as [`std::cell::Cell`] or
     /// [`std::cell::RefCell`] etc. and if it does, returns a chain of types that causes
-    /// this type to be interior mutable.  False negatives may be expected for infinitely recursive
+    /// this type to be interior mutable. False negatives may be expected for infinitely recursive
     /// types, and `None` will be returned there.
     pub fn interior_mut_ty_chain(&mut self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<&'tcx ty::List<Ty<'tcx>>> {
         self.interior_mut_ty_chain_inner(cx, ty, 0)
@@ -1191,13 +1192,11 @@ pub fn make_normalized_projection_with_regions<'tcx>(
             .enumerate()
             .find(|(_, arg)| arg.has_escaping_bound_vars())
         {
-            debug_assert!(
-                false,
+            panic!(
                 "args contain late-bound region at index `{i}` which can't be normalized.\n\
                     use `TyCtxt::instantiate_bound_regions_with_erased`\n\
                     note: arg is `{arg:#?}`",
             );
-            return None;
         }
         let cause = ObligationCause::dummy();
         let (infcx, param_env) = tcx.infer_ctxt().build_with_typing_env(typing_env);
@@ -1247,17 +1246,14 @@ pub fn deref_chain<'cx, 'tcx>(cx: &'cx LateContext<'tcx>, ty: Ty<'tcx>) -> impl 
 /// This does not look for impls in the type's `Deref::Target` type.
 /// If you need this, you should wrap this call in `clippy_utils::ty::deref_chain().any(...)`.
 pub fn get_adt_inherent_method<'a>(cx: &'a LateContext<'_>, ty: Ty<'_>, method_name: Symbol) -> Option<&'a AssocItem> {
-    if let Some(ty_did) = ty.ty_adt_def().map(AdtDef::did) {
-        cx.tcx.inherent_impls(ty_did).iter().find_map(|&did| {
-            cx.tcx
-                .associated_items(did)
-                .filter_by_name_unhygienic(method_name)
-                .next()
-                .filter(|item| item.tag() == AssocTag::Fn)
-        })
-    } else {
-        None
-    }
+    let ty_did = ty.ty_adt_def().map(AdtDef::did)?;
+    cx.tcx.inherent_impls(ty_did).iter().find_map(|&did| {
+        cx.tcx
+            .associated_items(did)
+            .filter_by_name_unhygienic(method_name)
+            .next()
+            .filter(|item| item.tag() == AssocTag::Fn)
+    })
 }
 
 /// Gets the type of a field by name.

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -1294,7 +1294,7 @@ impl<'tcx> InteriorMut<'tcx> {
 
     /// Check if given type has interior mutability such as [`std::cell::Cell`] or
     /// [`std::cell::RefCell`] etc. and if it does, returns a chain of types that causes
-    /// this type to be interior mutable.  False negatives may be expected for infinitely recursive
+    /// this type to be interior mutable. False negatives may be expected for infinitely recursive
     /// types, and `None` will be returned there.
     pub fn interior_mut_ty_chain(&mut self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<&'tcx ty::List<Ty<'tcx>>> {
         self.interior_mut_ty_chain_inner(cx, ty, 0)
@@ -1399,13 +1399,11 @@ pub fn make_normalized_projection_with_regions<'tcx>(
             .enumerate()
             .find(|(_, arg)| arg.has_escaping_bound_vars())
         {
-            debug_assert!(
-                false,
+            panic!(
                 "args contain late-bound region at index `{i}` which can't be normalized.\n\
                     use `TyCtxt::instantiate_bound_regions_with_erased`\n\
                     note: arg is `{arg:#?}`",
             );
-            return None;
         }
         let cause = ObligationCause::dummy();
         let (infcx, param_env) = tcx.infer_ctxt().build_with_typing_env(typing_env);

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -15,8 +15,8 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, FnDecl};
 use rustc_hir_analysis::lower_ty;
 use rustc_infer::infer::TyCtxtInferExt as _;
-use rustc_lint::LateContext;
 use rustc_lint::unused::must_use::{IsTyMustUse, MustUsePath, is_ty_must_use};
+use rustc_lint::{LateContext, LintContext as _};
 use rustc_middle::mir::ConstValue;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::traits::EvaluationResult;
@@ -38,7 +38,7 @@ use std::{debug_assert_matches, iter, mem};
 
 use crate::paths::{PathNS, lookup_path_str};
 use crate::res::{MaybeDef as _, MaybeQPath as _};
-use crate::{over, sym};
+use crate::{get_unique_builtin_attr, over, sym};
 
 mod type_certainty;
 pub use type_certainty::expr_type_is_certain;
@@ -1297,6 +1297,22 @@ impl<'tcx> InteriorMut<'tcx> {
     /// this type to be interior mutable. False negatives may be expected for infinitely recursive
     /// types, and `None` will be returned there.
     pub fn interior_mut_ty_chain(&mut self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<&'tcx ty::List<Ty<'tcx>>> {
+        // Check if given type has a `#[clippy::private_interior_mutability]` attribute
+        if let Some(did) = ty.ty_adt_def().map(AdtDef::did)
+            && !self.ignored_def_ids.contains(&did)
+            && get_unique_builtin_attr(
+                cx.sess(),
+                #[expect(deprecated, reason = "`private_interior_mutability` is not a parsed attr")]
+                cx.tcx.get_all_attrs(did),
+                sym::private_interior_mutability,
+            )
+            .is_some()
+        {
+            self.ignored_def_ids.insert(did);
+            // Small optimization: since we know that we're going to ignore interior mutability for
+            // this type anyway, running `self.interior_mut_ty_chain_inner` is unnecessary
+            return None;
+        }
         self.interior_mut_ty_chain_inner(cx, ty, 0)
     }
 

--- a/tests/ui/borrow_interior_mutable_const.rs
+++ b/tests/ui/borrow_interior_mutable_const.rs
@@ -235,4 +235,11 @@ fn main() {
             }
         }
     }
+    fn issue13865() {
+        #[clippy::ignore_interior_mutability]
+        struct Foo(Cell<i32>);
+
+        const FOO: Foo = Foo(Cell::new(0));
+        let _ = &FOO;
+    }
 }

--- a/tests/ui/borrow_interior_mutable_const.rs
+++ b/tests/ui/borrow_interior_mutable_const.rs
@@ -234,4 +234,11 @@ fn main() {
             }
         }
     }
+    fn issue13865() {
+        #[clippy::private_interior_mutability]
+        struct Foo(Cell<i32>);
+
+        const FOO: Foo = Foo(Cell::new(0));
+        let _ = &FOO;
+    }
 }

--- a/tests/ui/declare_interior_mutable_const.rs
+++ b/tests/ui/declare_interior_mutable_const.rs
@@ -198,3 +198,9 @@ impl WithGenericAssocCell for i32 {
 
 thread_local!(static THREAD_LOCAL_CELL: Cell<u32> = const { Cell::new(0) });
 thread_local!(static THREAD_LOCAL_CELL2: Cell<u32> = Cell::new(0));
+
+fn issue13865() {
+    #[clippy::ignore_interior_mutability]
+    struct IgnoreInteriorMut(Cell<u32>);
+    const IIM: IgnoreInteriorMut = IgnoreInteriorMut(Cell::new(0));
+}

--- a/tests/ui/declare_interior_mutable_const.rs
+++ b/tests/ui/declare_interior_mutable_const.rs
@@ -198,3 +198,9 @@ impl WithGenericAssocCell for i32 {
 
 thread_local!(static THREAD_LOCAL_CELL: Cell<u32> = const { Cell::new(0) });
 thread_local!(static THREAD_LOCAL_CELL2: Cell<u32> = Cell::new(0));
+
+fn issue13865() {
+    #[clippy::private_interior_mutability]
+    struct IgnoreInteriorMut(Cell<u32>);
+    const IIM: IgnoreInteriorMut = IgnoreInteriorMut(Cell::new(0));
+}

--- a/tests/ui/ifs_same_cond.rs
+++ b/tests/ui/ifs_same_cond.rs
@@ -1,6 +1,8 @@
 #![warn(clippy::ifs_same_cond)]
 #![allow(clippy::if_same_then_else, clippy::needless_ifs, clippy::needless_else)] // all empty blocks
 
+use std::cell::Cell;
+
 fn ifs_same_cond() {
     let a = 0;
     let b = false;
@@ -72,11 +74,41 @@ fn issue10272() {
     } else {
     }
 
-    let x = std::cell::Cell::new(true);
+    let x = Cell::new(true);
     if x.get() {
     } else if !x.take() {
     } else if x.get() {
         // ok, x is interior mutable type
+    } else {
+    }
+}
+
+fn issue13865() {
+    #[clippy::ignore_interior_mutability]
+    struct X<T>(Cell<T>);
+
+    // delegate some methods so that the test case works
+    impl<T> X<T> {
+        fn get(&self) -> T
+        where
+            T: Copy,
+        {
+            self.0.get()
+        }
+        fn take(&self) -> T
+        where
+            T: Default,
+        {
+            self.0.take()
+        }
+    }
+
+    let x = X(Cell::new(true));
+    if x.get() {
+        //~^ ifs_same_cond
+        // x is interior mutable type, but that should be ignored, so we lint
+    } else if !x.take() {
+    } else if x.get() {
     } else {
     }
 }

--- a/tests/ui/ifs_same_cond.rs
+++ b/tests/ui/ifs_same_cond.rs
@@ -5,6 +5,8 @@
     clippy::needless_else
 )]
 
+use std::cell::Cell;
+
 fn ifs_same_cond() {
     let a = 0;
     let b = false;
@@ -76,11 +78,41 @@ fn issue10272() {
     } else {
     }
 
-    let x = std::cell::Cell::new(true);
+    let x = Cell::new(true);
     if x.get() {
     } else if !x.take() {
     } else if x.get() {
         // ok, x is interior mutable type
+    } else {
+    }
+}
+
+fn issue13865() {
+    #[clippy::private_interior_mutability]
+    struct X<T>(Cell<T>);
+
+    // delegate some methods so that the test case works
+    impl<T> X<T> {
+        fn get(&self) -> T
+        where
+            T: Copy,
+        {
+            self.0.get()
+        }
+        fn take(&self) -> T
+        where
+            T: Default,
+        {
+            self.0.take()
+        }
+    }
+
+    let x = X(Cell::new(true));
+    if x.get() {
+        //~^ ifs_same_cond
+        // x is interior mutable type, but that should be ignored, so we lint
+    } else if !x.take() {
+    } else if x.get() {
     } else {
     }
 }

--- a/tests/ui/ifs_same_cond.stderr
+++ b/tests/ui/ifs_same_cond.stderr
@@ -1,5 +1,5 @@
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:8:8
+  --> tests/ui/ifs_same_cond.rs:10:8
    |
 LL |     if b {
    |        ^
@@ -11,7 +11,7 @@ LL |     } else if b {
    = help: to override `-D warnings` add `#[allow(clippy::ifs_same_cond)]`
 
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:13:8
+  --> tests/ui/ifs_same_cond.rs:15:8
    |
 LL |     if b {
    |        ^
@@ -22,7 +22,7 @@ LL |     } else if b {
    |               ^
 
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:19:8
+  --> tests/ui/ifs_same_cond.rs:21:8
    |
 LL |     if a == 1 {
    |        ^^^^^^
@@ -31,7 +31,7 @@ LL |     } else if a == 1 {
    |               ^^^^^^
 
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:24:8
+  --> tests/ui/ifs_same_cond.rs:26:8
    |
 LL |     if 2 * a == 1 {
    |        ^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |     } else if 2 * a == 1 {
    |               ^^^^^^^^^^
 
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:58:8
+  --> tests/ui/ifs_same_cond.rs:60:8
    |
 LL |     if a.contains("ah") {
    |        ^^^^^^^^^^^^^^^^
@@ -48,5 +48,14 @@ LL |
 LL |     } else if a.contains("ah") {
    |               ^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: these `if` branches have the same condition
+  --> tests/ui/ifs_same_cond.rs:107:8
+   |
+LL |     if x.get() {
+   |        ^^^^^^^
+...
+LL |     } else if x.get() {
+   |               ^^^^^^^
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/ifs_same_cond.stderr
+++ b/tests/ui/ifs_same_cond.stderr
@@ -1,5 +1,5 @@
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:12:8
+  --> tests/ui/ifs_same_cond.rs:14:8
    |
 LL |     if b {
    |        ^
@@ -11,7 +11,7 @@ LL |     } else if b {
    = help: to override `-D warnings` add `#[allow(clippy::ifs_same_cond)]`
 
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:17:8
+  --> tests/ui/ifs_same_cond.rs:19:8
    |
 LL |     if b {
    |        ^
@@ -22,7 +22,7 @@ LL |     } else if b {
    |               ^
 
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:23:8
+  --> tests/ui/ifs_same_cond.rs:25:8
    |
 LL |     if a == 1 {
    |        ^^^^^^
@@ -31,7 +31,7 @@ LL |     } else if a == 1 {
    |               ^^^^^^
 
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:28:8
+  --> tests/ui/ifs_same_cond.rs:30:8
    |
 LL |     if 2 * a == 1 {
    |        ^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |     } else if 2 * a == 1 {
    |               ^^^^^^^^^^
 
 error: these `if` branches have the same condition
-  --> tests/ui/ifs_same_cond.rs:62:8
+  --> tests/ui/ifs_same_cond.rs:64:8
    |
 LL |     if a.contains("ah") {
    |        ^^^^^^^^^^^^^^^^
@@ -48,5 +48,14 @@ LL |
 LL |     } else if a.contains("ah") {
    |               ^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: these `if` branches have the same condition
+  --> tests/ui/ifs_same_cond.rs:111:8
+   |
+LL |     if x.get() {
+   |        ^^^^^^^
+...
+LL |     } else if x.get() {
+   |               ^^^^^^^
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/mut_key.rs
+++ b/tests/ui/mut_key.rs
@@ -113,3 +113,14 @@ fn main() {
     let _map = HashMap::<&mut usize, usize>::new();
     let _map = HashMap::<Result<&mut usize, ()>, usize>::new();
 }
+
+fn issue13865() {
+    #[clippy::ignore_interior_mutability]
+    struct IgnoreMut {
+        cell: std::cell::Cell<&'static [u32]>,
+    }
+
+    fn main() {
+        let a: HashSet<IgnoreMut> = HashSet::new();
+    }
+}

--- a/tests/ui/mut_key.rs
+++ b/tests/ui/mut_key.rs
@@ -113,3 +113,14 @@ fn main() {
     let _map = HashMap::<&mut usize, usize>::new();
     let _map = HashMap::<Result<&mut usize, ()>, usize>::new();
 }
+
+fn issue13865() {
+    #[clippy::private_interior_mutability]
+    struct IgnoreMut {
+        cell: std::cell::Cell<&'static [u32]>,
+    }
+
+    fn main() {
+        let a: HashSet<IgnoreMut> = HashSet::new();
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/rust-lang/rust-clippy/issues/13865

Unresolved questions:
- Does this need more documentation?
- It could be nice to be able to specify a [lint reason](https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-reasons)
- It could be nice to have expect-like behavior

changelog: introduce `#[clippy::private_interior_mutability]` attribute, analogous to the `ignore-interior-mutability` config option

r? @llogiq