### PR TITLE
Fix `multiple_inherent_impl` false negatives for generic impl blocks

### DIFF
--- a/tests/ui/impl.rs
+++ b/tests/ui/impl.rs
@@ -14,6 +14,7 @@ impl MyStruct {
 }
 
 impl<'a> MyStruct {
+    //~^ multiple_inherent_impl
     fn lifetimed() {}
 }
 
@@ -90,10 +91,12 @@ struct Lifetime<'s> {
 }
 
 impl Lifetime<'_> {}
-impl Lifetime<'_> {} // false negative
+impl Lifetime<'_> {}
+//~^ multiple_inherent_impl
 
 impl<'a> Lifetime<'a> {}
-impl<'a> Lifetime<'a> {} // false negative
+impl<'a> Lifetime<'a> {}
+//~^ multiple_inherent_impl
 
 impl<'b> Lifetime<'b> {} // false negative?
 
@@ -104,6 +107,39 @@ struct Generic<G> {
 }
 
 impl<G> Generic<G> {}
-impl<G> Generic<G> {} // false negative
+impl<G> Generic<G> {}
+//~^ multiple_inherent_impl
+
+use std::fmt::Debug;
+
+#[derive(Debug)]
+struct GenericWithBounds<T: Debug>(T);
+
+impl<T: Debug> GenericWithBounds<T> {
+    fn make_one(_one: T) -> Self {
+        todo!()
+    }
+}
+
+impl<T: Debug> GenericWithBounds<T> {
+    //~^ multiple_inherent_impl
+    fn make_two(_two: T) -> Self {
+        todo!()
+    }
+}
+
+struct MultipleTraitBounds<T>(T);
+
+impl<T: Debug> MultipleTraitBounds<T> {
+    fn debug_fn() {}
+}
+
+impl<T: Clone> MultipleTraitBounds<T> {
+    fn clone_fn() {}
+}
+
+impl<T: Debug + Clone> MultipleTraitBounds<T> {
+    fn debug_clone_fn() {}
+}
 
 fn main() {}

--- a/tests/ui/impl.stderr
+++ b/tests/ui/impl.stderr
@@ -19,7 +19,24 @@ LL | | }
    = help: to override `-D warnings` add `#[allow(clippy::multiple_inherent_impl)]`
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:26:5
+  --> tests/ui/impl.rs:16:1
+   |
+LL | / impl<'a> MyStruct {
+LL | |
+LL | |     fn lifetimed() {}
+LL | | }
+   | |_^
+   |
+note: first implementation here
+  --> tests/ui/impl.rs:6:1
+   |
+LL | / impl MyStruct {
+LL | |     fn first() {}
+LL | | }
+   | |_^
+
+error: multiple implementations of this structure
+  --> tests/ui/impl.rs:27:5
    |
 LL | /     impl super::MyStruct {
 LL | |
@@ -37,7 +54,7 @@ LL | | }
    | |_^
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:48:1
+  --> tests/ui/impl.rs:49:1
    |
 LL | / impl WithArgs<u64> {
 LL | |
@@ -47,7 +64,7 @@ LL | | }
    | |_^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:45:1
+  --> tests/ui/impl.rs:46:1
    |
 LL | / impl WithArgs<u64> {
 LL | |     fn f2() {}
@@ -55,28 +72,85 @@ LL | | }
    | |_^
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:71:1
+  --> tests/ui/impl.rs:72:1
    |
 LL | impl OneAllowedImpl {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:68:1
+  --> tests/ui/impl.rs:69:1
    |
 LL | impl OneAllowedImpl {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:84:1
+  --> tests/ui/impl.rs:85:1
    |
 LL | impl OneExpected {}
    | ^^^^^^^^^^^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:81:1
+  --> tests/ui/impl.rs:82:1
    |
 LL | impl OneExpected {}
    | ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: multiple implementations of this structure
+  --> tests/ui/impl.rs:94:1
+   |
+LL | impl Lifetime<'_> {}
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+note: first implementation here
+  --> tests/ui/impl.rs:93:1
+   |
+LL | impl Lifetime<'_> {}
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: multiple implementations of this structure
+  --> tests/ui/impl.rs:98:1
+   |
+LL | impl<'a> Lifetime<'a> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first implementation here
+  --> tests/ui/impl.rs:97:1
+   |
+LL | impl<'a> Lifetime<'a> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: multiple implementations of this structure
+  --> tests/ui/impl.rs:110:1
+   |
+LL | impl<G> Generic<G> {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first implementation here
+  --> tests/ui/impl.rs:109:1
+   |
+LL | impl<G> Generic<G> {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: multiple implementations of this structure
+  --> tests/ui/impl.rs:124:1
+   |
+LL | / impl<T: Debug> GenericWithBounds<T> {
+LL | |
+LL | |     fn make_two(_two: T) -> Self {
+LL | |         todo!()
+LL | |     }
+LL | | }
+   | |_^
+   |
+note: first implementation here
+  --> tests/ui/impl.rs:118:1
+   |
+LL | / impl<T: Debug> GenericWithBounds<T> {
+LL | |     fn make_one(_one: T) -> Self {
+LL | |         todo!()
+LL | |     }
+LL | | }
+   | |_^
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
lint now correctly detects multiple impl blocks for generic types with identical bounds. Fixes: https://github.com/rust-lang/rust-clippy/issues/16283

changelog: [`multiple_inherent_impl`]: fix false negatives for generic impl blocks
