### PR TITLE
Fix `cloned_ref_to_slice_refs` FN on `to_owned()`

### DIFF
--- a/clippy_lints/src/cloned_ref_to_slice_refs.rs
+++ b/clippy_lints/src/cloned_ref_to_slice_refs.rs
@@ -1,15 +1,22 @@
+use std::ops::ControlFlow;
+
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::sugg::Sugg;
 use clippy_utils::visitors::is_const_evaluatable;
-use clippy_utils::{is_in_const_context, is_mutable};
+use clippy_utils::{is_in_const_context, is_mutable, sym};
+use rustc_ast::Mutability;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, HirId, LangItem};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
+use rustc_middle::ty::adjustment::{Adjust, DerefAdjustKind, OverloadedDeref};
 use rustc_session::impl_lint_pass;
-use rustc_span::sym;
+use rustc_span::Symbol;
+
+use crate::methods::is_clone_like;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -73,29 +80,116 @@ impl<'tcx> LateLintPass<'tcx> for ClonedRefToSliceRefs<'_> {
             && let ExprKind::Array([item]) = &arr.kind
 
             // check for clones
-            && let ExprKind::MethodCall(_, val, _, _) = item.kind
-            && cx.ty_based_def(item).opt_parent(cx).is_diag_item(cx, sym::Clone)
+            && let ExprKind::MethodCall(path, recv, _, _) = item.kind
+            && let Some(adjustment) = is_needless_clone_or_equivalent(cx, recv, path.ident.name, item.hir_id)
 
             // check for immutability or purity
-            && (!is_mutable(cx, val) || is_const_evaluatable(cx, val))
+            && (!is_mutable(cx, recv) || is_const_evaluatable(cx, recv))
 
             // get appropriate crate for `slice::from_ref`
             && let Some(builtin_crate) = clippy_utils::std_or_core(cx)
         {
-            let mut sugg = Sugg::hir(cx, val, "_");
-            if !cx.typeck_results().expr_ty(val).is_ref() {
-                sugg = sugg.addr();
-            }
+            let mut applicability = Applicability::MachineApplicable;
+            let sugg = Sugg::hir_with_context(cx, recv, expr.span.ctxt(), "_", &mut applicability);
 
             span_lint_and_sugg(
                 cx,
                 CLONED_REF_TO_SLICE_REFS,
                 expr.span,
-                format!("this call to `clone` can be replaced with `{builtin_crate}::slice::from_ref`"),
+                format!(
+                    "unnecessary use of `{}` to create a slice from a reference",
+                    path.ident.name
+                ),
                 "try",
-                format!("{builtin_crate}::slice::from_ref({sugg})"),
-                Applicability::MaybeIncorrect,
+                format!("{builtin_crate}::slice::from_ref({adjustment}{sugg})"),
+                applicability,
             );
         }
     }
