### PR TITLE
chore(needless_if): rename to `needless_ifs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6584,6 +6584,7 @@ Released 2018-09-13
 [`needless_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_else
 [`needless_for_each`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each
 [`needless_if`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_if
+[`needless_ifs`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_ifs
 [`needless_late_init`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
 [`needless_lifetimes`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
 [`needless_match`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_match

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -544,7 +544,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::needless_continue::NEEDLESS_CONTINUE_INFO,
     crate::needless_else::NEEDLESS_ELSE_INFO,
     crate::needless_for_each::NEEDLESS_FOR_EACH_INFO,
-    crate::needless_if::NEEDLESS_IF_INFO,
+    crate::needless_ifs::NEEDLESS_IFS_INFO,
     crate::needless_late_init::NEEDLESS_LATE_INIT_INFO,
     crate::needless_maybe_sized::NEEDLESS_MAYBE_SIZED_INFO,
     crate::needless_parens_on_range_literals::NEEDLESS_PARENS_ON_RANGE_LITERALS_INFO,

--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -139,6 +139,8 @@ declare_with_version! { RENAMED(RENAMED_VERSION) = [
     ("clippy::mem_discriminant_non_enum", "enum_intrinsics_non_enums"),
     #[clippy::version = "1.80.0"]
     ("clippy::mismatched_target_os", "unexpected_cfgs"),
+    #[clippy::version = "1.92.0"]
+    ("clippy::needless_if", "clippy::needless_ifs"),
     #[clippy::version = ""]
     ("clippy::new_without_default_derive", "clippy::new_without_default"),
     #[clippy::version = ""]

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -253,7 +253,7 @@ mod needless_borrows_for_generic_args;
 mod needless_continue;
 mod needless_else;
 mod needless_for_each;
-mod needless_if;
+mod needless_ifs;
 mod needless_late_init;
 mod needless_maybe_sized;
 mod needless_parens_on_range_literals;
@@ -752,7 +752,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     store.register_late_pass(|_| Box::new(endian_bytes::EndianBytes));
     store.register_late_pass(|_| Box::new(redundant_type_annotations::RedundantTypeAnnotations));
     store.register_late_pass(|_| Box::new(arc_with_non_send_sync::ArcWithNonSendSync));
-    store.register_late_pass(|_| Box::new(needless_if::NeedlessIf));
+    store.register_late_pass(|_| Box::new(needless_ifs::NeedlessIfs));
     store.register_late_pass(move |_| Box::new(min_ident_chars::MinIdentChars::new(conf)));
     store.register_late_pass(move |_| Box::new(large_stack_frames::LargeStackFrames::new(conf)));
     store.register_late_pass(|_| Box::new(single_range_in_vec_init::SingleRangeInVecInit));

--- a/clippy_lints/src/needless_ifs.rs
+++ b/clippy_lints/src/needless_ifs.rs
@@ -29,13 +29,13 @@ declare_clippy_lint! {
     /// really_expensive_condition_with_side_effects(&mut i);
     /// ```
     #[clippy::version = "1.72.0"]
-    pub NEEDLESS_IF,
+    pub NEEDLESS_IFS,
     complexity,
     "checks for empty if branches"
 }
-declare_lint_pass!(NeedlessIf => [NEEDLESS_IF]);
+declare_lint_pass!(NeedlessIfs => [NEEDLESS_IFS]);
 
-impl LateLintPass<'_> for NeedlessIf {
+impl LateLintPass<'_> for NeedlessIfs {
     fn check_stmt<'tcx>(&mut self, cx: &LateContext<'tcx>, stmt: &Stmt<'tcx>) {
         if let StmtKind::Expr(expr) = stmt.kind
             && let Some(If {
@@ -62,7 +62,7 @@ impl LateLintPass<'_> for NeedlessIf {
         {
             span_lint_and_sugg(
                 cx,
-                NEEDLESS_IF,
+                NEEDLESS_IFS,
                 stmt.span,
                 "this `if` branch is empty",
                 "you can remove it",

--- a/tests/ui-toml/excessive_nesting/excessive_nesting.rs
+++ b/tests/ui-toml/excessive_nesting/excessive_nesting.rs
@@ -9,7 +9,7 @@
     clippy::no_effect,
     clippy::unnecessary_operation,
     clippy::never_loop,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::collapsible_if,
     clippy::blocks_in_conditions,
     clippy::single_match,

--- a/tests/ui/auxiliary/proc_macros.rs
+++ b/tests/ui/auxiliary/proc_macros.rs
@@ -1,5 +1,5 @@
 #![feature(proc_macro_span)]
-#![allow(clippy::needless_if, dead_code)]
+#![allow(clippy::needless_ifs, dead_code)]
 
 extern crate proc_macro;
 

--- a/tests/ui/blocks_in_conditions.fixed
+++ b/tests/ui/blocks_in_conditions.fixed
@@ -4,7 +4,7 @@
 #![allow(
     unused,
     unnecessary_transmutes,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::missing_transmute_annotations
 )]
 #![warn(clippy::nonminimal_bool)]

--- a/tests/ui/blocks_in_conditions.rs
+++ b/tests/ui/blocks_in_conditions.rs
@@ -4,7 +4,7 @@
 #![allow(
     unused,
     unnecessary_transmutes,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::missing_transmute_annotations
 )]
 #![warn(clippy::nonminimal_bool)]

--- a/tests/ui/bool_comparison.fixed
+++ b/tests/ui/bool_comparison.fixed
@@ -1,4 +1,4 @@
-#![allow(non_local_definitions, clippy::needless_if)]
+#![allow(non_local_definitions, clippy::needless_ifs)]
 #![warn(clippy::bool_comparison)]
 #![allow(clippy::non_canonical_partial_ord_impl)]
 

--- a/tests/ui/bool_comparison.rs
+++ b/tests/ui/bool_comparison.rs
@@ -1,4 +1,4 @@
-#![allow(non_local_definitions, clippy::needless_if)]
+#![allow(non_local_definitions, clippy::needless_ifs)]
 #![warn(clippy::bool_comparison)]
 #![allow(clippy::non_canonical_partial_ord_impl)]
 

--- a/tests/ui/cmp_owned/asymmetric_partial_eq.fixed
+++ b/tests/ui/cmp_owned/asymmetric_partial_eq.fixed
@@ -1,6 +1,6 @@
 #![allow(
     unused,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::redundant_clone,
     clippy::derive_partial_eq_without_eq
 )] // See #5700

--- a/tests/ui/cmp_owned/asymmetric_partial_eq.rs
+++ b/tests/ui/cmp_owned/asymmetric_partial_eq.rs
@@ -1,6 +1,6 @@
 #![allow(
     unused,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::redundant_clone,
     clippy::derive_partial_eq_without_eq
 )] // See #5700

--- a/tests/ui/collapsible_else_if.fixed
+++ b/tests/ui/collapsible_else_if.fixed
@@ -1,4 +1,4 @@
-#![allow(clippy::assertions_on_constants, clippy::equatable_if_let, clippy::needless_if)]
+#![allow(clippy::assertions_on_constants, clippy::equatable_if_let, clippy::needless_ifs)]
 #![warn(clippy::collapsible_if, clippy::collapsible_else_if)]
 
 #[rustfmt::skip]

--- a/tests/ui/collapsible_else_if.rs
+++ b/tests/ui/collapsible_else_if.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::assertions_on_constants, clippy::equatable_if_let, clippy::needless_if)]
+#![allow(clippy::assertions_on_constants, clippy::equatable_if_let, clippy::needless_ifs)]
 #![warn(clippy::collapsible_if, clippy::collapsible_else_if)]
 
 #[rustfmt::skip]

--- a/tests/ui/collapsible_if.fixed
+++ b/tests/ui/collapsible_if.fixed
@@ -1,7 +1,7 @@
 #![allow(
     clippy::assertions_on_constants,
     clippy::equatable_if_let,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::nonminimal_bool,
     clippy::eq_op,
     clippy::redundant_pattern_matching

--- a/tests/ui/collapsible_if.rs
+++ b/tests/ui/collapsible_if.rs
@@ -1,7 +1,7 @@
 #![allow(
     clippy::assertions_on_constants,
     clippy::equatable_if_let,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::nonminimal_bool,
     clippy::eq_op,
     clippy::redundant_pattern_matching

--- a/tests/ui/comparison_to_empty.fixed
+++ b/tests/ui/comparison_to_empty.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::comparison_to_empty)]
-#![allow(clippy::borrow_deref_ref, clippy::needless_if, clippy::useless_vec)]
+#![allow(clippy::borrow_deref_ref, clippy::needless_ifs, clippy::useless_vec)]
 
 fn main() {
     // Disallow comparisons to empty

--- a/tests/ui/comparison_to_empty.rs
+++ b/tests/ui/comparison_to_empty.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::comparison_to_empty)]
-#![allow(clippy::borrow_deref_ref, clippy::needless_if, clippy::useless_vec)]
+#![allow(clippy::borrow_deref_ref, clippy::needless_ifs, clippy::useless_vec)]
 
 fn main() {
     // Disallow comparisons to empty

--- a/tests/ui/crashes/ice-7169.fixed
+++ b/tests/ui/crashes/ice-7169.fixed
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 #[derive(Default)]
 struct A<T> {

--- a/tests/ui/crashes/ice-7169.rs
+++ b/tests/ui/crashes/ice-7169.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 #[derive(Default)]
 struct A<T> {

--- a/tests/ui/disallowed_names.rs
+++ b/tests/ui/disallowed_names.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 #![allow(
     dead_code,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::similar_names,
     clippy::single_match,
     clippy::toplevel_ref_arg,

--- a/tests/ui/double_comparison.fixed
+++ b/tests/ui/double_comparison.fixed
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 fn main() {
     let x = 1;

--- a/tests/ui/double_comparison.rs
+++ b/tests/ui/double_comparison.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 fn main() {
     let x = 1;

--- a/tests/ui/equatable_if_let.fixed
+++ b/tests/ui/equatable_if_let.fixed
@@ -4,7 +4,7 @@
     unused_variables,
     dead_code,
     clippy::derive_partial_eq_without_eq,
-    clippy::needless_if
+    clippy::needless_ifs
 )]
 #![warn(clippy::equatable_if_let)]
 

--- a/tests/ui/equatable_if_let.rs
+++ b/tests/ui/equatable_if_let.rs
@@ -4,7 +4,7 @@
     unused_variables,
     dead_code,
     clippy::derive_partial_eq_without_eq,
-    clippy::needless_if
+    clippy::needless_ifs
 )]
 #![warn(clippy::equatable_if_let)]
 

--- a/tests/ui/expect_tool_lint_rfc_2383.rs
+++ b/tests/ui/expect_tool_lint_rfc_2383.rs
@@ -10,7 +10,7 @@
 //! This test can't cover every lint from Clippy, rustdoc and potentially other
 //! tools that will be developed. This therefore only tests a small subset of lints
 #![expect(rustdoc::missing_crate_level_docs)]
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 mod rustc_ok {
     //! See <https://doc.rust-lang.org/rustc/lints/index.html>

--- a/tests/ui/filetype_is_file.rs
+++ b/tests/ui/filetype_is_file.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 #![warn(clippy::filetype_is_file)]
 
 fn main() -> std::io::Result<()> {

--- a/tests/ui/if_same_then_else2.rs
+++ b/tests/ui/if_same_then_else2.rs
@@ -5,7 +5,7 @@
     clippy::equatable_if_let,
     clippy::collapsible_if,
     clippy::ifs_same_cond,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::needless_return,
     clippy::single_element_loop,
     clippy::branches_sharing_code

--- a/tests/ui/ifs_same_cond.rs
+++ b/tests/ui/ifs_same_cond.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::ifs_same_cond)]
-#![allow(clippy::if_same_then_else, clippy::needless_if, clippy::needless_else)] // all empty blocks
+#![allow(clippy::if_same_then_else, clippy::needless_ifs, clippy::needless_else)] // all empty blocks
 
 fn ifs_same_cond() {
     let a = 0;

--- a/tests/ui/len_zero.fixed
+++ b/tests/ui/len_zero.fixed
@@ -2,7 +2,7 @@
 #![allow(
     dead_code,
     unused,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::len_without_is_empty,
     clippy::const_is_empty
 )]

