### PR TITLE
Fix `main_recursion` tests

### DIFF
--- a/tests/ui/crate_level_checks/entrypoint_recursion.rs
+++ b/tests/ui/crate_level_checks/entrypoint_recursion.rs
@@ -1,12 +1,11 @@
-//@check-pass
 //@ignore-target: apple
-
 #![feature(rustc_attrs)]
-
 #[warn(clippy::main_recursion)]
 #[allow(unconditional_recursion)]
 #[rustc_main]
 fn a() {
-    println!("Hello, World!");
     a();
+    //~^ main_recursion
 }
+
+fn main() {}

--- a/tests/ui/crate_level_checks/entrypoint_recursion.stderr
+++ b/tests/ui/crate_level_checks/entrypoint_recursion.stderr
@@ -1,0 +1,12 @@
+error: recursing into entrypoint `a`
+  --> tests/ui/crate_level_checks/entrypoint_recursion.rs:7:5
+   |
+LL |     a();
+   |     ^
+   |
+   = help: consider using another function for this recursion
+   = note: `-D clippy::main-recursion` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::main_recursion)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/crate_level_checks/no_std_main_recursion.rs
+++ b/tests/ui/crate_level_checks/no_std_main_recursion.rs
@@ -1,0 +1,13 @@
+//@check-pass
+//@compile-flags: -Cpanic=abort
+#![no_std]
+#[warn(clippy::main_recursion)]
+#[allow(unconditional_recursion)]
+fn main() {
+    main();
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#11034

changelog: [`main_recursion`]: none