### PR TITLE
Fix `unnecessary_to_owned` wrongly unmangled macros

### DIFF
--- a/tests/ui/unnecessary_to_owned.fixed
+++ b/tests/ui/unnecessary_to_owned.fixed
@@ -681,3 +681,12 @@ fn issue14833() {
     let mut s = HashSet::<&String>::new();
     s.remove(&"hello".to_owned());
 }
+
+#[allow(clippy::redundant_clone)]
+fn issue16351() {
+    fn take(_: impl AsRef<str>) {}
+
+    let dot = ".";
+    take(&format!("ouch{dot}"));
+    //~^ unnecessary_to_owned
+}

--- a/tests/ui/unnecessary_to_owned.rs
+++ b/tests/ui/unnecessary_to_owned.rs
@@ -681,3 +681,12 @@ fn issue14833() {
     let mut s = HashSet::<&String>::new();
     s.remove(&"hello".to_owned());
 }
+
+#[allow(clippy::redundant_clone)]
+fn issue16351() {
+    fn take(_: impl AsRef<str>) {}
+
+    let dot = ".";
+    take(format!("ouch{dot}").to_string());
+    //~^ unnecessary_to_owned
+}

--- a/tests/ui/unnecessary_to_owned.stderr
+++ b/tests/ui/unnecessary_to_owned.stderr
@@ -550,5 +550,11 @@ error: unnecessary use of `to_vec`
 LL |     s.remove(&(&["b"]).to_vec());
    |              ^^^^^^^^^^^^^^^^^^ help: replace it with: `(&["b"]).as_slice()`
 
-error: aborting due to 82 previous errors
+error: unnecessary use of `to_string`
+  --> tests/ui/unnecessary_to_owned.rs:690:10
+   |
+LL |     take(format!("ouch{dot}").to_string());
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `&format!("ouch{dot}")`
+
+error: aborting due to 83 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16351 

changelog: [`unnecessary_to_owned`] fix wrongly unmangled macros
