### PR TITLE
Fix `needless_type_cast` suggesting invalid code for non-literal initializers

### DIFF
--- a/clippy_lints/src/casts/needless_type_cast.rs
+++ b/clippy_lints/src/casts/needless_type_cast.rs
@@ -1,6 +1,8 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::sugg::Sugg;
 use clippy_utils::visitors::{Descend, for_each_expr, for_each_expr_without_closures};
 use core::ops::ControlFlow;
+use rustc_ast::ast::{LitFloatType, LitIntType, LitKind};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
@@ -14,6 +16,7 @@ use super::NEEDLESS_TYPE_CAST;
 struct BindingInfo<'a> {
     source_ty: Ty<'a>,
     ty_span: Span,
+    init: Option<&'a Expr<'a>>,
 }
 
 struct UsageInfo<'a> {
@@ -73,6 +76,7 @@ fn collect_binding_from_let<'a>(
                 BindingInfo {
                     source_ty: ty,
                     ty_span: ty_hir.span,
+                    init: Some(let_expr.init),
                 },
             );
         }
@@ -103,6 +107,7 @@ fn collect_binding_from_local<'a>(
                 BindingInfo {
                     source_ty: ty,
                     ty_span: ty_hir.span,
+                    init: let_stmt.init,
                 },
             );
         }
@@ -229,6 +234,18 @@ fn is_cast_in_generic_context<'a>(cx: &LateContext<'a>, cast_expr: &Expr<'a>) ->
     }
 }
 
+fn can_coerce_to_target_type(expr: &Expr<'_>) -> bool {
+    match expr.kind {
+        ExprKind::Lit(lit) => matches!(
+            lit.node,
+            LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed)
+        ),
+        ExprKind::Unary(rustc_hir::UnOp::Neg, inner) => can_coerce_to_target_type(inner),
+        ExprKind::Binary(_, lhs, rhs) => can_coerce_to_target_type(lhs) && can_coerce_to_target_type(rhs),
+        _ => false,
+    }
+}
+
 fn check_binding_usages<'a>(cx: &LateContext<'a>, body: &Body<'a>, hir_id: HirId, binding_info: &BindingInfo<'a>) {
     let mut usages = Vec::new();
 
@@ -269,7 +286,19 @@ fn check_binding_usages<'a>(cx: &LateContext<'a>, body: &Body<'a>, hir_id: HirId
         return;
     };
 
-    span_lint_and_sugg(
+    // Don't lint if there's exactly one use and the initializer cannot be coerced to the
+    // target type (i.e., would require an explicit cast). In such cases, the fix would add
+    // a cast to the initializer rather than eliminating one - the cast isn't truly "needless."
+    // See: https://github.com/rust-lang/rust-clippy/issues/16240
+    if usages.len() == 1
+        && binding_info
+            .init
+            .is_some_and(|init| !can_coerce_to_target_type(init) && !init.span.from_expansion())
+    {
+        return;
+    }
+
+    span_lint_and_then(
         cx,
         NEEDLESS_TYPE_CAST,
         binding_info.ty_span,
@@ -277,8 +306,28 @@ fn check_binding_usages<'a>(cx: &LateContext<'a>, body: &Body<'a>, hir_id: HirId
             "this binding is defined as `{}` but is always cast to `{}`",
             binding_info.source_ty, first_target
         ),
-        "consider defining it as",
-        first_target.to_string(),
-        Applicability::MaybeIncorrect,
+        |diag| {
+            if let Some(init) = binding_info
+                .init
+                .filter(|i| !can_coerce_to_target_type(i) && !i.span.from_expansion())
+            {
+                let sugg = Sugg::hir(cx, init, "..").as_ty(first_target);
+                diag.multipart_suggestion(
+                    format!("consider defining it as `{first_target}` and casting the initializer"),
+                    vec![
+                        (binding_info.ty_span, first_target.to_string()),
+                        (init.span, sugg.to_string()),
+                    ],
+                    Applicability::MachineApplicable,
+                );
+            } else {
+                diag.span_suggestion(
+                    binding_info.ty_span,
+                    "consider defining it as",
+                    first_target.to_string(),
+                    Applicability::MachineApplicable,
+                );
+            }
+        },
     );
 }

--- a/tests/ui/needless_type_cast.fixed
+++ b/tests/ui/needless_type_cast.fixed
@@ -9,6 +9,10 @@ fn generic<T>(x: T) -> T {
     x
 }
 
