### PR TITLE
Use actions/checkout@v6 consistently

### DIFF
--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Setup
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         # Unsetting this would make so that any malicious package could get our Github Token
         persist-credentials: false

--- a/.github/workflows/clippy_pr.yml
+++ b/.github/workflows/clippy_pr.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     # Setup
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         # Unsetting this would make so that any malicious package could get our Github Token
         persist-credentials: false


### PR DESCRIPTION
Two places were not updated from v5 to v6.

changelog: none
r? flip1995 