### PR TITLE
Treat `f16` and `f128` as floats in constant evaluation

### DIFF
--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -62,16 +62,10 @@ impl<'tcx> LateLintPass<'tcx> for NegMultiply {
 }
 
 fn check_mul(cx: &LateContext<'_>, mul_expr: &Expr<'_>, lit: &Expr<'_>, exp: &Expr<'_>) {
-    const F16_ONE: u16 = 1.0_f16.to_bits();
-    const F128_ONE: u128 = 1.0_f128.to_bits();
     if let ExprKind::Lit(l) = lit.kind
         && matches!(
             consts::lit_to_mir_constant(&l.node, cx.typeck_results().expr_ty_opt(lit)),
-            Constant::Int(1)
-                | Constant::F16(F16_ONE)
-                | Constant::F32(1.0)
-                | Constant::F64(1.0)
-                | Constant::F128(F128_ONE)
+            Constant::Int(1) | Constant::F16(1.0) | Constant::F32(1.0) | Constant::F64(1.0) | Constant::F128(1.0)
         )
         && cx.typeck_results().expr_ty(exp).is_numeric()
     {

--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -61,16 +61,10 @@ impl<'tcx> LateLintPass<'tcx> for NegMultiply {
 }
 
 fn check_mul(cx: &LateContext<'_>, mul_expr: &Expr<'_>, lit: &Expr<'_>, exp: &Expr<'_>) {
-    const F16_ONE: u16 = 1.0_f16.to_bits();
-    const F128_ONE: u128 = 1.0_f128.to_bits();
     if let ExprKind::Lit(l) = lit.kind
         && matches!(
             consts::lit_to_mir_constant(&l.node, cx.typeck_results().expr_ty_opt(lit)),
-            Constant::Int(1)
-                | Constant::F16(F16_ONE)
-                | Constant::F32(1.0)
-                | Constant::F64(1.0)
-                | Constant::F128(F128_ONE)
+            Constant::Int(1) | Constant::F16(1.0) | Constant::F32(1.0) | Constant::F64(1.0) | Constant::F128(1.0)
         )
         && cx.typeck_results().expr_ty(exp).is_numeric()
     {

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -10,7 +10,7 @@ use crate::{clip, is_direct_expn_of, sext, sym, unsext};
 
 use rustc_abi::Size;
 use rustc_apfloat::Float as _;
-use rustc_apfloat::ieee::{Half, Quad};
+use rustc_apfloat::ieee::Quad;
 use rustc_ast::ast::{LitFloatType, LitKind};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{
@@ -41,16 +41,14 @@ pub enum Constant {
     Char(char),
     /// An integer's bit representation.
     Int(u128),
-    /// An `f16` bitcast to a `u16`.
-    // FIXME(f16_f128): use `f16` once builtins are available on all host tools platforms.
-    F16(u16),
+    /// An `f16`.
+    F16(f16),
     /// An `f32`.
     F32(f32),
     /// An `f64`.
     F64(f64),
     /// An `f128` bitcast to a `u128`.
-    // FIXME(f16_f128): use `f128` once builtins are available on all host tools platforms.
-    F128(u128),
+    F128(f128),
     /// `true` or `false`.
     Bool(bool),
     /// An array of constants.
@@ -172,8 +170,7 @@ impl Hash for Constant {
                 i.hash(state);
             },
             Self::F16(f) => {
-                // FIXME(f16_f128): once conversions to/from `f128` are available on all platforms,
-                f.hash(state);
+                f64::from(f).to_bits().hash(state);
             },
             Self::F32(f) => {
                 f64::from(f).to_bits().hash(state);
@@ -182,7 +179,7 @@ impl Hash for Constant {
                 f.to_bits().hash(state);
             },
             Self::F128(f) => {
-                f.hash(state);
+                f.to_bits().hash(state);
             },
             Self::Bool(b) => {
                 b.hash(state);
@@ -284,14 +281,9 @@ impl Constant {
         self
     }
 
-    fn parse_f16(s: &str) -> Self {
-        let f: Half = s.parse().unwrap();
-        Self::F16(f.to_bits().try_into().unwrap())
-    }
-
     fn parse_f128(s: &str) -> Self {
         let f: Quad = s.parse().unwrap();
-        Self::F128(f.to_bits())
+        Self::F128(f128::from_bits(f.to_bits()))
     }
 
     pub fn new_numeric_min<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Self> {
@@ -397,18 +389,20 @@ impl Constant {
 
     pub fn is_pos_infinity(&self) -> bool {
         match *self {
-            // FIXME(f16_f128): add f16 and f128 when constants are available
+            Constant::F16(x) => x == f16::INFINITY,
             Constant::F32(x) => x == f32::INFINITY,
             Constant::F64(x) => x == f64::INFINITY,
+            Constant::F128(x) => x == f128::INFINITY,
             _ => false,
         }
     }
 
     pub fn is_neg_infinity(&self) -> bool {
         match *self {
-            // FIXME(f16_f128): add f16 and f128 when constants are available
+            Constant::F16(x) => x == f16::NEG_INFINITY,
             Constant::F32(x) => x == f32::NEG_INFINITY,
             Constant::F64(x) => x == f64::NEG_INFINITY,
+            Constant::F128(x) => x == f128::NEG_INFINITY,
             _ => false,
         }
     }
@@ -423,14 +417,14 @@ pub fn lit_to_mir_constant(lit: &LitKind, ty: Option<Ty<'_>>) -> Constant {
         LitKind::Char(c) => Constant::Char(c),
         LitKind::Int(n, _) => Constant::Int(n.get()),
         LitKind::Float(ref is, LitFloatType::Suffixed(fty)) => match fty {
-            // FIXME(f16_f128): just use `parse()` directly when available for `f16`/`f128`
-            FloatTy::F16 => Constant::parse_f16(is.as_str()),
+            FloatTy::F16 => Constant::F16(is.as_str().parse().unwrap()),
             FloatTy::F32 => Constant::F32(is.as_str().parse().unwrap()),
             FloatTy::F64 => Constant::F64(is.as_str().parse().unwrap()),
+            // FIXME(f16_f128): just use `parse()` directly when available for `f128`
             FloatTy::F128 => Constant::parse_f128(is.as_str()),
         },
         LitKind::Float(ref is, LitFloatType::Unsuffixed) => match ty.expect("type of float is known").kind() {
-            ty::Float(FloatTy::F16) => Constant::parse_f16(is.as_str()),
+            ty::Float(FloatTy::F16) => Constant::F16(is.as_str().parse().unwrap()),
             ty::Float(FloatTy::F32) => Constant::F32(is.as_str().parse().unwrap()),
             ty::Float(FloatTy::F64) => Constant::F64(is.as_str().parse().unwrap()),
             ty::Float(FloatTy::F128) => Constant::parse_f128(is.as_str()),
@@ -1056,7 +1050,20 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
                 },
                 _ => None,
             },
-            // FIXME(f16_f128): add these types when binary operations are available on all platforms
+            (Constant::F16(l), Some(Constant::F16(r))) => match op {
+                BinOpKind::Add => Some(Constant::F16(l + r)),
+                BinOpKind::Sub => Some(Constant::F16(l - r)),
+                BinOpKind::Mul => Some(Constant::F16(l * r)),
+                BinOpKind::Div => Some(Constant::F16(l / r)),
+                BinOpKind::Rem => Some(Constant::F16(l % r)),
+                BinOpKind::Eq => Some(Constant::Bool(l == r)),
+                BinOpKind::Ne => Some(Constant::Bool(l != r)),
+                BinOpKind::Lt => Some(Constant::Bool(l < r)),
+                BinOpKind::Le => Some(Constant::Bool(l <= r)),
+                BinOpKind::Ge => Some(Constant::Bool(l >= r)),
+                BinOpKind::Gt => Some(Constant::Bool(l > r)),
+                _ => None,
+            },
             (Constant::F32(l), Some(Constant::F32(r))) => match op {
                 BinOpKind::Add => Some(Constant::F32(l + r)),
                 BinOpKind::Sub => Some(Constant::F32(l - r)),
@@ -1077,6 +1084,20 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
                 BinOpKind::Mul => Some(Constant::F64(l * r)),
                 BinOpKind::Div => Some(Constant::F64(l / r)),
                 BinOpKind::Rem => Some(Constant::F64(l % r)),
+                BinOpKind::Eq => Some(Constant::Bool(l == r)),
+                BinOpKind::Ne => Some(Constant::Bool(l != r)),
+                BinOpKind::Lt => Some(Constant::Bool(l < r)),
+                BinOpKind::Le => Some(Constant::Bool(l <= r)),
+                BinOpKind::Ge => Some(Constant::Bool(l >= r)),
+                BinOpKind::Gt => Some(Constant::Bool(l > r)),
+                _ => None,
+            },
+            (Constant::F128(l), Some(Constant::F128(r))) => match op {
+                BinOpKind::Add => Some(Constant::F128(l + r)),
+                BinOpKind::Sub => Some(Constant::F128(l - r)),
+                BinOpKind::Mul => Some(Constant::F128(l * r)),
+                BinOpKind::Div => Some(Constant::F128(l / r)),
+                BinOpKind::Rem => Some(Constant::F128(l % r)),
                 BinOpKind::Eq => Some(Constant::Bool(l == r)),
                 BinOpKind::Ne => Some(Constant::Bool(l != r)),
                 BinOpKind::Lt => Some(Constant::Bool(l < r)),
@@ -1106,10 +1127,10 @@ pub fn mir_to_const<'tcx>(tcx: TyCtxt<'tcx>, val: ConstValue, ty: Ty<'tcx>) -> O
         (ConstValue::Scalar(Scalar::Int(int)), _) => match ty.kind() {
             ty::Bool => Some(Constant::Bool(int == ScalarInt::TRUE)),
             ty::Uint(_) | ty::Int(_) => Some(Constant::Int(int.to_bits(int.size()))),
-            ty::Float(FloatTy::F16) => Some(Constant::F16(int.into())),
+            ty::Float(FloatTy::F16) => Some(Constant::F16(f16::from_bits(int.into()))),
             ty::Float(FloatTy::F32) => Some(Constant::F32(f32::from_bits(int.into()))),
             ty::Float(FloatTy::F64) => Some(Constant::F64(f64::from_bits(int.into()))),
-            ty::Float(FloatTy::F128) => Some(Constant::F128(int.into())),
+            ty::Float(FloatTy::F128) => Some(Constant::F128(f128::from_bits(int.into()))),
             ty::RawPtr(_, _) => Some(Constant::RawPtr(int.to_bits(int.size()))),
             _ => None,
         },
@@ -1129,10 +1150,10 @@ pub fn mir_to_const<'tcx>(tcx: TyCtxt<'tcx>, val: ConstValue, ty: Ty<'tcx>) -> O
                 let range = alloc_range(offset + size * idx, size);
                 let val = alloc.read_scalar(&tcx, range, /* read_provenance */ false).ok()?;
                 res.push(match flt {
-                    FloatTy::F16 => Constant::F16(val.to_u16().discard_err()?),
+                    FloatTy::F16 => Constant::F16(f16::from_bits(val.to_u16().discard_err()?)),
                     FloatTy::F32 => Constant::F32(f32::from_bits(val.to_u32().discard_err()?)),
                     FloatTy::F64 => Constant::F64(f64::from_bits(val.to_u64().discard_err()?)),
-                    FloatTy::F128 => Constant::F128(val.to_u128().discard_err()?),
+                    FloatTy::F128 => Constant::F128(f128::from_bits(val.to_u128().discard_err()?)),
                 });
             }
             Some(Constant::Vec(res))

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(box_patterns)]
+#![feature(f128)]
+#![feature(f16)]
 #![feature(macro_metavar_expr)]
 #![feature(rustc_private)]
 #![feature(unwrap_infallible)]

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(deref_patterns)]
+#![feature(f128)]
+#![feature(f16)]
 #![feature(macro_metavar_expr)]
 #![feature(rustc_private)]
 #![feature(unwrap_infallible)]

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -163,11 +163,9 @@ pub fn association_with_structures_should_not_trigger_the_lint() {
 
 pub fn hard_coded_allowed() {
     let _ = 1f16 + 1f16;
-    //~^ arithmetic_side_effects
     let _ = 1f32 + 1f32;
     let _ = 1f64 + 1f64;
     let _ = 1f128 + 1f128;
-    //~^ arithmetic_side_effects
 
     let _ = Saturating(0u32) + Saturating(0u32);
     let _ = String::new() + "";

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -1,791 +1,779 @@
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:165:13
+  --> tests/ui/arithmetic_side_effects.rs:307:5
    |
-LL |     let _ = 1f16 + 1f16;
-   |             ^^^^^^^^^^^
+LL |     _n += 1;
+   |     ^^^^^^^
    |
    = note: `-D clippy::arithmetic-side-effects` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::arithmetic_side_effects)]`
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:169:13
-   |
-LL |     let _ = 1f128 + 1f128;
-   |             ^^^^^^^^^^^^^
-
-error: arithmetic operation that can potentially result in unexpected side-effects
   --> tests/ui/arithmetic_side_effects.rs:309:5
-   |
-LL |     _n += 1;
-   |     ^^^^^^^
-
-error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:311:5
    |
 LL |     _n += &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:313:5
+  --> tests/ui/arithmetic_side_effects.rs:311:5
    |
 LL |     _n -= 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:315:5
+  --> tests/ui/arithmetic_side_effects.rs:313:5
    |
 LL |     _n -= &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:317:5
+  --> tests/ui/arithmetic_side_effects.rs:315:5
    |
 LL |     _n /= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:319:5
+  --> tests/ui/arithmetic_side_effects.rs:317:5
    |
 LL |     _n /= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:321:5
+  --> tests/ui/arithmetic_side_effects.rs:319:5
    |
 LL |     _n %= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:323:5
+  --> tests/ui/arithmetic_side_effects.rs:321:5
    |
 LL |     _n %= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:325:5
+  --> tests/ui/arithmetic_side_effects.rs:323:5
    |
 LL |     _n *= 2;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:327:5
+  --> tests/ui/arithmetic_side_effects.rs:325:5
    |
 LL |     _n *= &2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:329:5
+  --> tests/ui/arithmetic_side_effects.rs:327:5
    |
 LL |     _n += -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:331:5
+  --> tests/ui/arithmetic_side_effects.rs:329:5
    |
 LL |     _n += &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:333:5
+  --> tests/ui/arithmetic_side_effects.rs:331:5
    |
 LL |     _n -= -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:335:5
+  --> tests/ui/arithmetic_side_effects.rs:333:5
    |
 LL |     _n -= &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:337:5
+  --> tests/ui/arithmetic_side_effects.rs:335:5
    |
 LL |     _n /= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:339:5
+  --> tests/ui/arithmetic_side_effects.rs:337:5
    |
 LL |     _n /= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:341:5
+  --> tests/ui/arithmetic_side_effects.rs:339:5
    |
 LL |     _n %= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:343:5
+  --> tests/ui/arithmetic_side_effects.rs:341:5
    |
 LL |     _n %= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:345:5
+  --> tests/ui/arithmetic_side_effects.rs:343:5
    |
 LL |     _n *= -2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:347:5
+  --> tests/ui/arithmetic_side_effects.rs:345:5
    |
 LL |     _n *= &-2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:349:5
+  --> tests/ui/arithmetic_side_effects.rs:347:5
    |
 LL |     _custom += Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:351:5
+  --> tests/ui/arithmetic_side_effects.rs:349:5
    |
 LL |     _custom += &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:353:5
+  --> tests/ui/arithmetic_side_effects.rs:351:5
    |
 LL |     _custom -= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:355:5
+  --> tests/ui/arithmetic_side_effects.rs:353:5
    |
 LL |     _custom -= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:357:5
+  --> tests/ui/arithmetic_side_effects.rs:355:5
    |
 LL |     _custom /= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:359:5
+  --> tests/ui/arithmetic_side_effects.rs:357:5
    |
 LL |     _custom /= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:361:5
+  --> tests/ui/arithmetic_side_effects.rs:359:5
    |
 LL |     _custom %= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:363:5
+  --> tests/ui/arithmetic_side_effects.rs:361:5
    |
 LL |     _custom %= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:365:5
+  --> tests/ui/arithmetic_side_effects.rs:363:5
    |
 LL |     _custom *= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:367:5
+  --> tests/ui/arithmetic_side_effects.rs:365:5
    |
 LL |     _custom *= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:369:5
+  --> tests/ui/arithmetic_side_effects.rs:367:5
    |
 LL |     _custom >>= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:371:5
+  --> tests/ui/arithmetic_side_effects.rs:369:5
    |
 LL |     _custom >>= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:373:5
+  --> tests/ui/arithmetic_side_effects.rs:371:5
    |
 LL |     _custom <<= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:375:5
+  --> tests/ui/arithmetic_side_effects.rs:373:5
    |
 LL |     _custom <<= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:377:5
+  --> tests/ui/arithmetic_side_effects.rs:375:5
    |
 LL |     _custom += -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:379:5
+  --> tests/ui/arithmetic_side_effects.rs:377:5
    |
 LL |     _custom += &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:381:5
+  --> tests/ui/arithmetic_side_effects.rs:379:5
    |
 LL |     _custom -= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:383:5
+  --> tests/ui/arithmetic_side_effects.rs:381:5
    |
 LL |     _custom -= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:385:5
+  --> tests/ui/arithmetic_side_effects.rs:383:5
    |
 LL |     _custom /= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:387:5
+  --> tests/ui/arithmetic_side_effects.rs:385:5
    |
 LL |     _custom /= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:389:5
+  --> tests/ui/arithmetic_side_effects.rs:387:5
    |
 LL |     _custom %= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:391:5
+  --> tests/ui/arithmetic_side_effects.rs:389:5
    |
 LL |     _custom %= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:393:5
+  --> tests/ui/arithmetic_side_effects.rs:391:5
    |
 LL |     _custom *= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:395:5
+  --> tests/ui/arithmetic_side_effects.rs:393:5
    |
 LL |     _custom *= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:397:5
+  --> tests/ui/arithmetic_side_effects.rs:395:5
    |
 LL |     _custom >>= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:399:5
+  --> tests/ui/arithmetic_side_effects.rs:397:5
    |
 LL |     _custom >>= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:401:5
+  --> tests/ui/arithmetic_side_effects.rs:399:5
    |
 LL |     _custom <<= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:403:5
+  --> tests/ui/arithmetic_side_effects.rs:401:5
    |
 LL |     _custom <<= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:407:10
+  --> tests/ui/arithmetic_side_effects.rs:405:10
    |
 LL |     _n = _n + 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:409:10
+  --> tests/ui/arithmetic_side_effects.rs:407:10
    |
 LL |     _n = _n + &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:411:10
+  --> tests/ui/arithmetic_side_effects.rs:409:10
    |
 LL |     _n = 1 + _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:413:10
+  --> tests/ui/arithmetic_side_effects.rs:411:10
    |
 LL |     _n = &1 + _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:415:10
+  --> tests/ui/arithmetic_side_effects.rs:413:10
    |
 LL |     _n = _n - 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:417:10
+  --> tests/ui/arithmetic_side_effects.rs:415:10
    |
 LL |     _n = _n - &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:419:10
+  --> tests/ui/arithmetic_side_effects.rs:417:10
    |
 LL |     _n = 1 - _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:421:10
+  --> tests/ui/arithmetic_side_effects.rs:419:10
    |
 LL |     _n = &1 - _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:423:10
+  --> tests/ui/arithmetic_side_effects.rs:421:10
    |
 LL |     _n = _n / 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:425:10
+  --> tests/ui/arithmetic_side_effects.rs:423:10
    |
 LL |     _n = _n / &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:427:10
+  --> tests/ui/arithmetic_side_effects.rs:425:10
    |
 LL |     _n = _n % 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:429:10
+  --> tests/ui/arithmetic_side_effects.rs:427:10
    |
 LL |     _n = _n % &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:431:10
+  --> tests/ui/arithmetic_side_effects.rs:429:10
    |
 LL |     _n = _n * 2;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:433:10
+  --> tests/ui/arithmetic_side_effects.rs:431:10
    |
 LL |     _n = _n * &2;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:435:10
+  --> tests/ui/arithmetic_side_effects.rs:433:10
    |
 LL |     _n = 2 * _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:437:10
+  --> tests/ui/arithmetic_side_effects.rs:435:10
    |
 LL |     _n = &2 * _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:439:10
+  --> tests/ui/arithmetic_side_effects.rs:437:10
    |
 LL |     _n = 23 + &85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:441:10
+  --> tests/ui/arithmetic_side_effects.rs:439:10
    |
 LL |     _n = &23 + 85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:443:10
+  --> tests/ui/arithmetic_side_effects.rs:441:10
    |
 LL |     _n = &23 + &85;
    |          ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:445:15
+  --> tests/ui/arithmetic_side_effects.rs:443:15
    |
 LL |     _custom = _custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:447:15
+  --> tests/ui/arithmetic_side_effects.rs:445:15
    |
 LL |     _custom = _custom + &_custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:449:15
+  --> tests/ui/arithmetic_side_effects.rs:447:15
    |
 LL |     _custom = Custom + _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:451:15
+  --> tests/ui/arithmetic_side_effects.rs:449:15
    |
 LL |     _custom = &Custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:453:15
+  --> tests/ui/arithmetic_side_effects.rs:451:15
    |
 LL |     _custom = _custom - Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:455:15
+  --> tests/ui/arithmetic_side_effects.rs:453:15
    |
 LL |     _custom = _custom - &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:457:15
+  --> tests/ui/arithmetic_side_effects.rs:455:15
    |
 LL |     _custom = Custom - _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:459:15
+  --> tests/ui/arithmetic_side_effects.rs:457:15
    |
 LL |     _custom = &Custom - _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:461:15
+  --> tests/ui/arithmetic_side_effects.rs:459:15
    |
 LL |     _custom = _custom / Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:463:15
+  --> tests/ui/arithmetic_side_effects.rs:461:15
    |
 LL |     _custom = _custom / &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:465:15
+  --> tests/ui/arithmetic_side_effects.rs:463:15
    |
 LL |     _custom = _custom % Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:467:15
+  --> tests/ui/arithmetic_side_effects.rs:465:15
    |
 LL |     _custom = _custom % &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:469:15
+  --> tests/ui/arithmetic_side_effects.rs:467:15
    |
 LL |     _custom = _custom * Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:471:15
+  --> tests/ui/arithmetic_side_effects.rs:469:15
    |
 LL |     _custom = _custom * &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:473:15
+  --> tests/ui/arithmetic_side_effects.rs:471:15
    |
 LL |     _custom = Custom * _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:475:15
+  --> tests/ui/arithmetic_side_effects.rs:473:15
    |
 LL |     _custom = &Custom * _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:477:15
+  --> tests/ui/arithmetic_side_effects.rs:475:15
    |
 LL |     _custom = Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:479:15
+  --> tests/ui/arithmetic_side_effects.rs:477:15
    |
 LL |     _custom = &Custom + Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:481:15
+  --> tests/ui/arithmetic_side_effects.rs:479:15
    |
 LL |     _custom = &Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:483:15
+  --> tests/ui/arithmetic_side_effects.rs:481:15
    |
 LL |     _custom = _custom >> _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:485:15
+  --> tests/ui/arithmetic_side_effects.rs:483:15
    |
 LL |     _custom = _custom >> &_custom;
    |               ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:487:15
+  --> tests/ui/arithmetic_side_effects.rs:485:15
    |
 LL |     _custom = Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:489:15
+  --> tests/ui/arithmetic_side_effects.rs:487:15
    |
 LL |     _custom = &Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:493:23
+  --> tests/ui/arithmetic_side_effects.rs:491:23
    |
 LL |     _n.saturating_div(0);
    |                       ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:495:21
+  --> tests/ui/arithmetic_side_effects.rs:493:21
    |
 LL |     _n.wrapping_div(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:497:21
+  --> tests/ui/arithmetic_side_effects.rs:495:21
    |
 LL |     _n.wrapping_rem(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:499:28
+  --> tests/ui/arithmetic_side_effects.rs:497:28
    |
 LL |     _n.wrapping_rem_euclid(0);
    |                            ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:502:23
+  --> tests/ui/arithmetic_side_effects.rs:500:23
    |
 LL |     _n.saturating_div(_n);
    |                       ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:504:21
+  --> tests/ui/arithmetic_side_effects.rs:502:21
    |
 LL |     _n.wrapping_div(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:506:21
+  --> tests/ui/arithmetic_side_effects.rs:504:21
    |
 LL |     _n.wrapping_rem(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:508:28
+  --> tests/ui/arithmetic_side_effects.rs:506:28
    |
 LL |     _n.wrapping_rem_euclid(_n);
    |                            ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:511:23
+  --> tests/ui/arithmetic_side_effects.rs:509:23
    |
 LL |     _n.saturating_div(*Box::new(_n));
    |                       ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:515:10
+  --> tests/ui/arithmetic_side_effects.rs:513:10
    |
 LL |     _n = -_n;
    |          ^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:517:10
+  --> tests/ui/arithmetic_side_effects.rs:515:10
    |
 LL |     _n = -&_n;
    |          ^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:519:15
+  --> tests/ui/arithmetic_side_effects.rs:517:15
    |
 LL |     _custom = -_custom;
    |               ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:521:15
+  --> tests/ui/arithmetic_side_effects.rs:519:15
    |
 LL |     _custom = -&_custom;
    |               ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:523:9
+  --> tests/ui/arithmetic_side_effects.rs:521:9
    |
 LL |     _ = -*Box::new(_n);
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:533:5
+  --> tests/ui/arithmetic_side_effects.rs:531:5
    |
 LL |     1 + i;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:535:5
+  --> tests/ui/arithmetic_side_effects.rs:533:5
    |
 LL |     i * 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:537:5
+  --> tests/ui/arithmetic_side_effects.rs:535:5
    |
 LL |     1 % i / 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:539:5
+  --> tests/ui/arithmetic_side_effects.rs:537:5
    |
 LL |     i - 2 + 2 - i;
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:541:5
+  --> tests/ui/arithmetic_side_effects.rs:539:5
    |
 LL |     -i;
    |     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:553:5
+  --> tests/ui/arithmetic_side_effects.rs:551:5
    |
 LL |     i += 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:555:5
+  --> tests/ui/arithmetic_side_effects.rs:553:5
    |
 LL |     i -= 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:557:5
+  --> tests/ui/arithmetic_side_effects.rs:555:5
    |
 LL |     i *= 2;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:560:5
+  --> tests/ui/arithmetic_side_effects.rs:558:5
    |
 LL |     i /= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:563:5
+  --> tests/ui/arithmetic_side_effects.rs:561:5
    |
 LL |     i /= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:565:5
+  --> tests/ui/arithmetic_side_effects.rs:563:5
    |
 LL |     i /= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:568:5
+  --> tests/ui/arithmetic_side_effects.rs:566:5
    |
 LL |     i %= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:571:5
+  --> tests/ui/arithmetic_side_effects.rs:569:5
    |
 LL |     i %= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:573:5
+  --> tests/ui/arithmetic_side_effects.rs:571:5
    |
 LL |     i %= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:584:5
+  --> tests/ui/arithmetic_side_effects.rs:582:5
    |
 LL |     10 / a
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:639:9
+  --> tests/ui/arithmetic_side_effects.rs:637:9
    |
 LL |         x / maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:644:9
+  --> tests/ui/arithmetic_side_effects.rs:642:9
    |
 LL |         x % maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:656:5
+  --> tests/ui/arithmetic_side_effects.rs:654:5
    |
 LL |     one.add_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:661:5
+  --> tests/ui/arithmetic_side_effects.rs:659:5
    |
 LL |     one.sub_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:682:5
+  --> tests/ui/arithmetic_side_effects.rs:680:5
    |
 LL |     one.add(&one);
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:684:5
+  --> tests/ui/arithmetic_side_effects.rs:682:5
    |
 LL |     Box::new(one).add(one);
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:693:13
+  --> tests/ui/arithmetic_side_effects.rs:691:13
    |
 LL |     let _ = u128::MAX + u128::from(1u8);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:710:13
+  --> tests/ui/arithmetic_side_effects.rs:708:13
    |
 LL |     let _ = u128::MAX * u128::from(1u8);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:733:33
+  --> tests/ui/arithmetic_side_effects.rs:731:33
    |
 LL |     let _ = Duration::from_secs(86400 * Foo::from(1));
    |                                 ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:739:33
+  --> tests/ui/arithmetic_side_effects.rs:737:33
    |
 LL |     let _ = Duration::from_secs(86400 * shift(1));
    |                                 ^^^^^^^^^^^^^^^^
 
-error: aborting due to 131 previous errors
+error: aborting due to 129 previous errors
 

--- a/tests/ui/neg_multiply.fixed
+++ b/tests/ui/neg_multiply.fixed
@@ -1,3 +1,5 @@
+#![feature(f128)]
+#![feature(f16)]
 #![warn(clippy::neg_multiply)]
 #![allow(clippy::precedence)]
 #![expect(clippy::no_effect)]
@@ -78,6 +80,12 @@ fn float() {
     -(3.0_f32 as f64);
     //~^ neg_multiply
     -(3.0_f32 as f64);
+    //~^ neg_multiply
+
+    -3.0_f16;
+    //~^ neg_multiply
+
+    -3.0_f128;
     //~^ neg_multiply
 
     -1.0 * -1.0; // should be ok

--- a/tests/ui/neg_multiply.rs
+++ b/tests/ui/neg_multiply.rs
@@ -1,3 +1,5 @@
+#![feature(f128)]
+#![feature(f16)]
 #![warn(clippy::neg_multiply)]
 #![allow(clippy::precedence)]
 #![expect(clippy::no_effect)]
@@ -78,6 +80,12 @@ fn float() {
     3.0_f32 as f64 * -1.0;
     //~^ neg_multiply
     (3.0_f32 as f64) * -1.0;
+    //~^ neg_multiply
+
+    3.0_f16 * -1.0;
+    //~^ neg_multiply
+
+    3.0_f128 * -1.0;
     //~^ neg_multiply
 
     -1.0 * -1.0; // should be ok

--- a/tests/ui/neg_multiply.stderr
+++ b/tests/ui/neg_multiply.stderr
@@ -1,5 +1,5 @@
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:28:5
+  --> tests/ui/neg_multiply.rs:30:5
    |
 LL |     x * -1;
    |     ^^^^^^ help: consider using: `-x`
@@ -8,100 +8,112 @@ LL |     x * -1;
    = help: to override `-D warnings` add `#[allow(clippy::neg_multiply)]`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:31:5
+  --> tests/ui/neg_multiply.rs:33:5
    |
 LL |     -1 * x;
    |     ^^^^^^ help: consider using: `-x`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:34:11
+  --> tests/ui/neg_multiply.rs:36:11
    |
 LL |     100 + x * -1;
    |           ^^^^^^ help: consider using: `-x`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:37:5
+  --> tests/ui/neg_multiply.rs:39:5
    |
 LL |     (100 + x) * -1;
    |     ^^^^^^^^^^^^^^ help: consider using: `-(100 + x)`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:40:5
+  --> tests/ui/neg_multiply.rs:42:5
    |
 LL |     -1 * 17;
    |     ^^^^^^^ help: consider using: `-17`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:43:14
+  --> tests/ui/neg_multiply.rs:45:14
    |
 LL |     0xcafe | 0xff00 * -1;
    |              ^^^^^^^^^^^ help: consider using: `-0xff00`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:46:5
+  --> tests/ui/neg_multiply.rs:48:5
    |
 LL |     3_usize as i32 * -1;
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `-(3_usize as i32)`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:48:5
+  --> tests/ui/neg_multiply.rs:50:5
    |
 LL |     (3_usize as i32) * -1;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `-(3_usize as i32)`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:60:5
+  --> tests/ui/neg_multiply.rs:62:5
    |
 LL |     x * -1.0;
    |     ^^^^^^^^ help: consider using: `-x`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:63:5
+  --> tests/ui/neg_multiply.rs:65:5
    |
 LL |     -1.0 * x;
    |     ^^^^^^^^ help: consider using: `-x`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:66:13
+  --> tests/ui/neg_multiply.rs:68:13
    |
 LL |     100.0 + x * -1.0;
    |             ^^^^^^^^ help: consider using: `-x`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:69:5
+  --> tests/ui/neg_multiply.rs:71:5
    |
 LL |     (100.0 + x) * -1.0;
    |     ^^^^^^^^^^^^^^^^^^ help: consider using: `-(100.0 + x)`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:72:5
+  --> tests/ui/neg_multiply.rs:74:5
    |
 LL |     -1.0 * 17.0;
    |     ^^^^^^^^^^^ help: consider using: `-17.0`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:75:11
+  --> tests/ui/neg_multiply.rs:77:11
    |
 LL |     0.0 + 0.0 * -1.0;
    |           ^^^^^^^^^^ help: consider using: `-0.0`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:78:5
+  --> tests/ui/neg_multiply.rs:80:5
    |
 LL |     3.0_f32 as f64 * -1.0;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `-(3.0_f32 as f64)`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:80:5
+  --> tests/ui/neg_multiply.rs:82:5
    |
 LL |     (3.0_f32 as f64) * -1.0;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `-(3.0_f32 as f64)`
 
 error: this multiplication by -1 can be written more succinctly
-  --> tests/ui/neg_multiply.rs:93:13
+  --> tests/ui/neg_multiply.rs:85:5
+   |
+LL |     3.0_f16 * -1.0;
+   |     ^^^^^^^^^^^^^^ help: consider using: `-3.0_f16`
+
+error: this multiplication by -1 can be written more succinctly
+  --> tests/ui/neg_multiply.rs:88:5
+   |
+LL |     3.0_f128 * -1.0;
+   |     ^^^^^^^^^^^^^^^ help: consider using: `-3.0_f128`
+
+error: this multiplication by -1 can be written more succinctly
+  --> tests/ui/neg_multiply.rs:101:13
    |
 LL |     let _ = ((a.delta - 0.5).abs() * -1.0).total_cmp(&1.0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(-(a.delta - 0.5).abs())`
 
-error: aborting due to 17 previous errors
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
Basis for enabling handling of `f16` and `f128` in other existing lints.

changelog: none