### PR TITLE
Fix `useless_asref` suggests wrongly when used in ctor

### DIFF
--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -258,6 +258,41 @@ fn issue_14828() {
     ().as_ref();
 }
 
+fn issue16098(exts: Vec<&str>) {
+    use std::borrow::Cow;
+
+    let v: Vec<Cow<'_, str>> = exts.iter().map(|s| Cow::Borrowed(*s)).collect();
+    //~^ useless_asref
+
+    trait Identity {
+        fn id(self) -> Self
+        where
+            Self: Sized,
+        {
+            self
+        }
+    }
+    impl Identity for &str {}
+
+    let v: Vec<Cow<'_, str>> = exts.iter().map(|s| Cow::Borrowed(s.id())).collect();
+    //~^ useless_asref
+
+    let v: Vec<Cow<'_, str>> = exts
+        .iter()
+        .map(|s| Cow::Borrowed(*std::convert::identity(s)))
+        //~^ useless_asref
+        .collect();
+
+    struct Wrapper<'a>(&'a str);
+    let exts_field: Vec<Wrapper> = exts.iter().map(|s| Wrapper(s)).collect();
+    let v: Vec<Cow<'_, str>> = exts_field.iter().map(|w| Cow::Borrowed(w.0)).collect();
+    //~^ useless_asref
+
+    let exts_index: Vec<&[&str]> = exts.iter().map(|s| std::slice::from_ref(s)).collect();
+    let v: Vec<Cow<'_, str>> = exts_index.iter().map(|arr| Cow::Borrowed(arr[0])).collect();
+    //~^ useless_asref
+}
+
 fn main() {
     not_ok();
     ok();

--- a/tests/ui/useless_asref.stderr
+++ b/tests/ui/useless_asref.stderr
@@ -112,5 +112,35 @@ error: this call to `as_ref.map(...)` does nothing
 LL |         Some(1).as_ref().map(|&x| x.clone());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(1).clone()`
 
-error: aborting due to 18 previous errors
+error: this call to `as_ref` does nothing
+  --> tests/ui/useless_asref.rs:264:66
+   |
+LL |     let v: Vec<Cow<'_, str>> = exts.iter().map(|s| Cow::Borrowed(s.as_ref())).collect();
+   |                                                                  ^^^^^^^^^^ help: try: `*s`
+
+error: this call to `as_ref` does nothing
+  --> tests/ui/useless_asref.rs:277:66
+   |
+LL |     let v: Vec<Cow<'_, str>> = exts.iter().map(|s| Cow::Borrowed(s.id().as_ref())).collect();
+   |                                                                  ^^^^^^^^^^^^^^^ help: try: `s.id()`
+
+error: this call to `as_ref` does nothing
+  --> tests/ui/useless_asref.rs:282:32
+   |
+LL |         .map(|s| Cow::Borrowed(std::convert::identity(s).as_ref()))
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `*std::convert::identity(s)`
+
+error: this call to `as_ref` does nothing
+  --> tests/ui/useless_asref.rs:288:72
+   |
+LL |     let v: Vec<Cow<'_, str>> = exts_field.iter().map(|w| Cow::Borrowed(w.0.as_ref())).collect();
+   |                                                                        ^^^^^^^^^^^^ help: try: `w.0`
+
+error: this call to `as_ref` does nothing
+  --> tests/ui/useless_asref.rs:292:74
+   |
+LL |     let v: Vec<Cow<'_, str>> = exts_index.iter().map(|arr| Cow::Borrowed(arr[0].as_ref())).collect();
+   |                                                                          ^^^^^^^^^^^^^^^ help: try: `arr[0]`
+
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16098 

changelog: [`useless_asref`] fix wrong suggestions when used in ctor
