### PR TITLE
Remove copyright year

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,6 +1,6 @@
 // REUSE-IgnoreStart
 
-Copyright 2014-2026 The Rust Project Developers
+Copyright (c) The Rust Project Contributors
 
 Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2014-2026 The Rust Project Developers
+Copyright (c) The Rust Project Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2026 The Rust Project Developers
+Copyright (c) The Rust Project Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ If you want to contribute to Clippy, you can find more information in [CONTRIBUT
 
 <!-- REUSE-IgnoreStart -->
 
-Copyright 2014-2026 The Rust Project Developers
+Copyright (c) The Rust Project Contributors
 
 Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)> or the MIT license

--- a/clippy_utils/README.md
+++ b/clippy_utils/README.md
@@ -30,7 +30,7 @@ Function signatures can change or be removed without replacement without any pri
 
 <!-- REUSE-IgnoreStart -->
 
-Copyright 2014-2026 The Rust Project Developers
+Copyright (c) The Rust Project Contributors
 
 Licensed under the Apache License, Version 2.0
 <[https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)> or the MIT license

--- a/rustc_tools_util/README.md
+++ b/rustc_tools_util/README.md
@@ -51,7 +51,7 @@ The changelog for `rustc_tools_util` is available under:
 
 <!-- REUSE-IgnoreStart -->
 
-Copyright 2014-2026 The Rust Project Developers
+Copyright (c) The Rust Project Contributors
 
 Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 http://www.apache.org/licenses/LICENSE-2.0> or the MIT license


### PR DESCRIPTION
https://aboutcode.org/2023/update-copyright-each-new-year/

Match wording in rust-lang/rust repo: https://github.com/rust-lang/rust/blob/4fa80a5e733e2202d7ca4c203c2fdfda41cfe7dc/LICENSE-MIT#L1C1-L1C44

changelog: none
