### PR TITLE
Clippy lints page improvements and cleanups

### DIFF
--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -152,13 +152,11 @@ Otherwise, have a great day =^.^=
                 </div> {# #}
             </div> {# #}
             <div class="search-control"> {# #}
-                <div class="input-group"> {# #}
-                    <label class="input-group-addon" id="filter-label" for="search-input">Filter:</label> {# #}
-                    <input type="text" class="form-control filter-input" placeholder="Keywords or search string (`S` or `/` to focus)" id="search-input" /> {# #}
-                    <button id="filter-clear" type="button"> {# #}
-                        Clear {# #}
-                    </button> {# #}
-                </div> {# #}
+                <label class="input-group-addon" id="filter-label" for="search-input">Filter:</label> {# #}
+                <input type="text" class="form-control filter-input" placeholder="Keywords or search string (`S` or `/` to focus)" id="search-input" /> {# #}
+                <button id="filter-clear" type="button"> {# #}
+                    Clear {# #}
+                </button> {# #}
             </div> {# #}
             <div class="btn-group expansion-group"> {# #}
                 <button title="Collapse All" class="btn-default expansion-control" type="button" id="collapse-all"> {# #}

--- a/util/gh-pages/style.css
+++ b/util/gh-pages/style.css
@@ -239,33 +239,10 @@ article:hover .panel-title-name .anchor { display: inline;}
     min-height: 1px;
     padding-right: 15px;
     padding-left: 15px;
-}
-
-.input-group {
-    position: relative;
     display: flex;
 }
-.input-group > :last-child {
-    border-left: 0;
-}
-.input-group > :first-child, .btn-group > :first-child {
-    border-right: 0;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-}
-.input-group > :last-child, .btn-group > :last-child {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-}
-.input-group .form-control:not(:first-child):not(:last-child) {
-    border-radius: 0;
-}
-.form-control:focus {
-    border-color: #66afe9;
-    outline: 0;
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);
-}
-.input-group-addon {
+
+#filter-label {
     padding: 6px 12px;
     font-size: 14px;
     font-weight: 400;
@@ -277,6 +254,29 @@ article:hover .panel-title-name .anchor { display: inline;}
     display: flex;
     align-items: center;
     justify-content: center;
+    border-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+.search-control > :last-child {
+    border-left: 0;
+}
+.btn-group > :first-child {
+    border-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+.search-control > :last-child, .btn-group > :last-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+.search-control .form-control:not(:first-child):not(:last-child) {
+    border-radius: 0;
+}
+.form-control:focus {
+    border-color: #66afe9;
+    outline: 0;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);
 }
 
 .glyphicon.glyphicon-collapse-up::before, .glyphicon.glyphicon-collapse-down::before {
@@ -340,6 +340,7 @@ article:hover .panel-title-name .anchor { display: inline;}
 @media (min-width: 992px) {
     .search-control {
         margin-top: 0;
+        align-self: flex-start;
     }
     .container {
         width: 970px;


### PR DESCRIPTION
First commits fixes a display issue when JS is disabled. Before:

<img width="962" height="144" alt="image" src="https://github.com/user-attachments/assets/d9ca8077-2486-49eb-9a99-bd396c0d67fa" />

After:

<img width="962" height="144" alt="Screenshot From 2025-11-18 14-12-52" src="https://github.com/user-attachments/assets/a5f0c390-7e3c-4ad5-bb0d-95e0c1a1889b" />

The two other commits remove (each) one DOM level in the filters menu.

changelog: none

r? @Alexendoo 