### PR TITLE
refactor(elidable_lifetimes): harmonize suggestion-building logic with `extra_unused_type_parameters`

### DIFF
--- a/clippy_lints/src/extra_unused_type_parameters.rs
+++ b/clippy_lints/src/extra_unused_type_parameters.rs
@@ -157,6 +157,11 @@ impl<'cx, 'tcx> TypeWalker<'cx, 'tcx> {
             let spans = if explicit_params.len() == extra_params.len() {
                 vec![self.generics.span] // Remove the entire list of generics
             } else {
+                // 1. Start from the last extra param
+                // 2. While the params preceding it are also extra, construct spans going from the current param to
+                //    the comma before it
+                // 3. Once this chain of extra params stops, switch to constructing spans going from the current
+                //    param to the comma _after_ it
                 let mut end: Option<LocalDefId> = None;
                 extra_params
                     .iter()


### PR DESCRIPTION
It's nice to come up with a clever algorithm (https://github.com/rust-lang/rust-clippy/pull/15667), but it's even nicer to reuse logic that already exists elsewhere.
 
changelog: none

r? @samueltardieu as you reviewed the original PR