### PR TITLE
Don't flag cfg(test) as multiple inherent impl

### DIFF
--- a/clippy_lints/src/inherent_impl.rs
+++ b/clippy_lints/src/inherent_impl.rs
@@ -1,7 +1,7 @@
 use clippy_config::Conf;
 use clippy_config::types::InherentImplLintScope;
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::fulfill_or_allowed;
+use clippy_utils::{fulfill_or_allowed, is_cfg_test, is_in_cfg_test};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::{LocalDefId, LocalModDefId};
 use rustc_hir::{Item, ItemKind, Node};
@@ -100,7 +100,8 @@ impl<'tcx> LateLintPass<'tcx> for MultipleInherentImpl {
                     },
                     InherentImplLintScope::Crate => Criterion::Crate,
                 };
-                match type_map.entry((impl_ty, criterion)) {
+                let is_test = is_cfg_test(cx.tcx, hir_id) || is_in_cfg_test(cx.tcx, hir_id);
+                match type_map.entry((impl_ty, criterion, is_test)) {
                     Entry::Vacant(e) => {
                         // Store the id for the first impl block of this type. The span is retrieved lazily.
                         e.insert(IdOrSpan::Id(impl_id));

--- a/tests/ui/multiple_inherent_impl_cfg.rs
+++ b/tests/ui/multiple_inherent_impl_cfg.rs
@@ -13,8 +13,7 @@ impl A {}
 //~^ multiple_inherent_impl
 
 #[cfg(test)]
-impl A {} // false positive
-//~^ multiple_inherent_impl
+impl A {}
 
 #[cfg(test)]
 impl A {}
@@ -25,8 +24,7 @@ struct B;
 impl B {}
 
 #[cfg(test)]
-impl B {} // false positive
-//~^ multiple_inherent_impl
+impl B {}
 
 impl B {}
 //~^ multiple_inherent_impl

--- a/tests/ui/multiple_inherent_impl_cfg.stderr
+++ b/tests/ui/multiple_inherent_impl_cfg.stderr
@@ -16,76 +16,52 @@ LL | #![deny(clippy::multiple_inherent_impl)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: multiple implementations of this structure
+  --> tests/ui/multiple_inherent_impl_cfg.rs:19:1
+   |
+LL | impl A {}
+   | ^^^^^^^^^
+   |
+note: first implementation here
   --> tests/ui/multiple_inherent_impl_cfg.rs:16:1
    |
-LL | impl A {} // false positive
-   | ^^^^^^^^^
-   |
-note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:10:1
-   |
 LL | impl A {}
    | ^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:20:1
-   |
-LL | impl A {}
-   | ^^^^^^^^^
-   |
-note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:10:1
-   |
-LL | impl A {}
-   | ^^^^^^^^^
-
-error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:28:1
-   |
-LL | impl B {} // false positive
-   | ^^^^^^^^^
-   |
-note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:25:1
-   |
-LL | impl B {}
-   | ^^^^^^^^^
-
-error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:31:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:29:1
    |
 LL | impl B {}
    | ^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:25:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:24:1
    |
 LL | impl B {}
    | ^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:35:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:33:1
    |
 LL | impl B {}
    | ^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:25:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:27:1
    |
 LL | impl B {}
    | ^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:45:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:43:1
    |
 LL | impl C {}
    | ^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:42:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:40:1
    |
 LL | impl C {}
    | ^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
changelog: [`multiple_inherent_impl`]: Don't flag cfg(test) impls as repeats

fixes rust-lang/rust-clippy#13040