+fn returns_u8() -> u8 {
+    10
+}
+
 fn main() {
     let a: i32 = 10;
     //~^ needless_type_cast
@@ -179,4 +183,87 @@ fn test_loop_with_generic() {
         break generic(1);
     };
     let _ = x as i32;
+}
+
+fn test_size_of_cast() {
+    use std::mem::size_of;
+    // Should lint: suggest casting the initializer
+    let size: u64 = size_of::<u32>() as u64;
+    //~^ needless_type_cast
+    let _ = size as u64;
+    let _ = size as u64;
+}
+
+fn test_suffixed_literal_cast() {
+    // Should lint: suggest casting the initializer
+    let a: i32 = 10u8 as i32;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_negative_literal() {
+    // Negative literal - should just change type, not add cast
+    let a: i32 = -10;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_suffixed_negative_literal() {
+    // Suffixed negative - needs cast
+    let a: i32 = -10i8 as i32;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_binary_op() {
+    // Binary op needs parens in cast
+    let a: i32 = 10 + 5;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_fn_return_as_init() {
+    let a: i32 = returns_u8() as i32;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_method_as_init() {
+    let a: i32 = 2u8.saturating_add(3) as i32;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_const_as_init() {
+    const X: u8 = 10;
+    let a: i32 = X as i32;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_single_use_fn_call() {
+    // Should not lint: only one use, and fixing would just move the cast
+    // to the initializer rather than eliminating it
+    let a: u8 = returns_u8();
+    let _ = a as i32;
+}
+
+fn test_single_use_suffixed_literal() {
+    // Should not lint: only one use with a suffixed literal
+    let a: u8 = 10u8;
+    let _ = a as i32;
+}
+
+fn test_single_use_binary_op() {
+    // Should lint: binary op of unsuffixed literals can be coerced
+    let a: i32 = 10 + 5;
+    //~^ needless_type_cast
+    let _ = a as i32;
 }

--- a/tests/ui/needless_type_cast.rs
+++ b/tests/ui/needless_type_cast.rs
@@ -9,6 +9,10 @@ fn generic<T>(x: T) -> T {
     x
 }
 
+fn returns_u8() -> u8 {
+    10
+}
+
 fn main() {
     let a: u8 = 10;
     //~^ needless_type_cast
@@ -179,4 +183,87 @@ fn test_loop_with_generic() {
         break generic(1);
     };
     let _ = x as i32;
+}
+
+fn test_size_of_cast() {
+    use std::mem::size_of;
+    // Should lint: suggest casting the initializer
+    let size: usize = size_of::<u32>();
+    //~^ needless_type_cast
+    let _ = size as u64;
+    let _ = size as u64;
+}
+
+fn test_suffixed_literal_cast() {
+    // Should lint: suggest casting the initializer
+    let a: u8 = 10u8;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_negative_literal() {
+    // Negative literal - should just change type, not add cast
+    let a: i8 = -10;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_suffixed_negative_literal() {
+    // Suffixed negative - needs cast
+    let a: i8 = -10i8;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_binary_op() {
+    // Binary op needs parens in cast
+    let a: u8 = 10 + 5;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_fn_return_as_init() {
+    let a: u8 = returns_u8();
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_method_as_init() {
+    let a: u8 = 2u8.saturating_add(3);
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_const_as_init() {
+    const X: u8 = 10;
+    let a: u8 = X;
+    //~^ needless_type_cast
+    let _ = a as i32;
+    let _ = a as i32;
+}
+
+fn test_single_use_fn_call() {
+    // Should not lint: only one use, and fixing would just move the cast
+    // to the initializer rather than eliminating it
+    let a: u8 = returns_u8();
+    let _ = a as i32;
+}
+
+fn test_single_use_suffixed_literal() {
+    // Should not lint: only one use with a suffixed literal
+    let a: u8 = 10u8;
+    let _ = a as i32;
+}
+
+fn test_single_use_binary_op() {
+    // Should lint: binary op of unsuffixed literals can be coerced
+    let a: u8 = 10 + 5;
+    //~^ needless_type_cast
+    let _ = a as i32;
 }

--- a/tests/ui/needless_type_cast.stderr
+++ b/tests/ui/needless_type_cast.stderr
@@ -1,5 +1,5 @@
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:13:12
+  --> tests/ui/needless_type_cast.rs:17:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
@@ -8,64 +8,154 @@ LL |     let a: u8 = 10;
    = help: to override `-D warnings` add `#[allow(clippy::needless_type_cast)]`
 
 error: this binding is defined as `u8` but is always cast to `usize`
-  --> tests/ui/needless_type_cast.rs:33:12
+  --> tests/ui/needless_type_cast.rs:37:12
    |
 LL |     let f: u8 = 1;
    |            ^^ help: consider defining it as: `usize`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:39:12
+  --> tests/ui/needless_type_cast.rs:43:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:52:12
+  --> tests/ui/needless_type_cast.rs:56:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:59:12
+  --> tests/ui/needless_type_cast.rs:63:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:66:12
+  --> tests/ui/needless_type_cast.rs:70:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:77:12
+  --> tests/ui/needless_type_cast.rs:81:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:99:16
+  --> tests/ui/needless_type_cast.rs:103:16
    |
 LL |         let a: u8 = 10;
    |                ^^ help: consider defining it as: `i32`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:107:12
+  --> tests/ui/needless_type_cast.rs:111:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:116:12
+  --> tests/ui/needless_type_cast.rs:120:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
 
 error: this binding is defined as `u8` but is always cast to `i32`
-  --> tests/ui/needless_type_cast.rs:122:12
+  --> tests/ui/needless_type_cast.rs:126:12
    |
 LL |     let a: u8 = 10;
    |            ^^ help: consider defining it as: `i32`
 
-error: aborting due to 11 previous errors
+error: this binding is defined as `usize` but is always cast to `u64`
+  --> tests/ui/needless_type_cast.rs:191:15
+   |
+LL |     let size: usize = size_of::<u32>();
+   |               ^^^^^
+   |
+help: consider defining it as `u64` and casting the initializer
+   |
+LL -     let size: usize = size_of::<u32>();
+LL +     let size: u64 = size_of::<u32>() as u64;
+   |
+
+error: this binding is defined as `u8` but is always cast to `i32`
+  --> tests/ui/needless_type_cast.rs:199:12
+   |
+LL |     let a: u8 = 10u8;
+   |            ^^
+   |
+help: consider defining it as `i32` and casting the initializer
+   |
+LL -     let a: u8 = 10u8;
+LL +     let a: i32 = 10u8 as i32;
+   |
+
+error: this binding is defined as `i8` but is always cast to `i32`
+  --> tests/ui/needless_type_cast.rs:207:12
+   |
+LL |     let a: i8 = -10;
+   |            ^^ help: consider defining it as: `i32`
+
+error: this binding is defined as `i8` but is always cast to `i32`
+  --> tests/ui/needless_type_cast.rs:215:12
+   |
+LL |     let a: i8 = -10i8;
+   |            ^^
+   |
+help: consider defining it as `i32` and casting the initializer
+   |
+LL -     let a: i8 = -10i8;
+LL +     let a: i32 = -10i8 as i32;
+   |
+
+error: this binding is defined as `u8` but is always cast to `i32`
+  --> tests/ui/needless_type_cast.rs:223:12
+   |
+LL |     let a: u8 = 10 + 5;
+   |            ^^ help: consider defining it as: `i32`
+
+error: this binding is defined as `u8` but is always cast to `i32`
+  --> tests/ui/needless_type_cast.rs:230:12
+   |
+LL |     let a: u8 = returns_u8();
+   |            ^^
+   |
+help: consider defining it as `i32` and casting the initializer
+   |
+LL -     let a: u8 = returns_u8();
+LL +     let a: i32 = returns_u8() as i32;
+   |
+
+error: this binding is defined as `u8` but is always cast to `i32`
+  --> tests/ui/needless_type_cast.rs:237:12
+   |
+LL |     let a: u8 = 2u8.saturating_add(3);
+   |            ^^
+   |
+help: consider defining it as `i32` and casting the initializer
+   |
+LL -     let a: u8 = 2u8.saturating_add(3);
+LL +     let a: i32 = 2u8.saturating_add(3) as i32;
+   |
+
+error: this binding is defined as `u8` but is always cast to `i32`
+  --> tests/ui/needless_type_cast.rs:245:12
+   |
+LL |     let a: u8 = X;
+   |            ^^
+   |
+help: consider defining it as `i32` and casting the initializer
+   |
+LL -     let a: u8 = X;
+LL +     let a: i32 = X as i32;
+   |
+
+error: this binding is defined as `u8` but is always cast to `i32`
+  --> tests/ui/needless_type_cast.rs:266:12
+   |
+LL |     let a: u8 = 10 + 5;
+   |            ^^ help: consider defining it as: `i32`
+
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
When the initializer is a function call or suffixed literal (e.g., `size_of::<T>()` or `10u8`), suggest casting the initializer too, since changing only the type annotation would fail to compile. Fixes rust-lang/rust-clippy#16240

```
changelog: [`needless_type_cast`]: Fix suggesting invalid code for non-literal initializers
```
