### PR TITLE
Document lint levels in the book

### DIFF
--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -23,6 +23,11 @@ lint group `clippy::all`. You might want to use even more lints, or you may not
 agree with every Clippy lint, and for that there are ways to configure lint
 levels.
 
+The lint levels are:
+* allow: can appear in the source code
+* warn: emits a warning
+* deny: can't appear in the source code
+
 > _Note:_ Clippy is meant to be used with a generous sprinkling of
 > `#[allow(..)]`s through your code. So if you disagree with a lint, don't feel
 > bad disabling them for parts of your code or the whole project.


### PR DESCRIPTION
For people new to clippy, it's better to be explicit. The terminology of allow-by-default could also mean that the lint is enabled (vs. being allowed in the source code).

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: Document levels explicitly in the book 
