### PR TITLE
Fix `useless_conversion` wrongly unmangled macros

### DIFF
--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -354,7 +354,10 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                             return;
                         }
 
-                        let sugg = snippet(cx, recv.span, "<expr>").into_owned();
+                        let mut applicability = Applicability::MachineApplicable;
+                        let sugg = snippet_with_context(cx, recv.span, e.span.ctxt(), "<expr>", &mut applicability)
+                            .0
+                            .into_owned();
                         span_lint_and_sugg(
                             cx,
                             USELESS_CONVERSION,

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -442,3 +442,14 @@ fn issue14739() {
     let _ = R.map(|_x| 0);
     //~^ useless_conversion
 }
+
+fn issue16165() {
+    macro_rules! mac {
+        (iter $e:expr) => {
+            $e.iter()
+        };
+    }
+
+    for _ in mac!(iter [1, 2]) {}
+    //~^ useless_conversion
+}

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -442,3 +442,14 @@ fn issue14739() {
     let _ = R.into_iter().map(|_x| 0);
     //~^ useless_conversion
 }
+
+fn issue16165() {
+    macro_rules! mac {
+        (iter $e:expr) => {
+            $e.iter()
+        };
+    }
+
+    for _ in mac!(iter [1, 2]).into_iter() {}
+    //~^ useless_conversion
+}

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -389,5 +389,11 @@ error: useless conversion to the same type: `std::ops::Range<u32>`
 LL |     let _ = R.into_iter().map(|_x| 0);
    |             ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
-error: aborting due to 43 previous errors
+error: useless conversion to the same type: `std::slice::Iter<'_, i32>`
+  --> tests/ui/useless_conversion.rs:453:14
+   |
+LL |     for _ in mac!(iter [1, 2]).into_iter() {}
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `mac!(iter [1, 2])`
+
+error: aborting due to 44 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16165

changelog: [`useless_conversion`] fix wrongly unmangled macros
