### PR TITLE
refactor(time_subtraction): give the same message for `Instant - Duration` and `Duration - Duration`

### DIFF
--- a/clippy_lints/src/time_subtraction.rs
+++ b/clippy_lints/src/time_subtraction.rs
@@ -171,29 +171,26 @@ fn print_unchecked_duration_subtraction_sugg(
     right_expr: &Expr<'_>,
     expr: &Expr<'_>,
 ) {
-    let typeck = cx.typeck_results();
-    let left_ty = typeck.expr_ty(left_expr);
+    span_lint_and_then(
+        cx,
+        UNCHECKED_TIME_SUBTRACTION,
+        expr.span,
+        "unchecked subtraction of a `Duration`",
+        |diag| {
+            // For chained subtraction, like `(dur1 - dur2) - dur3` or `(instant - dur1) - dur2`,
+            // avoid suggestions
+            if !is_chained_time_subtraction(cx, left_expr) {
+                let mut applicability = Applicability::MachineApplicable;
+                let left_sugg = Sugg::hir_with_applicability(cx, left_expr, "<left>", &mut applicability);
+                let right_sugg = Sugg::hir_with_applicability(cx, right_expr, "<right>", &mut applicability);
 
-    let lint_msg = if left_ty.is_diag_item(cx, sym::Instant) {
-        "unchecked subtraction of a 'Duration' from an 'Instant'"
-    } else {
-        "unchecked subtraction between 'Duration' values"
-    };
-
-    span_lint_and_then(cx, UNCHECKED_TIME_SUBTRACTION, expr.span, lint_msg, |diag| {
-        // For chained subtraction, like `(dur1 - dur2) - dur3` or `(instant - dur1) - dur2`,
-        // avoid suggestions
-        if !is_chained_time_subtraction(cx, left_expr) {
-            let mut applicability = Applicability::MachineApplicable;
-            let left_sugg = Sugg::hir_with_applicability(cx, left_expr, "<left>", &mut applicability);
-            let right_sugg = Sugg::hir_with_applicability(cx, right_expr, "<right>", &mut applicability);
-
-            diag.span_suggestion(
-                expr.span,
-                "try",
-                format!("{}.checked_sub({}).unwrap()", left_sugg.maybe_paren(), right_sugg),
-                applicability,
-            );
-        }
-    });
+                diag.span_suggestion(
+                    expr.span,
+                    "try",
+                    format!("{}.checked_sub({}).unwrap()", left_sugg.maybe_paren(), right_sugg),
+                    applicability,
+                );
+            }
+        },
+    );
 }

--- a/tests/ui/unchecked_time_subtraction.stderr
+++ b/tests/ui/unchecked_time_subtraction.stderr
@@ -1,4 +1,4 @@
-error: unchecked subtraction of a 'Duration' from an 'Instant'
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction.rs:9:13
    |
 LL |     let _ = _first - second;
@@ -7,43 +7,43 @@ LL |     let _ = _first - second;
    = note: `-D clippy::unchecked-time-subtraction` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unchecked_time_subtraction)]`
 
-error: unchecked subtraction of a 'Duration' from an 'Instant'
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction.rs:12:13
    |
 LL |     let _ = Instant::now() - Duration::from_secs(5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Instant::now().checked_sub(Duration::from_secs(5)).unwrap()`
 
-error: unchecked subtraction of a 'Duration' from an 'Instant'
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction.rs:15:13
    |
 LL |     let _ = _first - Duration::from_secs(5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `_first.checked_sub(Duration::from_secs(5)).unwrap()`
 
-error: unchecked subtraction of a 'Duration' from an 'Instant'
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction.rs:18:13
    |
 LL |     let _ = Instant::now() - second;
    |             ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Instant::now().checked_sub(second).unwrap()`
 
-error: unchecked subtraction between 'Duration' values
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction.rs:25:13
    |
 LL |     let _ = dur1 - dur2;
    |             ^^^^^^^^^^^ help: try: `dur1.checked_sub(dur2).unwrap()`
 
-error: unchecked subtraction between 'Duration' values
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction.rs:28:13
    |
 LL |     let _ = Duration::from_secs(10) - Duration::from_secs(5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Duration::from_secs(10).checked_sub(Duration::from_secs(5)).unwrap()`
 
-error: unchecked subtraction between 'Duration' values
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction.rs:31:13
    |
 LL |     let _ = second - dur1;
    |             ^^^^^^^^^^^^^ help: try: `second.checked_sub(dur1).unwrap()`
 
-error: unchecked subtraction between 'Duration' values
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction.rs:35:13
    |
 LL |     let _ = 2 * dur1 - dur2;

--- a/tests/ui/unchecked_time_subtraction_unfixable.stderr
+++ b/tests/ui/unchecked_time_subtraction_unfixable.stderr
@@ -1,4 +1,4 @@
-error: unchecked subtraction between 'Duration' values
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction_unfixable.rs:12:13
    |
 LL |     let _ = dur1 - dur2 - dur3;
@@ -7,19 +7,19 @@ LL |     let _ = dur1 - dur2 - dur3;
    = note: `-D clippy::unchecked-time-subtraction` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unchecked_time_subtraction)]`
 
-error: unchecked subtraction between 'Duration' values
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction_unfixable.rs:12:13
    |
 LL |     let _ = dur1 - dur2 - dur3;
    |             ^^^^^^^^^^^ help: try: `dur1.checked_sub(dur2).unwrap()`
 
-error: unchecked subtraction of a 'Duration' from an 'Instant'
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction_unfixable.rs:19:13
    |
 LL |     let _ = instant1 - dur2 - dur3;
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error: unchecked subtraction of a 'Duration' from an 'Instant'
+error: unchecked subtraction of a `Duration`
   --> tests/ui/unchecked_time_subtraction_unfixable.rs:19:13
    |
 LL |     let _ = instant1 - dur2 - dur3;


### PR DESCRIPTION
Supersedes https://github.com/rust-lang/rust-clippy/pull/16057

changelog: [`time_subtraction`]: give the same message for `Instant - Duration` and `Duration - Duration`