### PR TITLE
Fix `new_without_default` misses where clause in `new`

### DIFF
--- a/tests/ui/new_without_default.fixed
+++ b/tests/ui/new_without_default.fixed
@@ -409,3 +409,58 @@ mod issue15778 {
         }
     }
 }
+
+pub mod issue16255 {
+    use std::fmt::Display;
+    use std::marker::PhantomData;
+
+    pub struct Foo<T> {
+        marker: PhantomData<T>,
+    }
+
+    impl<T> Default for Foo<T>
+    where
+        T: Display,
+        T: Clone,
+     {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<T> Foo<T>
+    where
+        T: Display,
+    {
+        pub fn new() -> Self
+        //~^ new_without_default
+        where
+            T: Clone,
+        {
+            Self { marker: PhantomData }
+        }
+    }
+
+    pub struct Bar<T> {
+        marker: PhantomData<T>,
+    }
+
+    impl<T> Default for Bar<T>
+    where
+        T: Clone,
+     {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<T> Bar<T> {
+        pub fn new() -> Self
+        //~^ new_without_default
+        where
+            T: Clone,
+        {
+            Self { marker: PhantomData }
+        }
+    }
+}

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -324,3 +324,39 @@ mod issue15778 {
         }
     }
 }
+
+pub mod issue16255 {
+    use std::fmt::Display;
+    use std::marker::PhantomData;
+
+    pub struct Foo<T> {
+        marker: PhantomData<T>,
+    }
+
+    impl<T> Foo<T>
+    where
+        T: Display,
+    {
+        pub fn new() -> Self
+        //~^ new_without_default
+        where
+            T: Clone,
+        {
+            Self { marker: PhantomData }
+        }
+    }
+
+    pub struct Bar<T> {
+        marker: PhantomData<T>,
+    }
+
+    impl<T> Bar<T> {
+        pub fn new() -> Self
+        //~^ new_without_default
+        where
+            T: Clone,
+        {
+            Self { marker: PhantomData }
+        }
+    }
+}

--- a/tests/ui/new_without_default.stderr
+++ b/tests/ui/new_without_default.stderr
@@ -250,5 +250,58 @@ LL +     }
 LL + }
    |
 
-error: aborting due to 13 previous errors
+error: you should consider adding a `Default` implementation for `Foo<T>`
+  --> tests/ui/new_without_default.rs:340:9
+   |
+LL | /         pub fn new() -> Self
+LL | |
+LL | |         where
+LL | |             T: Clone,
+LL | |         {
+LL | |             Self { marker: PhantomData }
+LL | |         }
+   | |_________^
+   |
+help: try adding this
+   |
+LL ~     impl<T> Default for Foo<T>
+LL +     where
+LL +         T: Display,
+LL +         T: Clone,
+LL +      {
+LL +         fn default() -> Self {
+LL +             Self::new()
+LL +         }
+LL +     }
+LL + 
+LL ~     impl<T> Foo<T>
+   |
+
+error: you should consider adding a `Default` implementation for `Bar<T>`
+  --> tests/ui/new_without_default.rs:354:9
+   |
+LL | /         pub fn new() -> Self
+LL | |
+LL | |         where
+LL | |             T: Clone,
+LL | |         {
+LL | |             Self { marker: PhantomData }
+LL | |         }
+   | |_________^
+   |
+help: try adding this
+   |
+LL ~     impl<T> Default for Bar<T>
+LL +     where
+LL +         T: Clone,
+LL +      {
+LL +         fn default() -> Self {
+LL +             Self::new()
+LL +         }
+LL +     }
+LL + 
+LL ~     impl<T> Bar<T> {
+   |
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16255 

changelog: [`new_without_default`] fix suggestions missing where clause in `new`
