### PR TITLE
`unnecessary_{find,filter}_map`: make diagnostic spans more precise

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5162,13 +5162,13 @@ impl Methods {
                 },
                 (sym::filter_map, [arg]) => {
                     unused_enumerate_index::check(cx, expr, recv, arg);
-                    unnecessary_filter_map::check(cx, expr, arg, unnecessary_filter_map::Kind::FilterMap);
+                    unnecessary_filter_map::check(cx, expr, arg, call_span, unnecessary_filter_map::Kind::FilterMap);
                     filter_map_bool_then::check(cx, expr, arg, call_span);
                     filter_map_identity::check(cx, expr, arg, span);
                 },
                 (sym::find_map, [arg]) => {
                     unused_enumerate_index::check(cx, expr, recv, arg);
-                    unnecessary_filter_map::check(cx, expr, arg, unnecessary_filter_map::Kind::FindMap);
+                    unnecessary_filter_map::check(cx, expr, arg, call_span, unnecessary_filter_map::Kind::FindMap);
                 },
                 (sym::flat_map, [arg]) => {
                     unused_enumerate_index::check(cx, expr, recv, arg);

--- a/clippy_lints/src/methods/unnecessary_filter_map.rs
+++ b/clippy_lints/src/methods/unnecessary_filter_map.rs
@@ -9,11 +9,18 @@ use core::ops::ControlFlow;
 use rustc_hir as hir;
 use rustc_hir::LangItem::{OptionNone, OptionSome};
 use rustc_lint::LateContext;
+use rustc_span::Span;
 use std::fmt::Display;
 
 use super::{UNNECESSARY_FILTER_MAP, UNNECESSARY_FIND_MAP};
 
-pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>, arg: &'tcx hir::Expr<'tcx>, kind: Kind) {
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx hir::Expr<'tcx>,
+    arg: &'tcx hir::Expr<'tcx>,
+    call_span: Span,
+    kind: Kind,
+) {
     if !cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator) {
         return;
     }
@@ -47,7 +54,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>, a
                 span_lint(
                     cx,
                     UNNECESSARY_FILTER_MAP,
-                    expr.span,
+                    call_span,
                     String::from("this call to `.filter_map(..)` is unnecessary"),
                 );
                 return;
@@ -75,7 +82,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>, a
                 Kind::FilterMap => UNNECESSARY_FILTER_MAP,
                 Kind::FindMap => UNNECESSARY_FIND_MAP,
             },
-            expr.span,
+            call_span,
             format!("this `.{kind}(..)` can be written more simply using `.{sugg}`"),
         );
     }

--- a/tests/ui/unnecessary_filter_map.stderr
+++ b/tests/ui/unnecessary_filter_map.stderr
@@ -1,17 +1,17 @@
 error: this `.filter_map(..)` can be written more simply using `.filter(..)`
-  --> tests/ui/unnecessary_filter_map.rs:4:13
+  --> tests/ui/unnecessary_filter_map.rs:4:20
    |
 LL |     let _ = (0..4).filter_map(|x| if x > 1 { Some(x) } else { None });
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unnecessary-filter-map` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_filter_map)]`
 
 error: this `.filter_map(..)` can be written more simply using `.filter(..)`
-  --> tests/ui/unnecessary_filter_map.rs:7:13
+  --> tests/ui/unnecessary_filter_map.rs:7:20
    |
 LL |       let _ = (0..4).filter_map(|x| {
-   |  _____________^
+   |  ____________________^
 LL | |
 LL | |
 LL | |         if x > 1 {
@@ -21,10 +21,10 @@ LL | |     });
    | |______^
 
 error: this `.filter_map(..)` can be written more simply using `.filter(..)`
-  --> tests/ui/unnecessary_filter_map.rs:15:13
+  --> tests/ui/unnecessary_filter_map.rs:15:20
    |
 LL |       let _ = (0..4).filter_map(|x| match x {
-   |  _____________^
+   |  ____________________^
 LL | |
 LL | |         0 | 1 => None,
 LL | |         _ => Some(x),
@@ -32,22 +32,22 @@ LL | |     });
    | |______^
 
 error: this `.filter_map(..)` can be written more simply using `.map(..)`
-  --> tests/ui/unnecessary_filter_map.rs:21:13
+  --> tests/ui/unnecessary_filter_map.rs:21:20
    |
 LL |     let _ = (0..4).filter_map(|x| Some(x + 1));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `.filter_map(..)` is unnecessary
-  --> tests/ui/unnecessary_filter_map.rs:28:61
+  --> tests/ui/unnecessary_filter_map.rs:28:46
    |
 LL |     let _ = vec![Some(10), None].into_iter().filter_map(|x| Some(x));
-   |                                                             ^^^^
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `.filter_map(..)` can be written more simply using `.filter(..)`
-  --> tests/ui/unnecessary_filter_map.rs:166:14
+  --> tests/ui/unnecessary_filter_map.rs:166:33
    |
 LL |     let _x = std::iter::once(1).filter_map(|n| (n > 1).then_some(n));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/unnecessary_find_map.rs
+++ b/tests/ui/unnecessary_find_map.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 fn main() {
     let _ = (0..4).find_map(|x| if x > 1 { Some(x) } else { None });
     //~^ unnecessary_find_map

--- a/tests/ui/unnecessary_find_map.stderr
+++ b/tests/ui/unnecessary_find_map.stderr
@@ -1,17 +1,17 @@
 error: this `.find_map(..)` can be written more simply using `.find(..)`
-  --> tests/ui/unnecessary_find_map.rs:4:13
+  --> tests/ui/unnecessary_find_map.rs:2:20
    |
 LL |     let _ = (0..4).find_map(|x| if x > 1 { Some(x) } else { None });
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unnecessary-find-map` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_find_map)]`
 
 error: this `.find_map(..)` can be written more simply using `.find(..)`
-  --> tests/ui/unnecessary_find_map.rs:7:13
+  --> tests/ui/unnecessary_find_map.rs:5:20
    |
 LL |       let _ = (0..4).find_map(|x| {
-   |  _____________^
+   |  ____________________^
 LL | |
 LL | |
 LL | |         if x > 1 {
@@ -21,10 +21,10 @@ LL | |     });
    | |______^
 
 error: this `.find_map(..)` can be written more simply using `.find(..)`
-  --> tests/ui/unnecessary_find_map.rs:15:13
+  --> tests/ui/unnecessary_find_map.rs:13:20
    |
 LL |       let _ = (0..4).find_map(|x| match x {
-   |  _____________^
+   |  ____________________^
 LL | |
 LL | |         0 | 1 => None,
 LL | |         _ => Some(x),
@@ -32,16 +32,16 @@ LL | |     });
    | |______^
 
 error: this `.find_map(..)` can be written more simply using `.map(..).next()`
-  --> tests/ui/unnecessary_find_map.rs:21:13
+  --> tests/ui/unnecessary_find_map.rs:19:20
    |
 LL |     let _ = (0..4).find_map(|x| Some(x + 1));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `.find_map(..)` can be written more simply using `.find(..)`
-  --> tests/ui/unnecessary_find_map.rs:33:14
+  --> tests/ui/unnecessary_find_map.rs:31:33
    |
 LL |     let _x = std::iter::once(1).find_map(|n| (n > 1).then_some(n));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
changelog: [`unnecessary_find_map`]: make diagnostic spans more precise
changelog: [`unnecessary_filter_map`]: make diagnostic spans more precise