### PR TITLE
Fix `bool_assert_comparison` suggests wrongly for macros

### DIFF
--- a/tests/ui/bool_assert_comparison.fixed
+++ b/tests/ui/bool_assert_comparison.fixed
@@ -216,3 +216,16 @@ fn main() {
     assert!(!(b + b));
     //~^ bool_assert_comparison
 }
+
+fn issue16279() {
+    macro_rules! is_empty {
+        ($x:expr) => {
+            $x.is_empty()
+        };
+    }
+
+    assert!(!is_empty!("a"));
+    //~^ bool_assert_comparison
+    assert!(is_empty!(""));
+    //~^ bool_assert_comparison
+}

--- a/tests/ui/bool_assert_comparison.rs
+++ b/tests/ui/bool_assert_comparison.rs
@@ -216,3 +216,16 @@ fn main() {
     assert_eq!(b + b, false);
     //~^ bool_assert_comparison
 }
+
+fn issue16279() {
+    macro_rules! is_empty {
+        ($x:expr) => {
+            $x.is_empty()
+        };
+    }
+
+    assert_eq!(is_empty!("a"), false);
+    //~^ bool_assert_comparison
+    assert_eq!(is_empty!(""), true);
+    //~^ bool_assert_comparison
+}

--- a/tests/ui/bool_assert_comparison.stderr
+++ b/tests/ui/bool_assert_comparison.stderr
@@ -444,5 +444,29 @@ LL -     assert_eq!(b + b, false);
 LL +     assert!(!(b + b));
    |
 
-error: aborting due to 37 previous errors
+error: used `assert_eq!` with a literal bool
+  --> tests/ui/bool_assert_comparison.rs:227:5
+   |
+LL |     assert_eq!(is_empty!("a"), false);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!(is_empty!("a"), false);
+LL +     assert!(!is_empty!("a"));
+   |
+
+error: used `assert_eq!` with a literal bool
+  --> tests/ui/bool_assert_comparison.rs:229:5
+   |
+LL |     assert_eq!(is_empty!(""), true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!(is_empty!(""), true);
+LL +     assert!(is_empty!(""));
+   |
+
+error: aborting due to 39 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16279 

changelog: [`bool_assert_comparison`] fix wrong suggestions for macros 
