### PR TITLE
Fixes #16109: For non-sized types, use reborrow in suggestions to remove while-let loops

### DIFF
--- a/tests/ui/while_let_on_iterator.fixed
+++ b/tests/ui/while_let_on_iterator.fixed
@@ -523,6 +523,79 @@ fn issue16089_sized_trait_not_reborrowed() {
     }
 }
 
+fn issue16089_nested_derefs() {
+    struct S<T>(T);
+    impl<T> core::ops::Deref for S<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T> core::ops::DerefMut for S<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    fn f(mut x: S<S<&mut dyn Iterator<Item = u32>>>) {
+        for _ in &mut ***x {}
+        //~^ while_let_on_iterator
+    }
+}
+
+fn issue16089_nested_derefs_last_not_sized() {
+    struct WithSize<T>(T);
+    impl<T> core::ops::Deref for WithSize<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T> core::ops::DerefMut for WithSize<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+    // The suggestion must use `&mut **x`. Using `x.by_ref()` doesn't work in this
+    // case, since the last type adjustment for `x` in the expression `x.next()` is
+    // to dereference a `?Sized` trait.
+    fn f(mut x: WithSize<&mut dyn Iterator<Item = u32>>) {
+        for _ in &mut **x {}
+        //~^ while_let_on_iterator
+    }
+}
+
+fn issue16089_nested_derefs_last_sized() {
+    struct NoSize<T: ?Sized>(T);
+    impl<T: ?Sized> core::ops::Deref for NoSize<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T: ?Sized> core::ops::DerefMut for NoSize<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    struct SizedIter {}
+
+    impl Iterator for SizedIter {
+        type Item = u32;
+        fn next(&mut self) -> Option<u32> {
+            Some(0)
+        }
+    }
+
+    // We want the suggestion to be `x.by_ref()`. It works in this case since the last type
+    // adjustment for `x` in the expression `x.next()` is to dereference a Sized type.
+    fn f(mut x: NoSize<NoSize<SizedIter>>) {
+        for _ in x.by_ref() {}
+        //~^ while_let_on_iterator
+    }
+}
+
 fn main() {
     let mut it = 0..20;
     for _ in it {

--- a/tests/ui/while_let_on_iterator.rs
+++ b/tests/ui/while_let_on_iterator.rs
@@ -523,6 +523,79 @@ fn issue16089_sized_trait_not_reborrowed() {
     }
 }
 
+fn issue16089_nested_derefs() {
+    struct S<T>(T);
+    impl<T> core::ops::Deref for S<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T> core::ops::DerefMut for S<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    fn f(mut x: S<S<&mut dyn Iterator<Item = u32>>>) {
+        while let Some(_) = x.next() {}
+        //~^ while_let_on_iterator
+    }
+}
+
+fn issue16089_nested_derefs_last_not_sized() {
+    struct WithSize<T>(T);
+    impl<T> core::ops::Deref for WithSize<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T> core::ops::DerefMut for WithSize<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+    // The suggestion must use `&mut **x`. Using `x.by_ref()` doesn't work in this
+    // case, since the last type adjustment for `x` in the expression `x.next()` is
+    // to dereference a `?Sized` trait.
+    fn f(mut x: WithSize<&mut dyn Iterator<Item = u32>>) {
+        while let Some(_) = x.next() {}
+        //~^ while_let_on_iterator
+    }
+}
+
+fn issue16089_nested_derefs_last_sized() {
+    struct NoSize<T: ?Sized>(T);
+    impl<T: ?Sized> core::ops::Deref for NoSize<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T: ?Sized> core::ops::DerefMut for NoSize<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    struct SizedIter {}
+
+    impl Iterator for SizedIter {
+        type Item = u32;
+        fn next(&mut self) -> Option<u32> {
+            Some(0)
+        }
+    }
+
+    // We want the suggestion to be `x.by_ref()`. It works in this case since the last type
+    // adjustment for `x` in the expression `x.next()` is to dereference a Sized type.
+    fn f(mut x: NoSize<NoSize<SizedIter>>) {
+        while let Some(_) = x.next() {}
+        //~^ while_let_on_iterator
+    }
+}
+
 fn main() {
     let mut it = 0..20;
     while let Some(..) = it.next() {

--- a/tests/ui/while_let_on_iterator.stderr
+++ b/tests/ui/while_let_on_iterator.stderr
@@ -176,10 +176,28 @@ LL |             while let Some(r) = self.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for r in self.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:528:5
+  --> tests/ui/while_let_on_iterator.rs:541:9
+   |
+LL |         while let Some(_) = x.next() {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in &mut ***x`
+
+error: this loop could be written as a `for` loop
+  --> tests/ui/while_let_on_iterator.rs:563:9
+   |
+LL |         while let Some(_) = x.next() {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in &mut **x`
+
+error: this loop could be written as a `for` loop
+  --> tests/ui/while_let_on_iterator.rs:594:9
+   |
+LL |         while let Some(_) = x.next() {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in x.by_ref()`
+
+error: this loop could be written as a `for` loop
+  --> tests/ui/while_let_on_iterator.rs:601:5
    |
 LL |     while let Some(..) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in it`
 
-error: aborting due to 30 previous errors
+error: aborting due to 33 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16019 by reborrowing, instead of using by_ref, when the iterator expression is not `Sized`.

```
changelog: [`while_let_on_iterator`]: fixes broken suggestion by using reborrow instead of `by_ref` for references to traits that are not `Sized`
```