### PR TITLE
refactor: use type-based checks in `arithmetic_side_effects`

### DIFF
--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -65,7 +65,20 @@ impl ArithmeticSideEffects {
 
     /// Checks if the lhs and the rhs types of a binary operation like "addition" or
     /// "multiplication" are present in the inner set of allowed types.
-    fn has_allowed_binary(&self, lhs_ty: Ty<'_>, rhs_ty: Ty<'_>) -> bool {
+    fn has_allowed_binary(&self, cx: &LateContext<'_>, lhs_ty: Ty<'_>, rhs_ty: Ty<'_>) -> bool {
+        if let (ty::Float(lhs_float), ty::Float(rhs_float)) = (lhs_ty.kind(), rhs_ty.kind())
+            && lhs_float == rhs_float
+            && matches!(lhs_float, ty::FloatTy::F32 | ty::FloatTy::F64)
+        {
+            return true;
+        }
+
+        if matches!(lhs_ty.opt_diag_name(cx), Some(sym::String))
+            && (rhs_ty.is_str() || matches!(rhs_ty.opt_diag_name(cx), Some(sym::String)))
+        {
+            return true;
+        }
+
         let lhs_ty_string = lhs_ty.to_string();
         let lhs_ty_string_elem = lhs_ty_string.split('<').next().unwrap_or_default();
         let rhs_ty_string = rhs_ty.to_string();
@@ -86,7 +99,17 @@ impl ArithmeticSideEffects {
 
     /// Checks if the type of an unary operation like "negation" is present in the inner set of
     /// allowed types.
-    fn has_allowed_unary(&self, ty: Ty<'_>) -> bool {
+    fn has_allowed_unary(&self, cx: &LateContext<'_>, ty: Ty<'_>) -> bool {
+        if let ty::Float(float_ty) = ty.kind()
+            && matches!(float_ty, ty::FloatTy::F32 | ty::FloatTy::F64)
+        {
+            return true;
+        }
+
+        if matches!(ty.opt_diag_name(cx), Some(sym::Saturating | sym::Wrapping)) {
+            return true;
+        }
+
         let ty_string = ty.to_string();
         let ty_string_elem = ty_string.split('<').next().unwrap_or_default();
         self.allowed_unary.contains(ty_string_elem)
@@ -167,7 +190,7 @@ impl ArithmeticSideEffects {
 
         let lhs_ty = cx.typeck_results().expr_ty(actual_lhs).peel_refs();
         let rhs_ty = cx.typeck_results().expr_ty_adjusted(actual_rhs).peel_refs();
-        if self.has_allowed_binary(lhs_ty, rhs_ty)
+        if self.has_allowed_binary(cx, lhs_ty, rhs_ty)
             | has_specific_allowed_type_and_operation(cx, lhs_ty, op, rhs_ty)
             | is_safe_due_to_smaller_source_type(cx, op, (actual_lhs, lhs_ty), actual_rhs)
             | is_safe_due_to_smaller_source_type(cx, op, (actual_rhs, rhs_ty), actual_lhs)
@@ -253,7 +276,7 @@ impl ArithmeticSideEffects {
             return;
         }
         let ty = cx.typeck_results().expr_ty_adjusted(expr).peel_refs();
-        if self.has_allowed_unary(ty) {
+        if self.has_allowed_unary(cx, ty) {
             return;
         }
         let actual_un_expr = peel_hir_expr_refs(un_expr).0;

--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -73,9 +73,7 @@ impl ArithmeticSideEffects {
             return true;
         }
 
-        if matches!(lhs_ty.opt_diag_name(cx), Some(sym::String))
-            && (rhs_ty.is_str() || matches!(rhs_ty.opt_diag_name(cx), Some(sym::String)))
-        {
+        if lhs_ty.is_diag_item(cx, sym::String) && (rhs_ty.is_str() || rhs_ty.is_diag_item(cx, sym::String)) {
             return true;
         }
 

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -180,15 +180,23 @@ pub fn lookup_path_str(tcx: TyCtxt<'_>, ns: PathNS, path: &str) -> Vec<DefId> {
 /// [2]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.downcast-1
 /// [3]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.downcast-2
 pub fn lookup_path(tcx: TyCtxt<'_>, ns: PathNS, path: &[Symbol]) -> Vec<DefId> {
-    let (root, rest) = match *path {
-        [] | [_] => return Vec::new(),
-        [root, ref rest @ ..] => (root, rest),
-    };
-
     let mut out = Vec::new();
-    for &base in find_crates(tcx, root).iter().chain(find_primitive_impls(tcx, root)) {
-        lookup_with_base(tcx, base, ns, rest, &mut out);
+
+    match *path {
+        [] => {},
+        // Single segment: search from current crate root
+        // This allows resolving local type names like "Foo" from clippy.toml
+        [_name] => {
+            lookup_with_base(tcx, LOCAL_CRATE.as_def_id(), ns, path, &mut out);
+        },
+        // Multi-segment paths: existing behavior
+        [root, ref rest @ ..] => {
+            for &base in find_crates(tcx, root).iter().chain(find_primitive_impls(tcx, root)) {
+                lookup_with_base(tcx, base, ns, rest, &mut out);
+            }
+        },
     }
+
     out
 }
 

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -187,6 +187,19 @@ pub fn hard_coded_allowed() {
     let _ = inferred_saturating + inferred_saturating;
     let _ = inferred_string + "";
     let _ = inferred_wrapping + inferred_wrapping;
+
+    // Type aliases should also be allowed (regression test for type alias handling)
+    type MySaturating = Saturating<u32>;
+    type MyWrapping = Wrapping<u32>;
+    type MyString = String;
+
+    let sat_alias: MySaturating = Saturating(0u32);
+    let wrap_alias: MyWrapping = Wrapping(0u32);
+    let str_alias: MyString = String::new();
+
+    let _ = sat_alias + sat_alias;
+    let _ = wrap_alias + wrap_alias;
+    let _ = str_alias + "";
 }
 
 #[rustfmt::skip]

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -14,775 +14,775 @@ LL |     let _ = 1f128 + 1f128;
    |             ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:311:5
+  --> tests/ui/arithmetic_side_effects.rs:324:5
    |
 LL |     _n += 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:313:5
+  --> tests/ui/arithmetic_side_effects.rs:326:5
    |
 LL |     _n += &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:315:5
+  --> tests/ui/arithmetic_side_effects.rs:328:5
    |
 LL |     _n -= 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:317:5
+  --> tests/ui/arithmetic_side_effects.rs:330:5
    |
 LL |     _n -= &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:319:5
+  --> tests/ui/arithmetic_side_effects.rs:332:5
    |
 LL |     _n /= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:321:5
+  --> tests/ui/arithmetic_side_effects.rs:334:5
    |
 LL |     _n /= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:323:5
+  --> tests/ui/arithmetic_side_effects.rs:336:5
    |
 LL |     _n %= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:325:5
+  --> tests/ui/arithmetic_side_effects.rs:338:5
    |
 LL |     _n %= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:327:5
+  --> tests/ui/arithmetic_side_effects.rs:340:5
    |
 LL |     _n *= 2;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:329:5
+  --> tests/ui/arithmetic_side_effects.rs:342:5
    |
 LL |     _n *= &2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:331:5
+  --> tests/ui/arithmetic_side_effects.rs:344:5
    |
 LL |     _n += -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:333:5
+  --> tests/ui/arithmetic_side_effects.rs:346:5
    |
 LL |     _n += &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:335:5
+  --> tests/ui/arithmetic_side_effects.rs:348:5
    |
 LL |     _n -= -1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:337:5
+  --> tests/ui/arithmetic_side_effects.rs:350:5
    |
 LL |     _n -= &-1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:339:5
+  --> tests/ui/arithmetic_side_effects.rs:352:5
    |
 LL |     _n /= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:341:5
+  --> tests/ui/arithmetic_side_effects.rs:354:5
    |
 LL |     _n /= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:343:5
+  --> tests/ui/arithmetic_side_effects.rs:356:5
    |
 LL |     _n %= -0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:345:5
+  --> tests/ui/arithmetic_side_effects.rs:358:5
    |
 LL |     _n %= &-0;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:347:5
+  --> tests/ui/arithmetic_side_effects.rs:360:5
    |
 LL |     _n *= -2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:349:5
+  --> tests/ui/arithmetic_side_effects.rs:362:5
    |
 LL |     _n *= &-2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:351:5
+  --> tests/ui/arithmetic_side_effects.rs:364:5
    |
 LL |     _custom += Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:353:5
+  --> tests/ui/arithmetic_side_effects.rs:366:5
    |
 LL |     _custom += &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:355:5
+  --> tests/ui/arithmetic_side_effects.rs:368:5
    |
 LL |     _custom -= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:357:5
+  --> tests/ui/arithmetic_side_effects.rs:370:5
    |
 LL |     _custom -= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:359:5
+  --> tests/ui/arithmetic_side_effects.rs:372:5
    |
 LL |     _custom /= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:361:5
+  --> tests/ui/arithmetic_side_effects.rs:374:5
    |
 LL |     _custom /= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:363:5
+  --> tests/ui/arithmetic_side_effects.rs:376:5
    |
 LL |     _custom %= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:365:5
+  --> tests/ui/arithmetic_side_effects.rs:378:5
    |
 LL |     _custom %= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:367:5
+  --> tests/ui/arithmetic_side_effects.rs:380:5
    |
 LL |     _custom *= Custom;
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:369:5
+  --> tests/ui/arithmetic_side_effects.rs:382:5
    |
 LL |     _custom *= &Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:371:5
+  --> tests/ui/arithmetic_side_effects.rs:384:5
    |
 LL |     _custom >>= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:373:5
+  --> tests/ui/arithmetic_side_effects.rs:386:5
    |
 LL |     _custom >>= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:375:5
+  --> tests/ui/arithmetic_side_effects.rs:388:5
    |
 LL |     _custom <<= Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:377:5
+  --> tests/ui/arithmetic_side_effects.rs:390:5
    |
 LL |     _custom <<= &Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:379:5
+  --> tests/ui/arithmetic_side_effects.rs:392:5
    |
 LL |     _custom += -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:381:5
+  --> tests/ui/arithmetic_side_effects.rs:394:5
    |
 LL |     _custom += &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:383:5
+  --> tests/ui/arithmetic_side_effects.rs:396:5
    |
 LL |     _custom -= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:385:5
+  --> tests/ui/arithmetic_side_effects.rs:398:5
    |
 LL |     _custom -= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:387:5
+  --> tests/ui/arithmetic_side_effects.rs:400:5
    |
 LL |     _custom /= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:389:5
+  --> tests/ui/arithmetic_side_effects.rs:402:5
    |
 LL |     _custom /= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:391:5
+  --> tests/ui/arithmetic_side_effects.rs:404:5
    |
 LL |     _custom %= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:393:5
+  --> tests/ui/arithmetic_side_effects.rs:406:5
    |
 LL |     _custom %= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:395:5
+  --> tests/ui/arithmetic_side_effects.rs:408:5
    |
 LL |     _custom *= -Custom;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:397:5
+  --> tests/ui/arithmetic_side_effects.rs:410:5
    |
 LL |     _custom *= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:399:5
+  --> tests/ui/arithmetic_side_effects.rs:412:5
    |
 LL |     _custom >>= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:401:5
+  --> tests/ui/arithmetic_side_effects.rs:414:5
    |
 LL |     _custom >>= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:403:5
+  --> tests/ui/arithmetic_side_effects.rs:416:5
    |
 LL |     _custom <<= -Custom;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:405:5
+  --> tests/ui/arithmetic_side_effects.rs:418:5
    |
 LL |     _custom <<= &-Custom;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:409:10
+  --> tests/ui/arithmetic_side_effects.rs:422:10
    |
 LL |     _n = _n + 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:411:10
+  --> tests/ui/arithmetic_side_effects.rs:424:10
    |
 LL |     _n = _n + &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:413:10
+  --> tests/ui/arithmetic_side_effects.rs:426:10
    |
 LL |     _n = 1 + _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:415:10
+  --> tests/ui/arithmetic_side_effects.rs:428:10
    |
 LL |     _n = &1 + _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:417:10
+  --> tests/ui/arithmetic_side_effects.rs:430:10
    |
 LL |     _n = _n - 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:419:10
+  --> tests/ui/arithmetic_side_effects.rs:432:10
    |
 LL |     _n = _n - &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:421:10
+  --> tests/ui/arithmetic_side_effects.rs:434:10
    |
 LL |     _n = 1 - _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:423:10
+  --> tests/ui/arithmetic_side_effects.rs:436:10
    |
 LL |     _n = &1 - _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:425:10
+  --> tests/ui/arithmetic_side_effects.rs:438:10
    |
 LL |     _n = _n / 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:427:10
+  --> tests/ui/arithmetic_side_effects.rs:440:10
    |
 LL |     _n = _n / &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:429:10
+  --> tests/ui/arithmetic_side_effects.rs:442:10
    |
 LL |     _n = _n % 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:431:10
+  --> tests/ui/arithmetic_side_effects.rs:444:10
    |
 LL |     _n = _n % &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:433:10
+  --> tests/ui/arithmetic_side_effects.rs:446:10
    |
 LL |     _n = _n * 2;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:435:10
+  --> tests/ui/arithmetic_side_effects.rs:448:10
    |
 LL |     _n = _n * &2;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:437:10
+  --> tests/ui/arithmetic_side_effects.rs:450:10
    |
 LL |     _n = 2 * _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:439:10
+  --> tests/ui/arithmetic_side_effects.rs:452:10
    |
 LL |     _n = &2 * _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:441:10
+  --> tests/ui/arithmetic_side_effects.rs:454:10
    |
 LL |     _n = 23 + &85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:443:10
+  --> tests/ui/arithmetic_side_effects.rs:456:10
    |
 LL |     _n = &23 + 85;
    |          ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:445:10
+  --> tests/ui/arithmetic_side_effects.rs:458:10
    |
 LL |     _n = &23 + &85;
    |          ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:447:15
+  --> tests/ui/arithmetic_side_effects.rs:460:15
    |
 LL |     _custom = _custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:449:15
+  --> tests/ui/arithmetic_side_effects.rs:462:15
    |
 LL |     _custom = _custom + &_custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:451:15
+  --> tests/ui/arithmetic_side_effects.rs:464:15
    |
 LL |     _custom = Custom + _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:453:15
+  --> tests/ui/arithmetic_side_effects.rs:466:15
    |
 LL |     _custom = &Custom + _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:455:15
+  --> tests/ui/arithmetic_side_effects.rs:468:15
    |
 LL |     _custom = _custom - Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:457:15
+  --> tests/ui/arithmetic_side_effects.rs:470:15
    |
 LL |     _custom = _custom - &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:459:15
+  --> tests/ui/arithmetic_side_effects.rs:472:15
    |
 LL |     _custom = Custom - _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:461:15
+  --> tests/ui/arithmetic_side_effects.rs:474:15
    |
 LL |     _custom = &Custom - _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:463:15
+  --> tests/ui/arithmetic_side_effects.rs:476:15
    |
 LL |     _custom = _custom / Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:465:15
+  --> tests/ui/arithmetic_side_effects.rs:478:15
    |
 LL |     _custom = _custom / &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:467:15
+  --> tests/ui/arithmetic_side_effects.rs:480:15
    |
 LL |     _custom = _custom % Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:469:15
+  --> tests/ui/arithmetic_side_effects.rs:482:15
    |
 LL |     _custom = _custom % &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:471:15
+  --> tests/ui/arithmetic_side_effects.rs:484:15
    |
 LL |     _custom = _custom * Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:473:15
+  --> tests/ui/arithmetic_side_effects.rs:486:15
    |
 LL |     _custom = _custom * &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:475:15
+  --> tests/ui/arithmetic_side_effects.rs:488:15
    |
 LL |     _custom = Custom * _custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:477:15
+  --> tests/ui/arithmetic_side_effects.rs:490:15
    |
 LL |     _custom = &Custom * _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:479:15
+  --> tests/ui/arithmetic_side_effects.rs:492:15
    |
 LL |     _custom = Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:481:15
+  --> tests/ui/arithmetic_side_effects.rs:494:15
    |
 LL |     _custom = &Custom + Custom;
    |               ^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:483:15
+  --> tests/ui/arithmetic_side_effects.rs:496:15
    |
 LL |     _custom = &Custom + &Custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:485:15
+  --> tests/ui/arithmetic_side_effects.rs:498:15
    |
 LL |     _custom = _custom >> _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:487:15
+  --> tests/ui/arithmetic_side_effects.rs:500:15
    |
 LL |     _custom = _custom >> &_custom;
    |               ^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:489:15
+  --> tests/ui/arithmetic_side_effects.rs:502:15
    |
 LL |     _custom = Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:491:15
+  --> tests/ui/arithmetic_side_effects.rs:504:15
    |
 LL |     _custom = &Custom << _custom;
    |               ^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:495:23
+  --> tests/ui/arithmetic_side_effects.rs:508:23
    |
 LL |     _n.saturating_div(0);
    |                       ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:497:21
+  --> tests/ui/arithmetic_side_effects.rs:510:21
    |
 LL |     _n.wrapping_div(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:499:21
+  --> tests/ui/arithmetic_side_effects.rs:512:21
    |
 LL |     _n.wrapping_rem(0);
    |                     ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:501:28
+  --> tests/ui/arithmetic_side_effects.rs:514:28
    |
 LL |     _n.wrapping_rem_euclid(0);
    |                            ^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:504:23
+  --> tests/ui/arithmetic_side_effects.rs:517:23
    |
 LL |     _n.saturating_div(_n);
    |                       ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:506:21
+  --> tests/ui/arithmetic_side_effects.rs:519:21
    |
 LL |     _n.wrapping_div(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:508:21
+  --> tests/ui/arithmetic_side_effects.rs:521:21
    |
 LL |     _n.wrapping_rem(_n);
    |                     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:510:28
+  --> tests/ui/arithmetic_side_effects.rs:523:28
    |
 LL |     _n.wrapping_rem_euclid(_n);
    |                            ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:513:23
+  --> tests/ui/arithmetic_side_effects.rs:526:23
    |
 LL |     _n.saturating_div(*Box::new(_n));
    |                       ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:517:10
+  --> tests/ui/arithmetic_side_effects.rs:530:10
    |
 LL |     _n = -_n;
    |          ^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:519:10
+  --> tests/ui/arithmetic_side_effects.rs:532:10
    |
 LL |     _n = -&_n;
    |          ^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:521:15
+  --> tests/ui/arithmetic_side_effects.rs:534:15
    |
 LL |     _custom = -_custom;
    |               ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:523:15
+  --> tests/ui/arithmetic_side_effects.rs:536:15
    |
 LL |     _custom = -&_custom;
    |               ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:525:9
+  --> tests/ui/arithmetic_side_effects.rs:538:9
    |
 LL |     _ = -*Box::new(_n);
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:535:5
+  --> tests/ui/arithmetic_side_effects.rs:548:5
    |
 LL |     1 + i;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:537:5
+  --> tests/ui/arithmetic_side_effects.rs:550:5
    |
 LL |     i * 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:539:5
+  --> tests/ui/arithmetic_side_effects.rs:552:5
    |
 LL |     1 % i / 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:541:5
+  --> tests/ui/arithmetic_side_effects.rs:554:5
    |
 LL |     i - 2 + 2 - i;
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:543:5
+  --> tests/ui/arithmetic_side_effects.rs:556:5
    |
 LL |     -i;
    |     ^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:555:5
+  --> tests/ui/arithmetic_side_effects.rs:568:5
    |
 LL |     i += 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:557:5
+  --> tests/ui/arithmetic_side_effects.rs:570:5
    |
 LL |     i -= 1;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:559:5
+  --> tests/ui/arithmetic_side_effects.rs:572:5
    |
 LL |     i *= 2;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:562:5
+  --> tests/ui/arithmetic_side_effects.rs:575:5
    |
 LL |     i /= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:565:5
+  --> tests/ui/arithmetic_side_effects.rs:578:5
    |
 LL |     i /= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:567:5
+  --> tests/ui/arithmetic_side_effects.rs:580:5
    |
 LL |     i /= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:570:5
+  --> tests/ui/arithmetic_side_effects.rs:583:5
    |
 LL |     i %= 0;
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:573:5
+  --> tests/ui/arithmetic_side_effects.rs:586:5
    |
 LL |     i %= var1;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:575:5
+  --> tests/ui/arithmetic_side_effects.rs:588:5
    |
 LL |     i %= var2;
    |     ^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:586:5
+  --> tests/ui/arithmetic_side_effects.rs:599:5
    |
 LL |     10 / a
    |     ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:641:9
+  --> tests/ui/arithmetic_side_effects.rs:654:9
    |
 LL |         x / maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:646:9
+  --> tests/ui/arithmetic_side_effects.rs:659:9
    |
 LL |         x % maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:658:5
+  --> tests/ui/arithmetic_side_effects.rs:671:5
    |
 LL |     one.add_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:663:5
+  --> tests/ui/arithmetic_side_effects.rs:676:5
    |
 LL |     one.sub_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:684:5
+  --> tests/ui/arithmetic_side_effects.rs:697:5
    |
 LL |     one.add(&one);
    |     ^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:686:5
+  --> tests/ui/arithmetic_side_effects.rs:699:5
    |
 LL |     Box::new(one).add(one);
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:695:13
+  --> tests/ui/arithmetic_side_effects.rs:708:13
    |
 LL |     let _ = u128::MAX + u128::from(1u8);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:712:13
+  --> tests/ui/arithmetic_side_effects.rs:725:13
    |
 LL |     let _ = u128::MAX * u128::from(1u8);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:735:33
+  --> tests/ui/arithmetic_side_effects.rs:748:33
    |
 LL |     let _ = Duration::from_secs(86400 * Foo::from(1));
    |                                 ^^^^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:741:33
+  --> tests/ui/arithmetic_side_effects.rs:754:33
    |
 LL |     let _ = Duration::from_secs(86400 * shift(1));
    |                                 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR refactors `arithmetic_side_effects` to use type-based checks instead of string representation matching, as suggested in rust-lang/rust-clippy#16359.

## Changes

Replaced string-based type comparison in `has_allowed_binary()` and `has_allowed_unary()` with proper type system checks:

- **Float types**: Use `ty::FloatTy::F32 | ty::FloatTy::F64` matching via `ty.kind()`
- **String type**: Use `opt_diag_name()` to check for `sym::String`
- **Saturating/Wrapping**: Use `opt_diag_name()` for `sym::Saturating | sym::Wrapping`

This follows the pattern used in `disallowed_types` lint.

## Benefits

- Correctly handles type aliases (`core::num::Wrapping` == `std::num::Wrapping`)
- More efficient than string comparison
- No behavior change for existing functionality

String-based matching is preserved as fallback for user-configured types from `clippy.toml`.

## Testing

All `arithmetic_side_effects` tests pass.

---

changelog: [`arithmetic_side_effects`]: use type-based matching instead of strings

Fixes rust-lang/rust-clippy#16359