### PR TITLE
refactor(unnecessary_map_or): move `.map_or(false, ` -> `.is_some_and(` transformation to `manual_is_variant_and`

### DIFF
--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -3,7 +3,7 @@ use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{SpanlessEq, get_parent_expr, sym};
+use clippy_utils::{SpanlessEq, get_parent_expr, is_from_proc_macro, sym};
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
@@ -286,6 +286,66 @@ pub(super) fn check_or<'tcx>(
                 "use",
                 format!("{recv_snip}.is_none_or({map_func_snip})"),
                 app,
+            );
+        },
+    );
+}
+
+pub(super) fn check_map_or<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &Expr<'tcx>,
+    recv: &Expr<'_>,
+    method_span: Span,
+    def: &Expr<'_>,
+    map: &Expr<'_>,
+    msrv: Msrv,
+) {
+    let ExprKind::Lit(def_kind) = def.kind else {
+        return;
+    };
+    let LitKind::Bool(def_bool) = def_kind.node else {
+        return;
+    };
+
+    let recv_ty = cx.typeck_results().expr_ty_adjusted(recv);
+
+    let flavor = match recv_ty.opt_diag_name(cx) {
+        Some(sym::Option) => Flavor::Option,
+        Some(sym::Result) => Flavor::Result,
+        Some(_) | None => return,
+    };
+
+    let ext_def_span = def.span.until(map.span);
+
+    let suggested_method = if !def_bool && msrv.meets(cx, msrvs::OPTION_RESULT_IS_VARIANT_AND) {
+        match flavor {
+            Flavor::Option => "is_some_and",
+            Flavor::Result => "is_ok_and",
+        }
+    } else if def_bool && matches!(flavor, Flavor::Option) && msrv.meets(cx, msrvs::IS_NONE_OR) {
+        "is_none_or"
+    } else {
+        return;
+    };
+
+    if is_from_proc_macro(cx, expr) {
+        return;
+    }
+
+    span_lint_and_then(
+        cx,
+        MANUAL_IS_VARIANT_AND,
+        expr.span,
+        "this `map_or` can be simplified",
+        |diag| {
+            let sugg = vec![
+                (method_span, suggested_method.to_owned()),
+                (ext_def_span, String::new()),
+            ];
+            diag.multipart_suggestion(
+                format!("use `{suggested_method}` instead"),
+                sugg,
+                Applicability::MachineApplicable,
             );
         },
     );

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5635,7 +5635,14 @@ impl Methods {
                 (sym::map_or, [def, map]) => {
                     option_map_or_none::check(cx, expr, recv, def, map);
                     manual_ok_or::check(cx, expr, recv, def, map);
-                    unnecessary_map_or::check(cx, expr, recv, def, map, span, self.msrv);
+                    // On an expression like `option.map_or(false, |n| n == 5)`,
+                    // `unnecessary_map_or` suggests `== Some(5)`,
+                    // while `manual_is_variant_and` suggests `.is_some_and(|n| n == 5)`.
+                    //
+                    // Try to give the first suggestion when possible, as it's more specific.
+                    if !unnecessary_map_or::check(cx, expr, recv, def, map) {
+                        manual_is_variant_and::check_map_or(cx, expr, recv, span, def, map, self.msrv);
+                    }
                 },
                 (sym::map_or_else, [def, map]) => {
                     result_map_or_else_none::check(cx, expr, recv, def, map);

--- a/clippy_lints/src/methods/unnecessary_map_or.rs
+++ b/clippy_lints/src/methods/unnecessary_map_or.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::eager_or_lazy::switch_to_eager_eval;
-use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::{MaybeDef, MaybeResPath};
 use clippy_utils::sugg::{Sugg, make_binop};
 use clippy_utils::ty::{implements_trait, is_copy};
@@ -12,29 +11,9 @@ use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, PatKind};
 use rustc_lint::LateContext;
-use rustc_span::{Span, sym};
+use rustc_span::sym;
 
 use super::UNNECESSARY_MAP_OR;
-
-pub(super) enum Variant {
-    Ok,
-    Some,
-}
-impl Variant {
-    pub fn variant_name(&self) -> &'static str {
-        match self {
-            Variant::Ok => "Ok",
-            Variant::Some => "Some",
-        }
-    }
-
-    pub fn method_name(&self) -> &'static str {
-        match self {
-            Variant::Ok => "is_ok_and",
-            Variant::Some => "is_some_and",
-        }
-    }
-}
 
 pub(super) fn check<'a>(
     cx: &LateContext<'a>,
@@ -42,119 +21,90 @@ pub(super) fn check<'a>(
     recv: &Expr<'_>,
     def: &Expr<'_>,
     map: &Expr<'_>,
