### PR TITLE
Do not warn about large stack arrays without having a valid span

### DIFF
--- a/clippy_lints/src/large_stack_arrays.rs
+++ b/clippy_lints/src/large_stack_arrays.rs
@@ -94,6 +94,15 @@ impl<'tcx> LateLintPass<'tcx> for LargeStackArrays {
             })
             && u128::from(self.maximum_allowed_size) < u128::from(element_count) * u128::from(element_size)
         {
+            // libtest might generate a large array containing the test cases, and no span will be associated
+            // to it. In this case it is better not to complain.
+            //
+            // Note that this condition is not checked explicitly by a unit test. Do not remove it without
+            // ensuring that <https://github.com/rust-lang/rust-clippy/issues/13774> stays fixed.
+            if expr.span.is_dummy() {
+                return;
+            }
+
             span_lint_and_then(
                 cx,
                 LARGE_STACK_ARRAYS,


### PR DESCRIPTION
The libtest harness generates an array with all the tests on the stack. However, it is generated with no location information, so we cannot tell the user anything useful.

This commit is not accompanied by a test, as it would require running Clippy on the result of libtest harness with a lot of tests, which would take a very long time. A note has been added to the source to indicate not to remove the check.

changelog: [`large_stack_arrays`]: do not warn for code auto-generated by libtest harness

Fixes rust-lang/rust-clippy#13774