### PR TITLE
`multiple_unsafe_ops_per_block`: still lint raw pointer to union field if MSRV < 1.92

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -892,6 +892,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`mem_replace_option_with_some`](https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_option_with_some)
 * [`mem_replace_with_default`](https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default)
 * [`missing_const_for_fn`](https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn)
+* [`multiple_unsafe_ops_per_block`](https://rust-lang.github.io/rust-clippy/master/index.html#multiple_unsafe_ops_per_block)
 * [`needless_borrow`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)
 * [`non_std_lazy_statics`](https://rust-lang.github.io/rust-clippy/master/index.html#non_std_lazy_statics)
 * [`option_as_ref_deref`](https://rust-lang.github.io/rust-clippy/master/index.html#option_as_ref_deref)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -781,6 +781,7 @@ define_Conf! {
         mem_replace_option_with_some,
         mem_replace_with_default,
         missing_const_for_fn,
+        multiple_unsafe_ops_per_block,
         needless_borrow,
         non_std_lazy_statics,
         option_as_ref_deref,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -765,7 +765,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(move |_| Box::new(semicolon_block::SemicolonBlock::new(conf))),
         Box::new(|_| Box::new(permissions_set_readonly_false::PermissionsSetReadonlyFalse)),
         Box::new(|_| Box::new(size_of_ref::SizeOfRef)),
-        Box::new(|_| Box::new(multiple_unsafe_ops_per_block::MultipleUnsafeOpsPerBlock)),
+        Box::new(move |_| Box::new(multiple_unsafe_ops_per_block::MultipleUnsafeOpsPerBlock::new(conf))),
         Box::new(move |_| Box::new(extra_unused_type_parameters::ExtraUnusedTypeParameters::new(conf))),
         Box::new(|_| Box::new(no_mangle_with_rust_abi::NoMangleWithRustAbi)),
         Box::new(|_| Box::new(collection_is_never_read::CollectionIsNeverRead)),

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -23,6 +23,7 @@ macro_rules! msrv_aliases {
 
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
+    1,92,0 { SAFE_RAW_PTR_TO_UNION_FIELD }
     1,88,0 { LET_CHAINS }
     1,87,0 { OS_STR_DISPLAY, INT_MIDPOINT, CONST_CHAR_IS_DIGIT, UNSIGNED_IS_MULTIPLE_OF, INTEGER_SIGN_CAST }
     1,85,0 { UINT_FLOAT_MIDPOINT, CONST_SIZE_OF_VAL }

--- a/tests/ui/multiple_unsafe_ops_per_block.rs
+++ b/tests/ui/multiple_unsafe_ops_per_block.rs
@@ -1,5 +1,6 @@
 //@needs-asm-support
 //@aux-build:proc_macros.rs
+#![feature(stmt_expr_attributes)]
 #![expect(
     dropping_copy_types,
     clippy::unnecessary_operation,
@@ -227,7 +228,16 @@ fn issue16076() {
     let u = U { i: 0 };
 
     // Taking a raw pointer to a place is safe since Rust 1.92
+    #[clippy::msrv = "1.92"]
     unsafe {
+        _ = &raw const u.i;
+        _ = &raw const u.i;
+    }
+
+    // However it was not the case before Rust 1.92
+    #[clippy::msrv = "1.91"]
+    unsafe {
+        //~^ multiple_unsafe_ops_per_block
         _ = &raw const u.i;
         _ = &raw const u.i;
     }

--- a/tests/ui/multiple_unsafe_ops_per_block.stderr
+++ b/tests/ui/multiple_unsafe_ops_per_block.stderr
@@ -1,5 +1,5 @@
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:38:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:39:5
    |
 LL | /     unsafe {
 LL | |
@@ -9,12 +9,12 @@ LL | |     }
    | |_____^
    |
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:40:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:41:9
    |
 LL |         STATIC += 1;
    |         ^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:41:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:42:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |         not_very_safe();
    = help: to override `-D warnings` add `#[allow(clippy::multiple_unsafe_ops_per_block)]`
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:48:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:49:5
    |
 LL | /     unsafe {
 LL | |
@@ -32,18 +32,18 @@ LL | |     }
    | |_____^
    |
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:50:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:51:14
    |
 LL |         drop(u.u);
    |              ^^^
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:51:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:52:9
    |
 LL |         *raw_ptr();
    |         ^^^^^^^^^^
 
 error: this `unsafe` block contains 3 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:56:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:57:5
    |
 LL | /     unsafe {
 LL | |
@@ -54,23 +54,23 @@ LL | |     }
    | |_____^
    |
 note: inline assembly used here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:58:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:59:9
    |
 LL |         asm!("nop");
    |         ^^^^^^^^^^^
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:59:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:60:9
    |
 LL |         sample.not_very_safe();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:60:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:61:9
    |
 LL |         STATIC = 0;
    |         ^^^^^^^^^^
 
 error: this `unsafe` block contains 6 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:66:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:67:5
    |
 LL | /     unsafe {
 LL | |
@@ -82,38 +82,38 @@ LL | |     }
    | |_____^
    |
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:68:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:69:14
    |
 LL |         drop(u.u);
    |              ^^^
 note: access of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:69:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:70:14
    |
 LL |         drop(STATIC);
    |              ^^^^^^
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:70:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:71:9
    |
 LL |         sample.not_very_safe();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:71:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:72:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:72:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:73:9
    |
 LL |         *raw_ptr();
    |         ^^^^^^^^^^
 note: inline assembly used here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:73:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:74:9
    |
 LL |         asm!("nop");
    |         ^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:109:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:110:5
    |
 LL | /     unsafe {
 LL | |
@@ -123,35 +123,35 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:111:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:112:9
    |
 LL |         f();
    |         ^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:112:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:113:9
    |
 LL |         f();
    |         ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:9
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:18
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:18
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:43
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:43
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |                                           ^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:139:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:140:9
    |
 LL | /         unsafe {
 LL | |
@@ -161,18 +161,18 @@ LL | |         }
    | |_________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:141:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:142:13
    |
 LL |             x();
    |             ^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:142:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:143:13
    |
 LL |             x();
    |             ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:151:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:152:13
    |
 LL | /             unsafe {
 LL | |
@@ -182,18 +182,18 @@ LL | |             }
    | |_____________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:153:17
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:154:17
    |
 LL |                 T::X();
    |                 ^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:154:17
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:155:17
    |
 LL |                 T::X();
    |                 ^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:162:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:163:9
    |
 LL | /         unsafe {
 LL | |
@@ -203,18 +203,18 @@ LL | |         }
    | |_________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:164:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:165:13
    |
 LL |             x.0();
    |             ^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:165:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:166:13
    |
 LL |             x.0();
    |             ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:192:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:193:5
    |
 LL | /     unsafe {
 LL | |
@@ -225,18 +225,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:194:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:195:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:195:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:196:9
    |
 LL |         STATIC += 1;
    |         ^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:207:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:208:5
    |
 LL | /     unsafe {
 LL | |
@@ -246,18 +246,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:209:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:210:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:210:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:211:9
    |
 LL |         foo_unchecked().await;
    |         ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:214:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:215:5
    |
 LL | /     unsafe {
 LL | |
@@ -266,18 +266,39 @@ LL | |     }
    | |_____^
    |
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:216:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:217:9
    |
 LL |         Some(foo_unchecked()).unwrap_unchecked().await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:216:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:217:14
    |
 LL |         Some(foo_unchecked()).unwrap_unchecked().await;
    |              ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:236:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:239:5
+   |
+LL | /     unsafe {
+LL | |
+LL | |         _ = &raw const u.i;
+LL | |         _ = &raw const u.i;
+LL | |     }
+   | |_____^
+   |
+note: union field access occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:241:24
+   |
+LL |         _ = &raw const u.i;
+   |                        ^^^
+note: union field access occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:242:24
+   |
+LL |         _ = &raw const u.i;
+   |                        ^^^
+
+error: this `unsafe` block contains 2 unsafe operations, expected only one
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:246:5
    |
 LL | /     unsafe {
 LL | |
@@ -287,18 +308,18 @@ LL | |     }
    | |_____^
    |
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:238:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:248:14
    |
 LL |         _ = &u.i;
    |              ^^^
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:239:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:249:14
    |
 LL |         _ = &u.i;
    |              ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:244:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:254:5
    |
 LL | /     unsafe {
 LL | |
@@ -308,18 +329,18 @@ LL | |     }
    | |_____^
    |
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:246:24
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:256:24
    |
 LL |         _ = &raw const (*&raw const u).i;
    |                        ^^^^^^^^^^^^^^^
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:247:24
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:257:24
    |
 LL |         _ = &raw const (*&raw const u).i;
    |                        ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:294:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:304:5
    |
 LL | /     unsafe {
 LL | |
@@ -329,18 +350,18 @@ LL | |     }
    | |_____^
    |
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:296:24
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:306:24
    |
 LL |         _ = &raw const w.s.i;
    |                        ^^^
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:297:24
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:307:24
    |
 LL |         _ = &raw const w.s.i;
    |                        ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:309:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:319:5
    |
 LL | /     unsafe {
 LL | |
@@ -349,15 +370,15 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:311:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:321:9
    |
 LL |         apply(|| f(0));
    |         ^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:311:18
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:321:18
    |
 LL |         apply(|| f(0));
    |                  ^^^^
 
-error: aborting due to 16 previous errors
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
changelog: [`multiple_unsafe_ops_per_block`]: distinguish operations per MSRV

Blocked by rust-lang/rust-clippy#16079

@rustbot label S-blocked
