### PR TITLE
Update `askama` version to `0.15.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ walkdir = "2.3"
 filetime = "0.2.9"
 itertools = "0.12"
 pulldown-cmark = { version = "0.11", default-features = false, features = ["html"] }
-askama = { version = "0.14", default-features = false, features = ["alloc", "config", "derive"] }
+askama = { version = "0.15.1", default-features = false, features = ["alloc", "config", "derive"] }
 
 [dev-dependencies.toml]
 version = "0.9.7"


### PR DESCRIPTION
Just released a new version of `askama` which comes new features and better performance. That's it. :)

changelog: none