### PR TITLE
Fix `result_large_err` FN on closures

### DIFF
--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -596,4 +596,8 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
         impl_trait_in_params::check_trait_item(cx, item, self.avoid_breaking_exported_api);
         ref_option::check_trait_item(cx, item, self.avoid_breaking_exported_api);
     }
+
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        result::check_expr(cx, expr, self.large_error_threshold, &self.large_error_ignored);
+    }
 }

--- a/tests/ui/result_large_err.rs
+++ b/tests/ui/result_large_err.rs
@@ -141,3 +141,12 @@ fn _empty_error() -> Result<(), Empty> {
 }
 
 fn main() {}
+
+fn issue16249() {
+    type Large = [u8; 1024];
+
+    let closure = || -> Result<(), Large> { Ok(()) };
+    //~^ result_large_err
+    let closure = || Ok::<(), Large>(());
+    //~^ result_large_err
+}

--- a/tests/ui/result_large_err.stderr
+++ b/tests/ui/result_large_err.stderr
@@ -104,5 +104,21 @@ LL | pub fn array_error<T, U>() -> Result<(), ArrayError<(i32, T), U>> {
    |
    = help: try reducing the size of `ArrayError<(i32, T), U>`, for example by boxing large elements or replacing it with `Box<ArrayError<(i32, T), U>>`
 
-error: aborting due to 12 previous errors
+error: the `Err`-variant returned from this closure is very large
+  --> tests/ui/result_large_err.rs:148:25
+   |
+LL |     let closure = || -> Result<(), Large> { Ok(()) };
+   |                         ^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 1024 bytes
+   |
+   = help: try reducing the size of `[u8; 1024]`, for example by boxing large elements or replacing it with `Box<[u8; 1024]>`
+
+error: the `Err`-variant returned from this closure is very large
+  --> tests/ui/result_large_err.rs:150:19
+   |
+LL |     let closure = || Ok::<(), Large>(());
+   |                   ^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 1024 bytes
+   |
+   = help: try reducing the size of `[u8; 1024]`, for example by boxing large elements or replacing it with `Box<[u8; 1024]>`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16249 

changelog: [`result_large_err`] fix FN on closures
