### PR TITLE
Allow multiline suggestions in `map-unwrap-or`

### DIFF
--- a/clippy_lints/src/methods/map_unwrap_or.rs
+++ b/clippy_lints/src/methods/map_unwrap_or.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg};
+use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
 use clippy_utils::source::snippet;
@@ -51,11 +51,8 @@ pub(super) fn check<'tcx>(
         // get snippets for args to map() and unwrap_or_else()
         let map_snippet = snippet(cx, map_arg.span, "..");
         let unwrap_snippet = snippet(cx, unwrap_arg.span, "..");
-        // lint, with note if neither arg is > 1 line and both map() and
-        // unwrap_or_else() have the same span
-        let multiline = map_snippet.lines().count() > 1 || unwrap_snippet.lines().count() > 1;
-        let same_span = map_arg.span.eq_ctxt(unwrap_arg.span);
-        if same_span && !multiline {
+        // lint, with note if both map() and unwrap_or_else() have the same span
+        if map_arg.span.eq_ctxt(unwrap_arg.span) {
             let var_snippet = snippet(cx, recv.span, "..");
             span_lint_and_sugg(
                 cx,
@@ -66,9 +63,6 @@ pub(super) fn check<'tcx>(
                 format!("{var_snippet}.map_or_else({unwrap_snippet}, {map_snippet})"),
                 Applicability::MachineApplicable,
             );
-            return true;
-        } else if same_span && multiline {
-            span_lint(cx, MAP_UNWRAP_OR, expr.span, msg);
             return true;
         }
     }

--- a/tests/ui/map_unwrap_or.stderr
+++ b/tests/ui/map_unwrap_or.stderr
@@ -123,6 +123,14 @@ LL | |         x + 1
 LL | |     }
 LL | |     ).unwrap_or_else(|| 0);
    | |__________________________^
+   |
+help: try
+   |
+LL ~     let _ = opt.map_or_else(|| 0, |x| {
+LL +
+LL +         x + 1
+LL ~     });
+   |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:63:13
@@ -134,6 +142,12 @@ LL | |         .unwrap_or_else(||
 LL | |             0
 LL | |         );
    | |_________^
+   |
+help: try
+   |
+LL ~     let _ = opt.map_or_else(||
+LL ~             0, |x| x + 1);
+   |
 
 error: called `map(<f>).unwrap_or(false)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:70:13
@@ -157,6 +171,14 @@ LL | |         x + 1
 LL | |     }
 LL | |     ).unwrap_or_else(|_e| 0);
    | |____________________________^
+   |
+help: try
+   |
+LL ~     let _ = res.map_or_else(|_e| 0, |x| {
+LL +
+LL +         x + 1
+LL ~     });
+   |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
   --> tests/ui/map_unwrap_or.rs:86:13
@@ -168,6 +190,13 @@ LL | |         .unwrap_or_else(|_e| {
 LL | |             0
 LL | |         });
    | |__________^
+   |
+help: try
+   |
+LL ~     let _ = res.map_or_else(|_e| {
+LL +             0
+LL ~         }, |x| x + 1);
+   |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
   --> tests/ui/map_unwrap_or.rs:111:13


### PR DESCRIPTION
I recently got a `map-unwrap-or` warning with no suggestion, and was very confused because I couldn't tell what the lint was flagging.

It turned out the "else" part had multiple lines, so the lint decided not to include a suggestion.

Please look at this PR's stderr file, and decide whether you like it. Then look at [its predecessor](https://github.com/rust-lang/rust-clippy/blob/24e16f992c2dda1904fe8d4a94b391513832ce60/tests/ui/map_unwrap_or.stderr), and decide whether you like it.

IMHO, the one with the suggestions is much more informative, even if not as pretty.

changelog: Allow multiline suggestions in `map-unwrap-or`