+}
+
+/// Checks if a method call is a needless clone or equivalent. If so, returns the necessary
+/// adjustments to use the method receiver directly without cloning.
+/// For example, in the code below:
+/// ```rust,no_run
+/// use std::path::PathBuf;
+///
+/// let w = &PathBuf::new();
+/// let b = &[w.to_path_buf()];
+/// ```
+/// We would replace `&[w.to_path_buf()]` with `std::slice::from_ref(&*w)`,
+/// hence we return `Some("&*")` as the adjustment.
+fn is_needless_clone_or_equivalent<'tcx>(
+    cx: &LateContext<'tcx>,
+    method_recv: &'tcx Expr<'tcx>,
+    method_name: Symbol,
+    hir_id: HirId,
+) -> Option<String> {
+    let method_def = cx.ty_based_def(hir_id).opt_parent(cx)?;
+    if !method_def.is_lang_item(cx, LangItem::Clone) && !is_clone_like(cx, method_name, method_def) {
+        return None;
+    }
+
+    let method_ret_ty = cx.typeck_results().node_type(hir_id);
+    let method_recv_ty = cx.typeck_results().expr_ty_adjusted(method_recv);
+    let ty::Ref(_, method_recv_ty_inner, Mutability::Not) = method_recv_ty.kind() else {
+        return None;
+    };
+
+    let method_recv_adjustments = cx.typeck_results().expr_adjustments(method_recv);
+
+    // The return type of the clone-like method should be the same as the inner type of the reference
+    // being cloned, except for the following special cases:
+    // 1. `OsString`, which is first dereferenced to `OsStr` and the borrowed as `&OsStr`.
+    // 2. `PathBuf`, which is first dereferenced to `Path` and then borrowed as `&Path`.
+    let adjust_target_ty = if method_ret_ty == *method_recv_ty_inner {
+        method_ret_ty
+    } else if let Some(after_special_case_ty_name @ (sym::OsStr | sym::Path)) = method_recv_ty_inner.opt_diag_name(cx)
+        // Looking for the `OSString -> OSStr` or `PathBuf -> Path` adjustment in the abovementioned special cases
+        && let [preceeding_derefs @ .., special_case, last_borrow] = method_recv_adjustments
+        && matches!(
+            special_case.kind,
+            Adjust::Deref(DerefAdjustKind::Overloaded(OverloadedDeref {
+                mutbl: Mutability::Not,
+                ..
+            }))
+        )
+        && matches!(last_borrow.kind, Adjust::Borrow(_))
+        && special_case.target.is_diag_item(cx, after_special_case_ty_name)
+        && let before_special_case_ty = preceeding_derefs
+            .last().map_or_else(|| cx.typeck_results().expr_ty(method_recv), |a| a.target)
+        && matches!(
+            (before_special_case_ty.opt_diag_name(cx)?, after_special_case_ty_name),
+            (sym::OsString, sym::OsStr) | (sym::PathBuf, sym::Path))
+    {
+        before_special_case_ty
+    } else {
+        return None;
+    };
+
+    // Find the number of adjustments required until `method_recv_ty_source` becomes `adjust_target_ty`
+    let method_recv_ty_source = cx.typeck_results().expr_ty(method_recv);
+    let adjust_count = method_recv_adjustments
+        .iter()
+        .enumerate()
+        .try_fold(method_recv_ty_source, |ty, (i, a)| {
+            if ty == adjust_target_ty {
+                ControlFlow::Break(i)
+            } else {
+                ControlFlow::Continue(a.target)
+            }
+        })
+        .break_value()?;
+
+    let (needs_borrow, deref_count) = if adjust_count == 0 || !method_recv_ty_source.is_ref() {
+        (true, adjust_count)
+    } else {
+        (false, adjust_count - 1)
+    };
+
+    Some(if needs_borrow {
+        format!("&{}", "*".repeat(deref_count))
+    } else {
+        "*".repeat(deref_count)
+    })
 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -155,7 +155,6 @@ use clippy_utils::macros::FormatArgsStorage;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::{contains_return, iter_input_pats, peel_blocks, sym};
-pub use path_ends_with_ext::DEFAULT_ALLOWED_DOTFILES;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::{self as hir, Expr, ExprKind, Node, Stmt, StmtKind, TraitItem, TraitItemKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
@@ -164,6 +163,9 @@ use rustc_session::impl_lint_pass;
 use rustc_span::{Span, Symbol};
 
 use crate::matches::manual_filter;
+
+pub use implicit_clone::is_clone_like;
+pub use path_ends_with_ext::DEFAULT_ALLOWED_DOTFILES;
 
 declare_clippy_lint! {
     /// ### What it does

--- a/tests/ui/cloned_ref_to_slice_refs.fixed
+++ b/tests/ui/cloned_ref_to_slice_refs.fixed
@@ -1,3 +1,4 @@
+#![allow(clippy::borrow_deref_ref)]
 #![warn(clippy::cloned_ref_to_slice_refs)]
 
 #[derive(Clone)]
@@ -7,18 +8,18 @@ fn main() {
     {
         let data = Data;
         let data_ref = &data;
-        let _ = std::slice::from_ref(data_ref); //~ ERROR: this call to `clone` can be replaced with `std::slice::from_ref`
+        let _ = std::slice::from_ref(data_ref); //~ cloned_ref_to_slice_refs
     }
 
     {
-        let _ = std::slice::from_ref(&Data); //~ ERROR: this call to `clone` can be replaced with `std::slice::from_ref`
+        let _ = std::slice::from_ref(&Data); //~ cloned_ref_to_slice_refs
     }
 
     {
         #[derive(Clone)]
         struct Point(i32, i32);
 
-        let _ = std::slice::from_ref(&Point(0, 0)); //~ ERROR: this call to `clone` can be replaced with `std::slice::from_ref`
+        let _ = std::slice::from_ref(&Point(0, 0)); //~ cloned_ref_to_slice_refs
     }
 
     // the string was cloned with the intention to not mutate
@@ -61,4 +62,77 @@ fn main() {
         let data_2 = Data;
         let _ = &[data_1.clone(), data_2.clone()];
     }
+}
+
+fn issue16320(items: &[String]) {
+    use std::ffi::OsString;
+    use std::ops::Deref;
+    use std::path::PathBuf;
+
+    let _a = String::new();
+    let _b = std::slice::from_ref(&_a);
+    //~^ cloned_ref_to_slice_refs
+    let _c = std::slice::from_ref(&_a);
+    //~^ cloned_ref_to_slice_refs
+
+    let _a = OsString::new();
+    let _b = std::slice::from_ref(&_a);
+    //~^ cloned_ref_to_slice_refs
+
+    let _a = PathBuf::new();
+    let _b = std::slice::from_ref(&_a);
+    //~^ cloned_ref_to_slice_refs
+
+    let _a = &PathBuf::new();
+    let _b = std::slice::from_ref(_a);
+    //~^ cloned_ref_to_slice_refs
+
+    #[derive(Clone)]
+    struct A(i32);
+
+    impl std::fmt::Display for A {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    let a = A(42);
+    _ = &[a.to_string()];
+
+    struct Wrapper<T>(T);
+    impl<T> Deref for Wrapper<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    let w = Wrapper(String::from("hello"));
+    let w = Wrapper(w);
+    let _b = std::slice::from_ref(&**w);
+    //~^ cloned_ref_to_slice_refs
+
+    let w = Wrapper(&PathBuf::new());
+    let w = Wrapper(w);
+    let _b = std::slice::from_ref(&***w);
+    //~^ cloned_ref_to_slice_refs
+}
+
+fn wrongly_unmangled_macros(items: &[String]) {
+    use std::path::PathBuf;
+
+    struct Wrapper {
+        inner: PathBuf,
+    }
+
+    let _a = Wrapper { inner: PathBuf::new() };
+
+    macro_rules! accessor {
+        ($e:expr) => {
+            $e.inner
+        };
+    }
+
+    let _d = std::slice::from_ref(&accessor!(_a));
+    //~^ cloned_ref_to_slice_refs
 }

--- a/tests/ui/cloned_ref_to_slice_refs.rs
+++ b/tests/ui/cloned_ref_to_slice_refs.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::borrow_deref_ref)]
 #![warn(clippy::cloned_ref_to_slice_refs)]
 
 #[derive(Clone)]
@@ -7,18 +8,18 @@ fn main() {
     {
         let data = Data;
         let data_ref = &data;
-        let _ = &[data_ref.clone()]; //~ ERROR: this call to `clone` can be replaced with `std::slice::from_ref`
+        let _ = &[data_ref.clone()]; //~ cloned_ref_to_slice_refs
     }
 
     {
-        let _ = &[Data.clone()]; //~ ERROR: this call to `clone` can be replaced with `std::slice::from_ref`
+        let _ = &[Data.clone()]; //~ cloned_ref_to_slice_refs
     }
 
     {
         #[derive(Clone)]
         struct Point(i32, i32);
 
-        let _ = &[Point(0, 0).clone()]; //~ ERROR: this call to `clone` can be replaced with `std::slice::from_ref`
+        let _ = &[Point(0, 0).clone()]; //~ cloned_ref_to_slice_refs
     }
 
     // the string was cloned with the intention to not mutate
@@ -61,4 +62,77 @@ fn main() {
         let data_2 = Data;
         let _ = &[data_1.clone(), data_2.clone()];
     }
+}
+
+fn issue16320(items: &[String]) {
+    use std::ffi::OsString;
+    use std::ops::Deref;
+    use std::path::PathBuf;
+
+    let _a = String::new();
+    let _b = &[_a.to_owned()];
+    //~^ cloned_ref_to_slice_refs
+    let _c = &[_a.to_string()];
+    //~^ cloned_ref_to_slice_refs
+
+    let _a = OsString::new();
+    let _b = &[_a.to_os_string()];
+    //~^ cloned_ref_to_slice_refs
+
+    let _a = PathBuf::new();
+    let _b = &[_a.to_path_buf()];
+    //~^ cloned_ref_to_slice_refs
+
+    let _a = &PathBuf::new();
+    let _b = &[_a.to_path_buf()];
+    //~^ cloned_ref_to_slice_refs
+
+    #[derive(Clone)]
+    struct A(i32);
+
+    impl std::fmt::Display for A {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    let a = A(42);
+    _ = &[a.to_string()];
+
+    struct Wrapper<T>(T);
+    impl<T> Deref for Wrapper<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    let w = Wrapper(String::from("hello"));
+    let w = Wrapper(w);
+    let _b = &[w.to_string()];
+    //~^ cloned_ref_to_slice_refs
+
+    let w = Wrapper(&PathBuf::new());
+    let w = Wrapper(w);
+    let _b = &[w.to_path_buf()];
+    //~^ cloned_ref_to_slice_refs
+}
+
+fn wrongly_unmangled_macros(items: &[String]) {
+    use std::path::PathBuf;
+
+    struct Wrapper {
+        inner: PathBuf,
+    }
+
+    let _a = Wrapper { inner: PathBuf::new() };
+
+    macro_rules! accessor {
+        ($e:expr) => {
+            $e.inner
+        };
+    }
+
+    let _d = &[accessor!(_a).to_path_buf()];
+    //~^ cloned_ref_to_slice_refs
 }

--- a/tests/ui/cloned_ref_to_slice_refs.stderr
+++ b/tests/ui/cloned_ref_to_slice_refs.stderr
@@ -1,5 +1,5 @@
-error: this call to `clone` can be replaced with `std::slice::from_ref`
-  --> tests/ui/cloned_ref_to_slice_refs.rs:10:17
+error: unnecessary use of `clone` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:11:17
    |
 LL |         let _ = &[data_ref.clone()];
    |                 ^^^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(data_ref)`
@@ -7,17 +7,65 @@ LL |         let _ = &[data_ref.clone()];
    = note: `-D clippy::cloned-ref-to-slice-refs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::cloned_ref_to_slice_refs)]`
 
-error: this call to `clone` can be replaced with `std::slice::from_ref`
-  --> tests/ui/cloned_ref_to_slice_refs.rs:14:17
+error: unnecessary use of `clone` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:15:17
    |
 LL |         let _ = &[Data.clone()];
    |                 ^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&Data)`
 
-error: this call to `clone` can be replaced with `std::slice::from_ref`
-  --> tests/ui/cloned_ref_to_slice_refs.rs:21:17
+error: unnecessary use of `clone` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:22:17
    |
 LL |         let _ = &[Point(0, 0).clone()];
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&Point(0, 0))`
 
-error: aborting due to 3 previous errors
+error: unnecessary use of `to_owned` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:73:14
+   |
+LL |     let _b = &[_a.to_owned()];
+   |              ^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&_a)`
+
+error: unnecessary use of `to_string` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:75:14
+   |
+LL |     let _c = &[_a.to_string()];
+   |              ^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&_a)`
+
+error: unnecessary use of `to_os_string` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:79:14
+   |
+LL |     let _b = &[_a.to_os_string()];
+   |              ^^^^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&_a)`
+
+error: unnecessary use of `to_path_buf` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:83:14
+   |
+LL |     let _b = &[_a.to_path_buf()];
+   |              ^^^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&_a)`
+
+error: unnecessary use of `to_path_buf` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:87:14
+   |
+LL |     let _b = &[_a.to_path_buf()];
+   |              ^^^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(_a)`
+
+error: unnecessary use of `to_string` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:112:14
+   |
+LL |     let _b = &[w.to_string()];
+   |              ^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&**w)`
+
+error: unnecessary use of `to_path_buf` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:117:14
+   |
+LL |     let _b = &[w.to_path_buf()];
+   |              ^^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&***w)`
+
+error: unnecessary use of `to_path_buf` to create a slice from a reference
+  --> tests/ui/cloned_ref_to_slice_refs.rs:136:14
+   |
+LL |     let _d = &[accessor!(_a).to_path_buf()];
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&accessor!(_a))`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16329)*

Closes rust-lang/rust-clippy#16320 

changelog: [`cloned_ref_to_slice_refs`] fix FN on `to_owned()`
