### PR TITLE
Add unused_async_trait_impl lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7375,6 +7375,7 @@ Released 2018-09-13
 [`unstable_as_mut_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#unstable_as_mut_slice
 [`unstable_as_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#unstable_as_slice
 [`unused_async`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_async
+[`unused_async_trait_impl`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_async_trait_impl
 [`unused_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_collect
 [`unused_enumerate_index`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_enumerate_index
 [`unused_format_specs`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_format_specs

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -783,6 +783,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::unnested_or_patterns::UNNESTED_OR_PATTERNS_INFO,
     crate::unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME_INFO,
     crate::unused_async::UNUSED_ASYNC_INFO,
+    crate::unused_async::UNUSED_ASYNC_TRAIT_IMPL_INFO,
     crate::unused_io_amount::UNUSED_IO_AMOUNT_INFO,
     crate::unused_peekable::UNUSED_PEEKABLE_INFO,
     crate::unused_result_ok::UNUSED_RESULT_OK_INFO,

--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -1,11 +1,13 @@
-use clippy_utils::diagnostics::span_lint_hir_and_then;
+use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::is_def_id_trait_method;
+use clippy_utils::source::{HasSession, snippet_with_applicability, walk_span_to_context};
 use clippy_utils::usage::is_todo_unimplemented_stub;
+use rustc_errors::Applicability;
 use rustc_hir::def::DefKind;
 use rustc_hir::intravisit::{FnKind, Visitor, walk_expr, walk_fn};
 use rustc_hir::{
-    Body, Closure, ClosureKind, CoroutineDesugaring, CoroutineKind, Defaultness, Expr, ExprKind, FnDecl, HirId, Node,
-    TraitItem, YieldSource,
+    Body, Closure, ClosureKind, CoroutineDesugaring, CoroutineKind, Defaultness, Expr, ExprKind, FnDecl, HirId,
+    ImplItem, ImplItemKind, IsAsync, Node, TraitItem, YieldSource,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::hir::nested_filter;
@@ -43,7 +45,52 @@ declare_clippy_lint! {
     "finds async functions with no await statements"
 }
 
-impl_lint_pass!(UnusedAsync => [UNUSED_ASYNC]);
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for trait method implementations that are declared `async` but have no `.await`s inside of them.
+    ///
+    /// ### Why is this bad?
+    /// Async functions with no async code create computational overhead.
+    /// Even though the trait requires the method to return a future,
+    /// returning a `core::future::ready` with the result is more efficient
+    /// as it reduces the number of states in the Future state machine by at least one.
+    ///
+    /// Note that the behaviour is slightly different when using `core::future::ready`,
+    /// as the value is computed immediately and stored in a future for later retrieval at the first (and only valid) call to `poll`.
+    /// An `async` block generates code that completely defers the computation of this value until the Future is polled.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// trait AsyncTrait {
+    ///     async fn get_random_number() -> i64;
+    /// }
+    ///
+    /// impl AsyncTrait for () {
+    ///     async fn get_random_number() -> i64 {
+    ///         4 // Chosen by fair dice roll. Guaranteed to be random.
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// trait AsyncTrait {
+    ///     async fn get_random_number() -> i64;
+    /// }
+    ///
+    /// impl AsyncTrait for () {
+    ///     fn get_random_number() -> impl Future<Output = i64> {
+    ///         core::future::ready(4) // Chosen by fair dice roll. Guaranteed to be random.
+    ///     }
+    /// }
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub UNUSED_ASYNC_TRAIT_IMPL,
+    pedantic,
+    "finds async trait impl functions with no await statements"
+}
+
+impl_lint_pass!(UnusedAsync => [UNUSED_ASYNC, UNUSED_ASYNC_TRAIT_IMPL]);
 
 #[derive(Default)]
 pub struct UnusedAsync {
@@ -194,6 +241,72 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
             );
         }
     }
+
+    fn check_impl_item(&mut self, cx: &LateContext<'tcx>, impl_item: &'tcx ImplItem<'_>) {
+        if let ImplItemKind::Fn(ref sig, body_id) = impl_item.kind
+            && let IsAsync::Async(async_span) = sig.header.asyncness
+            && let body = cx.tcx.hir_body(body_id)
+            && !async_fn_contains_todo_unimplemented_macro(cx, body)
+        {
+            let mut visitor = AsyncFnVisitor {
+                cx,
+                found_await: false,
+                await_in_async_block: None,
+                async_depth: 0,
+            };
+            visitor.visit_nested_body(body_id);
+
+            if !visitor.found_await
+                && let Some(builtin_crate) = clippy_utils::std_or_core(cx)
+                && let Some(inner) = unpack_async_fn_body(cx, body)
+                // Find the tail expression contained in the async fn (if any),
+                // which will be wrapped in std::future::ready.
+                && let ExprKind::Block(block, _) = inner.kind
+                && let Some(tail_expr) = block.expr
+            {
+                span_lint_and_then(
+                    cx,
+                    UNUSED_ASYNC_TRAIT_IMPL,
+                    impl_item.span,
+                    "unused `async` for async trait impl function with no `.await` statements",
+                    |diag| {
+                        diag.note(format!(
+                            "`{builtin_crate}::future::ready` creates a `Future` which returns the value immediately when `poll`ed"
+                        ));
+
+                        let ctxt = impl_item.span.ctxt();
+                        if let Some(signature_span) = walk_span_to_context(sig.decl.output.span(), ctxt)
+                            && let Some(tail_span) = walk_span_to_context(tail_expr.span, ctxt)
+                        {
+                            // The suggestion might be incorrect. The future changes from awaiting for the first poll to
+                            // evaluate the expression, to immediately evaluate the expression.
+                            let mut app = Applicability::MaybeIncorrect;
+
+                            let async_span = cx.sess().source_map().span_extend_while_whitespace(async_span);
+
+                            let signature_snippet = snippet_with_applicability(cx, signature_span, "_", &mut app);
+                            let tail_snippet = snippet_with_applicability(cx, tail_span, "_", &mut app).to_string();
+
+                            let sugg = vec![
+                                (async_span, String::new()),
+                                (signature_span, format!("impl Future<Output = {signature_snippet}>")),
+                                (tail_span, format!("{builtin_crate}::future::ready({tail_snippet})")),
+                            ];
+
+                            diag.multipart_suggestion(
+                                format!(
+                                    "consider removing the `async` from this function \
+                                    and returning `impl Future<Output = {signature_snippet}>` instead"
+                                ),
+                                sugg,
+                                app,
+                            );
+                        }
+                    },
+                );
+            }
+        }
+    }
 }
 
 fn is_default_trait_impl(cx: &LateContext<'_>, def_id: LocalDefId) -> bool {
@@ -206,7 +319,34 @@ fn is_default_trait_impl(cx: &LateContext<'_>, def_id: LocalDefId) -> bool {
     )
 }
 
-fn async_fn_contains_todo_unimplemented_macro(cx: &LateContext<'_>, body: &Body<'_>) -> bool {
+/// Get the inner expression of the body of an async function.
+///
+/// If it is not an async function, returns `None`.
+///
+/// An async function like
+/// ```rs
+/// async fn get_random_number() -> i64 {
+///    do_something();
+///    4
+/// }
+/// ```
+/// (roughly) desugars to
+/// ```rs
+/// fn get_random_number() -> impl Future<Output = i64> {
+///     async move {
+///         do_something();
+///         4
+///     }
+/// }
+/// ```
+///
+/// We first get to the `async move {}` block,
+/// which is the one and only expression in the body of the function.
+/// This block is a coroutine wrapped in a closure.
+/// The expression in this block is contained in a terminating scope.
+///
+/// This function returns that expression in `Some(...)` if this body indeed is an async function.
+fn unpack_async_fn_body<'hir>(cx: &LateContext<'hir>, body: &Body<'hir>) -> Option<&'hir Expr<'hir>> {
     if let ExprKind::Closure(closure) = body.value.kind
         && let ClosureKind::Coroutine(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) = closure.kind
         && let body = cx.tcx.hir_body(closure.body)
@@ -214,8 +354,12 @@ fn async_fn_contains_todo_unimplemented_macro(cx: &LateContext<'_>, body: &Body<
         && let Some(expr) = block.expr
         && let ExprKind::DropTemps(inner) = expr.kind
     {
-        return is_todo_unimplemented_stub(cx, inner);
+        Some(inner)
+    } else {
+        None
     }
+}
 
-    false
+fn async_fn_contains_todo_unimplemented_macro<'hir>(cx: &LateContext<'hir>, body: &Body<'hir>) -> bool {
+    unpack_async_fn_body(cx, body).is_some_and(|inner| is_todo_unimplemented_stub(cx, inner))
 }

--- a/tests/ui/unused_async_trait_impl.fixed
+++ b/tests/ui/unused_async_trait_impl.fixed
@@ -1,0 +1,109 @@
+#![warn(clippy::unused_async_trait_impl)]
+
+trait HasAsyncMethod {
+    async fn do_something() -> u32;
+}
+
+struct Stub;
+
+mod typical {
+    struct Inefficient;
+    struct Efficient;
+
+    use crate::Stub;
+
+    impl crate::HasAsyncMethod for Inefficient {
+        fn do_something() -> impl Future<Output = u32> {
+            //~^ unused_async_trait_impl
+            std::future::ready(1)
+        }
+    }
+
+    impl crate::HasAsyncMethod for Efficient {
+        fn do_something() -> impl Future<Output = u32> {
+            std::future::ready(1)
+        }
+    }
+
+    impl crate::HasAsyncMethod for crate::Stub {
+        async fn do_something() -> u32 {
+            todo!() // Do not emit the lint in this case.
+        }
+    }
+}
+
+// Test to check if the identation of the various snippets goes as intended.
+mod indented {
+    struct Indented;
+
+    impl crate::HasAsyncMethod for Indented {
+        fn do_something() -> impl Future<Output = u32> {
+            //~^ unused_async_trait_impl
+            let mut x = 0;
+            for y in 0..64 {
+                x = (x + 1) * y;
+            }
+
+            let fake_fut = async {
+                if x == 0 {
+                    panic!("Fake example");
+                }
+            };
+
+            std::future::ready(x)
+        }
+    }
+
+    struct Complex<T>(std::marker::PhantomData<T>);
+
+    impl<T> crate::HasAsyncMethod for Complex<T>
+    where
+        T: Sized,
+    {
+        fn do_something() -> impl Future<Output = u32> {
+            //~^ unused_async_trait_impl
+            std::future::ready(5)
+        }
+    }
+}
+
+mod default_unchanged {
+    trait HasDefaultAsyncMethod {
+        // The lint should not suggest a change for trait fn's as changing that decl
+        // implies a less restrictive Future type.
+        async fn do_something() -> u32 {
+            0
+        }
+    }
+
+    impl HasDefaultAsyncMethod for crate::Stub {
+        // Nothing!
+    }
+}
+
+mod macros {
+    trait HasAsyncMethodVec {
+        async fn do_something() -> Vec<u32>;
+    }
+
+    struct MacroInType;
+    struct MacroInExpr;
+
+    macro_rules! vec_ty {
+        ($t:ty) => { Vec<$t> }
+    }
+
+    impl HasAsyncMethodVec for MacroInType {
+        fn do_something() -> impl Future<Output = vec_ty!(u32)> {
+            //~^ unused_async_trait_impl
+            std::future::ready(Vec::new())
+        }
+    }
+
+    impl HasAsyncMethodVec for MacroInExpr {
+        fn do_something() -> impl Future<Output = Vec<u32>> {
+            //~^ unused_async_trait_impl
+            std::future::ready(vec![])
+        }
+    }
+}

--- a/tests/ui/unused_async_trait_impl.rs
+++ b/tests/ui/unused_async_trait_impl.rs
@@ -1,0 +1,109 @@
+#![warn(clippy::unused_async_trait_impl)]
+
+trait HasAsyncMethod {
+    async fn do_something() -> u32;
+}
+
+struct Stub;
+
+mod typical {
+    struct Inefficient;
+    struct Efficient;
+
+    use crate::Stub;
+
+    impl crate::HasAsyncMethod for Inefficient {
+        async fn do_something() -> u32 {
+            //~^ unused_async_trait_impl
+            1
+        }
+    }
+
+    impl crate::HasAsyncMethod for Efficient {
+        fn do_something() -> impl Future<Output = u32> {
+            std::future::ready(1)
+        }
+    }
+
+    impl crate::HasAsyncMethod for crate::Stub {
+        async fn do_something() -> u32 {
+            todo!() // Do not emit the lint in this case.
+        }
+    }
+}
+
+// Test to check if the identation of the various snippets goes as intended.
+mod indented {
+    struct Indented;
+
+    impl crate::HasAsyncMethod for Indented {
+        async fn do_something() -> u32 {
+            //~^ unused_async_trait_impl
+            let mut x = 0;
+            for y in 0..64 {
+                x = (x + 1) * y;
+            }
+
+            let fake_fut = async {
+                if x == 0 {
+                    panic!("Fake example");
+                }
+            };
+
+            x
+        }
+    }
+
+    struct Complex<T>(std::marker::PhantomData<T>);
+
+    impl<T> crate::HasAsyncMethod for Complex<T>
+    where
+        T: Sized,
+    {
+        async fn do_something() -> u32 {
+            //~^ unused_async_trait_impl
+            5
+        }
+    }
+}
+
+mod default_unchanged {
+    trait HasDefaultAsyncMethod {
+        // The lint should not suggest a change for trait fn's as changing that decl
+        // implies a less restrictive Future type.
+        async fn do_something() -> u32 {
+            0
+        }
+    }
+
+    impl HasDefaultAsyncMethod for crate::Stub {
+        // Nothing!
+    }
+}
+
+mod macros {
+    trait HasAsyncMethodVec {
+        async fn do_something() -> Vec<u32>;
+    }
+
+    struct MacroInType;
+    struct MacroInExpr;
+
+    macro_rules! vec_ty {
+        ($t:ty) => { Vec<$t> }
+    }
+
+    impl HasAsyncMethodVec for MacroInType {
+        async fn do_something() -> vec_ty!(u32) {
+            //~^ unused_async_trait_impl
+            Vec::new()
+        }
+    }
+
+    impl HasAsyncMethodVec for MacroInExpr {
+        async fn do_something() -> Vec<u32> {
+            //~^ unused_async_trait_impl
+            vec![]
+        }
+    }
+}

--- a/tests/ui/unused_async_trait_impl.stderr
+++ b/tests/ui/unused_async_trait_impl.stderr
@@ -1,0 +1,94 @@
+error: unused `async` for async trait impl function with no `.await` statements
+  --> tests/ui/unused_async_trait_impl.rs:16:9
+   |
+LL | /         async fn do_something() -> u32 {
+LL | |
+LL | |             1
+LL | |         }
+   | |_________^
+   |
+   = note: `std::future::ready` creates a `Future` which returns the value immediately when `poll`ed
+   = note: `-D clippy::unused-async-trait-impl` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_async_trait_impl)]`
+help: consider removing the `async` from this function and returning `impl Future<Output = u32>` instead
+   |
+LL ~         fn do_something() -> impl Future<Output = u32> {
+LL |
+LL ~             std::future::ready(1)
+   |
+
+error: unused `async` for async trait impl function with no `.await` statements
+  --> tests/ui/unused_async_trait_impl.rs:40:9
+   |
+LL | /         async fn do_something() -> u32 {
+LL | |
+LL | |             let mut x = 0;
+LL | |             for y in 0..64 {
+...  |
+LL | |             x
+LL | |         }
+   | |_________^
+   |
+   = note: `std::future::ready` creates a `Future` which returns the value immediately when `poll`ed
+help: consider removing the `async` from this function and returning `impl Future<Output = u32>` instead
+   |
+LL ~         fn do_something() -> impl Future<Output = u32> {
+LL |
+...
+LL |
+LL ~             std::future::ready(x)
+   |
+
+error: unused `async` for async trait impl function with no `.await` statements
+  --> tests/ui/unused_async_trait_impl.rs:63:9
+   |
+LL | /         async fn do_something() -> u32 {
+LL | |
+LL | |             5
+LL | |         }
+   | |_________^
+   |
+   = note: `std::future::ready` creates a `Future` which returns the value immediately when `poll`ed
+help: consider removing the `async` from this function and returning `impl Future<Output = u32>` instead
+   |
+LL ~         fn do_something() -> impl Future<Output = u32> {
+LL |
+LL ~             std::future::ready(5)
+   |
+
+error: unused `async` for async trait impl function with no `.await` statements
+  --> tests/ui/unused_async_trait_impl.rs:97:9
+   |
+LL | /         async fn do_something() -> vec_ty!(u32) {
+LL | |
+LL | |             Vec::new()
+LL | |         }
+   | |_________^
+   |
+   = note: `std::future::ready` creates a `Future` which returns the value immediately when `poll`ed
+help: consider removing the `async` from this function and returning `impl Future<Output = vec_ty!(u32)>` instead
+   |
+LL ~         fn do_something() -> impl Future<Output = vec_ty!(u32)> {
+LL |
+LL ~             std::future::ready(Vec::new())
+   |
+
+error: unused `async` for async trait impl function with no `.await` statements
+  --> tests/ui/unused_async_trait_impl.rs:104:9
+   |
+LL | /         async fn do_something() -> Vec<u32> {
+LL | |
+LL | |             vec![]
+LL | |         }
+   | |_________^
+   |
+   = note: `std::future::ready` creates a `Future` which returns the value immediately when `poll`ed
+help: consider removing the `async` from this function and returning `impl Future<Output = Vec<u32>>` instead
+   |
+LL ~         fn do_something() -> impl Future<Output = Vec<u32>> {
+LL |
+LL ~             std::future::ready(vec![])
+   |
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/unused_async_trait_impl_no_std.fixed
+++ b/tests/ui/unused_async_trait_impl_no_std.fixed
@@ -1,0 +1,15 @@
+#![no_std]
+#![warn(clippy::unused_async_trait_impl)]
+
+trait HasAsyncMethod {
+    async fn do_something() -> u32;
+}
+
+struct Inefficient;
+
+impl HasAsyncMethod for Inefficient {
+    fn do_something() -> impl Future<Output = u32> {
+        //~^ unused_async_trait_impl
+        core::future::ready(1)
+    }
+}

--- a/tests/ui/unused_async_trait_impl_no_std.rs
+++ b/tests/ui/unused_async_trait_impl_no_std.rs
@@ -1,0 +1,15 @@
+#![no_std]
+#![warn(clippy::unused_async_trait_impl)]
+
+trait HasAsyncMethod {
+    async fn do_something() -> u32;
+}
+
+struct Inefficient;
+
+impl HasAsyncMethod for Inefficient {
+    async fn do_something() -> u32 {
+        //~^ unused_async_trait_impl
+        1
+    }
+}

--- a/tests/ui/unused_async_trait_impl_no_std.stderr
+++ b/tests/ui/unused_async_trait_impl_no_std.stderr
@@ -1,0 +1,21 @@
+error: unused `async` for async trait impl function with no `.await` statements
+  --> tests/ui/unused_async_trait_impl_no_std.rs:11:5
+   |
+LL | /     async fn do_something() -> u32 {
+LL | |
+LL | |         1
+LL | |     }
+   | |_____^
+   |
+   = note: `core::future::ready` creates a `Future` which returns the value immediately when `poll`ed
+   = note: `-D clippy::unused-async-trait-impl` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_async_trait_impl)]`
+help: consider removing the `async` from this function and returning `impl Future<Output = u32>` instead
+   |
+LL ~     fn do_something() -> impl Future<Output = u32> {
+LL |
+LL ~         core::future::ready(1)
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16244)*

changelog: [`unused_async_trait_impl`]: new lint

Adds Lint that checks for trait impl functions that are unnecessarily `async`. By rewriting them to return a `core::future::ready` an unnecessary coroutine is prevented.

In an embedded context having many trivial async blocks potentially hurts code size significantly. This lint enables projects to quickly find the cases that this applies to.