### PR TITLE
Do not look for disallowed methods inside desugared code

### DIFF
--- a/clippy_lints/src/disallowed_methods.rs
+++ b/clippy_lints/src/disallowed_methods.rs
@@ -88,6 +88,9 @@ impl_lint_pass!(DisallowedMethods => [DISALLOWED_METHODS]);
 
 impl<'tcx> LateLintPass<'tcx> for DisallowedMethods {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        if expr.span.desugaring_kind().is_some() {
+            return;
+        }
         let (id, span) = match &expr.kind {
             ExprKind::Path(path) if let Res::Def(_, id) = cx.qpath_res(path, expr.hir_id) => (id, expr.span),
             ExprKind::MethodCall(name, ..) if let Some(id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) => {

--- a/tests/ui-toml/toml_disallowed_methods/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_methods/clippy.toml
@@ -17,4 +17,6 @@ disallowed-methods = [
     # re-exports
     "conf_disallowed_methods::identity",
     "conf_disallowed_methods::renamed",
+    # also used in desugaring
+    "std::future::Future::poll",
 ]

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
@@ -80,3 +80,19 @@ fn main() {
     renamed(1);
     //~^ disallowed_methods
 }
+
+mod issue16185 {
+    use std::pin::Pin;
+    use std::task::Context;
+
+    async fn test(f: impl Future<Output = ()>) {
+        // Should not lint even though desugaring uses
+        // disallowed method `std::future::Future::poll()`.
+        f.await
+    }
+
+    fn explicit<F: Future<Output = ()>>(f: Pin<&mut F>, cx: &mut Context<'_>) {
+        f.poll(cx);
+        //~^ disallowed_methods
+    }
+}

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -99,5 +99,11 @@ error: use of a disallowed method `conf_disallowed_methods::renamed`
 LL |     renamed(1);
    |     ^^^^^^^
 
-error: aborting due to 16 previous errors
+error: use of a disallowed method `std::future::Future::poll`
+  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:95:11
+   |
+LL |         f.poll(cx);
+   |           ^^^^
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
changelog: [`disallowed_methods`]: do not check compiler-generated code

Fixes rust-lang/rust-clippy#16185 