### PR TITLE
fix(let_and_return): disallow _any_ text between let and return

### DIFF
--- a/clippy_lints/src/returns/let_and_return.rs
+++ b/clippy_lints/src/returns/let_and_return.rs
@@ -3,7 +3,7 @@ use clippy_utils::res::MaybeResPath;
 use clippy_utils::source::SpanRangeExt;
 use clippy_utils::sugg::has_enclosing_paren;
 use clippy_utils::visitors::for_each_expr;
-use clippy_utils::{binary_expr_needs_parentheses, fn_def_id, span_contains_cfg};
+use clippy_utils::{binary_expr_needs_parentheses, fn_def_id, span_contains_non_whitespace};
 use core::ops::ControlFlow;
 use rustc_errors::Applicability;
 use rustc_hir::{Block, Expr, PatKind, StmtKind};
@@ -27,7 +27,7 @@ pub(super) fn check_block<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'_>) 
         && !initexpr.span.in_external_macro(cx.sess().source_map())
         && !retexpr.span.in_external_macro(cx.sess().source_map())
         && !local.span.from_expansion()
-        && !span_contains_cfg(cx, stmt.span.between(retexpr.span))
+        && !span_contains_non_whitespace(cx, stmt.span.between(retexpr.span), true)
     {
         span_lint_hir_and_then(
             cx,

--- a/tests/ui/let_and_return.edition2021.fixed
+++ b/tests/ui/let_and_return.edition2021.fixed
@@ -261,4 +261,14 @@ fn issue14164() -> Result<u32, ()> {
     //~[edition2024]^ let_and_return
 }
 
+fn issue15987() -> i32 {
+    macro_rules! sample {
+        ( $( $args:expr ),+ ) => {};
+    }
+
+    let r = 5;
+    sample!(r);
+    r
+}
+
 fn main() {}

--- a/tests/ui/let_and_return.edition2024.fixed
+++ b/tests/ui/let_and_return.edition2024.fixed
@@ -261,4 +261,14 @@ fn issue14164() -> Result<u32, ()> {
     //~[edition2024]^ let_and_return
 }
 
+fn issue15987() -> i32 {
+    macro_rules! sample {
+        ( $( $args:expr ),+ ) => {};
+    }
+
+    let r = 5;
+    sample!(r);
+    r
+}
+
 fn main() {}

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -261,4 +261,14 @@ fn issue14164() -> Result<u32, ()> {
     //~[edition2024]^ let_and_return
 }
 
+fn issue15987() -> i32 {
+    macro_rules! sample {
+        ( $( $args:expr ),+ ) => {};
+    }
+
+    let r = 5;
+    sample!(r);
+    r
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/15987

changelog: [`let_and_return`]: disallow _any_ text between let and return