--- a/tests/ui/len_zero.rs
+++ b/tests/ui/len_zero.rs
@@ -2,7 +2,7 @@
 #![allow(
     dead_code,
     unused,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::len_without_is_empty,
     clippy::const_is_empty
 )]

--- a/tests/ui/manual_float_methods.rs
+++ b/tests/ui/manual_float_methods.rs
@@ -1,6 +1,6 @@
 //@no-rustfix: overlapping suggestions
 //@aux-build:proc_macros.rs
-#![allow(clippy::needless_if, unused)]
+#![allow(clippy::needless_ifs, unused)]
 #![warn(clippy::manual_is_infinite, clippy::manual_is_finite)]
 
 // FIXME(f16_f128): add tests for these types once constants are available

--- a/tests/ui/manual_let_else.rs
+++ b/tests/ui/manual_let_else.rs
@@ -6,7 +6,7 @@
     clippy::let_unit_value,
     clippy::match_single_binding,
     clippy::never_loop,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::diverging_sub_expression,
     clippy::single_match,
     clippy::manual_unwrap_or_default

--- a/tests/ui/match_overlapping_arm.rs
+++ b/tests/ui/match_overlapping_arm.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::match_overlapping_arm)]
 #![allow(clippy::redundant_pattern_matching)]
-#![allow(clippy::if_same_then_else, clippy::equatable_if_let, clippy::needless_if)]
+#![allow(clippy::if_same_then_else, clippy::equatable_if_let, clippy::needless_ifs)]
 
 fn overlapping() {
     const FOO: u64 = 2;

--- a/tests/ui/needless_bool/fixable.fixed
+++ b/tests/ui/needless_bool/fixable.fixed
@@ -5,7 +5,7 @@
     clippy::no_effect,
     clippy::if_same_then_else,
     clippy::equatable_if_let,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::needless_return,
     clippy::self_named_constructors,
     clippy::struct_field_names

--- a/tests/ui/needless_bool/fixable.rs
+++ b/tests/ui/needless_bool/fixable.rs
@@ -5,7 +5,7 @@
     clippy::no_effect,
     clippy::if_same_then_else,
     clippy::equatable_if_let,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::needless_return,
     clippy::self_named_constructors,
     clippy::struct_field_names

--- a/tests/ui/needless_borrowed_ref.fixed
+++ b/tests/ui/needless_borrowed_ref.fixed
@@ -4,7 +4,7 @@
     irrefutable_let_patterns,
     non_shorthand_field_patterns,
     clippy::needless_borrow,
-    clippy::needless_if
+    clippy::needless_ifs
 )]
 
 fn main() {}

--- a/tests/ui/needless_borrowed_ref.rs
+++ b/tests/ui/needless_borrowed_ref.rs
@@ -4,7 +4,7 @@
     irrefutable_let_patterns,
     non_shorthand_field_patterns,
     clippy::needless_borrow,
-    clippy::needless_if
+    clippy::needless_ifs
 )]
 
 fn main() {}

