### PR TITLE
Remove myself from rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -65,6 +65,7 @@ users_on_vacation = [
     "Manishearth",
     "Alexendoo",
     "y21",
+    "blyxyas",
 ]
 
 [assign.owners]
@@ -77,7 +78,6 @@ users_on_vacation = [
     "@Alexendoo",
     "@dswij",
     "@Jarcho",
-    "@blyxyas",
     "@y21",
     "@samueltardieu",
 ]


### PR DESCRIPTION
Turns out that I'm still in burnout, the two RFCs that I'm working on, the Rust-For-Linux support, some conferences, my blog, I got a new job that is also quite time consuming.
I don't have the time to do reviews right now, I'm sorry to everyone on the team. I'll try to scale down as much as possible and then I'll come back to rotation.

r? ghost
changelog:none