### PR TITLE
Fix `indexing_slicing` to only lint when get() accepts the index type

### DIFF
--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -4,10 +4,15 @@ use clippy_utils::diagnostics::{span_lint, span_lint_and_then};
 use clippy_utils::ty::{deref_chain, get_adt_inherent_method};
 use clippy_utils::{higher, is_from_proc_macro, is_in_test, sym};
 use rustc_ast::ast::RangeLimits;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, LangItem};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_session::impl_lint_pass;
+
+const NOTE: &str = "the suggestion might not be applicable in constant blocks";
+const RANGE_HELP_MSG_BOUNDED: &str = "consider using `.get(n..m)` or `.get_mut(n..m)` instead";
+const RANGE_HELP_MSG_FROM: &str = "consider using `.get(n..)` or `.get_mut(n..)` instead";
+const RANGE_HELP_MSG_TO: &str = "consider using `.get(..n)` or `.get_mut(..n)` instead";
 
 declare_clippy_lint! {
     /// ### What it does
@@ -114,121 +119,137 @@ impl<'tcx> LateLintPass<'tcx> for IndexingSlicing {
             && (!self.suppress_restriction_lint_in_const || !cx.tcx.hir_is_inside_const_context(expr.hir_id))
             && let expr_ty = cx.typeck_results().expr_ty(array)
             && let mut deref = deref_chain(cx, expr_ty)
-            && deref.any(|l| {
-                l.peel_refs().is_slice()
-                    || l.peel_refs().is_array()
-                    || ty_has_applicable_get_function(cx, l.peel_refs(), expr_ty, expr)
-            })
+            && deref.any(|l| ty_has_applicable_get_function(cx, l.peel_refs(), expr_ty, index))
             && !is_from_proc_macro(cx, expr)
         {
-            let note = "the suggestion might not be applicable in constant blocks";
             let ty = cx.typeck_results().expr_ty(array).peel_refs();
             let allowed_in_tests = self.allow_indexing_slicing_in_tests && is_in_test(cx.tcx, expr.hir_id);
+
             if let Some(range) = higher::Range::hir(cx, index) {
-                // Ranged indexes, i.e., &x[n..m], &x[n..], &x[..n] and &x[..]
-                if let ty::Array(_, s) = ty.kind() {
-                    let size: u128 = if let Some(size) = s.try_to_target_usize(cx.tcx) {
-                        size.into()
-                    } else {
-                        return;
-                    };
-
-                    let const_range = to_const_range(cx, range, size);
-
-                    if let (Some(start), _) = const_range
-                        && start > size
-                    {
-                        span_lint(
-                            cx,
-                            OUT_OF_BOUNDS_INDEXING,
-                            range.start.map_or(expr.span, |start| start.span),
-                            "range is out of bounds",
-                        );
-                        return;
-                    }
-
-                    if let (_, Some(end)) = const_range
-                        && end > size
-                    {
-                        span_lint(
-                            cx,
-                            OUT_OF_BOUNDS_INDEXING,
-                            range.end.map_or(expr.span, |end| end.span),
-                            "range is out of bounds",
-                        );
-                        return;
-                    }
-
-                    if let (Some(_), Some(_)) = const_range {
-                        // early return because both start and end are constants
-                        // and we have proven above that they are in bounds
-                        return;
-                    }
-                }
-
-                let help_msg = match (range.start, range.end) {
-                    (None, Some(_)) => "consider using `.get(..n)`or `.get_mut(..n)` instead",
-                    (Some(_), None) => "consider using `.get(n..)` or .get_mut(n..)` instead",
-                    (Some(_), Some(_)) => "consider using `.get(n..m)` or `.get_mut(n..m)` instead",
-                    (None, None) => return, // [..] is ok.
-                };
-
-                if allowed_in_tests {
-                    return;
-                }
-
-                span_lint_and_then(cx, INDEXING_SLICING, expr.span, "slicing may panic", |diag| {
-                    diag.help(help_msg);
-
-                    if cx.tcx.hir_is_inside_const_context(expr.hir_id) {
-                        diag.note(note);
-                    }
-                });
+                check_range(cx, expr, range, ty, allowed_in_tests);
             } else {
-                // Catchall non-range index, i.e., [n] or [n << m]
-                if let ty::Array(..) = ty.kind() {
-                    // Index is a const block.
-                    if let ExprKind::ConstBlock(..) = index.kind {
-                        return;
-                    }
-                    // Index is a constant uint.
-                    if let Some(constant) = ConstEvalCtxt::new(cx).eval(index) {
-                        // only `usize` index is legal in rust array index
-                        // leave other type to rustc
-                        if let Constant::Int(off) = constant
-                            && off <= usize::MAX as u128
-                            && let ty::Uint(utype) = cx.typeck_results().expr_ty(index).kind()
-                            && *utype == ty::UintTy::Usize
-                            && let ty::Array(_, s) = ty.kind()
-                            && let Some(size) = s.try_to_target_usize(cx.tcx)
-                        {
-                            // get constant offset and check whether it is in bounds
-                            let off = usize::try_from(off).unwrap();
-                            let size = usize::try_from(size).unwrap();
-
-                            if off >= size {
-                                span_lint(cx, OUT_OF_BOUNDS_INDEXING, expr.span, "index is out of bounds");
-                            }
-                        }
-                        // Let rustc's `const_err` lint handle constant `usize` indexing on arrays.
-                        return;
-                    }
-                }
-
-                if allowed_in_tests {
-                    return;
-                }
-
-                span_lint_and_then(cx, INDEXING_SLICING, expr.span, "indexing may panic", |diag| {
-                    diag.help("consider using `.get(n)` or `.get_mut(n)` instead");
-
-                    if cx.tcx.hir_is_inside_const_context(expr.hir_id) {
-                        diag.note(note);
-                    }
-                });
+                check_non_range(cx, expr, index, ty, allowed_in_tests);
             }
         }
     }
+}
+
+fn check_range<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    range: higher::Range<'tcx>,
+    ty: Ty<'tcx>,
+    allowed_in_tests: bool,
+) {
+    // Ranged indexes, i.e., &x[n..m], &x[n..], &x[..n] and &x[..]
+    if let ty::Array(_, s) = ty.kind() {
+        let size: u128 = if let Some(size) = s.try_to_target_usize(cx.tcx) {
+            size.into()
+        } else {
+            return;
+        };
+
+        let const_range = to_const_range(cx, range, size);
+
+        if let (Some(start), _) = const_range
+            && start > size
+        {
+            span_lint(
+                cx,
+                OUT_OF_BOUNDS_INDEXING,
+                range.start.map_or(expr.span, |start| start.span),
+                "range is out of bounds",
+            );
+            return;
+        }
+
+        if let (_, Some(end)) = const_range
+            && end > size
+        {
+            span_lint(
+                cx,
+                OUT_OF_BOUNDS_INDEXING,
+                range.end.map_or(expr.span, |end| end.span),
+                "range is out of bounds",
+            );
+            return;
+        }
+
+        if let (Some(_), Some(_)) = const_range {
+            // early return because both start and end are constants
+            // and we have proven above that they are in bounds
+            return;
+        }
+    }
+
+    let help_msg = match (range.start, range.end) {
+        (None, Some(_)) => RANGE_HELP_MSG_TO,
+        (Some(_), None) => RANGE_HELP_MSG_FROM,
+        (Some(_), Some(_)) => RANGE_HELP_MSG_BOUNDED,
+        (None, None) => return, // [..] is ok
+    };
+
+    if allowed_in_tests {
+        return;
+    }
+
+    span_lint_and_then(cx, INDEXING_SLICING, expr.span, "slicing may panic", |diag| {
+        diag.help(help_msg);
+
+        if cx.tcx.hir_is_inside_const_context(expr.hir_id) {
+            diag.note(NOTE);
+        }
+    });
+}
+
+fn check_non_range<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    index: &'tcx Expr<'_>,
+    ty: Ty<'tcx>,
+    allowed_in_tests: bool,
+) {
+    // Catchall non-range index, i.e., [n] or [n << m]
+    if let ty::Array(..) = ty.kind() {
+        // Index is a const block.
+        if let ExprKind::ConstBlock(..) = index.kind {
+            return;
+        }
+        // Index is a constant uint.
+        if let Some(constant) = ConstEvalCtxt::new(cx).eval(index) {
+            // only `usize` index is legal in rust array index
+            // leave other type to rustc
+            if let Constant::Int(off) = constant
+                && off <= usize::MAX as u128
+                && let ty::Uint(utype) = cx.typeck_results().expr_ty(index).kind()
+                && *utype == ty::UintTy::Usize
+                && let ty::Array(_, s) = ty.kind()
+                && let Some(size) = s.try_to_target_usize(cx.tcx)
+            {
+                // get constant offset and check whether it is in bounds
+                let off = usize::try_from(off).unwrap();
+                let size = usize::try_from(size).unwrap();
+
+                if off >= size {
+                    span_lint(cx, OUT_OF_BOUNDS_INDEXING, expr.span, "index is out of bounds");
+                }
+            }
+            // Let rustc's `const_err` lint handle constant `usize` indexing on arrays.
+            return;
+        }
+    }
+
+    if allowed_in_tests {
+        return;
+    }
+
+    span_lint_and_then(cx, INDEXING_SLICING, expr.span, "indexing may panic", |diag| {
+        diag.help("consider using `.get(n)` or `.get_mut(n)` instead");
+
+        if cx.tcx.hir_is_inside_const_context(expr.hir_id) {
+            diag.note(NOTE);
+        }
+    });
 }
 
 /// Returns a tuple of options with the start and end (exclusive) values of
