### PR TITLE
Fix `implicit_saturating_sub` suggests wrongly on untyped int literal

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -90,7 +90,7 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 use itertools::Itertools;
 use rustc_abi::Integer;
 use rustc_ast::ast::{self, LitKind, RangeLimits};
-use rustc_ast::join_path_syms;
+use rustc_ast::{LitIntType, join_path_syms};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::indexmap;
 use rustc_data_structures::packed::Pu128;
@@ -1382,6 +1382,17 @@ pub fn is_integer_literal(expr: &Expr<'_>, value: u128) -> bool {
     {
         return v == value;
     }
+    false
+}
+
+/// Checks whether the given expression is an untyped integer literal.
+pub fn is_integer_literal_untyped(expr: &Expr<'_>) -> bool {
+    if let ExprKind::Lit(spanned) = expr.kind
+        && let LitKind::Int(_, suffix) = spanned.node
+    {
+        return suffix == LitIntType::Unsuffixed;
+    }
+
     false
 }
 

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -127,7 +127,7 @@ impl<'a> Sugg<'a> {
 
     /// Generate a suggestion for an expression with the given snippet. This is used by the `hir_*`
     /// function variants of `Sugg`, since these use different snippet functions.
-    fn hir_from_snippet(
+    pub fn hir_from_snippet(
         cx: &LateContext<'_>,
         expr: &hir::Expr<'_>,
         mut get_snippet: impl FnMut(Span) -> Cow<'a, str>,

--- a/tests/ui/implicit_saturating_sub.fixed
+++ b/tests/ui/implicit_saturating_sub.fixed
@@ -252,3 +252,11 @@ fn arbitrary_expression() {
         0
     };
 }
+
+fn issue16307() {
+    let x: u8 = 100;
+    let y = 100_u8.saturating_sub(x);
+    //~^ implicit_saturating_sub
+
+    println!("{y}");
+}

--- a/tests/ui/implicit_saturating_sub.rs
+++ b/tests/ui/implicit_saturating_sub.rs
@@ -326,3 +326,11 @@ fn arbitrary_expression() {
         0
     };
 }
+
+fn issue16307() {
+    let x: u8 = 100;
+    let y = if x >= 100 { 0 } else { 100 - x };
+    //~^ implicit_saturating_sub
+
+    println!("{y}");
+}

--- a/tests/ui/implicit_saturating_sub.stderr
+++ b/tests/ui/implicit_saturating_sub.stderr
@@ -238,5 +238,11 @@ error: manual arithmetic check found
 LL |     let _ = if a < b * 2 { 0 } else { a - b * 2 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `a.saturating_sub(b * 2)`
 
-error: aborting due to 27 previous errors
+error: manual arithmetic check found
+  --> tests/ui/implicit_saturating_sub.rs:332:13
+   |
+LL |     let y = if x >= 100 { 0 } else { 100 - x };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `100_u8.saturating_sub(x)`
+
+error: aborting due to 28 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16307 

changelog: [`implicit_saturating_sub`] fix wrong suggestions on untyped int literal
