### PR TITLE
Fix: `cmp_owned` wrongly unmangled macros

### DIFF
--- a/tests/ui/cmp_owned/with_suggestion.fixed
+++ b/tests/ui/cmp_owned/with_suggestion.fixed
@@ -83,3 +83,32 @@ fn issue_8103() {
     let _ = foo1 == foo2;
     //~^ cmp_owned
 }
+
+macro_rules! issue16322_macro_generator {
+    ($locale:ident) => {
+        mod $locale {
+            macro_rules! _make {
+                ($token:tt) => {
+                    stringify!($token)
+                };
+            }
+
+            pub(crate) use _make;
+        }
+
+        macro_rules! t {
+            ($token:tt) => {
+                crate::$locale::_make!($token)
+            };
+        }
+    };
+}
+
+issue16322_macro_generator!(de);
+
+fn issue16322(item: String) {
+    if item == t!(frohes_neu_Jahr) {
+        //~^ cmp_owned
+        println!("Ja!");
+    }
+}

--- a/tests/ui/cmp_owned/with_suggestion.rs
+++ b/tests/ui/cmp_owned/with_suggestion.rs
@@ -83,3 +83,32 @@ fn issue_8103() {
     let _ = foo1 == foo2.to_owned();
     //~^ cmp_owned
 }
+
+macro_rules! issue16322_macro_generator {
+    ($locale:ident) => {
+        mod $locale {
+            macro_rules! _make {
+                ($token:tt) => {
+                    stringify!($token)
+                };
+            }
+
+            pub(crate) use _make;
+        }
+
+        macro_rules! t {
+            ($token:tt) => {
+                crate::$locale::_make!($token)
+            };
+        }
+    };
+}
+
+issue16322_macro_generator!(de);
+
+fn issue16322(item: String) {
+    if item == t!(frohes_neu_Jahr).to_string() {
+        //~^ cmp_owned
+        println!("Ja!");
+    }
+}

--- a/tests/ui/cmp_owned/with_suggestion.stderr
+++ b/tests/ui/cmp_owned/with_suggestion.stderr
@@ -49,5 +49,11 @@ error: this creates an owned instance just for comparison
 LL |     let _ = foo1 == foo2.to_owned();
    |                     ^^^^^^^^^^^^^^^ help: try: `foo2`
 
-error: aborting due to 8 previous errors
+error: this creates an owned instance just for comparison
+  --> tests/ui/cmp_owned/with_suggestion.rs:110:16
+   |
+LL |     if item == t!(frohes_neu_Jahr).to_string() {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t!(frohes_neu_Jahr)`
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16322 

changelog: [`cmp_owned`] fix wrongly unmangled macros
