### PR TITLE
Fix `useless_let_if_seq` FN when `if` is in the last expr of block

### DIFF
--- a/tests/ui/let_if_seq.rs
+++ b/tests/ui/let_if_seq.rs
@@ -149,3 +149,24 @@ fn issue16062(bar: fn() -> bool) {
         foo = 0;
     }
 }
+
+fn issue16064(bar: fn() -> bool) {
+    macro_rules! mac {
+        ($e:expr) => {
+            $e()
+        };
+        ($base:expr, $lit:expr) => {
+            $lit * $base + 2
+        };
+    }
+
+    let foo;
+    //~^ useless_let_if_seq
+    if mac!(bar) {
+        foo = mac!(10, 4);
+    } else {
+        foo = 0;
+    }
+
+    let bar = 1;
+}

--- a/tests/ui/let_if_seq.stderr
+++ b/tests/ui/let_if_seq.stderr
@@ -64,5 +64,17 @@ LL | |         foo = 0;
 LL | |     }
    | |_____^ help: it is more idiomatic to write: `let foo = if bar() { 42 } else { 0 };`
 
-error: aborting due to 5 previous errors
+error: `if _ { .. } else { .. }` is an expression
+  --> tests/ui/let_if_seq.rs:163:5
+   |
+LL | /     let foo;
+LL | |
+LL | |     if mac!(bar) {
+LL | |         foo = mac!(10, 4);
+LL | |     } else {
+LL | |         foo = 0;
+LL | |     }
+   | |_____^ help: it is more idiomatic to write: `let foo = if mac!(bar) { mac!(10, 4) } else { 0 };`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16062 
Closes rust-lang/rust-clippy#16064 

changelog: [`useless_let_if_seq`] fix FN when `if` is in the last expr of block
