### PR TITLE
Move `collapsible_else_if` to `pedantic`

### DIFF
--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -76,7 +76,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.51.0"]
     pub COLLAPSIBLE_ELSE_IF,
-    style,
+    pedantic,
     "nested `else`-`if` expressions that can be collapsed (e.g., `else { if x { ... } }`)"
 }
 

--- a/tests/ui-toml/collapsible_if/collapsible_else_if.fixed
+++ b/tests/ui-toml/collapsible_if/collapsible_else_if.fixed
@@ -1,5 +1,5 @@
 #![allow(clippy::eq_op, clippy::nonminimal_bool)]
-#![warn(clippy::collapsible_if)]
+#![warn(clippy::collapsible_else_if)]
 
 #[rustfmt::skip]
 fn main() {

--- a/tests/ui-toml/collapsible_if/collapsible_else_if.rs
+++ b/tests/ui-toml/collapsible_if/collapsible_else_if.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::eq_op, clippy::nonminimal_bool)]
-#![warn(clippy::collapsible_if)]
+#![warn(clippy::collapsible_else_if)]
 
 #[rustfmt::skip]
 fn main() {

--- a/tests/ui/collapsible_else_if.fixed
+++ b/tests/ui/collapsible_else_if.fixed
@@ -1,5 +1,5 @@
 #![allow(clippy::assertions_on_constants, clippy::equatable_if_let, clippy::needless_ifs)]
-#![warn(clippy::collapsible_if, clippy::collapsible_else_if)]
+#![warn(clippy::collapsible_else_if)]
 
 #[rustfmt::skip]
 fn main() {
@@ -88,28 +88,10 @@ fn issue_7318() {
 }
 
 fn issue_13365() {
-    // all the `expect`s that we should fulfill
+    // ensure we fulfill `#[expect]`
     if true {
     } else {
         #[expect(clippy::collapsible_else_if)]
-        if false {}
-    }
-
-    if true {
-    } else {
-        #[expect(clippy::style)]
-        if false {}
-    }
-
-    if true {
-    } else {
-        #[expect(clippy::all)]
-        if false {}
-    }
-
-    if true {
-    } else {
-        #[expect(warnings)]
         if false {}
     }
 }

--- a/tests/ui/collapsible_else_if.rs
+++ b/tests/ui/collapsible_else_if.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::assertions_on_constants, clippy::equatable_if_let, clippy::needless_ifs)]
-#![warn(clippy::collapsible_if, clippy::collapsible_else_if)]
+#![warn(clippy::collapsible_else_if)]
 
 #[rustfmt::skip]
 fn main() {
@@ -104,28 +104,10 @@ fn issue_7318() {
 }
 
 fn issue_13365() {
-    // all the `expect`s that we should fulfill
+    // ensure we fulfill `#[expect]`
     if true {
     } else {
         #[expect(clippy::collapsible_else_if)]
-        if false {}
-    }
-
-    if true {
-    } else {
-        #[expect(clippy::style)]
-        if false {}
-    }
-
-    if true {
-    } else {
-        #[expect(clippy::all)]
-        if false {}
-    }
-
-    if true {
-    } else {
-        #[expect(warnings)]
         if false {}
     }
 }

--- a/tests/ui/collapsible_else_if.stderr
+++ b/tests/ui/collapsible_else_if.stderr
@@ -151,7 +151,7 @@ LL | |     }
    | |_____^ help: collapse nested if block: `if false {}`
 
 error: this `else { if .. }` block can be collapsed
-  --> tests/ui/collapsible_else_if.rs:157:12
+  --> tests/ui/collapsible_else_if.rs:139:12
    |
 LL |       } else {
    |  ____________^


### PR DESCRIPTION
Looks like a good number of people disagree with this lint so it shouldn't be on by default

Fixes https://github.com/rust-lang/rust-clippy/issues/16209

changelog: [`collapsible_else_if`]: move to `pedantic`