### PR TITLE
Fix `match_like_matches_macro` wrongly unmangled macros

### DIFF
--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -3,7 +3,7 @@
 use super::REDUNDANT_PATTERN_MATCHING;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::higher::has_let_expr;
-use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use clippy_utils::{is_lint_allowed, is_wild, span_contains_comment};
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
@@ -44,6 +44,8 @@ pub(crate) fn check_if_let<'tcx>(
         {
             ex_new = ex_inner;
         }
+
+        let (snippet, _) = snippet_with_context(cx, ex_new.span, expr.span.ctxt(), "..", &mut applicability);
         span_lint_and_then(
             cx,
             MATCH_LIKE_MATCHES_MACRO,
@@ -53,11 +55,7 @@ pub(crate) fn check_if_let<'tcx>(
                 diag.span_suggestion_verbose(
                     expr.span,
                     "use `matches!` directly",
-                    format!(
-                        "{}matches!({}, {pat})",
-                        if b0 { "" } else { "!" },
-                        snippet_with_applicability(cx, ex_new.span, "..", &mut applicability),
-                    ),
+                    format!("{}matches!({snippet}, {pat})", if b0 { "" } else { "!" }),
                     applicability,
                 );
             },
@@ -178,6 +176,8 @@ pub(super) fn check_match<'tcx>(
         {
             ex_new = ex_inner;
         }
+
+        let (snippet, _) = snippet_with_context(cx, ex_new.span, e.span.ctxt(), "..", &mut applicability);
         span_lint_and_then(
             cx,
             MATCH_LIKE_MATCHES_MACRO,
@@ -187,11 +187,7 @@ pub(super) fn check_match<'tcx>(
                 diag.span_suggestion_verbose(
                     e.span,
                     "use `matches!` directly",
-                    format!(
-                        "{}matches!({}, {pat_and_guard})",
-                        if b0 { "" } else { "!" },
-                        snippet_with_applicability(cx, ex_new.span, "..", &mut applicability),
-                    ),
+                    format!("{}matches!({snippet}, {pat_and_guard})", if b0 { "" } else { "!" },),
                     applicability,
                 );
             },

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -1,6 +1,7 @@
 #![warn(clippy::match_like_matches_macro)]
 #![allow(
     unreachable_patterns,
+    irrefutable_let_patterns,
     clippy::equatable_if_let,
     clippy::needless_borrowed_reference,
     clippy::redundant_guards
@@ -229,4 +230,25 @@ fn issue15841(opt: Option<Option<Option<i32>>>, value: i32) {
     // Lint: no if-let _in the guard_
     let _ = matches!(opt, Some(first) if (if let Some(second) = first { true } else { todo!() }));
     //~^^^^ match_like_matches_macro
+}
+
+fn issue16015<T: 'static, U: 'static>() -> bool {
+    use std::any::{TypeId, type_name};
+    pub struct GetTypeId<T>(T);
+
+    impl<T: 'static> GetTypeId<T> {
+        pub const VALUE: TypeId = TypeId::of::<T>();
+    }
+
+    macro_rules! typeid {
+        ($t:ty) => {
+            GetTypeId::<$t>::VALUE
+        };
+    }
+
+    matches!(typeid!(T), _);
+    //~^^^^ match_like_matches_macro
+
+    matches!(typeid!(U), _)
+    //~^ match_like_matches_macro
 }

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::match_like_matches_macro)]
 #![allow(
     unreachable_patterns,
+    irrefutable_let_patterns,
     clippy::equatable_if_let,
     clippy::needless_borrowed_reference,
     clippy::redundant_guards
@@ -276,4 +277,28 @@ fn issue15841(opt: Option<Option<Option<i32>>>, value: i32) {
         _ => false,
     };
     //~^^^^ match_like_matches_macro
