### PR TITLE
Fix `double_parens` FP on macro repetition patterns

### DIFF
--- a/clippy_lints/src/double_parens.rs
+++ b/clippy_lints/src/double_parens.rs
@@ -114,6 +114,8 @@ fn check_source(cx: &EarlyContext<'_>, inner: &Expr) -> bool {
         && inner.starts_with('(')
         && inner.ends_with(')')
         && outer_after_inner.trim_start().starts_with(')')
+        // Don't lint macro repetition patterns like `($($result),*)` where parens are necessary
+        && !inner.trim_start_matches('(').trim_start().starts_with("$(")
     {
         true
     } else {

--- a/tests/ui/double_parens.fixed
+++ b/tests/ui/double_parens.fixed
@@ -161,4 +161,20 @@ fn issue15940() {
     pub struct Person;
 }
 
+fn issue16224() {
+    fn test() -> i32 { 42 }
+
+    macro_rules! call {
+        ($matcher:pat $(=> $result:expr)?) => {
+            match test() {
+                $matcher => Result::Ok(($($result),*)),
+                _ => Result::Err("No match".to_string()),
+            }
+        };
+    }
+
+    let _: Result<(), String> = call!(_);
+    let _: Result<i32, String> = call!(_ => 42);
+}
+
 fn main() {}

--- a/tests/ui/double_parens.rs
+++ b/tests/ui/double_parens.rs
@@ -161,4 +161,20 @@ fn issue15940() {
     pub struct Person;
 }
 
+fn issue16224() {
+    fn test() -> i32 { 42 }
+
+    macro_rules! call {
+        ($matcher:pat $(=> $result:expr)?) => {
+            match test() {
+                $matcher => Result::Ok(($($result),*)),
+                _ => Result::Err("No match".to_string()),
+            }
+        };
+    }
+
+    let _: Result<(), String> = call!(_);
+    let _: Result<i32, String> = call!(_ => 42);
+}
+
 fn main() {}


### PR DESCRIPTION
rust-lang/rust-clippy#16224

changelog: [`double_parens`]: fix FP on macro repetition patterns