### PR TITLE
Fix `tuple_array_conversions` FP when binded vars are used before conversion

### DIFF
--- a/tests/ui/tuple_array_conversions.rs
+++ b/tests/ui/tuple_array_conversions.rs
@@ -116,3 +116,26 @@ fn msrv_juust_right() {
     let x = &[1, 2];
     let x = (x[0], x[1]);
 }
+
+fn issue16192() {
+    fn do_something(tuple: (u32, u32)) {}
+    fn produce_array() -> [u32; 2] {
+        [1, 2]
+    }
+
+    let [a, b] = produce_array();
+    for tuple in [(a, b), (b, a)] {
+        do_something(tuple);
+    }
+
+    let [a, b] = produce_array();
+    let x = b;
+    do_something((a, b));
+
+    let [a, b] = produce_array();
+    do_something((b, a));
+
+    let [a, b] = produce_array();
+    do_something((a, b));
+    //~^ tuple_array_conversions
+}

--- a/tests/ui/tuple_array_conversions.stderr
+++ b/tests/ui/tuple_array_conversions.stderr
@@ -80,5 +80,13 @@ LL |     let x = [x.0, x.1];
    |
    = help: use `.into()` instead, or `<[T; N]>::from` if type annotations are needed
 
-error: aborting due to 10 previous errors
+error: it looks like you're trying to convert an array to a tuple
+  --> tests/ui/tuple_array_conversions.rs:139:18
+   |
+LL |     do_something((a, b));
+   |                  ^^^^^^
+   |
+   = help: use `.into()` instead, or `<(T0, T1, ..., Tn)>::from` if type annotations are needed
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16192 

changelog: [`tuple_array_conversions`] fix FP when binded vars are used before conversion
