### PR TITLE
feat: add lint for `map_or_else` to `map_or`

### DIFF
--- a/clippy_lints/src/matches/match_single_binding.rs
+++ b/clippy_lints/src/matches/match_single_binding.rs
@@ -302,7 +302,7 @@ fn expr_in_nested_block(cx: &LateContext<'_>, match_expr: &Expr<'_>) -> bool {
     if let Node::Block(block) = cx.tcx.parent_hir_node(match_expr.hir_id) {
         return block
             .expr
-            .map_or_else(|| matches!(block.stmts, [_]), |_| block.stmts.is_empty());
+            .map_or(matches!(block.stmts, [_]), |_| block.stmts.is_empty());
     }
     false
 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1934,6 +1934,7 @@ declare_clippy_lint! {
     ///  - `or_else` to `or`
     ///  - `get_or_insert_with` to `get_or_insert`
     ///  - `ok_or_else` to `ok_or`
+    ///  - `map_or_else` to `map_or`
     ///  - `then` to `then_some` (for msrv >= 1.62.0)
     ///
     /// ### Why is this bad?
@@ -5409,6 +5410,7 @@ impl Methods {
                     result_map_or_else_none::check(cx, expr, recv, def, map);
                     unnecessary_option_map_or_else::check(cx, expr, recv, def, map);
                     unnecessary_result_map_or_else::check(cx, expr, recv, def, map);
+                    unnecessary_lazy_eval::check_map_or_else(cx, expr, recv, def, map);
                 },
                 (sym::next, []) => {
                     if let Some((name2, recv2, args2, _, _)) = method_call(recv) {

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -533,7 +533,7 @@ fn reindent_multiline_inner(s: &str, ignore_first: bool, indent: Option<usize>, 
 /// snippet(cx, span2, "..") // -> "Vec::new()"
 /// ```
 pub fn snippet<'a>(sess: &impl HasSession, span: Span, default: &'a str) -> Cow<'a, str> {
-    snippet_opt(sess, span).map_or_else(|| Cow::Borrowed(default), From::from)
+    snippet_opt(sess, span).map_or(Cow::Borrowed(default), From::from)
 }
 
 /// Same as [`snippet`], but it adapts the applicability level by following rules:

--- a/tests/ui/manual_ok_or.fixed
+++ b/tests/ui/manual_ok_or.fixed
@@ -2,6 +2,7 @@
 #![allow(clippy::or_fun_call)]
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::redundant_closure)]
+#![allow(clippy::unnecessary_lazy_evaluations)]
 #![allow(dead_code)]
 #![allow(unused_must_use)]
 

--- a/tests/ui/manual_ok_or.rs
+++ b/tests/ui/manual_ok_or.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::or_fun_call)]
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::redundant_closure)]
+#![allow(clippy::unnecessary_lazy_evaluations)]
 #![allow(dead_code)]
 #![allow(unused_must_use)]
 

--- a/tests/ui/manual_ok_or.stderr
+++ b/tests/ui/manual_ok_or.stderr
@@ -1,5 +1,5 @@
 error: this pattern reimplements `Option::ok_or`
-  --> tests/ui/manual_ok_or.rs:11:5
+  --> tests/ui/manual_ok_or.rs:12:5
    |
 LL |     foo.map_or(Err("error"), |v| Ok(v));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `foo.ok_or("error")`
@@ -8,19 +8,19 @@ LL |     foo.map_or(Err("error"), |v| Ok(v));
    = help: to override `-D warnings` add `#[allow(clippy::manual_ok_or)]`
 
 error: this pattern reimplements `Option::ok_or`
-  --> tests/ui/manual_ok_or.rs:15:5
+  --> tests/ui/manual_ok_or.rs:16:5
    |
 LL |     foo.map_or(Err("error"), Ok);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `foo.ok_or("error")`
 
 error: this pattern reimplements `Option::ok_or`
-  --> tests/ui/manual_ok_or.rs:19:5
+  --> tests/ui/manual_ok_or.rs:20:5
    |
 LL |     None::<i32>.map_or(Err("error"), |v| Ok(v));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `None::<i32>.ok_or("error")`
 
 error: this pattern reimplements `Option::ok_or`
