### PR TITLE
fix(useless_conversion): respect reduced applicability

### DIFF
--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -365,7 +365,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                             format!("useless conversion to the same type: `{b}`"),
                             "consider removing `.into_iter()`",
                             sugg,
-                            Applicability::MachineApplicable, // snippet
+                            applicability,
                         );
                     }
                 }


### PR DESCRIPTION
changelog: [`useless_conversion`]: respect reduced applicability
