### PR TITLE
chore(unnecessary_map_on_constructor): clean-up

### DIFF
--- a/clippy_lints/src/unnecessary_map_on_constructor.rs
+++ b/clippy_lints/src/unnecessary_map_on_constructor.rs
@@ -35,18 +35,17 @@ declare_lint_pass!(UnnecessaryMapOnConstructor => [UNNECESSARY_MAP_ON_CONSTRUCTO
 
 impl<'tcx> LateLintPass<'tcx> for UnnecessaryMapOnConstructor {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx>) {
-        if expr.span.from_expansion() {
-            return;
-        }
-        if let hir::ExprKind::MethodCall(path, recv, [map_arg], ..) = expr.kind
+        if !expr.span.from_expansion()
+            && let hir::ExprKind::MethodCall(path, recv, [map_arg], ..) = expr.kind
+            && !map_arg.span.from_expansion()
+            && let hir::ExprKind::Path(fun) = map_arg.kind
             && let Some(sym::Option | sym::Result) = cx.typeck_results().expr_ty(recv).opt_diag_name(cx)
         {
             let (constructor_path, constructor_item) = if let hir::ExprKind::Call(constructor, [arg, ..]) = recv.kind
                 && let hir::ExprKind::Path(constructor_path) = constructor.kind
+                && !constructor.span.from_expansion()
+                && !arg.span.from_expansion()
             {
-                if constructor.span.from_expansion() || arg.span.from_expansion() {
-                    return;
-                }
                 (constructor_path, arg)
             } else {
                 return;
@@ -67,29 +66,22 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryMapOnConstructor {
                 _ => return,
             }
 
-            if let hir::ExprKind::Path(fun) = map_arg.kind {
-                if map_arg.span.from_expansion() {
-                    return;
-                }
-                let mut applicability = Applicability::MachineApplicable;
-                let fun_snippet = snippet_with_applicability(cx, fun.span(), "_", &mut applicability);
-                let constructor_snippet =
-                    snippet_with_applicability(cx, constructor_path.span(), "_", &mut applicability);
-                let constructor_arg_snippet =
-                    snippet_with_applicability(cx, constructor_item.span, "_", &mut applicability);
-                span_lint_and_sugg(
-                    cx,
-                    UNNECESSARY_MAP_ON_CONSTRUCTOR,
-                    expr.span,
-                    format!(
-                        "unnecessary {} on constructor {constructor_snippet}(_)",
-                        path.ident.name
-                    ),
-                    "try",
-                    format!("{constructor_snippet}({fun_snippet}({constructor_arg_snippet}))"),
-                    applicability,
-                );
-            }
+            let mut app = Applicability::MachineApplicable;
+            let fun_snippet = snippet_with_applicability(cx, fun.span(), "_", &mut app);
+            let constructor_snippet = snippet_with_applicability(cx, constructor_path.span(), "_", &mut app);
+            let constructor_arg_snippet = snippet_with_applicability(cx, constructor_item.span, "_", &mut app);
+            span_lint_and_sugg(
+                cx,
+                UNNECESSARY_MAP_ON_CONSTRUCTOR,
+                expr.span,
+                format!(
+                    "unnecessary `{}` on constructor `{constructor_snippet}(_)`",
+                    path.ident.name
+                ),
+                "try",
+                format!("{constructor_snippet}({fun_snippet}({constructor_arg_snippet}))"),
+                app,
+            );
         }
     }
 }

--- a/tests/ui/unnecessary_map_on_constructor.stderr
+++ b/tests/ui/unnecessary_map_on_constructor.stderr
@@ -1,4 +1,4 @@
-error: unnecessary map on constructor Some(_)
+error: unnecessary `map` on constructor `Some(_)`
   --> tests/ui/unnecessary_map_on_constructor.rs:32:13
    |
 LL |     let a = Some(x).map(fun);
@@ -7,43 +7,43 @@ LL |     let a = Some(x).map(fun);
    = note: `-D clippy::unnecessary-map-on-constructor` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_on_constructor)]`
 
-error: unnecessary map on constructor Ok(_)
+error: unnecessary `map` on constructor `Ok(_)`
   --> tests/ui/unnecessary_map_on_constructor.rs:34:27
    |
 LL |     let b: SimpleResult = Ok(x).map(fun);
    |                           ^^^^^^^^^^^^^^ help: try: `Ok(fun(x))`
 
-error: unnecessary map_err on constructor Err(_)
+error: unnecessary `map_err` on constructor `Err(_)`
   --> tests/ui/unnecessary_map_on_constructor.rs:36:27
    |
 LL |     let c: SimpleResult = Err(err).map_err(notfun);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Err(notfun(err))`
 
-error: unnecessary map on constructor Option::Some(_)
+error: unnecessary `map` on constructor `Option::Some(_)`
   --> tests/ui/unnecessary_map_on_constructor.rs:39:13
    |
 LL |     let a = Option::Some(x).map(fun);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Option::Some(fun(x))`
 
-error: unnecessary map on constructor SimpleResult::Ok(_)
+error: unnecessary `map` on constructor `SimpleResult::Ok(_)`
   --> tests/ui/unnecessary_map_on_constructor.rs:41:27
    |
 LL |     let b: SimpleResult = SimpleResult::Ok(x).map(fun);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `SimpleResult::Ok(fun(x))`
 
-error: unnecessary map_err on constructor SimpleResult::Err(_)
+error: unnecessary `map_err` on constructor `SimpleResult::Err(_)`
   --> tests/ui/unnecessary_map_on_constructor.rs:43:27
    |
 LL |     let c: SimpleResult = SimpleResult::Err(err).map_err(notfun);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `SimpleResult::Err(notfun(err))`
 
-error: unnecessary map on constructor Ok(_)
+error: unnecessary `map` on constructor `Ok(_)`
   --> tests/ui/unnecessary_map_on_constructor.rs:45:52
    |
 LL |     let b: std::result::Result<i32, SimpleError> = Ok(x).map(fun);
    |                                                    ^^^^^^^^^^^^^^ help: try: `Ok(fun(x))`
 
-error: unnecessary map_err on constructor Err(_)
+error: unnecessary `map_err` on constructor `Err(_)`
   --> tests/ui/unnecessary_map_on_constructor.rs:47:52
    |
 LL |     let c: std::result::Result<i32, SimpleError> = Err(err).map_err(notfun);


### PR DESCRIPTION
- reduce indentation
- print constructor/method name in backticks

changelog: [`unnecessary_map_on_constructor`]: print constructor/method name in backticks