### PR TITLE
Improve `useless_conversion` `.into_iter()` suggestion for nested references

### DIFF
--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -1,4 +1,5 @@
 #![deny(clippy::useless_conversion)]
+#![allow(clippy::into_iter_on_ref)]
 #![allow(clippy::needless_ifs, clippy::unnecessary_wraps, unused)]
 // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
 #![allow(static_mut_refs)]
@@ -130,6 +131,15 @@ fn main() {
     lint_into_iter_on_const_implementing_iterator_2();
     dont_lint_into_iter_on_copy_iter();
     dont_lint_into_iter_on_static_copy_iter();
+
+    {
+        // triggers the IntoIterator trait
+        fn consume(_: impl IntoIterator) {}
+
+        // Should suggest `*items` instead of `&**items`
+        let items = &&[1, 2, 3];
+        consume(*items); //~ useless_conversion
+    }
 
     let _: String = "foo".into();
     let _: String = From::from("foo");

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::useless_conversion)]
+#![allow(clippy::into_iter_on_ref)]
 #![allow(clippy::needless_ifs, clippy::unnecessary_wraps, unused)]
 // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
 #![allow(static_mut_refs)]
@@ -130,6 +131,15 @@ fn main() {
     lint_into_iter_on_const_implementing_iterator_2();
     dont_lint_into_iter_on_copy_iter();
     dont_lint_into_iter_on_static_copy_iter();
+
+    {
+        // triggers the IntoIterator trait
+        fn consume(_: impl IntoIterator) {}
+
+        // Should suggest `*items` instead of `&**items`
+        let items = &&[1, 2, 3];
+        consume(items.into_iter()); //~ useless_conversion
+    }
 
     let _: String = "foo".into();
     let _: String = From::from("foo");

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -1,5 +1,5 @@
 error: useless conversion to the same type: `T`
-  --> tests/ui/useless_conversion.rs:9:13
+  --> tests/ui/useless_conversion.rs:10:13
    |
 LL |     let _ = T::from(val);
    |             ^^^^^^^^^^^^ help: consider removing `T::from()`: `val`
@@ -11,115 +11,132 @@ LL | #![deny(clippy::useless_conversion)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: useless conversion to the same type: `T`
-  --> tests/ui/useless_conversion.rs:11:5
+  --> tests/ui/useless_conversion.rs:12:5
    |
 LL |     val.into()
    |     ^^^^^^^^^^ help: consider removing `.into()`: `val`
 
 error: useless conversion to the same type: `i32`
-  --> tests/ui/useless_conversion.rs:24:22
+  --> tests/ui/useless_conversion.rs:25:22
    |
 LL |         let _: i32 = 0i32.into();
    |                      ^^^^^^^^^^^ help: consider removing `.into()`: `0i32`
 
 error: useless conversion to the same type: `std::str::Lines<'_>`
-  --> tests/ui/useless_conversion.rs:55:22
+  --> tests/ui/useless_conversion.rs:56:22
    |
 LL |     if Some("ok") == lines.into_iter().next() {}
    |                      ^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `lines`
 
 error: useless conversion to the same type: `std::str::Lines<'_>`
-  --> tests/ui/useless_conversion.rs:61:21
+  --> tests/ui/useless_conversion.rs:62:21
    |
 LL |     let mut lines = text.lines().into_iter();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `text.lines()`
 
 error: useless conversion to the same type: `std::str::Lines<'_>`
-  --> tests/ui/useless_conversion.rs:68:22
+  --> tests/ui/useless_conversion.rs:69:22
    |
 LL |     if Some("ok") == text.lines().into_iter().next() {}
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `text.lines()`
 
 error: useless conversion to the same type: `std::ops::Range<i32>`
-  --> tests/ui/useless_conversion.rs:75:13
+  --> tests/ui/useless_conversion.rs:76:13
    |
 LL |     let _ = NUMBERS.into_iter().next();
    |             ^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `NUMBERS`
 
 error: useless conversion to the same type: `std::ops::Range<i32>`
-  --> tests/ui/useless_conversion.rs:81:17
+  --> tests/ui/useless_conversion.rs:82:17
    |
 LL |     let mut n = NUMBERS.into_iter();
    |                 ^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `NUMBERS`
 
+error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
+  --> tests/ui/useless_conversion.rs:141:17
+   |
+LL |         consume(items.into_iter());
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
+  --> tests/ui/useless_conversion.rs:137:28
+   |
+LL |         fn consume(_: impl IntoIterator) {}
+   |                            ^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -         consume(items.into_iter());
+LL +         consume(*items);
+   |
+
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:144:21
+  --> tests/ui/useless_conversion.rs:154:21
    |
 LL |     let _: String = "foo".to_string().into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `"foo".to_string()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:146:21
+  --> tests/ui/useless_conversion.rs:156:21
    |
 LL |     let _: String = From::from("foo".to_string());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `From::from()`: `"foo".to_string()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:148:13
+  --> tests/ui/useless_conversion.rs:158:13
    |
 LL |     let _ = String::from("foo".to_string());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `"foo".to_string()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:150:13
+  --> tests/ui/useless_conversion.rs:160:13
    |
 LL |     let _ = String::from(format!("A: {:04}", 123));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `format!("A: {:04}", 123)`
 
 error: useless conversion to the same type: `std::str::Lines<'_>`
-  --> tests/ui/useless_conversion.rs:152:13
+  --> tests/ui/useless_conversion.rs:162:13
    |
 LL |     let _ = "".lines().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `"".lines()`
 
 error: useless conversion to the same type: `std::vec::IntoIter<i32>`
-  --> tests/ui/useless_conversion.rs:154:13
+  --> tests/ui/useless_conversion.rs:164:13
    |
 LL |     let _ = vec![1, 2, 3].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2, 3].into_iter()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:156:21
