### PR TITLE
Fix `needless_for_each` FN when `for_each` is in the expr of a block

### DIFF
--- a/tests/ui/needless_for_each_fixable.fixed
+++ b/tests/ui/needless_for_each_fixable.fixed
@@ -149,3 +149,11 @@ fn issue15256() {
     for v in vec.iter() { println!("{v}"); }
     //~^ needless_for_each
 }
+
+fn issue16294() {
+    let vec: Vec<i32> = Vec::new();
+    for elem in vec.iter() {
+        //~^ needless_for_each
+        println!("{elem}");
+    }
+}

--- a/tests/ui/needless_for_each_fixable.rs
+++ b/tests/ui/needless_for_each_fixable.rs
@@ -149,3 +149,11 @@ fn issue15256() {
     vec.iter().for_each(|v| println!("{v}"));
     //~^ needless_for_each
 }
+
+fn issue16294() {
+    let vec: Vec<i32> = Vec::new();
+    vec.iter().for_each(|elem| {
+        //~^ needless_for_each
+        println!("{elem}");
+    })
+}

--- a/tests/ui/needless_for_each_fixable.stderr
+++ b/tests/ui/needless_for_each_fixable.stderr
@@ -154,5 +154,22 @@ error: needless use of `for_each`
 LL |     vec.iter().for_each(|v| println!("{v}"));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for v in vec.iter() { println!("{v}"); }`
 
-error: aborting due to 11 previous errors
+error: needless use of `for_each`
+  --> tests/ui/needless_for_each_fixable.rs:155:5
+   |
+LL | /     vec.iter().for_each(|elem| {
+LL | |
+LL | |         println!("{elem}");
+LL | |     })
+   | |______^
+   |
+help: try
+   |
+LL ~     for elem in vec.iter() {
+LL +
+LL +         println!("{elem}");
+LL +     }
+   |
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16294 

changelog: [`needless_for_each`] fix FN when `for_each` is in the expr of a block