--- a/tests/ui/needless_collect.fixed
+++ b/tests/ui/needless_collect.fixed
@@ -1,6 +1,6 @@
 #![allow(
     unused,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::suspicious_map,
     clippy::iter_count,
     clippy::manual_contains

--- a/tests/ui/needless_collect.rs
+++ b/tests/ui/needless_collect.rs
@@ -1,6 +1,6 @@
 #![allow(
     unused,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::suspicious_map,
     clippy::iter_count,
     clippy::manual_contains

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::uninlined_format_args, clippy::useless_vec, clippy::needless_if)]
+#![allow(clippy::uninlined_format_args, clippy::useless_vec, clippy::needless_ifs)]
 #![warn(clippy::needless_collect)]
 //@no-rustfix
 use std::collections::{BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};

--- a/tests/ui/needless_ifs.fixed
+++ b/tests/ui/needless_ifs.fixed
@@ -12,7 +12,7 @@
     clippy::redundant_pattern_matching,
     unused
 )]
-#![warn(clippy::needless_if)]
+#![warn(clippy::needless_ifs)]
 
 extern crate proc_macros;
 use proc_macros::{external, with_span};
@@ -23,19 +23,19 @@ fn maybe_side_effect() -> bool {
 
 fn main() {
     // Lint
-    if (true) {}
-    //~^ needless_if
+    
+    //~^ needless_ifs
     // Do not remove the condition
-    if maybe_side_effect() {}
-    //~^ needless_if
+    maybe_side_effect();
+    //~^ needless_ifs
     // Do not lint
     if (true) {
     } else {
     }
-    if {
-        //~^ needless_if
+    ({
+        //~^ needless_ifs
         return;
-    } {}
+    });
     // Do not lint if `else if` is present
     if (true) {
     } else if (true) {
@@ -47,8 +47,8 @@ fn main() {
     {}
     if true && let true = true {}
     // Can lint nested `if let`s
-    if {
-        //~^ needless_if
+    ({
+        //~^ needless_ifs
         if let true = true
             && true
         {
@@ -56,8 +56,7 @@ fn main() {
         } else {
             false
         }
-    } && true
-    {}
+    } && true);
     external! { if (true) {} }
     with_span! {
         span
@@ -92,25 +91,25 @@ fn main() {
     empty_repetition!();
 
     // Must be placed into an expression context to not be interpreted as a block
-    if { maybe_side_effect() } {}
-    //~^ needless_if
+    ({ maybe_side_effect() });
+    //~^ needless_ifs
     // Would be a block followed by `&&true` - a double reference to `true`
-    if { maybe_side_effect() } && true {}
-    //~^ needless_if
+    ({ maybe_side_effect() } && true);
+    //~^ needless_ifs
 
     // Don't leave trailing attributes
     #[allow(unused)]
-    if true {}
-    //~^ needless_if
+    true;
+    //~^ needless_ifs
 
     let () = if maybe_side_effect() {};
 }
 
 fn issue15960() -> i32 {
-    if matches!(2, 3) {}
-    //~^ needless_if
-    if matches!(2, 3) == (2 * 2 == 5) {}
-    //~^ needless_if
+    matches!(2, 3);
+    //~^ needless_ifs
+    matches!(2, 3) == (2 * 2 == 5);
+    //~^ needless_ifs
 
     1 // put something here so that `if` is a statement not an expression
 }

--- a/tests/ui/needless_ifs.rs
+++ b/tests/ui/needless_ifs.rs
@@ -12,7 +12,7 @@
     clippy::redundant_pattern_matching,
     unused
 )]
-#![warn(clippy::needless_if)]
+#![warn(clippy::needless_ifs)]
 
 extern crate proc_macros;
 use proc_macros::{external, with_span};
@@ -23,19 +23,19 @@ fn maybe_side_effect() -> bool {
 
 fn main() {
     // Lint
-    
-    //~^ needless_if
+    if (true) {}
+    //~^ needless_ifs
     // Do not remove the condition
-    maybe_side_effect();
-    //~^ needless_if
+    if maybe_side_effect() {}
+    //~^ needless_ifs
     // Do not lint
     if (true) {
     } else {
     }
-    ({
-        //~^ needless_if
+    if {
+        //~^ needless_ifs
         return;
-    });
+    } {}
     // Do not lint if `else if` is present
     if (true) {
     } else if (true) {
@@ -47,8 +47,8 @@ fn main() {
     {}
     if true && let true = true {}
     // Can lint nested `if let`s
-    ({
-        //~^ needless_if
+    if {
+        //~^ needless_ifs
         if let true = true
             && true
         {
@@ -56,7 +56,8 @@ fn main() {
         } else {
             false
         }
-    } && true);
+    } && true
+    {}
     external! { if (true) {} }
     with_span! {
         span
@@ -91,25 +92,25 @@ fn main() {
     empty_repetition!();
 
     // Must be placed into an expression context to not be interpreted as a block
-    ({ maybe_side_effect() });
-    //~^ needless_if
+    if { maybe_side_effect() } {}
+    //~^ needless_ifs
     // Would be a block followed by `&&true` - a double reference to `true`
-    ({ maybe_side_effect() } && true);
-    //~^ needless_if
+    if { maybe_side_effect() } && true {}
+    //~^ needless_ifs
 
     // Don't leave trailing attributes
     #[allow(unused)]
-    true;
-    //~^ needless_if
+    if true {}
+    //~^ needless_ifs
 
     let () = if maybe_side_effect() {};
 }
 
 fn issue15960() -> i32 {
-    matches!(2, 3);
-    //~^ needless_if
-    matches!(2, 3) == (2 * 2 == 5);
-    //~^ needless_if
+    if matches!(2, 3) {}
+    //~^ needless_ifs
+    if matches!(2, 3) == (2 * 2 == 5) {}
+    //~^ needless_ifs
 
     1 // put something here so that `if` is a statement not an expression
 }

--- a/tests/ui/needless_ifs.stderr
+++ b/tests/ui/needless_ifs.stderr
@@ -1,20 +1,20 @@
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:26:5
+  --> tests/ui/needless_ifs.rs:26:5
    |
 LL |     if (true) {}
    |     ^^^^^^^^^^^^ help: you can remove it
    |
-   = note: `-D clippy::needless-if` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::needless_if)]`
+   = note: `-D clippy::needless-ifs` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::needless_ifs)]`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:29:5
+  --> tests/ui/needless_ifs.rs:29:5
    |
 LL |     if maybe_side_effect() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `maybe_side_effect();`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:35:5
+  --> tests/ui/needless_ifs.rs:35:5
    |
 LL | /     if {
 LL | |
@@ -31,7 +31,7 @@ LL +     });
    |
 
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:50:5
+  --> tests/ui/needless_ifs.rs:50:5
    |
 LL | /     if {
 LL | |
@@ -57,31 +57,31 @@ LL +     } && true);
    |
 
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:95:5
+  --> tests/ui/needless_ifs.rs:95:5
    |
 LL |     if { maybe_side_effect() } {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `({ maybe_side_effect() });`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:98:5
+  --> tests/ui/needless_ifs.rs:98:5
    |
 LL |     if { maybe_side_effect() } && true {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `({ maybe_side_effect() } && true);`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:103:5
+  --> tests/ui/needless_ifs.rs:103:5
    |
 LL |     if true {}
    |     ^^^^^^^^^^ help: you can remove it: `true;`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:110:5
+  --> tests/ui/needless_ifs.rs:110:5
    |
 LL |     if matches!(2, 3) {}
    |     ^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `matches!(2, 3);`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_if.rs:112:5
+  --> tests/ui/needless_ifs.rs:112:5
    |
 LL |     if matches!(2, 3) == (2 * 2 == 5) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `matches!(2, 3) == (2 * 2 == 5);`

--- a/tests/ui/nonminimal_bool.rs
+++ b/tests/ui/nonminimal_bool.rs
@@ -2,7 +2,7 @@
 #![allow(
     unused,
     clippy::diverging_sub_expression,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::redundant_pattern_matching
 )]
 #![warn(clippy::nonminimal_bool)]

--- a/tests/ui/nonminimal_bool_methods.fixed
+++ b/tests/ui/nonminimal_bool_methods.fixed
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::diverging_sub_expression, clippy::needless_if)]
+#![allow(unused, clippy::diverging_sub_expression, clippy::needless_ifs)]
 #![warn(clippy::nonminimal_bool)]
 
 fn methods_with_negation() {

--- a/tests/ui/nonminimal_bool_methods.rs
+++ b/tests/ui/nonminimal_bool_methods.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::diverging_sub_expression, clippy::needless_if)]
+#![allow(unused, clippy::diverging_sub_expression, clippy::needless_ifs)]
 #![warn(clippy::nonminimal_bool)]
 
 fn methods_with_negation() {

--- a/tests/ui/op_ref.fixed
+++ b/tests/ui/op_ref.fixed
@@ -111,7 +111,7 @@ mod issue_2597 {
     }
 }
 
-#[allow(clippy::needless_if)]
+#[allow(clippy::needless_ifs)]
 fn issue15063() {
     use std::ops::BitAnd;
 

--- a/tests/ui/op_ref.rs
+++ b/tests/ui/op_ref.rs
@@ -111,7 +111,7 @@ mod issue_2597 {
     }
 }
 
-#[allow(clippy::needless_if)]
+#[allow(clippy::needless_ifs)]
 fn issue15063() {
     use std::ops::BitAnd;
 

--- a/tests/ui/panicking_overflow_checks.rs
+++ b/tests/ui/panicking_overflow_checks.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::panicking_overflow_checks)]
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 fn test(a: u32, b: u32, c: u32) {
     if a + b < a {}

--- a/tests/ui/partialeq_to_none.fixed
+++ b/tests/ui/partialeq_to_none.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op, clippy::needless_if)]
+#![allow(clippy::eq_op, clippy::needless_ifs)]
 
 struct Foobar;
 

--- a/tests/ui/partialeq_to_none.rs
+++ b/tests/ui/partialeq_to_none.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op, clippy::needless_if)]
+#![allow(clippy::eq_op, clippy::needless_ifs)]
 
 struct Foobar;
 

