### PR TITLE
Fix typo in deprecated lint `string_to_string` message

### DIFF
--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -34,7 +34,7 @@ declare_with_version! { DEPRECATED(DEPRECATED_VERSION) = [
     #[clippy::version = "pre 1.29.0"]
     ("clippy::should_assert_eq", "`assert!(a == b)` can now print the values the same way `assert_eq!(a, b) can"),
     #[clippy::version = "1.91.0"]
-    ("clippy::string_to_string", "`clippy:implicit_clone` covers those cases"),
+    ("clippy::string_to_string", "`clippy::implicit_clone` covers those cases"),
     #[clippy::version = "pre 1.29.0"]
     ("clippy::unsafe_vector_initialization", "the suggested alternative could be substantially slower"),
     #[clippy::version = "pre 1.29.0"]

--- a/tests/ui/deprecated.stderr
+++ b/tests/ui/deprecated.stderr
@@ -61,7 +61,7 @@ error: lint `clippy::should_assert_eq` has been removed: `assert!(a == b)` can n
 LL | #![warn(clippy::should_assert_eq)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: lint `clippy::string_to_string` has been removed: `clippy:implicit_clone` covers those cases
+error: lint `clippy::string_to_string` has been removed: `clippy::implicit_clone` covers those cases
   --> tests/ui/deprecated.rs:15:9
    |
 LL | #![warn(clippy::string_to_string)]


### PR DESCRIPTION
Closes: rust-lang/rust-clippy#16204

----

changelog: Fix typo in deprecated lint `string_to_string` message
