### PR TITLE
feat(strlen_on_c_strings): mention the specific type (`CString` or `CStr`)

### DIFF
--- a/tests/ui/strlen_on_c_strings.fixed
+++ b/tests/ui/strlen_on_c_strings.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::strlen_on_c_strings)]
-#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::manual_c_str_literals, clippy::boxed_local)]
 
 use libc::strlen;
 use std::ffi::{CStr, CString};
@@ -7,7 +7,7 @@ use std::ffi::{CStr, CString};
 fn main() {
     // CString
     let cstring = CString::new("foo").expect("CString::new failed");
-    let _ = cstring.as_bytes().len();
+    let _ = cstring.to_bytes().len();
     //~^ ERROR: using `libc::strlen` on a `CString` value
 
     // CStr
@@ -33,4 +33,14 @@ fn main() {
     let f: unsafe fn(_) -> _ = unsafe_identity;
     let _ = unsafe { f(cstr).to_bytes().len() };
     //~^ ERROR: using `libc::strlen` on a `CStr` value
+}
+
+// make sure we lint types that _adjust_ to `CStr`
+fn adjusted(box_cstring: Box<CString>, box_cstr: Box<CStr>, arc_cstring: std::sync::Arc<CStr>) {
+    let _ = box_cstring.to_bytes().len();
+    //~^ ERROR: using `libc::strlen` on a type that dereferences to `CStr`
+    let _ = box_cstr.to_bytes().len();
+    //~^ ERROR: using `libc::strlen` on a type that dereferences to `CStr`
+    let _ = arc_cstring.to_bytes().len();
+    //~^ ERROR: using `libc::strlen` on a type that dereferences to `CStr`
 }

--- a/tests/ui/strlen_on_c_strings.rs
+++ b/tests/ui/strlen_on_c_strings.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::strlen_on_c_strings)]
-#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::manual_c_str_literals, clippy::boxed_local)]
 
 use libc::strlen;
 use std::ffi::{CStr, CString};
@@ -33,4 +33,14 @@ fn main() {
     let f: unsafe fn(_) -> _ = unsafe_identity;
     let _ = unsafe { strlen(f(cstr).as_ptr()) };
     //~^ ERROR: using `libc::strlen` on a `CStr` value
+}
+
+// make sure we lint types that _adjust_ to `CStr`
+fn adjusted(box_cstring: Box<CString>, box_cstr: Box<CStr>, arc_cstring: std::sync::Arc<CStr>) {
+    let _ = unsafe { libc::strlen(box_cstring.as_ptr()) };
+    //~^ ERROR: using `libc::strlen` on a type that dereferences to `CStr`
+    let _ = unsafe { libc::strlen(box_cstr.as_ptr()) };
+    //~^ ERROR: using `libc::strlen` on a type that dereferences to `CStr`
+    let _ = unsafe { libc::strlen(arc_cstring.as_ptr()) };
+    //~^ ERROR: using `libc::strlen` on a type that dereferences to `CStr`
 }

--- a/tests/ui/strlen_on_c_strings.stderr
+++ b/tests/ui/strlen_on_c_strings.stderr
@@ -2,7 +2,7 @@ error: using `libc::strlen` on a `CString` value
   --> tests/ui/strlen_on_c_strings.rs:10:13
    |
 LL |     let _ = unsafe { libc::strlen(cstring.as_ptr()) };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `cstring.as_bytes().len()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `cstring.to_bytes().len()`
    |
    = note: `-D clippy::strlen-on-c-strings` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::strlen_on_c_strings)]`
@@ -43,5 +43,23 @@ error: using `libc::strlen` on a `CStr` value
 LL |     let _ = unsafe { strlen(f(cstr).as_ptr()) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `f(cstr).to_bytes().len()`
 
-error: aborting due to 7 previous errors
+error: using `libc::strlen` on a type that dereferences to `CStr`
+  --> tests/ui/strlen_on_c_strings.rs:40:13
+   |
+LL |     let _ = unsafe { libc::strlen(box_cstring.as_ptr()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `box_cstring.to_bytes().len()`
+
+error: using `libc::strlen` on a type that dereferences to `CStr`
+  --> tests/ui/strlen_on_c_strings.rs:42:13
+   |
+LL |     let _ = unsafe { libc::strlen(box_cstr.as_ptr()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `box_cstr.to_bytes().len()`
+
+error: using `libc::strlen` on a type that dereferences to `CStr`
+  --> tests/ui/strlen_on_c_strings.rs:44:13
+   |
+LL |     let _ = unsafe { libc::strlen(arc_cstring.as_ptr()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `arc_cstring.to_bytes().len()`
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
The vague "or" was a bit silly

changelog: [`strlen_on_c_strings`]: mention the specific type (`CString` or `CStr`)
changelog: [`strlen_on_c_strings`]: lint all types that dereference to `CStr`