### PR TITLE
Fix `map_entry` FP when it would cause `MutexGuard` to be held across an

### DIFF
--- a/tests/ui/entry.fixed
+++ b/tests/ui/entry.fixed
@@ -248,4 +248,28 @@ mod issue14449 {
     }
 }
 
+// Don't suggest when it would cause `MutexGuard` to be held across an await point.
+mod issue_16173 {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    async fn f() {}
+
+    async fn foo() {
+        let mu_map = Mutex::new(HashMap::new());
+        if !mu_map.lock().unwrap().contains_key(&0) {
+            f().await;
+            mu_map.lock().unwrap().insert(0, 0);
+        }
+
+        if mu_map.lock().unwrap().contains_key(&1) {
+            todo!();
+        } else {
+            mu_map.lock().unwrap().insert(1, 42);
+            todo!();
+            f().await;
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/entry.rs
+++ b/tests/ui/entry.rs
@@ -254,4 +254,28 @@ mod issue14449 {
     }
 }
 
+// Don't suggest when it would cause `MutexGuard` to be held across an await point.
+mod issue_16173 {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    async fn f() {}
+
+    async fn foo() {
+        let mu_map = Mutex::new(HashMap::new());
+        if !mu_map.lock().unwrap().contains_key(&0) {
+            f().await;
+            mu_map.lock().unwrap().insert(0, 0);
+        }
+
+        if mu_map.lock().unwrap().contains_key(&1) {
+            todo!();
+        } else {
+            mu_map.lock().unwrap().insert(1, 42);
+            todo!();
+            f().await;
+        }
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
await point.

Closes: rust-lang/rust-clippy#16173

----

changelog: [`map_entry`] fix FP when it would cause `MutexGuard` to be held across an await point.


