### PR TITLE
refactor(option_as_ref_cloned): move the `method_call` call out of the `check`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5050,7 +5050,11 @@ impl Methods {
                 (sym::bytes, []) => unbuffered_bytes::check(cx, expr, recv),
                 (sym::cloned, []) => {
                     cloned_instead_of_copied::check(cx, expr, recv, span, self.msrv);
-                    option_as_ref_cloned::check(cx, recv, span);
+                    if let Some((method @ (sym::as_ref | sym::as_mut), as_ref_recv, [], as_ref_ident_span, _)) =
+                        method_call(recv)
+                    {
+                        option_as_ref_cloned::check(cx, span, method, as_ref_recv, as_ref_ident_span);
+                    }
                 },
                 (sym::collect, []) if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator) => {
                     needless_collect::check(cx, span, expr, recv, call_span);

--- a/clippy_lints/src/methods/option_as_ref_cloned.rs
+++ b/clippy_lints/src/methods/option_as_ref_cloned.rs
@@ -4,24 +4,28 @@ use clippy_utils::sym;
 use rustc_errors::Applicability;
 use rustc_hir::Expr;
 use rustc_lint::LateContext;
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 
-use super::{OPTION_AS_REF_CLONED, method_call};
+use super::OPTION_AS_REF_CLONED;
 
-pub(super) fn check(cx: &LateContext<'_>, cloned_recv: &Expr<'_>, cloned_ident_span: Span) {
-    if let Some((method @ (sym::as_ref | sym::as_mut), as_ref_recv, [], as_ref_ident_span, _)) =
-        method_call(cloned_recv)
-        && cx
-            .typeck_results()
-            .expr_ty(as_ref_recv)
-            .peel_refs()
-            .is_diag_item(cx, sym::Option)
+pub(super) fn check(
+    cx: &LateContext<'_>,
+    cloned_ident_span: Span,
+    as_ref_method: Symbol,
+    as_ref_recv: &Expr<'_>,
+    as_ref_ident_span: Span,
+) {
+    if cx
+        .typeck_results()
+        .expr_ty(as_ref_recv)
+        .peel_refs()
+        .is_diag_item(cx, sym::Option)
     {
         span_lint_and_sugg(
             cx,
             OPTION_AS_REF_CLONED,
             as_ref_ident_span.to(cloned_ident_span),
-            format!("cloning an `Option<_>` using `.{method}().cloned()`"),
+            format!("cloning an `Option<_>` using `.{as_ref_method}().cloned()`"),
             "this can be written more concisely by cloning the `Option<_>` directly",
             "clone".into(),
             Applicability::MachineApplicable,


### PR DESCRIPTION
This is more consistent with what the other `methods/` lints do.

changelog: none