### PR TITLE
feat(search_is_some): Fix when the closure spans multiple lines

### DIFF
--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -765,7 +765,7 @@ pub struct DerefClosure {
 /// such as explicit deref and borrowing cases.
 /// Returns `None` if no such use cases have been triggered in closure body
 ///
-/// note: this only works on single line immutable closures with exactly one input parameter.
+/// note: This only works on immutable closures with exactly one input parameter.
 pub fn deref_closure_args(cx: &LateContext<'_>, closure: &hir::Expr<'_>) -> Option<DerefClosure> {
     if let ExprKind::Closure(&Closure {
         fn_decl, def_id, body, ..

--- a/tests/ui/search_is_some.rs
+++ b/tests/ui/search_is_some.rs
@@ -8,31 +8,6 @@ use option_helpers::IteratorFalsePositives;
 //@no-rustfix
 #[rustfmt::skip]
 fn main() {
-    let v = vec![3, 2, 1, 0, -1, -2, -3];
-    let y = &&42;
-
-
-    // Check `find().is_some()`, multi-line case.
-    let _ = v.iter().find(|&x| {
-    //~^ search_is_some
-                              *x < 0
-                          }
-                   ).is_some();
-
-    // Check `position().is_some()`, multi-line case.
-    let _ = v.iter().position(|&x| {
-    //~^ search_is_some
-                                  x < 0
-                              }
-                   ).is_some();
-
-    // Check `rposition().is_some()`, multi-line case.
-    let _ = v.iter().rposition(|&x| {
-    //~^ search_is_some
-                                   x < 0
-                               }
-                   ).is_some();
-
     // Check that we don't lint if the caller is not an `Iterator` or string
     let falsepos = IteratorFalsePositives { foo: 0 };
     let _ = falsepos.find().is_some();
@@ -49,31 +24,6 @@ fn main() {
 
 #[rustfmt::skip]
 fn is_none() {
-    let v = vec![3, 2, 1, 0, -1, -2, -3];
-    let y = &&42;
-
-
-    // Check `find().is_none()`, multi-line case.
-    let _ = v.iter().find(|&x| {
-    //~^ search_is_some
-                              *x < 0
-                          }
-                   ).is_none();
-
-    // Check `position().is_none()`, multi-line case.
-    let _ = v.iter().position(|&x| {
-    //~^ search_is_some
-                                  x < 0
-                              }
-                   ).is_none();
-
-    // Check `rposition().is_none()`, multi-line case.
-    let _ = v.iter().rposition(|&x| {
-    //~^ search_is_some
-                                   x < 0
-                               }
-                   ).is_none();
-
     // Check that we don't lint if the caller is not an `Iterator` or string
     let falsepos = IteratorFalsePositives { foo: 0 };
     let _ = falsepos.find().is_none();
@@ -86,19 +36,4 @@ fn is_none() {
     let some_closure = |x: &u32| *x == 0;
     let _ = (0..1).find(some_closure).is_none();
     //~^ search_is_some
-}
-
-#[allow(clippy::match_like_matches_macro)]
-fn issue15102() {
-    let values = [None, Some(3)];
-    let has_even = values
-        //~^ search_is_some
-        .iter()
-        .find(|v| match v {
-            Some(x) if x % 2 == 0 => true,
-            _ => false,
-        })
-        .is_some();
-
-    println!("{has_even}");
 }

--- a/tests/ui/search_is_some.stderr
+++ b/tests/ui/search_is_some.stderr
@@ -1,109 +1,17 @@
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some.rs:16:13
-   |
-LL |       let _ = v.iter().find(|&x| {
-   |  _____________^
-LL | |
-LL | |                               *x < 0
-LL | |                           }
-LL | |                    ).is_some();
-   | |______________________________^
-   |
-   = help: this is more succinctly expressed by calling `any()`
-   = note: `-D clippy::search-is-some` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::search_is_some)]`
-
-error: called `is_some()` after searching an `Iterator` with `position`
-  --> tests/ui/search_is_some.rs:23:13
-   |
-LL |       let _ = v.iter().position(|&x| {
-   |  _____________^
-LL | |
-LL | |                                   x < 0
-LL | |                               }
-LL | |                    ).is_some();
-   | |______________________________^
-   |
-   = help: this is more succinctly expressed by calling `any()`
-
-error: called `is_some()` after searching an `Iterator` with `rposition`
-  --> tests/ui/search_is_some.rs:30:13
-   |
-LL |       let _ = v.iter().rposition(|&x| {
-   |  _____________^
-LL | |
-LL | |                                    x < 0
-LL | |                                }
-LL | |                    ).is_some();
-   | |______________________________^
-   |
-   = help: this is more succinctly expressed by calling `any()`
-
-error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some.rs:46:20
+  --> tests/ui/search_is_some.rs:21:20
    |
 LL |     let _ = (0..1).find(some_closure).is_some();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(some_closure)`
+   |
+   = note: `-D clippy::search-is-some` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::search_is_some)]`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some.rs:57:13
-   |
-LL |       let _ = v.iter().find(|&x| {
-   |  _____________^
-LL | |
-LL | |                               *x < 0
-LL | |                           }
-LL | |                    ).is_none();
-   | |______________________________^
-   |
-   = help: this is more succinctly expressed by calling `any()` with negation
-
-error: called `is_none()` after searching an `Iterator` with `position`
-  --> tests/ui/search_is_some.rs:64:13
-   |
-LL |       let _ = v.iter().position(|&x| {
-   |  _____________^
-LL | |
-LL | |                                   x < 0
-LL | |                               }
-LL | |                    ).is_none();
-   | |______________________________^
-   |
-   = help: this is more succinctly expressed by calling `any()` with negation
-
-error: called `is_none()` after searching an `Iterator` with `rposition`
-  --> tests/ui/search_is_some.rs:71:13
-   |
-LL |       let _ = v.iter().rposition(|&x| {
-   |  _____________^
-LL | |
-LL | |                                    x < 0
-LL | |                                }
-LL | |                    ).is_none();
-   | |______________________________^
-   |
-   = help: this is more succinctly expressed by calling `any()` with negation
-
-error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some.rs:87:13
+  --> tests/ui/search_is_some.rs:37:13
    |
 LL |     let _ = (0..1).find(some_closure).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!(0..1).any(some_closure)`
 
-error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some.rs:94:20
-   |
-LL |       let has_even = values
-   |  ____________________^
-LL | |
-LL | |         .iter()
-LL | |         .find(|v| match v {
-...  |
-LL | |         })
-LL | |         .is_some();
-   | |__________________^
-   |
-   = help: this is more succinctly expressed by calling `any()`
-
-error: aborting due to 9 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/search_is_some_fixable_none.fixed
+++ b/tests/ui/search_is_some_fixable_none.fixed
@@ -24,14 +24,32 @@ fn main() {
     let _ = !(1..3).any(|x| [1, 2, 3].contains(&x) || x == 0);
     //~^ search_is_some
     let _ = !(1..3).any(|x| [1, 2, 3].contains(&x) || x == 0 || [4, 5, 6].contains(&x) || x == -1);
+    // Check `find().is_none()`, multi-line case.
+    let _ = !v
+        //~^ search_is_some
+        .iter().any(|x| {
+            *x < 0 //
+        });
 
     // Check `position().is_none()`, single-line case.
     let _ = !v.iter().any(|&x| x < 0);
     //~^ search_is_some
+    // Check `position().is_none()`, multi-line case.
+    let _ = !v
+        //~^ search_is_some
+        .iter().any(|&x| {
+            x < 0 //
+        });
 
     // Check `rposition().is_none()`, single-line case.
     let _ = !v.iter().any(|&x| x < 0);
     //~^ search_is_some
+    // Check `rposition().is_none()`, multi-line case.
+    let _ = !v
+        //~^ search_is_some
+        .iter().any(|&x| {
+            x < 0 //
+        });
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");

--- a/tests/ui/search_is_some_fixable_none.rs
+++ b/tests/ui/search_is_some_fixable_none.rs
@@ -27,14 +27,38 @@ fn main() {
         //~^ search_is_some
         .find(|x| [1, 2, 3].contains(x) || *x == 0 || [4, 5, 6].contains(x) || *x == -1)
         .is_none();
+    // Check `find().is_none()`, multi-line case.
+    let _ = v
+        //~^ search_is_some
+        .iter()
+        .find(|&x| {
+            *x < 0 //
+        })
+        .is_none();
 
     // Check `position().is_none()`, single-line case.
     let _ = v.iter().position(|&x| x < 0).is_none();
     //~^ search_is_some
+    // Check `position().is_none()`, multi-line case.
+    let _ = v
+        //~^ search_is_some
+        .iter()
+        .position(|&x| {
+            x < 0 //
+        })
+        .is_none();
 
     // Check `rposition().is_none()`, single-line case.
     let _ = v.iter().rposition(|&x| x < 0).is_none();
     //~^ search_is_some
+    // Check `rposition().is_none()`, multi-line case.
+    let _ = v
+        //~^ search_is_some
+        .iter()
+        .rposition(|&x| {
+            x < 0 //
+        })
+        .is_none();
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");

--- a/tests/ui/search_is_some_fixable_none.stderr
+++ b/tests/ui/search_is_some_fixable_none.stderr
@@ -59,92 +59,158 @@ LL | |         .find(|x| [1, 2, 3].contains(x) || *x == 0 || [4, 5, 6].contains(
 LL | |         .is_none();
    | |__________________^ help: consider using: `!(1..3).any(|x| [1, 2, 3].contains(&x) || x == 0 || [4, 5, 6].contains(&x) || x == -1)`
 
+error: called `is_none()` after searching an `Iterator` with `find`
+  --> tests/ui/search_is_some_fixable_none.rs:31:13
+   |
+LL |       let _ = v
+   |  _____________^
+LL | |
+LL | |         .iter()
+LL | |         .find(|&x| {
+LL | |             *x < 0 //
+LL | |         })
+LL | |         .is_none();
+   | |__________________^
+   |
+help: consider using
+   |
+LL ~     let _ = !v
+LL +
+LL +         .iter().any(|x| {
+LL +             *x < 0 //
+LL ~         });
+   |
+
 error: called `is_none()` after searching an `Iterator` with `position`
-  --> tests/ui/search_is_some_fixable_none.rs:32:13
+  --> tests/ui/search_is_some_fixable_none.rs:40:13
    |
 LL |     let _ = v.iter().position(|&x| x < 0).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|&x| x < 0)`
 
+error: called `is_none()` after searching an `Iterator` with `position`
+  --> tests/ui/search_is_some_fixable_none.rs:43:13
+   |
+LL |       let _ = v
+   |  _____________^
+LL | |
+LL | |         .iter()
+LL | |         .position(|&x| {
+LL | |             x < 0 //
+LL | |         })
+LL | |         .is_none();
+   | |__________________^
+   |
+help: consider using
+   |
+LL ~     let _ = !v
+LL +
+LL +         .iter().any(|&x| {
+LL +             x < 0 //
+LL ~         });
+   |
+
 error: called `is_none()` after searching an `Iterator` with `rposition`
-  --> tests/ui/search_is_some_fixable_none.rs:36:13
+  --> tests/ui/search_is_some_fixable_none.rs:52:13
    |
 LL |     let _ = v.iter().rposition(|&x| x < 0).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|&x| x < 0)`
 
+error: called `is_none()` after searching an `Iterator` with `rposition`
+  --> tests/ui/search_is_some_fixable_none.rs:55:13
+   |
+LL |       let _ = v
+   |  _____________^
+LL | |
+LL | |         .iter()
+LL | |         .rposition(|&x| {
+LL | |             x < 0 //
+LL | |         })
+LL | |         .is_none();
+   | |__________________^
+   |
+help: consider using
+   |
+LL ~     let _ = !v
+LL +
+LL +         .iter().any(|&x| {
+LL +             x < 0 //
+LL ~         });
+   |
+
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:43:13
+  --> tests/ui/search_is_some_fixable_none.rs:67:13
    |
 LL |     let _ = "hello world".find("world").is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!"hello world".contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:45:13
+  --> tests/ui/search_is_some_fixable_none.rs:69:13
    |
 LL |     let _ = "hello world".find(&s2).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!"hello world".contains(&s2)`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:47:13
+  --> tests/ui/search_is_some_fixable_none.rs:71:13
    |
 LL |     let _ = "hello world".find(&s2[2..]).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!"hello world".contains(&s2[2..])`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:50:13
+  --> tests/ui/search_is_some_fixable_none.rs:74:13
    |
 LL |     let _ = s1.find("world").is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s1.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:52:13
+  --> tests/ui/search_is_some_fixable_none.rs:76:13
    |
 LL |     let _ = s1.find(&s2).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s1.contains(&s2)`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:54:13
+  --> tests/ui/search_is_some_fixable_none.rs:78:13
    |
 LL |     let _ = s1.find(&s2[2..]).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s1.contains(&s2[2..])`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:57:13
+  --> tests/ui/search_is_some_fixable_none.rs:81:13
    |
 LL |     let _ = s1[2..].find("world").is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s1[2..].contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:59:13
+  --> tests/ui/search_is_some_fixable_none.rs:83:13
    |
 LL |     let _ = s1[2..].find(&s2).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s1[2..].contains(&s2)`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:61:13
+  --> tests/ui/search_is_some_fixable_none.rs:85:13
    |
 LL |     let _ = s1[2..].find(&s2[2..]).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s1[2..].contains(&s2[2..])`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:78:25
+  --> tests/ui/search_is_some_fixable_none.rs:102:25
    |
 LL |             .filter(|c| filter_hand.iter().find(|cc| c == cc).is_none())
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!filter_hand.iter().any(|cc| c == &cc)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:95:30
+  --> tests/ui/search_is_some_fixable_none.rs:119:30
    |
 LL |             .filter(|(c, _)| filter_hand.iter().find(|cc| c == *cc).is_none())
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!filter_hand.iter().any(|cc| c == cc)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:107:17
+  --> tests/ui/search_is_some_fixable_none.rs:131:17
    |
 LL |         let _ = vfoo.iter().find(|v| v.foo == 1 && v.bar == 2).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!vfoo.iter().any(|v| v.foo == 1 && v.bar == 2)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:111:17
+  --> tests/ui/search_is_some_fixable_none.rs:135:17
    |
 LL |           let _ = vfoo
    |  _________________^
@@ -162,55 +228,55 @@ LL ~             .iter().any(|(i, v)| *i == 42 && v.foo == 1 && v.bar == 2);
    |
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:120:17
+  --> tests/ui/search_is_some_fixable_none.rs:144:17
    |
 LL |         let _ = vfoo.iter().find(|a| a[0] == 42).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!vfoo.iter().any(|a| a[0] == 42)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:127:17
+  --> tests/ui/search_is_some_fixable_none.rs:151:17
    |
 LL |         let _ = vfoo.iter().find(|sub| sub[1..4].len() == 3).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!vfoo.iter().any(|sub| sub[1..4].len() == 3)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:146:17
+  --> tests/ui/search_is_some_fixable_none.rs:170:17
    |
 LL |         let _ = [ppx].iter().find(|ppp_x: &&&u32| please(**ppp_x)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `![ppx].iter().any(|ppp_x: &&u32| please(ppp_x))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:148:17
+  --> tests/ui/search_is_some_fixable_none.rs:172:17
    |
 LL |         let _ = [String::from("Hey hey")].iter().find(|s| s.len() == 2).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `![String::from("Hey hey")].iter().any(|s| s.len() == 2)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:152:17
+  --> tests/ui/search_is_some_fixable_none.rs:176:17
    |
 LL |         let _ = v.iter().find(|x| deref_enough(**x)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|x| deref_enough(*x))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:154:17
+  --> tests/ui/search_is_some_fixable_none.rs:178:17
    |
 LL |         let _ = v.iter().find(|x: &&u32| deref_enough(**x)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|x: &u32| deref_enough(*x))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:158:17
+  --> tests/ui/search_is_some_fixable_none.rs:182:17
    |
 LL |         let _ = v.iter().find(|x| arg_no_deref(x)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|x| arg_no_deref(&x))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:161:17
+  --> tests/ui/search_is_some_fixable_none.rs:185:17
    |
 LL |         let _ = v.iter().find(|x: &&u32| arg_no_deref(x)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|x: &u32| arg_no_deref(&x))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:182:17
+  --> tests/ui/search_is_some_fixable_none.rs:206:17
    |
 LL |           let _ = vfoo
    |  _________________^
@@ -228,25 +294,25 @@ LL ~             .iter().any(|v| v.inner_double.bar[0][0] == 2 && v.inner.bar[0]
    |
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:199:17
+  --> tests/ui/search_is_some_fixable_none.rs:223:17
    |
 LL |         let _ = vfoo.iter().find(|v| v.inner[0].bar == 2).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!vfoo.iter().any(|v| v.inner[0].bar == 2)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:205:17
+  --> tests/ui/search_is_some_fixable_none.rs:229:17
    |
 LL |         let _ = vfoo.iter().find(|x| (**x)[0] == 9).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!vfoo.iter().any(|x| (**x)[0] == 9)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:219:17
+  --> tests/ui/search_is_some_fixable_none.rs:243:17
    |
 LL |         let _ = vfoo.iter().find(|v| v.by_ref(&v.bar)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!vfoo.iter().any(|v| v.by_ref(&v.bar))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:224:17
+  --> tests/ui/search_is_some_fixable_none.rs:248:17
    |
 LL |           let _ = [&(&1, 2), &(&3, 4), &(&5, 4)]
    |  _________________^
@@ -264,106 +330,106 @@ LL ~             .iter().any(|&&(&x, ref y)| x == *y);
    |
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:247:17
+  --> tests/ui/search_is_some_fixable_none.rs:271:17
    |
 LL |         let _ = v.iter().find(|s| s[0].is_empty()).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|s| s[0].is_empty())`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:249:17
+  --> tests/ui/search_is_some_fixable_none.rs:273:17
    |
 LL |         let _ = v.iter().find(|s| test_string_1(&s[0])).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|s| test_string_1(&s[0]))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:259:17
+  --> tests/ui/search_is_some_fixable_none.rs:283:17
    |
 LL |         let _ = v.iter().find(|fp| fp.field.is_power_of_two()).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|fp| fp.field.is_power_of_two())`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:261:17
+  --> tests/ui/search_is_some_fixable_none.rs:285:17
    |
 LL |         let _ = v.iter().find(|fp| test_u32_1(fp.field)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|fp| test_u32_1(fp.field))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:263:17
+  --> tests/ui/search_is_some_fixable_none.rs:287:17
    |
 LL |         let _ = v.iter().find(|fp| test_u32_2(*fp.field)).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|fp| test_u32_2(*fp.field))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:280:17
+  --> tests/ui/search_is_some_fixable_none.rs:304:17
    |
 LL |         let _ = v.iter().find(|x| **x == 42).is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|x| *x == 42)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:282:17
+  --> tests/ui/search_is_some_fixable_none.rs:306:17
    |
 LL |         Foo.bar(v.iter().find(|x| **x == 42).is_none());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!v.iter().any(|x| *x == 42)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:288:9
+  --> tests/ui/search_is_some_fixable_none.rs:312:9
    |
 LL |         v.iter().find(|x| **x == 42).is_none().then(computations);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!v.iter().any(|x| *x == 42))`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_none.rs:294:9
+  --> tests/ui/search_is_some_fixable_none.rs:318:9
    |
 LL |         v.iter().find(|x| **x == 42).is_none().then_some(0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!v.iter().any(|x| *x == 42))`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:300:17
+  --> tests/ui/search_is_some_fixable_none.rs:324:17
    |
 LL |         let _ = s.find("world").is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:302:17
+  --> tests/ui/search_is_some_fixable_none.rs:326:17
    |
 LL |         Foo.bar(s.find("world").is_none());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:305:17
+  --> tests/ui/search_is_some_fixable_none.rs:329:17
    |
 LL |         let _ = s.find("world").is_none();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:307:17
+  --> tests/ui/search_is_some_fixable_none.rs:331:17
    |
 LL |         Foo.bar(s.find("world").is_none());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `!s.contains("world")`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:313:17
+  --> tests/ui/search_is_some_fixable_none.rs:337:17
    |
 LL |         let _ = s.find("world").is_none().then(computations);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!s.contains("world"))`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:316:17
+  --> tests/ui/search_is_some_fixable_none.rs:340:17
    |
 LL |         let _ = s.find("world").is_none().then(computations);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!s.contains("world"))`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:322:17
+  --> tests/ui/search_is_some_fixable_none.rs:346:17
    |
 LL |         let _ = s.find("world").is_none().then_some(0);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!s.contains("world"))`
 
 error: called `is_none()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_none.rs:325:17
+  --> tests/ui/search_is_some_fixable_none.rs:349:17
    |
 LL |         let _ = s.find("world").is_none().then_some(0);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(!s.contains("world"))`
 
-error: aborting due to 54 previous errors
+error: aborting due to 57 previous errors
 

--- a/tests/ui/search_is_some_fixable_some.fixed
+++ b/tests/ui/search_is_some_fixable_some.fixed
@@ -25,14 +25,35 @@ fn main() {
     //~^ search_is_some
     let _ = (1..3)
         .any(|x| [1, 2, 3].contains(&x) || x == 0 || [4, 5, 6].contains(&x) || x == -1);
+    // Check `find().is_some()`, multi-line case.
+    let _ = v
+        .iter()
+        .any(|x| {
+            //~^ search_is_some
+            *x < 0
+        });
 
     // Check `position().is_some()`, single-line case.
     let _ = v.iter().any(|&x| x < 0);
     //~^ search_is_some
+    // Check `position().is_some()`, multi-line case.
+    let _ = v
+        .iter()
+        .any(|&x| {
+            //~^ search_is_some
+            x < 0
+        });
 
     // Check `rposition().is_some()`, single-line case.
     let _ = v.iter().any(|&x| x < 0);
     //~^ search_is_some
+    // Check `rposition().is_some()`, multi-line case.
+    let _ = v
+        .iter()
+        .any(|&x| {
+            //~^ search_is_some
+            x < 0
+        });
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
@@ -290,9 +311,19 @@ mod issue9120 {
     }
 }
 
+#[allow(clippy::match_like_matches_macro)]
 fn issue15102() {
     let values = [None, Some(3)];
     let has_even = values.iter().any(|v| matches!(&v, Some(x) if x % 2 == 0));
     //~^ search_is_some
+    println!("{has_even}");
+
+    let has_even = values
+        .iter()
+        .any(|v| match &v {
+            //~^ search_is_some
+            Some(x) if x % 2 == 0 => true,
+            _ => false,
+        });
     println!("{has_even}");
 }

--- a/tests/ui/search_is_some_fixable_some.rs
+++ b/tests/ui/search_is_some_fixable_some.rs
@@ -27,14 +27,38 @@ fn main() {
         .find(|x| [1, 2, 3].contains(x) || *x == 0 || [4, 5, 6].contains(x) || *x == -1)
         //~^ search_is_some
         .is_some();
+    // Check `find().is_some()`, multi-line case.
+    let _ = v
+        .iter()
+        .find(|&x| {
+            //~^ search_is_some
+            *x < 0
+        })
+        .is_some();
 
     // Check `position().is_some()`, single-line case.
     let _ = v.iter().position(|&x| x < 0).is_some();
     //~^ search_is_some
+    // Check `position().is_some()`, multi-line case.
+    let _ = v
+        .iter()
+        .position(|&x| {
+            //~^ search_is_some
+            x < 0
+        })
+        .is_some();
 
     // Check `rposition().is_some()`, single-line case.
     let _ = v.iter().rposition(|&x| x < 0).is_some();
     //~^ search_is_some
+    // Check `rposition().is_some()`, multi-line case.
+    let _ = v
+        .iter()
+        .rposition(|&x| {
+            //~^ search_is_some
+            x < 0
+        })
+        .is_some();
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
@@ -298,9 +322,20 @@ mod issue9120 {
     }
 }
 
+#[allow(clippy::match_like_matches_macro)]
 fn issue15102() {
     let values = [None, Some(3)];
     let has_even = values.iter().find(|v| matches!(v, Some(x) if x % 2 == 0)).is_some();
     //~^ search_is_some
+    println!("{has_even}");
+
+    let has_even = values
+        .iter()
+        .find(|v| match v {
+            //~^ search_is_some
+            Some(x) if x % 2 == 0 => true,
+            _ => false,
+        })
+        .is_some();
     println!("{has_even}");
 }

--- a/tests/ui/search_is_some_fixable_some.stderr
+++ b/tests/ui/search_is_some_fixable_some.stderr
@@ -58,92 +58,149 @@ LL | |
 LL | |         .is_some();
    | |__________________^ help: consider using: `any(|x| [1, 2, 3].contains(&x) || x == 0 || [4, 5, 6].contains(&x) || x == -1)`
 
+error: called `is_some()` after searching an `Iterator` with `find`
+  --> tests/ui/search_is_some_fixable_some.rs:33:10
+   |
+LL |           .find(|&x| {
+   |  __________^
+LL | |
+LL | |             *x < 0
+LL | |         })
+LL | |         .is_some();
+   | |__________________^
+   |
+help: consider using
+   |
+LL ~         .any(|x| {
+LL +
+LL +             *x < 0
+LL ~         });
+   |
+
 error: called `is_some()` after searching an `Iterator` with `position`
-  --> tests/ui/search_is_some_fixable_some.rs:32:22
+  --> tests/ui/search_is_some_fixable_some.rs:40:22
    |
 LL |     let _ = v.iter().position(|&x| x < 0).is_some();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|&x| x < 0)`
 
+error: called `is_some()` after searching an `Iterator` with `position`
+  --> tests/ui/search_is_some_fixable_some.rs:45:10
+   |
+LL |           .position(|&x| {
+   |  __________^
+LL | |
+LL | |             x < 0
+LL | |         })
+LL | |         .is_some();
+   | |__________________^
+   |
+help: consider using
+   |
+LL ~         .any(|&x| {
+LL +
+LL +             x < 0
+LL ~         });
+   |
+
 error: called `is_some()` after searching an `Iterator` with `rposition`
-  --> tests/ui/search_is_some_fixable_some.rs:36:22
+  --> tests/ui/search_is_some_fixable_some.rs:52:22
    |
 LL |     let _ = v.iter().rposition(|&x| x < 0).is_some();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|&x| x < 0)`
 
+error: called `is_some()` after searching an `Iterator` with `rposition`
+  --> tests/ui/search_is_some_fixable_some.rs:57:10
+   |
+LL |           .rposition(|&x| {
+   |  __________^
+LL | |
+LL | |             x < 0
+LL | |         })
+LL | |         .is_some();
+   | |__________________^
+   |
+help: consider using
+   |
+LL ~         .any(|&x| {
+LL +
+LL +             x < 0
+LL ~         });
+   |
+
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:42:27
+  --> tests/ui/search_is_some_fixable_some.rs:66:27
    |
 LL |     let _ = "hello world".find("world").is_some();
    |                           ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `contains("world")`
 
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:44:27
+  --> tests/ui/search_is_some_fixable_some.rs:68:27
    |
 LL |     let _ = "hello world".find(&s2).is_some();
    |                           ^^^^^^^^^^^^^^^^^^^ help: consider using: `contains(&s2)`
 
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:46:27
+  --> tests/ui/search_is_some_fixable_some.rs:70:27
    |
 LL |     let _ = "hello world".find(&s2[2..]).is_some();
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `contains(&s2[2..])`
 
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:49:16
+  --> tests/ui/search_is_some_fixable_some.rs:73:16
    |
 LL |     let _ = s1.find("world").is_some();
    |                ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `contains("world")`
 
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:51:16
+  --> tests/ui/search_is_some_fixable_some.rs:75:16
    |
 LL |     let _ = s1.find(&s2).is_some();
    |                ^^^^^^^^^^^^^^^^^^^ help: consider using: `contains(&s2)`
 
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:53:16
+  --> tests/ui/search_is_some_fixable_some.rs:77:16
    |
 LL |     let _ = s1.find(&s2[2..]).is_some();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `contains(&s2[2..])`
 
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:56:21
+  --> tests/ui/search_is_some_fixable_some.rs:80:21
    |
 LL |     let _ = s1[2..].find("world").is_some();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `contains("world")`
 
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:58:21
+  --> tests/ui/search_is_some_fixable_some.rs:82:21
    |
 LL |     let _ = s1[2..].find(&s2).is_some();
    |                     ^^^^^^^^^^^^^^^^^^^ help: consider using: `contains(&s2)`
 
 error: called `is_some()` after calling `find()` on a string
-  --> tests/ui/search_is_some_fixable_some.rs:60:21
+  --> tests/ui/search_is_some_fixable_some.rs:84:21
    |
 LL |     let _ = s1[2..].find(&s2[2..]).is_some();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `contains(&s2[2..])`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:77:44
+  --> tests/ui/search_is_some_fixable_some.rs:101:44
    |
 LL |             .filter(|c| filter_hand.iter().find(|cc| c == cc).is_some())
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|cc| c == &cc)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:94:49
+  --> tests/ui/search_is_some_fixable_some.rs:118:49
    |
 LL |             .filter(|(c, _)| filter_hand.iter().find(|cc| c == *cc).is_some())
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|cc| c == cc)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:106:29
+  --> tests/ui/search_is_some_fixable_some.rs:130:29
    |
 LL |         let _ = vfoo.iter().find(|v| v.foo == 1 && v.bar == 2).is_some();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|v| v.foo == 1 && v.bar == 2)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:112:14
+  --> tests/ui/search_is_some_fixable_some.rs:136:14
    |
 LL |               .find(|(i, v)| *i == 42 && v.foo == 1 && v.bar == 2)
    |  ______________^
@@ -152,55 +209,55 @@ LL | |             .is_some();
    | |______________________^ help: consider using: `any(|(i, v)| *i == 42 && v.foo == 1 && v.bar == 2)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:119:29
+  --> tests/ui/search_is_some_fixable_some.rs:143:29
    |
 LL |         let _ = vfoo.iter().find(|a| a[0] == 42).is_some();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|a| a[0] == 42)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:126:29
+  --> tests/ui/search_is_some_fixable_some.rs:150:29
    |
 LL |         let _ = vfoo.iter().find(|sub| sub[1..4].len() == 3).is_some();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|sub| sub[1..4].len() == 3)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:145:30
