### PR TITLE
Do not ignore statements before a `break` when simplifying loop

### DIFF
--- a/tests/ui/while_let_loop.rs
+++ b/tests/ui/while_let_loop.rs
@@ -253,3 +253,24 @@ fn let_assign() {
         }
     }
 }
+
+fn issue16378() {
+    // This does not lint today because of the extra statement(s)
+    // before the `break`.
+    // TODO: When the `break` statement/expr in the `let`/`else` is the
+    // only way to leave the loop, the lint could trigger and move
+    // the statements preceeding the `break` after the loop, as in:
+    // ```rust
+    // while let Some(x) = std::hint::black_box(None::<i32>) {
+    //     println!("x = {x}");
+    // }
+    // println!("fail");
+    // ```
+    loop {
+        let Some(x) = std::hint::black_box(None::<i32>) else {
+            println!("fail");
+            break;
+        };
+        println!("x = {x}");
+    }
+}


### PR DESCRIPTION
The previous tests ignored statements in a block and only looked at the final expression to determine if the block was made of a single `break`.

changelog: [`while_let_loop`]: do not ignore statements before a `break` when simplifying loop

Fixes rust-lang/rust-clippy#16378 