### PR TITLE
Post `needless_continue` diagnostic on the right node

### DIFF
--- a/tests/ui/needless_continue.rs
+++ b/tests/ui/needless_continue.rs
@@ -342,3 +342,38 @@ fn issue15548() {
         }
     }
 }
+
+fn issue16256() {
+    fn some_condition() -> bool {
+        true
+    }
+    fn another_condition() -> bool {
+        true
+    }
+
+    for _ in 0..5 {
+        if some_condition() {
+            // ...
+            continue;
+        }
+
+        if another_condition() {
+            // ...
+            // "this `continue` expression is redundant" is posted on
+            // the `continue` node.
+            #[expect(clippy::needless_continue)]
+            continue;
+        }
+    }
+
+    for _ in 0..5 {
+        // "This `else` block is redundant" is posted on the
+        // `else` node.
+        #[expect(clippy::needless_continue)]
+        if some_condition() {
+            // ...
+        } else {
+            continue;
+        }
+    }
+}


### PR DESCRIPTION
changelog: [`needless_continue`]: `allow` and `expect` attributes can also be used on the statement triggering the lint instead of only the whole loop.

Fixes rust-lang/rust-clippy#16256 