### PR TITLE
Fix `dbg_macro` ICE when used iterated by for loop

### DIFF
--- a/tests/ui/dbg_macro/dbg_macro.fixed
+++ b/tests/ui/dbg_macro/dbg_macro.fixed
@@ -139,3 +139,8 @@ mod issue14914 {
         //~^ dbg_macro
     }
 }
+
+fn issue16008() {
+    for _ in [1, 2] {}
+    //~^ dbg_macro
+}

--- a/tests/ui/dbg_macro/dbg_macro.rs
+++ b/tests/ui/dbg_macro/dbg_macro.rs
@@ -139,3 +139,8 @@ mod issue14914 {
         //~^ dbg_macro
     }
 }
+
+fn issue16008() {
+    for _ in dbg!([1, 2]) {}
+    //~^ dbg_macro
+}

--- a/tests/ui/dbg_macro/dbg_macro.stderr
+++ b/tests/ui/dbg_macro/dbg_macro.stderr
@@ -242,5 +242,17 @@ LL -         takes_async_fn(async |val| dbg!(val));
 LL +         takes_async_fn(async |val| val);
    |
 
-error: aborting due to 20 previous errors
+error: the `dbg!` macro is intended as a debugging tool
+  --> tests/ui/dbg_macro/dbg_macro.rs:144:14
+   |
+LL |     for _ in dbg!([1, 2]) {}
+   |              ^^^^^^^^^^^^
+   |
+help: remove the invocation before committing it to a version control system
+   |
+LL -     for _ in dbg!([1, 2]) {}
+LL +     for _ in [1, 2] {}
+   |
+
+error: aborting due to 21 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16008 

changelog: [`dbg_macro`] fix ICE when used iterated by for loop
