### PR TITLE
Add documentation for `clippy_utils::numeric_literal`

### DIFF
--- a/clippy_utils/src/numeric_literal.rs
+++ b/clippy_utils/src/numeric_literal.rs
@@ -1,11 +1,16 @@
 use rustc_ast::ast::{LitFloatType, LitIntType, LitKind};
 use std::iter;
 
+/// Represents the base of a numeric literal, used for parsing and formatting.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Radix {
+    /// A binary literal (e.g., `0b1010`)
     Binary,
+    /// An octal literal (e.g., `0o670`)
     Octal,
+    /// A decimal literal (e.g., `123`)
     Decimal,
+    /// A hexadecimal literal (e.g., `0xFF`)
     Hexadecimal,
 }
 
@@ -46,6 +51,7 @@ pub struct NumericLiteral<'a> {
 }
 
 impl<'a> NumericLiteral<'a> {
+    /// Attempts to parse a `NumericLiteral` from the source string of an `ast::LitKind`.
     pub fn from_lit_kind(src: &'a str, lit_kind: &LitKind) -> Option<NumericLiteral<'a>> {
         let unsigned_src = src.strip_prefix('-').map_or(src, |s| s);
         if lit_kind.is_numeric()
@@ -63,6 +69,7 @@ impl<'a> NumericLiteral<'a> {
         }
     }
 
+    /// Parses a raw numeric literal string into its structured `NumericLiteral` parts.
     #[must_use]
     pub fn new(lit: &'a str, suffix: Option<&'a str>, float: bool) -> Self {
         let unsigned_lit = lit.trim_start_matches('-');
@@ -102,11 +109,12 @@ impl<'a> NumericLiteral<'a> {
         }
     }
 
+    /// Checks if the literal's radix is `Radix::Decimal`
     pub fn is_decimal(&self) -> bool {
         self.radix == Radix::Decimal
     }
 
-    pub fn split_digit_parts(digits: &str, float: bool) -> (&str, Option<&str>, Option<(&str, &str)>) {
+    fn split_digit_parts(digits: &str, float: bool) -> (&str, Option<&str>, Option<(&str, &str)>) {
         let mut integer = digits;
         let mut fraction = None;
         let mut exponent = None;
@@ -180,7 +188,7 @@ impl<'a> NumericLiteral<'a> {
         output
     }
 
-    pub fn group_digits(output: &mut String, input: &str, group_size: usize, partial_group_first: bool, pad: bool) {
+    fn group_digits(output: &mut String, input: &str, group_size: usize, partial_group_first: bool, zero_pad: bool) {
         debug_assert!(group_size > 0);
 
         let mut digits = input.chars().filter(|&c| c != '_');
@@ -196,7 +204,7 @@ impl<'a> NumericLiteral<'a> {
 
         if partial_group_first {
             first_group_size = (digits.clone().count() - 1) % group_size + 1;
-            if pad {
+            if zero_pad {
                 for _ in 0..group_size - first_group_size {
                     output.push('0');
                 }


### PR DESCRIPTION
For rust-lang/rust-clippy#15569 

changelog: none
