### PR TITLE
Allow `expect` on `impl` for `derive_ord_xor_partial_ord`

### DIFF
--- a/clippy_lints/src/derive/mod.rs
+++ b/clippy_lints/src/derive/mod.rs
@@ -208,7 +208,7 @@ impl<'tcx> LateLintPass<'tcx> for Derive {
             let is_automatically_derived = cx.tcx.is_automatically_derived(item.owner_id.to_def_id());
 
             derived_hash_with_manual_eq::check(cx, item.span, trait_ref, ty, adt_hir_id, is_automatically_derived);
-            derive_ord_xor_partial_ord::check(cx, item.span, trait_ref, ty, adt_hir_id, is_automatically_derived);
+            derive_ord_xor_partial_ord::check(cx, item, trait_ref, ty, adt_hir_id, is_automatically_derived);
 
             if is_automatically_derived {
                 unsafe_derive_deserialize::check(cx, item, trait_ref, ty, adt_hir_id);

--- a/tests/ui/derive_ord_xor_partial_ord.rs
+++ b/tests/ui/derive_ord_xor_partial_ord.rs
@@ -91,3 +91,17 @@ mod issue15708 {
         }
     }
 }
+
+mod issue16298 {
+    #[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
+    struct Normalized<S>(S);
+
+    impl<S: Eq> Eq for Normalized<S> {}
+
+    #[expect(clippy::derive_ord_xor_partial_ord)]
+    impl<S: Eq + PartialOrd> Ord for Normalized<S> {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            self.partial_cmp(other).unwrap()
+        }
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16298 

This lint flags on the type defination, while also giving a warning on the span of the impl block. It is counter-intuitive that you need to put the `expect` on top of the type defination instead of the impl block to suppress the warning, and this PR addresses that.

changelog: [`derive_ord_xor_partial_ord`] allow `expect` on `impl` block
