### PR TITLE
move `multiple_bound_locations` to style

### DIFF
--- a/clippy_lints/src/multiple_bound_locations.rs
+++ b/clippy_lints/src/multiple_bound_locations.rs
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.78.0"]
     pub MULTIPLE_BOUND_LOCATIONS,
-    suspicious,
+    style,
     "defining generic bounds in multiple locations"
 }
 


### PR DESCRIPTION
This PR moves the `multiple_bound_locations` lint from `suspicious` to `style`. The `suspicious` category is described as "code that is most likely wrong or useless", which is not the case here at all, so `style` seems more fitting.
Fixes rust-lang/rust-clippy#15736, with some prior discussion at https://github.com/rust-lang/rust/pull/146540.

changelog: move `multiple_bound_locations` lint to `style` group
