### PR TITLE
`transmuting_null`: Add checks for `without_provenance` and `without_provenance_mut`

### DIFF
--- a/tests/ui/transmuting_null.rs
+++ b/tests/ui/transmuting_null.rs
@@ -47,9 +47,20 @@ fn transumute_single_expr_blocks() {
     }
 }
 
+fn transmute_pointer_creators() {
+    unsafe {
+        let _: &u64 = std::mem::transmute(std::ptr::without_provenance::<u64>(0));
+        //~^ transmuting_null
+
+        let _: &u64 = std::mem::transmute(std::ptr::without_provenance_mut::<u64>(0));
+        //~^ transmuting_null
+    }
+}
+
 fn main() {
     one_liners();
     transmute_const();
     transmute_const_int();
     transumute_single_expr_blocks();
+    transmute_pointer_creators();
 }

--- a/tests/ui/transmuting_null.stderr
+++ b/tests/ui/transmuting_null.stderr
@@ -37,5 +37,17 @@ error: transmuting a known null pointer into a reference
 LL |         let _: &u64 = std::mem::transmute(const { u64::MIN as *const u64 });
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: transmuting a known null pointer into a reference
+  --> tests/ui/transmuting_null.rs:52:23
+   |
+LL |         let _: &u64 = std::mem::transmute(std::ptr::without_provenance::<u64>(0));
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: transmuting a known null pointer into a reference
+  --> tests/ui/transmuting_null.rs:55:23
+   |
+LL |         let _: &u64 = std::mem::transmute(std::ptr::without_provenance_mut::<u64>(0));
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
changelog: [`transmuting_null`]: now checks for [`ptr::without_provenance`](https://doc.rust-lang.org/core/ptr/fn.without_provenance.html) and [`ptr::without_provenance_mut`](https://doc.rust-lang.org/core/ptr/fn.without_provenance_mut.html) which create null pointers