### PR TITLE
Add lint to suggest as_chunks over chunks_exact with constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6328,6 +6328,7 @@ Released 2018-09-13
 [`chars_last_cmp`]: https://rust-lang.github.io/rust-clippy/master/index.html#chars_last_cmp
 [`chars_next_cmp`]: https://rust-lang.github.io/rust-clippy/master/index.html#chars_next_cmp
 [`checked_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#checked_conversions
+[`chunks_exact_to_as_chunks`]: https://rust-lang.github.io/rust-clippy/master/index.html#chunks_exact_to_as_chunks
 [`clear_with_drain`]: https://rust-lang.github.io/rust-clippy/master/index.html#clear_with_drain
 [`clone_double_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#clone_double_ref
 [`clone_on_copy`]: https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -356,6 +356,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::CASE_SENSITIVE_FILE_EXTENSION_COMPARISONS_INFO,
     crate::methods::CHARS_LAST_CMP_INFO,
     crate::methods::CHARS_NEXT_CMP_INFO,
+    crate::methods::CHUNKS_EXACT_TO_AS_CHUNKS_INFO,
     crate::methods::CLEAR_WITH_DRAIN_INFO,
     crate::methods::CLONED_INSTEAD_OF_COPIED_INFO,
     crate::methods::CLONE_ON_COPY_INFO,

--- a/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
+++ b/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
@@ -1,0 +1,108 @@
+use super::CHUNKS_EXACT_TO_AS_CHUNKS;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::visitors::is_const_evaluatable;
+use clippy_utils::{expr_use_ctxt, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, Node, PatKind};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+use rustc_span::{DesugaringKind, ExpnKind, Span, Symbol};
+
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    recv: &'tcx Expr<'tcx>,
+    arg: &'tcx Expr<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    call_span: Span,
+    method_name: Symbol,
+    msrv: Msrv,
+) {
+    let recv_ty = cx.typeck_results().expr_ty_adjusted(recv);
+    if !matches!(recv_ty.kind(), ty::Ref(_, inner, _) if inner.is_slice()) {
+        return;
+    }
+
+    if is_const_evaluatable(cx, arg) {
+        if !msrv.meets(cx, msrvs::AS_CHUNKS) {
+            return;
+        }
+
+        let suggestion_method = if method_name == sym::chunks_exact_mut {
+            "as_chunks_mut"
+        } else {
+            "as_chunks"
+        };
+
+        let mut applicability = Applicability::MachineApplicable;
+        let arg_str = snippet_with_context(cx, arg.span, expr.span.ctxt(), "_", &mut applicability).0;
+
+        let as_chunks = format_args!("{suggestion_method}::<{arg_str}>()");
+
+        span_lint_and_then(
+            cx,
+            CHUNKS_EXACT_TO_AS_CHUNKS,
+            call_span,
+            format!("using `{method_name}` with a constant chunk size"),
+            |diag| {
+                let use_ctxt = expr_use_ctxt(cx, expr);
+
+                if use_ctxt.is_ty_unified {
+                    diag.span_help(call_span, format!("consider using `{as_chunks}` instead"));
+                    return;
+                }
+
+                if let Node::Expr(use_expr) = use_ctxt.node {
+                    match use_expr.kind {
+                        ExprKind::Call(_, [recv]) | ExprKind::MethodCall(_, recv, [], _)
+                            if recv.hir_id == use_ctxt.child_id
+                                && matches!(
+                                    use_expr.span.ctxt().outer_expn_data().kind,
+                                    ExpnKind::Desugaring(DesugaringKind::ForLoop),
+                                ) =>
+                        {
+                            // Suggest `.0`
+                            diag.span_suggestion(
+                                call_span,
+                                "consider using `as_chunks` instead",
+                                format!("{as_chunks}.0"),
+                                applicability,
+                            );
+                            return;
+                        },
+                        ExprKind::MethodCall(_, recv, ..)
+                            if recv.hir_id == use_ctxt.child_id
+                                && cx
+                                    .ty_based_def(use_expr)
+                                    .assoc_fn_parent(cx)
+                                    .is_diag_item(cx, sym::Iterator) =>
+                        {
+                            // Suggest `.0.iter()`
+                            diag.span_suggestion(
+                                call_span,
+                                "consider using `as_chunks` instead",
+                                format!("{as_chunks}.0.iter()"),
+                                applicability,
+                            );
+                            return;
+                        },
+                        _ => {},
+                    }
+                }
+
+                // Fallback suggestion
+                diag.span_help(call_span, format!("consider using `{as_chunks}` instead"));
+
+                if let Node::LetStmt(let_stmt) = use_ctxt.node
+                    && let PatKind::Binding(_, _, ident, _) = let_stmt.pat.kind
+                {
+                    diag.note(format!(
+                        "you can access the chunks using `{ident}.0.iter()`, and the remainder using `{ident}.1`"
+                    ));
+                }
+            },
+        );
+    }
+}

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -24,7 +24,7 @@ macro_rules! msrv_aliases {
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
     1,91,0 { DURATION_FROM_MINUTES_HOURS }
-    1,88,0 { LET_CHAINS }
+    1,88,0 { LET_CHAINS, AS_CHUNKS }
     1,87,0 { OS_STR_DISPLAY, INT_MIDPOINT, CONST_CHAR_IS_DIGIT, UNSIGNED_IS_MULTIPLE_OF, INTEGER_SIGN_CAST }
     1,85,0 { UINT_FLOAT_MIDPOINT, CONST_SIZE_OF_VAL }
     1,84,0 { CONST_OPTION_AS_SLICE, MANUAL_DANGLING_PTR }

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -112,6 +112,8 @@ generate! {
     checked_pow,
     checked_rem_euclid,
     checked_sub,
+    chunks_exact,
+    chunks_exact_mut,
     clamp,
     clippy_utils,
     clone_into,

--- a/tests/ui/chunks_exact_to_as_chunks.rs
+++ b/tests/ui/chunks_exact_to_as_chunks.rs
@@ -6,13 +6,13 @@ fn main() {
 
     // Should trigger lint - literal constant
     let mut it = slice.chunks_exact(4);
-    //~^ ERROR: using `chunks_exact` with a constant chunk size
+    //~^ chunks_exact_to_as_chunks
     for chunk in it {}
 
     // Should trigger lint - const value
     const CHUNK_SIZE: usize = 4;
     let mut it = slice.chunks_exact(CHUNK_SIZE);
-    //~^ ERROR: using `chunks_exact` with a constant chunk size
+    //~^ chunks_exact_to_as_chunks
     for chunk in it {}
 
     // Should NOT trigger - runtime value
@@ -22,13 +22,22 @@ fn main() {
 
     // Should trigger lint - with remainder
     let mut it = slice.chunks_exact(3);
-    //~^ ERROR: using `chunks_exact` with a constant chunk size
+    //~^ chunks_exact_to_as_chunks
     for chunk in &mut it {}
     for e in it.remainder() {}
 
     // Should trigger - mutable variant
     let mut arr = [1, 2, 3, 4, 5, 6, 7, 8];
     let mut it = arr.chunks_exact_mut(4);
-    //~^ ERROR: using `chunks_exact_mut` with a constant chunk size
+    //~^ chunks_exact_to_as_chunks
     for chunk in it {}
+
+    // Should NOT trigger - type must unify with another branch
+    let condition = true;
+    let y = 3;
+    let _ = if condition {
+        slice.chunks_exact(5)
+    } else {
+        slice.chunks_exact(y)
+    };
 }

--- a/tests/ui/chunks_exact_to_as_chunks.rs
+++ b/tests/ui/chunks_exact_to_as_chunks.rs
@@ -1,0 +1,34 @@
+#![warn(clippy::chunks_exact_to_as_chunks)]
+#![allow(unused)]
+
+fn main() {
+    let slice = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    // Should trigger lint - literal constant
+    let mut it = slice.chunks_exact(4);
+    //~^ ERROR: using `chunks_exact` with a constant chunk size
+    for chunk in it {}
+
+    // Should trigger lint - const value
+    const CHUNK_SIZE: usize = 4;
+    let mut it = slice.chunks_exact(CHUNK_SIZE);
+    //~^ ERROR: using `chunks_exact` with a constant chunk size
+    for chunk in it {}
+
+    // Should NOT trigger - runtime value
+    let size = 4;
+    let mut it = slice.chunks_exact(size);
+    for chunk in it {}
+
+    // Should trigger lint - with remainder
+    let mut it = slice.chunks_exact(3);
+    //~^ ERROR: using `chunks_exact` with a constant chunk size
+    for chunk in &mut it {}
+    for e in it.remainder() {}
+
+    // Should trigger - mutable variant
+    let mut arr = [1, 2, 3, 4, 5, 6, 7, 8];
+    let mut it = arr.chunks_exact_mut(4);
+    //~^ ERROR: using `chunks_exact_mut` with a constant chunk size
+    for chunk in it {}
+}

--- a/tests/ui/chunks_exact_to_as_chunks.stderr
+++ b/tests/ui/chunks_exact_to_as_chunks.stderr
@@ -1,0 +1,56 @@
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks.rs:8:24
+   |
+LL |     let mut it = slice.chunks_exact(4);
+   |                        ^^^^^^^^^^^^^^^
+   |
+help: consider using `as_chunks::<4>()` instead
+  --> tests/ui/chunks_exact_to_as_chunks.rs:8:24
+   |
+LL |     let mut it = slice.chunks_exact(4);
+   |                        ^^^^^^^^^^^^^^^
+   = note: you can access the chunks using `it.0.iter()`, and the remainder using `it.1`
+   = note: `-D clippy::chunks-exact-to-as-chunks` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::chunks_exact_to_as_chunks)]`
+
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks.rs:14:24
+   |
+LL |     let mut it = slice.chunks_exact(CHUNK_SIZE);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `as_chunks::<CHUNK_SIZE>()` instead
+  --> tests/ui/chunks_exact_to_as_chunks.rs:14:24
+   |
+LL |     let mut it = slice.chunks_exact(CHUNK_SIZE);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: you can access the chunks using `it.0.iter()`, and the remainder using `it.1`
+
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks.rs:24:24
+   |
+LL |     let mut it = slice.chunks_exact(3);
+   |                        ^^^^^^^^^^^^^^^
+   |
+help: consider using `as_chunks::<3>()` instead
+  --> tests/ui/chunks_exact_to_as_chunks.rs:24:24
+   |
+LL |     let mut it = slice.chunks_exact(3);
+   |                        ^^^^^^^^^^^^^^^
+   = note: you can access the chunks using `it.0.iter()`, and the remainder using `it.1`
+
+error: using `chunks_exact_mut` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks.rs:31:22
+   |
+LL |     let mut it = arr.chunks_exact_mut(4);
+   |                      ^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `as_chunks_mut::<4>()` instead
+  --> tests/ui/chunks_exact_to_as_chunks.rs:31:22
+   |
+LL |     let mut it = arr.chunks_exact_mut(4);
+   |                      ^^^^^^^^^^^^^^^^^^^
+   = note: you can access the chunks using `it.0.iter()`, and the remainder using `it.1`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16002)*

Adds a new lint `chunks_exact_to_as_chunks` that suggests using  `as_chunks` instead of `chunks_exact` when the chunk size is a compile-time constant.

changelog: [`chunks_exact_to_as_chunks`]: Suggest using slice.as_chunks::<N>() when chunks_exact(N) is called with a compile-time constant. This provides better ergonomics and type safety.

fixes rust-lang/rust-clippy#15882 