### PR TITLE
chore(unnecessary_mut_passed): show the intention not to lint `&raw` references

### DIFF
--- a/tests/ui/unnecessary_mut_passed.fixed
+++ b/tests/ui/unnecessary_mut_passed.fixed
@@ -146,7 +146,7 @@ fn main() {
     my_struct.takes_raw_mut(a);
 }
 
-// not supported currently
+// These shouldn't be linted, see https://github.com/rust-lang/rust-clippy/pull/15962#issuecomment-3503704832
 fn raw_ptrs(my_struct: MyStruct) {
     let mut n = 42;
 

--- a/tests/ui/unnecessary_mut_passed.rs
+++ b/tests/ui/unnecessary_mut_passed.rs
@@ -146,7 +146,7 @@ fn main() {
     my_struct.takes_raw_mut(a);
 }
 
-// not supported currently
+// These shouldn't be linted, see https://github.com/rust-lang/rust-clippy/pull/15962#issuecomment-3503704832
 fn raw_ptrs(my_struct: MyStruct) {
     let mut n = 42;
 


### PR DESCRIPTION
Supersedes https://github.com/rust-lang/rust-clippy/pull/15962

changelog: none

r? @Jarcho