### PR TITLE
CI: use macOS 14 instead of GitHub-deprecated macOS 13 in merge queue checks

### DIFF
--- a/.github/workflows/clippy_mq.yml
+++ b/.github/workflows/clippy_mq.yml
@@ -25,7 +25,7 @@ jobs:
           host: i686-unknown-linux-gnu
         - os: windows-latest
           host: x86_64-pc-windows-msvc
-        - os: macos-13
+        - os: macos-14
           host: x86_64-apple-darwin
         - os: macos-latest
           host: aarch64-apple-darwin


### PR DESCRIPTION
The "macos 13" runners are being phased out (https://github.com/actions/runner-images/issues/13046).

Some jobs have started to fail in the CI while attempting a merge because of the brownout period.

changelog: none

r? flip1995