### PR TITLE
fix(match_as_ref): also suggest downcasting references

### DIFF
--- a/tests/ui/match_as_ref.fixed
+++ b/tests/ui/match_as_ref.fixed
@@ -84,3 +84,9 @@ fn recv_requiring_parens() {
 
     let _ = (!S).as_ref();
 }
+
+fn issue15932() {
+    let _: Option<&i32> = Some(0).as_mut().map(|x| x as _);
+
+    let _: Option<&dyn std::fmt::Debug> = Some(0).as_mut().map(|x| x as _);
+}

--- a/tests/ui/match_as_ref.rs
+++ b/tests/ui/match_as_ref.rs
@@ -100,3 +100,17 @@ fn recv_requiring_parens() {
         Some(ref v) => Some(v),
     };
 }
+
+fn issue15932() {
+    let _: Option<&i32> = match Some(0) {
+        //~^ match_as_ref
+        None => None,
+        Some(ref mut v) => Some(v),
+    };
+
+    let _: Option<&dyn std::fmt::Debug> = match Some(0) {
+        //~^ match_as_ref
+        None => None,
+        Some(ref mut v) => Some(v),
+    };
+}

--- a/tests/ui/match_as_ref.stderr
+++ b/tests/ui/match_as_ref.stderr
@@ -83,5 +83,47 @@ LL -     };
 LL +     let _ = (!S).as_ref();
    |
 
-error: aborting due to 4 previous errors
+error: manual implementation of `Option::as_mut`
+  --> tests/ui/match_as_ref.rs:105:27
+   |
+LL |       let _: Option<&i32> = match Some(0) {
+   |  ___________________________^
+LL | |
+LL | |         None => None,
+LL | |         Some(ref mut v) => Some(v),
+LL | |     };
+   | |_____^
+   |
+help: use `Option::as_mut()` directly
+   |
+LL -     let _: Option<&i32> = match Some(0) {
+LL -
+LL -         None => None,
+LL -         Some(ref mut v) => Some(v),
+LL -     };
+LL +     let _: Option<&i32> = Some(0).as_mut().map(|x| x as _);
+   |
+
+error: manual implementation of `Option::as_mut`
+  --> tests/ui/match_as_ref.rs:111:43
+   |
+LL |       let _: Option<&dyn std::fmt::Debug> = match Some(0) {
+   |  ___________________________________________^
+LL | |
+LL | |         None => None,
+LL | |         Some(ref mut v) => Some(v),
+LL | |     };
+   | |_____^
+   |
+help: use `Option::as_mut()` directly
+   |
+LL -     let _: Option<&dyn std::fmt::Debug> = match Some(0) {
+LL -
+LL -         None => None,
+LL -         Some(ref mut v) => Some(v),
+LL -     };
+LL +     let _: Option<&dyn std::fmt::Debug> = Some(0).as_mut().map(|x| x as _);
+   |
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
v2 of https://github.com/rust-lang/rust-clippy/pull/15934

changelog: [`match_as_ref`]: also suggest downcasting references

r? @samueltardieu 