-    method_span: Span,
-    msrv: Msrv,
-) {
-    let ExprKind::Lit(def_kind) = def.kind else {
-        return;
-    };
-    let LitKind::Bool(def_bool) = def_kind.node else {
-        return;
-    };
-
-    let typeck = cx.typeck_results();
-
-    let recv_ty = typeck.expr_ty_adjusted(recv);
-
-    let variant = match recv_ty.opt_diag_name(cx) {
-        Some(sym::Option) => Variant::Some,
-        Some(sym::Result) => Variant::Ok,
-        Some(_) | None => return,
-    };
-
-    let ext_def_span = def.span.until(map.span);
-
-    let (sugg, method, applicability): (_, Cow<'_, _>, _) = if typeck.expr_adjustments(recv).is_empty()
-            && let ExprKind::Closure(map_closure) = map.kind
-            && let closure_body = cx.tcx.hir_body(map_closure.body)
-            && let closure_body_value = closure_body.value.peel_blocks()
-            && let ExprKind::Binary(op, l, r) = closure_body_value.kind
-            && let [param] = closure_body.params
-            && let PatKind::Binding(_, hir_id, _, _) = param.pat.kind
-            // checking that map_or is one of the following:
-            // .map_or(false, |x| x == y)
-            // .map_or(false, |x| y == x) - swapped comparison
-            // .map_or(true, |x| x != y)
-            // .map_or(true, |x| y != x) - swapped comparison
-            && ((BinOpKind::Eq == op.node && !def_bool) || (BinOpKind::Ne == op.node && def_bool))
-            && let non_binding_location = if l.res_local_id() == Some(hir_id) { r } else { l }
-            && switch_to_eager_eval(cx, non_binding_location)
-            // if it's both then that's a strange edge case and
-            // we can just ignore it, since by default clippy will error on this
-            && (l.res_local_id() == Some(hir_id)) != (r.res_local_id() == Some(hir_id))
-            && !is_local_used(cx, non_binding_location, hir_id)
-            && let l_ty = typeck.expr_ty(l)
-            && l_ty == typeck.expr_ty(r)
-            && let Some(partial_eq) = cx.tcx.lang_items().eq_trait()
-            && implements_trait(cx, recv_ty, partial_eq, &[recv_ty.into()])
-            && is_copy(cx, l_ty)
-    {
-        let wrap = variant.variant_name();
-
-        // we may need to add parens around the suggestion
-        // in case the parent expression has additional method calls,
-        // since for example `Some(5).map_or(false, |x| x == 5).then(|| 1)`
-        // being converted to `Some(5) == Some(5).then(|| 1)` isn't
-        // the same thing
-
-        let mut app = Applicability::MachineApplicable;
-        let inner_non_binding = Sugg::NonParen(Cow::Owned(format!(
-            "{wrap}({})",
-            Sugg::hir_with_applicability(cx, non_binding_location, "", &mut app)
-        )));
-
-        let binop = make_binop(
-            op.node,
-            &Sugg::hir_with_applicability(cx, recv, "..", &mut app),
-            &inner_non_binding,
-        );
-
-        let sugg = if let Some(parent_expr) = get_parent_expr(cx, expr) {
-            if parent_expr.span.eq_ctxt(expr.span) {
-                match parent_expr.kind {
-                    ExprKind::Binary(..) | ExprKind::Unary(..) | ExprKind::Cast(..) => binop.maybe_paren(),
-                    ExprKind::MethodCall(_, receiver, _, _) if receiver.hir_id == expr.hir_id => binop.maybe_paren(),
-                    _ => binop,
-                }
-            } else {
-                // if our parent expr is created by a macro, then it should be the one taking care of
-                // parenthesising us if necessary
-                binop
-            }
-        } else {
-            binop
+) -> bool {
+    if let ExprKind::Lit(def_kind) = def.kind
+        && let LitKind::Bool(def_bool) = def_kind.node
+        && let typeck = cx.typeck_results()
+        && let recv_ty = typeck.expr_ty_adjusted(recv)
+        && let wrap = match recv_ty.opt_diag_name(cx) {
+            Some(sym::Option) => "Some",
+            Some(sym::Result) => "Ok",
+            Some(_) | None => return false,
         }
-        .into_string();
+        && typeck.expr_adjustments(recv).is_empty()
+        && let ExprKind::Closure(map_closure) = map.kind
+        && let closure_body = cx.tcx.hir_body(map_closure.body)
+        && let closure_body_value = closure_body.value.peel_blocks()
+        && let ExprKind::Binary(op, l, r) = closure_body_value.kind
+        && let [param] = closure_body.params
+        && let PatKind::Binding(_, hir_id, _, _) = param.pat.kind
+        // checking that map_or is one of the following:
+        // .map_or(false, |x| x == y)
+        // .map_or(false, |x| y == x) - swapped comparison
+        // .map_or(true, |x| x != y)
+        // .map_or(true, |x| y != x) - swapped comparison
+        && ((BinOpKind::Eq == op.node && !def_bool) || (BinOpKind::Ne == op.node && def_bool))
+        && let non_binding_location = if l.res_local_id() == Some(hir_id) { r } else { l }
+        && switch_to_eager_eval(cx, non_binding_location)
+        // if it's both then that's a strange edge case and
+        // we can just ignore it, since by default clippy will error on this
+        && (l.res_local_id() == Some(hir_id)) != (r.res_local_id() == Some(hir_id))
+        && !is_local_used(cx, non_binding_location, hir_id)
+        && let l_ty = typeck.expr_ty(l)
+        && l_ty == typeck.expr_ty(r)
+        && let Some(partial_eq) = cx.tcx.lang_items().eq_trait()
+        && implements_trait(cx, recv_ty, partial_eq, &[recv_ty.into()])
+        && is_copy(cx, l_ty)
+        && !is_from_proc_macro(cx, expr)
+    {
+        let mut fired = false;
+        span_lint_and_then(
+            cx,
+            UNNECESSARY_MAP_OR,
+            expr.span,
+            "this `map_or` can be simplified",
+            |diag| {
+                // we may need to add parens around the suggestion
+                // in case the parent expression has additional method calls,
+                // since for example `Some(5).map_or(false, |x| x == 5).then(|| 1)`
+                // being converted to `Some(5) == Some(5).then(|| 1)` isn't
+                // the same thing
 
-        (vec![(expr.span, sugg)], "a standard comparison".into(), app)
-    } else if !def_bool && msrv.meets(cx, msrvs::OPTION_RESULT_IS_VARIANT_AND) {
-        let suggested_name = variant.method_name();
-        (
-            vec![(method_span, suggested_name.into()), (ext_def_span, String::new())],
-            format!("`{suggested_name}`").into(),
-            Applicability::MachineApplicable,
-        )
-    } else if def_bool && matches!(variant, Variant::Some) && msrv.meets(cx, msrvs::IS_NONE_OR) {
-        (
-            vec![(method_span, "is_none_or".into()), (ext_def_span, String::new())],
-            "`is_none_or`".into(),
-            Applicability::MachineApplicable,
-        )
-    } else {
-        return;
-    };
+                let mut app = Applicability::MachineApplicable;
+                let inner_non_binding = Sugg::NonParen(Cow::Owned(format!(
+                    "{wrap}({})",
+                    Sugg::hir_with_applicability(cx, non_binding_location, "", &mut app)
+                )));
 
-    if is_from_proc_macro(cx, expr) {
-        return;
+                let binop = make_binop(
+                    op.node,
+                    &Sugg::hir_with_applicability(cx, recv, "..", &mut app),
+                    &inner_non_binding,
+                );
+
+                let sugg = if let Some(parent_expr) = get_parent_expr(cx, expr) {
+                    if parent_expr.span.eq_ctxt(expr.span) {
+                        match parent_expr.kind {
+                            ExprKind::Binary(..) | ExprKind::Unary(..) | ExprKind::Cast(..) => binop.maybe_paren(),
+                            ExprKind::MethodCall(_, receiver, _, _) if receiver.hir_id == expr.hir_id => {
+                                binop.maybe_paren()
+                            },
+                            _ => binop,
+                        }
+                    } else {
+                        // if our parent expr is created by a macro, then it should be the one taking care of
+                        // parenthesising us if necessary
+                        binop
+                    }
+                } else {
+                    binop
+                };
+                diag.span_suggestion_verbose(expr.span, "use a standard comparison instead", sugg.to_string(), app);
+
+                fired = true;
+            },
+        );
+        return fired;
     }
-
-    span_lint_and_then(
-        cx,
-        UNNECESSARY_MAP_OR,
-        expr.span,
-        "this `map_or` can be simplified",
-        |diag| {
-            diag.multipart_suggestion(format!("use {method} instead"), sugg, applicability);
-        },
-    );
+    false
 }

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -1,9 +1,17 @@
 //@aux-build:option_helpers.rs
+//@aux-build:proc_macros.rs
 #![warn(clippy::manual_is_variant_and)]
-#![allow(clippy::redundant_closure)]
+#![allow(
+    clippy::nonminimal_bool,
+    clippy::eq_op,
+    clippy::unnecessary_lazy_evaluations,
+    clippy::redundant_closure
+)]
 
 #[macro_use]
 extern crate option_helpers;
+#[macro_use]
+extern crate proc_macros;
 
 struct Foo<T>(T);
 
@@ -77,6 +85,27 @@ fn option_methods() {
     //~^ manual_is_variant_and
     let _ = opt_map!(opt2, |x| x == 'a').unwrap_or_default(); // should not lint
 
+    // Check for `option.map_or(true, _)` and `option.map_or(false, _)` use.
+    let _ = Some(5).is_some_and(|n| {
+        //~^ manual_is_variant_and
+        let _ = n;
+        6 >= 5
+    });
+    let _ = Some(vec![5]).is_some_and(|n| n == [5]);
+    //~^ manual_is_variant_and
+    let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_some_and(|n| n == n);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
+    //~^ manual_is_variant_and
+    let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_none_or(|n| n == 5);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_none_or(|n| 5 == n);
+    //~^ manual_is_variant_and
+
     // Should not lint.
     let _ = Foo::<u32>(0).map(|x| x.is_multiple_of(2)) == Some(true);
     let _ = Some(2).map(|x| x % 2 == 0) != foo();
@@ -84,12 +113,22 @@ fn option_methods() {
     let _ = mac!(some 2).map(|x| x % 2 == 0) == Some(true);
     let _ = mac!(some_map 2) == Some(true);
     let _ = mac!(map Some(2)) == Some(true);
+    let _ = mac!(some 2).map_or(true, |x| x % 2 == 0);
+    let _ = mac!(some 2).map_or(false, |x| x % 2 == 0);
+    external! {
+        let _ = Some(5).map_or(false, |n| n > 5);
+    }
+    with_span! {
+        let _ = Some(5).map_or(false, |n| n > 5);
+    }
+
 }
 
 #[rustfmt::skip]
 fn result_methods() {
     let res: Result<i32, ()> = Ok(1);
 
+    // Check for `result.map(_).unwrap_or_default()` use.
     // multi line cases
     let _ = res.is_ok_and(|x| {
     //~^ manual_is_variant_and
@@ -111,9 +150,86 @@ fn result_methods() {
     let _ = res2.is_ok_and(char::is_alphanumeric); // should lint
     //~^ manual_is_variant_and
     let _ = opt_map!(res2, |x| x == 'a').unwrap_or_default(); // should not lint
+
+    // Check for `result.map_or(false, _)` use.
+    let _ = res.is_ok_and(|x| x > 8);
+    //~^ manual_is_variant_and
+
+    // Don't lint, `unnecessary_map_or` will take over
+    #[derive(PartialEq)]
+    struct S1;
+    let mut r: Result<i32, S1> = Ok(3);
+    let _ = r == Ok(7);
+    //~^ unnecessary_map_or
+
+    // But do lint if `unnecessary_map_or` is `allow`ed
+    r = Ok(3);
+    #[allow(clippy::unnecessary_map_or)]
+    let _ = r.is_ok_and(|x| x == 7); //~ manual_is_variant_and
+    // ...or `expect`ed
+    r = Ok(3);
+    #[allow(clippy::unnecessary_map_or)]
+    let _ = r.is_ok_and(|x| x == 7); //~ manual_is_variant_and
+
+    // Lint, as `S2` doesn't implement `PartialEq`
+    struct S2;
+    let r: Result<i32, S2> = Ok(3);
+    let _ = r.is_ok_and(|x| x == 7);
+    //~^ manual_is_variant_and
+
 }
 
 fn main() {}
+
+#[clippy::msrv = "1.69.0"]
+fn msrv_1_69() {
+    // is_some_and added in 1.70.0
+    let _ = Some(5).map_or(false, |n| n > if 2 > 1 { n } else { 0 });
+}
+
+#[clippy::msrv = "1.81.0"]
+fn msrv_1_81() {
+    // is_none_or added in 1.82.0
+    let _ = Some(5).map_or(true, |n| n > if 2 > 1 { n } else { 0 });
+}
+
+fn with_refs(o: &mut Option<u32>) -> bool {
+    o.is_none_or(|n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
+    //~^ manual_is_variant_and
+    //~| manual_is_variant_and
+}
+
+struct S;
+
+impl std::ops::Deref for S {
+    type Target = Option<u32>;
+    fn deref(&self) -> &Self::Target {
+        &Some(0)
+    }
+}
+
+fn with_deref(o: &S) -> bool {
+    o.is_none_or(|n| n > 5)
+    //~^ manual_is_variant_and
+}
+
+fn issue14201(a: Option<String>, b: Option<String>, s: &String) -> bool {
+    let x = a.is_some_and(|a| a == *s);
+    //~^ manual_is_variant_and
+    let y = b.is_none_or(|b| b == *s);
+    //~^ manual_is_variant_and
+    x && y
+}
+
+fn issue15180() {
+    let s = std::sync::Mutex::new(Some("foo"));
+    _ = s.lock().unwrap().is_some_and(|s| s == "foo");
+    //~^ manual_is_variant_and
+
+    let s = &&&&Some("foo");
+    _ = s.is_some_and(|s| s == "foo");
+    //~^ manual_is_variant_and
+}
 
 fn issue15202() {
     let xs = [None, Some(b'_'), Some(b'1')];
@@ -184,7 +300,10 @@ mod with_func {
         let a1 = b.is_some_and(iad);
         //~^ manual_is_variant_and
         let a2 = b.is_some_and(iad);
-        assert_eq!(a1, a2);
+        //~^ manual_is_variant_and
+        let a3 = b.is_some_and(iad);
+        assert_eq!(a1, a3);
+        assert_eq!(a2, a3);
 
         let a1 = b.is_some_and(|x| !iad(x));
         //~^ manual_is_variant_and
@@ -199,14 +318,20 @@ mod with_func {
         let a1 = b.is_none_or(iad);
         //~^ manual_is_variant_and
         let a2 = b.is_none_or(iad);
-        assert_eq!(a1, a2);
+        //~^ manual_is_variant_and
+        let a3 = b.is_none_or(iad);
+        assert_eq!(a2, a3);
+        assert_eq!(a1, a3);
     }
 
     fn check_result(b: Result<u8, ()>) {
         let a1 = b.is_ok_and(iad);
         //~^ manual_is_variant_and
         let a2 = b.is_ok_and(iad);
-        assert_eq!(a1, a2);
+        //~^ manual_is_variant_and
+        let a3 = b.is_ok_and(iad);
+        assert_eq!(a1, a3);
+        assert_eq!(a2, a3);
 
         let a1 = b.is_ok_and(|x| !iad(x));
         //~^ manual_is_variant_and

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -1,9 +1,17 @@
 //@aux-build:option_helpers.rs
+//@aux-build:proc_macros.rs
 #![warn(clippy::manual_is_variant_and)]
-#![allow(clippy::redundant_closure)]
+#![allow(
+    clippy::nonminimal_bool,
+    clippy::eq_op,
+    clippy::unnecessary_lazy_evaluations,
+    clippy::redundant_closure
+)]
 
 #[macro_use]
 extern crate option_helpers;
+#[macro_use]
+extern crate proc_macros;
 
 struct Foo<T>(T);
 
@@ -83,6 +91,27 @@ fn option_methods() {
     //~^ manual_is_variant_and
     let _ = opt_map!(opt2, |x| x == 'a').unwrap_or_default(); // should not lint
 
+    // Check for `option.map_or(true, _)` and `option.map_or(false, _)` use.
+    let _ = Some(5).map_or(false, |n| {
+        //~^ manual_is_variant_and
+        let _ = n;
+        6 >= 5
+    });
+    let _ = Some(vec![5]).map_or(false, |n| n == [5]);
+    //~^ manual_is_variant_and
+    let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(false, |n| n == n);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
+    //~^ manual_is_variant_and
+    let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(true, |n| n == 5);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(true, |n| 5 == n);
+    //~^ manual_is_variant_and
+
     // Should not lint.
     let _ = Foo::<u32>(0).map(|x| x.is_multiple_of(2)) == Some(true);
     let _ = Some(2).map(|x| x % 2 == 0) != foo();
@@ -90,12 +119,22 @@ fn option_methods() {
     let _ = mac!(some 2).map(|x| x % 2 == 0) == Some(true);
     let _ = mac!(some_map 2) == Some(true);
     let _ = mac!(map Some(2)) == Some(true);
+    let _ = mac!(some 2).map_or(true, |x| x % 2 == 0);
+    let _ = mac!(some 2).map_or(false, |x| x % 2 == 0);
+    external! {
+        let _ = Some(5).map_or(false, |n| n > 5);
+    }
+    with_span! {
+        let _ = Some(5).map_or(false, |n| n > 5);
+    }
+
 }
 
 #[rustfmt::skip]
 fn result_methods() {
     let res: Result<i32, ()> = Ok(1);
 
+    // Check for `result.map(_).unwrap_or_default()` use.
     // multi line cases
     let _ = res.map(|x| {
     //~^ manual_is_variant_and
@@ -120,9 +159,86 @@ fn result_methods() {
     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
     //~^ manual_is_variant_and
     let _ = opt_map!(res2, |x| x == 'a').unwrap_or_default(); // should not lint
+
+    // Check for `result.map_or(false, _)` use.
+    let _ = res.map_or(false, |x| x > 8);
+    //~^ manual_is_variant_and
+
+    // Don't lint, `unnecessary_map_or` will take over
+    #[derive(PartialEq)]
+    struct S1;
+    let mut r: Result<i32, S1> = Ok(3);
+    let _ = r.map_or(false, |x| x == 7);
+    //~^ unnecessary_map_or
+
+    // But do lint if `unnecessary_map_or` is `allow`ed
+    r = Ok(3);
+    #[allow(clippy::unnecessary_map_or)]
+    let _ = r.map_or(false, |x| x == 7); //~ manual_is_variant_and
+    // ...or `expect`ed
+    r = Ok(3);
+    #[allow(clippy::unnecessary_map_or)]
+    let _ = r.map_or(false, |x| x == 7); //~ manual_is_variant_and
+
+    // Lint, as `S2` doesn't implement `PartialEq`
+    struct S2;
+    let r: Result<i32, S2> = Ok(3);
+    let _ = r.map_or(false, |x| x == 7);
+    //~^ manual_is_variant_and
+
 }
 
 fn main() {}
+
+#[clippy::msrv = "1.69.0"]
+fn msrv_1_69() {
+    // is_some_and added in 1.70.0
+    let _ = Some(5).map_or(false, |n| n > if 2 > 1 { n } else { 0 });
+}
+
+#[clippy::msrv = "1.81.0"]
+fn msrv_1_81() {
+    // is_none_or added in 1.82.0
+    let _ = Some(5).map_or(true, |n| n > if 2 > 1 { n } else { 0 });
+}
+
+fn with_refs(o: &mut Option<u32>) -> bool {
+    o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+    //~^ manual_is_variant_and
+    //~| manual_is_variant_and
+}
+
+struct S;
+
+impl std::ops::Deref for S {
+    type Target = Option<u32>;
+    fn deref(&self) -> &Self::Target {
+        &Some(0)
+    }
+}
+
+fn with_deref(o: &S) -> bool {
+    o.map_or(true, |n| n > 5)
+    //~^ manual_is_variant_and
+}
+
+fn issue14201(a: Option<String>, b: Option<String>, s: &String) -> bool {
+    let x = a.map_or(false, |a| a == *s);
+    //~^ manual_is_variant_and
+    let y = b.map_or(true, |b| b == *s);
+    //~^ manual_is_variant_and
+    x && y
+}
+
+fn issue15180() {
+    let s = std::sync::Mutex::new(Some("foo"));
+    _ = s.lock().unwrap().map_or(false, |s| s == "foo");
+    //~^ manual_is_variant_and
+
+    let s = &&&&Some("foo");
+    _ = s.map_or(false, |s| s == "foo");
+    //~^ manual_is_variant_and
+}
 
 fn issue15202() {
     let xs = [None, Some(b'_'), Some(b'1')];
@@ -192,8 +308,11 @@ mod with_func {
     fn check_option(b: Option<u8>) {
         let a1 = b.map(iad) == Some(true);
         //~^ manual_is_variant_and
-        let a2 = b.is_some_and(iad);
-        assert_eq!(a1, a2);
+        let a2 = b.map_or(false, iad);
+        //~^ manual_is_variant_and
+        let a3 = b.is_some_and(iad);
+        assert_eq!(a1, a3);
+        assert_eq!(a2, a3);
 
         let a1 = b.map(iad) == Some(false);
         //~^ manual_is_variant_and
@@ -207,15 +326,21 @@ mod with_func {
 
         let a1 = b.map(iad) != Some(false);
         //~^ manual_is_variant_and
-        let a2 = b.is_none_or(iad);
-        assert_eq!(a1, a2);
+        let a2 = b.map_or(true, iad);
+        //~^ manual_is_variant_and
+        let a3 = b.is_none_or(iad);
+        assert_eq!(a2, a3);
+        assert_eq!(a1, a3);
     }
 
     fn check_result(b: Result<u8, ()>) {
         let a1 = b.map(iad) == Ok(true);
         //~^ manual_is_variant_and
-        let a2 = b.is_ok_and(iad);
-        assert_eq!(a1, a2);
+        let a2 = b.map_or(false, iad);
+        //~^ manual_is_variant_and
+        let a3 = b.is_ok_and(iad);
+        assert_eq!(a1, a3);
+        assert_eq!(a2, a3);
 
         let a1 = b.map(iad) == Ok(false);
         //~^ manual_is_variant_and

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -1,5 +1,5 @@
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:52:17
+  --> tests/ui/manual_is_variant_and.rs:60:17
    |
 LL |       let _ = opt.map(|x| x > 1)
    |  _________________^
@@ -11,7 +11,7 @@ LL | |         .unwrap_or_default();
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:57:17
+  --> tests/ui/manual_is_variant_and.rs:65:17
    |
 LL |       let _ = opt.map(|x| {
    |  _________________^
@@ -30,13 +30,13 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:62:17
+  --> tests/ui/manual_is_variant_and.rs:70:17
    |
 LL |     let _ = opt.map(|x| x > 1).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:65:10
+  --> tests/ui/manual_is_variant_and.rs:73:10
    |
 LL |           .map(|x| x > 1)
    |  __________^
@@ -45,37 +45,138 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:69:13
+  --> tests/ui/manual_is_variant_and.rs:77:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:71:13
+  --> tests/ui/manual_is_variant_and.rs:79:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 != 0)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:73:13
+  --> tests/ui/manual_is_variant_and.rs:81:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == some_true!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:75:13
+  --> tests/ui/manual_is_variant_and.rs:83:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != some_false!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:82:18
+  --> tests/ui/manual_is_variant_and.rs:90:18
    |
 LL |     let _ = opt2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(char::is_alphanumeric)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:95:13
+   |
+LL |       let _ = Some(5).map_or(false, |n| {
+   |  _____________^
+LL | |
+LL | |         let _ = n;
+LL | |         6 >= 5
+LL | |     });
+   | |______^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(5).map_or(false, |n| {
+LL +     let _ = Some(5).is_some_and(|n| {
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:100:13
+   |
+LL |     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
+LL +     let _ = Some(vec![5]).is_some_and(|n| n == [5]);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:102:13
+   |
+LL |     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
+LL +     let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:104:13
+   |
+LL |     let _ = Some(5).map_or(false, |n| n == n);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(5).map_or(false, |n| n == n);
+LL +     let _ = Some(5).is_some_and(|n| n == n);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:106:13
+   |
+LL |     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
+LL +     let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:108:13
+   |
+LL |     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
+LL +     let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:110:13
+   |
+LL |     let _ = Some(5).map_or(true, |n| n == 5);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = Some(5).map_or(true, |n| n == 5);
+LL +     let _ = Some(5).is_none_or(|n| n == 5);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:112:13
+   |
+LL |     let _ = Some(5).map_or(true, |n| 5 == n);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = Some(5).map_or(true, |n| 5 == n);
+LL +     let _ = Some(5).is_none_or(|n| 5 == n);
+   |
+
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:100:17
+  --> tests/ui/manual_is_variant_and.rs:139:17
    |
 LL |       let _ = res.map(|x| {
    |  _________________^
@@ -94,7 +195,7 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:105:17
+  --> tests/ui/manual_is_variant_and.rs:144:17
    |
 LL |       let _ = res.map(|x| x > 1)
    |  _________________^
@@ -103,160 +204,342 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_ok_and(|x| x > 1)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:109:13
+  --> tests/ui/manual_is_variant_and.rs:148:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) == Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:111:13
+  --> tests/ui/manual_is_variant_and.rs:150:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:113:13
+  --> tests/ui/manual_is_variant_and.rs:152:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:120:18
+  --> tests/ui/manual_is_variant_and.rs:159:18
    |
 LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:164:13
+   |
+LL |     let _ = res.map_or(false, |x| x > 8);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res.map_or(false, |x| x > 8);
+LL +     let _ = res.is_ok_and(|x| x > 8);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:171:13
+   |
+LL |     let _ = r.map_or(false, |x| x == 7);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::unnecessary-map-or` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_or)]`
+help: use a standard comparison instead
+   |
+LL -     let _ = r.map_or(false, |x| x == 7);
+LL +     let _ = r == Ok(7);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:177:13
+   |
+LL |     let _ = r.map_or(false, |x| x == 7);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = r.map_or(false, |x| x == 7);
+LL +     let _ = r.is_ok_and(|x| x == 7);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:181:13
+   |
+LL |     let _ = r.map_or(false, |x| x == 7);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = r.map_or(false, |x| x == 7);
+LL +     let _ = r.is_ok_and(|x| x == 7);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:186:13
+   |
+LL |     let _ = r.map_or(false, |x| x == 7);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = r.map_or(false, |x| x == 7);
+LL +     let _ = r.is_ok_and(|x| x == 7);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:206:5
+   |
+LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+LL +     o.is_none_or(|n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:206:34
+   |
+LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+LL +     o.map_or(true, |n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:221:5
+   |
+LL |     o.map_or(true, |n| n > 5)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     o.map_or(true, |n| n > 5)
+LL +     o.is_none_or(|n| n > 5)
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:226:13
+   |
+LL |     let x = a.map_or(false, |a| a == *s);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let x = a.map_or(false, |a| a == *s);
+LL +     let x = a.is_some_and(|a| a == *s);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:228:13
+   |
+LL |     let y = b.map_or(true, |b| b == *s);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let y = b.map_or(true, |b| b == *s);
+LL +     let y = b.is_none_or(|b| b == *s);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:235:9
+   |
+LL |     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
+LL +     _ = s.lock().unwrap().is_some_and(|s| s == "foo");
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:239:9
+   |
+LL |     _ = s.map_or(false, |s| s == "foo");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     _ = s.map_or(false, |s| s == "foo");
+LL +     _ = s.is_some_and(|s| s == "foo");
+   |
+
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:130:18
+  --> tests/ui/manual_is_variant_and.rs:246:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:137:18
+  --> tests/ui/manual_is_variant_and.rs:253:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:144:18
+  --> tests/ui/manual_is_variant_and.rs:260:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:151:18
+  --> tests/ui/manual_is_variant_and.rs:267:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:159:18
+  --> tests/ui/manual_is_variant_and.rs:275:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:166:18
+  --> tests/ui/manual_is_variant_and.rs:282:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:173:18
+  --> tests/ui/manual_is_variant_and.rs:289:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:180:18
+  --> tests/ui/manual_is_variant_and.rs:296:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:193:18
+  --> tests/ui/manual_is_variant_and.rs:309:18
    |
 LL |         let a1 = b.map(iad) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(iad)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:311:18
+   |
+LL |         let a2 = b.map_or(false, iad);
+   |                  ^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -         let a2 = b.map_or(false, iad);
+LL +         let a2 = b.is_some_and(iad);
+   |
+
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:198:18
+  --> tests/ui/manual_is_variant_and.rs:317:18
    |
 LL |         let a1 = b.map(iad) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:203:18
+  --> tests/ui/manual_is_variant_and.rs:322:18
    |
 LL |         let a1 = b.map(iad) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:208:18
+  --> tests/ui/manual_is_variant_and.rs:327:18
    |
 LL |         let a1 = b.map(iad) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(iad)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:329:18
+   |
+LL |         let a2 = b.map_or(true, iad);
+   |                  ^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -         let a2 = b.map_or(true, iad);
+LL +         let a2 = b.is_none_or(iad);
+   |
+
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:215:18
+  --> tests/ui/manual_is_variant_and.rs:337:18
    |
 LL |         let a1 = b.map(iad) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(iad)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:339:18
+   |
+LL |         let a2 = b.map_or(false, iad);
+   |                  ^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -         let a2 = b.map_or(false, iad);
+LL +         let a2 = b.is_ok_and(iad);
+   |
+
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:220:18
+  --> tests/ui/manual_is_variant_and.rs:345:18
    |
 LL |         let a1 = b.map(iad) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(|x| !iad(x))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:225:18
+  --> tests/ui/manual_is_variant_and.rs:350:18
    |
 LL |         let a1 = b.map(iad) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(iad)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:230:18
+  --> tests/ui/manual_is_variant_and.rs:355:18
    |
 LL |         let a1 = b.map(iad) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:240:13
+  --> tests/ui/manual_is_variant_and.rs:365:13
    |
 LL |     let _ = opt.is_none() || opt.is_some_and(then_fn);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:243:13
+  --> tests/ui/manual_is_variant_and.rs:368:13
    |
 LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_some_and`
-  --> tests/ui/manual_is_variant_and.rs:259:5
+  --> tests/ui/manual_is_variant_and.rs:384:5
    |
 LL |     opt.filter(|x| condition(x)).is_some();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_some_and(|x| condition(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:261:5
+  --> tests/ui/manual_is_variant_and.rs:386:5
    |
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`
 
 error: called `.ok().is_some_and(..)` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:273:13
+  --> tests/ui/manual_is_variant_and.rs:398:13
    |
 LL |     let _ = res.ok().is_some_and(|x| x > 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `is_ok_and` instead: `res.is_ok_and(|x| x > 0)`
 
 error: called `.ok().is_some_and(..)` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:276:13
+  --> tests/ui/manual_is_variant_and.rs:401:13
    |
 LL |     let _ = res.ok().is_some_and(|x| x > 0) || res.is_err();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `is_ok_and` instead: `res.is_ok_and(|x| x > 0)`
 
-error: aborting due to 37 previous errors
+error: aborting due to 60 previous errors
 

--- a/tests/ui/unnecessary_map_or.fixed
+++ b/tests/ui/unnecessary_map_or.fixed
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-#![warn(clippy::unnecessary_map_or)]
+#![warn(clippy::unnecessary_map_or, clippy::manual_is_variant_and)]
 #![allow(
     clippy::no_effect,
     clippy::eq_op,
@@ -7,7 +7,7 @@
     clippy::nonminimal_bool,
     clippy::manual_assert_eq
 )]
-#[clippy::msrv = "1.70.0"]
+#[clippy::msrv = "1.82.0"]
 #[macro_use]
 extern crate proc_macros;
 
@@ -18,28 +18,9 @@ fn main() {
     let _ = Some(5) != Some(5);
     //~^ unnecessary_map_or
     let _ = Some(5) == Some(5);
-    let _ = Some(5).is_some_and(|n| {
-        //~^ unnecessary_map_or
-        let _ = n;
-        6 >= 5
-    });
-    let _ = Some(vec![5]).is_some_and(|n| n == [5]);
-    //~^ unnecessary_map_or
-    let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_some_and(|n| n == n);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
-    //~^ unnecessary_map_or
-    let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
-    //~^ unnecessary_map_or
     let _ = Ok::<i32, i32>(5) == Ok(5);
     //~^ unnecessary_map_or
     let _ = (Some(5) == Some(5)).then(|| 1);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_none_or(|n| n == 5);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_none_or(|n| 5 == n);
     //~^ unnecessary_map_or
     let _ = !(Some(5) == Some(5));
     //~^ unnecessary_map_or
@@ -57,8 +38,6 @@ fn main() {
     let _ = x!().map_or(false, |n| n == 1);
     let _ = x!().map_or(false, |n| n == vec![1][0]);
 
-    msrv_1_69();
-
     external! {
         let _ = Some(5).map_or(false, |n| n == 5);
     }
@@ -67,21 +46,11 @@ fn main() {
         let _ = Some(5).map_or(false, |n| n == 5);
     }
 
-    // check for presence of PartialEq, and alter suggestion to use `is_ok_and` if absent
+    // do not lint in absense of PartialEq (covered by `manual_is_variant_and`)
     struct S;
     let r: Result<i32, S> = Ok(3);
     let _ = r.is_ok_and(|x| x == 7);
-    //~^ unnecessary_map_or
-
-    // lint constructs that are not comparisons as well
-    let func = |_x| true;
-    let r: Result<i32, S> = Ok(3);
-    let _ = r.is_ok_and(func);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_some_and(func);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_none_or(func);
-    //~^ unnecessary_map_or
+    //~^ manual_is_variant_and
 
     #[derive(PartialEq)]
     struct S2;
@@ -89,49 +58,15 @@ fn main() {
     let _ = r == Ok(8);
     //~^ unnecessary_map_or
 
-    // do not lint `Result::map_or(true, …)`
-    let r: Result<i32, S2> = Ok(4);
-    let _ = r.map_or(true, |x| x == 8);
-}
-
-#[clippy::msrv = "1.69.0"]
-fn msrv_1_69() {
-    // is_some_and added in 1.70.0
-    let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-}
-
-#[clippy::msrv = "1.81.0"]
-fn msrv_1_81() {
-    // is_none_or added in 1.82.0
-    let _ = Some(5).map_or(true, |n| n == if 2 > 1 { n } else { 0 });
-}
-
-fn with_refs(o: &mut Option<u32>) -> bool {
-    o.is_none_or(|n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
-    //~^ unnecessary_map_or
-    //~| unnecessary_map_or
-}
-
-struct S;
-
-impl std::ops::Deref for S {
-    type Target = Option<u32>;
-    fn deref(&self) -> &Self::Target {
-        &Some(0)
-    }
-}
-
-fn with_deref(o: &S) -> bool {
-    o.is_none_or(|n| n > 5)
-    //~^ unnecessary_map_or
-}
-
-fn issue14201(a: Option<String>, b: Option<String>, s: &String) -> bool {
-    let x = a.is_some_and(|a| a == *s);
-    //~^ unnecessary_map_or
-    let y = b.is_none_or(|b| b == *s);
-    //~^ unnecessary_map_or
-    x && y
+    // do not lint constructs that are not comparisons (covered by `manual_is_variant_and`)
+    let func = |_x| true;
+    let r: Result<i32, S> = Ok(3);
+    let _ = r.is_ok_and(func);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_some_and(func);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_none_or(func);
+    //~^ manual_is_variant_and
 }
 
 fn issue14714() {
@@ -152,14 +87,4 @@ fn issue14714() {
         };
     }
     m!(Some(5));
-}
-
-fn issue15180() {
-    let s = std::sync::Mutex::new(Some("foo"));
-    _ = s.lock().unwrap().is_some_and(|s| s == "foo");
-    //~^ unnecessary_map_or
-
-    let s = &&&&Some("foo");
-    _ = s.is_some_and(|s| s == "foo");
-    //~^ unnecessary_map_or
 }

--- a/tests/ui/unnecessary_map_or.rs
+++ b/tests/ui/unnecessary_map_or.rs
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-#![warn(clippy::unnecessary_map_or)]
+#![warn(clippy::unnecessary_map_or, clippy::manual_is_variant_and)]
 #![allow(
     clippy::no_effect,
     clippy::eq_op,
@@ -7,7 +7,7 @@
     clippy::nonminimal_bool,
     clippy::manual_assert_eq
 )]
-#[clippy::msrv = "1.70.0"]
+#[clippy::msrv = "1.82.0"]
 #[macro_use]
 extern crate proc_macros;
 
@@ -22,28 +22,9 @@ fn main() {
         let _ = 1;
         n == 5
     });
-    let _ = Some(5).map_or(false, |n| {
-        //~^ unnecessary_map_or
-        let _ = n;
-        6 >= 5
-    });
-    let _ = Some(vec![5]).map_or(false, |n| n == [5]);
-    //~^ unnecessary_map_or
-    let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(false, |n| n == n);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-    //~^ unnecessary_map_or
-    let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
-    //~^ unnecessary_map_or
     let _ = Ok::<i32, i32>(5).map_or(false, |n| n == 5);
     //~^ unnecessary_map_or
     let _ = Some(5).map_or(false, |n| n == 5).then(|| 1);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(true, |n| n == 5);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(true, |n| 5 == n);
     //~^ unnecessary_map_or
     let _ = !Some(5).map_or(false, |n| n == 5);
     //~^ unnecessary_map_or
@@ -61,8 +42,6 @@ fn main() {
     let _ = x!().map_or(false, |n| n == 1);
     let _ = x!().map_or(false, |n| n == vec![1][0]);
 
-    msrv_1_69();
-
     external! {
         let _ = Some(5).map_or(false, |n| n == 5);
     }
@@ -71,21 +50,11 @@ fn main() {
         let _ = Some(5).map_or(false, |n| n == 5);
     }
 
-    // check for presence of PartialEq, and alter suggestion to use `is_ok_and` if absent
+    // do not lint in absense of PartialEq (covered by `manual_is_variant_and`)
     struct S;
     let r: Result<i32, S> = Ok(3);
     let _ = r.map_or(false, |x| x == 7);
-    //~^ unnecessary_map_or
-
-    // lint constructs that are not comparisons as well
-    let func = |_x| true;
-    let r: Result<i32, S> = Ok(3);
-    let _ = r.map_or(false, func);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(false, func);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(true, func);
-    //~^ unnecessary_map_or
+    //~^ manual_is_variant_and
 
     #[derive(PartialEq)]
     struct S2;
@@ -93,49 +62,15 @@ fn main() {
     let _ = r.map_or(false, |x| x == 8);
     //~^ unnecessary_map_or
 
-    // do not lint `Result::map_or(true, …)`
-    let r: Result<i32, S2> = Ok(4);
-    let _ = r.map_or(true, |x| x == 8);
-}
-
-#[clippy::msrv = "1.69.0"]
-fn msrv_1_69() {
-    // is_some_and added in 1.70.0
-    let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-}
-
-#[clippy::msrv = "1.81.0"]
-fn msrv_1_81() {
-    // is_none_or added in 1.82.0
-    let _ = Some(5).map_or(true, |n| n == if 2 > 1 { n } else { 0 });
-}
-
-fn with_refs(o: &mut Option<u32>) -> bool {
-    o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-    //~^ unnecessary_map_or
-    //~| unnecessary_map_or
-}
-
-struct S;
-
-impl std::ops::Deref for S {
-    type Target = Option<u32>;
-    fn deref(&self) -> &Self::Target {
-        &Some(0)
-    }
-}
-
-fn with_deref(o: &S) -> bool {
-    o.map_or(true, |n| n > 5)
-    //~^ unnecessary_map_or
-}
-
-fn issue14201(a: Option<String>, b: Option<String>, s: &String) -> bool {
-    let x = a.map_or(false, |a| a == *s);
-    //~^ unnecessary_map_or
-    let y = b.map_or(true, |b| b == *s);
-    //~^ unnecessary_map_or
-    x && y
+    // do not lint constructs that are not comparisons (covered by `manual_is_variant_and`)
+    let func = |_x| true;
+    let r: Result<i32, S> = Ok(3);
+    let _ = r.map_or(false, func);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(false, func);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(true, func);
+    //~^ manual_is_variant_and
 }
 
 fn issue14714() {
@@ -156,14 +91,4 @@ fn issue14714() {
         };
     }
     m!(Some(5));
-}
-
-fn issue15180() {
-    let s = std::sync::Mutex::new(Some("foo"));
-    _ = s.lock().unwrap().map_or(false, |s| s == "foo");
-    //~^ unnecessary_map_or
-
-    let s = &&&&Some("foo");
-    _ = s.map_or(false, |s| s == "foo");
-    //~^ unnecessary_map_or
 }

--- a/tests/ui/unnecessary_map_or.stderr
+++ b/tests/ui/unnecessary_map_or.stderr
@@ -48,83 +48,6 @@ LL +     let _ = Some(5) == Some(5);
 error: this `map_or` can be simplified
   --> tests/ui/unnecessary_map_or.rs:25:13
    |
-LL |       let _ = Some(5).map_or(false, |n| {
-   |  _____________^
-LL | |
-LL | |         let _ = n;
-LL | |         6 >= 5
-LL | |     });
-   | |______^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(5).map_or(false, |n| {
-LL +     let _ = Some(5).is_some_and(|n| {
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:30:13
-   |
-LL |     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
-LL +     let _ = Some(vec![5]).is_some_and(|n| n == [5]);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:32:13
-   |
-LL |     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
-LL +     let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:34:13
-   |
-LL |     let _ = Some(5).map_or(false, |n| n == n);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(5).map_or(false, |n| n == n);
-LL +     let _ = Some(5).is_some_and(|n| n == n);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:36:13
-   |
-LL |     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-LL +     let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:38:13
-   |
-LL |     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_ok_and` instead
-   |
-LL -     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
-LL +     let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:40:13
-   |
 LL |     let _ = Ok::<i32, i32>(5).map_or(false, |n| n == 5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -135,7 +58,7 @@ LL +     let _ = Ok::<i32, i32>(5) == Ok(5);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:42:13
+  --> tests/ui/unnecessary_map_or.rs:27:13
    |
 LL |     let _ = Some(5).map_or(false, |n| n == 5).then(|| 1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -147,31 +70,7 @@ LL +     let _ = (Some(5) == Some(5)).then(|| 1);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:44:13
-   |
-LL |     let _ = Some(5).map_or(true, |n| n == 5);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     let _ = Some(5).map_or(true, |n| n == 5);
-LL +     let _ = Some(5).is_none_or(|n| n == 5);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:46:13
-   |
-LL |     let _ = Some(5).map_or(true, |n| 5 == n);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     let _ = Some(5).map_or(true, |n| 5 == n);
-LL +     let _ = Some(5).is_none_or(|n| 5 == n);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:48:14
+  --> tests/ui/unnecessary_map_or.rs:29:14
    |
 LL |     let _ = !Some(5).map_or(false, |n| n == 5);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +82,7 @@ LL +     let _ = !(Some(5) == Some(5));
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:50:13
+  --> tests/ui/unnecessary_map_or.rs:31:13
    |
 LL |     let _ = Some(5).map_or(false, |n| n == 5) || false;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -195,7 +94,7 @@ LL +     let _ = (Some(5) == Some(5)) || false;
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:52:13
+  --> tests/ui/unnecessary_map_or.rs:33:13
    |
 LL |     let _ = Some(5).map_or(false, |n| n == 5) as usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -207,11 +106,13 @@ LL +     let _ = (Some(5) == Some(5)) as usize;
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:77:13
+  --> tests/ui/unnecessary_map_or.rs:56:13
    |
 LL |     let _ = r.map_or(false, |x| x == 7);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: `-D clippy::manual-is-variant-and` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 help: use `is_ok_and` instead
    |
 LL -     let _ = r.map_or(false, |x| x == 7);
@@ -219,43 +120,7 @@ LL +     let _ = r.is_ok_and(|x| x == 7);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:83:13
-   |
-LL |     let _ = r.map_or(false, func);
-   |             ^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_ok_and` instead
-   |
-LL -     let _ = r.map_or(false, func);
-LL +     let _ = r.is_ok_and(func);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:85:13
-   |
-LL |     let _ = Some(5).map_or(false, func);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(5).map_or(false, func);
-LL +     let _ = Some(5).is_some_and(func);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:87:13
-   |
-LL |     let _ = Some(5).map_or(true, func);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     let _ = Some(5).map_or(true, func);
-LL +     let _ = Some(5).is_none_or(func);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:93:13
+  --> tests/ui/unnecessary_map_or.rs:62:13
    |
 LL |     let _ = r.map_or(false, |x| x == 8);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -267,67 +132,43 @@ LL +     let _ = r == Ok(8);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:114:5
+  --> tests/ui/unnecessary_map_or.rs:68:13
    |
-LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = r.map_or(false, func);
+   |             ^^^^^^^^^^^^^^^^^^^^^
    |
-help: use `is_none_or` instead
+help: use `is_ok_and` instead
    |
-LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-LL +     o.is_none_or(|n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:114:34
-   |
-LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-LL +     o.map_or(true, |n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
+LL -     let _ = r.map_or(false, func);
+LL +     let _ = r.is_ok_and(func);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:129:5
+  --> tests/ui/unnecessary_map_or.rs:70:13
    |
-LL |     o.map_or(true, |n| n > 5)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     o.map_or(true, |n| n > 5)
-LL +     o.is_none_or(|n| n > 5)
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:134:13
-   |
-LL |     let x = a.map_or(false, |a| a == *s);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = Some(5).map_or(false, func);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: use `is_some_and` instead
    |
-LL -     let x = a.map_or(false, |a| a == *s);
-LL +     let x = a.is_some_and(|a| a == *s);
+LL -     let _ = Some(5).map_or(false, func);
+LL +     let _ = Some(5).is_some_and(func);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:136:13
+  --> tests/ui/unnecessary_map_or.rs:72:13
    |
-LL |     let y = b.map_or(true, |b| b == *s);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = Some(5).map_or(true, func);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: use `is_none_or` instead
    |
-LL -     let y = b.map_or(true, |b| b == *s);
-LL +     let y = b.is_none_or(|b| b == *s);
+LL -     let _ = Some(5).map_or(true, func);
+LL +     let _ = Some(5).is_none_or(func);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:142:13
+  --> tests/ui/unnecessary_map_or.rs:77:13
    |
 LL |     assert!(Some("test").map_or(false, |x| x == "test"));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -339,7 +180,7 @@ LL +     assert!(Some("test") == Some("test"));
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:146:13
+  --> tests/ui/unnecessary_map_or.rs:81:13
    |
 LL |     assert!(Some("test").map_or(false, |x| x == "test").then(|| 1).is_some());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,29 +191,5 @@ LL -     assert!(Some("test").map_or(false, |x| x == "test").then(|| 1).is_some(
 LL +     assert!((Some("test") == Some("test")).then(|| 1).is_some());
    |
 
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:163:9
-   |
-LL |     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
-LL +     _ = s.lock().unwrap().is_some_and(|s| s == "foo");
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:167:9
-   |
-LL |     _ = s.map_or(false, |s| s == "foo");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     _ = s.map_or(false, |s| s == "foo");
-LL +     _ = s.is_some_and(|s| s == "foo");
-   |
-
-error: aborting due to 30 previous errors
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16388)*

This is the third commit of https://github.com/rust-lang/rust-clippy/pull/16383

Resolves rust-lang/rust-clippy#15998

Diffs best viewed with whitespace ignored and `--color-moved`

changelog: [`unnecessary_map_or`]: move `.map_or(false, ` -> `.is_some_and(` and similar transformations to `manual_is_variant_and`