### PR TITLE
Bump `askama` dev-dependency to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ walkdir = "2.3"
 filetime = "0.2.9"
 itertools = "0.12"
 pulldown-cmark = { version = "0.11", default-features = false, features = ["html"] }
-askama = { version = "0.14", default-features = false, features = ["alloc", "config", "derive"] }
+askama = { version = "0.15", default-features = false, features = ["alloc", "config", "derive"] }
 
 [dev-dependencies.toml]
 version = "0.9.7"


### PR DESCRIPTION
The rust-lang/rust workspace is currently using 0.15, so this will eliminate a duplicate dependency.
```
changelog: none
```

