### PR TITLE
feat(needless_is_variant_and): new lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7129,6 +7129,7 @@ Released 2018-09-13
 [`needless_for_each`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each
 [`needless_if`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_if
 [`needless_ifs`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_ifs
+[`needless_is_variant_and`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_is_variant_and
 [`needless_late_init`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
 [`needless_lifetimes`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
 [`needless_match`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_match

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -445,6 +445,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::NEEDLESS_AS_BYTES_INFO,
     crate::methods::NEEDLESS_CHARACTER_ITERATION_INFO,
     crate::methods::NEEDLESS_COLLECT_INFO,
+    crate::methods::NEEDLESS_IS_VARIANT_AND_INFO,
     crate::methods::NEEDLESS_OPTION_AS_DEREF_INFO,
     crate::methods::NEEDLESS_OPTION_TAKE_INFO,
     crate::methods::NEEDLESS_SPLITN_INFO,

--- a/clippy_lints/src/manual_float_methods.rs
+++ b/clippy_lints/src/manual_float_methods.rs
@@ -152,7 +152,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualFloatMethods {
             && let ctxt = expr.span.ctxt()
             && let Some(const_1) = ecx.eval_local(const_1, ctxt)
             && let Some(const_2) = ecx.eval_local(const_2, ctxt)
-            && first.res_local_id().is_some_and(|f| second.res_local_id().is_some_and(|s| f == s))
+            && first.res_local_id().is_some_and(|f| Some(f) == second.res_local_id())
             // The actual infinity check, we also allow `NEG_INFINITY` before` INFINITY` just in
             // case somebody does that for some reason
             && (const_1.is_pos_infinity() && const_2.is_neg_infinity()

--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -397,7 +397,9 @@ pub(super) fn check_ok_is_some_and<'tcx>(
     expr: &'tcx Expr<'tcx>,
     is_some_and_recv: &'tcx Expr<'tcx>,
     arg: &'tcx Expr<'tcx>,
-) {
+) -> bool {
+    let mut fired = false;
+
     // `is_some_and` and `is_ok_and` were both stabilized in the same release, so if the receiver
     // already calls `is_some_and` then `is_ok_and` is necessarily available too: no MSRV check.
     if !expr.span.from_expansion()
@@ -406,17 +408,26 @@ pub(super) fn check_ok_is_some_and<'tcx>(
             .ty_based_def(is_some_and_recv)
             .is_diag_item(cx, sym::result_ok_method)
     {
-        let mut app = Applicability::MachineApplicable;
-        let recv_snip = snippet_with_context(cx, result_recv.span, expr.span.ctxt(), "_", &mut app).0;
-        let arg_snip = snippet_with_context(cx, arg.span, expr.span.ctxt(), "_", &mut app).0;
-        span_lint_and_sugg(
+        span_lint_and_then(
             cx,
             MANUAL_IS_VARIANT_AND,
             expr.span,
             "called `.ok().is_some_and(..)` on a `Result` value",
-            "use `is_ok_and` instead",
-            format!("{recv_snip}.is_ok_and({arg_snip})"),
-            app,
+            |diag| {
+                let mut app = Applicability::MachineApplicable;
+                let ctxt = expr.span.ctxt();
+                let recv_snip = snippet_with_context(cx, result_recv.span, ctxt, "_", &mut app).0;
+                let arg_snip = snippet_with_context(cx, arg.span, ctxt, "_", &mut app).0;
+                diag.span_suggestion(
+                    expr.span,
+                    "use `is_ok_and` instead",
+                    format!("{recv_snip}.is_ok_and({arg_snip})"),
+                    app,
+                );
+                fired = true;
+            },
         );
     }
+
+    fired
 }

--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -3,7 +3,7 @@ use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{SpanlessEq, get_parent_expr, sym};
+use clippy_utils::{SpanlessEq, get_parent_expr, is_from_proc_macro, sym};
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
@@ -286,6 +286,66 @@ pub(super) fn check_or<'tcx>(
                 "use",
                 format!("{recv_snip}.is_none_or({map_func_snip})"),
                 app,
+            );
+        },
+    );
+}
+
+pub(super) fn check_map_or<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &Expr<'tcx>,
+    recv: &Expr<'_>,
+    method_span: Span,
+    def: &Expr<'_>,
+    map: &Expr<'_>,
+    msrv: Msrv,
+) {
+    let ExprKind::Lit(def_kind) = def.kind else {
+        return;
+    };
+    let LitKind::Bool(def_bool) = def_kind.node else {
+        return;
+    };
+
+    let recv_ty = cx.typeck_results().expr_ty_adjusted(recv);
+
+    let flavor = match recv_ty.opt_diag_name(cx) {
+        Some(sym::Option) => Flavor::Option,
+        Some(sym::Result) => Flavor::Result,
+        Some(_) | None => return,
+    };
+
+    let ext_def_span = def.span.until(map.span);
+
+    let suggested_method = if !def_bool && msrv.meets(cx, msrvs::OPTION_RESULT_IS_VARIANT_AND) {
+        match flavor {
+            Flavor::Option => "is_some_and",
+            Flavor::Result => "is_ok_and",
+        }
+    } else if def_bool && matches!(flavor, Flavor::Option) && msrv.meets(cx, msrvs::IS_NONE_OR) {
+        "is_none_or"
+    } else {
+        return;
+    };
+
+    if is_from_proc_macro(cx, expr) {
+        return;
+    }
+
+    span_lint_and_then(
+        cx,
+        MANUAL_IS_VARIANT_AND,
+        expr.span,
+        "this `map_or` can be simplified",
+        |diag| {
+            let sugg = vec![
+                (method_span, suggested_method.to_owned()),
+                (ext_def_span, String::new()),
+            ];
+            diag.multipart_suggestion(
+                format!("use `{suggested_method}` instead"),
+                sugg,
+                Applicability::MachineApplicable,
             );
         },
     );

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -61,6 +61,7 @@ mod lines_filter_map_ok;
 mod manual_c_str_literals;
 mod manual_clear;
 mod manual_contains;
+mod manual_eq_optional;
 mod manual_inspect;
 mod manual_is_variant_and;
 mod manual_next_back;
@@ -138,7 +139,6 @@ mod unnecessary_iter_cloned;
 mod unnecessary_join;
 mod unnecessary_lazy_eval;
 mod unnecessary_literal_unwrap;
-mod unnecessary_map_or;
 mod unnecessary_map_or_else;
 mod unnecessary_min_or_max;
 mod unnecessary_sort_by;
@@ -2649,6 +2649,41 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Converts some constructs mapping an Enum value for equality comparison.
+    ///
+    /// ### Why is this bad?
+    /// Calls such as `opt.is_some_and(|val| val == 5)` are needlessly long and cumbersome,
+    /// and can be reduced to, for example, `opt == Some(5)` assuming `opt` implements `PartialEq`.
+    /// This lint offers readability and conciseness improvements.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// pub fn a(opt: Option<i32>, res: Result<i32, i32>) -> (bool, bool, bool) {
+    ///     (
+    ///         opt.is_some_and(|n| n == 5),
+    ///         opt.is_none_or(|n| n != 5),
+    ///         res.is_ok_and(|n| n == 5),
+    ///     )
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// pub fn a(opt: Option<i32>, res: Result<i32, i32>) -> (bool, bool, bool) {
+    ///     (
+    ///         opt == Some(5),
+    ///         opt != Some(5),
+    ///         res == Ok(5),
+    ///     )
+    /// }
+    /// ```
+    #[clippy::version = "1.94.0"]
+    pub NEEDLESS_IS_VARIANT_AND,
+    style,
+    "reduce unnecessary calls to `.is_some_and(…)`, `.is_none_or(…)`, and `.is_ok_and(…)`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for no-op uses of `Option::{as_deref, as_deref_mut}`,
     /// for example, `Option<&T>::as_deref()` returns the same type.
     ///
@@ -4435,8 +4470,6 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// Calls such as `opt.map_or(false, |val| val == 5)` are needlessly long and cumbersome,
     /// and can be reduced to, for example, `opt == Some(5)` assuming `opt` implements `PartialEq`.
-    /// Also, calls such as `opt.map_or(true, |val| val == 5)` can be reduced to
-    /// `opt.is_none_or(|val| val == 5)`.
     /// This lint offers readability and conciseness improvements.
     ///
     /// ### Example
@@ -4444,7 +4477,7 @@ declare_clippy_lint! {
     /// pub fn a(x: Option<i32>) -> (bool, bool) {
     ///     (
     ///         x.map_or(false, |n| n == 5),
-    ///         x.map_or(true, |n| n > 5),
+    ///         x.map_or(true, |n| n != 5),
     ///     )
     /// }
     /// ```
@@ -4453,7 +4486,7 @@ declare_clippy_lint! {
     /// pub fn a(x: Option<i32>) -> (bool, bool) {
     ///     (
     ///         x == Some(5),
-    ///         x.is_none_or(|n| n > 5),
+    ///         x != Some(5),
     ///     )
     /// }
     /// ```
@@ -5007,6 +5040,7 @@ impl_lint_pass!(Methods => [
     NEEDLESS_AS_BYTES,
     NEEDLESS_CHARACTER_ITERATION,
     NEEDLESS_COLLECT,
+    NEEDLESS_IS_VARIANT_AND,
     NEEDLESS_OPTION_AS_DEREF,
     NEEDLESS_OPTION_TAKE,
     NEEDLESS_SPLITN,
@@ -5561,8 +5595,14 @@ impl Methods {
                 (sym::is_file, []) => filetype_is_file::check(cx, expr, recv),
                 (sym::is_digit, [radix]) => is_digit_ascii_radix::check(cx, expr, recv, radix, self.msrv),
                 (sym::is_none, []) => check_is_some_is_none(cx, expr, recv, call_span, false, self.msrv),
+                (sym::is_none_or, [predicate]) => manual_eq_optional::check_is_none_or(cx, expr, recv, predicate),
+                (sym::is_ok_and, [predicate]) => manual_eq_optional::check_is_ok_and(cx, expr, recv, predicate),
                 (sym::is_some, []) => check_is_some_is_none(cx, expr, recv, call_span, true, self.msrv),
-                (sym::is_some_and, [arg]) => manual_is_variant_and::check_ok_is_some_and(cx, expr, recv, arg),
+                (sym::is_some_and, [arg]) => {
+                    if !manual_is_variant_and::check_ok_is_some_and(cx, expr, recv, arg) {
+                        manual_eq_optional::check_is_some_and(cx, expr, recv, arg);
+                    }
+                },
                 (sym::iter | sym::iter_mut | sym::into_iter, []) => {
                     iter_on_single_or_empty_collections::check(cx, expr, name, recv);
                 },
@@ -5640,7 +5680,7 @@ impl Methods {
                     // while `manual_is_variant_and` suggests `.is_some_and(|n| n == 5)`.
                     //
                     // Try to give the first suggestion when possible, as it's more specific.
-                    if !unnecessary_map_or::check(cx, expr, recv, def, map) {
+                    if !manual_eq_optional::check_map_or(cx, expr, recv, def, map) {
                         manual_is_variant_and::check_map_or(cx, expr, recv, span, def, map, self.msrv);
                     }
                 },

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5635,7 +5635,14 @@ impl Methods {
                 (sym::map_or, [def, map]) => {
                     option_map_or_none::check(cx, expr, recv, def, map);
                     manual_ok_or::check(cx, expr, recv, def, map);
-                    unnecessary_map_or::check(cx, expr, recv, def, map, span, self.msrv);
+                    // On an expression like `option.map_or(false, |n| n == 5)`,
+                    // `unnecessary_map_or` suggests `== Some(5)`,
+                    // while `manual_is_variant_and` suggests `.is_some_and(|n| n == 5)`.
+                    //
+                    // Try to give the first suggestion when possible, as it's more specific.
+                    if !unnecessary_map_or::check(cx, expr, recv, def, map) {
+                        manual_is_variant_and::check_map_or(cx, expr, recv, span, def, map, self.msrv);
+                    }
                 },
                 (sym::map_or_else, [def, map]) => {
                     result_map_or_else_none::check(cx, expr, recv, def, map);

--- a/clippy_lints/src/methods/needless_collect.rs
+++ b/clippy_lints/src/methods/needless_collect.rs
@@ -513,8 +513,8 @@ impl<'tcx> Visitor<'tcx> for IterFunctionVisitor<'_, 'tcx> {
                             func: IterFunctionKind::Contains(args[0].span),
                             span: expr.span,
                         })),
-                        name if let is_push_back = self.extra_spec.push_symbol.back.is_some_and(|sym| name == sym)
-                            && (is_push_back || self.extra_spec.push_symbol.front.is_some_and(|sym| name == sym))
+                        name if let is_push_back = self.extra_spec.push_symbol.back == Some(name)
+                            && (is_push_back || self.extra_spec.push_symbol.front == Some(name))
                             && self.uses.is_empty() =>
                         {
                             let span = get_span_of_expr_or_parent_stmt(self.cx, expr);
@@ -551,9 +551,7 @@ impl<'tcx> Visitor<'tcx> for IterFunctionVisitor<'_, 'tcx> {
                                 },
                             }
                         },
-                        name if self.extra_spec.extend_symbol.is_some_and(|sym| name == sym)
-                            && self.uses.is_empty() =>
-                        {
+                        name if self.extra_spec.extend_symbol == Some(name) && self.uses.is_empty() => {
                             let span = get_span_of_expr_or_parent_stmt(self.cx, expr);
                             self.extras.push(ExtraFunction::Extend(ExtraFunctionSpan {
                                 func_span: span,

--- a/clippy_lints/src/methods/unnecessary_filter_map.rs
+++ b/clippy_lints/src/methods/unnecessary_filter_map.rs
@@ -64,7 +64,7 @@ pub(super) fn check<'tcx>(
             }
         } else if !found_mapping && !mutates_arg && (!clone_or_copy_needed || is_copy(cx, in_ty)) {
             let ty = cx.typeck_results().expr_ty(body.value);
-            if option_arg_ty(cx, ty).is_some_and(|t| t == in_ty) {
+            if option_arg_ty(cx, ty) == Some(in_ty) {
                 match kind {
                     Kind::FilterMap => "filter(..)",
                     Kind::FindMap => "find(..)",

--- a/clippy_lints/src/methods/unnecessary_map_or.rs
+++ b/clippy_lints/src/methods/unnecessary_map_or.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::eager_or_lazy::switch_to_eager_eval;
-use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::{MaybeDef, MaybeResPath};
 use clippy_utils::sugg::{Sugg, make_binop};
 use clippy_utils::ty::{implements_trait, is_copy};
@@ -12,29 +11,9 @@ use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, PatKind};
 use rustc_lint::LateContext;
-use rustc_span::{Span, sym};
+use rustc_span::sym;
 
 use super::UNNECESSARY_MAP_OR;
-
-pub(super) enum Variant {
-    Ok,
-    Some,
-}
-impl Variant {
-    pub fn variant_name(&self) -> &'static str {
-        match self {
-            Variant::Ok => "Ok",
-            Variant::Some => "Some",
-        }
-    }
-
-    pub fn method_name(&self) -> &'static str {
-        match self {
-            Variant::Ok => "is_ok_and",
-            Variant::Some => "is_some_and",
-        }
-    }
-}
 
 pub(super) fn check<'a>(
     cx: &LateContext<'a>,
@@ -42,119 +21,90 @@ pub(super) fn check<'a>(
     recv: &Expr<'_>,
     def: &Expr<'_>,
     map: &Expr<'_>,
-    method_span: Span,
-    msrv: Msrv,
-) {
-    let ExprKind::Lit(def_kind) = def.kind else {
-        return;
-    };
-    let LitKind::Bool(def_bool) = def_kind.node else {
-        return;
-    };
-
-    let typeck = cx.typeck_results();
-
-    let recv_ty = typeck.expr_ty_adjusted(recv);
-
-    let variant = match recv_ty.opt_diag_name(cx) {
-        Some(sym::Option) => Variant::Some,
-        Some(sym::Result) => Variant::Ok,
-        Some(_) | None => return,
-    };
-
-    let ext_def_span = def.span.until(map.span);
-
-    let (sugg, method, applicability): (_, Cow<'_, _>, _) = if typeck.expr_adjustments(recv).is_empty()
-            && let ExprKind::Closure(map_closure) = map.kind
-            && let closure_body = cx.tcx.hir_body(map_closure.body)
-            && let closure_body_value = closure_body.value.peel_blocks()
-            && let ExprKind::Binary(op, l, r) = closure_body_value.kind
-            && let [param] = closure_body.params
-            && let PatKind::Binding(_, hir_id, _, _) = param.pat.kind
-            // checking that map_or is one of the following:
-            // .map_or(false, |x| x == y)
-            // .map_or(false, |x| y == x) - swapped comparison
-            // .map_or(true, |x| x != y)
-            // .map_or(true, |x| y != x) - swapped comparison
-            && ((BinOpKind::Eq == op.node && !def_bool) || (BinOpKind::Ne == op.node && def_bool))
-            && let non_binding_location = if l.res_local_id() == Some(hir_id) { r } else { l }
-            && switch_to_eager_eval(cx, non_binding_location)
-            // if it's both then that's a strange edge case and
-            // we can just ignore it, since by default clippy will error on this
-            && (l.res_local_id() == Some(hir_id)) != (r.res_local_id() == Some(hir_id))
-            && !is_local_used(cx, non_binding_location, hir_id)
-            && let l_ty = typeck.expr_ty(l)
-            && l_ty == typeck.expr_ty(r)
-            && let Some(partial_eq) = cx.tcx.lang_items().eq_trait()
-            && implements_trait(cx, recv_ty, partial_eq, &[recv_ty.into()])
-            && is_copy(cx, l_ty)
-    {
-        let wrap = variant.variant_name();
-
-        // we may need to add parens around the suggestion
-        // in case the parent expression has additional method calls,
-        // since for example `Some(5).map_or(false, |x| x == 5).then(|| 1)`
-        // being converted to `Some(5) == Some(5).then(|| 1)` isn't
-        // the same thing
-
-        let mut app = Applicability::MachineApplicable;
-        let inner_non_binding = Sugg::NonParen(Cow::Owned(format!(
-            "{wrap}({})",
-            Sugg::hir_with_applicability(cx, non_binding_location, "", &mut app)
-        )));
-
-        let binop = make_binop(
-            op.node,
-            &Sugg::hir_with_applicability(cx, recv, "..", &mut app),
-            &inner_non_binding,
-        );
-
-        let sugg = if let Some(parent_expr) = get_parent_expr(cx, expr) {
-            if parent_expr.span.eq_ctxt(expr.span) {
-                match parent_expr.kind {
-                    ExprKind::Binary(..) | ExprKind::Unary(..) | ExprKind::Cast(..) => binop.maybe_paren(),
-                    ExprKind::MethodCall(_, receiver, _, _) if receiver.hir_id == expr.hir_id => binop.maybe_paren(),
-                    _ => binop,
-                }
-            } else {
-                // if our parent expr is created by a macro, then it should be the one taking care of
-                // parenthesising us if necessary
-                binop
-            }
-        } else {
-            binop
+) -> bool {
+    if let ExprKind::Lit(def_kind) = def.kind
+        && let LitKind::Bool(def_bool) = def_kind.node
+        && let typeck = cx.typeck_results()
+        && let recv_ty = typeck.expr_ty_adjusted(recv)
+        && let wrap = match recv_ty.opt_diag_name(cx) {
+            Some(sym::Option) => "Some",
+            Some(sym::Result) => "Ok",
+            Some(_) | None => return false,
         }
-        .into_string();
+        && typeck.expr_adjustments(recv).is_empty()
+        && let ExprKind::Closure(map_closure) = map.kind
+        && let closure_body = cx.tcx.hir_body(map_closure.body)
+        && let closure_body_value = closure_body.value.peel_blocks()
+        && let ExprKind::Binary(op, l, r) = closure_body_value.kind
+        && let [param] = closure_body.params
+        && let PatKind::Binding(_, hir_id, _, _) = param.pat.kind
+        // checking that map_or is one of the following:
+        // .map_or(false, |x| x == y)
+        // .map_or(false, |x| y == x) - swapped comparison
+        // .map_or(true, |x| x != y)
+        // .map_or(true, |x| y != x) - swapped comparison
+        && ((BinOpKind::Eq == op.node && !def_bool) || (BinOpKind::Ne == op.node && def_bool))
+        && let non_binding_location = if l.res_local_id() == Some(hir_id) { r } else { l }
+        && switch_to_eager_eval(cx, non_binding_location)
+        // if it's both then that's a strange edge case and
+        // we can just ignore it, since by default clippy will error on this
+        && (l.res_local_id() == Some(hir_id)) != (r.res_local_id() == Some(hir_id))
+        && !is_local_used(cx, non_binding_location, hir_id)
+        && let l_ty = typeck.expr_ty(l)
+        && l_ty == typeck.expr_ty(r)
+        && let Some(partial_eq) = cx.tcx.lang_items().eq_trait()
+        && implements_trait(cx, recv_ty, partial_eq, &[recv_ty.into()])
+        && is_copy(cx, l_ty)
+        && !is_from_proc_macro(cx, expr)
+    {
+        let mut fired = false;
+        span_lint_and_then(
+            cx,
+            UNNECESSARY_MAP_OR,
+            expr.span,
+            "this `map_or` can be simplified",
+            |diag| {
+                // we may need to add parens around the suggestion
+                // in case the parent expression has additional method calls,
+                // since for example `Some(5).map_or(false, |x| x == 5).then(|| 1)`
+                // being converted to `Some(5) == Some(5).then(|| 1)` isn't
+                // the same thing
 
-        (vec![(expr.span, sugg)], "a standard comparison".into(), app)
-    } else if !def_bool && msrv.meets(cx, msrvs::OPTION_RESULT_IS_VARIANT_AND) {
-        let suggested_name = variant.method_name();
-        (
-            vec![(method_span, suggested_name.into()), (ext_def_span, String::new())],
-            format!("`{suggested_name}`").into(),
-            Applicability::MachineApplicable,
-        )
-    } else if def_bool && matches!(variant, Variant::Some) && msrv.meets(cx, msrvs::IS_NONE_OR) {
-        (
-            vec![(method_span, "is_none_or".into()), (ext_def_span, String::new())],
-            "`is_none_or`".into(),
-            Applicability::MachineApplicable,
-        )
-    } else {
-        return;
-    };
+                let mut app = Applicability::MachineApplicable;
+                let inner_non_binding = Sugg::NonParen(Cow::Owned(format!(
+                    "{wrap}({})",
+                    Sugg::hir_with_applicability(cx, non_binding_location, "", &mut app)
+                )));
 
-    if is_from_proc_macro(cx, expr) {
-        return;
+                let binop = make_binop(
+                    op.node,
+                    &Sugg::hir_with_applicability(cx, recv, "..", &mut app),
+                    &inner_non_binding,
+                );
+
+                let sugg = if let Some(parent_expr) = get_parent_expr(cx, expr) {
+                    if parent_expr.span.eq_ctxt(expr.span) {
+                        match parent_expr.kind {
+                            ExprKind::Binary(..) | ExprKind::Unary(..) | ExprKind::Cast(..) => binop.maybe_paren(),
+                            ExprKind::MethodCall(_, receiver, _, _) if receiver.hir_id == expr.hir_id => {
+                                binop.maybe_paren()
+                            },
+                            _ => binop,
+                        }
+                    } else {
+                        // if our parent expr is created by a macro, then it should be the one taking care of
+                        // parenthesising us if necessary
+                        binop
+                    }
+                } else {
+                    binop
+                };
+                diag.span_suggestion_verbose(expr.span, "use a standard comparison instead", sugg.to_string(), app);
+
+                fired = true;
+            },
+        );
+        return fired;
     }
-
-    span_lint_and_then(
-        cx,
-        UNNECESSARY_MAP_OR,
-        expr.span,
-        "this `map_or` can be simplified",
-        |diag| {
-            diag.multipart_suggestion(format!("use {method} instead"), sugg, applicability);
-        },
-    );
+    false
 }

--- a/clippy_lints/src/methods/useless_asref.rs
+++ b/clippy_lints/src/methods/useless_asref.rs
@@ -158,7 +158,7 @@ fn is_calling_clone(cx: &LateContext<'_>, arg: &hir::Expr<'_>) -> bool {
                         && let Some(fn_id) = cx.typeck_results().type_dependent_def_id(closure_expr.hir_id)
                         && let Some(trait_id) = cx.tcx.trait_of_assoc(fn_id)
                         // We check it's the `Clone` trait.
-                        && cx.tcx.lang_items().clone_trait().is_some_and(|id| id == trait_id)
+                        && cx.tcx.lang_items().clone_trait() == Some(trait_id)
                         // no autoderefs
                         && !cx.typeck_results().expr_adjustments(obj).iter()
                             .any(|a| matches!(a.kind, Adjust::Deref(DerefAdjustKind::Overloaded(..))))

--- a/clippy_lints/src/ptr/ptr_arg.rs
+++ b/clippy_lints/src/ptr/ptr_arg.rs
@@ -263,7 +263,7 @@ fn check_fn_args<'cx, 'tcx: 'cx>(
                                         | ty::ReErased
                                         | ty::ReError(_) => None,
                                     })
-                                    .any(|def_id| def_id.as_local().is_some_and(|def_id| def_id == param_def_id))
+                                    .any(|def_id| def_id.as_local() == Some(param_def_id))
                             {
                                 // `&Cow<'a, T>` when the return type uses 'a is okay
                                 return None;

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -200,7 +200,7 @@ pub fn is_local_used_except<'tcx>(
     except: Option<HirId>,
 ) -> bool {
     for_each_expr(cx.tcx, visitable, |e| {
-        if except.is_some_and(|it| it == e.hir_id) {
+        if except == Some(e.hir_id) {
             ControlFlow::Continue(Descend::No)
         } else if e.res_local_id() == Some(id) {
             ControlFlow::Break(())

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -381,6 +381,7 @@ generate! {
     is_none,
     is_none_or,
     is_ok,
+    is_ok_and,
     is_partitioned,
     is_some,
     is_some_and,

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -3,6 +3,7 @@
 #![warn(clippy::manual_is_variant_and)]
 #![allow(
     clippy::nonminimal_bool,
+    clippy::needless_is_variant_and, // fires after the `unnecessary_map_or` fixes
     clippy::eq_op,
     clippy::unnecessary_lazy_evaluations,
     clippy::redundant_closure

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -1,9 +1,17 @@
 //@aux-build:option_helpers.rs
+//@aux-build:proc_macros.rs
 #![warn(clippy::manual_is_variant_and)]
-#![allow(clippy::redundant_closure)]
+#![allow(
+    clippy::nonminimal_bool,
+    clippy::eq_op,
+    clippy::unnecessary_lazy_evaluations,
+    clippy::redundant_closure
+)]
 
 #[macro_use]
 extern crate option_helpers;
+#[macro_use]
+extern crate proc_macros;
 
 struct Foo<T>(T);
 
@@ -77,6 +85,27 @@ fn option_methods() {
     //~^ manual_is_variant_and
     let _ = opt_map!(opt2, |x| x == 'a').unwrap_or_default(); // should not lint
 
+    // Check for `option.map_or(true, _)` and `option.map_or(false, _)` use.
+    let _ = Some(5).is_some_and(|n| {
+        //~^ manual_is_variant_and
+        let _ = n;
+        6 >= 5
+    });
+    let _ = Some(vec![5]).is_some_and(|n| n == [5]);
+    //~^ manual_is_variant_and
+    let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_some_and(|n| n == n);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
+    //~^ manual_is_variant_and
+    let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_none_or(|n| n == 5);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_none_or(|n| 5 == n);
+    //~^ manual_is_variant_and
+
     // Should not lint.
     let _ = Foo::<u32>(0).map(|x| x.is_multiple_of(2)) == Some(true);
     let _ = Some(2).map(|x| x % 2 == 0) != foo();
@@ -84,12 +113,22 @@ fn option_methods() {
     let _ = mac!(some 2).map(|x| x % 2 == 0) == Some(true);
     let _ = mac!(some_map 2) == Some(true);
     let _ = mac!(map Some(2)) == Some(true);
+    let _ = mac!(some 2).map_or(true, |x| x % 2 == 0);
+    let _ = mac!(some 2).map_or(false, |x| x % 2 == 0);
+    external! {
+        let _ = Some(5).map_or(false, |n| n > 5);
+    }
+    with_span! {
+        let _ = Some(5).map_or(false, |n| n > 5);
+    }
+
 }
 
 #[rustfmt::skip]
 fn result_methods() {
     let res: Result<i32, ()> = Ok(1);
 
+    // Check for `result.map(_).unwrap_or_default()` use.
     // multi line cases
     let _ = res.is_ok_and(|x| {
     //~^ manual_is_variant_and
@@ -111,9 +150,86 @@ fn result_methods() {
     let _ = res2.is_ok_and(char::is_alphanumeric); // should lint
     //~^ manual_is_variant_and
     let _ = opt_map!(res2, |x| x == 'a').unwrap_or_default(); // should not lint
+
+    // Check for `result.map_or(false, _)` use.
+    let _ = res.is_ok_and(|x| x > 8);
+    //~^ manual_is_variant_and
+
+    // Don't lint, `unnecessary_map_or` will take over
+    #[derive(PartialEq)]
+    struct S1;
+    let mut r: Result<i32, S1> = Ok(3);
+    let _ = r == Ok(7);
+    //~^ unnecessary_map_or
+
+    // But do lint if `unnecessary_map_or` is `allow`ed
+    r = Ok(3);
+    #[allow(clippy::unnecessary_map_or)]
+    let _ = r.is_ok_and(|x| x == 7); //~ manual_is_variant_and
+    // ...or `expect`ed
+    r = Ok(3);
+    #[allow(clippy::unnecessary_map_or)]
+    let _ = r.is_ok_and(|x| x == 7); //~ manual_is_variant_and
+
+    // Lint, as `S2` doesn't implement `PartialEq`
+    struct S2;
+    let r: Result<i32, S2> = Ok(3);
+    let _ = r.is_ok_and(|x| x == 7);
+    //~^ manual_is_variant_and
+
 }
 
 fn main() {}
+
+#[clippy::msrv = "1.69.0"]
+fn msrv_1_69() {
+    // is_some_and added in 1.70.0
+    let _ = Some(5).map_or(false, |n| n > if 2 > 1 { n } else { 0 });
+}
+
+#[clippy::msrv = "1.81.0"]
+fn msrv_1_81() {
+    // is_none_or added in 1.82.0
+    let _ = Some(5).map_or(true, |n| n > if 2 > 1 { n } else { 0 });
+}
+
+fn with_refs(o: &mut Option<u32>) -> bool {
+    o.is_none_or(|n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
+    //~^ manual_is_variant_and
+    //~| manual_is_variant_and
+}
+
+struct S;
+
+impl std::ops::Deref for S {
+    type Target = Option<u32>;
+    fn deref(&self) -> &Self::Target {
+        &Some(0)
+    }
+}
+
+fn with_deref(o: &S) -> bool {
+    o.is_none_or(|n| n > 5)
+    //~^ manual_is_variant_and
+}
+
+fn issue14201(a: Option<String>, b: Option<String>, s: &String) -> bool {
+    let x = a.is_some_and(|a| a == *s);
+    //~^ manual_is_variant_and
+    let y = b.is_none_or(|b| b == *s);
+    //~^ manual_is_variant_and
+    x && y
+}
+
+fn issue15180() {
+    let s = std::sync::Mutex::new(Some("foo"));
+    _ = s.lock().unwrap().is_some_and(|s| s == "foo");
+    //~^ manual_is_variant_and
+
+    let s = &&&&Some("foo");
+    _ = s.is_some_and(|s| s == "foo");
+    //~^ manual_is_variant_and
+}
 
 fn issue15202() {
     let xs = [None, Some(b'_'), Some(b'1')];
@@ -184,7 +300,10 @@ mod with_func {
         let a1 = b.is_some_and(iad);
         //~^ manual_is_variant_and
         let a2 = b.is_some_and(iad);
-        assert_eq!(a1, a2);
+        //~^ manual_is_variant_and
+        let a3 = b.is_some_and(iad);
+        assert_eq!(a1, a3);
+        assert_eq!(a2, a3);
 
         let a1 = b.is_some_and(|x| !iad(x));
         //~^ manual_is_variant_and
@@ -199,14 +318,20 @@ mod with_func {
         let a1 = b.is_none_or(iad);
         //~^ manual_is_variant_and
         let a2 = b.is_none_or(iad);
-        assert_eq!(a1, a2);
+        //~^ manual_is_variant_and
+        let a3 = b.is_none_or(iad);
+        assert_eq!(a2, a3);
+        assert_eq!(a1, a3);
     }
 
     fn check_result(b: Result<u8, ()>) {
         let a1 = b.is_ok_and(iad);
         //~^ manual_is_variant_and
         let a2 = b.is_ok_and(iad);
-        assert_eq!(a1, a2);
+        //~^ manual_is_variant_and
+        let a3 = b.is_ok_and(iad);
+        assert_eq!(a1, a3);
+        assert_eq!(a2, a3);
 
         let a1 = b.is_ok_and(|x| !iad(x));
         //~^ manual_is_variant_and

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -1,9 +1,17 @@
 //@aux-build:option_helpers.rs
+//@aux-build:proc_macros.rs
 #![warn(clippy::manual_is_variant_and)]
-#![allow(clippy::redundant_closure)]
+#![allow(
+    clippy::nonminimal_bool,
+    clippy::eq_op,
+    clippy::unnecessary_lazy_evaluations,
+    clippy::redundant_closure
+)]
 
 #[macro_use]
 extern crate option_helpers;
+#[macro_use]
+extern crate proc_macros;
 
 struct Foo<T>(T);
 
@@ -83,6 +91,27 @@ fn option_methods() {
     //~^ manual_is_variant_and
     let _ = opt_map!(opt2, |x| x == 'a').unwrap_or_default(); // should not lint
 
+    // Check for `option.map_or(true, _)` and `option.map_or(false, _)` use.
+    let _ = Some(5).map_or(false, |n| {
+        //~^ manual_is_variant_and
+        let _ = n;
+        6 >= 5
+    });
+    let _ = Some(vec![5]).map_or(false, |n| n == [5]);
+    //~^ manual_is_variant_and
+    let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(false, |n| n == n);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
+    //~^ manual_is_variant_and
+    let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(true, |n| n == 5);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(true, |n| 5 == n);
+    //~^ manual_is_variant_and
+
     // Should not lint.
     let _ = Foo::<u32>(0).map(|x| x.is_multiple_of(2)) == Some(true);
     let _ = Some(2).map(|x| x % 2 == 0) != foo();
@@ -90,12 +119,22 @@ fn option_methods() {
     let _ = mac!(some 2).map(|x| x % 2 == 0) == Some(true);
     let _ = mac!(some_map 2) == Some(true);
     let _ = mac!(map Some(2)) == Some(true);
+    let _ = mac!(some 2).map_or(true, |x| x % 2 == 0);
+    let _ = mac!(some 2).map_or(false, |x| x % 2 == 0);
+    external! {
+        let _ = Some(5).map_or(false, |n| n > 5);
+    }
+    with_span! {
+        let _ = Some(5).map_or(false, |n| n > 5);
+    }
+
 }
 
 #[rustfmt::skip]
 fn result_methods() {
     let res: Result<i32, ()> = Ok(1);
 
+    // Check for `result.map(_).unwrap_or_default()` use.
     // multi line cases
     let _ = res.map(|x| {
     //~^ manual_is_variant_and
@@ -120,9 +159,86 @@ fn result_methods() {
     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
     //~^ manual_is_variant_and
     let _ = opt_map!(res2, |x| x == 'a').unwrap_or_default(); // should not lint
+
+    // Check for `result.map_or(false, _)` use.
+    let _ = res.map_or(false, |x| x > 8);
+    //~^ manual_is_variant_and
+
+    // Don't lint, `unnecessary_map_or` will take over
+    #[derive(PartialEq)]
+    struct S1;
+    let mut r: Result<i32, S1> = Ok(3);
+    let _ = r.map_or(false, |x| x == 7);
+    //~^ unnecessary_map_or
+
+    // But do lint if `unnecessary_map_or` is `allow`ed
+    r = Ok(3);
+    #[allow(clippy::unnecessary_map_or)]
+    let _ = r.map_or(false, |x| x == 7); //~ manual_is_variant_and
+    // ...or `expect`ed
+    r = Ok(3);
+    #[allow(clippy::unnecessary_map_or)]
+    let _ = r.map_or(false, |x| x == 7); //~ manual_is_variant_and
+
+    // Lint, as `S2` doesn't implement `PartialEq`
+    struct S2;
+    let r: Result<i32, S2> = Ok(3);
+    let _ = r.map_or(false, |x| x == 7);
+    //~^ manual_is_variant_and
+
 }
 
 fn main() {}
+
+#[clippy::msrv = "1.69.0"]
+fn msrv_1_69() {
+    // is_some_and added in 1.70.0
+    let _ = Some(5).map_or(false, |n| n > if 2 > 1 { n } else { 0 });
+}
+
+#[clippy::msrv = "1.81.0"]
+fn msrv_1_81() {
+    // is_none_or added in 1.82.0
+    let _ = Some(5).map_or(true, |n| n > if 2 > 1 { n } else { 0 });
+}
+
+fn with_refs(o: &mut Option<u32>) -> bool {
+    o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+    //~^ manual_is_variant_and
+    //~| manual_is_variant_and
+}
+
+struct S;
+
+impl std::ops::Deref for S {
+    type Target = Option<u32>;
+    fn deref(&self) -> &Self::Target {
+        &Some(0)
+    }
+}
+
+fn with_deref(o: &S) -> bool {
+    o.map_or(true, |n| n > 5)
+    //~^ manual_is_variant_and
+}
+
+fn issue14201(a: Option<String>, b: Option<String>, s: &String) -> bool {
+    let x = a.map_or(false, |a| a == *s);
+    //~^ manual_is_variant_and
+    let y = b.map_or(true, |b| b == *s);
+    //~^ manual_is_variant_and
+    x && y
+}
+
+fn issue15180() {
+    let s = std::sync::Mutex::new(Some("foo"));
+    _ = s.lock().unwrap().map_or(false, |s| s == "foo");
+    //~^ manual_is_variant_and
+
+    let s = &&&&Some("foo");
+    _ = s.map_or(false, |s| s == "foo");
+    //~^ manual_is_variant_and
+}
 
 fn issue15202() {
     let xs = [None, Some(b'_'), Some(b'1')];
@@ -192,8 +308,11 @@ mod with_func {
     fn check_option(b: Option<u8>) {
         let a1 = b.map(iad) == Some(true);
         //~^ manual_is_variant_and
-        let a2 = b.is_some_and(iad);
-        assert_eq!(a1, a2);
+        let a2 = b.map_or(false, iad);
+        //~^ manual_is_variant_and
+        let a3 = b.is_some_and(iad);
+        assert_eq!(a1, a3);
+        assert_eq!(a2, a3);
 
         let a1 = b.map(iad) == Some(false);
         //~^ manual_is_variant_and
@@ -207,15 +326,21 @@ mod with_func {
 
         let a1 = b.map(iad) != Some(false);
         //~^ manual_is_variant_and
-        let a2 = b.is_none_or(iad);
-        assert_eq!(a1, a2);
+        let a2 = b.map_or(true, iad);
+        //~^ manual_is_variant_and
+        let a3 = b.is_none_or(iad);
+        assert_eq!(a2, a3);
+        assert_eq!(a1, a3);
     }
 
     fn check_result(b: Result<u8, ()>) {
         let a1 = b.map(iad) == Ok(true);
         //~^ manual_is_variant_and
-        let a2 = b.is_ok_and(iad);
-        assert_eq!(a1, a2);
+        let a2 = b.map_or(false, iad);
+        //~^ manual_is_variant_and
+        let a3 = b.is_ok_and(iad);
+        assert_eq!(a1, a3);
+        assert_eq!(a2, a3);
 
         let a1 = b.map(iad) == Ok(false);
         //~^ manual_is_variant_and

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::manual_is_variant_and)]
 #![allow(
     clippy::nonminimal_bool,
+    clippy::needless_is_variant_and, // fires after the `unnecessary_map_or` fixes
     clippy::eq_op,
     clippy::unnecessary_lazy_evaluations,
     clippy::redundant_closure

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -1,5 +1,5 @@
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:60:17
+  --> tests/ui/manual_is_variant_and.rs:61:17
    |
 LL |       let _ = opt.map(|x| x > 1)
    |  _________________^
@@ -11,7 +11,7 @@ LL | |         .unwrap_or_default();
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:65:17
+  --> tests/ui/manual_is_variant_and.rs:66:17
    |
 LL |       let _ = opt.map(|x| {
    |  _________________^
@@ -30,13 +30,13 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:70:17
+  --> tests/ui/manual_is_variant_and.rs:71:17
    |
 LL |     let _ = opt.map(|x| x > 1).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:73:10
+  --> tests/ui/manual_is_variant_and.rs:74:10
    |
 LL |           .map(|x| x > 1)
    |  __________^
@@ -45,37 +45,37 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:77:13
+  --> tests/ui/manual_is_variant_and.rs:78:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:79:13
+  --> tests/ui/manual_is_variant_and.rs:80:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 != 0)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:81:13
+  --> tests/ui/manual_is_variant_and.rs:82:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == some_true!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:83:13
+  --> tests/ui/manual_is_variant_and.rs:84:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != some_false!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:90:18
+  --> tests/ui/manual_is_variant_and.rs:91:18
    |
 LL |     let _ = opt2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(char::is_alphanumeric)`
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:95:13
+  --> tests/ui/manual_is_variant_and.rs:96:13
    |
 LL |       let _ = Some(5).map_or(false, |n| {
    |  _____________^
@@ -92,7 +92,7 @@ LL +     let _ = Some(5).is_some_and(|n| {
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:100:13
+  --> tests/ui/manual_is_variant_and.rs:101:13
    |
 LL |     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +104,7 @@ LL +     let _ = Some(vec![5]).is_some_and(|n| n == [5]);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:102:13
+  --> tests/ui/manual_is_variant_and.rs:103:13
    |
 LL |     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -116,7 +116,7 @@ LL +     let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:104:13
+  --> tests/ui/manual_is_variant_and.rs:105:13
    |
 LL |     let _ = Some(5).map_or(false, |n| n == n);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -128,7 +128,7 @@ LL +     let _ = Some(5).is_some_and(|n| n == n);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:106:13
+  --> tests/ui/manual_is_variant_and.rs:107:13
    |
 LL |     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +140,7 @@ LL +     let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:108:13
+  --> tests/ui/manual_is_variant_and.rs:109:13
    |
 LL |     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -152,7 +152,7 @@ LL +     let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:110:13
+  --> tests/ui/manual_is_variant_and.rs:111:13
    |
 LL |     let _ = Some(5).map_or(true, |n| n == 5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -164,7 +164,7 @@ LL +     let _ = Some(5).is_none_or(|n| n == 5);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:112:13
+  --> tests/ui/manual_is_variant_and.rs:113:13
    |
 LL |     let _ = Some(5).map_or(true, |n| 5 == n);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +176,7 @@ LL +     let _ = Some(5).is_none_or(|n| 5 == n);
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:139:17
+  --> tests/ui/manual_is_variant_and.rs:140:17
    |
 LL |       let _ = res.map(|x| {
    |  _________________^
@@ -195,7 +195,7 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:144:17
+  --> tests/ui/manual_is_variant_and.rs:145:17
    |
 LL |       let _ = res.map(|x| x > 1)
    |  _________________^
@@ -204,31 +204,31 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_ok_and(|x| x > 1)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:148:13
+  --> tests/ui/manual_is_variant_and.rs:149:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) == Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:150:13
+  --> tests/ui/manual_is_variant_and.rs:151:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:152:13
+  --> tests/ui/manual_is_variant_and.rs:153:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:159:18
+  --> tests/ui/manual_is_variant_and.rs:160:18
    |
 LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:164:13
+  --> tests/ui/manual_is_variant_and.rs:165:13
    |
 LL |     let _ = res.map_or(false, |x| x > 8);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -240,7 +240,7 @@ LL +     let _ = res.is_ok_and(|x| x > 8);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:171:13
+  --> tests/ui/manual_is_variant_and.rs:172:13
    |
 LL |     let _ = r.map_or(false, |x| x == 7);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -254,7 +254,7 @@ LL +     let _ = r == Ok(7);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:177:13
+  --> tests/ui/manual_is_variant_and.rs:178:13
    |
 LL |     let _ = r.map_or(false, |x| x == 7);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -266,7 +266,7 @@ LL +     let _ = r.is_ok_and(|x| x == 7);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:181:13
+  --> tests/ui/manual_is_variant_and.rs:182:13
    |
 LL |     let _ = r.map_or(false, |x| x == 7);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -278,7 +278,7 @@ LL +     let _ = r.is_ok_and(|x| x == 7);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:186:13
+  --> tests/ui/manual_is_variant_and.rs:187:13
    |
 LL |     let _ = r.map_or(false, |x| x == 7);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -290,7 +290,7 @@ LL +     let _ = r.is_ok_and(|x| x == 7);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:206:5
+  --> tests/ui/manual_is_variant_and.rs:207:5
    |
 LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -302,7 +302,7 @@ LL +     o.is_none_or(|n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:206:34
+  --> tests/ui/manual_is_variant_and.rs:207:34
    |
 LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -314,7 +314,7 @@ LL +     o.map_or(true, |n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:221:5
+  --> tests/ui/manual_is_variant_and.rs:222:5
    |
 LL |     o.map_or(true, |n| n > 5)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -326,7 +326,7 @@ LL +     o.is_none_or(|n| n > 5)
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:226:13
+  --> tests/ui/manual_is_variant_and.rs:227:13
    |
 LL |     let x = a.map_or(false, |a| a == *s);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -338,7 +338,7 @@ LL +     let x = a.is_some_and(|a| a == *s);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:228:13
+  --> tests/ui/manual_is_variant_and.rs:229:13
    |
 LL |     let y = b.map_or(true, |b| b == *s);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,7 +350,7 @@ LL +     let y = b.is_none_or(|b| b == *s);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:235:9
+  --> tests/ui/manual_is_variant_and.rs:236:9
    |
 LL |     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -362,7 +362,7 @@ LL +     _ = s.lock().unwrap().is_some_and(|s| s == "foo");
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:239:9
+  --> tests/ui/manual_is_variant_and.rs:240:9
    |
 LL |     _ = s.map_or(false, |s| s == "foo");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -374,61 +374,61 @@ LL +     _ = s.is_some_and(|s| s == "foo");
    |
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:246:18
+  --> tests/ui/manual_is_variant_and.rs:247:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:253:18
+  --> tests/ui/manual_is_variant_and.rs:254:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:260:18
+  --> tests/ui/manual_is_variant_and.rs:261:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:267:18
+  --> tests/ui/manual_is_variant_and.rs:268:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:275:18
+  --> tests/ui/manual_is_variant_and.rs:276:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:282:18
+  --> tests/ui/manual_is_variant_and.rs:283:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:289:18
+  --> tests/ui/manual_is_variant_and.rs:290:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:296:18
+  --> tests/ui/manual_is_variant_and.rs:297:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:309:18
+  --> tests/ui/manual_is_variant_and.rs:310:18
    |
 LL |         let a1 = b.map(iad) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(iad)`
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:311:18
+  --> tests/ui/manual_is_variant_and.rs:312:18
    |
 LL |         let a2 = b.map_or(false, iad);
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -440,25 +440,25 @@ LL +         let a2 = b.is_some_and(iad);
    |
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:317:18
+  --> tests/ui/manual_is_variant_and.rs:318:18
    |
 LL |         let a1 = b.map(iad) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:322:18
+  --> tests/ui/manual_is_variant_and.rs:323:18
    |
 LL |         let a1 = b.map(iad) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:327:18
+  --> tests/ui/manual_is_variant_and.rs:328:18
    |
 LL |         let a1 = b.map(iad) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(iad)`
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:329:18
+  --> tests/ui/manual_is_variant_and.rs:330:18
    |
 LL |         let a2 = b.map_or(true, iad);
    |                  ^^^^^^^^^^^^^^^^^^^
@@ -470,13 +470,13 @@ LL +         let a2 = b.is_none_or(iad);
    |
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:337:18
+  --> tests/ui/manual_is_variant_and.rs:338:18
    |
 LL |         let a1 = b.map(iad) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(iad)`
 
 error: this `map_or` can be simplified
-  --> tests/ui/manual_is_variant_and.rs:339:18
+  --> tests/ui/manual_is_variant_and.rs:340:18
    |
 LL |         let a2 = b.map_or(false, iad);
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -488,43 +488,43 @@ LL +         let a2 = b.is_ok_and(iad);
    |
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:345:18
+  --> tests/ui/manual_is_variant_and.rs:346:18
    |
 LL |         let a1 = b.map(iad) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(|x| !iad(x))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:350:18
+  --> tests/ui/manual_is_variant_and.rs:351:18
    |
 LL |         let a1 = b.map(iad) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(iad)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:355:18
+  --> tests/ui/manual_is_variant_and.rs:356:18
    |
 LL |         let a1 = b.map(iad) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:365:13
+  --> tests/ui/manual_is_variant_and.rs:366:13
    |
 LL |     let _ = opt.is_none() || opt.is_some_and(then_fn);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:368:13
+  --> tests/ui/manual_is_variant_and.rs:369:13
    |
 LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_some_and`
-  --> tests/ui/manual_is_variant_and.rs:384:5
+  --> tests/ui/manual_is_variant_and.rs:385:5
    |
 LL |     opt.filter(|x| condition(x)).is_some();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_some_and(|x| condition(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:386:5
+  --> tests/ui/manual_is_variant_and.rs:387:5
    |
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -1,5 +1,5 @@
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:52:17
+  --> tests/ui/manual_is_variant_and.rs:60:17
    |
 LL |       let _ = opt.map(|x| x > 1)
    |  _________________^
@@ -11,7 +11,7 @@ LL | |         .unwrap_or_default();
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:57:17
+  --> tests/ui/manual_is_variant_and.rs:65:17
    |
 LL |       let _ = opt.map(|x| {
    |  _________________^
@@ -30,13 +30,13 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:62:17
+  --> tests/ui/manual_is_variant_and.rs:70:17
    |
 LL |     let _ = opt.map(|x| x > 1).unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:65:10
+  --> tests/ui/manual_is_variant_and.rs:73:10
    |
 LL |           .map(|x| x > 1)
    |  __________^
@@ -45,37 +45,138 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_some_and(|x| x > 1)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:69:13
+  --> tests/ui/manual_is_variant_and.rs:77:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:71:13
+  --> tests/ui/manual_is_variant_and.rs:79:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != Some(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 != 0)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:73:13
+  --> tests/ui/manual_is_variant_and.rs:81:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) == some_true!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_some_and(|x| x % 2 == 0)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:75:13
+  --> tests/ui/manual_is_variant_and.rs:83:13
    |
 LL |     let _ = Some(2).map(|x| x % 2 == 0) != some_false!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Some(2).is_none_or(|x| x % 2 == 0)`
 
 error: called `map(<f>).unwrap_or_default()` on an `Option` value
-  --> tests/ui/manual_is_variant_and.rs:82:18
+  --> tests/ui/manual_is_variant_and.rs:90:18
    |
 LL |     let _ = opt2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_some_and(char::is_alphanumeric)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:95:13
+   |
+LL |       let _ = Some(5).map_or(false, |n| {
+   |  _____________^
+LL | |
+LL | |         let _ = n;
+LL | |         6 >= 5
+LL | |     });
+   | |______^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(5).map_or(false, |n| {
+LL +     let _ = Some(5).is_some_and(|n| {
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:100:13
+   |
+LL |     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
+LL +     let _ = Some(vec![5]).is_some_and(|n| n == [5]);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:102:13
+   |
+LL |     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
+LL +     let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:104:13
+   |
+LL |     let _ = Some(5).map_or(false, |n| n == n);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(5).map_or(false, |n| n == n);
+LL +     let _ = Some(5).is_some_and(|n| n == n);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:106:13
+   |
+LL |     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
+LL +     let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:108:13
+   |
+LL |     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
+LL +     let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:110:13
+   |
+LL |     let _ = Some(5).map_or(true, |n| n == 5);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = Some(5).map_or(true, |n| n == 5);
+LL +     let _ = Some(5).is_none_or(|n| n == 5);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:112:13
+   |
+LL |     let _ = Some(5).map_or(true, |n| 5 == n);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let _ = Some(5).map_or(true, |n| 5 == n);
+LL +     let _ = Some(5).is_none_or(|n| 5 == n);
+   |
+
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:100:17
+  --> tests/ui/manual_is_variant_and.rs:139:17
    |
 LL |       let _ = res.map(|x| {
    |  _________________^
@@ -94,7 +195,7 @@ LL ~     });
    |
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:105:17
+  --> tests/ui/manual_is_variant_and.rs:144:17
    |
 LL |       let _ = res.map(|x| x > 1)
    |  _________________^
@@ -103,160 +204,342 @@ LL | |         .unwrap_or_default();
    | |____________________________^ help: use: `is_ok_and(|x| x > 1)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:109:13
+  --> tests/ui/manual_is_variant_and.rs:148:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) == Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:111:13
+  --> tests/ui/manual_is_variant_and.rs:150:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:113:13
+  --> tests/ui/manual_is_variant_and.rs:152:13
    |
 LL |     let _ = Ok::<usize, ()>(2).map(|x| x.is_multiple_of(2)) != Ok(true);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!Ok::<usize, ()>(2).is_ok_and(|x| x.is_multiple_of(2))`
 
 error: called `map(<f>).unwrap_or_default()` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:120:18
+  --> tests/ui/manual_is_variant_and.rs:159:18
    |
 LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should lint
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:164:13
+   |
+LL |     let _ = res.map_or(false, |x| x > 8);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = res.map_or(false, |x| x > 8);
+LL +     let _ = res.is_ok_and(|x| x > 8);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:171:13
+   |
+LL |     let _ = r.map_or(false, |x| x == 7);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::unnecessary-map-or` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_or)]`
+help: use a standard comparison instead
+   |
+LL -     let _ = r.map_or(false, |x| x == 7);
+LL +     let _ = r == Ok(7);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:177:13
+   |
+LL |     let _ = r.map_or(false, |x| x == 7);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = r.map_or(false, |x| x == 7);
+LL +     let _ = r.is_ok_and(|x| x == 7);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:181:13
+   |
+LL |     let _ = r.map_or(false, |x| x == 7);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = r.map_or(false, |x| x == 7);
+LL +     let _ = r.is_ok_and(|x| x == 7);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:186:13
+   |
+LL |     let _ = r.map_or(false, |x| x == 7);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -     let _ = r.map_or(false, |x| x == 7);
+LL +     let _ = r.is_ok_and(|x| x == 7);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:206:5
+   |
+LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+LL +     o.is_none_or(|n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:206:34
+   |
+LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
+LL +     o.map_or(true, |n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:221:5
+   |
+LL |     o.map_or(true, |n| n > 5)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     o.map_or(true, |n| n > 5)
+LL +     o.is_none_or(|n| n > 5)
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:226:13
+   |
+LL |     let x = a.map_or(false, |a| a == *s);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     let x = a.map_or(false, |a| a == *s);
+LL +     let x = a.is_some_and(|a| a == *s);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:228:13
+   |
+LL |     let y = b.map_or(true, |b| b == *s);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -     let y = b.map_or(true, |b| b == *s);
+LL +     let y = b.is_none_or(|b| b == *s);
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:235:9
+   |
+LL |     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
+LL +     _ = s.lock().unwrap().is_some_and(|s| s == "foo");
+   |
+
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:239:9
+   |
+LL |     _ = s.map_or(false, |s| s == "foo");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -     _ = s.map_or(false, |s| s == "foo");
+LL +     _ = s.is_some_and(|s| s == "foo");
+   |
+
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:130:18
+  --> tests/ui/manual_is_variant_and.rs:246:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:137:18
+  --> tests/ui/manual_is_variant_and.rs:253:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:144:18
+  --> tests/ui/manual_is_variant_and.rs:260:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:151:18
+  --> tests/ui/manual_is_variant_and.rs:267:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:159:18
+  --> tests/ui/manual_is_variant_and.rs:275:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:166:18
+  --> tests/ui/manual_is_variant_and.rs:282:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:173:18
+  --> tests/ui/manual_is_variant_and.rs:289:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:180:18
+  --> tests/ui/manual_is_variant_and.rs:296:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:193:18
+  --> tests/ui/manual_is_variant_and.rs:309:18
    |
 LL |         let a1 = b.map(iad) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(iad)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:311:18
+   |
+LL |         let a2 = b.map_or(false, iad);
+   |                  ^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_some_and` instead
+   |
+LL -         let a2 = b.map_or(false, iad);
+LL +         let a2 = b.is_some_and(iad);
+   |
+
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:198:18
+  --> tests/ui/manual_is_variant_and.rs:317:18
    |
 LL |         let a1 = b.map(iad) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:203:18
+  --> tests/ui/manual_is_variant_and.rs:322:18
    |
 LL |         let a1 = b.map(iad) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:208:18
+  --> tests/ui/manual_is_variant_and.rs:327:18
    |
 LL |         let a1 = b.map(iad) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(iad)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:329:18
+   |
+LL |         let a2 = b.map_or(true, iad);
+   |                  ^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_none_or` instead
+   |
+LL -         let a2 = b.map_or(true, iad);
+LL +         let a2 = b.is_none_or(iad);
+   |
+
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:215:18
+  --> tests/ui/manual_is_variant_and.rs:337:18
    |
 LL |         let a1 = b.map(iad) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(iad)`
 
+error: this `map_or` can be simplified
+  --> tests/ui/manual_is_variant_and.rs:339:18
+   |
+LL |         let a2 = b.map_or(false, iad);
+   |                  ^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `is_ok_and` instead
+   |
+LL -         let a2 = b.map_or(false, iad);
+LL +         let a2 = b.is_ok_and(iad);
+   |
+
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:220:18
+  --> tests/ui/manual_is_variant_and.rs:345:18
    |
 LL |         let a1 = b.map(iad) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(|x| !iad(x))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:225:18
+  --> tests/ui/manual_is_variant_and.rs:350:18
    |
 LL |         let a1 = b.map(iad) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(iad)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:230:18
+  --> tests/ui/manual_is_variant_and.rs:355:18
    |
 LL |         let a1 = b.map(iad) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:240:13
+  --> tests/ui/manual_is_variant_and.rs:365:13
    |
 LL |     let _ = opt.is_none() || opt.is_some_and(then_fn);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:243:13
+  --> tests/ui/manual_is_variant_and.rs:368:13
    |
 LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_some_and`
-  --> tests/ui/manual_is_variant_and.rs:259:5
+  --> tests/ui/manual_is_variant_and.rs:384:5
    |
 LL |     opt.filter(|x| condition(x)).is_some();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_some_and(|x| condition(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:261:5
+  --> tests/ui/manual_is_variant_and.rs:386:5
    |
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`
 
 error: called `.ok().is_some_and(..)` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:273:13
+  --> tests/ui/manual_is_variant_and.rs:398:13
    |
 LL |     let _ = res.ok().is_some_and(|x| x > 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `is_ok_and` instead: `res.is_ok_and(|x| x > 0)`
 
 error: called `.ok().is_some_and(..)` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:276:13
+  --> tests/ui/manual_is_variant_and.rs:401:13
    |
 LL |     let _ = res.ok().is_some_and(|x| x > 0) || res.is_err();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `is_ok_and` instead: `res.is_ok_and(|x| x > 0)`
 
-error: aborting due to 37 previous errors
+error: aborting due to 60 previous errors
 

--- a/tests/ui/map_unwrap_or_fixable.fixed
+++ b/tests/ui/map_unwrap_or_fixable.fixed
@@ -1,6 +1,7 @@
 //@aux-build:option_helpers.rs
 
 #![warn(clippy::map_unwrap_or)]
+#![allow(clippy::needless_is_variant_and)]
 
 #[macro_use]
 extern crate option_helpers;

--- a/tests/ui/map_unwrap_or_fixable.rs
+++ b/tests/ui/map_unwrap_or_fixable.rs
@@ -1,6 +1,7 @@
 //@aux-build:option_helpers.rs
 
 #![warn(clippy::map_unwrap_or)]
+#![allow(clippy::needless_is_variant_and)]
 
 #[macro_use]
 extern crate option_helpers;

--- a/tests/ui/map_unwrap_or_fixable.stderr
+++ b/tests/ui/map_unwrap_or_fixable.stderr
@@ -1,5 +1,5 @@
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:16:13
+  --> tests/ui/map_unwrap_or_fixable.rs:17:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -11,7 +11,7 @@ LL | |         .unwrap_or_else(|| 0);
    = help: to override `-D warnings` add `#[allow(clippy::map_unwrap_or)]`
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:47:13
+  --> tests/ui/map_unwrap_or_fixable.rs:48:13
    |
 LL |       let _ = res.map(|x| x + 1)
    |  _____________^
@@ -20,7 +20,7 @@ LL | |         .unwrap_or_else(|_e| 0);
    | |_______________________________^ help: try: `res.map_or_else(|_e| 0, |x| x + 1)`
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:61:20
+  --> tests/ui/map_unwrap_or_fixable.rs:62:20
    |
 LL |     println!("{}", o.map(|y| y + 1).unwrap_or(3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,13 +32,13 @@ LL +     println!("{}", o.map_or(3, |y| y + 1));
    |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:63:20
+  --> tests/ui/map_unwrap_or_fixable.rs:64:20
    |
 LL |     println!("{}", o.map(|y| y + 1).unwrap_or_else(|| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `o.map_or_else(|| 3, |y| y + 1)`
 
 error: called `map(<f>).unwrap_or(<a>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:65:20
+  --> tests/ui/map_unwrap_or_fixable.rs:66:20
    |
 LL |     println!("{}", r.map(|y| y + 1).unwrap_or(3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,13 +50,13 @@ LL +     println!("{}", r.map_or(3, |y| y + 1));
    |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:67:20
+  --> tests/ui/map_unwrap_or_fixable.rs:68:20
    |
 LL |     println!("{}", r.map(|y| y + 1).unwrap_or_else(|()| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `r.map_or_else(|()| 3, |y| y + 1)`
 
 error: called `map(<f>).unwrap_or(false)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:70:20
+  --> tests/ui/map_unwrap_or_fixable.rs:71:20
    |
 LL |     println!("{}", r.map(|y| y == 1).unwrap_or(false));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL +     println!("{}", r.is_ok_and(|y| y == 1));
    |
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:76:20
+  --> tests/ui/map_unwrap_or_fixable.rs:77:20
    |
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or(3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL +     println!("{}", x.map_or(3, |y| y + 1));
    |
 
 error: called `map(<f>).unwrap_or(<a>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:80:20
+  --> tests/ui/map_unwrap_or_fixable.rs:81:20
    |
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or(3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,13 +92,13 @@ LL +     println!("{}", x.map_or(3, |y| y + 1));
    |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:84:20
+  --> tests/ui/map_unwrap_or_fixable.rs:85:20
    |
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or_else(|| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.map_or_else(|| 3, |y| y + 1)`
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:88:20
+  --> tests/ui/map_unwrap_or_fixable.rs:89:20
    |
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or_else(|_| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.map_or_else(|_| 3, |y| y + 1)`

--- a/tests/ui/needless_is_variant_and.fixed
+++ b/tests/ui/needless_is_variant_and.fixed
@@ -1,0 +1,83 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::needless_is_variant_and, clippy::manual_is_variant_and)]
+#![allow(clippy::no_effect)]
+#![allow(clippy::eq_op)]
+#![allow(clippy::unnecessary_lazy_evaluations)]
+#![allow(clippy::nonminimal_bool)]
+#[clippy::msrv = "1.82.0"]
+#[macro_use]
+extern crate proc_macros;
+
+fn main() {
+    // should trigger
+    let _ = Some(5) == Some(5);
+    //~^ needless_is_variant_and
+    let _ = Some(5) != Some(5);
+    //~^ needless_is_variant_and
+    let _ = Some(5) == Some(5);
+    let _ = Ok::<i32, i32>(5) == Ok(5);
+    //~^ needless_is_variant_and
+    let _ = (Some(5) == Some(5)).then(|| 1);
+    //~^ needless_is_variant_and
+    let _ = !(Some(5) == Some(5));
+    //~^ needless_is_variant_and
+    let _ = (Some(5) == Some(5)) || false;
+    //~^ needless_is_variant_and
+    let _ = (Some(5) == Some(5)) as usize;
+    //~^ needless_is_variant_and
+
+    macro_rules! x {
+        () => {
+            Some(1)
+        };
+    }
+    // methods lints dont fire on macros
+    let _ = x!().is_some_and(|n| n == 1);
+    let _ = x!().is_some_and(|n| n == vec![1][0]);
+
+    external! {
+        let _ = Some(5).is_some_and(|n| n == 5);
+    }
+
+    with_span! {
+        let _ = Some(5).is_some_and(|n| n == 5);
+    }
+
+    // do not lint in absense of PartialEq
+    struct S;
+    let r: Result<i32, S> = Ok(3);
+    let _ = r.is_ok_and(|x| x == 7);
+
+    #[derive(PartialEq)]
+    struct S2;
+    let r: Result<i32, S2> = Ok(4);
+    let _ = r == Ok(8);
+    //~^ needless_is_variant_and
+
+    // do not lint constructs that are not comparisons
+    let func = |_x| true;
+    let r: Result<i32, S> = Ok(3);
+    let _ = r.is_ok_and(func);
+    let _ = Some(5).is_some_and(func);
+    let _ = Some(5).is_none_or(func);
+}
+
+fn issue14714() {
+    assert!(Some("test") == Some("test"));
+    //~^ needless_is_variant_and
+
+    // even though we're in a macro context, we still need to parenthesise because of the `then`
+    assert!((Some("test") == Some("test")).then(|| 1).is_some());
+    //~^ needless_is_variant_and
+
+    // method lints don't fire on macros
+    macro_rules! m {
+        ($x:expr) => {
+            // should become !($x == Some(1))
+            let _ = !$x.is_some_and(|v| v == 1);
+            // should become $x == Some(1)
+            let _ = $x.is_some_and(|v| v == 1);
+        };
+    }
+    m!(Some(5));
+}

--- a/tests/ui/needless_is_variant_and.stderr
+++ b/tests/ui/needless_is_variant_and.stderr
@@ -1,0 +1,145 @@
+error: this `is_some_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:13:13
+   |
+LL |     let _ = Some(5).is_some_and(|n| n == 5);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::needless-is-variant-and` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::needless_is_variant_and)]`
+help: use a standard comparison instead
+   |
+LL -     let _ = Some(5).is_some_and(|n| n == 5);
+LL +     let _ = Some(5) == Some(5);
+   |
+
+error: this `is_none_or` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:15:13
+   |
+LL |     let _ = Some(5).is_none_or(|n| n != 5);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     let _ = Some(5).is_none_or(|n| n != 5);
+LL +     let _ = Some(5) != Some(5);
+   |
+
+error: this `is_some_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:17:13
+   |
+LL |       let _ = Some(5).is_some_and(|n| {
+   |  _____________^
+LL | |
+LL | |         let _ = 1;
+LL | |         n == 5
+LL | |     });
+   | |______^
+   |
+help: use a standard comparison instead
+   |
+LL -     let _ = Some(5).is_some_and(|n| {
+LL -
+LL -         let _ = 1;
+LL -         n == 5
+LL -     });
+LL +     let _ = Some(5) == Some(5);
+   |
+
+error: this `is_ok_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:22:13
+   |
+LL |     let _ = Ok::<i32, i32>(5).is_ok_and(|n| n == 5);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     let _ = Ok::<i32, i32>(5).is_ok_and(|n| n == 5);
+LL +     let _ = Ok::<i32, i32>(5) == Ok(5);
+   |
+
+error: this `is_some_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:24:13
+   |
+LL |     let _ = Some(5).is_some_and(|n| n == 5).then(|| 1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     let _ = Some(5).is_some_and(|n| n == 5).then(|| 1);
+LL +     let _ = (Some(5) == Some(5)).then(|| 1);
+   |
+
+error: this `is_some_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:26:14
+   |
+LL |     let _ = !Some(5).is_some_and(|n| n == 5);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     let _ = !Some(5).is_some_and(|n| n == 5);
+LL +     let _ = !(Some(5) == Some(5));
+   |
+
+error: this `is_some_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:28:13
+   |
+LL |     let _ = Some(5).is_some_and(|n| n == 5) || false;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     let _ = Some(5).is_some_and(|n| n == 5) || false;
+LL +     let _ = (Some(5) == Some(5)) || false;
+   |
+
+error: this `is_some_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:30:13
+   |
+LL |     let _ = Some(5).is_some_and(|n| n == 5) as usize;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     let _ = Some(5).is_some_and(|n| n == 5) as usize;
+LL +     let _ = (Some(5) == Some(5)) as usize;
+   |
+
+error: this `is_ok_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:58:13
+   |
+LL |     let _ = r.is_ok_and(|x| x == 8);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     let _ = r.is_ok_and(|x| x == 8);
+LL +     let _ = r == Ok(8);
+   |
+
+error: this `is_some_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:70:13
+   |
+LL |     assert!(Some("test").is_some_and(|x| x == "test"));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     assert!(Some("test").is_some_and(|x| x == "test"));
+LL +     assert!(Some("test") == Some("test"));
+   |
+
+error: this `is_some_and` can be simplified
+  --> tests/ui/needless_is_variant_and.rs:74:13
+   |
+LL |     assert!(Some("test").is_some_and(|x| x == "test").then(|| 1).is_some());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a standard comparison instead
+   |
+LL -     assert!(Some("test").is_some_and(|x| x == "test").then(|| 1).is_some());
+LL +     assert!((Some("test") == Some("test")).then(|| 1).is_some());
+   |
+
+error: aborting due to 11 previous errors
+

--- a/tests/ui/nonminimal_bool_methods.fixed
+++ b/tests/ui/nonminimal_bool_methods.fixed
@@ -1,4 +1,8 @@
-#![allow(unused, clippy::diverging_sub_expression, clippy::needless_ifs)]
+#![allow(
+    clippy::diverging_sub_expression,
+    clippy::needless_ifs,
+    clippy::needless_is_variant_and
+)]
 #![warn(clippy::nonminimal_bool)]
 
 fn methods_with_negation() {

--- a/tests/ui/nonminimal_bool_methods.rs
+++ b/tests/ui/nonminimal_bool_methods.rs
@@ -1,4 +1,8 @@
-#![allow(unused, clippy::diverging_sub_expression, clippy::needless_ifs)]
+#![allow(
+    clippy::diverging_sub_expression,
+    clippy::needless_ifs,
+    clippy::needless_is_variant_and
+)]
 #![warn(clippy::nonminimal_bool)]
 
 fn methods_with_negation() {

--- a/tests/ui/nonminimal_bool_methods.stderr
+++ b/tests/ui/nonminimal_bool_methods.stderr
@@ -1,5 +1,5 @@
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:8:13
+  --> tests/ui/nonminimal_bool_methods.rs:12:13
    |
 LL |     let _ = !a.is_some();
    |             ^^^^^^^^^^^^ help: try: `a.is_none()`
@@ -8,25 +8,25 @@ LL |     let _ = !a.is_some();
    = help: to override `-D warnings` add `#[allow(clippy::nonminimal_bool)]`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:11:13
+  --> tests/ui/nonminimal_bool_methods.rs:15:13
    |
 LL |     let _ = !a.is_none();
    |             ^^^^^^^^^^^^ help: try: `a.is_some()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:14:13
+  --> tests/ui/nonminimal_bool_methods.rs:18:13
    |
 LL |     let _ = !b.is_err();
    |             ^^^^^^^^^^^ help: try: `b.is_ok()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:17:13
+  --> tests/ui/nonminimal_bool_methods.rs:21:13
    |
 LL |     let _ = !b.is_ok();
    |             ^^^^^^^^^^ help: try: `b.is_err()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:20:13
+  --> tests/ui/nonminimal_bool_methods.rs:24:13
    |
 LL |     let _ = !(a.is_some() && !c);
    |             ^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL +     let _ = a.is_none() || c;
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:22:13
+  --> tests/ui/nonminimal_bool_methods.rs:26:13
    |
 LL |     let _ = !(a.is_some() || !c);
    |             ^^^^^^^^^^^^^^^^^^^^
@@ -50,217 +50,217 @@ LL +     let _ = a.is_none() && c;
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:24:26
+  --> tests/ui/nonminimal_bool_methods.rs:28:26
    |
 LL |     let _ = !(!c ^ c) || !a.is_some();
    |                          ^^^^^^^^^^^^ help: try: `a.is_none()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:26:25
+  --> tests/ui/nonminimal_bool_methods.rs:30:25
    |
 LL |     let _ = (!c ^ c) || !a.is_some();
    |                         ^^^^^^^^^^^^ help: try: `a.is_none()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:28:23
+  --> tests/ui/nonminimal_bool_methods.rs:32:23
    |
 LL |     let _ = !c ^ c || !a.is_some();
    |                       ^^^^^^^^^^^^ help: try: `a.is_none()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:101:8
+  --> tests/ui/nonminimal_bool_methods.rs:105:8
    |
 LL |     if !res.is_ok() {}
    |        ^^^^^^^^^^^^ help: try: `res.is_err()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:103:8
+  --> tests/ui/nonminimal_bool_methods.rs:107:8
    |
 LL |     if !res.is_err() {}
    |        ^^^^^^^^^^^^^ help: try: `res.is_ok()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:107:8
+  --> tests/ui/nonminimal_bool_methods.rs:111:8
    |
 LL |     if !res.is_some() {}
    |        ^^^^^^^^^^^^^^ help: try: `res.is_none()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:109:8
+  --> tests/ui/nonminimal_bool_methods.rs:113:8
    |
 LL |     if !res.is_none() {}
    |        ^^^^^^^^^^^^^^ help: try: `res.is_some()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:126:8
+  --> tests/ui/nonminimal_bool_methods.rs:130:8
    |
 LL |     if !(a as u64 >= b) {}
    |        ^^^^^^^^^^^^^^^^ help: try: `((a as u64) < b)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:128:8
+  --> tests/ui/nonminimal_bool_methods.rs:132:8
    |
 LL |     if !((a as u64) >= b) {}
    |        ^^^^^^^^^^^^^^^^^^ help: try: `((a as u64) < b)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:130:8
+  --> tests/ui/nonminimal_bool_methods.rs:134:8
    |
 LL |     if !(a as u64 <= b) {}
    |        ^^^^^^^^^^^^^^^^ help: try: `(a as u64 > b)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:138:8
+  --> tests/ui/nonminimal_bool_methods.rs:142:8
    |
 LL |     if !(a >= b) as i32 == c {}
    |        ^^^^^^^^^ help: try: `(a < b)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:140:8
+  --> tests/ui/nonminimal_bool_methods.rs:144:8
    |
 LL |     if !(a >= b) | !(a <= c) {}
    |        ^^^^^^^^^ help: try: `(a < b)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:140:20
+  --> tests/ui/nonminimal_bool_methods.rs:144:20
    |
 LL |     if !(a >= b) | !(a <= c) {}
    |                    ^^^^^^^^^ help: try: `(a > c)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:145:8
+  --> tests/ui/nonminimal_bool_methods.rs:149:8
    |
 LL |     if !res.is_ok() as i32 == c {}
    |        ^^^^^^^^^^^^ help: try: `res.is_err()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:147:8
+  --> tests/ui/nonminimal_bool_methods.rs:151:8
    |
 LL |     if !res.is_ok() | !opt.is_none() {}
    |        ^^^^^^^^^^^^ help: try: `res.is_err()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:147:23
+  --> tests/ui/nonminimal_bool_methods.rs:151:23
    |
 LL |     if !res.is_ok() | !opt.is_none() {}
    |                       ^^^^^^^^^^^^^^ help: try: `opt.is_some()`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:152:9
+  --> tests/ui/nonminimal_bool_methods.rs:156:9
    |
 LL |         (!(4 > 3)).b()
    |         ^^^^^^^^^^ help: try: `(4 <= 3)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:178:9
+  --> tests/ui/nonminimal_bool_methods.rs:182:9
    |
 LL |     _ = !opt.is_some_and(|x| x < 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x >= 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:180:9
+  --> tests/ui/nonminimal_bool_methods.rs:184:9
    |
 LL |     _ = !opt.is_some_and(|x| x <= 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x > 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:182:9
+  --> tests/ui/nonminimal_bool_methods.rs:186:9
    |
 LL |     _ = !opt.is_some_and(|x| x > 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x <= 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:184:9
+  --> tests/ui/nonminimal_bool_methods.rs:188:9
    |
 LL |     _ = !opt.is_some_and(|x| x >= 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x < 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:186:9
+  --> tests/ui/nonminimal_bool_methods.rs:190:9
    |
 LL |     _ = !opt.is_some_and(|x| x == 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x != 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:188:9
+  --> tests/ui/nonminimal_bool_methods.rs:192:9
    |
 LL |     _ = !opt.is_some_and(|x| x != 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x == 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:198:9
+  --> tests/ui/nonminimal_bool_methods.rs:202:9
    |
 LL |     _ = !opt.is_none_or(|x| x < 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x >= 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:200:9
+  --> tests/ui/nonminimal_bool_methods.rs:204:9
    |
 LL |     _ = !opt.is_none_or(|x| x <= 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x > 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:202:9
+  --> tests/ui/nonminimal_bool_methods.rs:206:9
    |
 LL |     _ = !opt.is_none_or(|x| x > 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x <= 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:204:9
+  --> tests/ui/nonminimal_bool_methods.rs:208:9
    |
 LL |     _ = !opt.is_none_or(|x| x >= 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x < 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:206:9
+  --> tests/ui/nonminimal_bool_methods.rs:210:9
    |
 LL |     _ = !opt.is_none_or(|x| x == 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x != 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:208:9
+  --> tests/ui/nonminimal_bool_methods.rs:212:9
    |
 LL |     _ = !opt.is_none_or(|x| x != 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x == 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:216:9
+  --> tests/ui/nonminimal_bool_methods.rs:220:9
    |
 LL |     _ = !opt.is_some_and(|x| !x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:221:9
+  --> tests/ui/nonminimal_bool_methods.rs:225:9
    |
 LL |     _ = !opt.is_none_or(|x| !x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:229:9
+  --> tests/ui/nonminimal_bool_methods.rs:233:9
    |
 LL |     _ = !opt.is_some_and(|x| x.is_ok());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x.is_err())`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:231:9
+  --> tests/ui/nonminimal_bool_methods.rs:235:9
    |
 LL |     _ = !opt.is_some_and(|x| x.is_err());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x.is_ok())`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:233:9
+  --> tests/ui/nonminimal_bool_methods.rs:237:9
    |
 LL |     _ = !opt.is_none_or(|x| x.is_ok());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x.is_err())`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:235:9
+  --> tests/ui/nonminimal_bool_methods.rs:239:9
    |
 LL |     _ = !opt.is_none_or(|x| x.is_err());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x.is_ok())`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:246:5
+  --> tests/ui/nonminimal_bool_methods.rs:250:5
    |
 LL |     !(vec![1, 2, 3] <= vec![1, 2, 3, 3]);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(vec![1, 2, 3] > vec![1, 2, 3, 3])`

--- a/tests/ui/unnecessary_map_or.fixed
+++ b/tests/ui/unnecessary_map_or.fixed
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-#![warn(clippy::unnecessary_map_or)]
+#![warn(clippy::unnecessary_map_or, clippy::manual_is_variant_and)]
 #![allow(
     clippy::no_effect,
     clippy::eq_op,
@@ -7,7 +7,7 @@
     clippy::nonminimal_bool,
     clippy::manual_assert_eq
 )]
-#[clippy::msrv = "1.70.0"]
+#[clippy::msrv = "1.82.0"]
 #[macro_use]
 extern crate proc_macros;
 
@@ -18,28 +18,9 @@ fn main() {
     let _ = Some(5) != Some(5);
     //~^ unnecessary_map_or
     let _ = Some(5) == Some(5);
-    let _ = Some(5).is_some_and(|n| {
-        //~^ unnecessary_map_or
-        let _ = n;
-        6 >= 5
-    });
-    let _ = Some(vec![5]).is_some_and(|n| n == [5]);
-    //~^ unnecessary_map_or
-    let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_some_and(|n| n == n);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
-    //~^ unnecessary_map_or
-    let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
-    //~^ unnecessary_map_or
     let _ = Ok::<i32, i32>(5) == Ok(5);
     //~^ unnecessary_map_or
     let _ = (Some(5) == Some(5)).then(|| 1);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_none_or(|n| n == 5);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_none_or(|n| 5 == n);
     //~^ unnecessary_map_or
     let _ = !(Some(5) == Some(5));
     //~^ unnecessary_map_or
@@ -57,8 +38,6 @@ fn main() {
     let _ = x!().map_or(false, |n| n == 1);
     let _ = x!().map_or(false, |n| n == vec![1][0]);
 
-    msrv_1_69();
-
     external! {
         let _ = Some(5).map_or(false, |n| n == 5);
     }
@@ -67,21 +46,11 @@ fn main() {
         let _ = Some(5).map_or(false, |n| n == 5);
     }
 
-    // check for presence of PartialEq, and alter suggestion to use `is_ok_and` if absent
+    // do not lint in absense of PartialEq (covered by `manual_is_variant_and`)
     struct S;
     let r: Result<i32, S> = Ok(3);
     let _ = r.is_ok_and(|x| x == 7);
-    //~^ unnecessary_map_or
-
-    // lint constructs that are not comparisons as well
-    let func = |_x| true;
-    let r: Result<i32, S> = Ok(3);
-    let _ = r.is_ok_and(func);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_some_and(func);
-    //~^ unnecessary_map_or
-    let _ = Some(5).is_none_or(func);
-    //~^ unnecessary_map_or
+    //~^ manual_is_variant_and
 
     #[derive(PartialEq)]
     struct S2;
@@ -89,49 +58,15 @@ fn main() {
     let _ = r == Ok(8);
     //~^ unnecessary_map_or
 
-    // do not lint `Result::map_or(true, …)`
-    let r: Result<i32, S2> = Ok(4);
-    let _ = r.map_or(true, |x| x == 8);
-}
-
-#[clippy::msrv = "1.69.0"]
-fn msrv_1_69() {
-    // is_some_and added in 1.70.0
-    let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-}
-
-#[clippy::msrv = "1.81.0"]
-fn msrv_1_81() {
-    // is_none_or added in 1.82.0
-    let _ = Some(5).map_or(true, |n| n == if 2 > 1 { n } else { 0 });
-}
-
-fn with_refs(o: &mut Option<u32>) -> bool {
-    o.is_none_or(|n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
-    //~^ unnecessary_map_or
-    //~| unnecessary_map_or
-}
-
-struct S;
-
-impl std::ops::Deref for S {
-    type Target = Option<u32>;
-    fn deref(&self) -> &Self::Target {
-        &Some(0)
-    }
-}
-
-fn with_deref(o: &S) -> bool {
-    o.is_none_or(|n| n > 5)
-    //~^ unnecessary_map_or
-}
-
-fn issue14201(a: Option<String>, b: Option<String>, s: &String) -> bool {
-    let x = a.is_some_and(|a| a == *s);
-    //~^ unnecessary_map_or
-    let y = b.is_none_or(|b| b == *s);
-    //~^ unnecessary_map_or
-    x && y
+    // do not lint constructs that are not comparisons (covered by `manual_is_variant_and`)
+    let func = |_x| true;
+    let r: Result<i32, S> = Ok(3);
+    let _ = r.is_ok_and(func);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_some_and(func);
+    //~^ manual_is_variant_and
+    let _ = Some(5).is_none_or(func);
+    //~^ manual_is_variant_and
 }
 
 fn issue14714() {
@@ -152,14 +87,4 @@ fn issue14714() {
         };
     }
     m!(Some(5));
-}
-
-fn issue15180() {
-    let s = std::sync::Mutex::new(Some("foo"));
-    _ = s.lock().unwrap().is_some_and(|s| s == "foo");
-    //~^ unnecessary_map_or
-
-    let s = &&&&Some("foo");
-    _ = s.is_some_and(|s| s == "foo");
-    //~^ unnecessary_map_or
 }

--- a/tests/ui/unnecessary_map_or.rs
+++ b/tests/ui/unnecessary_map_or.rs
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-#![warn(clippy::unnecessary_map_or)]
+#![warn(clippy::unnecessary_map_or, clippy::manual_is_variant_and)]
 #![allow(
     clippy::no_effect,
     clippy::eq_op,
@@ -7,7 +7,7 @@
     clippy::nonminimal_bool,
     clippy::manual_assert_eq
 )]
-#[clippy::msrv = "1.70.0"]
+#[clippy::msrv = "1.82.0"]
 #[macro_use]
 extern crate proc_macros;
 
@@ -22,28 +22,9 @@ fn main() {
         let _ = 1;
         n == 5
     });
-    let _ = Some(5).map_or(false, |n| {
-        //~^ unnecessary_map_or
-        let _ = n;
-        6 >= 5
-    });
-    let _ = Some(vec![5]).map_or(false, |n| n == [5]);
-    //~^ unnecessary_map_or
-    let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(false, |n| n == n);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-    //~^ unnecessary_map_or
-    let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
-    //~^ unnecessary_map_or
     let _ = Ok::<i32, i32>(5).map_or(false, |n| n == 5);
     //~^ unnecessary_map_or
     let _ = Some(5).map_or(false, |n| n == 5).then(|| 1);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(true, |n| n == 5);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(true, |n| 5 == n);
     //~^ unnecessary_map_or
     let _ = !Some(5).map_or(false, |n| n == 5);
     //~^ unnecessary_map_or
@@ -61,8 +42,6 @@ fn main() {
     let _ = x!().map_or(false, |n| n == 1);
     let _ = x!().map_or(false, |n| n == vec![1][0]);
 
-    msrv_1_69();
-
     external! {
         let _ = Some(5).map_or(false, |n| n == 5);
     }
@@ -71,21 +50,11 @@ fn main() {
         let _ = Some(5).map_or(false, |n| n == 5);
     }
 
-    // check for presence of PartialEq, and alter suggestion to use `is_ok_and` if absent
+    // do not lint in absense of PartialEq (covered by `manual_is_variant_and`)
     struct S;
     let r: Result<i32, S> = Ok(3);
     let _ = r.map_or(false, |x| x == 7);
-    //~^ unnecessary_map_or
-
-    // lint constructs that are not comparisons as well
-    let func = |_x| true;
-    let r: Result<i32, S> = Ok(3);
-    let _ = r.map_or(false, func);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(false, func);
-    //~^ unnecessary_map_or
-    let _ = Some(5).map_or(true, func);
-    //~^ unnecessary_map_or
+    //~^ manual_is_variant_and
 
     #[derive(PartialEq)]
     struct S2;
@@ -93,49 +62,15 @@ fn main() {
     let _ = r.map_or(false, |x| x == 8);
     //~^ unnecessary_map_or
 
-    // do not lint `Result::map_or(true, …)`
-    let r: Result<i32, S2> = Ok(4);
-    let _ = r.map_or(true, |x| x == 8);
-}
-
-#[clippy::msrv = "1.69.0"]
-fn msrv_1_69() {
-    // is_some_and added in 1.70.0
-    let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-}
-
-#[clippy::msrv = "1.81.0"]
-fn msrv_1_81() {
-    // is_none_or added in 1.82.0
-    let _ = Some(5).map_or(true, |n| n == if 2 > 1 { n } else { 0 });
-}
-
-fn with_refs(o: &mut Option<u32>) -> bool {
-    o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-    //~^ unnecessary_map_or
-    //~| unnecessary_map_or
-}
-
-struct S;
-
-impl std::ops::Deref for S {
-    type Target = Option<u32>;
-    fn deref(&self) -> &Self::Target {
-        &Some(0)
-    }
-}
-
-fn with_deref(o: &S) -> bool {
-    o.map_or(true, |n| n > 5)
-    //~^ unnecessary_map_or
-}
-
-fn issue14201(a: Option<String>, b: Option<String>, s: &String) -> bool {
-    let x = a.map_or(false, |a| a == *s);
-    //~^ unnecessary_map_or
-    let y = b.map_or(true, |b| b == *s);
-    //~^ unnecessary_map_or
-    x && y
+    // do not lint constructs that are not comparisons (covered by `manual_is_variant_and`)
+    let func = |_x| true;
+    let r: Result<i32, S> = Ok(3);
+    let _ = r.map_or(false, func);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(false, func);
+    //~^ manual_is_variant_and
+    let _ = Some(5).map_or(true, func);
+    //~^ manual_is_variant_and
 }
 
 fn issue14714() {
@@ -156,14 +91,4 @@ fn issue14714() {
         };
     }
     m!(Some(5));
-}
-
-fn issue15180() {
-    let s = std::sync::Mutex::new(Some("foo"));
-    _ = s.lock().unwrap().map_or(false, |s| s == "foo");
-    //~^ unnecessary_map_or
-
-    let s = &&&&Some("foo");
-    _ = s.map_or(false, |s| s == "foo");
-    //~^ unnecessary_map_or
 }

--- a/tests/ui/unnecessary_map_or.stderr
+++ b/tests/ui/unnecessary_map_or.stderr
@@ -48,83 +48,6 @@ LL +     let _ = Some(5) == Some(5);
 error: this `map_or` can be simplified
   --> tests/ui/unnecessary_map_or.rs:25:13
    |
-LL |       let _ = Some(5).map_or(false, |n| {
-   |  _____________^
-LL | |
-LL | |         let _ = n;
-LL | |         6 >= 5
-LL | |     });
-   | |______^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(5).map_or(false, |n| {
-LL +     let _ = Some(5).is_some_and(|n| {
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:30:13
-   |
-LL |     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(vec![5]).map_or(false, |n| n == [5]);
-LL +     let _ = Some(vec![5]).is_some_and(|n| n == [5]);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:32:13
-   |
-LL |     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(vec![1]).map_or(false, |n| vec![2] == n);
-LL +     let _ = Some(vec![1]).is_some_and(|n| vec![2] == n);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:34:13
-   |
-LL |     let _ = Some(5).map_or(false, |n| n == n);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(5).map_or(false, |n| n == n);
-LL +     let _ = Some(5).is_some_and(|n| n == n);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:36:13
-   |
-LL |     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(5).map_or(false, |n| n == if 2 > 1 { n } else { 0 });
-LL +     let _ = Some(5).is_some_and(|n| n == if 2 > 1 { n } else { 0 });
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:38:13
-   |
-LL |     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_ok_and` instead
-   |
-LL -     let _ = Ok::<Vec<i32>, i32>(vec![5]).map_or(false, |n| n == [5]);
-LL +     let _ = Ok::<Vec<i32>, i32>(vec![5]).is_ok_and(|n| n == [5]);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:40:13
-   |
 LL |     let _ = Ok::<i32, i32>(5).map_or(false, |n| n == 5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -135,7 +58,7 @@ LL +     let _ = Ok::<i32, i32>(5) == Ok(5);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:42:13
+  --> tests/ui/unnecessary_map_or.rs:27:13
    |
 LL |     let _ = Some(5).map_or(false, |n| n == 5).then(|| 1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -147,31 +70,7 @@ LL +     let _ = (Some(5) == Some(5)).then(|| 1);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:44:13
-   |
-LL |     let _ = Some(5).map_or(true, |n| n == 5);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     let _ = Some(5).map_or(true, |n| n == 5);
-LL +     let _ = Some(5).is_none_or(|n| n == 5);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:46:13
-   |
-LL |     let _ = Some(5).map_or(true, |n| 5 == n);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     let _ = Some(5).map_or(true, |n| 5 == n);
-LL +     let _ = Some(5).is_none_or(|n| 5 == n);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:48:14
+  --> tests/ui/unnecessary_map_or.rs:29:14
    |
 LL |     let _ = !Some(5).map_or(false, |n| n == 5);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +82,7 @@ LL +     let _ = !(Some(5) == Some(5));
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:50:13
+  --> tests/ui/unnecessary_map_or.rs:31:13
    |
 LL |     let _ = Some(5).map_or(false, |n| n == 5) || false;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -195,7 +94,7 @@ LL +     let _ = (Some(5) == Some(5)) || false;
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:52:13
+  --> tests/ui/unnecessary_map_or.rs:33:13
    |
 LL |     let _ = Some(5).map_or(false, |n| n == 5) as usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -207,11 +106,13 @@ LL +     let _ = (Some(5) == Some(5)) as usize;
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:77:13
+  --> tests/ui/unnecessary_map_or.rs:56:13
    |
 LL |     let _ = r.map_or(false, |x| x == 7);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: `-D clippy::manual-is-variant-and` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_is_variant_and)]`
 help: use `is_ok_and` instead
    |
 LL -     let _ = r.map_or(false, |x| x == 7);
@@ -219,43 +120,7 @@ LL +     let _ = r.is_ok_and(|x| x == 7);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:83:13
-   |
-LL |     let _ = r.map_or(false, func);
-   |             ^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_ok_and` instead
-   |
-LL -     let _ = r.map_or(false, func);
-LL +     let _ = r.is_ok_and(func);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:85:13
-   |
-LL |     let _ = Some(5).map_or(false, func);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     let _ = Some(5).map_or(false, func);
-LL +     let _ = Some(5).is_some_and(func);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:87:13
-   |
-LL |     let _ = Some(5).map_or(true, func);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     let _ = Some(5).map_or(true, func);
-LL +     let _ = Some(5).is_none_or(func);
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:93:13
+  --> tests/ui/unnecessary_map_or.rs:62:13
    |
 LL |     let _ = r.map_or(false, |x| x == 8);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -267,67 +132,43 @@ LL +     let _ = r == Ok(8);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:114:5
+  --> tests/ui/unnecessary_map_or.rs:68:13
    |
-LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = r.map_or(false, func);
+   |             ^^^^^^^^^^^^^^^^^^^^^
    |
-help: use `is_none_or` instead
+help: use `is_ok_and` instead
    |
-LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-LL +     o.is_none_or(|n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:114:34
-   |
-LL |     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     o.map_or(true, |n| n > 5) || (o as &Option<u32>).map_or(true, |n| n < 5)
-LL +     o.map_or(true, |n| n > 5) || (o as &Option<u32>).is_none_or(|n| n < 5)
+LL -     let _ = r.map_or(false, func);
+LL +     let _ = r.is_ok_and(func);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:129:5
+  --> tests/ui/unnecessary_map_or.rs:70:13
    |
-LL |     o.map_or(true, |n| n > 5)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_none_or` instead
-   |
-LL -     o.map_or(true, |n| n > 5)
-LL +     o.is_none_or(|n| n > 5)
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:134:13
-   |
-LL |     let x = a.map_or(false, |a| a == *s);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = Some(5).map_or(false, func);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: use `is_some_and` instead
    |
-LL -     let x = a.map_or(false, |a| a == *s);
-LL +     let x = a.is_some_and(|a| a == *s);
+LL -     let _ = Some(5).map_or(false, func);
+LL +     let _ = Some(5).is_some_and(func);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:136:13
+  --> tests/ui/unnecessary_map_or.rs:72:13
    |
-LL |     let y = b.map_or(true, |b| b == *s);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = Some(5).map_or(true, func);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: use `is_none_or` instead
    |
-LL -     let y = b.map_or(true, |b| b == *s);
-LL +     let y = b.is_none_or(|b| b == *s);
+LL -     let _ = Some(5).map_or(true, func);
+LL +     let _ = Some(5).is_none_or(func);
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:142:13
+  --> tests/ui/unnecessary_map_or.rs:77:13
    |
 LL |     assert!(Some("test").map_or(false, |x| x == "test"));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -339,7 +180,7 @@ LL +     assert!(Some("test") == Some("test"));
    |
 
 error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:146:13
+  --> tests/ui/unnecessary_map_or.rs:81:13
    |
 LL |     assert!(Some("test").map_or(false, |x| x == "test").then(|| 1).is_some());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,29 +191,5 @@ LL -     assert!(Some("test").map_or(false, |x| x == "test").then(|| 1).is_some(
 LL +     assert!((Some("test") == Some("test")).then(|| 1).is_some());
    |
 
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:163:9
-   |
-LL |     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     _ = s.lock().unwrap().map_or(false, |s| s == "foo");
-LL +     _ = s.lock().unwrap().is_some_and(|s| s == "foo");
-   |
-
-error: this `map_or` can be simplified
-  --> tests/ui/unnecessary_map_or.rs:167:9
-   |
-LL |     _ = s.map_or(false, |s| s == "foo");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and` instead
-   |
-LL -     _ = s.map_or(false, |s| s == "foo");
-LL +     _ = s.is_some_and(|s| s == "foo");
-   |
-
-error: aborting due to 30 previous errors
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16389)*

This is the fourth and fifth commits of https://github.com/rust-lang/rust-clippy/pull/16383

This lint transforms `.is_some_and(|n| n == 5)` into `== Some(5)`
- "needless" was chosen in order to comply with [RFC 344](https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints), but also for being shorter and easier to write than "unnecessary" 
- the test suite is largely identical to that of `unnecessary_map_or`

For further reasoning, please see the documentation on `manual_eq_optional.rs`.

Resolves rust-lang/rust-clippy#14713
Resolves rust-lang/rust-clippy#15999

Diffs best viewed with whitespace ignored and `--color-moved`

cc @teofr

changelog: [`needless_is_variant_and`]: new lint