### PR TITLE
Fix `if_not_else` wrong unmangled macros

### DIFF
--- a/tests/ui/if_not_else.fixed
+++ b/tests/ui/if_not_else.fixed
@@ -76,3 +76,20 @@ fn with_annotations() {
         println!("foo is false");
     }
 }
+
+fn issue15924() {
+    let x = 0;
+    if matches!(x, 0..10) {
+        println!(":(");
+    } else {
+        //~^ if_not_else
+        println!(":)");
+    }
+
+    if dbg!(x) == 1 {
+        println!(":(");
+    } else {
+        //~^ if_not_else
+        println!(":)");
+    }
+}

--- a/tests/ui/if_not_else.rs
+++ b/tests/ui/if_not_else.rs
@@ -76,3 +76,20 @@ fn with_annotations() {
         println!("foo"); /* foo */
     }
 }
+
+fn issue15924() {
+    let x = 0;
+    if !matches!(x, 0..10) {
+        //~^ if_not_else
+        println!(":)");
+    } else {
+        println!(":(");
+    }
+
+    if dbg!(x) != 1 {
+        //~^ if_not_else
+        println!(":)");
+    } else {
+        println!(":(");
+    }
+}

--- a/tests/ui/if_not_else.stderr
+++ b/tests/ui/if_not_else.stderr
@@ -147,5 +147,47 @@ LL +         println!("foo is false");
 LL +     }
    |
 
-error: aborting due to 6 previous errors
+error: unnecessary boolean `not` operation
+  --> tests/ui/if_not_else.rs:82:5
+   |
+LL | /     if !matches!(x, 0..10) {
+LL | |
+LL | |         println!(":)");
+LL | |     } else {
+LL | |         println!(":(");
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if matches!(x, 0..10) {
+LL +         println!(":(");
+LL +     } else {
+LL +
+LL +         println!(":)");
+LL +     }
+   |
+
+error: unnecessary `!=` operation
+  --> tests/ui/if_not_else.rs:89:5
+   |
+LL | /     if dbg!(x) != 1 {
+LL | |
+LL | |         println!(":)");
+LL | |     } else {
+LL | |         println!(":(");
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if dbg!(x) == 1 {
+LL +         println!(":(");
+LL +     } else {
+LL +
+LL +         println!(":)");
+LL +     }
+   |
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15924

changelog: [`if_not_else`] fix wrongly unmangled macros
