### PR TITLE
Move `needless_type_cast` lint to nursery

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -836,7 +836,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.93.0"]
     pub NEEDLESS_TYPE_CAST,
-    pedantic,
+    nursery,
     "binding defined with one type but always cast to another"
 }
 


### PR DESCRIPTION
changelog: [`needless_type_cast`]: move into nursery until bugs are ironed out

[Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/Moving.20.60needless_type_cast.60.20to.20.60nursery.60)