### PR TITLE
fix: `let-and-return` suggests invalid cast (#16135)

### DIFF
--- a/clippy_lints/src/returns/let_and_return.rs
+++ b/clippy_lints/src/returns/let_and_return.rs
@@ -45,7 +45,10 @@ pub(super) fn check_block<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'_>) 
                         } else {
                             format!("({src})")
                         }
-                    } else if !cx.typeck_results().expr_adjustments(retexpr).is_empty() {
+                    } else if !cx.typeck_results().expr_adjustments(retexpr).is_empty()
+                        // Do not suggest 'as _' for raw pointers; it's an invalid cast
+                        && !cx.typeck_results().expr_ty_adjusted(retexpr).is_raw_ptr()
+                    {
                         if has_enclosing_paren(&src) {
                             format!("{src} as _")
                         } else {

--- a/tests/ui/let_and_return.edition2021.fixed
+++ b/tests/ui/let_and_return.edition2021.fixed
@@ -271,4 +271,17 @@ fn issue15987() -> i32 {
     r
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/16135
+mod issue16135 {
+    struct S;
+    trait T {}
+    impl T for &S {}
+
+    fn f(x: &S) -> Box<dyn T + '_> {
+        
+        (Box::new(Clone::clone(&x))) as _
+        //~^ let_and_return
+    }
+}
+
 fn main() {}

--- a/tests/ui/let_and_return.edition2021.stderr
+++ b/tests/ui/let_and_return.edition2021.stderr
@@ -148,5 +148,19 @@ LL ~
 LL ~             ({ true } || { false } && { 2 <= 3 })
    |
 
-error: aborting due to 10 previous errors
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:282:9
+   |
+LL |         let x = Box::new(Clone::clone(&x));
+   |         ----------------------------------- unnecessary `let` binding
+LL |         x
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         (Box::new(Clone::clone(&x))) as _
+   |
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/let_and_return.edition2024.fixed
+++ b/tests/ui/let_and_return.edition2024.fixed
@@ -271,4 +271,17 @@ fn issue15987() -> i32 {
     r
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/16135
+mod issue16135 {
+    struct S;
+    trait T {}
+    impl T for &S {}
+
+    fn f(x: &S) -> Box<dyn T + '_> {
+        
+        (Box::new(Clone::clone(&x))) as _
+        //~^ let_and_return
+    }
+}
+
 fn main() {}

--- a/tests/ui/let_and_return.edition2024.stderr
+++ b/tests/ui/let_and_return.edition2024.stderr
@@ -224,5 +224,19 @@ LL +         None => Ok(Ok(0)),
 LL +     }?
    |
 
-error: aborting due to 15 previous errors
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:282:9
+   |
+LL |         let x = Box::new(Clone::clone(&x));
+   |         ----------------------------------- unnecessary `let` binding
+LL |         x
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         (Box::new(Clone::clone(&x))) as _
+   |
+
+error: aborting due to 16 previous errors
 

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -271,4 +271,17 @@ fn issue15987() -> i32 {
     r
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/16135
+mod issue16135 {
+    struct S;
+    trait T {}
+    impl T for &S {}
+
+    fn f(x: &S) -> Box<dyn T + '_> {
+        let x = Box::new(Clone::clone(&x));
+        x
+        //~^ let_and_return
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Simple PR that handles a special case where a raw pointer was invalidly cast via `as _`.

First PR, would appreciate feedback.

changelog: [`let_and_return`]: fix lint suggestion for invalid cast to raw pointer.