### PR TITLE
refactor(rc_buffer): remove `RcKind`

### DIFF
--- a/clippy_lints/src/types/rc_buffer.rs
+++ b/clippy_lints/src/types/rc_buffer.rs
@@ -8,15 +8,14 @@ use rustc_hir::{QPath, Ty, TyKind};
 use rustc_lint::LateContext;
 use rustc_span::symbol::sym;
 use std::borrow::Cow;
-use std::fmt;
 
 use super::RC_BUFFER;
 
 pub(super) fn check(cx: &LateContext<'_>, hir_ty: &Ty<'_>, qpath: &QPath<'_>, def_id: DefId) -> bool {
     let mut app = Applicability::Unspecified;
-    let kind = match cx.tcx.get_diagnostic_name(def_id) {
-        Some(sym::Rc) => RcKind::Rc,
-        Some(sym::Arc) => RcKind::Arc,
+    let rc = match cx.tcx.get_diagnostic_name(def_id) {
+        Some(sym::Rc) => "Rc",
+        Some(sym::Arc) => "Arc",
         _ => return false,
     };
     if let Some(ty) = qpath_generic_tys(qpath).next()
@@ -26,7 +25,7 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &Ty<'_>, qpath: &QPath<'_>, de
             cx,
             RC_BUFFER,
             hir_ty.span,
-            format!("usage of `{kind}<T>` when `T` is a buffer type"),
+            format!("usage of `{rc}<T>` when `T` is a buffer type"),
             |diag| {
                 diag.span_suggestion_verbose(ty.span, "try", alternate, app);
             },
@@ -34,20 +33,6 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &Ty<'_>, qpath: &QPath<'_>, de
         true
     } else {
         false
-    }
-}
-
-enum RcKind {
-    Rc,
-    Arc,
-}
-
-impl fmt::Display for RcKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Rc => f.write_str("Rc"),
-            Self::Arc => f.write_str("Arc"),
-        }
     }
 }
 


### PR DESCRIPTION
not really necessary

Follow-up to https://github.com/rust-lang/rust-clippy/pull/15803

changelog: none

r? @llogiq 