### PR TITLE
Fix `nonminimal_bool` wrongly unmangled terms

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -3,7 +3,7 @@ use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_hir_and_then};
 use clippy_utils::higher::has_let_expr;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
-use clippy_utils::source::SpanRangeExt;
+use clippy_utils::source::{SpanRangeExt, snippet_with_context};
 use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::implements_trait;
 use clippy_utils::{eq_expr_value, sym};
@@ -415,19 +415,20 @@ fn simplify_not(cx: &LateContext<'_>, curr_msrv: Msrv, expr: &Expr<'_>) -> Optio
                 BinOpKind::Ge => Some(" < "),
                 _ => None,
             }
-            .and_then(|op| {
-                let lhs_snippet = lhs.span.get_source_text(cx)?;
-                let rhs_snippet = rhs.span.get_source_text(cx)?;
+            .map(|op| {
+                let mut app = Applicability::MachineApplicable;
+                let (lhs_snippet, _) = snippet_with_context(cx, lhs.span, SyntaxContext::root(), "", &mut app);
+                let (rhs_snippet, _) = snippet_with_context(cx, rhs.span, SyntaxContext::root(), "", &mut app);
 
                 if !(lhs_snippet.starts_with('(') && lhs_snippet.ends_with(')'))
                     && let (ExprKind::Cast(..), BinOpKind::Ge) = (&lhs.kind, binop.node)
                 {
                     // e.g. `(a as u64) < b`. Without the parens the `<` is
                     // interpreted as a start of generic arguments for `u64`
-                    return Some(format!("({lhs_snippet}){op}{rhs_snippet}"));
+                    return format!("({lhs_snippet}){op}{rhs_snippet}");
                 }
 
-                Some(format!("{lhs_snippet}{op}{rhs_snippet}"))
+                format!("{lhs_snippet}{op}{rhs_snippet}")
             })
         },
         ExprKind::MethodCall(path, receiver, args, _) => {

--- a/tests/ui/nonminimal_bool_methods.fixed
+++ b/tests/ui/nonminimal_bool_methods.fixed
@@ -242,4 +242,9 @@ fn issue_13436() {
     }
 }
 
+fn issue16014() {
+    (vec![1, 2, 3] > vec![1, 2, 3, 3]);
+    //~^ nonminimal_bool
+}
+
 fn main() {}

--- a/tests/ui/nonminimal_bool_methods.rs
+++ b/tests/ui/nonminimal_bool_methods.rs
@@ -242,4 +242,9 @@ fn issue_13436() {
     }
 }
 
+fn issue16014() {
+    !(vec![1, 2, 3] <= vec![1, 2, 3, 3]);
+    //~^ nonminimal_bool
+}
+
 fn main() {}

--- a/tests/ui/nonminimal_bool_methods.stderr
+++ b/tests/ui/nonminimal_bool_methods.stderr
@@ -247,5 +247,11 @@ error: this boolean expression can be simplified
 LL |     _ = !opt.is_none_or(|x| x.is_err());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x.is_ok())`
 
-error: aborting due to 41 previous errors
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:246:5
+   |
+LL |     !(vec![1, 2, 3] <= vec![1, 2, 3, 3]);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(vec![1, 2, 3] > vec![1, 2, 3, 3])`
+
+error: aborting due to 42 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16014 

changelog: [`nonminimal_bool`] fix wrongly unmangled terms