--- a/tests/ui/redundant_pattern_matching_drop_order.fixed
+++ b/tests/ui/redundant_pattern_matching_drop_order.fixed
@@ -3,7 +3,7 @@
 #![allow(
     clippy::if_same_then_else,
     clippy::equatable_if_let,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::needless_else
 )]
 use std::task::Poll::{Pending, Ready};

--- a/tests/ui/redundant_pattern_matching_drop_order.rs
+++ b/tests/ui/redundant_pattern_matching_drop_order.rs
@@ -3,7 +3,7 @@
 #![allow(
     clippy::if_same_then_else,
     clippy::equatable_if_let,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::needless_else
 )]
 use std::task::Poll::{Pending, Ready};

--- a/tests/ui/redundant_pattern_matching_if_let_true.fixed
+++ b/tests/ui/redundant_pattern_matching_if_let_true.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::redundant_pattern_matching)]
-#![allow(clippy::needless_if, clippy::no_effect, clippy::nonminimal_bool)]
+#![allow(clippy::needless_ifs, clippy::no_effect, clippy::nonminimal_bool)]
 
 macro_rules! condition {
     () => {

--- a/tests/ui/redundant_pattern_matching_if_let_true.rs
+++ b/tests/ui/redundant_pattern_matching_if_let_true.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::redundant_pattern_matching)]
-#![allow(clippy::needless_if, clippy::no_effect, clippy::nonminimal_bool)]
+#![allow(clippy::needless_ifs, clippy::no_effect, clippy::nonminimal_bool)]
 
 macro_rules! condition {
     () => {

--- a/tests/ui/redundant_pattern_matching_ipaddr.fixed
+++ b/tests/ui/redundant_pattern_matching_ipaddr.fixed
@@ -2,7 +2,7 @@
 #![allow(
     clippy::match_like_matches_macro,
     clippy::needless_bool,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::uninlined_format_args
 )]
 

--- a/tests/ui/redundant_pattern_matching_ipaddr.rs
+++ b/tests/ui/redundant_pattern_matching_ipaddr.rs
@@ -2,7 +2,7 @@
 #![allow(
     clippy::match_like_matches_macro,
     clippy::needless_bool,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::uninlined_format_args
 )]
 

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -2,7 +2,7 @@
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
     clippy::needless_bool,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -2,7 +2,7 @@
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
     clippy::needless_bool,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else

--- a/tests/ui/redundant_pattern_matching_poll.fixed
+++ b/tests/ui/redundant_pattern_matching_poll.fixed
@@ -1,7 +1,7 @@
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
     clippy::needless_bool,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else

--- a/tests/ui/redundant_pattern_matching_poll.rs
+++ b/tests/ui/redundant_pattern_matching_poll.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
     clippy::needless_bool,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -4,7 +4,7 @@
     clippy::if_same_then_else,
     clippy::match_like_matches_macro,
     clippy::needless_bool,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps
 )]

--- a/tests/ui/redundant_pattern_matching_result.rs
+++ b/tests/ui/redundant_pattern_matching_result.rs
@@ -4,7 +4,7 @@
     clippy::if_same_then_else,
     clippy::match_like_matches_macro,
     clippy::needless_bool,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps
 )]

--- a/tests/ui/rename.fixed
+++ b/tests/ui/rename.fixed
@@ -43,6 +43,7 @@
 #![allow(clippy::overly_complex_bool_expr)]
 #![allow(unexpected_cfgs)]
 #![allow(enum_intrinsics_non_enums)]
+#![allow(clippy::needless_ifs)]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::bind_instead_of_map)]
 #![allow(clippy::expect_used)]
@@ -111,6 +112,7 @@
 #![warn(unexpected_cfgs)] //~ ERROR: lint `clippy::maybe_misused_cfg`
 #![warn(enum_intrinsics_non_enums)] //~ ERROR: lint `clippy::mem_discriminant_non_enum`
 #![warn(unexpected_cfgs)] //~ ERROR: lint `clippy::mismatched_target_os`
+#![warn(clippy::needless_ifs)] //~ ERROR: lint `clippy::needless_if`
 #![warn(clippy::new_without_default)] //~ ERROR: lint `clippy::new_without_default_derive`
 #![warn(clippy::bind_instead_of_map)] //~ ERROR: lint `clippy::option_and_then_some`
 #![warn(clippy::expect_used)] //~ ERROR: lint `clippy::option_expect_used`

--- a/tests/ui/rename.rs
+++ b/tests/ui/rename.rs
@@ -43,6 +43,7 @@
 #![allow(clippy::overly_complex_bool_expr)]
 #![allow(unexpected_cfgs)]
 #![allow(enum_intrinsics_non_enums)]
+#![allow(clippy::needless_ifs)]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::bind_instead_of_map)]
 #![allow(clippy::expect_used)]
@@ -111,6 +112,7 @@
 #![warn(clippy::maybe_misused_cfg)] //~ ERROR: lint `clippy::maybe_misused_cfg`
 #![warn(clippy::mem_discriminant_non_enum)] //~ ERROR: lint `clippy::mem_discriminant_non_enum`
 #![warn(clippy::mismatched_target_os)] //~ ERROR: lint `clippy::mismatched_target_os`
