### PR TITLE
feat(manual_is_variant): Check for `.iter().any()`

### DIFF
--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -202,7 +202,10 @@ fn emit_lint<'tcx>(
     );
 }
 
-pub(super) fn check_map(cx: &LateContext<'_>, expr: &Expr<'_>) {
+pub(super) fn check_map(cx: &LateContext<'_>, expr: &Expr<'_>, msrv: Msrv) {
+    if !msrv.meets(cx, msrvs::OPTION_RESULT_IS_VARIANT_AND) {
+        return;
+    }
     if let Some(parent_expr) = get_parent_expr(cx, expr)
         && let ExprKind::Binary(op, left, right) = parent_expr.kind
         && op.span.eq_ctxt(expr.span)

--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -2,7 +2,8 @@ use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
-use clippy_utils::sugg::Sugg;
+use clippy_utils::sugg::{DerefClosure, Sugg, deref_closure_args};
+use clippy_utils::ty::is_copy;
 use clippy_utils::{SpanlessEq, get_parent_expr, sym};
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
@@ -13,7 +14,7 @@ use rustc_lint::LateContext;
 use rustc_middle::ty;
 use rustc_span::{Span, Symbol};
 
-use super::MANUAL_IS_VARIANT_AND;
+use super::{MANUAL_IS_VARIANT_AND, method_call};
 
 #[derive(Clone, Copy, PartialEq)]
 enum Flavor {
@@ -329,4 +330,81 @@ pub(super) fn check_is_some_is_none<'tcx>(
             },
         );
     }
