### PR TITLE
fix `clippy_utils::std_or_core(_)`

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2031,12 +2031,12 @@ pub fn is_expr_temporary_value(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
 }
 
 pub fn std_or_core(cx: &LateContext<'_>) -> Option<&'static str> {
-    if !is_no_std_crate(cx) {
-        Some("std")
-    } else if !is_no_core_crate(cx) {
+    if is_no_core_crate(cx) {
+        None
+    } else if is_no_std_crate(cx) {
         Some("core")
     } else {
-        None
+        Some("std")
     }
 }
 


### PR DESCRIPTION
While working on rust-lang/rust-clippy#16368, I found that this function doesn't work correctly, presumably because the author was befuddled with the negation.

r? @samueltardieu

---

changelog: none
