### PR TITLE
Fix `significant_drop_tightening` suggests wrongly for non-method usage

### DIFF
--- a/tests/ui/significant_drop_tightening.fixed
+++ b/tests/ui/significant_drop_tightening.fixed
@@ -146,3 +146,39 @@ pub fn unnecessary_contention_with_single_owned_results() {
 pub fn do_heavy_computation_that_takes_time<T>(_: T) {}
 
 fn main() {}
+
+fn issue15574() {
+    use std::io::{BufRead, Read, stdin};
+    use std::process;
+
+    println!("Hello, what's your name?");
+    
+    let mut stdin = stdin().lock().take(40);
+    //~^ significant_drop_tightening
+    let mut buffer = String::with_capacity(10);
+
+    
+    //~^ significant_drop_tightening
+    if stdin.read_line(&mut buffer).is_err() {
+        eprintln!("An error has occured while reading.");
+        return;
+    }
+    drop(stdin);
+    println!("Our string has a capacity of {}", buffer.capacity());
+    println!("Hello {}!", buffer);
+}
+
+fn issue16343() {
+    fn get_items(x: &()) -> Vec<()> {
+        vec![*x]
+    }
+
+    let storage = Mutex::new(());
+    let lock = storage.lock().unwrap();
+    //~^ significant_drop_tightening
+    let items = get_items(&lock);
+    drop(lock);
+    for item in items {
+        println!("item {:?}", item);
+    }
+}

--- a/tests/ui/significant_drop_tightening.stderr
+++ b/tests/ui/significant_drop_tightening.stderr
@@ -83,5 +83,74 @@ LL |
 LL ~         
    |
 
-error: aborting due to 4 previous errors
+error: temporary with significant `Drop` can be early dropped
+  --> tests/ui/significant_drop_tightening.rs:151:9
+   |
+LL |   fn issue15574() {
+   |  _________________-
+LL | |     use std::io::{BufRead, Read, stdin};
+LL | |     use std::process;
+...  |
+LL | |     let stdin = stdin().lock();
+   | |         ^^^^^
+...  |
+LL | |     println!("Hello {}!", buffer);
+LL | | }
+   | |_- temporary `stdin` is currently being dropped at the end of its contained scope
+   |
+   = note: this might lead to unnecessary resource contention
+help: merge the temporary construction with its single usage
+   |
+LL ~     
+LL +     let mut stdin = stdin().lock().take(40);
+LL |
+LL |     let mut buffer = String::with_capacity(10);
+LL |
+LL ~     
+   |
+
+error: temporary with significant `Drop` can be early dropped
+  --> tests/ui/significant_drop_tightening.rs:155:13
+   |
+LL |   fn issue15574() {
+   |  _________________-
+LL | |     use std::io::{BufRead, Read, stdin};
+LL | |     use std::process;
+...  |
+LL | |     let mut stdin = stdin.take(40);
+   | |             ^^^^^
+...  |
+LL | |     println!("Hello {}!", buffer);
+LL | | }
+   | |_- temporary `stdin` is currently being dropped at the end of its contained scope
+   |
+   = note: this might lead to unnecessary resource contention
+help: drop the temporary after the end of its last usage
+   |
+LL ~     }
+LL +     drop(stdin);
+   |
+
+error: temporary with significant `Drop` can be early dropped
+  --> tests/ui/significant_drop_tightening.rs:171:9
+   |
+LL |   fn issue16343() {
+   |  _________________-
+LL | |     fn get_items(x: &()) -> Vec<()> {
+LL | |         vec![*x]
+...  |
+LL | |     let lock = storage.lock().unwrap();
+   | |         ^^^^
+...  |
+LL | | }
+   | |_- temporary `lock` is currently being dropped at the end of its contained scope
+   |
+   = note: this might lead to unnecessary resource contention
+help: drop the temporary after the end of its last usage
+   |
+LL ~     let items = get_items(&lock);
+LL +     drop(lock);
+   |
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16343 
Closes rust-lang/rust-clippy#15574

----

changelog: [`significant_drop_tightening`]: fix wrong suggestions for non-method usage
