### PR TITLE
`missing_asserts_for_indexing`: support comparing to `const` values

### DIFF
--- a/tests/ui/missing_asserts_for_indexing.fixed
+++ b/tests/ui/missing_asserts_for_indexing.fixed
@@ -180,4 +180,24 @@ mod issue15988 {
     }
 }
 
+fn assert_cmp_to_const(v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8]) {
+    const N: usize = 2;
+
+    assert!(v1.len() >= N);
+    assert!(v2.len() > N);
+    assert!(v3.len() >= 4);
+    assert!(v4.len() > 3);
+
+    let _ = v1[0] + v1[1];
+
+    let _ = v2[0] + v2[1] + v2[2];
+    //~^ missing_asserts_for_indexing
+
+    let _ = v3[0] + v3[1] + v3[2] + v3[3];
+    //~^ missing_asserts_for_indexing
+
+    let _ = v4[0] + v4[1] + v4[2] + v4[3];
+    //~^ missing_asserts_for_indexing
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing.rs
+++ b/tests/ui/missing_asserts_for_indexing.rs
@@ -180,4 +180,24 @@ mod issue15988 {
     }
 }
 
+fn assert_cmp_to_const(v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8]) {
+    const N: usize = 2;
+
+    assert!(v1.len() >= N);
+    assert!(v2.len() >= N);
+    assert!(v3.len() >= N);
+    assert!(v4.len() > N);
+
+    let _ = v1[0] + v1[1];
+
+    let _ = v2[0] + v2[1] + v2[2];
+    //~^ missing_asserts_for_indexing
+
+    let _ = v3[0] + v3[1] + v3[2] + v3[3];
+    //~^ missing_asserts_for_indexing
+
+    let _ = v4[0] + v4[1] + v4[2] + v4[3];
+    //~^ missing_asserts_for_indexing
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing.stderr
+++ b/tests/ui/missing_asserts_for_indexing.stderr
@@ -187,5 +187,41 @@ LL -         debug_assert_eq!(v.len(), 2);
 LL +         debug_assert_eq!(v.len(), 3);
    |
 
-error: aborting due to 15 previous errors
+error: indexing into a slice multiple times with an `assert` that does not cover the highest index
+  --> tests/ui/missing_asserts_for_indexing.rs:193:13
+   |
+LL |     let _ = v2[0] + v2[1] + v2[2];
+   |             ^^^^^   ^^^^^   ^^^^^
+   |
+help: provide the highest index that is indexed with
+   |
+LL -     assert!(v2.len() >= N);
+LL +     assert!(v2.len() > N);
+   |
+
+error: indexing into a slice multiple times with an `assert` that does not cover the highest index
+  --> tests/ui/missing_asserts_for_indexing.rs:196:13
+   |
+LL |     let _ = v3[0] + v3[1] + v3[2] + v3[3];
+   |             ^^^^^   ^^^^^   ^^^^^   ^^^^^
+   |
+help: provide the highest index that is indexed with
+   |
+LL -     assert!(v3.len() >= N);
+LL +     assert!(v3.len() >= 4);
+   |
+
+error: indexing into a slice multiple times with an `assert` that does not cover the highest index
+  --> tests/ui/missing_asserts_for_indexing.rs:199:13
+   |
+LL |     let _ = v4[0] + v4[1] + v4[2] + v4[3];
+   |             ^^^^^   ^^^^^   ^^^^^   ^^^^^
+   |
+help: provide the highest index that is indexed with
+   |
+LL -     assert!(v4.len() > N);
+LL +     assert!(v4.len() > 3);
+   |
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16237

I think current behavior is unsatisfying because comparing `v.len()` with `const` values in `assert!()` is pretty common ([**31.2k results on GitHub**](https://github.com/search?q=language%3Arust+%2F%28%3F-i%29assert%28_eq%29%3F%21%5C%28%5Cw%2B%5C.len%5C%28%5C%29%5Cs*%28%2C%7C%5B%3C%3E%5D%3D%3F%29%5Cs*%5BA-Z_%5D%2B%2F&type=code)).
This PR would make enabling this lint less painful in my opinion.

# Example
```rs
#![warn(clippy::missing_asserts_for_indexing)]

const MIN_LEN: usize = 2;
fn assert_cmp_to_const(v: &[u8]) {
    assert!(v.len() >= MIN_LEN);

    let _ = v[0] + v[1]; // was warning, now ok
    let _ = v[0] + v[1] + v[2]; // correctly warned
}
```

---

changelog: [`missing_asserts_for_indexing`]: support comparing to `const` values