+  --> tests/ui/useless_conversion.rs:166:21
    |
 LL |     let _: String = format!("Hello {}", "world").into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `format!("Hello {}", "world")`
 
 error: useless conversion to the same type: `i32`
-  --> tests/ui/useless_conversion.rs:162:13
+  --> tests/ui/useless_conversion.rs:172:13
    |
 LL |     let _ = i32::from(a + b) * 3;
    |             ^^^^^^^^^^^^^^^^ help: consider removing `i32::from()`: `(a + b)`
 
 error: useless conversion to the same type: `Foo<'a'>`
-  --> tests/ui/useless_conversion.rs:169:23
+  --> tests/ui/useless_conversion.rs:179:23
    |
 LL |     let _: Foo<'a'> = s2.into();
    |                       ^^^^^^^^^ help: consider removing `.into()`: `s2`
 
 error: useless conversion to the same type: `Foo<'a'>`
-  --> tests/ui/useless_conversion.rs:172:13
+  --> tests/ui/useless_conversion.rs:182:13
    |
 LL |     let _ = Foo::<'a'>::from(s3);
    |             ^^^^^^^^^^^^^^^^^^^^ help: consider removing `Foo::<'a'>::from()`: `s3`
 
 error: useless conversion to the same type: `std::vec::IntoIter<Foo<'a'>>`
