### PR TITLE
Fix `missing_transmute_annotations` example

### DIFF
--- a/clippy_lints/src/transmute/mod.rs
+++ b/clippy_lints/src/transmute/mod.rs
@@ -435,7 +435,7 @@ declare_clippy_lint! {
     /// to infer a technically correct yet unexpected type.
     ///
     /// ### Example
-    /// ```no_run
+    /// ```
     /// # unsafe {
     /// let mut x: i32 = 0;
     /// // Avoid "naked" calls to `transmute()`!
@@ -450,7 +450,7 @@ declare_clippy_lint! {
     /// # }
     /// ```
     /// Use instead:
-    /// ```no_run
+    /// ```
     /// # unsafe {
     /// let x = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
     ///


### PR DESCRIPTION
The "bad" example in the `missing_transmute_annotations` example didn't actually trigger the lint and so wasn't a "bad" example. This PR replaces it with an actual "bad" example.

It was discussed on zulip [here](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/missing_transmute_annotations/near/547657390).

changelog: Fix `missing_transmute_annotations` example

r? @Centri3 