### PR TITLE
Fix display of dropdown menu "buttons"

### DIFF
--- a/util/gh-pages/style.css
+++ b/util/gh-pages/style.css
@@ -637,14 +637,14 @@ pre, hr {
     display: flex;
 }
 
-ul.dropdown-menu li.checkbox > button {
+#menu-filters ul.dropdown-menu li.checkbox > button {
     border: 0;
     width: 100%;
     background: var(--theme-popup-bg);
     color: var(--fg);
 }
 
-ul.dropdown-menu li.checkbox > button:hover {
+#menu-filters ul.dropdown-menu li.checkbox > button:hover {
     background: var(--theme-hover);
     box-shadow: none;
 }


### PR DESCRIPTION
Before this PR:

<img width="722" height="306" alt="Screenshot From 2025-11-28 13-04-55" src="https://github.com/user-attachments/assets/8c2d1eb2-6030-43d1-984a-174988c73e76" />

With this PR:

<img width="722" height="306" alt="Screenshot From 2025-11-28 13-05-01" src="https://github.com/user-attachments/assets/ae8a344f-b876-44b3-9ddc-aaeebc0dccd4" />

r? @Alexendoo 

changelog: Fix display of dropdown menu "buttons"