+#![warn(clippy::needless_if)] //~ ERROR: lint `clippy::needless_if`
 #![warn(clippy::new_without_default_derive)] //~ ERROR: lint `clippy::new_without_default_derive`
 #![warn(clippy::option_and_then_some)] //~ ERROR: lint `clippy::option_and_then_some`
 #![warn(clippy::option_expect_used)] //~ ERROR: lint `clippy::option_expect_used`

--- a/tests/ui/rename.stderr
+++ b/tests/ui/rename.stderr
@@ -1,5 +1,5 @@
 error: lint `clippy::almost_complete_letter_range` has been renamed to `clippy::almost_complete_range`
-  --> tests/ui/rename.rs:69:9
+  --> tests/ui/rename.rs:70:9
    |
 LL | #![warn(clippy::almost_complete_letter_range)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::almost_complete_range`
@@ -8,448 +8,454 @@ LL | #![warn(clippy::almost_complete_letter_range)]
    = help: to override `-D warnings` add `#[allow(renamed_and_removed_lints)]`
 
 error: lint `clippy::blacklisted_name` has been renamed to `clippy::disallowed_names`
-  --> tests/ui/rename.rs:70:9
+  --> tests/ui/rename.rs:71:9
    |
 LL | #![warn(clippy::blacklisted_name)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::disallowed_names`
 
 error: lint `clippy::block_in_if_condition_expr` has been renamed to `clippy::blocks_in_conditions`
-  --> tests/ui/rename.rs:71:9
+  --> tests/ui/rename.rs:72:9
    |
 LL | #![warn(clippy::block_in_if_condition_expr)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::blocks_in_conditions`
 
 error: lint `clippy::block_in_if_condition_stmt` has been renamed to `clippy::blocks_in_conditions`
-  --> tests/ui/rename.rs:72:9
+  --> tests/ui/rename.rs:73:9
    |
 LL | #![warn(clippy::block_in_if_condition_stmt)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::blocks_in_conditions`
 
 error: lint `clippy::blocks_in_if_conditions` has been renamed to `clippy::blocks_in_conditions`
-  --> tests/ui/rename.rs:73:9
+  --> tests/ui/rename.rs:74:9
    |
 LL | #![warn(clippy::blocks_in_if_conditions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::blocks_in_conditions`
 
 error: lint `clippy::box_vec` has been renamed to `clippy::box_collection`
-  --> tests/ui/rename.rs:74:9
+  --> tests/ui/rename.rs:75:9
    |
 LL | #![warn(clippy::box_vec)]
    |         ^^^^^^^^^^^^^^^ help: use the new name: `clippy::box_collection`
 
 error: lint `clippy::cast_ref_to_mut` has been renamed to `invalid_reference_casting`
-  --> tests/ui/rename.rs:75:9
+  --> tests/ui/rename.rs:76:9
    |
 LL | #![warn(clippy::cast_ref_to_mut)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `invalid_reference_casting`
 
 error: lint `clippy::clone_double_ref` has been renamed to `suspicious_double_ref_op`
-  --> tests/ui/rename.rs:76:9
+  --> tests/ui/rename.rs:77:9
    |
 LL | #![warn(clippy::clone_double_ref)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `suspicious_double_ref_op`
 
 error: lint `clippy::cmp_nan` has been renamed to `invalid_nan_comparisons`
-  --> tests/ui/rename.rs:77:9
+  --> tests/ui/rename.rs:78:9
    |
 LL | #![warn(clippy::cmp_nan)]
    |         ^^^^^^^^^^^^^^^ help: use the new name: `invalid_nan_comparisons`
 
 error: lint `clippy::const_static_lifetime` has been renamed to `clippy::redundant_static_lifetimes`
-  --> tests/ui/rename.rs:78:9
+  --> tests/ui/rename.rs:79:9
    |
 LL | #![warn(clippy::const_static_lifetime)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::redundant_static_lifetimes`
 
 error: lint `clippy::cyclomatic_complexity` has been renamed to `clippy::cognitive_complexity`
-  --> tests/ui/rename.rs:79:9
+  --> tests/ui/rename.rs:80:9
    |
 LL | #![warn(clippy::cyclomatic_complexity)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::cognitive_complexity`
 
 error: lint `clippy::derive_hash_xor_eq` has been renamed to `clippy::derived_hash_with_manual_eq`
-  --> tests/ui/rename.rs:80:9
+  --> tests/ui/rename.rs:81:9
    |
 LL | #![warn(clippy::derive_hash_xor_eq)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::derived_hash_with_manual_eq`
 
 error: lint `clippy::disallowed_method` has been renamed to `clippy::disallowed_methods`
-  --> tests/ui/rename.rs:81:9
+  --> tests/ui/rename.rs:82:9
    |
 LL | #![warn(clippy::disallowed_method)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::disallowed_methods`
 
 error: lint `clippy::disallowed_type` has been renamed to `clippy::disallowed_types`
-  --> tests/ui/rename.rs:82:9
+  --> tests/ui/rename.rs:83:9
    |
 LL | #![warn(clippy::disallowed_type)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::disallowed_types`
 
 error: lint `clippy::double_neg` has been renamed to `double_negations`
-  --> tests/ui/rename.rs:83:9
+  --> tests/ui/rename.rs:84:9
    |
 LL | #![warn(clippy::double_neg)]
    |         ^^^^^^^^^^^^^^^^^^ help: use the new name: `double_negations`
 
 error: lint `clippy::drop_bounds` has been renamed to `drop_bounds`
-  --> tests/ui/rename.rs:84:9
+  --> tests/ui/rename.rs:85:9
    |
 LL | #![warn(clippy::drop_bounds)]
    |         ^^^^^^^^^^^^^^^^^^^ help: use the new name: `drop_bounds`
 
 error: lint `clippy::drop_copy` has been renamed to `dropping_copy_types`
-  --> tests/ui/rename.rs:85:9
+  --> tests/ui/rename.rs:86:9
    |
 LL | #![warn(clippy::drop_copy)]
    |         ^^^^^^^^^^^^^^^^^ help: use the new name: `dropping_copy_types`
 
 error: lint `clippy::drop_ref` has been renamed to `dropping_references`
-  --> tests/ui/rename.rs:86:9
+  --> tests/ui/rename.rs:87:9
    |
 LL | #![warn(clippy::drop_ref)]
    |         ^^^^^^^^^^^^^^^^ help: use the new name: `dropping_references`
 
 error: lint `clippy::empty_enum` has been renamed to `clippy::empty_enums`
-  --> tests/ui/rename.rs:87:9
+  --> tests/ui/rename.rs:88:9
    |
 LL | #![warn(clippy::empty_enum)]
    |         ^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::empty_enums`
 
 error: lint `clippy::eval_order_dependence` has been renamed to `clippy::mixed_read_write_in_expression`
-  --> tests/ui/rename.rs:88:9
+  --> tests/ui/rename.rs:89:9
    |
 LL | #![warn(clippy::eval_order_dependence)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::mixed_read_write_in_expression`
 
 error: lint `clippy::filter_map` has been renamed to `clippy::manual_filter_map`
-  --> tests/ui/rename.rs:89:9
+  --> tests/ui/rename.rs:90:9
    |
 LL | #![warn(clippy::filter_map)]
    |         ^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::manual_filter_map`
 
 error: lint `clippy::find_map` has been renamed to `clippy::manual_find_map`
-  --> tests/ui/rename.rs:90:9
+  --> tests/ui/rename.rs:91:9
    |
 LL | #![warn(clippy::find_map)]
    |         ^^^^^^^^^^^^^^^^ help: use the new name: `clippy::manual_find_map`
 
 error: lint `clippy::fn_address_comparisons` has been renamed to `unpredictable_function_pointer_comparisons`
-  --> tests/ui/rename.rs:91:9
+  --> tests/ui/rename.rs:92:9
    |
 LL | #![warn(clippy::fn_address_comparisons)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unpredictable_function_pointer_comparisons`
 
 error: lint `clippy::fn_null_check` has been renamed to `useless_ptr_null_checks`
