### PR TITLE
CI: do not run merge queue tests on tier 2 x86_64-apple-darwin

### DIFF
--- a/.github/workflows/clippy_mq.yml
+++ b/.github/workflows/clippy_mq.yml
@@ -25,8 +25,6 @@ jobs:
           host: i686-unknown-linux-gnu
         - os: windows-latest
           host: x86_64-pc-windows-msvc
-        - os: macos-14
-          host: x86_64-apple-darwin
         - os: macos-latest
           host: aarch64-apple-darwin
 


### PR DESCRIPTION
x86_64-apple-darwin has been demoted to tier 2 since Rust 1.90. Moreover, Github runners for macOS 14 on x86_64 are much slower than the others.

changelog: none

r? flip1995