### PR TITLE
Fix `redundant_pattern_matching` misses `)` in suggestion span

### DIFF
--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -195,3 +195,16 @@ fn issue16045() {
         }
     }
 }
+
+fn issue14989() {
+    macro_rules! x {
+        () => {
+            None::<i32>
+        };
+    }
+
+    if x! {}.is_some() {};
+    //~^ redundant_pattern_matching
+    while x! {}.is_some() {}
+    //~^ redundant_pattern_matching
+}

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -231,3 +231,16 @@ fn issue16045() {
         }
     }
 }
+
+fn issue14989() {
+    macro_rules! x {
+        () => {
+            None::<i32>
+        };
+    }
+
+    if let Some(_) = (x! {}) {};
+    //~^ redundant_pattern_matching
+    while let Some(_) = (x! {}) {}
+    //~^ redundant_pattern_matching
+}

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -236,5 +236,17 @@ error: redundant pattern matching, consider using `is_some()`
 LL |         if let Some(_) = x.await {
    |         -------^^^^^^^---------- help: try: `if x.await.is_some()`
 
-error: aborting due to 33 previous errors
+error: redundant pattern matching, consider using `is_some()`
+  --> tests/ui/redundant_pattern_matching_option.rs:242:12
+   |
+LL |     if let Some(_) = (x! {}) {};
+   |     -------^^^^^^^---------- help: try: `if x! {}.is_some()`
+
+error: redundant pattern matching, consider using `is_some()`
+  --> tests/ui/redundant_pattern_matching_option.rs:244:15
+   |
+LL |     while let Some(_) = (x! {}) {}
+   |     ----------^^^^^^^---------- help: try: `while x! {}.is_some()`
+
+error: aborting due to 35 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14989

changelog: [`redundant_pattern_matching`] fix missing `)` in suggestion span
