### PR TITLE
Move `replace_box` into `nursery`

### DIFF
--- a/clippy_lints/src/replace_box.rs
+++ b/clippy_lints/src/replace_box.rs
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.92.0"]
     pub REPLACE_BOX,
-    perf,
+    nursery,
     "assigning a newly created box to `Box<T>` is inefficient"
 }
 declare_lint_pass!(ReplaceBox => [REPLACE_BOX]);


### PR DESCRIPTION
`replace_box` is a new `perf` lint in Rust 1.92 which detects assignments of a newly created `Box` over an existing box instead of replacing the box content.

However, the lint triggers even when the target of the assignment has been moved and is no longer replaceable without reassignment. Until this is fixed, this lint is moved to `nursery`.

changelog: [`replace_box`]: move to nursery until a known bug has been fixed

r? flip1995

<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [Do not merge before backport time](https://github.com/rust-lang/rust-clippy/pull/15974#issuecomment-3457918234) by [samueltardieu](https://github.com/samueltardieu)

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->