### PR TITLE
Fix `replace_box` FP when the box is moved

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -820,6 +820,6 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     store.register_late_pass(|_| Box::new(coerce_container_to_any::CoerceContainerToAny));
     store.register_late_pass(|_| Box::new(toplevel_ref_arg::ToplevelRefArg));
     store.register_late_pass(|_| Box::new(volatile_composites::VolatileComposites));
-    store.register_late_pass(|_| Box::new(replace_box::ReplaceBox));
+    store.register_late_pass(|_| Box::new(replace_box::ReplaceBox::default()));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/tests/ui/replace_box.fixed
+++ b/tests/ui/replace_box.fixed
@@ -70,3 +70,74 @@ fn main() {
     let bb: Box<u32>;
     bb = Default::default();
 }
+
+fn issue15951() {
+    struct Foo {
+        inner: String,
+    }
+
+    fn embedded_body() {
+        let mut x = Box::new(());
+        let y = x;
+        x = Box::new(());
+
+        let mut x = Box::new(Foo { inner: String::new() });
+        let y = x.inner;
+        *x = Foo { inner: String::new() };
+        //~^ replace_box
+    }
+
+    let mut x = Box::new(Foo { inner: String::new() });
+    let in_closure = || {
+        *x = Foo { inner: String::new() };
+        //~^ replace_box
+    };
+}
+
+static R: fn(&mut Box<String>) = |x| **x = String::new();
+//~^ replace_box
+
+fn field() {
+    struct T {
+        content: String,
+    }
+
+    impl T {
+        fn new() -> Self {
+            Self { content: String::new() }
+        }
+    }
+
+    struct S {
+        b: Box<T>,
+    }
+
+    let mut s = S { b: Box::new(T::new()) };
+    let _b = s.b;
+    s.b = Box::new(T::new());
+
+    // Interestingly, the lint and fix are valid here as `s.b` is not really moved
+    let mut s = S { b: Box::new(T::new()) };
+    _ = s.b;
+    *s.b = T::new();
+    //~^ replace_box
+
+    let mut s = S { b: Box::new(T::new()) };
+    *s.b = T::new();
+    //~^ replace_box
+
+    struct Q(Box<T>);
+    let mut q = Q(Box::new(T::new()));
+    let _b = q.0;
+    q.0 = Box::new(T::new());
+
+    let mut q = Q(Box::new(T::new()));
+    _ = q.0;
+    *q.0 = T::new();
+    //~^ replace_box
+
+    // This one is a false negative, but it will need MIR analysis to work properly
+    let mut x = Box::new(String::new());
+    x = Box::new(String::new());
+    x;
+}

--- a/tests/ui/replace_box.stderr
+++ b/tests/ui/replace_box.stderr
@@ -48,5 +48,53 @@ LL |     b = Box::new(mac!(three));
    |
    = note: this creates a needless allocation
 
-error: aborting due to 6 previous errors
+error: creating a new box
+  --> tests/ui/replace_box.rs:86:9
+   |
+LL |         x = Box::new(Foo { inner: String::new() });
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace existing content with inner value instead: `*x = Foo { inner: String::new() }`
+   |
+   = note: this creates a needless allocation
+
+error: creating a new box
+  --> tests/ui/replace_box.rs:92:9
+   |
+LL |         x = Box::new(Foo { inner: String::new() });
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace existing content with inner value instead: `*x = Foo { inner: String::new() }`
+   |
+   = note: this creates a needless allocation
+
+error: creating a new box
+  --> tests/ui/replace_box.rs:97:38
+   |
+LL | static R: fn(&mut Box<String>) = |x| *x = Box::new(String::new());
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace existing content with inner value instead: `**x = String::new()`
+   |
+   = note: this creates a needless allocation
+
+error: creating a new box
+  --> tests/ui/replace_box.rs:122:5
+   |
+LL |     s.b = Box::new(T::new());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace existing content with inner value instead: `*s.b = T::new()`
+   |
+   = note: this creates a needless allocation
+
+error: creating a new box
+  --> tests/ui/replace_box.rs:126:5
+   |
+LL |     s.b = Box::new(T::new());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace existing content with inner value instead: `*s.b = T::new()`
+   |
+   = note: this creates a needless allocation
+
+error: creating a new box
+  --> tests/ui/replace_box.rs:136:5
+   |
+LL |     q.0 = Box::new(T::new());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace existing content with inner value instead: `*q.0 = T::new()`
+   |
+   = note: this creates a needless allocation
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15968 

changelog: [`replace_box`] fix FP when the box is moved

r? samueltardieu As you wish


<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [Beta-nomination](https://github.com/rust-lang/rust-clippy/pull/15984#issuecomment-3469127087) by [samueltardieu](https://github.com/samueltardieu)

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->