-  --> tests/ui/rename.rs:92:9
+  --> tests/ui/rename.rs:93:9
    |
 LL | #![warn(clippy::fn_null_check)]
    |         ^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `useless_ptr_null_checks`
 
 error: lint `clippy::for_loop_over_option` has been renamed to `for_loops_over_fallibles`
-  --> tests/ui/rename.rs:93:9
+  --> tests/ui/rename.rs:94:9
    |
 LL | #![warn(clippy::for_loop_over_option)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `for_loops_over_fallibles`
 
 error: lint `clippy::for_loop_over_result` has been renamed to `for_loops_over_fallibles`
-  --> tests/ui/rename.rs:94:9
+  --> tests/ui/rename.rs:95:9
    |
 LL | #![warn(clippy::for_loop_over_result)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `for_loops_over_fallibles`
 
 error: lint `clippy::for_loops_over_fallibles` has been renamed to `for_loops_over_fallibles`
-  --> tests/ui/rename.rs:95:9
+  --> tests/ui/rename.rs:96:9
    |
 LL | #![warn(clippy::for_loops_over_fallibles)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `for_loops_over_fallibles`
 
 error: lint `clippy::forget_copy` has been renamed to `forgetting_copy_types`
-  --> tests/ui/rename.rs:96:9
+  --> tests/ui/rename.rs:97:9
    |
 LL | #![warn(clippy::forget_copy)]
    |         ^^^^^^^^^^^^^^^^^^^ help: use the new name: `forgetting_copy_types`
 
 error: lint `clippy::forget_ref` has been renamed to `forgetting_references`
-  --> tests/ui/rename.rs:97:9
+  --> tests/ui/rename.rs:98:9
    |
 LL | #![warn(clippy::forget_ref)]
    |         ^^^^^^^^^^^^^^^^^^ help: use the new name: `forgetting_references`
 
 error: lint `clippy::identity_conversion` has been renamed to `clippy::useless_conversion`
-  --> tests/ui/rename.rs:98:9
+  --> tests/ui/rename.rs:99:9
    |
 LL | #![warn(clippy::identity_conversion)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::useless_conversion`
 
 error: lint `clippy::if_let_redundant_pattern_matching` has been renamed to `clippy::redundant_pattern_matching`
-  --> tests/ui/rename.rs:99:9
+  --> tests/ui/rename.rs:100:9
    |
 LL | #![warn(clippy::if_let_redundant_pattern_matching)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::redundant_pattern_matching`
 
 error: lint `clippy::if_let_some_result` has been renamed to `clippy::match_result_ok`
-  --> tests/ui/rename.rs:100:9
+  --> tests/ui/rename.rs:101:9
    |
 LL | #![warn(clippy::if_let_some_result)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::match_result_ok`
 
 error: lint `clippy::incorrect_clone_impl_on_copy_type` has been renamed to `clippy::non_canonical_clone_impl`
-  --> tests/ui/rename.rs:101:9
+  --> tests/ui/rename.rs:102:9
    |
 LL | #![warn(clippy::incorrect_clone_impl_on_copy_type)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::non_canonical_clone_impl`
 
 error: lint `clippy::incorrect_partial_ord_impl_on_ord_type` has been renamed to `clippy::non_canonical_partial_ord_impl`
-  --> tests/ui/rename.rs:102:9
+  --> tests/ui/rename.rs:103:9
    |
 LL | #![warn(clippy::incorrect_partial_ord_impl_on_ord_type)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::non_canonical_partial_ord_impl`
 
 error: lint `clippy::integer_arithmetic` has been renamed to `clippy::arithmetic_side_effects`
-  --> tests/ui/rename.rs:103:9
+  --> tests/ui/rename.rs:104:9
    |
 LL | #![warn(clippy::integer_arithmetic)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::arithmetic_side_effects`
 
 error: lint `clippy::into_iter_on_array` has been renamed to `array_into_iter`
-  --> tests/ui/rename.rs:104:9
+  --> tests/ui/rename.rs:105:9
    |
 LL | #![warn(clippy::into_iter_on_array)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `array_into_iter`
 
 error: lint `clippy::invalid_atomic_ordering` has been renamed to `invalid_atomic_ordering`
-  --> tests/ui/rename.rs:105:9
+  --> tests/ui/rename.rs:106:9
    |
 LL | #![warn(clippy::invalid_atomic_ordering)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `invalid_atomic_ordering`
 
 error: lint `clippy::invalid_null_ptr_usage` has been renamed to `invalid_null_arguments`
-  --> tests/ui/rename.rs:106:9
+  --> tests/ui/rename.rs:107:9
    |
 LL | #![warn(clippy::invalid_null_ptr_usage)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `invalid_null_arguments`
 
 error: lint `clippy::invalid_ref` has been renamed to `invalid_value`
-  --> tests/ui/rename.rs:107:9
+  --> tests/ui/rename.rs:108:9
    |
 LL | #![warn(clippy::invalid_ref)]
    |         ^^^^^^^^^^^^^^^^^^^ help: use the new name: `invalid_value`
 
 error: lint `clippy::invalid_utf8_in_unchecked` has been renamed to `invalid_from_utf8_unchecked`
-  --> tests/ui/rename.rs:108:9
+  --> tests/ui/rename.rs:109:9
    |
 LL | #![warn(clippy::invalid_utf8_in_unchecked)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `invalid_from_utf8_unchecked`
 
 error: lint `clippy::let_underscore_drop` has been renamed to `let_underscore_drop`
-  --> tests/ui/rename.rs:109:9
+  --> tests/ui/rename.rs:110:9
    |
 LL | #![warn(clippy::let_underscore_drop)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `let_underscore_drop`
 
 error: lint `clippy::logic_bug` has been renamed to `clippy::overly_complex_bool_expr`
-  --> tests/ui/rename.rs:110:9
+  --> tests/ui/rename.rs:111:9
    |
 LL | #![warn(clippy::logic_bug)]
    |         ^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::overly_complex_bool_expr`
 
 error: lint `clippy::maybe_misused_cfg` has been renamed to `unexpected_cfgs`
-  --> tests/ui/rename.rs:111:9
+  --> tests/ui/rename.rs:112:9
    |
 LL | #![warn(clippy::maybe_misused_cfg)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unexpected_cfgs`
 
 error: lint `clippy::mem_discriminant_non_enum` has been renamed to `enum_intrinsics_non_enums`
-  --> tests/ui/rename.rs:112:9
+  --> tests/ui/rename.rs:113:9
    |
 LL | #![warn(clippy::mem_discriminant_non_enum)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `enum_intrinsics_non_enums`
 
 error: lint `clippy::mismatched_target_os` has been renamed to `unexpected_cfgs`
-  --> tests/ui/rename.rs:113:9
+  --> tests/ui/rename.rs:114:9
    |
 LL | #![warn(clippy::mismatched_target_os)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unexpected_cfgs`
 
+error: lint `clippy::needless_if` has been renamed to `clippy::needless_ifs`
+  --> tests/ui/rename.rs:115:9
+   |
+LL | #![warn(clippy::needless_if)]
+   |         ^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::needless_ifs`
+
 error: lint `clippy::new_without_default_derive` has been renamed to `clippy::new_without_default`
-  --> tests/ui/rename.rs:114:9
+  --> tests/ui/rename.rs:116:9
    |
 LL | #![warn(clippy::new_without_default_derive)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::new_without_default`
 
 error: lint `clippy::option_and_then_some` has been renamed to `clippy::bind_instead_of_map`
