### PR TITLE
The path from a type to itself is `Self`

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -3256,6 +3256,8 @@ fn maybe_get_relative_path(from: &DefPath, to: &DefPath, max_super: usize) -> St
                 None
             }
         })))
+    } else if go_up_by == 0 && path.is_empty() {
+        String::from("Self")
     } else {
         join_path_syms(repeat_n(kw::Super, go_up_by).chain(path))
     }

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -643,3 +643,12 @@ where
 {
     maybe.map(|x| visitor(x));
 }
+
+trait Issue16360: Sized {
+    fn method(&self);
+
+    fn ice_machine(array: [Self; 1]) {
+        array.iter().for_each(Self::method);
+        //~^ redundant_closure_for_method_calls
+    }
+}

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -643,3 +643,12 @@ where
 {
     maybe.map(|x| visitor(x));
 }
+
+trait Issue16360: Sized {
+    fn method(&self);
+
+    fn ice_machine(array: [Self; 1]) {
+        array.iter().for_each(|item| item.method());
+        //~^ redundant_closure_for_method_calls
+    }
+}

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -256,5 +256,11 @@ error: redundant closure
 LL |         .map(|n| f(n))
    |              ^^^^^^^^ help: replace the closure with the function itself: `f`
 
-error: aborting due to 42 previous errors
+error: redundant closure
+  --> tests/ui/eta.rs:651:31
+   |
+LL |         array.iter().for_each(|item| item.method());
+   |                               ^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `Self::method`
+
+error: aborting due to 43 previous errors
 


### PR DESCRIPTION
changelog: [`redundant_closure_for_method_calls`]: fix ICE when computing the path from a type to itself

Fixes rust-lang/rust-clippy#16360 