### PR TITLE
Fix `missing_asserts_for_indexing` changes `assert_eq` to `assert`

### DIFF
--- a/tests/ui/missing_asserts_for_indexing.fixed
+++ b/tests/ui/missing_asserts_for_indexing.fixed
@@ -150,9 +150,9 @@ fn highest_index_first(v1: &[u8]) {
 }
 
 fn issue14255(v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8]) {
-    assert!(v1.len() == 3);
+    assert_eq!(v1.len(), 3);
     assert_eq!(v2.len(), 4);
-    assert!(v3.len() == 3);
+    assert_eq!(v3.len(), 3);
     assert_eq!(4, v4.len());
 
     let _ = v1[0] + v1[1] + v1[2];
@@ -164,6 +164,20 @@ fn issue14255(v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8]) {
     //~^ missing_asserts_for_indexing
 
     let _ = v4[0] + v4[1] + v4[2];
+}
+
+mod issue15988 {
+    fn assert_eq_len(v: &[i32]) {
+        assert_eq!(v.len(), 3);
+        let _ = v[0] + v[1] + v[2];
+        //~^ missing_asserts_for_indexing
+    }
+
+    fn debug_assert_eq_len(v: &[i32]) {
+        debug_assert_eq!(v.len(), 3);
+        let _ = v[0] + v[1] + v[2];
+        //~^ missing_asserts_for_indexing
+    }
 }
 
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing.rs
+++ b/tests/ui/missing_asserts_for_indexing.rs
@@ -166,4 +166,18 @@ fn issue14255(v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8]) {
     let _ = v4[0] + v4[1] + v4[2];
 }
 
+mod issue15988 {
+    fn assert_eq_len(v: &[i32]) {
+        assert_eq!(v.len(), 2);
+        let _ = v[0] + v[1] + v[2];
+        //~^ missing_asserts_for_indexing
+    }
+
+    fn debug_assert_eq_len(v: &[i32]) {
+        debug_assert_eq!(v.len(), 2);
+        let _ = v[0] + v[1] + v[2];
+        //~^ missing_asserts_for_indexing
+    }
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing.stderr
+++ b/tests/ui/missing_asserts_for_indexing.stderr
@@ -305,7 +305,7 @@ error: indexing into a slice multiple times with an `assert` that does not cover
   --> tests/ui/missing_asserts_for_indexing.rs:158:13
    |
 LL |     assert_eq!(v1.len(), 2);
-   |     ----------------------- help: provide the highest index that is indexed with: `assert!(v1.len() == 3)`
+   |     ----------------------- help: provide the highest index that is indexed with: `assert_eq!(v1.len(), 3)`
 ...
 LL |     let _ = v1[0] + v1[1] + v1[2];
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -331,7 +331,7 @@ error: indexing into a slice multiple times with an `assert` that does not cover
   --> tests/ui/missing_asserts_for_indexing.rs:163:13
    |
 LL |     assert_eq!(2, v3.len());
-   |     ----------------------- help: provide the highest index that is indexed with: `assert!(v3.len() == 3)`
+   |     ----------------------- help: provide the highest index that is indexed with: `assert_eq!(v3.len(), 3)`
 ...
 LL |     let _ = v3[0] + v3[1] + v3[2];
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -353,5 +353,55 @@ LL |     let _ = v3[0] + v3[1] + v3[2];
    |                             ^^^^^
    = note: asserting the length before indexing will elide bounds checks
 
-error: aborting due to 13 previous errors
+error: indexing into a slice multiple times with an `assert` that does not cover the highest index
+  --> tests/ui/missing_asserts_for_indexing.rs:172:17
+   |
+LL |         assert_eq!(v.len(), 2);
+   |         ---------------------- help: provide the highest index that is indexed with: `assert_eq!(v.len(), 3)`
+LL |         let _ = v[0] + v[1] + v[2];
+   |                 ^^^^^^^^^^^^^^^^^^
+   |
+note: slice indexed here
+  --> tests/ui/missing_asserts_for_indexing.rs:172:17
+   |
+LL |         let _ = v[0] + v[1] + v[2];
+   |                 ^^^^
+note: slice indexed here
+  --> tests/ui/missing_asserts_for_indexing.rs:172:24
+   |
+LL |         let _ = v[0] + v[1] + v[2];
+   |                        ^^^^
+note: slice indexed here
+  --> tests/ui/missing_asserts_for_indexing.rs:172:31
+   |
+LL |         let _ = v[0] + v[1] + v[2];
+   |                               ^^^^
+   = note: asserting the length before indexing will elide bounds checks
+
+error: indexing into a slice multiple times with an `assert` that does not cover the highest index
+  --> tests/ui/missing_asserts_for_indexing.rs:178:17
+   |
+LL |         debug_assert_eq!(v.len(), 2);
+   |         ---------------------------- help: provide the highest index that is indexed with: `debug_assert_eq!(v.len(), 3)`
+LL |         let _ = v[0] + v[1] + v[2];
+   |                 ^^^^^^^^^^^^^^^^^^
+   |
+note: slice indexed here
+  --> tests/ui/missing_asserts_for_indexing.rs:178:17
+   |
+LL |         let _ = v[0] + v[1] + v[2];
+   |                 ^^^^
+note: slice indexed here
+  --> tests/ui/missing_asserts_for_indexing.rs:178:24
+   |
+LL |         let _ = v[0] + v[1] + v[2];
+   |                        ^^^^
+note: slice indexed here
+  --> tests/ui/missing_asserts_for_indexing.rs:178:31
+   |
+LL |         let _ = v[0] + v[1] + v[2];
+   |                               ^^^^
+   = note: asserting the length before indexing will elide bounds checks
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16026 

changelog: [`missing_asserts_for_indexing`] fix wrongly changing `assert_eq` to `assert`
