### PR TITLE
Do not attempt to use `nth` with non-usize argument

### DIFF
--- a/clippy_lints/src/methods/needless_collect.rs
+++ b/clippy_lints/src/methods/needless_collect.rs
@@ -81,7 +81,9 @@ pub(super) fn check<'tcx>(
                     },
                     _ => return,
                 };
-            } else if let ExprKind::Index(_, index, _) = parent.kind {
+            } else if let ExprKind::Index(_, index, _) = parent.kind
+                && cx.typeck_results().expr_ty(index).is_usize()
+            {
                 app = Applicability::MaybeIncorrect;
                 let snip = snippet_with_applicability(cx, index.span, "_", &mut app);
                 sugg = format!("nth({snip}).unwrap()");

--- a/tests/ui/needless_collect.fixed
+++ b/tests/ui/needless_collect.fixed
@@ -214,3 +214,8 @@ mod issue8055_regression {
         .len();
     }
 }
+
+fn issue16270() {
+    // Do not lint, `..` implements `Index` but is not `usize`
+    _ = &(1..3).collect::<Vec<i32>>()[..];
+}

--- a/tests/ui/needless_collect.rs
+++ b/tests/ui/needless_collect.rs
@@ -214,3 +214,8 @@ mod issue8055_regression {
         .len();
     }
 }
+
+fn issue16270() {
+    // Do not lint, `..` implements `Index` but is not `usize`
+    _ = &(1..3).collect::<Vec<i32>>()[..];
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16270

----

changelog: [`needless_collect`]: do not attempt to suggest `nth` when argument is not a `usize`