### PR TITLE
fix(`manual_let_else`): expressions ending with `'}'`

### DIFF
--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -183,7 +183,13 @@ fn emit_manual_let_else(
                 format!("{{ {sn_else} }}")
             };
             let sn_bl = replace_in_pattern(cx, span, ident_map, pat, &mut app, true);
-            let sugg = format!("let {sn_bl} = {sn_expr} else {else_bl};");
+            let sugg = if sn_expr.ends_with('}') {
+                // let-else statement expressions are not allowed to end with `}`
+                // https://rust-lang.github.io/rfcs/3137-let-else.html#let-pattern--if--else--else-
+                format!("let {sn_bl} = ({sn_expr}) else {else_bl};")
+            } else {
+                format!("let {sn_bl} = {sn_expr} else {else_bl};")
+            };
             diag.span_suggestion(span, "consider writing", sugg, app);
         },
     );

--- a/tests/ui/manual_let_else.rs
+++ b/tests/ui/manual_let_else.rs
@@ -546,3 +546,28 @@ mod issue14598 {
         todo!()
     }
 }
+
+mod issue15914 {
+    // https://github.com/rust-lang/rust-clippy/issues/15914
+    unsafe fn something_unsafe() -> Option<u32> {
+        None
+    }
+
+    fn foo() {
+        let value = if let Some(value) = unsafe { something_unsafe() } {
+            //~^ manual_let_else
+            value
+        } else {
+            return;
+        };
+
+        let some_flag = true;
+
+        let value = if let Some(value) = if some_flag { None } else { Some(3) } {
+            //~^ manual_let_else
+            value
+        } else {
+            return;
+        };
+    }
+}

--- a/tests/ui/manual_let_else.stderr
+++ b/tests/ui/manual_let_else.stderr
@@ -549,5 +549,41 @@ LL | |             Some(x) => x,
 LL | |         };
    | |__________^ help: consider writing: `let Some(v) = w else { return Err("abc") };`
 
-error: aborting due to 35 previous errors
+error: this could be rewritten as `let...else`
+  --> tests/ui/manual_let_else.rs:557:9
+   |
+LL | /         let value = if let Some(value) = unsafe { something_unsafe() } {
+LL | |
+LL | |             value
+LL | |         } else {
+LL | |             return;
+LL | |         };
+   | |__________^
+   |
+help: consider writing
+   |
+LL ~         let Some(value) = (unsafe { something_unsafe() }) else {
+LL +             return;
+LL +         };
+   |
+
+error: this could be rewritten as `let...else`
+  --> tests/ui/manual_let_else.rs:566:9
+   |
+LL | /         let value = if let Some(value) = if some_flag { None } else { Some(3) } {
+LL | |
+LL | |             value
+LL | |         } else {
+LL | |             return;
+LL | |         };
+   | |__________^
+   |
+help: consider writing
+   |
+LL ~         let Some(value) = (if some_flag { None } else { Some(3) }) else {
+LL +             return;
+LL +         };
+   |
+
+error: aborting due to 37 previous errors
 


### PR DESCRIPTION
`let-else` statements do not allow the init expression to end with '}'

Fixes rust-lang/rust-clippy#15914

changelog: [`manual_let_else`]: If the init expression ends with `'}'` wrap it with `(...)` 