+}
+
+/// Check for things like `.into_iter().all()`.
+pub(super) fn check_iter_reduce(
+    cx: &LateContext<'_>,
+    expr: &Expr<'_>,
+    recv: &Expr<'_>,
+    arg: &Expr<'_>,
+    second_call: Span,
+    msrv: Msrv,
+    method: Symbol,
+) {
+    // Find how the iterator is created.
+    let (mut referenced, first_recv, first_call) = match method_call(recv) {
+        Some((sym::into_iter, first_recv, [], _, first_call)) => (false, first_recv, first_call),
+        Some((sym::iter, first_recv, [], _, first_call)) => (true, first_recv, first_call),
+        _ => {
+            return;
+        },
+    };
+
+    // Find the method to suggest.
+    let recv_type = cx.typeck_results().expr_ty(first_recv);
+    let (replacement_method, since_version) = match recv_type.kind() {
+        ty::Adt(adt, _) if cx.tcx.is_diagnostic_item(sym::Result, adt.did()) && method == sym::any => {
+            (sym::is_ok_and, msrvs::OPTION_RESULT_IS_VARIANT_AND)
+        },
+        ty::Adt(adt, _) if cx.tcx.is_diagnostic_item(sym::Option, adt.did()) => match method {
+            sym::all => (sym::is_none_or, msrvs::IS_NONE_OR),
+            sym::any => (sym::is_some_and, msrvs::OPTION_RESULT_IS_VARIANT_AND),
+            _ => panic!("The method is checked in the caller."),
+        },
+        _ => return,
+    };
+    if !msrv.meets(cx, since_version) {
+        return;
+    }
+
+    // The replacement methods pass the value to the closure.  The original
+    // methods may pass the reference.  If possible, the program modifies the
+    // closure to take the value.
+    let (replacement_closure, applicability) = if referenced
+        && is_copy(cx, recv_type)
+        && let Some(DerefClosure {
+            suggestion,
+            applicability,
+        }) = deref_closure_args(cx, arg)
+    {
+        referenced = false;
+        (Some((arg.span, suggestion)), applicability)
+    } else {
+        (None, Applicability::MachineApplicable)
+    };
+    // If it is not possible to modify the closure, the program suggests the
+    // `as_ref` method.
+    let replacement_call = if referenced {
+        format!("as_ref().{replacement_method}")
+    } else {
+        replacement_method.to_string()
+    };
+
+    let mut suggestion = vec![
+        // Remove the call to get the iterator.
+        (first_call.with_lo(first_recv.span.hi()), String::new()),
+        // Replace the call to reduce it.
+        (second_call, replacement_call),
+    ];
+    suggestion.extend(replacement_closure);
+    span_lint_and_then(
+        cx,
+        MANUAL_IS_VARIANT_AND,
+        expr.span,
+        format!("use of `option::Iter::{method}`"),
+        |diag| {
+            diag.multipart_suggestion(format!("use `{replacement_method}` instead"), suggestion, applicability);
+        },
+    );
 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5418,7 +5418,7 @@ impl Methods {
                     if name == sym::map {
                         map_clone::check(cx, expr, recv, m_arg, self.msrv);
                         map_with_unused_argument_over_ranges::check(cx, expr, recv, m_arg, self.msrv, span);
-                        manual_is_variant_and::check_map(cx, expr);
+                        manual_is_variant_and::check_map(cx, expr, self.msrv);
                         match method_call(recv) {
                             Some((map_name @ (sym::iter | sym::into_iter), recv2, _, _, _)) => {
                                 iter_kv_map::check(cx, map_name, expr, recv2, m_arg, self.msrv, sym::map);

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1883,6 +1883,10 @@ declare_clippy_lint! {
     /// result.map(|a| a > 10) == Ok(true);
     /// option.map(|a| a > 10) != Some(true);
     /// result.map(|a| a > 10) != Ok(true);
+    ///
+    /// option.into_iter().any(|a| a > 10);
+    /// result.into_iter().any(|a| a > 10);
+    /// option.into_iter().all(|a| a > 10);
     /// ```
     /// Use instead:
     /// ```no_run
@@ -1895,6 +1899,10 @@ declare_clippy_lint! {
     /// result.is_ok_and(|a| a > 10);
     /// option.is_none_or(|a| a > 10);
     /// !result.is_ok_and(|a| a > 10);
+    ///
+    /// option.is_some_and(|a| a > 10);
+    /// result.is_ok_and(|a| a > 10);
+    /// option.is_none_or(|a| a > 10);
     /// ```
     #[clippy::version = "1.77.0"]
     pub MANUAL_IS_VARIANT_AND,
@@ -5096,6 +5104,7 @@ impl Methods {
                     zst_offset::check(cx, expr, recv);
                 },
                 (sym::all, [arg]) => {
+                    manual_is_variant_and::check_iter_reduce(cx, expr, recv, arg, span, self.msrv, name);
                     needless_character_iteration::check(cx, expr, recv, arg, true);
                     match method_call(recv) {
                         Some((sym::cloned, recv2, [], _, _)) => {
@@ -5125,6 +5134,7 @@ impl Methods {
                     }
                 },
                 (sym::any, [arg]) => {
+                    manual_is_variant_and::check_iter_reduce(cx, expr, recv, arg, span, self.msrv, name);
                     needless_character_iteration::check(cx, expr, recv, arg, false);
                     match method_call(recv) {
                         Some((sym::cloned, recv2, [], _, _)) => iter_overeager_cloned::check(

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -377,6 +377,7 @@ generate! {
     is_none,
     is_none_or,
     is_ok,
+    is_ok_and,
     is_partitioned,
     is_some,
     is_some_and,

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -51,6 +51,7 @@ macro_rules! mac {
 
 #[clippy::msrv = "1.69"]
 fn under_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.map(|x| x != 0) == Ok(true);
     let _ = res.into_iter().any(|x| x != 0);
     let _ = opt.map(|x| x != 0).unwrap_or_default();
     let _ = opt.iter().all(|x| *x != 0);
@@ -59,6 +60,8 @@ fn under_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
 
 #[clippy::msrv = "1.70"]
 fn meets_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.is_ok_and(|x| x != 0);
+    //~^ manual_is_variant_and
     let _ = res.is_ok_and(|x| x != 0);
     //~^ manual_is_variant_and
     let _ = opt.is_some_and(|x| x != 0);
@@ -72,6 +75,8 @@ fn meets_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
 fn under_msrv_is_none_or(opt: Option<u32>, res: Result<u32, ()>) {
     let _ = res.is_ok_and(|x| x != 0);
     //~^ manual_is_variant_and
+    let _ = res.is_ok_and(|x| x != 0);
+    //~^ manual_is_variant_and
     let _ = opt.is_some_and(|x| x != 0);
     //~^ manual_is_variant_and
     let _ = opt.iter().all(|x| *x != 0);
@@ -81,6 +86,8 @@ fn under_msrv_is_none_or(opt: Option<u32>, res: Result<u32, ()>) {
 
 #[clippy::msrv = "1.82"]
 fn meets_msrv_is_none_or(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.is_ok_and(|x| x != 0);
+    //~^ manual_is_variant_and
     let _ = res.is_ok_and(|x| x != 0);
     //~^ manual_is_variant_and
     let _ = opt.is_some_and(|x| x != 0);

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -28,6 +28,12 @@ macro_rules! some_false {
     };
 }
 
+macro_rules! into_iter {
+    ($x:expr) => {
+        $x.into_iter()
+    };
+}
+
 macro_rules! mac {
     (some $e:expr) => {
         Some($e)
@@ -43,8 +49,51 @@ macro_rules! mac {
     };
 }
 
+#[clippy::msrv = "1.69"]
+fn under_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.into_iter().any(|x| x != 0);
+    let _ = opt.map(|x| x != 0).unwrap_or_default();
+    let _ = opt.iter().all(|x| *x != 0);
+    let _ = opt.iter().any(|&x| x != 0);
+}
+
+#[clippy::msrv = "1.70"]
+fn meets_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.is_ok_and(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.is_some_and(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.iter().all(|x| *x != 0);
+    let _ = opt.is_some_and(|x| x != 0);
+    //~^ manual_is_variant_and
+}
+
+#[clippy::msrv = "1.81"]
+fn under_msrv_is_none_or(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.is_ok_and(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.is_some_and(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.iter().all(|x| *x != 0);
+    let _ = opt.is_some_and(|x| x != 0);
+    //~^ manual_is_variant_and
+}
+
+#[clippy::msrv = "1.82"]
+fn meets_msrv_is_none_or(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.is_ok_and(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.is_some_and(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.is_none_or(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.is_some_and(|x| x != 0);
+    //~^ manual_is_variant_and
+}
+
 #[rustfmt::skip]
 fn option_methods() {
+    let opt_non_copy: Option<String> = None;
     let opt = Some(1);
 
     // Check for `option.map(_).unwrap_or_default()` use.
@@ -68,6 +117,36 @@ fn option_methods() {
     //~^ manual_is_variant_and
     let _ = Some(2).is_none_or(|x| x % 2 == 0);
     //~^ manual_is_variant_and
+    let _ = opt.is_none_or(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = (opt).is_none_or(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.is_some_and(i32::is_negative);
+    //~^ manual_is_variant_and
+    let _ = opt.is_some_and(|x| x != 0);
+    //~^ manual_is_variant_and
+
+    // The type does not copy.  The linter should suggest `as_ref`.
+    let _ = (opt_non_copy).as_ref().is_some_and(|x| x.is_empty());
+    //~^ manual_is_variant_and
+    let _ = opt_non_copy.as_ref().is_some_and(|x| x.is_empty());
+    //~^ manual_is_variant_and
+    let _ = opt_non_copy.as_ref().is_some_and(|x| ".." == *x);
+    //~^ manual_is_variant_and
+    // The type copies.  The linter should not suggest `as_ref`.
+    let _ = opt.is_none_or(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.as_ref().is_none_or(|_| false);
+    //~^ manual_is_variant_and
+    let _ = opt.is_some_and(|x| x != 0);
+    //~^ manual_is_variant_and
+    let _ = opt.is_none_or(|_| false);
+    //~^ manual_is_variant_and
+    // The argument is defined elsewhere.  It cannot be changed to take the
+    // value.  The linter should suggest `as_ref`.
+    let zerop = |x: &i32| *x == 0;
+    let _ = opt.as_ref().is_none_or(zerop);
+    //~^ manual_is_variant_and
 
     // won't fix because the return type of the closure is not `bool`
     let _ = opt.map(|x| x + 1).unwrap_or_default();
@@ -84,10 +163,13 @@ fn option_methods() {
     let _ = mac!(some 2).map(|x| x % 2 == 0) == Some(true);
     let _ = mac!(some_map 2) == Some(true);
     let _ = mac!(map Some(2)) == Some(true);
+    // The first method call is elsewhere.  The linter cannot change it.
+    let _ = into_iter!(opt).any(|x| x != 0);
 }
 
 #[rustfmt::skip]
 fn result_methods() {
+    let res_non_copy: Result<i32, String> = Ok(1);
     let res: Result<i32, ()> = Ok(1);
 
     // multi line cases
@@ -103,6 +185,12 @@ fn result_methods() {
     //~^ manual_is_variant_and
     let _ = !Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2));
     //~^ manual_is_variant_and
+    let _ = res.is_ok_and(i32::is_negative);
+    //~^ manual_is_variant_and
+    let _ = res_non_copy.as_ref().is_ok_and(|x| *x != 0);
+    //~^ manual_is_variant_and
+    let _ = res.is_ok_and(|x| x != 0);
+    //~^ manual_is_variant_and
 
     // won't fix because the return type of the closure is not `bool`
     let _ = res.map(|x| x + 1).unwrap_or_default();
@@ -110,7 +198,11 @@ fn result_methods() {
     let res2: Result<char, ()> = Ok('a');
     let _ = res2.is_ok_and(char::is_alphanumeric); // should lint
     //~^ manual_is_variant_and
-    let _ = opt_map!(res2, |x| x == 'a').unwrap_or_default(); // should not lint
+
+    // should not lint
+    let _ = opt_map!(res2, |x| x == 'a').unwrap_or_default();
+    // The result type comes with no shorthand for all.
+    let _ = res.into_iter().all(i32::is_negative);
 }
 
 fn main() {}

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -51,6 +51,7 @@ macro_rules! mac {
 
 #[clippy::msrv = "1.69"]
 fn under_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.map(|x| x != 0) == Ok(true);
     let _ = res.into_iter().any(|x| x != 0);
     let _ = opt.map(|x| x != 0).unwrap_or_default();
     let _ = opt.iter().all(|x| *x != 0);
@@ -59,6 +60,8 @@ fn under_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
 
 #[clippy::msrv = "1.70"]
 fn meets_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.map(|x| x != 0) == Ok(true);
+    //~^ manual_is_variant_and
     let _ = res.into_iter().any(|x| x != 0);
     //~^ manual_is_variant_and
     let _ = opt.map(|x| x != 0).unwrap_or_default();
@@ -70,6 +73,8 @@ fn meets_msrv_is_some_and(opt: Option<u32>, res: Result<u32, ()>) {
 
 #[clippy::msrv = "1.81"]
 fn under_msrv_is_none_or(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.map(|x| x != 0) == Ok(true);
+    //~^ manual_is_variant_and
     let _ = res.into_iter().any(|x| x != 0);
     //~^ manual_is_variant_and
     let _ = opt.map(|x| x != 0).unwrap_or_default();
@@ -81,6 +86,8 @@ fn under_msrv_is_none_or(opt: Option<u32>, res: Result<u32, ()>) {
 
 #[clippy::msrv = "1.82"]
 fn meets_msrv_is_none_or(opt: Option<u32>, res: Result<u32, ()>) {
+    let _ = res.map(|x| x != 0) == Ok(true);
+    //~^ manual_is_variant_and
     let _ = res.into_iter().any(|x| x != 0);
     //~^ manual_is_variant_and
     let _ = opt.map(|x| x != 0).unwrap_or_default();

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -1,17 +1,118 @@
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:62:13
+   |
+LL |     let _ = res.into_iter().any(|x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::manual-is-variant-and` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res.into_iter().any(|x| x != 0);
+LL +     let _ = res.is_ok_and(|x| x != 0);
+   |
+
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:52:17
+  --> tests/ui/manual_is_variant_and.rs:64:17
+   |
+LL |     let _ = opt.map(|x| x != 0).unwrap_or_default();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x != 0)`
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:67:13
+   |
+LL |     let _ = opt.iter().any(|&x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = opt.iter().any(|&x| x != 0);
+LL +     let _ = opt.is_some_and(|x| x != 0);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:73:13
+   |
+LL |     let _ = res.into_iter().any(|x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res.into_iter().any(|x| x != 0);
+LL +     let _ = res.is_ok_and(|x| x != 0);
+   |
+
+error: called `map(<f>).unwrap_or_default()` on an `Option` value
+  --> tests/ui/manual_is_variant_and.rs:75:17
+   |
+LL |     let _ = opt.map(|x| x != 0).unwrap_or_default();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x != 0)`
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:78:13
+   |
+LL |     let _ = opt.iter().any(|&x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = opt.iter().any(|&x| x != 0);
+LL +     let _ = opt.is_some_and(|x| x != 0);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:84:13
+   |
+LL |     let _ = res.into_iter().any(|x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res.into_iter().any(|x| x != 0);
+LL +     let _ = res.is_ok_and(|x| x != 0);
+   |
+
+error: called `map(<f>).unwrap_or_default()` on an `Option` value
+  --> tests/ui/manual_is_variant_and.rs:86:17
+   |
+LL |     let _ = opt.map(|x| x != 0).unwrap_or_default();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x != 0)`
+
+error: use of `option::Iter::all`
+  --> tests/ui/manual_is_variant_and.rs:88:13
+   |
+LL |     let _ = opt.iter().all(|x| *x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = opt.iter().all(|x| *x != 0);
+LL +     let _ = opt.is_none_or(|x| x != 0);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:90:13
+   |
+LL |     let _ = opt.iter().any(|&x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = opt.iter().any(|&x| x != 0);
+LL +     let _ = opt.is_some_and(|x| x != 0);
+   |
+
+error: called `map(<f>).unwrap_or_default()` on an `Option` value
+  --> tests/ui/manual_is_variant_and.rs:101:17
    |
 LL |       let _ = opt.map(|x| x > 1)
    |  _________________^
 ...  |
 LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
-   |
-   = note: `-D clippy::manual-is-variant-and` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:57:17
+  --> tests/ui/manual_is_variant_and.rs:106:17
    |
 LL |       let _ = opt.map(|x| {
    |  _________________^
@@ -30,13 +131,13 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:62:17
+  --> tests/ui/manual_is_variant_and.rs:111:17
    |
 LL |     let _ = opt.map(|x| x > 1).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:65:10
+  --> tests/ui/manual_is_variant_and.rs:114:10
    |
 LL |           .map(|x| x > 1)
    |  __________^
@@ -45,37 +146,181 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:69:13
+  --> tests/ui/manual_is_variant_and.rs:118:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:71:13
+  --> tests/ui/manual_is_variant_and.rs:120:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 != 0)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:73:13
+  --> tests/ui/manual_is_variant_and.rs:122:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == some_true!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:75:13
+  --> tests/ui/manual_is_variant_and.rs:124:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != some_false!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
 
+error: use of `option::Iter::all`
+  --> tests/ui/manual_is_variant_and.rs:126:13
+   |
+LL |     let _ = opt.into_iter().all(|x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = opt.into_iter().all(|x| x != 0);
+LL +     let _ = opt.is_none_or(|x| x != 0);
+   |
+
+error: use of `option::Iter::all`
+  --> tests/ui/manual_is_variant_and.rs:128:13
+   |
+LL |     let _ = (opt.into_iter()).all(|x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = (opt.into_iter()).all(|x| x != 0);
+LL +     let _ = (opt).is_none_or(|x| x != 0);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:130:13
+   |
+LL |     let _ = opt.into_iter().any(i32::is_negative);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = opt.into_iter().any(i32::is_negative);
+LL +     let _ = opt.is_some_and(i32::is_negative);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:132:13
+   |
+LL |     let _ = opt.into_iter().any(|x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = opt.into_iter().any(|x| x != 0);
+LL +     let _ = opt.is_some_and(|x| x != 0);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:136:13
+   |
+LL |     let _ = (opt_non_copy.iter()).any(|x| x.is_empty());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = (opt_non_copy.iter()).any(|x| x.is_empty());
+LL +     let _ = (opt_non_copy).as_ref().is_some_and(|x| x.is_empty());
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:138:13
+   |
+LL |     let _ = opt_non_copy.iter().any(|x| x.is_empty());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = opt_non_copy.iter().any(|x| x.is_empty());
+LL +     let _ = opt_non_copy.as_ref().is_some_and(|x| x.is_empty());
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:140:13
+   |
+LL |     let _ = opt_non_copy.iter().any(|x| ".." == *x);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = opt_non_copy.iter().any(|x| ".." == *x);
+LL +     let _ = opt_non_copy.as_ref().is_some_and(|x| ".." == *x);
+   |
+
+error: use of `option::Iter::all`
+  --> tests/ui/manual_is_variant_and.rs:143:13
+   |
+LL |     let _ = opt.iter().all(|x| *x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = opt.iter().all(|x| *x != 0);
+LL +     let _ = opt.is_none_or(|x| x != 0);
+   |
+
+error: use of `option::Iter::all`
+  --> tests/ui/manual_is_variant_and.rs:145:13
+   |
+LL |     let _ = opt.iter().all(|_| false);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = opt.iter().all(|_| false);
+LL +     let _ = opt.as_ref().is_none_or(|_| false);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:147:13
+   |
+LL |     let _ = opt.iter().any(|&x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = opt.iter().any(|&x| x != 0);
+LL +     let _ = opt.is_some_and(|x| x != 0);
+   |
+
+error: use of `option::Iter::all`
+  --> tests/ui/manual_is_variant_and.rs:149:13
+   |
+LL |     let _ = opt.iter().all(|&_| false);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = opt.iter().all(|&_| false);
+LL +     let _ = opt.is_none_or(|_| false);
+   |
+
+error: use of `option::Iter::all`
+  --> tests/ui/manual_is_variant_and.rs:154:13
+   |
+LL |     let _ = opt.iter().all(zerop);
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = opt.iter().all(zerop);
+LL +     let _ = opt.as_ref().is_none_or(zerop);
+   |
+
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:82:18
+  --> tests/ui/manual_is_variant_and.rs:161:18
    |
 LL |     let _ = opt2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(char::is_alphanumeric)`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:100:17
+  --> tests/ui/manual_is_variant_and.rs:182:17
    |
 LL |       let _ = res.map(|x| {
    |  _________________^
@@ -94,7 +339,7 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:105:17
+  --> tests/ui/manual_is_variant_and.rs:187:17
    |
 LL |       let _ = res.map(|x| x > 1)
    |  _________________^
@@ -103,148 +348,184 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_ok_and(|x| x > 1)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:109:13
+  --> tests/ui/manual_is_variant_and.rs:191:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) == Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:111:13
+  --> tests/ui/manual_is_variant_and.rs:193:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:113:13
+  --> tests/ui/manual_is_variant_and.rs:195:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:197:13
+   |
+LL |     let _ = res.into_iter().any(i32::is_negative);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res.into_iter().any(i32::is_negative);
+LL +     let _ = res.is_ok_and(i32::is_negative);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:199:13
+   |
+LL |     let _ = res_non_copy.iter().any(|x| *x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res_non_copy.iter().any(|x| *x != 0);
+LL +     let _ = res_non_copy.as_ref().is_ok_and(|x| *x != 0);
+   |
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:201:13
+   |
+LL |     let _ = res.iter().any(|x| *x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res.iter().any(|x| *x != 0);
+LL +     let _ = res.is_ok_and(|x| x != 0);
+   |
+
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:120:18
+  --> tests/ui/manual_is_variant_and.rs:208:18
    |
 LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:130:18
+  --> tests/ui/manual_is_variant_and.rs:222:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:137:18
+  --> tests/ui/manual_is_variant_and.rs:229:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:144:18
+  --> tests/ui/manual_is_variant_and.rs:236:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:151:18
+  --> tests/ui/manual_is_variant_and.rs:243:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:159:18
+  --> tests/ui/manual_is_variant_and.rs:251:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:166:18
+  --> tests/ui/manual_is_variant_and.rs:258:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:173:18
+  --> tests/ui/manual_is_variant_and.rs:265:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:180:18
+  --> tests/ui/manual_is_variant_and.rs:272:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:193:18
+  --> tests/ui/manual_is_variant_and.rs:285:18
    |
 LL |         let a1 = b.map(iad) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(iad)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:198:18
+  --> tests/ui/manual_is_variant_and.rs:290:18
    |
 LL |         let a1 = b.map(iad) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:203:18
+  --> tests/ui/manual_is_variant_and.rs:295:18
    |
 LL |         let a1 = b.map(iad) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:208:18
+  --> tests/ui/manual_is_variant_and.rs:300:18
    |
 LL |         let a1 = b.map(iad) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(iad)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:215:18
+  --> tests/ui/manual_is_variant_and.rs:307:18
    |
 LL |         let a1 = b.map(iad) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(iad)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:220:18
+  --> tests/ui/manual_is_variant_and.rs:312:18
    |
 LL |         let a1 = b.map(iad) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(|x| !iad(x))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:225:18
+  --> tests/ui/manual_is_variant_and.rs:317:18
    |
 LL |         let a1 = b.map(iad) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(iad)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:230:18
+  --> tests/ui/manual_is_variant_and.rs:322:18
    |
 LL |         let a1 = b.map(iad) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:240:13
+  --> tests/ui/manual_is_variant_and.rs:332:13
    |
 LL |     let _ = opt.is_none() || opt.is_some_and(then_fn);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:243:13
+  --> tests/ui/manual_is_variant_and.rs:335:13
    |
 LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_some_and`
-  --> tests/ui/manual_is_variant_and.rs:259:5
+  --> tests/ui/manual_is_variant_and.rs:351:5
    |
 LL |     opt.filter(|x| condition(x)).is_some();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_some_and(|x| condition(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:261:5
+  --> tests/ui/manual_is_variant_and.rs:353:5
    |
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`
 
-error: aborting due to 35 previous errors
+error: aborting due to 60 previous errors
 

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -1,11 +1,18 @@
+error: called `.map() == Ok()`
+  --> tests/ui/manual_is_variant_and.rs:63:13
+   |
+LL |     let _ = res.map(|x| x != 0) == Ok(true);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `res.is_ok_and(|x| x != 0)`
+   |
+   = note: `-D clippy::manual-is-variant-and` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
+
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:62:13
+  --> tests/ui/manual_is_variant_and.rs:65:13
    |
 LL |     let _ = res.into_iter().any(|x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `-D clippy::manual-is-variant-and` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 help: use `is_ok_and` instead
    |
 LL -     let _ = res.into_iter().any(|x| x != 0);
@@ -13,13 +20,13 @@ LL +     let _ = res.is_ok_and(|x| x != 0);
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:64:17
+  --> tests/ui/manual_is_variant_and.rs:67:17
    |
 LL |     let _ = opt.map(|x| x != 0).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x != 0)`
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:67:13
+  --> tests/ui/manual_is_variant_and.rs:70:13
    |
 LL |     let _ = opt.iter().any(|&x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -30,27 +37,33 @@ LL -     let _ = opt.iter().any(|&x| x != 0);
 LL +     let _ = opt.is_some_and(|x| x != 0);
    |
 
-error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:73:13
+error: called `.map() == Ok()`
+  --> tests/ui/manual_is_variant_and.rs:76:13
    |
-LL |     let _ = res.into_iter().any(|x| x != 0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_ok_and` instead
-   |
-LL -     let _ = res.into_iter().any(|x| x != 0);
-LL +     let _ = res.is_ok_and(|x| x != 0);
-   |
-
-error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:75:17
-   |
-LL |     let _ = opt.map(|x| x != 0).unwrap_or_default();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x != 0)`
+LL |     let _ = res.map(|x| x != 0) == Ok(true);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `res.is_ok_and(|x| x != 0)`
 
 error: use of `option::Iter::any`
   --> tests/ui/manual_is_variant_and.rs:78:13
    |
+LL |     let _ = res.into_iter().any(|x| x != 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res.into_iter().any(|x| x != 0);
+LL +     let _ = res.is_ok_and(|x| x != 0);
+   |
+
+error: called `map(<f>).unwrap_or_default()` on an `Option` value
+  --> tests/ui/manual_is_variant_and.rs:80:17
+   |
+LL |     let _ = opt.map(|x| x != 0).unwrap_or_default();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x != 0)`
+
+error: use of `option::Iter::any`
+  --> tests/ui/manual_is_variant_and.rs:83:13
+   |
 LL |     let _ = opt.iter().any(|&x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -60,8 +73,14 @@ LL -     let _ = opt.iter().any(|&x| x != 0);
 LL +     let _ = opt.is_some_and(|x| x != 0);
    |
 
+error: called `.map() == Ok()`
+  --> tests/ui/manual_is_variant_and.rs:89:13
+   |
+LL |     let _ = res.map(|x| x != 0) == Ok(true);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `res.is_ok_and(|x| x != 0)`
+
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:84:13
+  --> tests/ui/manual_is_variant_and.rs:91:13
    |
 LL |     let _ = res.into_iter().any(|x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,13 +92,13 @@ LL +     let _ = res.is_ok_and(|x| x != 0);
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:86:17
+  --> tests/ui/manual_is_variant_and.rs:93:17
    |
 LL |     let _ = opt.map(|x| x != 0).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x != 0)`
 
 error: use of `option::Iter::all`
-  --> tests/ui/manual_is_variant_and.rs:88:13
+  --> tests/ui/manual_is_variant_and.rs:95:13
    |
 LL |     let _ = opt.iter().all(|x| *x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -91,7 +110,7 @@ LL +     let _ = opt.is_none_or(|x| x != 0);
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:90:13
+  --> tests/ui/manual_is_variant_and.rs:97:13
    |
 LL |     let _ = opt.iter().any(|&x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +122,7 @@ LL +     let _ = opt.is_some_and(|x| x != 0);
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:101:17
+  --> tests/ui/manual_is_variant_and.rs:108:17
    |
 LL |       let _ = opt.map(|x| x > 1)
    |  _________________^
@@ -112,7 +131,7 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:106:17
+  --> tests/ui/manual_is_variant_and.rs:113:17
    |
 LL |       let _ = opt.map(|x| {
    |  _________________^
@@ -131,13 +150,13 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:111:17
+  --> tests/ui/manual_is_variant_and.rs:118:17
    |
 LL |     let _ = opt.map(|x| x > 1).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:114:10
+  --> tests/ui/manual_is_variant_and.rs:121:10
    |
 LL |           .map(|x| x > 1)
    |  __________^
@@ -146,31 +165,31 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:118:13
+  --> tests/ui/manual_is_variant_and.rs:125:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:120:13
+  --> tests/ui/manual_is_variant_and.rs:127:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 != 0)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:122:13
+  --> tests/ui/manual_is_variant_and.rs:129:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == some_true!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:124:13
+  --> tests/ui/manual_is_variant_and.rs:131:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != some_false!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
 
 error: use of `option::Iter::all`
-  --> tests/ui/manual_is_variant_and.rs:126:13
+  --> tests/ui/manual_is_variant_and.rs:133:13
    |
 LL |     let _ = opt.into_iter().all(|x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,7 +201,7 @@ LL +     let _ = opt.is_none_or(|x| x != 0);
    |
 
 error: use of `option::Iter::all`
-  --> tests/ui/manual_is_variant_and.rs:128:13
+  --> tests/ui/manual_is_variant_and.rs:135:13
    |
 LL |     let _ = (opt.into_iter()).all(|x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,7 +213,7 @@ LL +     let _ = (opt).is_none_or(|x| x != 0);
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:130:13
+  --> tests/ui/manual_is_variant_and.rs:137:13
    |
 LL |     let _ = opt.into_iter().any(i32::is_negative);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -206,7 +225,7 @@ LL +     let _ = opt.is_some_and(i32::is_negative);
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:132:13
+  --> tests/ui/manual_is_variant_and.rs:139:13
    |
 LL |     let _ = opt.into_iter().any(|x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -218,7 +237,7 @@ LL +     let _ = opt.is_some_and(|x| x != 0);
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:136:13
+  --> tests/ui/manual_is_variant_and.rs:143:13
    |
 LL |     let _ = (opt_non_copy.iter()).any(|x| x.is_empty());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,7 +249,7 @@ LL +     let _ = (opt_non_copy).as_ref().is_some_and(|x| x.is_empty());
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:138:13
+  --> tests/ui/manual_is_variant_and.rs:145:13
    |
 LL |     let _ = opt_non_copy.iter().any(|x| x.is_empty());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -242,7 +261,7 @@ LL +     let _ = opt_non_copy.as_ref().is_some_and(|x| x.is_empty());
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:140:13
+  --> tests/ui/manual_is_variant_and.rs:147:13
    |
 LL |     let _ = opt_non_copy.iter().any(|x| ".." == *x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -254,7 +273,7 @@ LL +     let _ = opt_non_copy.as_ref().is_some_and(|x| ".." == *x);
    |
 
 error: use of `option::Iter::all`
-  --> tests/ui/manual_is_variant_and.rs:143:13
+  --> tests/ui/manual_is_variant_and.rs:150:13
    |
 LL |     let _ = opt.iter().all(|x| *x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -266,7 +285,7 @@ LL +     let _ = opt.is_none_or(|x| x != 0);
    |
 
 error: use of `option::Iter::all`
-  --> tests/ui/manual_is_variant_and.rs:145:13
+  --> tests/ui/manual_is_variant_and.rs:152:13
    |
 LL |     let _ = opt.iter().all(|_| false);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -278,7 +297,7 @@ LL +     let _ = opt.as_ref().is_none_or(|_| false);
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:147:13
+  --> tests/ui/manual_is_variant_and.rs:154:13
    |
 LL |     let _ = opt.iter().any(|&x| x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -290,7 +309,7 @@ LL +     let _ = opt.is_some_and(|x| x != 0);
    |
 
 error: use of `option::Iter::all`
-  --> tests/ui/manual_is_variant_and.rs:149:13
+  --> tests/ui/manual_is_variant_and.rs:156:13
    |
 LL |     let _ = opt.iter().all(|&_| false);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -302,7 +321,7 @@ LL +     let _ = opt.is_none_or(|_| false);
    |
 
 error: use of `option::Iter::all`
-  --> tests/ui/manual_is_variant_and.rs:154:13
+  --> tests/ui/manual_is_variant_and.rs:161:13
    |
 LL |     let _ = opt.iter().all(zerop);
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -314,13 +333,13 @@ LL +     let _ = opt.as_ref().is_none_or(zerop);
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:161:18
+  --> tests/ui/manual_is_variant_and.rs:168:18
    |
 LL |     let _ = opt2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(char::is_alphanumeric)`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:182:17
+  --> tests/ui/manual_is_variant_and.rs:189:17
    |
 LL |       let _ = res.map(|x| {
    |  _________________^
@@ -339,7 +358,7 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:187:17
+  --> tests/ui/manual_is_variant_and.rs:194:17
    |
 LL |       let _ = res.map(|x| x > 1)
    |  _________________^
@@ -348,25 +367,25 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_ok_and(|x| x > 1)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:191:13
+  --> tests/ui/manual_is_variant_and.rs:198:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) == Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:193:13
+  --> tests/ui/manual_is_variant_and.rs:200:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:195:13
+  --> tests/ui/manual_is_variant_and.rs:202:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:197:13
+  --> tests/ui/manual_is_variant_and.rs:204:13
    |
 LL |     let _ = res.into_iter().any(i32::is_negative);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -378,7 +397,7 @@ LL +     let _ = res.is_ok_and(i32::is_negative);
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:199:13
+  --> tests/ui/manual_is_variant_and.rs:206:13
    |
 LL |     let _ = res_non_copy.iter().any(|x| *x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -390,7 +409,7 @@ LL +     let _ = res_non_copy.as_ref().is_ok_and(|x| *x != 0);
    |
 
 error: use of `option::Iter::any`
-  --> tests/ui/manual_is_variant_and.rs:201:13
+  --> tests/ui/manual_is_variant_and.rs:208:13
    |
 LL |     let _ = res.iter().any(|x| *x != 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -402,130 +421,130 @@ LL +     let _ = res.is_ok_and(|x| x != 0);
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:208:18
+  --> tests/ui/manual_is_variant_and.rs:215:18
    |
 LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:222:18
+  --> tests/ui/manual_is_variant_and.rs:229:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:229:18
+  --> tests/ui/manual_is_variant_and.rs:236:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:236:18
+  --> tests/ui/manual_is_variant_and.rs:243:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:243:18
+  --> tests/ui/manual_is_variant_and.rs:250:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:251:18
+  --> tests/ui/manual_is_variant_and.rs:258:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:258:18
+  --> tests/ui/manual_is_variant_and.rs:265:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:265:18
+  --> tests/ui/manual_is_variant_and.rs:272:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:272:18
+  --> tests/ui/manual_is_variant_and.rs:279:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:285:18
+  --> tests/ui/manual_is_variant_and.rs:292:18
    |
 LL |         let a1 = b.map(iad) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(iad)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:290:18
+  --> tests/ui/manual_is_variant_and.rs:297:18
    |
 LL |         let a1 = b.map(iad) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:295:18
+  --> tests/ui/manual_is_variant_and.rs:302:18
    |
 LL |         let a1 = b.map(iad) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:300:18
+  --> tests/ui/manual_is_variant_and.rs:307:18
    |
 LL |         let a1 = b.map(iad) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(iad)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:307:18
+  --> tests/ui/manual_is_variant_and.rs:314:18
    |
 LL |         let a1 = b.map(iad) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(iad)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:312:18
+  --> tests/ui/manual_is_variant_and.rs:319:18
    |
 LL |         let a1 = b.map(iad) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(|x| !iad(x))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:317:18
+  --> tests/ui/manual_is_variant_and.rs:324:18
    |
 LL |         let a1 = b.map(iad) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(iad)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:322:18
+  --> tests/ui/manual_is_variant_and.rs:329:18
    |
 LL |         let a1 = b.map(iad) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:332:13
+  --> tests/ui/manual_is_variant_and.rs:339:13
    |
 LL |     let _ = opt.is_none() || opt.is_some_and(then_fn);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:335:13
+  --> tests/ui/manual_is_variant_and.rs:342:13
    |
 LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_some_and`
-  --> tests/ui/manual_is_variant_and.rs:351:5
+  --> tests/ui/manual_is_variant_and.rs:358:5
    |
 LL |     opt.filter(|x| condition(x)).is_some();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_some_and(|x| condition(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:353:5
+  --> tests/ui/manual_is_variant_and.rs:360:5
    |
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`
 
-error: aborting due to 60 previous errors
+error: aborting due to 63 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/15989)*

Now the linter checks for calling the `iter` or `into_iter` method
followed by calling the `all` or `any` method.

We have used these methods by mistake ourselves.  The developer was not
familiar with the `is_some_and` method.  He tried to use the `any`
method on an option.  The compiler suggested using `iter` first.  The
developer did not get to learn about the idiomatic method.

The lint `search_is_some` involves converting a closure that takes the
reference into one that takes the value.  The code is split between the
function for the lint and a shared function.  The new feature that we
are adding involves the same transformation.  To do so it needs some of
the same code that is currently in the `search_is_some` lint.  So it is
moved from the lint into the shared function.

Before this patch, line 799 in the file `clippy_utils/src/sugg.rs` had a
check.  It made the function return none in case the closure did not
dereference the argument.  However, the code for the lint
`search_is_some` would then fall back to using the original closure.
That achieved the same effect as the check not existing.  So the check
is now removed.

changelog: [`manual_is_variant`]: check for calling the `iter` or
`into_iter` method followed by calling the `all` or `any` method

changelog: [`manual_is_variant`]: skip the check when the MSRV is before
1.70
