### PR TITLE
Make bug report issue template more similar to that of `rust-lang/rust`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,15 +20,15 @@ body:
       label: Reproducer
       description: Please provide the code and steps to reproduce the bug
       value: |
-        I tried this code:
+        Code:
 
         ```rust
         <code>
         ```
 
-        I expected to see this happen:
+        Current output:
 
-        Instead, this happened:
+        Desired output:
   - type: textarea
     id: version
     attributes:


### PR DESCRIPTION
It's always a bit jarring to be required to provide the expected output first, as usually one starts with having the existing output, and modifies that.

This commit reorders the two steps, and also gives them the same names as `rust-lang/rust` for some extra consistency

changelog: none