+}
+
+fn issue16015<T: 'static, U: 'static>() -> bool {
+    use std::any::{TypeId, type_name};
+    pub struct GetTypeId<T>(T);
+
+    impl<T: 'static> GetTypeId<T> {
+        pub const VALUE: TypeId = TypeId::of::<T>();
+    }
+
+    macro_rules! typeid {
+        ($t:ty) => {
+            GetTypeId::<$t>::VALUE
+        };
+    }
+
+    match typeid!(T) {
+        _ => true,
+        _ => false,
+    };
+    //~^^^^ match_like_matches_macro
+
+    if let _ = typeid!(U) { true } else { false }
+    //~^ match_like_matches_macro
 }

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -1,5 +1,5 @@
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:13:14
+  --> tests/ui/match_like_matches_macro.rs:14:14
    |
 LL |       let _y = match x {
    |  ______________^
@@ -20,7 +20,7 @@ LL +     let _y = matches!(x, Some(0));
    |
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/match_like_matches_macro.rs:20:14
+  --> tests/ui/match_like_matches_macro.rs:21:14
    |
 LL |       let _w = match x {
    |  ______________^
@@ -33,7 +33,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/match_like_matches_macro.rs:27:14
+  --> tests/ui/match_like_matches_macro.rs:28:14
    |
 LL |       let _z = match x {
    |  ______________^
@@ -43,7 +43,7 @@ LL | |     };
    | |_____^ help: try: `x.is_none()`
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:34:15
+  --> tests/ui/match_like_matches_macro.rs:35:15
    |
 LL |       let _zz = match x {
    |  _______________^
@@ -62,7 +62,7 @@ LL +     let _zz = !matches!(x, Some(r) if r == 0);
    |
 
 error: `if let .. else` expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:41:16
+  --> tests/ui/match_like_matches_macro.rs:42:16
    |
 LL |     let _zzz = if let Some(5) = x { true } else { false };
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,7 +74,7 @@ LL +     let _zzz = matches!(x, Some(5));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:66:20
+  --> tests/ui/match_like_matches_macro.rs:67:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -95,7 +95,7 @@ LL +         let _ans = matches!(x, E::A(_) | E::B(_));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:77:20
+  --> tests/ui/match_like_matches_macro.rs:78:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -119,7 +119,7 @@ LL +         let _ans = matches!(x, E::A(_) | E::B(_));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:88:20
+  --> tests/ui/match_like_matches_macro.rs:89:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -140,7 +140,7 @@ LL +         let _ans = !matches!(x, E::B(_) | E::C);
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:149:18
+  --> tests/ui/match_like_matches_macro.rs:150:18
    |
 LL |           let _z = match &z {
    |  __________________^
@@ -159,7 +159,7 @@ LL +         let _z = matches!(z, Some(3));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:159:18
+  --> tests/ui/match_like_matches_macro.rs:160:18
    |
 LL |           let _z = match &z {
    |  __________________^
@@ -178,7 +178,7 @@ LL +         let _z = matches!(&z, Some(3));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:177:21
+  --> tests/ui/match_like_matches_macro.rs:178:21
    |
 LL |               let _ = match &z {
    |  _____________________^
@@ -197,7 +197,7 @@ LL +             let _ = matches!(&z, AnEnum::X);
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:192:20
+  --> tests/ui/match_like_matches_macro.rs:193:20
    |
 LL |           let _res = match &val {
    |  ____________________^
@@ -216,7 +216,7 @@ LL +         let _res = matches!(&val, &Some(ref _a));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:205:20
+  --> tests/ui/match_like_matches_macro.rs:206:20
    |
 LL |           let _res = match &val {
    |  ____________________^
@@ -235,7 +235,7 @@ LL +         let _res = matches!(&val, &Some(ref _a));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:264:14
+  --> tests/ui/match_like_matches_macro.rs:265:14
    |
 LL |       let _y = match Some(5) {
    |  ______________^
@@ -254,7 +254,7 @@ LL +     let _y = matches!(Some(5), Some(0));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:274:13
+  --> tests/ui/match_like_matches_macro.rs:275:13
    |
 LL |       let _ = match opt {
    |  _____________^
@@ -272,5 +272,35 @@ LL -     };
 LL +     let _ = matches!(opt, Some(first) if (if let Some(second) = first { true } else { todo!() }));
    |
 
-error: aborting due to 15 previous errors
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:296:5
+   |
+LL | /     match typeid!(T) {
+LL | |         _ => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^
+   |
+help: use `matches!` directly
+   |
+LL -     match typeid!(T) {
+LL -         _ => true,
+LL -         _ => false,
+LL -     };
+LL +     matches!(typeid!(T), _);
+   |
+
+error: `if let .. else` expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:302:5
+   |
+LL |     if let _ = typeid!(U) { true } else { false }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `matches!` directly
+   |
+LL -     if let _ = typeid!(U) { true } else { false }
+LL +     matches!(typeid!(U), _)
+   |
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16015 

changelog: [`match_like_matches_macro`] fix wrongly unmangled macros