@@ -258,32 +279,75 @@ fn to_const_range(cx: &LateContext<'_>, range: higher::Range<'_>, array_size: u1
     (start, end)
 }
 
-/// Checks if the output Ty of the `get` method on this Ty (if any) matches the Ty returned by the
-/// indexing operation (if any).
+/// Checks if the type has an applicable `get` method that accepts the given index type.
 fn ty_has_applicable_get_function<'tcx>(
     cx: &LateContext<'tcx>,
     ty: Ty<'tcx>,
     array_ty: Ty<'tcx>,
     index_expr: &Expr<'_>,
 ) -> bool {
-    if let ty::Adt(_, _) = array_ty.kind()
-        && let Some(get_output_ty) = get_adt_inherent_method(cx, ty, sym::get).map(|m| {
-            cx.tcx
-                .fn_sig(m.def_id)
-                .skip_binder()
-                .output()
-                .skip_binder()
-        })
-        && let ty::Adt(def, args) = get_output_ty.kind()
-        && cx.tcx.is_diagnostic_item(sym::Option, def.0.did)
-        && let Some(option_generic_param) = args.first()
-        && let generic_ty = option_generic_param.expect_ty().peel_refs()
-        // FIXME: ideally this would handle type params and projections properly, for now just assume it's the same type
-        && (cx.typeck_results().expr_ty(index_expr).peel_refs() == generic_ty.peel_refs()
-            || matches!(generic_ty.peel_refs().kind(), ty::Param(_) | ty::Alias(_)))
-    {
-        true
-    } else {
-        false
+    let index_ty = cx.typeck_results().expr_ty(index_expr).peel_refs();
+    let array_ty = array_ty.peel_refs();
+
+    if ty.is_slice() || ty.is_array() {
+        if let ty::Adt(_, _) = array_ty.kind()
+            && array_ty != ty
+            && get_adt_inherent_method(cx, array_ty, sym::get).is_some()
+        {
+            return false;
+        }
+
+        return matches!(index_ty.kind(), ty::Uint(ty::UintTy::Usize)) || slice_range_kind(cx, index_ty).is_some();
     }
+
+    if let ty::Adt(_, _) = ty.kind()
+        && let Some(get_method) = get_adt_inherent_method(cx, ty, sym::get)
+        && let fn_sig = cx.tcx.fn_sig(get_method.def_id).skip_binder().skip_binder()
+        && let get_output_ty = fn_sig.output()
+        && let ty::Adt(def, _) = get_output_ty.kind()
+        && cx.tcx.is_diagnostic_item(sym::Option, def.0.did)
+        && let [_self, idx_param] = fn_sig.inputs()
+    {
+        let idx_param = idx_param.peel_refs();
+
+        // FIXME: ideally this would handle type params and projections properly.
+        return idx_param == index_ty || matches!(idx_param.kind(), ty::Param(_) | ty::Alias(..));
+    }
+
+    false
+}
+
+/// Checks if `ty` is a `Range*<usize>` type valid for slice indexing.
+fn slice_range_kind(cx: &LateContext<'_>, ty: Ty<'_>) -> Option<LangItem> {
+    if let ty::Adt(adt_def, args) = ty.kind() {
+        let did = adt_def.did();
+        let lang_items = cx.tcx.lang_items();
+
+        if lang_items.get(LangItem::RangeFull) == Some(did) {
+            return Some(LangItem::RangeFull);
+        }
+
+        let is_usize = args
+            .first()
+            .and_then(|arg| arg.as_type())
+            .is_some_and(|t| matches!(t.kind(), ty::Uint(ty::UintTy::Usize)));
+
+        if !is_usize {
+            return None;
+        }
+
+        for item in [
+            LangItem::Range,
+            LangItem::RangeFrom,
+            LangItem::RangeTo,
+            LangItem::RangeInclusiveStruct,
+            LangItem::RangeToInclusive,
+        ] {
+            if lang_items.get(item) == Some(did) {
+                return Some(item);
+            }
+        }
+    }
+
+    None
 }

--- a/tests/ui-toml/indexing_slicing/indexing_slicing.stderr
+++ b/tests/ui-toml/indexing_slicing/indexing_slicing.stderr
@@ -4,7 +4,7 @@ error: slicing may panic
 LL |     &x[index..];
    |      ^^^^^^^^^^
    |
-   = help: consider using `.get(n..)` or .get_mut(n..)` instead
+   = help: consider using `.get(n..)` or `.get_mut(n..)` instead
    = note: `-D clippy::indexing-slicing` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::indexing_slicing)]`
 

--- a/tests/ui/indexing_slicing_index.rs
+++ b/tests/ui/indexing_slicing_index.rs
@@ -102,3 +102,99 @@ fn main() {
     let _ = x[4];
     //~^ out_of_bounds_indexing
 }
+
+mod issue_16384 {
+    use std::ops::{Deref, Index};
+
+    enum Key {
+        A,
+        B,
+    }
+
+    struct MyMap {
+        data: [&'static str; 2],
+    }
+
+    impl Index<Key> for MyMap {
+        type Output = &'static str;
+        fn index(&self, key: Key) -> &Self::Output {
+            match key {
+                Key::A => &self.data[0],
+                Key::B => &self.data[1],
+            }
+        }
+    }
+
+    impl Deref for MyMap {
+        type Target = [&'static str];
+        fn deref(&self) -> &Self::Target {
+            &self.data
+        }
+    }
+
+    fn test() {
+        let map = MyMap { data: ["a", "b"] };
+        // Should NOT lint: `get()` takes `usize`, not `Key`
+        let _ = map[Key::A];
+    }
+}
+
+mod custom_range_index {
+    use std::ops::{Index, Range};
+
+    struct MyVec<T>(T);
+
+    impl<T> Index<Range<u32>> for MyVec<T> {
+        type Output = T;
+        fn index(&self, _index: Range<u32>) -> &Self::Output {
+            &self.0
+        }
+    }
+
+    impl<T> MyVec<T> {
+        fn get(&self, _index: Range<u32>) -> Option<&T> {
+            Some(&self.0)
+        }
+    }
+
+    fn test() {
+        let v = MyVec(1);
+        // Should lint: `get(Range<u32>)` matches index type
+        let _ = v[0..1];
+        //~^ indexing_slicing
+    }
+}
+
+mod issue_16384_get_shadowing {
+    use std::ops::Deref;
+
+    enum Key {
+        A,
+        B,
+    }
+
+    struct Map<V> {
+        values: [V; 2],
+    }
+
+    impl<V> Map<V> {
+        fn get(&self, _key: &Key) -> Option<&V> {
+            todo!()
+        }
+    }
+
+    impl<V> Deref for Map<V> {
+        type Target = [V];
+
+        fn deref(&self) -> &Self::Target {
+            &self.values
+        }
+    }
+
+    fn test() {
+        let map = Map { values: ["a", "b"] };
+
+        // Don't lint: the input type of `Map::get` doesn't match the index type.
+        let _ = map[0];
+    }
+}

--- a/tests/ui/indexing_slicing_index.stderr
+++ b/tests/ui/indexing_slicing_index.stderr
@@ -108,5 +108,13 @@ error: index is out of bounds
 LL |     let _ = x[4];
    |             ^^^^
 
-error: aborting due to 14 previous errors
+error: slicing may panic
+  --> tests/ui/indexing_slicing_index.rs:163:17
+   |
+LL |         let _ = v[0..1];
+   |                 ^^^^^^^
+   |
+   = help: consider using `.get(n..m)` or `.get_mut(n..m)` instead
+
+error: aborting due to 15 previous errors
 

--- a/tests/ui/indexing_slicing_slice.rs
+++ b/tests/ui/indexing_slicing_slice.rs
@@ -165,17 +165,16 @@ fn main() {
         true_value: 4,
     };
 
-    // Lint on this, because `get` does exist with same signature
+    // Lint: `get` exists with matching input type
     map_with_get[true];
     //~^ indexing_slicing
 
+    // Don't lint: `get()` doesn't accept the index type
     let s = S::<i32>(1);
     s[0];
-    //~^ indexing_slicing
 
     let y = Y::<i32>(1);
     y[0];
-    //~^ indexing_slicing
 
     let z = Z::<i32>(1);
     z[0];

--- a/tests/ui/indexing_slicing_slice.stderr
+++ b/tests/ui/indexing_slicing_slice.stderr
@@ -4,7 +4,7 @@ error: slicing may panic
 LL |     &x[index..];
    |      ^^^^^^^^^^
    |
-   = help: consider using `.get(n..)` or .get_mut(n..)` instead
+   = help: consider using `.get(n..)` or `.get_mut(n..)` instead
    = note: `-D clippy::indexing-slicing` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::indexing_slicing)]`
 
@@ -14,7 +14,7 @@ error: slicing may panic
 LL |     &x[..index];
    |      ^^^^^^^^^^
    |
-   = help: consider using `.get(..n)`or `.get_mut(..n)` instead
+   = help: consider using `.get(..n)` or `.get_mut(..n)` instead
 
 error: slicing may panic
   --> tests/ui/indexing_slicing_slice.rs:118:6
@@ -30,7 +30,7 @@ error: slicing may panic
 LL |     &x[index_from..][..index_to];
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider using `.get(..n)`or `.get_mut(..n)` instead
+   = help: consider using `.get(..n)` or `.get_mut(..n)` instead
 
 error: slicing may panic
   --> tests/ui/indexing_slicing_slice.rs:120:6
@@ -38,7 +38,7 @@ error: slicing may panic
 LL |     &x[index_from..][..index_to];
    |      ^^^^^^^^^^^^^^^
    |
-   = help: consider using `.get(n..)` or .get_mut(n..)` instead
+   = help: consider using `.get(n..)` or `.get_mut(n..)` instead
 
 error: slicing may panic
   --> tests/ui/indexing_slicing_slice.rs:123:6
@@ -46,7 +46,7 @@ error: slicing may panic
 LL |     &x[5..][..10];
    |      ^^^^^^^^^^^^
    |
-   = help: consider using `.get(..n)`or `.get_mut(..n)` instead
+   = help: consider using `.get(..n)` or `.get_mut(..n)` instead
 
 error: range is out of bounds
   --> tests/ui/indexing_slicing_slice.rs:123:8
@@ -63,7 +63,7 @@ error: slicing may panic
 LL |     &x[0..][..3];
    |      ^^^^^^^^^^^
    |
-   = help: consider using `.get(..n)`or `.get_mut(..n)` instead
+   = help: consider using `.get(..n)` or `.get_mut(..n)` instead
 
 error: slicing may panic
   --> tests/ui/indexing_slicing_slice.rs:128:6
@@ -71,7 +71,7 @@ error: slicing may panic
 LL |     &x[1..][..5];
    |      ^^^^^^^^^^^
    |
-   = help: consider using `.get(..n)`or `.get_mut(..n)` instead
+   = help: consider using `.get(..n)` or `.get_mut(..n)` instead
 
 error: range is out of bounds
   --> tests/ui/indexing_slicing_slice.rs:136:12
@@ -99,7 +99,7 @@ error: slicing may panic
 LL |     &x[10..][..100];
    |      ^^^^^^^^^^^^^^
    |
-   = help: consider using `.get(..n)`or `.get_mut(..n)` instead
+   = help: consider using `.get(..n)` or `.get_mut(..n)` instead
 
 error: range is out of bounds
   --> tests/ui/indexing_slicing_slice.rs:146:8
@@ -113,7 +113,7 @@ error: slicing may panic
 LL |     &v[10..];
    |      ^^^^^^^
    |
-   = help: consider using `.get(n..)` or .get_mut(n..)` instead
+   = help: consider using `.get(n..)` or `.get_mut(n..)` instead
 
 error: slicing may panic
   --> tests/ui/indexing_slicing_slice.rs:151:6
@@ -121,7 +121,7 @@ error: slicing may panic
 LL |     &v[..100];
    |      ^^^^^^^^
    |
-   = help: consider using `.get(..n)`or `.get_mut(..n)` instead
+   = help: consider using `.get(..n)` or `.get_mut(..n)` instead
 
 error: indexing may panic
   --> tests/ui/indexing_slicing_slice.rs:169:5
@@ -131,21 +131,5 @@ LL |     map_with_get[true];
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
-error: indexing may panic
-  --> tests/ui/indexing_slicing_slice.rs:173:5
-   |
-LL |     s[0];
-   |     ^^^^
-   |
-   = help: consider using `.get(n)` or `.get_mut(n)` instead
-
-error: indexing may panic
-  --> tests/ui/indexing_slicing_slice.rs:177:5
-   |
-LL |     y[0];
-   |     ^^^^
-   |
-   = help: consider using `.get(n)` or `.get_mut(n)` instead
-
-error: aborting due to 19 previous errors
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16395)*

fixes rust-lang/rust-clippy#16384 

changelog: [`indexing-slicing`]: only lints when get() accepts the index type