-  --> tests/ui/manual_ok_or.rs:24:5
+  --> tests/ui/manual_ok_or.rs:25:5
    |
 LL | /     foo.map_or(Err::<i32, &str>(
 LL | |

--- a/tests/ui/map_unwrap_or_fixable.fixed
+++ b/tests/ui/map_unwrap_or_fixable.fixed
@@ -1,6 +1,7 @@
 //@aux-build:option_helpers.rs
 
 #![warn(clippy::map_unwrap_or)]
+#![allow(clippy::unnecessary_lazy_evaluations)]
 
 #[macro_use]
 extern crate option_helpers;

--- a/tests/ui/map_unwrap_or_fixable.rs
+++ b/tests/ui/map_unwrap_or_fixable.rs
@@ -1,6 +1,7 @@
 //@aux-build:option_helpers.rs
 
 #![warn(clippy::map_unwrap_or)]
+#![allow(clippy::unnecessary_lazy_evaluations)]
 
 #[macro_use]
 extern crate option_helpers;

--- a/tests/ui/map_unwrap_or_fixable.stderr
+++ b/tests/ui/map_unwrap_or_fixable.stderr
@@ -1,5 +1,5 @@
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:16:13
+  --> tests/ui/map_unwrap_or_fixable.rs:17:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -11,7 +11,7 @@ LL | |         .unwrap_or_else(|| 0);
    = help: to override `-D warnings` add `#[allow(clippy::map_unwrap_or)]`
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:47:13
+  --> tests/ui/map_unwrap_or_fixable.rs:48:13
    |
 LL |       let _ = res.map(|x| x + 1)
    |  _____________^

--- a/tests/ui/result_map_or_into_option.fixed
+++ b/tests/ui/result_map_or_into_option.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::result_map_or_into_option)]
+#![allow(clippy::unnecessary_lazy_evaluations)]
 
 fn main() {
     let opt: Result<u32, &str> = Ok(1);

--- a/tests/ui/result_map_or_into_option.rs
+++ b/tests/ui/result_map_or_into_option.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::result_map_or_into_option)]
+#![allow(clippy::unnecessary_lazy_evaluations)]
 
 fn main() {
     let opt: Result<u32, &str> = Ok(1);

--- a/tests/ui/result_map_or_into_option.stderr
+++ b/tests/ui/result_map_or_into_option.stderr
@@ -1,5 +1,5 @@
 error: called `map_or(None, Some)` on a `Result` value
-  --> tests/ui/result_map_or_into_option.rs:5:13
+  --> tests/ui/result_map_or_into_option.rs:6:13
    |
 LL |     let _ = opt.map_or(None, Some);
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `ok`: `opt.ok()`
@@ -8,13 +8,13 @@ LL |     let _ = opt.map_or(None, Some);
    = help: to override `-D warnings` add `#[allow(clippy::result_map_or_into_option)]`
 
 error: called `map_or_else(|_| None, Some)` on a `Result` value
-  --> tests/ui/result_map_or_into_option.rs:8:13
+  --> tests/ui/result_map_or_into_option.rs:9:13
    |
 LL |     let _ = opt.map_or_else(|_| None, Some);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `ok`: `opt.ok()`
 
 error: called `map_or_else(|_| None, Some)` on a `Result` value
-  --> tests/ui/result_map_or_into_option.rs:12:13
+  --> tests/ui/result_map_or_into_option.rs:13:13
    |
 LL |     let _ = opt.map_or_else(|_| { None }, Some);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `ok`: `opt.ok()`

--- a/tests/ui/unnecessary_lazy_eval.fixed
+++ b/tests/ui/unnecessary_lazy_eval.fixed
@@ -238,6 +238,21 @@ fn main() {
     // neither bind_instead_of_map nor unnecessary_lazy_eval applies here
     let _: Result<usize, usize> = res.and_then(|x| Err(x));
     let _: Result<usize, usize> = res.or_else(|err| Ok(err));
+
+    // Issue #15829 - map_or_else
+    // Should lint - Option
+    let _ = opt.map_or(42, |_| 42);
+    //~^ unnecessary_lazy_evaluations
+
+    // Should lint - Result
+    let _ = res.map_or(42, |_| 42);
+    //~^ unnecessary_lazy_evaluations
+
+    // Should not lint - map_or_else (for unnecessary_lazy_evaluations)
+    // closure uses its parameter
+    let _ = res.map_or_else(|err| err, |x| x + 1);
+    // closure contains function call
+    let _ = opt.map_or_else(|| some_call(), |x| x + 1);
 }
 
 #[allow(unused)]

--- a/tests/ui/unnecessary_lazy_eval.rs
+++ b/tests/ui/unnecessary_lazy_eval.rs
@@ -238,6 +238,21 @@ fn main() {
     // neither bind_instead_of_map nor unnecessary_lazy_eval applies here
     let _: Result<usize, usize> = res.and_then(|x| Err(x));
     let _: Result<usize, usize> = res.or_else(|err| Ok(err));
+
+    // Issue #15829 - map_or_else
+    // Should lint - Option
+    let _ = opt.map_or_else(|| 42, |_| 42);
+    //~^ unnecessary_lazy_evaluations
+
+    // Should lint - Result
+    let _ = res.map_or_else(|_| 42, |_| 42);
+    //~^ unnecessary_lazy_evaluations
+
+    // Should not lint - map_or_else (for unnecessary_lazy_evaluations)
+    // closure uses its parameter
+    let _ = res.map_or_else(|err| err, |x| x + 1);
+    // closure contains function call
+    let _ = opt.map_or_else(|| some_call(), |x| x + 1);
 }
 
 #[allow(unused)]

--- a/tests/ui/unnecessary_lazy_eval.stderr
+++ b/tests/ui/unnecessary_lazy_eval.stderr
@@ -483,8 +483,32 @@ LL -     or_else(|_| Ok(ext_str.some_field));
 LL +     or(Ok(ext_str.some_field));
    |
 
+error: unnecessary closure used to substitute value for `Option::None`
+  --> tests/ui/unnecessary_lazy_eval.rs:244:13
+   |
+LL |     let _ = opt.map_or_else(|| 42, |_| 42);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `map_or` instead
+   |
+LL -     let _ = opt.map_or_else(|| 42, |_| 42);
+LL +     let _ = opt.map_or(42, |_| 42);
+   |
+
+error: unnecessary closure used to substitute value for `Result::Err`
+  --> tests/ui/unnecessary_lazy_eval.rs:248:13
+   |
+LL |     let _ = res.map_or_else(|_| 42, |_| 42);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `map_or` instead
+   |
+LL -     let _ = res.map_or_else(|_| 42, |_| 42);
+LL +     let _ = res.map_or(42, |_| 42);
+   |
+
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:259:14
+  --> tests/ui/unnecessary_lazy_eval.rs:274:14
    |
 LL |     let _x = false.then(|| i32::MAX + 1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -496,7 +520,7 @@ LL +     let _x = false.then_some(i32::MAX + 1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:261:14
+  --> tests/ui/unnecessary_lazy_eval.rs:276:14
    |
 LL |     let _x = false.then(|| i32::MAX * 2);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -508,7 +532,7 @@ LL +     let _x = false.then_some(i32::MAX * 2);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:263:14
+  --> tests/ui/unnecessary_lazy_eval.rs:278:14
    |
 LL |     let _x = false.then(|| i32::MAX - 1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -520,7 +544,7 @@ LL +     let _x = false.then_some(i32::MAX - 1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:265:14
+  --> tests/ui/unnecessary_lazy_eval.rs:280:14
    |
 LL |     let _x = false.then(|| i32::MIN - 1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -532,7 +556,7 @@ LL +     let _x = false.then_some(i32::MIN - 1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:267:14
+  --> tests/ui/unnecessary_lazy_eval.rs:282:14
    |
 LL |     let _x = false.then(|| (1 + 2 * 3 - 2 / 3 + 9) << 2);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -544,7 +568,7 @@ LL +     let _x = false.then_some((1 + 2 * 3 - 2 / 3 + 9) << 2);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:269:14
+  --> tests/ui/unnecessary_lazy_eval.rs:284:14
    |
 LL |     let _x = false.then(|| 255u8 << 7);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -556,7 +580,7 @@ LL +     let _x = false.then_some(255u8 << 7);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:271:14
+  --> tests/ui/unnecessary_lazy_eval.rs:286:14
    |
 LL |     let _x = false.then(|| 255u8 << 8);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -568,7 +592,7 @@ LL +     let _x = false.then_some(255u8 << 8);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:273:14
+  --> tests/ui/unnecessary_lazy_eval.rs:288:14
    |
 LL |     let _x = false.then(|| 255u8 >> 8);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -580,7 +604,7 @@ LL +     let _x = false.then_some(255u8 >> 8);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:276:14
+  --> tests/ui/unnecessary_lazy_eval.rs:291:14
    |
 LL |     let _x = false.then(|| i32::MAX + -1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -592,7 +616,7 @@ LL +     let _x = false.then_some(i32::MAX + -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:278:14
+  --> tests/ui/unnecessary_lazy_eval.rs:293:14
    |
 LL |     let _x = false.then(|| -i32::MAX);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -604,7 +628,7 @@ LL +     let _x = false.then_some(-i32::MAX);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:280:14
+  --> tests/ui/unnecessary_lazy_eval.rs:295:14
    |
 LL |     let _x = false.then(|| -i32::MIN);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -616,7 +640,7 @@ LL +     let _x = false.then_some(-i32::MIN);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:283:14
+  --> tests/ui/unnecessary_lazy_eval.rs:298:14
    |
 LL |     let _x = false.then(|| 255 >> -7);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -628,7 +652,7 @@ LL +     let _x = false.then_some(255 >> -7);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:285:14
+  --> tests/ui/unnecessary_lazy_eval.rs:300:14
    |
 LL |     let _x = false.then(|| 255 << -1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -640,7 +664,7 @@ LL +     let _x = false.then_some(255 << -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:287:14
+  --> tests/ui/unnecessary_lazy_eval.rs:302:14
    |
 LL |     let _x = false.then(|| 1 / 0);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -652,7 +676,7 @@ LL +     let _x = false.then_some(1 / 0);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:289:14
+  --> tests/ui/unnecessary_lazy_eval.rs:304:14
    |
 LL |     let _x = false.then(|| x << -1);
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -664,7 +688,7 @@ LL +     let _x = false.then_some(x << -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:291:14
+  --> tests/ui/unnecessary_lazy_eval.rs:306:14
    |
 LL |     let _x = false.then(|| x << 2);
    |              ^^^^^^^^^^^^^^^^^^^^^
@@ -676,7 +700,7 @@ LL +     let _x = false.then_some(x << 2);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:301:14
+  --> tests/ui/unnecessary_lazy_eval.rs:316:14
    |
 LL |     let _x = false.then(|| x / 0);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -688,7 +712,7 @@ LL +     let _x = false.then_some(x / 0);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:303:14
+  --> tests/ui/unnecessary_lazy_eval.rs:318:14
    |
 LL |     let _x = false.then(|| x % 0);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -700,7 +724,7 @@ LL +     let _x = false.then_some(x % 0);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:306:14
+  --> tests/ui/unnecessary_lazy_eval.rs:321:14
    |
 LL |     let _x = false.then(|| 1 / -1);
    |              ^^^^^^^^^^^^^^^^^^^^^
@@ -712,7 +736,7 @@ LL +     let _x = false.then_some(1 / -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:308:14
+  --> tests/ui/unnecessary_lazy_eval.rs:323:14
    |
 LL |     let _x = false.then(|| i32::MIN / -1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -724,7 +748,7 @@ LL +     let _x = false.then_some(i32::MIN / -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:311:14
+  --> tests/ui/unnecessary_lazy_eval.rs:326:14
    |
 LL |     let _x = false.then(|| i32::MIN / 0);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -736,7 +760,7 @@ LL +     let _x = false.then_some(i32::MIN / 0);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:313:14
+  --> tests/ui/unnecessary_lazy_eval.rs:328:14
    |
 LL |     let _x = false.then(|| 4 / 2);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -748,7 +772,7 @@ LL +     let _x = false.then_some(4 / 2);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:321:14
+  --> tests/ui/unnecessary_lazy_eval.rs:336:14
    |
 LL |     let _x = false.then(|| f1 + f2);
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -759,5 +783,5 @@ LL -     let _x = false.then(|| f1 + f2);
 LL +     let _x = false.then_some(f1 + f2);
    |
 
-error: aborting due to 63 previous errors
+error: aborting due to 65 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#15829

changelog: [`unnecessary_lazy_evaluations`]: lint for `map_or_else` to `map_or`