### PR TITLE
Fix typoed mention of config value using `_` of `-`

### DIFF
--- a/clippy_lints/src/cargo/mod.rs
+++ b/clippy_lints/src/cargo/mod.rs
@@ -132,7 +132,7 @@ declare_clippy_lint! {
     /// Because this can be caused purely by the dependencies
     /// themselves, it's not always possible to fix this issue.
     /// In those cases, you can allow that specific crate using
-    /// the `allowed_duplicate_crates` configuration option.
+    /// the `allowed-duplicate-crates` configuration option.
     ///
     /// ### Example
     /// ```toml


### PR DESCRIPTION
Fairly simple and self explanatory, the actual config value is `allowed-duplicate-crates` not `allowed_duplicate_crates` and will throw an error if you use the wrong one.

changelog: Fix typoed mention of config value using `_` of `-`
