### PR TITLE
`match_as_ref`: improve diagnostics

### DIFF
--- a/clippy_lints/src/matches/match_as_ref.rs
+++ b/clippy_lints/src/matches/match_as_ref.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::{MaybeDef, MaybeQPath};
-use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::option_arg_ty;
 use clippy_utils::{is_none_arm, peel_blocks};
 use rustc_errors::Applicability;
@@ -52,7 +52,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>], expr:
                     format!("use `Option::{method}()` directly"),
                     format!(
                         "{}.{method}(){cast}",
-                        snippet_with_applicability(cx, ex.span, "_", &mut applicability),
+                        Sugg::hir_with_applicability(cx, ex, "_", &mut applicability).maybe_paren(),
                     ),
                     applicability,
                 );

--- a/tests/ui/match_as_ref.fixed
+++ b/tests/ui/match_as_ref.fixed
@@ -71,3 +71,16 @@ mod issue15691 {
         };
     }
 }
+
+fn recv_requiring_parens() {
+    struct S;
+
+    impl std::ops::Not for S {
+        type Output = Option<u64>;
+        fn not(self) -> Self::Output {
+            None
+        }
+    }
+
+    let _ = (!S).as_ref();
+}

--- a/tests/ui/match_as_ref.rs
+++ b/tests/ui/match_as_ref.rs
@@ -83,3 +83,20 @@ mod issue15691 {
         };
     }
 }
+
+fn recv_requiring_parens() {
+    struct S;
+
+    impl std::ops::Not for S {
+        type Output = Option<u64>;
+        fn not(self) -> Self::Output {
+            None
+        }
+    }
+
+    let _ = match !S {
+        //~^ match_as_ref
+        None => None,
+        Some(ref v) => Some(v),
+    };
+}

--- a/tests/ui/match_as_ref.stderr
+++ b/tests/ui/match_as_ref.stderr
@@ -62,5 +62,26 @@ LL -             }
 LL +             self.source.as_ref().map(|x| x as _)
    |
 
-error: aborting due to 3 previous errors
+error: manual implementation of `Option::as_ref`
+  --> tests/ui/match_as_ref.rs:97:13
+   |
+LL |       let _ = match !S {
+   |  _____________^
+LL | |
+LL | |         None => None,
+LL | |         Some(ref v) => Some(v),
+LL | |     };
+   | |_____^
+   |
+help: use `Option::as_ref()` directly
+   |
+LL -     let _ = match !S {
+LL -
+LL -         None => None,
+LL -         Some(ref v) => Some(v),
+LL -     };
+LL +     let _ = (!S).as_ref();
+   |
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
- Make the diagnostic message actually desribe the problem
- Make the suggestion verbose, because we lint multiline exprs

changelog: [`match_as_ref`]: improve diagnostics