### PR TITLE
Document `pub` items in multiple `clippy_utils` modules

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -286,7 +286,8 @@ impl Constant {
         }
     }
 
-    /// Recursively consume [`Constant::Ref`] and return the innermost value.
+    /// Consume [`Constant::Ref`], removing all references to return the contained expression, e.g.
+    /// `&&T` -> `T`.
     #[must_use]
     pub fn peel_refs(mut self) -> Self {
         while let Constant::Ref(r) = self {
@@ -1082,8 +1083,9 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
 ///
 /// - If `ty` is an [`Adt`](ty::Adt) describing a struct, returns a [`Constant::Adt`] containing
 ///   `val`.
-/// - If `val` is a [`Int`](Scalar::Int), `ty` determines the variant of the returned constant.
-///   Returns `None` if `val` cannot be converted to the type described by `ty`.
+/// - If `val` is a [`Int`](Scalar::Int) (which also includes booleans and raw pointers), `ty`
+///   determines the variant of the returned constant. Returns `None` if `val` cannot be converted
+///   to the type described by `ty`.
 /// - If `ty` is a [`Ref`](ty::Ref) referring to a [`Str`](ty::Str) (i.e. a `&str`), returns a
 ///   [`Constant::Str`].
 /// - If `val` is a [`ConstValue::Indirect`] and `ty` is an [`Array`](ty::Array) of

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -32,6 +32,7 @@ use std::iter;
 /// A `LitKind`-like enum to fold constant `Expr`s into.
 #[derive(Debug, Clone)]
 pub enum Constant {
+    /// A constant representing an algebraic data type
     Adt(ConstValue),
     /// A `String` (e.g., "abc").
     Str(String),
@@ -206,6 +207,15 @@ impl Hash for Constant {
 }
 
 impl Constant {
+    /// Returns an ordering between `left` and `right`, if one exists. `cmp_type` determines
+    /// comparison behavior for constants with ambiguous typing (ex. [`Constant::Int`], which may be
+    /// signed or unsigned).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the compared type is ambiguous and `cmp_type` describes a nonsensical type. For
+    /// example, if `left` and `right` are [`Constant::Int`], `cmp_type.kind()` must be either
+    /// [`Int`](ty::Int) or [`Uint`](ty::Uint).
     pub fn partial_cmp(tcx: TyCtxt<'_>, cmp_type: Ty<'_>, left: &Self, right: &Self) -> Option<Ordering> {
         match (left, right) {
             (Self::Str(ls), Self::Str(rs)) => Some(ls.cmp(rs)),
@@ -276,6 +286,7 @@ impl Constant {
         }
     }
 
+    /// Recursively consume [`Constant::Ref`] and return the innermost value.
     #[must_use]
     pub fn peel_refs(mut self) -> Self {
         while let Constant::Ref(r) = self {
@@ -294,6 +305,8 @@ impl Constant {
         Self::F128(f.to_bits())
     }
 
+    /// Create a constant representing the minimum value of the type described by `ty`, if one
+    /// is defined.
     pub fn new_numeric_min<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Self> {
         match *ty.kind() {
             ty::Uint(_) => Some(Self::Int(0)),
@@ -315,6 +328,8 @@ impl Constant {
         }
     }
 
+    /// Create a constant representing the maximum value of the type described by `ty`, if one
+    /// is defined.
     pub fn new_numeric_max<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Self> {
         match *ty.kind() {
             ty::Uint(ty) => Some(Self::Int(match ty.normalize(tcx.sess.target.pointer_width) {
@@ -343,6 +358,8 @@ impl Constant {
         }
     }
 
+    /// Checks whether `self` is a numeric of the type `ty` and whether `self` is the minimum value
+    /// of that type.
     pub fn is_numeric_min<'tcx>(&self, tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         match (self, ty.kind()) {
             (&Self::Int(x), &ty::Uint(_)) => x == 0,
@@ -364,6 +381,8 @@ impl Constant {
         }
     }
 
+    /// Checks whether `self` is a numeric of the type `ty` and whether `self` is the maximum value
+    /// of that type.
     pub fn is_numeric_max<'tcx>(&self, tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         match (self, ty.kind()) {
             (&Self::Int(x), &ty::Uint(ty)) => {
@@ -395,6 +414,7 @@ impl Constant {
         }
     }
 
+    /// Checks whether `self` is a floating-point value representing positive infinity.
     pub fn is_pos_infinity(&self) -> bool {
         match *self {
             // FIXME(f16_f128): add f16 and f128 when constants are available
@@ -404,6 +424,7 @@ impl Constant {
         }
     }
 
+    /// Checks whether `self` is a floating-point value representing negative infinity.
     pub fn is_neg_infinity(&self) -> bool {
         match *self {
             // FIXME(f16_f128): add f16 and f128 when constants are available
@@ -451,14 +472,20 @@ pub enum ConstantSource {
     NonLocal,
 }
 impl ConstantSource {
+    /// Checks whether this constant value is determined solely from its expression, and is not
+    /// dependent on another definition.
     pub fn is_local(self) -> bool {
         matches!(self, Self::Local)
     }
 }
 
+/// An integer type (signed or unsigned) with enough bits to represent any integer that can be
+/// represented in Rust.
 #[derive(Copy, Clone, Debug, Eq)]
 pub enum FullInt {
+    /// Signed full int
     S(i128),
+    /// Unsigned full int
     U(u128),
 }
 
@@ -567,6 +594,7 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
         }
     }
 
+    /// Attempts to evaluate the given [pattern expression](PatExpr) as a [`Constant`].
     pub fn eval_pat_expr(&self, pat_expr: &PatExpr<'_>) -> Option<Constant> {
         match &pat_expr.kind {
             PatExprKind::Lit { lit, negated } => {
@@ -1050,6 +1078,18 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
     }
 }
 
+/// Converts a [`ConstValue`] to a [`Constant`], if possible.
+///
+/// - If `ty` is an [`Adt`](ty::Adt) describing a struct, returns a [`Constant::Adt`] containing
+///   `val`.
+/// - If `val` is a [`Int`](Scalar::Int), `ty` determines the variant of the returned constant.
+///   Returns `None` if `val` cannot be converted to the type described by `ty`.
+/// - If `ty` is a [`Ref`](ty::Ref) referring to a [`Str`](ty::Str) (i.e. a `&str`), returns a
+///   [`Constant::Str`].
+/// - If `val` is a [`ConstValue::Indirect`] and `ty` is an [`Array`](ty::Array) of
+///   [`Float`](ty::Float), returns a [`Constant::Vec`]
+///
+/// Otherwise, returns `None`.
 pub fn mir_to_const<'tcx>(tcx: TyCtxt<'tcx>, val: ConstValue, ty: Ty<'tcx>) -> Option<Constant> {
     match (val, ty.kind()) {
         (_, &ty::Adt(adt_def, _)) if adt_def.is_struct() => Some(Constant::Adt(val)),

--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -171,6 +171,7 @@ impl<'hir> IfLetOrMatch<'hir> {
         }
     }
 
+    /// Returns the [expression](Expr) scrutinized by this `if let` or `match` expression.
     pub fn scrutinee(&self) -> &'hir Expr<'hir> {
         match self {
             Self::Match(scrutinee, _, _) | Self::IfLet(scrutinee, _, _, _, _) => scrutinee,
@@ -321,6 +322,7 @@ pub struct While<'hir> {
     pub body: &'hir Expr<'hir>,
     /// Span of the loop header
     pub span: Span,
+    /// The loop's label, if present
     pub label: Option<ast::Label>,
 }
 
@@ -362,6 +364,7 @@ pub struct WhileLet<'hir> {
     pub let_expr: &'hir Expr<'hir>,
     /// `while let` loop body
     pub if_then: &'hir Expr<'hir>,
+    /// The loop's label, if present
     pub label: Option<ast::Label>,
     /// `while let PAT = EXPR`
     ///        ^^^^^^^^^^^^^^

--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -1,3 +1,5 @@
+//! Utilities for analyzing macro invocations and expansions.
+
 #![allow(clippy::similar_names)] // `expr` and `expn`
 
 use std::sync::{Arc, OnceLock};
@@ -65,6 +67,7 @@ pub struct MacroCall {
 }
 
 impl MacroCall {
+    /// Returns true if this macro call is from the root expansion or a locally defined macro
     pub fn is_local(&self) -> bool {
         span_is_local(self.span)
     }
@@ -228,6 +231,7 @@ pub fn is_assert_macro(cx: &LateContext<'_>, def_id: DefId) -> bool {
     matches!(name, sym::assert_macro | sym::debug_assert_macro)
 }
 
+/// A `panic!()` expression, which may contain arguments
 #[derive(Debug)]
 pub enum PanicExpn<'a> {
     /// No arguments - `panic!()`
@@ -241,6 +245,7 @@ pub enum PanicExpn<'a> {
 }
 
 impl<'a> PanicExpn<'a> {
+    /// Parses a `panic!()` expression
     pub fn parse(expr: &'a Expr<'a>) -> Option<Self> {
         let ExprKind::Call(callee, args) = &expr.kind else {
             return None;
@@ -516,7 +521,9 @@ pub enum FormatParamUsage {
 
 /// A node with a `HirId` and a `Span`
 pub trait HirNode {
+    /// Returns this node's [`HirId`]
     fn hir_id(&self) -> HirId;
+    /// Returns this node's [`Span`]
     fn span(&self) -> Span;
 }
 

--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -231,7 +231,7 @@ pub fn is_assert_macro(cx: &LateContext<'_>, def_id: DefId) -> bool {
     matches!(name, sym::assert_macro | sym::debug_assert_macro)
 }
 
-/// A `panic!()` expression, which may contain arguments
+/// An expansion of a `panic!()` expression into its arguments
 #[derive(Debug)]
 pub enum PanicExpn<'a> {
     /// No arguments - `panic!()`

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -23,8 +23,11 @@ use std::sync::OnceLock;
 /// arbitrary namespace
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum PathNS {
+    /// The [type namespace](TypeNS)
     Type,
+    /// The [value namespace](ValueNS)
     Value,
+    /// The [macro namespace](MacroNS)
     Macro,
 
     /// Resolves to the name in the first available namespace, e.g. for `std::vec` this would return

--- a/clippy_utils/src/res.rs
+++ b/clippy_utils/src/res.rs
@@ -1,3 +1,5 @@
+//! Utilities for node resolution.
+
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{
@@ -10,6 +12,7 @@ use rustc_span::{Ident, Symbol};
 
 /// Either a `HirId` or a type which can be identified by one.
 pub trait HasHirId: Copy {
+    /// Returns the [`HirId`] identifying `self`.
     fn hir_id(self) -> HirId;
 }
 impl HasHirId for HirId {
@@ -27,6 +30,7 @@ impl HasHirId for &Expr<'_> {
 
 type DefRes = (DefKind, DefId);
 
+/// Either a [`TypeckResults`] or a type that may contain one.
 pub trait MaybeTypeckRes<'tcx> {
     /// Gets the contained `TypeckResults`.
     ///
@@ -458,6 +462,7 @@ impl<'a, T: MaybeResPath<'a>> MaybeResPath<'a> for Option<T> {
 
 /// A type which may either contain a `DefId` or be referred to by a `DefId`.
 pub trait MaybeDef: Copy {
+    /// Gets the [`DefId`] contained by or referring to `self`
     fn opt_def_id(self) -> Option<DefId>;
 
     /// Gets this definition's id and kind. This will lookup the kind in the def

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -644,8 +644,9 @@ pub fn snippet_block_with_applicability(
     reindent_multiline(&snip, true, indent)
 }
 
-/// Same as [`snippet_block_with_applicability()`], but first walks the span up to the given context
-/// using [`snippet_with_context()`].
+/// Walks a span (from a block) up to the given context (using [`snippet_with_context()`]) and
+/// converts it to a code snippet if available, otherwise use default. Adapts the applicability
+/// level `app` by the rules of [`snippet_with_applicability()`].
 pub fn snippet_block_with_context(
     sess: &impl HasSession,
     span: Span,

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -20,7 +20,9 @@ use std::borrow::Cow;
 use std::fmt;
 use std::ops::{Deref, Index, Range};
 
+/// Either a [`Session`] or a type which can be associated with one.
 pub trait HasSession {
+    /// Gets the [`Session`] associated with `self`.
     fn sess(&self) -> &Session;
 }
 impl HasSession for Session {
@@ -46,6 +48,7 @@ impl HasSession for LateContext<'_> {
 
 /// Conversion of a value into the range portion of a `Span`.
 pub trait SpanRange: Sized {
+    /// Converts `self` into the range portion of a [`Span`].
     fn into_range(self) -> Range<BytePos>;
 }
 impl SpanRange for Span {
@@ -67,7 +70,9 @@ impl SpanRange for Range<BytePos> {
 
 /// Conversion of a value into a `Span`
 pub trait IntoSpan: Sized {
+    /// Converts `self` into a [`Span`].
     fn into_span(self) -> Span;
+    /// Converts `self` into a [`Span`], with [context](SyntaxContext).
     fn with_ctxt(self, ctxt: SyntaxContext) -> Span;
 }
 impl IntoSpan for Span {
@@ -95,6 +100,7 @@ impl IntoSpan for Range<BytePos> {
     }
 }
 
+/// Extensions to [`SpanRange`].
 pub trait SpanRangeExt: SpanRange {
     /// Attempts to get a handle to the source text. Returns `None` if either the span is malformed,
     /// or the source text is not accessible.
@@ -338,8 +344,11 @@ fn trim_start(sm: &SourceMap, sp: Range<BytePos>) -> Range<BytePos> {
     .unwrap_or(sp)
 }
 
+/// A range within a specific [source file](SourceFile).
 pub struct SourceFileRange {
+    /// The [source file](SourceFile) referred to by this range
     pub sf: Arc<SourceFile>,
+    /// The range within the associated [source file](SourceFile)
     pub range: Range<usize>,
 }
 impl SourceFileRange {
@@ -441,6 +450,11 @@ pub fn snippet_indent(sess: &impl HasSession, span: Span) -> Option<String> {
 // sources that the user has no control over.
 // For some reason these attributes don't have any expansion info on them, so
 // we have to check it this way until there is a better way.
+//
+/// Checks whether the code snippet referred to by the given [`Span`] is present in the source code.
+///
+/// For example, if the span refers to an attribute inserted during macro expansion, this will
+/// return false.
 pub fn is_present_in_source(sess: &impl HasSession, span: Span) -> bool {
     if let Some(snippet) = snippet_opt(sess, span)
         && snippet.is_empty()
@@ -630,6 +644,8 @@ pub fn snippet_block_with_applicability(
     reindent_multiline(&snip, true, indent)
 }
 
+/// Same as [`snippet_block_with_applicability()`], but first walks the span up to the given context
+/// using [`snippet_with_context()`].
 pub fn snippet_block_with_context(
     sess: &impl HasSession,
     span: Span,

--- a/clippy_utils/src/str_utils.rs
+++ b/clippy_utils/src/str_utils.rs
@@ -2,11 +2,13 @@
 
 /// Dealing with string indices can be hard, this struct ensures that both the
 /// character and byte index are provided for correct indexing.
+///
+/// `char_index` and `byte_index` *are not guaranteed* to agree with eachother.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct StrIndex {
-    /// The character-relative index within a string
+    /// The number of characters between the start of the `str` and this position
     pub char_index: usize,
-    /// The byte-relative index within a string
+    /// The number of bytes between the start of the `str` and this position
     pub byte_index: usize,
 }
 
@@ -172,6 +174,8 @@ pub fn camel_case_split(s: &str) -> Vec<&str> {
 
 /// Dealing with string comparison can be complicated, this struct ensures that both the
 /// character and byte count are provided for correct indexing.
+///
+/// `char_count` and `byte_count` *are not guaranteed* to agree with eachother.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct StrCount {
     /// The number of characters in a string.

--- a/clippy_utils/src/str_utils.rs
+++ b/clippy_utils/src/str_utils.rs
@@ -1,12 +1,17 @@
+//! Utilities for analyzing and transforming strings.
+
 /// Dealing with string indices can be hard, this struct ensures that both the
 /// character and byte index are provided for correct indexing.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct StrIndex {
+    /// The character-relative index within a string
     pub char_index: usize,
+    /// The byte-relative index within a string
     pub byte_index: usize,
 }
 
 impl StrIndex {
+    /// Creates a `StrIndex` from character and byte indices.
     pub fn new(char_index: usize, byte_index: usize) -> Self {
         Self { char_index, byte_index }
     }
@@ -169,11 +174,14 @@ pub fn camel_case_split(s: &str) -> Vec<&str> {
 /// character and byte count are provided for correct indexing.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct StrCount {
+    /// The number of characters in a string.
     pub char_count: usize,
+    /// The number of bytes in a string.
     pub byte_count: usize,
 }
 
 impl StrCount {
+    /// Creates a `StrCount` from character and byte counts.
     pub fn new(char_count: usize, byte_count: usize) -> Self {
         Self { char_count, byte_count }
     }

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -365,6 +365,7 @@ impl<'a> Sugg<'a> {
         }
     }
 
+    /// Convert this suggestion into a [`String`] to be displayed to the user.
     pub fn into_string(self) -> String {
         match self {
             Sugg::NonParen(p) | Sugg::MaybeParen(p) => p.into_owned(),

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -365,7 +365,7 @@ impl<'a> Sugg<'a> {
         }
     }
 
-    /// Convert this suggestion into a [`String`] to be displayed to the user.
+    /// Format this suggestion into a [`String`] to be displayed to the user.
     pub fn into_string(self) -> String {
         match self {
             Sugg::NonParen(p) | Sugg::MaybeParen(p) => p.into_owned(),

--- a/clippy_utils/src/usage.rs
+++ b/clippy_utils/src/usage.rs
@@ -1,3 +1,5 @@
+//! Contains utility functions for checking expression usage.
+
 use crate::macros::root_macro_call_first_node;
 use crate::res::MaybeResPath;
 use crate::visitors::{Descend, Visitable, for_each_expr, for_each_expr_without_closures};
@@ -29,10 +31,13 @@ pub fn mutated_variables<'tcx>(expr: &'tcx Expr<'_>, cx: &LateContext<'tcx>) -> 
     Some(delegate.used_mutably)
 }
 
+/// Checks whether it is possible that the given variable is mutated within the given
+/// [`Expr`].
 pub fn is_potentially_mutated<'tcx>(variable: HirId, expr: &'tcx Expr<'_>, cx: &LateContext<'tcx>) -> bool {
     mutated_variables(expr, cx).is_none_or(|mutated| mutated.contains(&variable))
 }
 
+/// Checks whether it is possible that the given [Place] refers to the given local.
 pub fn is_potentially_local_place(local_id: HirId, place: &Place<'_>) -> bool {
     match place.base {
         PlaceBase::Local(id) => id == local_id,
@@ -84,7 +89,9 @@ impl<'tcx> Delegate<'tcx> for MutVarsDelegate {
     fn fake_read(&mut self, _: &PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {}
 }
 
+/// A [`Visitor`] that collects all [`HirId`s](HirId) bound by visited [patterns](hir::Pat).
 pub struct ParamBindingIdCollector {
+    /// [`HirId`s](HirId) collected during calls to [`visit_pat`](Self::visit_pat).
     pub binding_hir_ids: Vec<HirId>,
 }
 impl<'tcx> ParamBindingIdCollector {
@@ -111,11 +118,14 @@ impl<'tcx> Visitor<'tcx> for ParamBindingIdCollector {
     }
 }
 
+/// A [`Visitor`] providing [`are_params_used()`](Self::are_params_used), which can be used to check
+/// parameter binding usage within a [`Body`](hir::Body).
 pub struct BindingUsageFinder<'a, 'tcx> {
     cx: &'a LateContext<'tcx>,
     binding_ids: Vec<HirId>,
 }
 impl<'a, 'tcx> BindingUsageFinder<'a, 'tcx> {
+    /// Checks whether the parameter bindings of the given [`Body`](hir::Body) are used within it.
     pub fn are_params_used(cx: &'a LateContext<'tcx>, body: &'tcx hir::Body<'tcx>) -> bool {
         let mut finder = BindingUsageFinder {
             cx,
@@ -181,6 +191,7 @@ pub fn contains_todo_unimplement_macro(cx: &LateContext<'_>, expr: &'_ Expr<'_>)
     .is_some()
 }
 
+/// Checks whether the given expression contains `return`, `break`, `continue`, or a macro call.
 pub fn contains_return_break_continue_macro(expression: &Expr<'_>) -> bool {
     for_each_expr_without_closures(expression, |e| {
         match e.kind {
@@ -195,6 +206,7 @@ pub fn contains_return_break_continue_macro(expression: &Expr<'_>) -> bool {
     .is_some()
 }
 
+/// Checks whether the given [`Visitable`] (ex. an [`Expr`]) contains the given local.
 pub fn local_used_in<'tcx>(cx: &LateContext<'tcx>, local_id: HirId, v: impl Visitable<'tcx>) -> bool {
     for_each_expr(cx, v, |e| {
         if e.res_local_id() == Some(local_id) {
@@ -206,6 +218,7 @@ pub fn local_used_in<'tcx>(cx: &LateContext<'tcx>, local_id: HirId, v: impl Visi
     .is_some()
 }
 
+/// Checks whether the given local is used after the given [`Expr`].
 pub fn local_used_after_expr(cx: &LateContext<'_>, local_id: HirId, after: &Expr<'_>) -> bool {
     let Some(block) = utils::get_enclosing_block(cx, local_id) else {
         return false;

--- a/clippy_utils/src/usage.rs
+++ b/clippy_utils/src/usage.rs
@@ -1,4 +1,4 @@
-//! Contains utility functions for checking expression usage.
+//! Contains utility functions for checking variable usage.
 
 use crate::macros::root_macro_call_first_node;
 use crate::res::MaybeResPath;
@@ -191,7 +191,8 @@ pub fn contains_todo_unimplement_macro(cx: &LateContext<'_>, expr: &'_ Expr<'_>)
     .is_some()
 }
 
-/// Checks whether the given expression contains `return`, `break`, `continue`, or a macro call.
+/// Checks whether the given expression contains `return`, `break`, `continue`, or a macro call
+/// (which may itself contain any of those expressions).
 pub fn contains_return_break_continue_macro(expression: &Expr<'_>) -> bool {
     for_each_expr_without_closures(expression, |e| {
         match e.kind {

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -777,7 +777,7 @@ pub fn for_each_local_assignment<'tcx, B>(
 }
 
 /// Checks whether the given [expression](Expr) contains any `break` or `continue` expressions. This
-/// does not enter any bodies or nested items.
+/// does not enter any bodies or nested items, because a `break` or `continue` would not apply to the expression's scope.
 pub fn contains_break_or_continue(expr: &Expr<'_>) -> bool {
     for_each_expr_without_closures(expr, |e| {
         if matches!(e.kind, ExprKind::Break(..) | ExprKind::Continue(..)) {

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -1,3 +1,5 @@
+//! Utilities for analyzing the contents of expressions and other [visitable](Visitable) items.
+
 use crate::get_enclosing_block;
 use crate::msrvs::Msrv;
 use crate::qualify_min_const_fn::is_stable_const_fn;
@@ -36,7 +38,9 @@ impl Continue for () {
 /// descending into child nodes.
 #[derive(Clone, Copy)]
 pub enum Descend {
+    /// Controlled [`Visitor`] should descend into child nodes.
     Yes,
+    /// Controlled [`Visitor`] should not descend into child nodes.
     No,
 }
 impl From<bool> for Descend {
@@ -204,6 +208,9 @@ fn contains_try(expr: &Expr<'_>) -> bool {
     .is_some()
 }
 
+/// Calls a given function of the form `|return_expr: &Expr| -> bool` for all `return` expressions
+/// in the given [expression](Expr), and returns whether that callback returned true for all found
+/// `return`s.
 pub fn find_all_ret_expressions<'hir, F>(_cx: &LateContext<'_>, expr: &'hir Expr<'hir>, callback: F) -> bool
 where
     F: FnMut(&'hir Expr<'hir>) -> bool,
@@ -589,9 +596,11 @@ pub fn for_each_local_use_after_expr<'tcx, B>(
     }
 }
 
-// Calls the given function for every unconsumed temporary created by the expression. Note the
-// function is only guaranteed to be called for types which need to be dropped, but it may be called
-// for other types.
+/// Calls a given function of the form `|temporary_type: Ty| -> ControlFlow<B>` for every unconsumed
+/// temporary created by the given [expression](Expr), and returns the result of that function.
+///
+/// Note the function is only guaranteed to be called for types which need to be dropped, but it may
+/// be called for other types.
 #[expect(clippy::too_many_lines)]
 pub fn for_each_unconsumed_temporary<'tcx, B>(
     cx: &LateContext<'tcx>,
@@ -708,6 +717,8 @@ pub fn for_each_unconsumed_temporary<'tcx, B>(
     helper(cx.typeck_results(), true, e, &mut f)
 }
 
+/// Checks whether the drop order matters for any unconsumed temporary created by the given
+/// [expression](Expr).
 pub fn any_temporaries_need_ordered_drop<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>) -> bool {
     for_each_unconsumed_temporary(cx, e, |ty| {
         if needs_ordered_drop(cx, ty) {
@@ -765,6 +776,8 @@ pub fn for_each_local_assignment<'tcx, B>(
     }
 }
 
+/// Checks whether the given [expression](Expr) contains any `break` or `continue` expressions. This
+/// does not enter any bodies or nested items.
 pub fn contains_break_or_continue(expr: &Expr<'_>) -> bool {
     for_each_expr_without_closures(expr, |e| {
         if matches!(e.kind, ExprKind::Break(..) | ExprKind::Continue(..)) {


### PR DESCRIPTION
Partially addressing rust-lang/rust-clippy#15569, document items in `clippy_utils::{consts, higher, macros, paths, res, source, str_utils, sugg, usage, visitors}`. The specific items documented are listed in each commit description, along with notes.

This is my first time contributing to any official Rust internals/tools, so please let me know if I misunderstood anything. (I'm not really sure that "refers" is the right verb for the relationship between a `Place` and a HIR node, for example.)

As I understand it, this is considered purely an internal change, so:
changelog: none
