### PR TITLE
missing_enforced_import_rename: Do not enforce for underscores

### DIFF
--- a/clippy_lints/src/missing_enforced_import_rename.rs
+++ b/clippy_lints/src/missing_enforced_import_rename.rs
@@ -82,7 +82,8 @@ impl LateLintPass<'_> for ImportRename {
                     && let Some(import) = match snip.split_once(" as ") {
                         None => Some(snip.as_str()),
                         Some((import, rename)) => {
-                            if rename.trim() == name.as_str() {
+                            let trimmed_rename = rename.trim();
+                            if trimmed_rename == "_" || trimmed_rename == name.as_str() {
                                 None
                             } else {
                                 Some(import.trim())

--- a/tests/ui-toml/missing_enforced_import_rename/clippy.toml
+++ b/tests/ui-toml/missing_enforced_import_rename/clippy.toml
@@ -6,5 +6,6 @@ enforced-import-renames = [
     { path = "std::clone", rename = "foo" },
     { path = "std::thread::sleep", rename = "thread_sleep" },
     { path = "std::any::type_name", rename = "ident" },
-    { path = "std::sync::Mutex", rename = "StdMutie" }
+    { path = "std::sync::Mutex", rename = "StdMutie" },
+    { path = "std::io::Write", rename = "to_test_rename_as_underscore" }
 ]

--- a/tests/ui-toml/missing_enforced_import_rename/conf_missing_enforced_import_rename.fixed
+++ b/tests/ui-toml/missing_enforced_import_rename/conf_missing_enforced_import_rename.fixed
@@ -15,6 +15,7 @@ use std::{
     sync :: Mutex as StdMutie,
     //~^ missing_enforced_import_renames
 };
+use std::io::Write as _;
 
 fn main() {
     use std::collections::BTreeMap as Map;

--- a/tests/ui-toml/missing_enforced_import_rename/conf_missing_enforced_import_rename.rs
+++ b/tests/ui-toml/missing_enforced_import_rename/conf_missing_enforced_import_rename.rs
@@ -15,6 +15,7 @@ use std::{
     sync :: Mutex,
     //~^ missing_enforced_import_renames
 };
+use std::io::Write as _;
 
 fn main() {
     use std::collections::BTreeMap as OopsWrongRename;

--- a/tests/ui-toml/missing_enforced_import_rename/conf_missing_enforced_import_rename.stderr
+++ b/tests/ui-toml/missing_enforced_import_rename/conf_missing_enforced_import_rename.stderr
@@ -32,7 +32,7 @@ LL |     sync :: Mutex,
    |     ^^^^^^^^^^^^^ help: try: `sync :: Mutex as StdMutie`
 
 error: this import should be renamed
-  --> tests/ui-toml/missing_enforced_import_rename/conf_missing_enforced_import_rename.rs:20:5
+  --> tests/ui-toml/missing_enforced_import_rename/conf_missing_enforced_import_rename.rs:21:5
    |
 LL |     use std::collections::BTreeMap as OopsWrongRename;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `use std::collections::BTreeMap as Map`


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16150 , do not error when importing anonymously using an underscore.

In the issue it is suggested that perhaps there could be a flag to enable/disable this new behavior, but I don't see a strong case for disallowing "as _" when a rename was specified.

Please let me know if you think that flag would be useful and I can implement that on top.

```
changelog: [`missing_enforced_import_rename`]: do not enforce renaming consistency in the case "import ... as _;"
```