### PR TITLE
fix(equatable_if_let): don't suggest `=` in const context

### DIFF
--- a/tests/ui/equatable_if_let.fixed
+++ b/tests/ui/equatable_if_let.fixed
@@ -139,3 +139,24 @@ mod issue8710 {
         }
     }
 }
+
+// PartialEq is not stable in consts yet
+fn issue15376() {
+    enum NonConstEq {
+        A,
+        B,
+    }
+    impl PartialEq for NonConstEq {
+        fn eq(&self, _other: &Self) -> bool {
+            true
+        }
+    }
+
+    const N: NonConstEq = NonConstEq::A;
+
+    // `impl PartialEq` is not const, suggest `matches!`
+    const _: u32 = if matches!(N, NonConstEq::A) { 0 } else { 1 };
+    //~^ ERROR: this pattern matching can be expressed using `matches!`
+    const _: u32 = if matches!(Some(N), Some(NonConstEq::A)) { 0 } else { 1 };
+    //~^ ERROR: this pattern matching can be expressed using `matches!`
+}

--- a/tests/ui/equatable_if_let.rs
+++ b/tests/ui/equatable_if_let.rs
@@ -139,3 +139,24 @@ mod issue8710 {
         }
     }
 }
+
+// PartialEq is not stable in consts yet
+fn issue15376() {
+    enum NonConstEq {
+        A,
+        B,
+    }
+    impl PartialEq for NonConstEq {
+        fn eq(&self, _other: &Self) -> bool {
+            true
+        }
+    }
+
+    const N: NonConstEq = NonConstEq::A;
+
+    // `impl PartialEq` is not const, suggest `matches!`
+    const _: u32 = if let NonConstEq::A = N { 0 } else { 1 };
+    //~^ ERROR: this pattern matching can be expressed using `matches!`
+    const _: u32 = if let Some(NonConstEq::A) = Some(N) { 0 } else { 1 };
+    //~^ ERROR: this pattern matching can be expressed using `matches!`
+}

--- a/tests/ui/equatable_if_let.stderr
+++ b/tests/ui/equatable_if_let.stderr
@@ -103,5 +103,17 @@ error: this pattern matching can be expressed using `matches!`
 LL |         if let Some(MyEnum::B) = get_enum() {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(get_enum(), Some(MyEnum::B))`
 
-error: aborting due to 17 previous errors
+error: this pattern matching can be expressed using `matches!`
+  --> tests/ui/equatable_if_let.rs:158:23
+   |
+LL |     const _: u32 = if let NonConstEq::A = N { 0 } else { 1 };
+   |                       ^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(N, NonConstEq::A)`
+
+error: this pattern matching can be expressed using `matches!`
+  --> tests/ui/equatable_if_let.rs:160:23
+   |
+LL |     const _: u32 = if let Some(NonConstEq::A) = Some(N) { 0 } else { 1 };
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(Some(N), Some(NonConstEq::A))`
+
+error: aborting due to 19 previous errors
 

--- a/tests/ui/equatable_if_let_const_cmp.fixed
+++ b/tests/ui/equatable_if_let_const_cmp.fixed
@@ -1,0 +1,24 @@
+#![warn(clippy::equatable_if_let)]
+#![allow(clippy::eq_op)]
+#![feature(const_trait_impl, const_cmp)]
+
+fn issue15376() {
+    enum ConstEq {
+        A,
+        B,
+    }
+    impl const PartialEq for ConstEq {
+        fn eq(&self, _other: &Self) -> bool {
+            true
+        }
+    }
+
+    const C: ConstEq = ConstEq::A;
+
+    // `impl PartialEq` is const... but we still suggest `matches!` for now
+    // TODO: detect this and suggest `=`
+    const _: u32 = if matches!(C, ConstEq::A) { 0 } else { 1 };
+    //~^ ERROR: this pattern matching can be expressed using `matches!`
+    const _: u32 = if matches!(Some(C), Some(ConstEq::A)) { 0 } else { 1 };
+    //~^ ERROR: this pattern matching can be expressed using `matches!`
+}

--- a/tests/ui/equatable_if_let_const_cmp.rs
+++ b/tests/ui/equatable_if_let_const_cmp.rs
@@ -1,0 +1,24 @@
+#![warn(clippy::equatable_if_let)]
+#![allow(clippy::eq_op)]
+#![feature(const_trait_impl, const_cmp)]
+
+fn issue15376() {
+    enum ConstEq {
+        A,
+        B,
+    }
+    impl const PartialEq for ConstEq {
+        fn eq(&self, _other: &Self) -> bool {
+            true
+        }
+    }
+
+    const C: ConstEq = ConstEq::A;
+
+    // `impl PartialEq` is const... but we still suggest `matches!` for now
+    // TODO: detect this and suggest `=`
+    const _: u32 = if let ConstEq::A = C { 0 } else { 1 };
+    //~^ ERROR: this pattern matching can be expressed using `matches!`
+    const _: u32 = if let Some(ConstEq::A) = Some(C) { 0 } else { 1 };
+    //~^ ERROR: this pattern matching can be expressed using `matches!`
+}

--- a/tests/ui/equatable_if_let_const_cmp.stderr
+++ b/tests/ui/equatable_if_let_const_cmp.stderr
@@ -1,0 +1,17 @@
+error: this pattern matching can be expressed using `matches!`
+  --> tests/ui/equatable_if_let_const_cmp.rs:20:23
+   |
+LL |     const _: u32 = if let ConstEq::A = C { 0 } else { 1 };
+   |                       ^^^^^^^^^^^^^^^^^^ help: try: `matches!(C, ConstEq::A)`
+   |
+   = note: `-D clippy::equatable-if-let` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::equatable_if_let)]`
+
+error: this pattern matching can be expressed using `matches!`
+  --> tests/ui/equatable_if_let_const_cmp.rs:22:23
+   |
+LL |     const _: u32 = if let Some(ConstEq::A) = Some(C) { 0 } else { 1 };
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(Some(C), Some(ConstEq::A))`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Supersedes https://github.com/rust-lang/rust-clippy/pull/15482

I wasn't able to get `is_const_method` to work, so for now we just don't suggest `=` in const context.

changelog: [`equatable_if_let`]: don't suggest `=` in const context