### PR TITLE
add `manual_sign_check` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6482,6 +6482,7 @@ Released 2018-09-13
 [`manual_retain`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_retain
 [`manual_rotate`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_rotate
 [`manual_saturating_arithmetic`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_saturating_arithmetic
+[`manual_sign_check`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_sign_check
 [`manual_slice_fill`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_slice_fill
 [`manual_slice_size_calculation`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_slice_size_calculation
 [`manual_split_once`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_split_once

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -594,6 +594,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::operators::INTEGER_DIVISION_INFO,
     crate::operators::MANUAL_IS_MULTIPLE_OF_INFO,
     crate::operators::MANUAL_MIDPOINT_INFO,
+    crate::operators::MANUAL_SIGN_CHECK_INFO,
     crate::operators::MISREFACTORED_ASSIGN_OP_INFO,
     crate::operators::MODULO_ARITHMETIC_INFO,
     crate::operators::MODULO_ONE_INFO,

--- a/clippy_lints/src/operators/manual_sign_check.rs
+++ b/clippy_lints/src/operators/manual_sign_check.rs
@@ -1,0 +1,67 @@
+use clippy_utils::consts::{ConstEvalCtxt, Constant};
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet_with_applicability;
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Expr};
+use rustc_lint::LateContext;
+
+use super::MANUAL_SIGN_CHECK;
+
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, op: BinOpKind, left: &'tcx Expr<'_>, right: &'tcx Expr<'_>) {
+    let (float_expr, direction) = if is_zero(cx, left) && is_float(cx, right) {
+        (right, Side::Right)
+    } else if is_zero(cx, right) && is_float(cx, left) {
+        (left, Side::Left)
+    } else {
+        return;
+    };
+
+    let mut applicability = Applicability::MachineApplicable;
+    let float_snippet = snippet_with_applicability(cx, float_expr.span, "..", &mut applicability);
+    let (method, negate) = match (direction, op) {
+        (Side::Left, BinOpKind::Lt) | (Side::Right, BinOpKind::Gt) => ("is_sign_negative", false),
+        (Side::Left, BinOpKind::Le) | (Side::Right, BinOpKind::Ge) => ("is_sign_positive", true),
+        (Side::Left, BinOpKind::Gt) | (Side::Right, BinOpKind::Lt) => ("is_sign_positive", false),
+        (Side::Left, BinOpKind::Ge) | (Side::Right, BinOpKind::Le) => ("is_sign_negative", true),
+        _ => return,
+    };
+
+    let suggestion = if negate {
+        format!("!{float_snippet}.{method}()")
+    } else {
+        format!("{float_snippet}.{method}()")
+    };
+
+    span_lint_and_sugg(
+        cx,
+        MANUAL_SIGN_CHECK,
+        float_expr.span.to(right.span),
+        "checking the sign of a floating point number by comparing it to zero",
+        format!("consider using `{method}` for clarity and performance"),
+        suggestion,
+        applicability,
+    );
+}
+
+enum Side {
+    Left,
+    Right,
+}
+
+fn is_zero(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    let ecx = ConstEvalCtxt::new(cx);
+    let Some(constant) = ecx.eval(expr) else {
+        return false;
+    };
+
+    match constant {
+        // FIXME(f16_f128): add when equality check is available on all platforms
+        Constant::F32(f) => f == 0.0,
+        Constant::F64(f) => f == 0.0,
+        _ => false,
+    }
+}
+
+fn is_float(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    cx.typeck_results().expr_ty(expr).is_floating_point()
+}

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -876,7 +876,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
-    /// let foo = 1.0;
+    /// let foo: f32 = 1.0;
     /// if foo < 0.0 {
     ///     println!("negative");
     /// }
@@ -884,7 +884,7 @@ declare_clippy_lint! {
     ///
     /// Use instead:
     /// ```rust
-    /// let foo = 1.0;
+    /// let foo: f32 = 1.0;
     /// if foo.is_sign_negative() {
     ///     println!("negative");
     /// }

--- a/tests/ui/manual_sign_check.fixed
+++ b/tests/ui/manual_sign_check.fixed
@@ -1,0 +1,17 @@
+#![allow(clippy::needless_if)]
+#![warn(clippy::manual_sign_check)]
+
+fn main() {
+    let x: f32 = 1.0;
+
+    if x.is_sign_negative() {}
+    //~^ manual_sign_check
+    if !x.is_sign_positive() {}
+    //~^ manual_sign_check
+    if x.is_sign_positive() {}
+    //~^ manual_sign_check
+    if !x.is_sign_negative() {}
+    //~^ manual_sign_check
+    if x == 0.0 {}
+    if x < 1.0 {}
+}

--- a/tests/ui/manual_sign_check.rs
+++ b/tests/ui/manual_sign_check.rs
@@ -1,0 +1,17 @@
+#![allow(clippy::needless_if)]
+#![warn(clippy::manual_sign_check)]
+
+fn main() {
+    let x: f32 = 1.0;
+
+    if x < 0.0 {}
+    //~^ manual_sign_check
+    if x <= 0.0 {}
+    //~^ manual_sign_check
+    if x > 0.0 {}
+    //~^ manual_sign_check
+    if x >= 0.0 {}
+    //~^ manual_sign_check
+    if x == 0.0 {}
+    if x < 1.0 {}
+}

--- a/tests/ui/manual_sign_check.stderr
+++ b/tests/ui/manual_sign_check.stderr
@@ -1,0 +1,29 @@
+error: checking the sign of a floating point number by comparing it to zero
+  --> tests/ui/manual_sign_check.rs:7:8
+   |
+LL |     if x < 0.0 {}
+   |        ^^^^^^^ help: consider using `is_sign_negative` for clarity and performance: `x.is_sign_negative()`
+   |
+   = note: `-D clippy::manual-sign-check` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_sign_check)]`
+
+error: checking the sign of a floating point number by comparing it to zero
+  --> tests/ui/manual_sign_check.rs:9:8
+   |
+LL |     if x <= 0.0 {}
+   |        ^^^^^^^^ help: consider using `is_sign_positive` for clarity and performance: `!x.is_sign_positive()`
+
+error: checking the sign of a floating point number by comparing it to zero
+  --> tests/ui/manual_sign_check.rs:11:8
+   |
+LL |     if x > 0.0 {}
+   |        ^^^^^^^ help: consider using `is_sign_positive` for clarity and performance: `x.is_sign_positive()`
+
+error: checking the sign of a floating point number by comparing it to zero
+  --> tests/ui/manual_sign_check.rs:13:8
+   |
+LL |     if x >= 0.0 {}
+   |        ^^^^^^^^ help: consider using `is_sign_negative` for clarity and performance: `!x.is_sign_negative()`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
changelog: [`manual_sign_check`]: add lint

Lints on things like `f < 0` and `0 <= f`for floats, recommending the use of `f*::is_positive`/`f*::is_negative` instead. Added to pedantic group.