### PR TITLE
`transmuting_null`: Check single expression const blocks and blocks

### DIFF
--- a/clippy_lints/src/transmute/transmuting_null.rs
+++ b/clippy_lints/src/transmute/transmuting_null.rs
@@ -2,7 +2,7 @@ use clippy_utils::consts::{ConstEvalCtxt, Constant};
 use clippy_utils::diagnostics::span_lint;
 use clippy_utils::is_integer_const;
 use clippy_utils::res::{MaybeDef, MaybeResPath};
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{ConstBlock, Expr, ExprKind};
 use rustc_lint::LateContext;
 use rustc_middle::ty::Ty;
 use rustc_span::symbol::sym;
@@ -40,6 +40,24 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, arg: &'t
     {
         span_lint(cx, TRANSMUTING_NULL, expr.span, LINT_MSG);
         return true;
+    }
+
+    // Catching:
+    // `std::mem::transmute({ 0 as *const u64 })` and similar const blocks
+    if let ExprKind::Block(block, _) = arg.kind
+        && block.stmts.is_empty()
+        && let Some(inner) = block.expr
+    {
+        // Run again with the inner expression
+        return check(cx, expr, inner, to_ty);
+    }
+
+    // Catching:
+    // `std::mem::transmute(const { u64::MIN as *const u64 });`
+    if let ExprKind::ConstBlock(ConstBlock { body, .. }) = arg.kind {
+        // Strip out the const and run again
+        let block = cx.tcx.hir_body(body).value;
+        return check(cx, expr, block, to_ty);
     }
 
     false

--- a/tests/ui/transmuting_null.rs
+++ b/tests/ui/transmuting_null.rs
@@ -37,8 +37,19 @@ fn transmute_const_int() {
     }
 }
 
+fn transumute_single_expr_blocks() {
+    unsafe {
+        let _: &u64 = std::mem::transmute({ 0 as *const u64 });
+        //~^ transmuting_null
+
+        let _: &u64 = std::mem::transmute(const { u64::MIN as *const u64 });
+        //~^ transmuting_null
+    }
+}
+
 fn main() {
     one_liners();
     transmute_const();
     transmute_const_int();
+    transumute_single_expr_blocks();
 }

--- a/tests/ui/transmuting_null.stderr
+++ b/tests/ui/transmuting_null.stderr
@@ -25,5 +25,17 @@ error: transmuting a known null pointer into a reference
 LL |         let _: &u64 = std::mem::transmute(u64::MIN as *const u64);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: transmuting a known null pointer into a reference
+  --> tests/ui/transmuting_null.rs:42:23
+   |
+LL |         let _: &u64 = std::mem::transmute({ 0 as *const u64 });
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: transmuting a known null pointer into a reference
+  --> tests/ui/transmuting_null.rs:45:23
+   |
+LL |         let _: &u64 = std::mem::transmute(const { u64::MIN as *const u64 });
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
changelog: [`transmuting_null`]: now checks const blocks and blocks with only a single expression