### PR TITLE
Do not show spans from external crates in `missing_trait_methods`

### DIFF
--- a/tests/ui/missing_trait_methods.rs
+++ b/tests/ui/missing_trait_methods.rs
@@ -62,3 +62,10 @@ impl MissingMultiple for Partial {}
 //~| missing_trait_methods
 
 fn main() {}
+
+//~v missing_trait_methods
+impl PartialEq<Partial> for Partial {
+    fn eq(&self, other: &Partial) -> bool {
+        todo!()
+    }
+}

--- a/tests/ui/missing_trait_methods.stderr
+++ b/tests/ui/missing_trait_methods.stderr
@@ -60,5 +60,13 @@ help: implement the method
 LL |     fn three() {}
    |     ^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: missing trait method provided by default: `ne`
+  --> tests/ui/missing_trait_methods.rs:67:1
+   |
+LL | impl PartialEq<Partial> for Partial {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: implement the missing `ne` method of the `PartialEq<Partial>` trait
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Pointing to the missing method definition in external crates will use paths which depend on the system, and even on the Rust compiler version used when the iterator is defined in the standard library.

When the trait being implemented and whose method is missing is external, point only to the trait implementation. The user will be able to figure out, or even navigate using their IDE, to the proper definition.

As a side-effect, this will remove a large lintcheck churn at every Rustup  for this lint.

changelog: [`missing_trait_methods`]: better help message