### PR TITLE
Changelog for Clippy 1.91 🎃

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,89 @@ document.
 
 [e9b7045...master](https://github.com/rust-lang/rust-clippy/compare/e9b7045...master)
 
+## Rust 1.91
+
+Current stable, released 2025-10-30
+
+[View all 146 merged pull requests](https://github.com/rust-lang/rust-clippy/pulls?q=merged%3A2025-07-25T21%3A05%3A11Z..2025-09-04T22%3A34%3A27Z+base%3Amaster)
+
+### New Lints
+
+* Added [`possible_missing_else`] to `suspicious`
+  [#15317](https://github.com/rust-lang/rust-clippy/pull/15317)
+
+### Moves and Deprecations
+
+* Moved [`cognitive_complexity`] from `nursery` to `restriction`
+  [#15415](https://github.com/rust-lang/rust-clippy/pull/15415)
+* Moved [`declare_interior_mutable_const`] from `style` to `suspicious`
+  [#15454](https://github.com/rust-lang/rust-clippy/pull/15454)
+* Moved [`crosspointer_transmute`] from `complexity` to `suspicious`
+  [#15403](https://github.com/rust-lang/rust-clippy/pull/15403)
+
+### Enhancements
+
+* [`excessive_precision`] added `const_literal_digits_threshold` option to suppress overly precise constants.
+  [#15193](https://github.com/rust-lang/rust-clippy/pull/15193)
+* [`unwrap_in_result`] rewritten for better accuracy; now lints on `.unwrap()` and `.expect()` 
+  directly and no longer mixes `Result` and `Option`.
+  [#15445](https://github.com/rust-lang/rust-clippy/pull/15445)
+* [`panic`] now works in `const` contexts.
+  [#15565](https://github.com/rust-lang/rust-clippy/pull/15565)
+* [`implicit_clone`] now also lints `to_string` calls (merging [`string_to_string`] behavior).
+  [#14177](https://github.com/rust-lang/rust-clippy/pull/14177)
+* [`collapsible_match`] improved suggestions to handle necessary ref/dereferencing.
+  [#14221](https://github.com/rust-lang/rust-clippy/pull/14221)
+* [`map_identity`] now suggests making variables mutable when required; recognizes tuple struct restructuring.
+  [#15261](https://github.com/rust-lang/rust-clippy/pull/15261)
+* [`option_map_unit_fn`] preserves `unsafe` blocks in suggestions.
+  [#15570](https://github.com/rust-lang/rust-clippy/pull/15570)
+* [`unnecessary_mut_passed`] provides structured, clearer fix suggestions.
+  [#15438](https://github.com/rust-lang/rust-clippy/pull/15438)
+* [`float_equality_without_abs`] now checks `f16` and `f128` types.
+  [#15054](https://github.com/rust-lang/rust-clippy/pull/15054)
+* [`doc_markdown`] expanded whitelist (`InfiniBand`, `RoCE`, `PowerPC`) and improved handling of 
+  identifiers like NixOS.
+  [#15558](https://github.com/rust-lang/rust-clippy/pull/15558)
+* [`clone_on_ref_ptr`] now suggests fully qualified paths to avoid resolution errors.
+  [#15561](https://github.com/rust-lang/rust-clippy/pull/15561)
+* [`manual_assert`] simplifies boolean expressions in suggested fixes.
+  [#15368](https://github.com/rust-lang/rust-clippy/pull/15368)
+* [`four_forward_slashes`] warns about bare CR in comments and avoids invalid autofixes.
+  [#15175](https://github.com/rust-lang/rust-clippy/pull/15175)
+
+### False Positive Fixes
+
+* [`alloc_instead_of_core`] fixed FP when `alloc` is an alias
+  [#15581](https://github.com/rust-lang/rust-clippy/pull/15581)
+* [`needless_range_loop`] fixed FP and FN when meeting multidimensional array
+  [#15486](https://github.com/rust-lang/rust-clippy/pull/15486)
+* [`semicolon_inside_block`] fixed FP when attribute over expr is not enabled
+  [#15476](https://github.com/rust-lang/rust-clippy/pull/15476)
+* [`unnested_or_patterns`] fixed FP on structs with only shorthand field patterns
+  [#15343](https://github.com/rust-lang/rust-clippy/pull/15343)
+* [`match_ref_pats`] fixed FP on match scrutinee of never type
+  [#15474](https://github.com/rust-lang/rust-clippy/pull/15474)
+* [`infinite_loop`] fixed FP in async blocks that are not awaited
+  [#15157](https://github.com/rust-lang/rust-clippy/pull/15157)
+* [`iter_on_single_items`] fixed FP on function pointers and let statements
+  [#15013](https://github.com/rust-lang/rust-clippy/pull/15013)
+
+### ICE Fixes
+
+* [`len_zero`] fix ICE when fn len has a return type without generic type params
+  [#15660](https://github.com/rust-lang/rust-clippy/pull/15660)
+
+### Documentation Improvements
+
+* [`cognitive_complexity`] corrected documentation to state lint is in `restriction`, not `nursery`
+  [#15563](https://github.com/rust-lang/rust-clippy/pull/15563)
+
+### Performance Improvements
+
+* [`doc_broken_link`] optimized by 99.77% (12M → 27k instructions)
+  [#15385](https://github.com/rust-lang/rust-clippy/pull/15385)
+
 ## Rust 1.90
 
 Current stable, released 2025-09-18

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -110,7 +110,7 @@ declare_clippy_lint! {
     /// } if bar { // looks like an `else` is missing here
     /// }
     /// ```
-    #[clippy::version = "1.90.0"]
+    #[clippy::version = "1.91.0"]
     pub POSSIBLE_MISSING_ELSE,
     suspicious,
     "possibly missing `else`"


### PR DESCRIPTION
Violets are red,
Roses are blue,
Ghosts haunt the night,
And pumpkins grin too.

-----

Meet @thefiddler's Mowgli and @bjornwein's Buffy, our winners at https://github.com/rust-lang/rust-clippy/pull/15670
It's our first dual winner of the Clippy Cat Changelog Contest!

<img width="1100" height="714" alt="image" src="https://github.com/user-attachments/assets/ee9399d5-f8bd-45bb-a18c-c24a94817672" />


<img width="1664" height="1940" alt="image" src="https://github.com/user-attachments/assets/2734c5df-2ebc-465f-89e4-5801f4d33678" />

-----

Cats for the next release can be traditionally nominated in the comments. 

changelog: none

r? flip1995