-  --> tests/ui/rename.rs:115:9
+  --> tests/ui/rename.rs:117:9
    |
 LL | #![warn(clippy::option_and_then_some)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::bind_instead_of_map`
 
 error: lint `clippy::option_expect_used` has been renamed to `clippy::expect_used`
-  --> tests/ui/rename.rs:116:9
+  --> tests/ui/rename.rs:118:9
    |
 LL | #![warn(clippy::option_expect_used)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::expect_used`
 
 error: lint `clippy::option_map_unwrap_or` has been renamed to `clippy::map_unwrap_or`
-  --> tests/ui/rename.rs:117:9
+  --> tests/ui/rename.rs:119:9
    |
 LL | #![warn(clippy::option_map_unwrap_or)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::map_unwrap_or`
 
 error: lint `clippy::option_map_unwrap_or_else` has been renamed to `clippy::map_unwrap_or`
-  --> tests/ui/rename.rs:118:9
+  --> tests/ui/rename.rs:120:9
    |
 LL | #![warn(clippy::option_map_unwrap_or_else)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::map_unwrap_or`
 
 error: lint `clippy::option_unwrap_used` has been renamed to `clippy::unwrap_used`
-  --> tests/ui/rename.rs:119:9
+  --> tests/ui/rename.rs:121:9
    |
 LL | #![warn(clippy::option_unwrap_used)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::unwrap_used`
 
 error: lint `clippy::overflow_check_conditional` has been renamed to `clippy::panicking_overflow_checks`
-  --> tests/ui/rename.rs:120:9
+  --> tests/ui/rename.rs:122:9
    |
 LL | #![warn(clippy::overflow_check_conditional)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::panicking_overflow_checks`
 
 error: lint `clippy::panic_params` has been renamed to `non_fmt_panics`
-  --> tests/ui/rename.rs:121:9
+  --> tests/ui/rename.rs:123:9
    |
 LL | #![warn(clippy::panic_params)]
    |         ^^^^^^^^^^^^^^^^^^^^ help: use the new name: `non_fmt_panics`
 
 error: lint `clippy::positional_named_format_parameters` has been renamed to `named_arguments_used_positionally`
-  --> tests/ui/rename.rs:122:9
+  --> tests/ui/rename.rs:124:9
    |
 LL | #![warn(clippy::positional_named_format_parameters)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `named_arguments_used_positionally`
 
 error: lint `clippy::ref_in_deref` has been renamed to `clippy::needless_borrow`
-  --> tests/ui/rename.rs:123:9
+  --> tests/ui/rename.rs:125:9
    |
 LL | #![warn(clippy::ref_in_deref)]
    |         ^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::needless_borrow`
 
 error: lint `clippy::result_expect_used` has been renamed to `clippy::expect_used`
-  --> tests/ui/rename.rs:124:9
+  --> tests/ui/rename.rs:126:9
    |
 LL | #![warn(clippy::result_expect_used)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::expect_used`
 
 error: lint `clippy::result_map_unwrap_or_else` has been renamed to `clippy::map_unwrap_or`
-  --> tests/ui/rename.rs:125:9
+  --> tests/ui/rename.rs:127:9
    |
 LL | #![warn(clippy::result_map_unwrap_or_else)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::map_unwrap_or`
 
 error: lint `clippy::result_unwrap_used` has been renamed to `clippy::unwrap_used`
-  --> tests/ui/rename.rs:126:9
+  --> tests/ui/rename.rs:128:9
    |
 LL | #![warn(clippy::result_unwrap_used)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::unwrap_used`
 
 error: lint `clippy::reverse_range_loop` has been renamed to `clippy::reversed_empty_ranges`
-  --> tests/ui/rename.rs:127:9
+  --> tests/ui/rename.rs:129:9
    |
 LL | #![warn(clippy::reverse_range_loop)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::reversed_empty_ranges`
 
 error: lint `clippy::single_char_push_str` has been renamed to `clippy::single_char_add_str`
-  --> tests/ui/rename.rs:128:9
+  --> tests/ui/rename.rs:130:9
    |
 LL | #![warn(clippy::single_char_push_str)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::single_char_add_str`
 
 error: lint `clippy::stutter` has been renamed to `clippy::module_name_repetitions`
-  --> tests/ui/rename.rs:129:9
+  --> tests/ui/rename.rs:131:9
    |
 LL | #![warn(clippy::stutter)]
    |         ^^^^^^^^^^^^^^^ help: use the new name: `clippy::module_name_repetitions`
 
 error: lint `clippy::temporary_cstring_as_ptr` has been renamed to `dangling_pointers_from_temporaries`
-  --> tests/ui/rename.rs:130:9
+  --> tests/ui/rename.rs:132:9
    |
 LL | #![warn(clippy::temporary_cstring_as_ptr)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `dangling_pointers_from_temporaries`
 
 error: lint `clippy::thread_local_initializer_can_be_made_const` has been renamed to `clippy::missing_const_for_thread_local`
-  --> tests/ui/rename.rs:131:9
+  --> tests/ui/rename.rs:133:9
    |
 LL | #![warn(clippy::thread_local_initializer_can_be_made_const)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::missing_const_for_thread_local`
 
 error: lint `clippy::to_string_in_display` has been renamed to `clippy::recursive_format_impl`
-  --> tests/ui/rename.rs:132:9
+  --> tests/ui/rename.rs:134:9
    |
 LL | #![warn(clippy::to_string_in_display)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::recursive_format_impl`
 
 error: lint `clippy::transmute_float_to_int` has been renamed to `unnecessary_transmutes`
-  --> tests/ui/rename.rs:133:9
+  --> tests/ui/rename.rs:135:9
    |
 LL | #![warn(clippy::transmute_float_to_int)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unnecessary_transmutes`
 
 error: lint `clippy::transmute_int_to_char` has been renamed to `unnecessary_transmutes`
-  --> tests/ui/rename.rs:134:9
+  --> tests/ui/rename.rs:136:9
    |
 LL | #![warn(clippy::transmute_int_to_char)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unnecessary_transmutes`
 
 error: lint `clippy::transmute_int_to_float` has been renamed to `unnecessary_transmutes`
-  --> tests/ui/rename.rs:135:9
+  --> tests/ui/rename.rs:137:9
    |
 LL | #![warn(clippy::transmute_int_to_float)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unnecessary_transmutes`
 
 error: lint `clippy::transmute_num_to_bytes` has been renamed to `unnecessary_transmutes`
-  --> tests/ui/rename.rs:136:9
+  --> tests/ui/rename.rs:138:9
    |
 LL | #![warn(clippy::transmute_num_to_bytes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unnecessary_transmutes`
 
 error: lint `clippy::unchecked_duration_subtraction` has been renamed to `clippy::unchecked_time_subtraction`
-  --> tests/ui/rename.rs:137:9
+  --> tests/ui/rename.rs:139:9
    |
 LL | #![warn(clippy::unchecked_duration_subtraction)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::unchecked_time_subtraction`
 
 error: lint `clippy::undropped_manually_drops` has been renamed to `undropped_manually_drops`
-  --> tests/ui/rename.rs:138:9
+  --> tests/ui/rename.rs:140:9
    |
 LL | #![warn(clippy::undropped_manually_drops)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `undropped_manually_drops`
 
 error: lint `clippy::unknown_clippy_lints` has been renamed to `unknown_lints`
-  --> tests/ui/rename.rs:139:9
+  --> tests/ui/rename.rs:141:9
    |
 LL | #![warn(clippy::unknown_clippy_lints)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unknown_lints`
 
 error: lint `clippy::unused_label` has been renamed to `unused_labels`
