### PR TITLE
ci: run tests with `--no-fail-fast`

### DIFF
--- a/.github/workflows/clippy_mq.yml
+++ b/.github/workflows/clippy_mq.yml
@@ -59,30 +59,30 @@ jobs:
 
     - name: Test
       if: matrix.host == 'x86_64-unknown-linux-gnu'
-      run: cargo test --features internal
+      run: cargo test --features internal --no-fail-fast
 
     - name: Test
       if: matrix.host != 'x86_64-unknown-linux-gnu'
-      run: cargo test --features internal -- --skip dogfood
+      run: cargo test --features internal --no-fail-fast -- --skip dogfood
 
     - name: Test clippy_lints
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: clippy_lints
 
     - name: Test clippy_utils
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: clippy_utils
 
     - name: Test clippy_config
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: clippy_config
 
     - name: Test rustc_tools_util
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: rustc_tools_util
 
     - name: Test clippy_dev
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: clippy_dev
 
     - name: Test clippy-driver

--- a/.github/workflows/clippy_pr.yml
+++ b/.github/workflows/clippy_pr.yml
@@ -39,22 +39,22 @@ jobs:
       run: cargo build --tests --features internal
 
     - name: Test
-      run: cargo test --features internal
+      run: cargo test --features internal --no-fail-fast
 
     - name: Test clippy_lints
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: clippy_lints
 
     - name: Test clippy_utils
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: clippy_utils
 
     - name: Test rustc_tools_util
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: rustc_tools_util
 
     - name: Test clippy_dev
-      run: cargo test
+      run: cargo test --no-fail-fast
       working-directory: clippy_dev
 
     - name: Test clippy-driver


### PR DESCRIPTION
When adding a lint that has a lot of hits in the repo itself, each run of CI only shows a couple of failures, as `cargo test` stops after the first error. This makes it so that all the failures are shown at once

changelog: none