### PR TITLE
Fix `panicking_unwrap` FP on field access with implicit deref

### DIFF
--- a/tests/ui/checked_unwrap/simple_conditionals.rs
+++ b/tests/ui/checked_unwrap/simple_conditionals.rs
@@ -472,3 +472,22 @@ fn issue15321() {
         //~^ unnecessary_unwrap
     }
 }
+
+mod issue16188 {
+    struct Foo {
+        value: Option<i32>,
+    }
+
+    impl Foo {
+        pub fn bar(&mut self) {
+            let print_value = |v: i32| {
+                println!("{}", v);
+            };
+
+            if self.value.is_none() {
+                self.value = Some(10);
+                print_value(self.value.unwrap());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16188 

----

changelog: [`panicking_unwrap`] fix FP on field access with implicit deref
