### PR TITLE
feat: add `cast_ptr_sized_int` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6377,6 +6377,7 @@ Released 2018-09-13
 [`cast_possible_wrap`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_wrap
 [`cast_precision_loss`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_precision_loss
 [`cast_ptr_alignment`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_ptr_alignment
+[`cast_ptr_sized_int`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_ptr_sized_int
 [`cast_ref_to_mut`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_ref_to_mut
 [`cast_sign_loss`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
 [`cast_slice_different_sizes`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_slice_different_sizes

--- a/clippy_lints/src/casts/cast_ptr_sized_int.rs
+++ b/clippy_lints/src/casts/cast_ptr_sized_int.rs
@@ -1,0 +1,115 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::ty::is_isize_or_usize;
+use rustc_hir::Expr;
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, Ty};
+
+use super::CAST_PTR_SIZED_INT;
+
+/// Checks for casts between pointer-sized integer types (`usize`/`isize`) and
+/// fixed-size integer types where the behavior depends on the target architecture.
+///
+/// Some casts are always safe and are NOT linted:
+/// - `u8`/`u16` → `usize`: always fits (usize is at least 16-bit)
+/// - `i8`/`i16` → `isize`: always fits (isize is at least 16-bit)
+/// - `usize` → `u64`/`u128`: always fits (usize is at most 64-bit)
+/// - `isize` → `i64`/`i128`: always fits (isize is at most 64-bit)
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, cast_from: Ty<'tcx>, cast_to: Ty<'tcx>) {
+    // Only consider integer-to-integer casts.
+    if !cast_from.is_integral() || !cast_to.is_integral() {
+        return;
+    }
+
+    let from_is_ptr_sized = is_isize_or_usize(cast_from);
+    let to_is_ptr_sized = is_isize_or_usize(cast_to);
+
+    // We only care about casts where exactly one side is pointer-sized.
+    if from_is_ptr_sized == to_is_ptr_sized {
+        return;
+    }
+
+    // Identify which side is the pointer-sized type and which is the fixed-size type.
+    let (ptr_sized_ty, fixed_ty, fixed_bits_opt, direction) = if from_is_ptr_sized {
+        (cast_from, cast_to, fixed_type_bits(cast_to), "to")
+    } else {
+        (cast_to, cast_from, fixed_type_bits(cast_from), "from")
+    };
+
+    let Some(fixed_bits) = fixed_bits_opt else {
+        // If the non-pointer side is not a fixed-size integer, bail out.
+        return;
+    };
+
+    // If this cast is always safe regardless of target pointer width, don't lint.
+    if is_always_safe_cast(
+        from_is_ptr_sized,
+        fixed_bits,
+        cast_from.is_signed(),
+        cast_to.is_signed(),
+    ) {
+        return;
+    }
+
+    let msg = format!("casting `{cast_from}` to `{cast_to}`: will always truncate");
+
+    span_lint_and_then(cx, CAST_PTR_SIZED_INT, expr.span, msg, |diag| {
+        let help_msg = format!(
+            "`{ptr_sized_ty}` varies in size depending on the target, \
+            so casting {direction} `{fixed_ty}` may produce different results across platforms"
+        );
+        diag.help(help_msg);
+        diag.help("consider using `TryFrom` or `TryInto` for explicit fallible conversions");
+    });
+}
+
+/// Returns the bit width of a fixed-size integer type, or None if not a fixed-size int.
+fn fixed_type_bits(ty: Ty<'_>) -> Option<u64> {
+    match ty.kind() {
+        ty::Int(int_ty) => int_ty.bit_width(),
+        ty::Uint(uint_ty) => uint_ty.bit_width(),
+        _ => None,
+    }
+}
+
+/// Determines if a cast between pointer-sized and fixed-size integers is always safe.
+///
+/// Always safe casts (no architecture dependency):
+/// - Small fixed → ptr-sized: u8/i8/u16/i16 → usize/isize (ptr-sized is at least 16-bit)
+/// - Ptr-sized → large fixed: usize/isize → u64/i64/u128/i128 (ptr-sized is at most 64-bit)
+///
+/// NOT safe (depends on architecture):
+/// - Large fixed → ptr-sized: u32/u64/etc → usize (may truncate on smaller ptr widths)
+/// - Ptr-sized → small fixed: usize → u8/u16/u32 (may truncate on larger ptr widths)
+fn is_always_safe_cast(from_is_ptr_sized: bool, fixed_bits: u64, from_signed: bool, to_signed: bool) -> bool {
+    // Note: sign-change issues are handled by a separate lint (cast_sign_loss). Here we
+    // only reason about whether the numeric magnitude will always fit regardless of
+    // the target pointer width.
+
+    if from_is_ptr_sized {
+        // Casting from pointer-sized -> fixed-size:
+        // - Pointer-sized integers (usize/isize) are at most 64 bits.
+        // - A fixed-size target with >= 64 bits can always hold the magnitude of a pointer-sized value, but
+        //   we must respect signedness:
+        //   * isize -> i64/i128 is safe (from_signed == true and to_signed && fixed_bits >= 64)
+        //   * usize -> u64/u128 is safe (from_signed == false and !to_signed && fixed_bits >= 64)
+        if fixed_bits < 64 {
+            return false;
+        }
+        if to_signed {
+            // Target is signed: safe only if source is signed (isize -> i64)
+            from_signed && fixed_bits >= 64
+        } else {
+            // Target is unsigned: safe only if source is unsigned (usize -> u64)
+            !from_signed && fixed_bits >= 64
+        }
+    } else if from_signed == to_signed {
+        // Casting from fixed-size -> pointer-sized:
+        // - Pointer-sized integers are at least 16 bits.
+        // - Small fixed-size types (<= 16 bits) always fit in the smallest pointer width.
+        // Same signedness: small fixed types (<=16 bits) are always safe.
+        fixed_bits <= 16
+    } else {
+        // Sign change: only the case unsigned small -> signed ptr is considered safe here.
+        fixed_bits <= 16 && !from_signed
+    }
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -61,6 +61,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::casts::CAST_POSSIBLE_WRAP_INFO,
     crate::casts::CAST_PRECISION_LOSS_INFO,
     crate::casts::CAST_PTR_ALIGNMENT_INFO,
+    crate::casts::CAST_PTR_SIZED_INT_INFO,
     crate::casts::CAST_SIGN_LOSS_INFO,
     crate::casts::CAST_SLICE_DIFFERENT_SIZES_INFO,
     crate::casts::CAST_SLICE_FROM_RAW_PARTS_INFO,

--- a/tests/ui/cast_ptr_sized_int.rs
+++ b/tests/ui/cast_ptr_sized_int.rs
@@ -1,0 +1,87 @@
+#![warn(clippy::cast_ptr_sized_int)]
+
+fn main() {
+    // Architecture-dependent behavior
+
+    let x: usize = 42;
+
+    // usize to small fixed-size (may truncate on larger ptr widths)
+    let _ = x as u8; //~ cast_ptr_sized_int
+    let _ = x as u16; //~ cast_ptr_sized_int
+    let _ = x as u32; //~ cast_ptr_sized_int
+    let _ = x as i8; //~ cast_ptr_sized_int
+    let _ = x as i16; //~ cast_ptr_sized_int
+    let _ = x as i32; //~ cast_ptr_sized_int
+
+    let y: isize = 42;
+
+    // isize to small fixed-size (may truncate on larger ptr widths)
+    let _ = y as u8; //~ cast_ptr_sized_int
+    let _ = y as u16; //~ cast_ptr_sized_int
+    let _ = y as u32; //~ cast_ptr_sized_int
+    let _ = y as i8; //~ cast_ptr_sized_int
+    let _ = y as i16; //~ cast_ptr_sized_int
+    let _ = y as i32; //~ cast_ptr_sized_int
+
+    // Large fixed-size to ptr-sized (may truncate on smaller ptr widths)
+    let c: u32 = 1;
+    let d: u64 = 1;
+    let e: u128 = 1;
+    let _ = c as usize; //~ cast_ptr_sized_int
+    let _ = d as usize; //~ cast_ptr_sized_int
+    let _ = e as usize; //~ cast_ptr_sized_int
+
+    let h: i32 = 1;
+    let i: i64 = 1;
+    let j: i128 = 1;
+    let _ = h as usize; //~ cast_ptr_sized_int
+    let _ = i as usize; //~ cast_ptr_sized_int
+    let _ = j as usize; //~ cast_ptr_sized_int
+
+    let _ = c as isize; //~ cast_ptr_sized_int
+    let _ = d as isize; //~ cast_ptr_sized_int
+    let _ = e as isize; //~ cast_ptr_sized_int
+    let _ = h as isize; //~ cast_ptr_sized_int
+    let _ = i as isize; //~ cast_ptr_sized_int
+    let _ = j as isize; //~ cast_ptr_sized_int
+
+    // usize to signed (potential sign issues)
+    let _ = x as i64; //~ cast_ptr_sized_int
+}
+
+// Always safe, no architecture dependency
+
+fn no_lint_always_safe() {
+    // Small fixed → ptr-sized: always safe (ptr-sized is at least 16-bit)
+    let a: u8 = 1;
+    let b: u16 = 1;
+    let _ = a as usize; // OK: u8 fits in any usize
+    let _ = b as usize; // OK: u16 fits in any usize
+
+    let f: i8 = 1;
+    let g: i16 = 1;
+    let _ = f as isize; // OK: i8 fits in any isize
+    let _ = g as isize; // OK: i16 fits in any isize
+
+    // Ptr-sized → large fixed: always safe (ptr-sized is at most 64-bit)
+    let x: usize = 42;
+    let y: isize = 42;
+    let _ = x as u64; // OK: usize fits in u64
+    let _ = x as u128; // OK: usize fits in u128
+    let _ = y as i64; // OK: isize fits in i64
+    let _ = y as i128; // OK: isize fits in i128
+}
+
+fn no_lint_same_kind() {
+    // Both pointer-sized (handled by other lints)
+    let x: usize = 42;
+    let _ = x as isize;
+
+    let y: isize = 42;
+    let _ = y as usize;
+
+    // Both fixed-size (handled by other lints)
+    let a: u32 = 1;
+    let _ = a as u64;
+    let _ = a as i64;
+}

--- a/tests/ui/cast_ptr_sized_int.stderr
+++ b/tests/ui/cast_ptr_sized_int.stderr
@@ -1,0 +1,229 @@
+error: casting `usize` to `u8`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:9:13
+   |
+LL |     let _ = x as u8;
+   |             ^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting to `u8` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+   = note: `-D clippy::cast-ptr-sized-int` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::cast_ptr_sized_int)]`
+
+error: casting `usize` to `u16`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:10:13
+   |
+LL |     let _ = x as u16;
+   |             ^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting to `u16` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `usize` to `u32`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:11:13
+   |
+LL |     let _ = x as u32;
+   |             ^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting to `u32` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `usize` to `i8`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:12:13
+   |
+LL |     let _ = x as i8;
+   |             ^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting to `i8` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `usize` to `i16`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:13:13
+   |
+LL |     let _ = x as i16;
+   |             ^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting to `i16` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `usize` to `i32`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:14:13
+   |
+LL |     let _ = x as i32;
+   |             ^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting to `i32` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `isize` to `u8`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:19:13
+   |
+LL |     let _ = y as u8;
+   |             ^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting to `u8` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `isize` to `u16`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:20:13
+   |
+LL |     let _ = y as u16;
+   |             ^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting to `u16` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `isize` to `u32`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:21:13
+   |
+LL |     let _ = y as u32;
+   |             ^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting to `u32` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `isize` to `i8`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:22:13
+   |
+LL |     let _ = y as i8;
+   |             ^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting to `i8` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `isize` to `i16`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:23:13
+   |
+LL |     let _ = y as i16;
+   |             ^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting to `i16` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `isize` to `i32`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:24:13
+   |
+LL |     let _ = y as i32;
+   |             ^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting to `i32` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `u32` to `usize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:30:13
+   |
+LL |     let _ = c as usize;
+   |             ^^^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting from `u32` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `u64` to `usize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:31:13
+   |
+LL |     let _ = d as usize;
+   |             ^^^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting from `u64` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `u128` to `usize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:32:13
+   |
+LL |     let _ = e as usize;
+   |             ^^^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting from `u128` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `i32` to `usize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:37:13
+   |
+LL |     let _ = h as usize;
+   |             ^^^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting from `i32` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `i64` to `usize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:38:13
+   |
+LL |     let _ = i as usize;
+   |             ^^^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting from `i64` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `i128` to `usize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:39:13
+   |
+LL |     let _ = j as usize;
+   |             ^^^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting from `i128` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `u32` to `isize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:41:13
+   |
+LL |     let _ = c as isize;
+   |             ^^^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting from `u32` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `u64` to `isize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:42:13
+   |
+LL |     let _ = d as isize;
+   |             ^^^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting from `u64` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `u128` to `isize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:43:13
+   |
+LL |     let _ = e as isize;
+   |             ^^^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting from `u128` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `i32` to `isize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:44:13
+   |
+LL |     let _ = h as isize;
+   |             ^^^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting from `i32` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `i64` to `isize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:45:13
+   |
+LL |     let _ = i as isize;
+   |             ^^^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting from `i64` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `i128` to `isize`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:46:13
+   |
+LL |     let _ = j as isize;
+   |             ^^^^^^^^^^
+   |
+   = help: `isize` varies in size depending on the target, so casting from `i128` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: casting `usize` to `i64`: will always truncate
+  --> tests/ui/cast_ptr_sized_int.rs:49:13
+   |
+LL |     let _ = x as i64;
+   |             ^^^^^^^^
+   |
+   = help: `usize` varies in size depending on the target, so casting to `i64` may produce different results across platforms
+   = help: consider using `TryFrom` or `TryInto` for explicit fallible conversions
+
+error: aborting due to 25 previous errors
+


### PR DESCRIPTION
Introduce a new restriction lint to identify casts between pointer-sized integer types (`usize`, `isize`) and fixed-size integer types.

Encourage the use of `TryFrom` or `TryInto` over direct `as` casts to make potential platform-specific truncation or zero-extension explicit and handled.

Also Provide machine-applicable suggestions to replace risky casts with fallible conversions while excluding constant contexts where such traits are not yet stable.

Closes: rust-lang/rust-clippy#9231

changelog: add cast_ptr_sized_int lint
