### PR TITLE
Honor `allow`/`expect` attributes on ADT and `impl Clone` nodes

### DIFF
--- a/clippy_lints/src/derive/expl_impl_clone_on_copy.rs
+++ b/clippy_lints/src/derive/expl_impl_clone_on_copy.rs
@@ -1,4 +1,5 @@
-use clippy_utils::diagnostics::span_lint_hir_and_then;
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::fulfill_or_allowed;
 use clippy_utils::ty::{implements_trait, is_copy};
 use rustc_hir::{self as hir, HirId, Item};
 use rustc_lint::LateContext;
@@ -60,14 +61,16 @@ pub(super) fn check<'tcx>(
         return;
     }
 
-    span_lint_hir_and_then(
+    if fulfill_or_allowed(cx, EXPL_IMPL_CLONE_ON_COPY, [adt_hir_id]) {
+        return;
+    }
+
+    span_lint_and_help(
         cx,
         EXPL_IMPL_CLONE_ON_COPY,
-        adt_hir_id,
         item.span,
         "you are implementing `Clone` explicitly on a `Copy` type",
-        |diag| {
-            diag.span_help(item.span, "consider deriving `Clone` or removing `Copy`");
-        },
+        None,
+        "consider deriving `Clone` or removing `Copy`",
     );
 }

--- a/tests/ui/derive.rs
+++ b/tests/ui/derive.rs
@@ -132,11 +132,24 @@ fn issue14558() {
 fn main() {}
 
 mod issue15708 {
-    // Check that the lint posts on the type definition node
+    // Check that `allow`/`expect` attributes are recognized on the type definition node
     #[expect(clippy::expl_impl_clone_on_copy)]
     #[derive(Copy)]
     struct S;
 
+    impl Clone for S {
+        fn clone(&self) -> Self {
+            S
+        }
+    }
+}
+
+mod issue15842 {
+    #[derive(Copy)]
+    struct S;
+
+    // Check that `allow`/`expect` attributes are recognized on the `impl Clone` node
+    #[expect(clippy::expl_impl_clone_on_copy)]
     impl Clone for S {
         fn clone(&self) -> Self {
             S

--- a/tests/ui/derive.stderr
+++ b/tests/ui/derive.stderr
@@ -9,16 +9,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-help: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:15:1
-   |
-LL | / impl Clone for Qux {
-LL | |
-LL | |
-LL | |     fn clone(&self) -> Self {
-...  |
-LL | | }
-   | |_^
+   = help: consider deriving `Clone` or removing `Copy`
    = note: `-D clippy::expl-impl-clone-on-copy` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::expl_impl_clone_on_copy)]`
 
@@ -33,16 +24,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-help: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:41:1
-   |
-LL | / impl<'a> Clone for Lt<'a> {
-LL | |
-LL | |
-LL | |     fn clone(&self) -> Self {
-...  |
-LL | | }
-   | |_^
+   = help: consider deriving `Clone` or removing `Copy`
 
 error: you are implementing `Clone` explicitly on a `Copy` type
   --> tests/ui/derive.rs:54:1
@@ -55,16 +37,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-help: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:54:1
-   |
-LL | / impl Clone for BigArray {
-LL | |
-LL | |
-LL | |     fn clone(&self) -> Self {
-...  |
-LL | | }
-   | |_^
+   = help: consider deriving `Clone` or removing `Copy`
 
 error: you are implementing `Clone` explicitly on a `Copy` type
   --> tests/ui/derive.rs:67:1
@@ -77,16 +50,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-help: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:67:1
-   |
-LL | / impl Clone for FnPtr {
-LL | |
-LL | |
-LL | |     fn clone(&self) -> Self {
-...  |
-LL | | }
-   | |_^
+   = help: consider deriving `Clone` or removing `Copy`
 
 error: you are implementing `Clone` explicitly on a `Copy` type
   --> tests/ui/derive.rs:89:1
@@ -99,16 +63,7 @@ LL | |     fn clone(&self) -> Self {
 LL | | }
    | |_^
    |
-help: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:89:1
-   |
-LL | / impl<T: Clone> Clone for Generic2<T> {
-LL | |
-LL | |
-LL | |     fn clone(&self) -> Self {
-...  |
-LL | | }
-   | |_^
+   = help: consider deriving `Clone` or removing `Copy`
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
changelog: [`expl_impl_clone_on_copy`]: honor `allow`/`expect` attributes on both the type declaration and the `impl`

Fixes rust-lang/rust-clippy#15842 

r? @blyxyas 