-  --> tests/ui/useless_conversion.rs:175:13
+  --> tests/ui/useless_conversion.rs:185:13
    |
 LL |     let _ = vec![s4, s4, s4].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![s4, s4, s4].into_iter()`
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:208:7
+  --> tests/ui/useless_conversion.rs:218:7
    |
 LL |     b(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -127,13 +144,13 @@ LL |     b(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:198:13
+  --> tests/ui/useless_conversion.rs:208:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:210:7
+  --> tests/ui/useless_conversion.rs:220:7
    |
 LL |     c(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -141,13 +158,13 @@ LL |     c(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:199:18
+  --> tests/ui/useless_conversion.rs:209:18
    |
 LL |     fn c(_: impl IntoIterator<Item = i32>) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:212:7
+  --> tests/ui/useless_conversion.rs:222:7
    |
 LL |     d(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -155,13 +172,13 @@ LL |     d(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:202:12
+  --> tests/ui/useless_conversion.rs:212:12
    |
 LL |         T: IntoIterator<Item = i32>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:216:7
+  --> tests/ui/useless_conversion.rs:226:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter());
    |       ^^^^^^^^^^------------------------
@@ -169,13 +186,13 @@ LL |     b(vec![1, 2].into_iter().into_iter());
    |                 help: consider removing the `.into_iter()`s
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:198:13
+  --> tests/ui/useless_conversion.rs:208:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:218:7
+  --> tests/ui/useless_conversion.rs:228:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter().into_iter());
    |       ^^^^^^^^^^------------------------------------
@@ -183,13 +200,13 @@ LL |     b(vec![1, 2].into_iter().into_iter().into_iter());
    |                 help: consider removing the `.into_iter()`s
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:198:13
+  --> tests/ui/useless_conversion.rs:208:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:265:24
+  --> tests/ui/useless_conversion.rs:275:24
    |
 LL |         foo2::<i32, _>([1, 2, 3].into_iter());
    |                        ^^^^^^^^^------------
@@ -197,13 +214,13 @@ LL |         foo2::<i32, _>([1, 2, 3].into_iter());
    |                                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:244:12
+  --> tests/ui/useless_conversion.rs:254:12
    |
 LL |         I: IntoIterator<Item = i32> + Helper<X>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:274:14
+  --> tests/ui/useless_conversion.rs:284:14
    |
 LL |         foo3([1, 2, 3].into_iter());
    |              ^^^^^^^^^------------
@@ -211,13 +228,13 @@ LL |         foo3([1, 2, 3].into_iter());
    |                       help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:253:12
+  --> tests/ui/useless_conversion.rs:263:12
    |
 LL |         I: IntoIterator<Item = i32>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:284:16
+  --> tests/ui/useless_conversion.rs:294:16
    |
 LL |         S1.foo([1, 2].into_iter());
    |                ^^^^^^------------
@@ -225,13 +242,13 @@ LL |         S1.foo([1, 2].into_iter());
    |                      help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:281:27
+  --> tests/ui/useless_conversion.rs:291:27
    |
 LL |             pub fn foo<I: IntoIterator>(&self, _: I) {}
    |                           ^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:304:44
+  --> tests/ui/useless_conversion.rs:314:44
    |
 LL |         v0.into_iter().interleave_shortest(v1.into_iter());
    |                                            ^^------------
@@ -239,67 +256,67 @@ LL |         v0.into_iter().interleave_shortest(v1.into_iter());
    |                                              help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:291:20
+  --> tests/ui/useless_conversion.rs:301:20
    |
 LL |                 J: IntoIterator,
    |                    ^^^^^^^^^^^^
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:332:58
+  --> tests/ui/useless_conversion.rs:342:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map(Into::into);
    |                                                          ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `std::io::Error`
-  --> tests/ui/useless_conversion.rs:335:58
+  --> tests/ui/useless_conversion.rs:345:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map_err(Into::into);
    |                                                          ^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:338:58
+  --> tests/ui/useless_conversion.rs:348:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map(From::from);
    |                                                          ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `std::io::Error`
-  --> tests/ui/useless_conversion.rs:341:58
+  --> tests/ui/useless_conversion.rs:351:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map_err(From::from);
    |                                                          ^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:345:31
+  --> tests/ui/useless_conversion.rs:355:31
    |
 LL |     let _: ControlFlow<()> = c.map_break(Into::into);
    |                               ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:349:31
+  --> tests/ui/useless_conversion.rs:359:31
    |
 LL |     let _: ControlFlow<()> = c.map_continue(Into::into);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `u32`
-  --> tests/ui/useless_conversion.rs:363:41
+  --> tests/ui/useless_conversion.rs:373:41
    |
 LL |     let _: Vec<u32> = [1u32].into_iter().map(Into::into).collect();
    |                                         ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `T`
-  --> tests/ui/useless_conversion.rs:374:18
+  --> tests/ui/useless_conversion.rs:384:18
    |
 LL |     x.into_iter().map(Into::into).collect()
    |                  ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:390:29
+  --> tests/ui/useless_conversion.rs:400:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:389:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -310,13 +327,13 @@ LL +             takes_into_iter(&self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:398:29
+  --> tests/ui/useless_conversion.rs:408:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:389:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -327,13 +344,13 @@ LL +             takes_into_iter(&mut self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:407:29
+  --> tests/ui/useless_conversion.rs:417:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:389:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -344,13 +361,13 @@ LL +             takes_into_iter(*self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:416:29
+  --> tests/ui/useless_conversion.rs:426:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:389:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -361,13 +378,13 @@ LL +             takes_into_iter(&*self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:425:29
+  --> tests/ui/useless_conversion.rs:435:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:379:32
+  --> tests/ui/useless_conversion.rs:389:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -378,22 +395,22 @@ LL +             takes_into_iter(&mut *self.my_field);
    |
 
 error: useless conversion to the same type: `std::ops::Range<u32>`
-  --> tests/ui/useless_conversion.rs:440:5
+  --> tests/ui/useless_conversion.rs:450:5
    |
 LL |     R.into_iter().for_each(|_x| {});
    |     ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
 error: useless conversion to the same type: `std::ops::Range<u32>`
-  --> tests/ui/useless_conversion.rs:442:13
+  --> tests/ui/useless_conversion.rs:452:13
    |
 LL |     let _ = R.into_iter().map(|_x| 0);
    |             ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
 error: useless conversion to the same type: `std::slice::Iter<'_, i32>`
-  --> tests/ui/useless_conversion.rs:453:14
+  --> tests/ui/useless_conversion.rs:463:14
    |
 LL |     for _ in mac!(iter [1, 2]).into_iter() {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `mac!(iter [1, 2])`
 
-error: aborting due to 44 previous errors
+error: aborting due to 45 previous errors
 


### PR DESCRIPTION
### Description
I updated the `useless_conversion` lint to stop applying adjustment prefixes once it reaches the final target type.

Previously, the lint would continue applying adjustments even after the type requirements were met, which often resulted in over-borrowed suggestions like `&**y`. By breaking the loop early once the target type is reached, we now emit the minimal, idiomatic suggestion (e.g., `*y`).

fixes rust-lang/rust-clippy#14847

### Test Plan
I added a targeted UI regression test: `tests/ui/useless_conversion.rs`.
This covers `.into_iter()` usage on nested slice references (`&&[T]`) and verifies that Clippy now suggests `*items` instead of the previous incorrect suggestion.

### Checklist

- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

---

changelog: [`useless_conversion`]: refine `.into_iter()` suggestions to stop at the final target type (fixing over-borrowed suggestions like `&**y`)