### PR TITLE
clean-up `unnecessary_map_or` and `manual_is_variant_and`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3933,7 +3933,8 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for usage of `option.map(f).unwrap_or_default()` and `result.map(f).unwrap_or_default()` where f is a function or closure that returns the `bool` type.
+    /// Checks for usage of `option.map(f).unwrap_or_default()` and `result.map(f).unwrap_or_default()` where `f` is a function or closure that returns the `bool` type.
+    ///
     /// Also checks for equality comparisons like `option.map(f) == Some(true)` and `result.map(f) == Ok(true)`.
     ///
     /// ### Why is this bad?
@@ -5629,7 +5630,7 @@ impl Methods {
                             manual_saturating_arithmetic::check_sub_unwrap_or_default(cx, expr, lhs, rhs);
                         },
                         Some((sym::map, m_recv, [arg], span, _)) => {
-                            manual_is_variant_and::check(cx, expr, m_recv, arg, span, self.msrv);
+                            manual_is_variant_and::check_map_unwrap_or_default(cx, expr, m_recv, arg, span, self.msrv);
                         },
                         Some((then_method @ (sym::then | sym::then_some), t_recv, [t_arg], _, _)) => {
                             obfuscated_if_else::check(

--- a/clippy_lints/src/methods/unnecessary_map_or.rs
+++ b/clippy_lints/src/methods/unnecessary_map_or.rs
@@ -8,7 +8,7 @@ use clippy_utils::sugg::{Sugg, make_binop};
 use clippy_utils::ty::{implements_trait, is_copy};
 use clippy_utils::visitors::is_local_used;
 use clippy_utils::{get_parent_expr, is_from_proc_macro};
-use rustc_ast::LitKind::Bool;
+use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, PatKind};
 use rustc_lint::LateContext;
@@ -48,12 +48,13 @@ pub(super) fn check<'a>(
     let ExprKind::Lit(def_kind) = def.kind else {
         return;
     };
-
-    let recv_ty = cx.typeck_results().expr_ty_adjusted(recv);
-
-    let Bool(def_bool) = def_kind.node else {
+    let LitKind::Bool(def_bool) = def_kind.node else {
         return;
     };
+
+    let typeck = cx.typeck_results();
+
+    let recv_ty = typeck.expr_ty_adjusted(recv);
 
     let variant = match recv_ty.opt_diag_name(cx) {
         Some(sym::Option) => Variant::Some,
@@ -63,12 +64,12 @@ pub(super) fn check<'a>(
 
     let ext_def_span = def.span.until(map.span);
 
-    let (sugg, method, applicability) = if cx.typeck_results().expr_adjustments(recv).is_empty()
+    let (sugg, method, applicability): (_, Cow<'_, _>, _) = if typeck.expr_adjustments(recv).is_empty()
             && let ExprKind::Closure(map_closure) = map.kind
             && let closure_body = cx.tcx.hir_body(map_closure.body)
             && let closure_body_value = closure_body.value.peel_blocks()
             && let ExprKind::Binary(op, l, r) = closure_body_value.kind
-            && let Some(param) = closure_body.params.first()
+            && let [param] = closure_body.params
             && let PatKind::Binding(_, hir_id, _, _) = param.pat.kind
             // checking that map_or is one of the following:
             // .map_or(false, |x| x == y)
@@ -78,14 +79,13 @@ pub(super) fn check<'a>(
             && ((BinOpKind::Eq == op.node && !def_bool) || (BinOpKind::Ne == op.node && def_bool))
             && let non_binding_location = if l.res_local_id() == Some(hir_id) { r } else { l }
             && switch_to_eager_eval(cx, non_binding_location)
-            // if its both then that's a strange edge case and
+            // if it's both then that's a strange edge case and
             // we can just ignore it, since by default clippy will error on this
             && (l.res_local_id() == Some(hir_id)) != (r.res_local_id() == Some(hir_id))
             && !is_local_used(cx, non_binding_location, hir_id)
-            && let typeck_results = cx.typeck_results()
-            && let l_ty = typeck_results.expr_ty(l)
-            && l_ty == typeck_results.expr_ty(r)
-            && let Some(partial_eq) = cx.tcx.get_diagnostic_item(sym::PartialEq)
+            && let l_ty = typeck.expr_ty(l)
+            && l_ty == typeck.expr_ty(r)
+            && let Some(partial_eq) = cx.tcx.lang_items().eq_trait()
             && implements_trait(cx, recv_ty, partial_eq, &[recv_ty.into()])
             && is_copy(cx, l_ty)
     {
@@ -126,18 +126,18 @@ pub(super) fn check<'a>(
         }
         .into_string();
 
-        (vec![(expr.span, sugg)], "a standard comparison", app)
+        (vec![(expr.span, sugg)], "a standard comparison".into(), app)
     } else if !def_bool && msrv.meets(cx, msrvs::OPTION_RESULT_IS_VARIANT_AND) {
         let suggested_name = variant.method_name();
         (
-            vec![(method_span, suggested_name.into()), (ext_def_span, String::default())],
-            suggested_name,
+            vec![(method_span, suggested_name.into()), (ext_def_span, String::new())],
+            format!("`{suggested_name}`").into(),
             Applicability::MachineApplicable,
         )
     } else if def_bool && matches!(variant, Variant::Some) && msrv.meets(cx, msrvs::IS_NONE_OR) {
         (
-            vec![(method_span, "is_none_or".into()), (ext_def_span, String::default())],
-            "is_none_or",
+            vec![(method_span, "is_none_or".into()), (ext_def_span, String::new())],
+            "`is_none_or`".into(),
             Applicability::MachineApplicable,
         )
     } else {

--- a/tests/ui/unnecessary_map_or.fixed
+++ b/tests/ui/unnecessary_map_or.fixed
@@ -70,7 +70,7 @@ fn main() {
     let _ = r.is_ok_and(|x| x == 7);
     //~^ unnecessary_map_or
 
-    // lint constructs that are not comparaisons as well
+    // lint constructs that are not comparisons as well
     let func = |_x| true;
     let r: Result<i32, S> = Ok(3);
     let _ = r.is_ok_and(func);

--- a/tests/ui/unnecessary_map_or.rs
+++ b/tests/ui/unnecessary_map_or.rs
@@ -74,7 +74,7 @@ fn main() {
     let _ = r.map_or(false, |x| x == 7);
     //~^ unnecessary_map_or
 
-    // lint constructs that are not comparaisons as well
+    // lint constructs that are not comparisons as well
     let func = |_x| true;
     let r: Result<i32, S> = Ok(3);
     let _ = r.map_or(false, func);

--- a/tests/ui/unnecessary_map_or.stderr
+++ b/tests/ui/unnecessary_map_or.stderr
@@ -56,7 +56,7 @@ LL | |         6 >= 5
 LL | |     });
    | |______^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     let _ = Some(5).map_or(false, |n| {
 LL +     let _ = Some(5).is_some_and(|n| {
@@ -68,7 +68,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
 LL +     let _ = Some(vec![5]).is_some_and(|n| n == [5]);
@@ -80,7 +80,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
 LL +     let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
@@ -92,7 +92,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Some(5).map_or(false, |n| n == n);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     let _ = Some(5).map_or(false, |n| n == n);
 LL +     let _ = Some(5).is_some_and(|n| n == n);
@@ -104,7 +104,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
 LL +     let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
@@ -116,7 +116,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_ok_and instead
+help: use `is_ok_and` instead
    |
 LL -     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
 LL +     let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
@@ -152,7 +152,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Some(5).map_or(true, |n| n == 5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_none_or instead
+help: use `is_none_or` instead
    |
 LL -     let _ = Some(5).map_or(true, |n| n == 5);
 LL +     let _ = Some(5).is_none_or(|n| n == 5);
@@ -164,7 +164,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Some(5).map_or(true, |n| 5 == n);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_none_or instead
+help: use `is_none_or` instead
    |
 LL -     let _ = Some(5).map_or(true, |n| 5 == n);
 LL +     let _ = Some(5).is_none_or(|n| 5 == n);
@@ -212,7 +212,7 @@ error: this `map_or` can be simplified
 LL |     let _ = r.map_or(false, |x| x == 7);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_ok_and instead
+help: use `is_ok_and` instead
    |
 LL -     let _ = r.map_or(false, |x| x == 7);
 LL +     let _ = r.is_ok_and(|x| x == 7);
@@ -224,7 +224,7 @@ error: this `map_or` can be simplified
 LL |     let _ = r.map_or(false, func);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_ok_and instead
+help: use `is_ok_and` instead
    |
 LL -     let _ = r.map_or(false, func);
 LL +     let _ = r.is_ok_and(func);
@@ -236,7 +236,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Some(5).map_or(false, func);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     let _ = Some(5).map_or(false, func);
 LL +     let _ = Some(5).is_some_and(func);
@@ -248,7 +248,7 @@ error: this `map_or` can be simplified
 LL |     let _ = Some(5).map_or(true, func);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_none_or instead
+help: use `is_none_or` instead
    |
 LL -     let _ = Some(5).map_or(true, func);
 LL +     let _ = Some(5).is_none_or(func);
@@ -272,7 +272,7 @@ error: this `map_or` can be simplified
 LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_none_or instead
+help: use `is_none_or` instead
    |
 LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
 LL +     o.is_none_or(|n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
@@ -284,7 +284,7 @@ error: this `map_or` can be simplified
 LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_none_or instead
+help: use `is_none_or` instead
    |
 LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
 LL +     o.map_or(true, |n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
@@ -296,7 +296,7 @@ error: this `map_or` can be simplified
 LL |     o.map_or(true, |n| n > 5)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_none_or instead
+help: use `is_none_or` instead
    |
 LL -     o.map_or(true, |n| n > 5)
 LL +     o.is_none_or(|n| n > 5)
@@ -308,7 +308,7 @@ error: this `map_or` can be simplified
 LL |     let x = a.map_or(false, |a| a == *s);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     let x = a.map_or(false, |a| a == *s);
 LL +     let x = a.is_some_and(|a| a == *s);
@@ -320,7 +320,7 @@ error: this `map_or` can be simplified
 LL |     let y = b.map_or(true, |b| b == *s);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_none_or instead
+help: use `is_none_or` instead
    |
 LL -     let y = b.map_or(true, |b| b == *s);
 LL +     let y = b.is_none_or(|b| b == *s);
@@ -356,7 +356,7 @@ error: this `map_or` can be simplified
 LL |     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
 LL +     _ = s.lock().unwrap().is_some_and(|s| s == "foo");
@@ -368,7 +368,7 @@ error: this `map_or` can be simplified
 LL |     _ = s.map_or(false, |s| s == "foo");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: use is_some_and instead
+help: use `is_some_and` instead
    |
 LL -     _ = s.map_or(false, |s| s == "foo");
 LL +     _ = s.is_some_and(|s| s == "foo");


### PR DESCRIPTION
This is the first commit of https://github.com/rust-lang/rust-clippy/pull/16383

changelog: none