### PR TITLE
fix(len_without_is_empty): allow `is_empty(&self)` with `len(&mut self)`

### DIFF
--- a/tests/ui/len_without_is_empty.rs
+++ b/tests/ui/len_without_is_empty.rs
@@ -473,4 +473,16 @@ impl Alias2 {
     }
 }
 
+// Issue #16190
+pub struct RefMutLenButRefIsEmpty;
+impl RefMutLenButRefIsEmpty {
+    pub fn len(&mut self) -> usize {
+        todo!()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        todo!()
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/16190

changelog: [`len_without_is_empty`]: allow `is_empty(&self)` with `len(&mut self)`

Diff best viewed with whitespace ignored