### PR TITLE
Enhance `needless_collect` to cover vec `push`-alike

### DIFF
--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -272,6 +272,7 @@ generate! {
     product,
     push,
     push_back,
+    push_front,
     push_str,
     read,
     read_exact,

--- a/tests/ui/needless_collect.fixed
+++ b/tests/ui/needless_collect.fixed
@@ -222,7 +222,7 @@ fn issue16270() {
 
 #[warn(clippy::needless_collect)]
 mod collect_push_then_iter {
-    use std::collections::{BinaryHeap, LinkedList};
+    use std::collections::{BinaryHeap, LinkedList, VecDeque};
 
     fn vec_push(iter: impl Iterator<Item = i32>) -> Vec<i32> {
         
@@ -269,5 +269,29 @@ mod collect_push_then_iter {
         //~^ needless_collect
         
         iter.chain(s).map(|x| x + 1).collect()
+    }
+
+    fn deque_push_front(iter: impl Iterator<Item = i32>) -> VecDeque<i32> {
+        
+        //~^ needless_collect
+        
+        
+        [1, 2].into_iter().chain(iter).map(|x| x + 1).collect()
+    }
+
+    fn linked_list_push_front_mixed(
+        iter: impl Iterator<Item = i32>,
+        iter2: impl Iterator<Item = i32>,
+    ) -> LinkedList<i32> {
+        
+        //~^ needless_collect
+        
+        
+        
+        
+        
+        
+        
+        [5].into_iter().chain([1, 3].into_iter().chain(iter).chain([2]).chain(iter2)).chain([4, 6]).map(|x| x + 1).collect()
     }
 }

--- a/tests/ui/needless_collect.rs
+++ b/tests/ui/needless_collect.rs
@@ -222,7 +222,7 @@ fn issue16270() {
 
 #[warn(clippy::needless_collect)]
 mod collect_push_then_iter {
-    use std::collections::{BinaryHeap, LinkedList};
+    use std::collections::{BinaryHeap, LinkedList, VecDeque};
 
     fn vec_push(iter: impl Iterator<Item = i32>) -> Vec<i32> {
         let mut v = iter.collect::<Vec<_>>();
@@ -269,5 +269,29 @@ mod collect_push_then_iter {
         //~^ needless_collect
         ll.extend(s);
         ll.into_iter().map(|x| x + 1).collect()
+    }
+
+    fn deque_push_front(iter: impl Iterator<Item = i32>) -> VecDeque<i32> {
+        let mut v = iter.collect::<VecDeque<_>>();
+        //~^ needless_collect
+        v.push_front(1);
+        v.push_front(2);
+        v.into_iter().map(|x| x + 1).collect()
+    }
+
+    fn linked_list_push_front_mixed(
+        iter: impl Iterator<Item = i32>,
+        iter2: impl Iterator<Item = i32>,
+    ) -> LinkedList<i32> {
+        let mut v = iter.collect::<LinkedList<_>>();
+        //~^ needless_collect
+        v.push_front(1);
+        v.push_back(2);
+        v.push_front(3);
+        v.extend(iter2);
+        v.push_back(4);
+        v.push_front(5);
+        v.push_back(6);
+        v.into_iter().map(|x| x + 1).collect()
     }
 }

--- a/tests/ui/needless_collect.stderr
+++ b/tests/ui/needless_collect.stderr
@@ -190,5 +190,46 @@ LL ~
 LL ~         iter.chain(s).map(|x| x + 1).collect()
    |
 
-error: aborting due to 24 previous errors
+error: avoid using `collect()` when not needed
+  --> tests/ui/needless_collect.rs:275:26
+   |
+LL |         let mut v = iter.collect::<VecDeque<_>>();
+   |                          ^^^^^^^
+...
+LL |         v.into_iter().map(|x| x + 1).collect()
+   |         ------------- the iterator could be used here instead
+   |
+help: use the original Iterator instead of collecting it and then producing a new one
+   |
+LL ~         
+LL |
+LL ~         
+LL ~         
+LL ~         [1, 2].into_iter().chain(iter).map(|x| x + 1).collect()
+   |
+
+error: avoid using `collect()` when not needed
+  --> tests/ui/needless_collect.rs:286:26
+   |
+LL |         let mut v = iter.collect::<LinkedList<_>>();
+   |                          ^^^^^^^
+...
+LL |         v.into_iter().map(|x| x + 1).collect()
+   |         ------------- the iterator could be used here instead
+   |
+help: use the original Iterator instead of collecting it and then producing a new one
+   |
+LL ~         
+LL |
+LL ~         
+LL ~         
+LL ~         
+LL ~         
+LL ~         
+LL ~         
+LL ~         
+LL ~         [5].into_iter().chain([1, 3].into_iter().chain(iter).chain([2]).chain(iter2)).chain([4, 6]).map(|x| x + 1).collect()
+   |
+
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14946

Implemented as an enhancement to `needless_collect`

changelog: [`needless_collect`] enhance to cover vec `push`-alike cases
