### PR TITLE
Fix `set-contains-or-insert` FP when set is mutated before `insert`

### DIFF
--- a/tests/ui/set_contains_or_insert.rs
+++ b/tests/ui/set_contains_or_insert.rs
@@ -164,3 +164,24 @@ fn main() {
     should_not_warn_hashset();
     should_not_warn_btreeset();
 }
+
+fn issue15990(s: &mut HashSet<usize>, v: usize) {
+    if !s.contains(&v) {
+        s.clear();
+        s.insert(v);
+    }
+
+    fn borrow_as_mut(v: usize, s: &mut HashSet<usize>) {
+        s.clear();
+    }
+    if !s.contains(&v) {
+        borrow_as_mut(v, s);
+        s.insert(v);
+    }
+
+    if !s.contains(&v) {
+        //~^ set_contains_or_insert
+        let _readonly_access = s.contains(&v);
+        s.insert(v);
+    }
+}

--- a/tests/ui/set_contains_or_insert.stderr
+++ b/tests/ui/set_contains_or_insert.stderr
@@ -127,5 +127,14 @@ LL |
 LL |         borrow_set.insert(value);
    |                    ^^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: usage of `HashSet::insert` after `HashSet::contains`
+  --> tests/ui/set_contains_or_insert.rs:182:11
+   |
+LL |     if !s.contains(&v) {
+   |           ^^^^^^^^^^^^
+...
+LL |         s.insert(v);
+   |           ^^^^^^^^^
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#15990 

changelog: [`set-contains-or-insert`] fix FP when set is mutated before `insert`
