### PR TITLE
`double_comparisons`: check for expressions such as `x != y && x >= y`

### DIFF
--- a/clippy_lints/src/operators/double_comparison.rs
+++ b/clippy_lints/src/operators/double_comparison.rs
@@ -39,6 +39,18 @@ pub(super) fn check(cx: &LateContext<'_>, op: BinOpKind, lhs: &Expr<'_>, rhs: &E
             | (BinOpKind::And, BinOpKind::Ge, BinOpKind::Le) => {
                 "=="
             },
+            // x != y && x >= y => x > y
+            (BinOpKind::And, BinOpKind::Ne, BinOpKind::Ge)
+            // x >= y && x != y => x > y
+            | (BinOpKind::And, BinOpKind::Ge, BinOpKind::Ne) => {
+                ">"
+            },
+            // x != y && x <= y => x < y
+            (BinOpKind::And, BinOpKind::Ne, BinOpKind::Le)
+            // x <= y && x != y => x < y
+            | (BinOpKind::And, BinOpKind::Le, BinOpKind::Ne) => {
+                "<"
+            },
             _ => return,
         };
 

--- a/tests/ui/double_comparison.fixed
+++ b/tests/ui/double_comparison.fixed
@@ -35,4 +35,20 @@ fn main() {
         //~^ double_comparisons
         // do something
     }
+    if x < y {
+        //~^ double_comparisons
+        // do something
+    }
+    if x < y {
+        //~^ double_comparisons
+        // do something
+    }
+    if x > y {
+        //~^ double_comparisons
+        // do something
+    }
+    if x > y {
+        //~^ double_comparisons
+        // do something
+    }
 }

--- a/tests/ui/double_comparison.rs
+++ b/tests/ui/double_comparison.rs
@@ -35,4 +35,20 @@ fn main() {
         //~^ double_comparisons
         // do something
     }
+    if x != y && x <= y {
+        //~^ double_comparisons
+        // do something
+    }
+    if x <= y && x != y {
+        //~^ double_comparisons
+        // do something
+    }
+    if x != y && x >= y {
+        //~^ double_comparisons
+        // do something
+    }
+    if x >= y && x != y {
+        //~^ double_comparisons
+        // do something
+    }
 }

--- a/tests/ui/double_comparison.stderr
+++ b/tests/ui/double_comparison.stderr
@@ -49,5 +49,29 @@ error: this binary expression can be simplified
 LL |     if x >= y && x <= y {
    |        ^^^^^^^^^^^^^^^^ help: try: `x == y`
 
-error: aborting due to 8 previous errors
+error: this binary expression can be simplified
+  --> tests/ui/double_comparison.rs:38:8
+   |
+LL |     if x != y && x <= y {
+   |        ^^^^^^^^^^^^^^^^ help: try: `x < y`
+
+error: this binary expression can be simplified
+  --> tests/ui/double_comparison.rs:42:8
+   |
+LL |     if x <= y && x != y {
+   |        ^^^^^^^^^^^^^^^^ help: try: `x < y`
+
+error: this binary expression can be simplified
+  --> tests/ui/double_comparison.rs:46:8
+   |
+LL |     if x != y && x >= y {
+   |        ^^^^^^^^^^^^^^^^ help: try: `x > y`
+
+error: this binary expression can be simplified
+  --> tests/ui/double_comparison.rs:50:8
+   |
+LL |     if x >= y && x != y {
+   |        ^^^^^^^^^^^^^^^^ help: try: `x > y`
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
This change expands the `double_comparisons` lint to check for expressions of the form `x != y && x >= y` and `x != y && x <= y`. Since the lint already checks for their dual (`x == y || x < y` and `x == y || x > y`, respectively) while also checking for `x <= y && x >= y` and its dual `x > y || x < y`, it seemed like these two new cases were, in some sense, missing.

Issues rust-lang/rust-clippy#685 and rust-lang/rust-clippy#753 appear pertinent here.

----

changelog: [`double_comparisons`]: check and offer suggestions for expressions such as `x != y && x >= y`
