### PR TITLE
fix(single_range_in_vec_init): don't apply the suggestion automatically

### DIFF
--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -98,7 +98,7 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
             && snippet.starts_with(suggested_type.starts_with())
             && snippet.ends_with(suggested_type.ends_with())
         {
-            let mut applicability = Applicability::MachineApplicable;
+            let mut applicability = Applicability::MaybeIncorrect;
             let (start_snippet, _) = snippet_with_context(cx, start.expr.span, span.ctxt(), "..", &mut applicability);
             let (end_snippet, _) = snippet_with_context(cx, end.expr.span, span.ctxt(), "..", &mut applicability);
 

--- a/tests/ui/single_range_in_vec_init_unfixable.rs
+++ b/tests/ui/single_range_in_vec_init_unfixable.rs
@@ -1,0 +1,12 @@
+//@no-rustfix
+#![warn(clippy::single_range_in_vec_init)]
+
+use std::ops::Range;
+
+fn issue16306(v: &[i32]) {
+    fn takes_range_slice(_: &[Range<i64>]) {}
+
+    let len = v.len();
+    takes_range_slice(&[0..len as i64]);
+    //~^ single_range_in_vec_init
+}

--- a/tests/ui/single_range_in_vec_init_unfixable.stderr
+++ b/tests/ui/single_range_in_vec_init_unfixable.stderr
@@ -1,0 +1,16 @@
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:10:24
+   |
+LL |     takes_range_slice(&[0..len as i64]);
+   |                        ^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::single-range-in-vec-init` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::single_range_in_vec_init)]`
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     takes_range_slice(&[0..len as i64]);
+LL +     takes_range_slice(&(0..len as i64).collect::<std::vec::Vec<i64>>());
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/16306

changelog: [`single_range_in_vec_init`]: don't apply the suggestion automatically