### PR TITLE
fix(match_like_matches_macro): FP with guards containing `if let`

### DIFF
--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -2,6 +2,7 @@
 
 use super::REDUNDANT_PATTERN_MATCHING;
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::higher::has_let_expr;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::{is_lint_allowed, is_wild, span_contains_comment};
 use rustc_ast::LitKind;
@@ -92,7 +93,10 @@ pub(super) fn check_match<'tcx>(
             // ```rs
             // matches!(e, Either::Left $(if $guard)|+)
             // ```
-            middle_arms.is_empty()
+            //
+            // But if the guard _is_ present, it may not be an `if-let` guard, as `matches!` doesn't
+            // support these (currently?)
+            (middle_arms.is_empty() && first_arm.guard.is_none_or(|g| !has_let_expr(g)))
 
             // - (added in #6216) There are middle arms
             //

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -223,3 +223,10 @@ fn msrv_1_42() {
     let _y = matches!(Some(5), Some(0));
     //~^^^^ match_like_matches_macro
 }
+
+#[expect(clippy::option_option)]
+fn issue15841(opt: Option<Option<Option<i32>>>, value: i32) {
+    // Lint: no if-let _in the guard_
+    let _ = matches!(opt, Some(first) if (if let Some(second) = first { true } else { todo!() }));
+    //~^^^^ match_like_matches_macro
+}

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -267,3 +267,13 @@ fn msrv_1_42() {
     };
     //~^^^^ match_like_matches_macro
 }
+
+#[expect(clippy::option_option)]
+fn issue15841(opt: Option<Option<Option<i32>>>, value: i32) {
+    // Lint: no if-let _in the guard_
+    let _ = match opt {
+        Some(first) if (if let Some(second) = first { true } else { todo!() }) => true,
+        _ => false,
+    };
+    //~^^^^ match_like_matches_macro
+}

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -253,5 +253,24 @@ LL -     };
 LL +     let _y = matches!(Some(5), Some(0));
    |
 
-error: aborting due to 14 previous errors
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:274:13
+   |
+LL |       let _ = match opt {
+   |  _____________^
+LL | |         Some(first) if (if let Some(second) = first { true } else { todo!() }) => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^
+   |
+help: use `matches!` directly
+   |
+LL -     let _ = match opt {
+LL -         Some(first) if (if let Some(second) = first { true } else { todo!() }) => true,
+LL -         _ => false,
+LL -     };
+LL +     let _ = matches!(opt, Some(first) if (if let Some(second) = first { true } else { todo!() }));
+   |
+
+error: aborting due to 15 previous errors
 

--- a/tests/ui/match_like_matches_macro_if_let_guard.rs
+++ b/tests/ui/match_like_matches_macro_if_let_guard.rs
@@ -1,0 +1,51 @@
+//@check-pass
+#![warn(clippy::match_like_matches_macro)]
+#![feature(if_let_guard)]
+
+#[expect(clippy::option_option)]
+fn issue15841(opt: Option<Option<Option<i32>>>, value: i32) {
+    let _ = match opt {
+        Some(first)
+            if let Some(second) = first
+                && let Some(third) = second
+                && third == value =>
+        {
+            true
+        },
+        _ => false,
+    };
+
+    // if-let is the second if
+    let _ = match opt {
+        Some(first)
+            if first.is_some()
+                && let Some(second) = first =>
+        {
+            true
+        },
+        _ => false,
+    };
+
+    // if-let is the third if
+    let _ = match opt {
+        Some(first)
+            if first.is_some()
+                && first.is_none()
+                && let Some(second) = first =>
+        {
+            true
+        },
+        _ => false,
+    };
+
+    // don't get confused by `or`s
+    let _ = match opt {
+        Some(first)
+            if (first.is_some() || first.is_none())
+                && let Some(second) = first =>
+        {
+            true
+        },
+        _ => false,
+    };
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15841

changelog: [`match_like_matches_macro`]: FP with guards containing `if let`