+  --> tests/ui/search_is_some_fixable_some.rs:169:30
    |
 LL |         let _ = [ppx].iter().find(|ppp_x: &&&u32| please(**ppp_x)).is_some();
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|ppp_x: &&u32| please(ppp_x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:147:50
+  --> tests/ui/search_is_some_fixable_some.rs:171:50
    |
 LL |         let _ = [String::from("Hey hey")].iter().find(|s| s.len() == 2).is_some();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|s| s.len() == 2)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:151:26
+  --> tests/ui/search_is_some_fixable_some.rs:175:26
    |
 LL |         let _ = v.iter().find(|x| deref_enough(**x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x| deref_enough(*x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:153:26
+  --> tests/ui/search_is_some_fixable_some.rs:177:26
    |
 LL |         let _ = v.iter().find(|x: &&u32| deref_enough(**x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| deref_enough(*x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:157:26
+  --> tests/ui/search_is_some_fixable_some.rs:181:26
    |
 LL |         let _ = v.iter().find(|x| arg_no_deref(x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x| arg_no_deref(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:160:26
+  --> tests/ui/search_is_some_fixable_some.rs:184:26
    |
 LL |         let _ = v.iter().find(|x: &&u32| arg_no_deref(x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| arg_no_deref(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:183:14
+  --> tests/ui/search_is_some_fixable_some.rs:207:14
    |
 LL |               .find(|v| v.inner_double.bar[0][0] == 2 && v.inner.bar[0] == 2)
    |  ______________^
@@ -209,25 +266,25 @@ LL | |             .is_some();
    | |______________________^ help: consider using: `any(|v| v.inner_double.bar[0][0] == 2 && v.inner.bar[0] == 2)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:198:29
+  --> tests/ui/search_is_some_fixable_some.rs:222:29
    |
 LL |         let _ = vfoo.iter().find(|v| v.inner[0].bar == 2).is_some();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|v| v.inner[0].bar == 2)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:204:29
+  --> tests/ui/search_is_some_fixable_some.rs:228:29
    |
 LL |         let _ = vfoo.iter().find(|x| (**x)[0] == 9).is_some();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x| (**x)[0] == 9)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:218:29
+  --> tests/ui/search_is_some_fixable_some.rs:242:29
    |
 LL |         let _ = vfoo.iter().find(|v| v.by_ref(&v.bar)).is_some();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|v| v.by_ref(&v.bar))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:225:14
+  --> tests/ui/search_is_some_fixable_some.rs:249:14
    |
 LL |               .find(|&&&(&x, ref y)| x == *y)
    |  ______________^
@@ -236,64 +293,85 @@ LL | |             .is_some();
    | |______________________^ help: consider using: `any(|&&(&x, ref y)| x == *y)`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:246:26
+  --> tests/ui/search_is_some_fixable_some.rs:270:26
    |
 LL |         let _ = v.iter().find(|s| s[0].is_empty()).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|s| s[0].is_empty())`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:248:26
+  --> tests/ui/search_is_some_fixable_some.rs:272:26
    |
 LL |         let _ = v.iter().find(|s| test_string_1(&s[0])).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|s| test_string_1(&s[0]))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:258:26
+  --> tests/ui/search_is_some_fixable_some.rs:282:26
    |
 LL |         let _ = v.iter().find(|fp| fp.field.is_power_of_two()).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|fp| fp.field.is_power_of_two())`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:260:26
+  --> tests/ui/search_is_some_fixable_some.rs:284:26
    |
 LL |         let _ = v.iter().find(|fp| test_u32_1(fp.field)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|fp| test_u32_1(fp.field))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:262:26
+  --> tests/ui/search_is_some_fixable_some.rs:286:26
    |
 LL |         let _ = v.iter().find(|fp| test_u32_2(*fp.field)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|fp| test_u32_2(*fp.field))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:278:18
+  --> tests/ui/search_is_some_fixable_some.rs:302:18
    |
 LL |         v.iter().find(|x: &&u32| func(x)).is_some()
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| func(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:288:26
+  --> tests/ui/search_is_some_fixable_some.rs:312:26
    |
 LL |         let _ = v.iter().find(|x: &&u32| arg_no_deref_impl(x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| arg_no_deref_impl(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:292:26
+  --> tests/ui/search_is_some_fixable_some.rs:316:26
    |
 LL |         let _ = v.iter().find(|x: &&u32| arg_no_deref_dyn(x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| arg_no_deref_dyn(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:296:26
+  --> tests/ui/search_is_some_fixable_some.rs:320:26
    |
 LL |         let _ = v.iter().find(|x: &&u32| (*arg_no_deref_dyn)(x)).is_some();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|x: &u32| (*arg_no_deref_dyn)(&x))`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> tests/ui/search_is_some_fixable_some.rs:303:34
+  --> tests/ui/search_is_some_fixable_some.rs:328:34
    |
 LL |     let has_even = values.iter().find(|v| matches!(v, Some(x) if x % 2 == 0)).is_some();
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|v| matches!(&v, Some(x) if x % 2 == 0))`
 
-error: aborting due to 47 previous errors
+error: called `is_some()` after searching an `Iterator` with `find`
+  --> tests/ui/search_is_some_fixable_some.rs:334:10
+   |
+LL |           .find(|v| match v {
+   |  __________^
+LL | |
+LL | |             Some(x) if x % 2 == 0 => true,
+LL | |             _ => false,
+LL | |         })
+LL | |         .is_some();
+   | |__________________^
+   |
+help: consider using
+   |
+LL ~         .any(|v| match &v {
+LL +
+LL +             Some(x) if x % 2 == 0 => true,
+LL +             _ => false,
+LL ~         });
+   |
+
+error: aborting due to 51 previous errors
 


### PR DESCRIPTION
Previously the program only fixed the code when the closure supplied to the method contained only 1 line.  This patch removes the restriction.

The code already works.  This patch only removes the extra check that causes the restriction.  The test cases that can now be fixed are moved into the files containing tests cases that can be fixed.

The unnecessary check has survived in the code this way.

- In Dec 2015, patch a6bd2d06227f, pull request rust-lang/rust-clippy#524.  The lint was first added.  The program did not support fixing code automatically yet.  So the suggested fix was printed as a part of the diagnostic message.  When the original code contained multiple lines, the suggested fix was omitted in order to keep the diagnostic message concise.

- In May 2019, patch bd0b75f6c3a8, pull request rust-lang/rust-clippy#4049.  Logic was added to strip the reference in the closure when the suggested replacement method required it.  Because the fix was still only printed when the code contained a single line, the new transformation was only done when the code contained a single line.

- In Aug 2019, patch 945d4cf69f7a, pull request rust-lang/rust-clippy#4454.  The lint was updated to fix code automatically.  Because the fixed code had only been printed in the diagnostic message for a single line, the fix was only added for a single line.

- In Nov 2021, patch 092fe209a656, pull request rust-lang/rust-clippy#7463.  The logic for transforming the closure was moved into another file.  A comment was added saying that it was only good for a single line because it had only been used for a single line.

changelog: [`search_is_some`] now fixes code spanning multiple lines