-  --> tests/ui/rename.rs:140:9
+  --> tests/ui/rename.rs:142:9
    |
 LL | #![warn(clippy::unused_label)]
    |         ^^^^^^^^^^^^^^^^^^^^ help: use the new name: `unused_labels`
 
 error: lint `clippy::unwrap_or_else_default` has been renamed to `clippy::unwrap_or_default`
-  --> tests/ui/rename.rs:141:9
+  --> tests/ui/rename.rs:143:9
    |
 LL | #![warn(clippy::unwrap_or_else_default)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::unwrap_or_default`
 
 error: lint `clippy::vtable_address_comparisons` has been renamed to `ambiguous_wide_pointer_comparisons`
-  --> tests/ui/rename.rs:142:9
+  --> tests/ui/rename.rs:144:9
    |
 LL | #![warn(clippy::vtable_address_comparisons)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `ambiguous_wide_pointer_comparisons`
 
 error: lint `clippy::zero_width_space` has been renamed to `clippy::invisible_characters`
-  --> tests/ui/rename.rs:143:9
+  --> tests/ui/rename.rs:145:9
    |
 LL | #![warn(clippy::zero_width_space)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::invisible_characters`
 
-error: aborting due to 75 previous errors
+error: aborting due to 76 previous errors
 

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -3,7 +3,7 @@
 #![warn(clippy::shadow_same, clippy::shadow_reuse, clippy::shadow_unrelated)]
 #![allow(
     clippy::let_unit_value,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::redundant_guards,
     clippy::redundant_locals
 )]

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -3,7 +3,7 @@
 #![allow(
     unused,
     clippy::uninlined_format_args,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::redundant_guards,
     clippy::redundant_pattern_matching,
     clippy::manual_unwrap_or_default

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -3,7 +3,7 @@
 #![allow(
     unused,
     clippy::uninlined_format_args,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::redundant_guards,
     clippy::redundant_pattern_matching,
     clippy::manual_unwrap_or_default

--- a/tests/ui/single_match_else_deref_patterns.fixed
+++ b/tests/ui/single_match_else_deref_patterns.fixed
@@ -5,7 +5,7 @@
     clippy::op_ref,
     clippy::deref_addrof,
     clippy::borrow_deref_ref,
-    clippy::needless_if
+    clippy::needless_ifs
 )]
 #![deny(clippy::single_match_else)]
 

--- a/tests/ui/single_match_else_deref_patterns.rs
+++ b/tests/ui/single_match_else_deref_patterns.rs
@@ -5,7 +5,7 @@
     clippy::op_ref,
     clippy::deref_addrof,
     clippy::borrow_deref_ref,
-    clippy::needless_if
+    clippy::needless_ifs
 )]
 #![deny(clippy::single_match_else)]
 

--- a/tests/ui/starts_ends_with.fixed
+++ b/tests/ui/starts_ends_with.fixed
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_if, dead_code, unused_must_use, clippy::double_ended_iterator_last)]
+#![allow(clippy::needless_ifs, dead_code, unused_must_use, clippy::double_ended_iterator_last)]
 
 fn main() {}
 

--- a/tests/ui/starts_ends_with.rs
+++ b/tests/ui/starts_ends_with.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_if, dead_code, unused_must_use, clippy::double_ended_iterator_last)]
+#![allow(clippy::needless_ifs, dead_code, unused_must_use, clippy::double_ended_iterator_last)]
 
 fn main() {}
 

--- a/tests/ui/suspicious_else_formatting.rs
+++ b/tests/ui/suspicious_else_formatting.rs
@@ -4,7 +4,7 @@
 #![allow(
     clippy::if_same_then_else,
     clippy::let_unit_value,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::needless_else
 )]
 

--- a/tests/ui/suspicious_unary_op_formatting.rs
+++ b/tests/ui/suspicious_unary_op_formatting.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::suspicious_unary_op_formatting)]
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 #[rustfmt::skip]
 fn main() {

--- a/tests/ui/unit_cmp.rs
+++ b/tests/ui/unit_cmp.rs
@@ -3,7 +3,7 @@
     clippy::no_effect,
     clippy::unnecessary_operation,
     clippy::derive_partial_eq_without_eq,
-    clippy::needless_if
+    clippy::needless_ifs
 )]
 
 #[derive(PartialEq)]

--- a/tests/ui/unnecessary_safety_comment.rs
+++ b/tests/ui/unnecessary_safety_comment.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::undocumented_unsafe_blocks, clippy::unnecessary_safety_comment)]
-#![allow(clippy::let_unit_value, clippy::missing_safety_doc, clippy::needless_if)]
+#![allow(clippy::let_unit_value, clippy::missing_safety_doc, clippy::needless_ifs)]
 
 mod unsafe_items_invalid_comment {
     // SAFETY:

--- a/tests/ui/unneeded_wildcard_pattern.fixed
+++ b/tests/ui/unneeded_wildcard_pattern.fixed
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 #![feature(stmt_expr_attributes)]
 #![deny(clippy::unneeded_wildcard_pattern)]
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/unneeded_wildcard_pattern.rs
+++ b/tests/ui/unneeded_wildcard_pattern.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 #![feature(stmt_expr_attributes)]
 #![deny(clippy::unneeded_wildcard_pattern)]
-#![allow(clippy::needless_if)]
+#![allow(clippy::needless_ifs)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/tests/ui/unnested_or_patterns.fixed
+++ b/tests/ui/unnested_or_patterns.fixed
@@ -4,7 +4,7 @@
     clippy::cognitive_complexity,
     clippy::match_ref_pats,
     clippy::upper_case_acronyms,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::manual_range_patterns
 )]
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused)]

--- a/tests/ui/unnested_or_patterns.rs
+++ b/tests/ui/unnested_or_patterns.rs
@@ -4,7 +4,7 @@
     clippy::cognitive_complexity,
     clippy::match_ref_pats,
     clippy::upper_case_acronyms,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::manual_range_patterns
 )]
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused)]

--- a/tests/ui/unnested_or_patterns2.fixed
+++ b/tests/ui/unnested_or_patterns2.fixed
@@ -3,7 +3,7 @@
 #![allow(
     clippy::cognitive_complexity,
     clippy::match_ref_pats,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::manual_range_patterns
 )]
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused_variables)]

--- a/tests/ui/unnested_or_patterns2.rs
+++ b/tests/ui/unnested_or_patterns2.rs
@@ -3,7 +3,7 @@
 #![allow(
     clippy::cognitive_complexity,
     clippy::match_ref_pats,
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::manual_range_patterns
 )]
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused_variables)]

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -1,5 +1,5 @@
 #![deny(clippy::useless_conversion)]
-#![allow(clippy::needless_if, clippy::unnecessary_wraps, unused)]
+#![allow(clippy::needless_ifs, clippy::unnecessary_wraps, unused)]
 // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
 #![allow(static_mut_refs)]
 

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::useless_conversion)]
-#![allow(clippy::needless_if, clippy::unnecessary_wraps, unused)]
+#![allow(clippy::needless_ifs, clippy::unnecessary_wraps, unused)]
 // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
 #![allow(static_mut_refs)]
 

--- a/tests/ui/useless_conversion_try.rs
+++ b/tests/ui/useless_conversion_try.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::useless_conversion)]
 #![allow(
-    clippy::needless_if,
+    clippy::needless_ifs,
     clippy::unnecessary_fallible_conversions,
     clippy::manual_unwrap_or_default
 )]


### PR DESCRIPTION
Lint names should be in plural.

changelog: [`needless_if`]: rename to `needless_ifs`