### PR TITLE
Reenable some tests on "apple" targets

### DIFF
--- a/tests/ui/crashes/ice-7410.rs
+++ b/tests/ui/crashes/ice-7410.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 //@compile-flags: -Clink-arg=-nostartfiles
-//@ignore-target: apple windows
+//@ignore-target: windows
 
 #![crate_type = "lib"]
 #![no_std]

--- a/tests/ui/def_id_nocore.rs
+++ b/tests/ui/def_id_nocore.rs
@@ -1,5 +1,3 @@
-//@ignore-target: apple
-
 #![feature(no_core, lang_items)]
 #![no_core]
 #![allow(clippy::missing_safety_doc)]

--- a/tests/ui/def_id_nocore.stderr
+++ b/tests/ui/def_id_nocore.stderr
@@ -1,5 +1,5 @@
 error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
-  --> tests/ui/def_id_nocore.rs:33:19
+  --> tests/ui/def_id_nocore.rs:31:19
    |
 LL |     pub fn as_ref(self) -> &'static str {
    |                   ^^^^

--- a/tests/ui/empty_loop_no_std.rs
+++ b/tests/ui/empty_loop_no_std.rs
@@ -1,6 +1,4 @@
 //@compile-flags: -Clink-arg=-nostartfiles
-//@ignore-target: apple
-
 #![warn(clippy::empty_loop)]
 #![crate_type = "lib"]
 #![no_std]

--- a/tests/ui/empty_loop_no_std.stderr
+++ b/tests/ui/empty_loop_no_std.stderr
@@ -1,5 +1,5 @@
 error: empty `loop {}` wastes CPU cycles
-  --> tests/ui/empty_loop_no_std.rs:10:5
+  --> tests/ui/empty_loop_no_std.rs:8:5
    |
 LL |     loop {}
    |     ^^^^^^^


### PR DESCRIPTION
Those tests appear to be passing on "apple" targets as well.

changelog: none