### PR TITLE
fix(extra_unused_type_parameters): don't suggest an autofix

### DIFF
--- a/clippy_lints/src/extra_unused_type_parameters.rs
+++ b/clippy_lints/src/extra_unused_type_parameters.rs
@@ -102,7 +102,7 @@ impl<'cx, 'tcx> TypeWalker<'cx, 'tcx> {
     fn emit_sugg(&self, spans: Vec<Span>, msg: String, help: &'static str) {
         let suggestions: Vec<(Span, String)> = spans.iter().copied().zip(std::iter::repeat(String::new())).collect();
         span_lint_and_then(self.cx, EXTRA_UNUSED_TYPE_PARAMETERS, spans, msg, |diag| {
-            diag.multipart_suggestion(help, suggestions, Applicability::MachineApplicable);
+            diag.multipart_suggestion(help, suggestions, Applicability::MaybeIncorrect);
         });
     }
 

--- a/tests/ui/extra_unused_type_parameters_unfixable.rs
+++ b/tests/ui/extra_unused_type_parameters_unfixable.rs
@@ -1,3 +1,5 @@
+//@no-rustfix
+
 #![warn(clippy::extra_unused_type_parameters)]
 
 fn unused_where_clause<T, U>(x: U)
@@ -22,6 +24,19 @@ where
     T: Default,
 {
     unimplemented!();
+}
+
+// The fix just removes the type parameter from the definition of `unused_ty`, but it doesn't adjust
+// its callsites, leading to compilation errors.
+mod issue15884 {
+    fn unused_ty<T>(x: u8) {
+        //~^ extra_unused_type_parameters
+        unimplemented!()
+    }
+
+    fn main() {
+        unused_ty::<String>(0);
+    }
 }
 
 fn main() {}

--- a/tests/ui/extra_unused_type_parameters_unfixable.stderr
+++ b/tests/ui/extra_unused_type_parameters_unfixable.stderr
@@ -1,5 +1,5 @@
 error: type parameter `T` goes unused in function definition
-  --> tests/ui/extra_unused_type_parameters_unfixable.rs:3:24
+  --> tests/ui/extra_unused_type_parameters_unfixable.rs:5:24
    |
 LL | fn unused_where_clause<T, U>(x: U)
    |                        ^
@@ -9,7 +9,7 @@ LL | fn unused_where_clause<T, U>(x: U)
    = help: to override `-D warnings` add `#[allow(clippy::extra_unused_type_parameters)]`
 
 error: type parameters go unused in function definition: T, V
-  --> tests/ui/extra_unused_type_parameters_unfixable.rs:11:30
+  --> tests/ui/extra_unused_type_parameters_unfixable.rs:13:30
    |
 LL | fn unused_multi_where_clause<T, U, V: Default>(x: U)
    |                              ^     ^^^^^^^^^^
@@ -17,12 +17,24 @@ LL | fn unused_multi_where_clause<T, U, V: Default>(x: U)
    = help: consider removing the parameters
 
 error: type parameters go unused in function definition: T, U, V
-  --> tests/ui/extra_unused_type_parameters_unfixable.rs:19:28
+  --> tests/ui/extra_unused_type_parameters_unfixable.rs:21:28
    |
 LL | fn unused_all_where_clause<T, U: Default, V: Default>()
    |                            ^  ^^^^^^^^^^  ^^^^^^^^^^
    |
    = help: consider removing the parameters
 
-error: aborting due to 3 previous errors
+error: type parameter `T` goes unused in function definition
+  --> tests/ui/extra_unused_type_parameters_unfixable.rs:32:17
+   |
+LL |     fn unused_ty<T>(x: u8) {
+   |                 ^^^
+   |
+help: consider removing the parameter
+   |
+LL -     fn unused_ty<T>(x: u8) {
+LL +     fn unused_ty(x: u8) {
+   |
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15884

changelog: [`extra_unused_type_parameters`]: don't suggest an autofix