### PR TITLE
Prepare for mdbook 0.5

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,8 +1,6 @@
 [book]
 authors = ["The Rust Clippy Developers"]
 language = "en"
-multilingual = false
-src = "src"
 title = "Clippy Documentation"
 
 [rust]


### PR DESCRIPTION
The `multilingual` field has been removed in mdbook 0.5. Additionally this removes the unnecessary `src` value which defaults to the same value.

changelog: none
