### PR TITLE
Mention an extra argument needed to check tests

### DIFF
--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -468,6 +468,10 @@ declare_clippy_lint! {
     /// #[ignore = "Some good reason"]
     /// fn test() {}
     /// ```
+    ///
+    /// ### Note
+    /// Clippy can only lint compiled code. For this lint to trigger, you must configure `cargo clippy`
+    /// to include test compilation, for instance, by using flags such as `--tests` or `--all-targets`.
     #[clippy::version = "1.88.0"]
     pub IGNORE_WITHOUT_REASON,
     pedantic,

--- a/clippy_lints/src/redundant_test_prefix.rs
+++ b/clippy_lints/src/redundant_test_prefix.rs
@@ -47,6 +47,10 @@ declare_clippy_lint! {
     ///   }
     /// }
     /// ```
+    ///
+    /// ### Note
+    /// Clippy can only lint compiled code. For this lint to trigger, you must configure `cargo clippy`
+    /// to include test compilation, for instance, by using flags such as `--tests` or `--all-targets`.
     #[clippy::version = "1.88.0"]
     pub REDUNDANT_TEST_PREFIX,
     restriction,


### PR DESCRIPTION
Add a note for tests-related lints that clippy needs to be run with `--tests` argument to actually check tests.

changelog: [`ignore_without_reason`, `redundant_test_prefix`]: Mention an extra `clippy` argument needed to check tests

Fixes rust-lang/rust-clippy#16111