### PR TITLE
Parent of struct constructor is the struct itself

### DIFF
--- a/clippy_lints/src/casts/needless_type_cast.rs
+++ b/clippy_lints/src/casts/needless_type_cast.rs
@@ -182,12 +182,7 @@ fn is_generic_res(cx: &LateContext<'_>, res: Res) -> bool {
             .iter()
             .any(|p| p.kind.is_ty_or_const())
     };
-    match res {
-        Res::Def(DefKind::Fn | DefKind::AssocFn, def_id) => has_type_params(def_id),
-        // Ctor → Variant → ADT: constructor's parent is variant, variant's parent is the ADT
-        Res::Def(DefKind::Ctor(..), def_id) => has_type_params(cx.tcx.parent(cx.tcx.parent(def_id))),
-        _ => false,
-    }
+    cx.tcx.res_generics_def_id(res).is_some_and(has_type_params)
 }
 
 fn is_cast_in_generic_context<'a>(cx: &LateContext<'a>, cast_expr: &Expr<'a>) -> bool {

--- a/tests/ui/needless_type_cast_unfixable.rs
+++ b/tests/ui/needless_type_cast_unfixable.rs
@@ -1,0 +1,20 @@
+//@no-rustfix
+#![warn(clippy::needless_type_cast)]
+
+struct Foo(*mut core::ffi::c_void);
+
+enum Bar {
+    Variant(*mut core::ffi::c_void),
+}
+
+// Suggestions will not compile directly, as `123` is a literal which
+// is not compatible with the suggested `*mut core::ffi::c_void` type
+fn issue_16243() {
+    let underlying: isize = 123;
+    //~^ needless_type_cast
+    let handle: Foo = Foo(underlying as _);
+
+    let underlying: isize = 123;
+    //~^ needless_type_cast
+    let handle: Bar = Bar::Variant(underlying as _);
+}

--- a/tests/ui/needless_type_cast_unfixable.stderr
+++ b/tests/ui/needless_type_cast_unfixable.stderr
@@ -1,0 +1,17 @@
+error: this binding is defined as `isize` but is always cast to `*mut std::ffi::c_void`
+  --> tests/ui/needless_type_cast_unfixable.rs:13:21
+   |
+LL |     let underlying: isize = 123;
+   |                     ^^^^^ help: consider defining it as: `*mut std::ffi::c_void`
+   |
+   = note: `-D clippy::needless-type-cast` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::needless_type_cast)]`
+
+error: this binding is defined as `isize` but is always cast to `*mut std::ffi::c_void`
+  --> tests/ui/needless_type_cast_unfixable.rs:17:21
+   |
+LL |     let underlying: isize = 123;
+   |                     ^^^^^ help: consider defining it as: `*mut std::ffi::c_void`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
The `Fn`/`AssocFn` cases were not tested anywhere, and according to the comments inside `TyCtxt::res_generic_def_id()` could have made the `TyCtxt::generics_of()` call also trigger an ICE.

changelog: [`needless_type_cast`]: do not ICE on struct constructor

Fixes rust-lang/rust-clippy#16243 