### PR TITLE
Skip elidable_lifetime_names lint for proc-macro generated code

### DIFF
--- a/tests/ui/extra_unused_lifetimes.rs
+++ b/tests/ui/extra_unused_lifetimes.rs
@@ -1,4 +1,5 @@
 //@aux-build:proc_macro_derive.rs
+//@aux-build:proc_macros.rs
 
 #![allow(
     unused,
@@ -11,6 +12,7 @@
 
 #[macro_use]
 extern crate proc_macro_derive;
+extern crate proc_macros;
 
 fn empty() {}
 
@@ -146,6 +148,36 @@ mod issue_13578 {
     pub trait Foo {}
 
     impl<'a, T: 'a> Foo for Option<T> where &'a T: Foo {}
+}
+
+// no lint on proc macro generated code
+mod proc_macro_generated {
+    use proc_macros::external;
+
+    // no lint on external macro (extra unused lifetimes in impl block)
+    external! {
+        struct ExternalImplStruct;
+
+        impl<'a> ExternalImplStruct {
+            fn foo() {}
+        }
+    }
+
+    // no lint on external macro (extra unused lifetimes in method)
+    external! {
+        struct ExternalMethodStruct;
+
+        impl ExternalMethodStruct {
+            fn bar<'a>(&self) {}
+        }
+    }
+
+    // no lint on external macro (extra unused lifetimes in trait method)
+    external! {
+        trait ExternalUnusedLifetimeTrait {
+            fn unused_lt<'a>(x: u8) {}
+        }
+    }
 }
 
 fn main() {}

--- a/tests/ui/extra_unused_lifetimes.stderr
+++ b/tests/ui/extra_unused_lifetimes.stderr
@@ -1,5 +1,5 @@
 error: this lifetime isn't used in the function definition
-  --> tests/ui/extra_unused_lifetimes.rs:19:14
+  --> tests/ui/extra_unused_lifetimes.rs:21:14
    |
 LL | fn unused_lt<'a>(x: u8) {}
    |              ^^
@@ -8,37 +8,37 @@ LL | fn unused_lt<'a>(x: u8) {}
    = help: to override `-D warnings` add `#[allow(clippy::extra_unused_lifetimes)]`
 
 error: this lifetime isn't used in the function definition
-  --> tests/ui/extra_unused_lifetimes.rs:47:10
+  --> tests/ui/extra_unused_lifetimes.rs:49:10
    |
 LL |     fn x<'a>(&self) {}
    |          ^^
 
 error: this lifetime isn't used in the function definition
-  --> tests/ui/extra_unused_lifetimes.rs:74:22
+  --> tests/ui/extra_unused_lifetimes.rs:76:22
    |
 LL |         fn unused_lt<'a>(x: u8) {}
    |                      ^^
 
 error: this lifetime isn't used in the impl
-  --> tests/ui/extra_unused_lifetimes.rs:86:10
+  --> tests/ui/extra_unused_lifetimes.rs:88:10
    |
 LL |     impl<'a> std::ops::AddAssign<&Scalar> for &mut Scalar {
    |          ^^
 
 error: this lifetime isn't used in the impl
-  --> tests/ui/extra_unused_lifetimes.rs:93:10
+  --> tests/ui/extra_unused_lifetimes.rs:95:10
    |
 LL |     impl<'b> Scalar {
    |          ^^
 
 error: this lifetime isn't used in the function definition
-  --> tests/ui/extra_unused_lifetimes.rs:95:26
+  --> tests/ui/extra_unused_lifetimes.rs:97:26
    |
 LL |         pub fn something<'c>() -> Self {
    |                          ^^
 
 error: this lifetime isn't used in the impl
-  --> tests/ui/extra_unused_lifetimes.rs:125:10
+  --> tests/ui/extra_unused_lifetimes.rs:127:10
    |
 LL |     impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
    |          ^^

--- a/tests/ui/needless_lifetimes.fixed
+++ b/tests/ui/needless_lifetimes.fixed
@@ -470,11 +470,34 @@ mod in_macro {
         }
     }
 
-    // no lint on external macro
+    // no lint on external macro (standalone function)
     external! {
         fn needless_lifetime<'a>(x: &'a u8) -> &'a u8 {
             unimplemented!()
         }
+    }
+
+    // no lint on external macro (method in impl block)
+    external! {
+        struct ExternalStruct;
+
+        impl ExternalStruct {
+            fn needless_lifetime_method<'a>(x: &'a u8) -> &'a u8 {
+                unimplemented!()
+            }
+        }
+    }
+
+    // no lint on external macro (trait method)
+    external! {
+        trait ExternalTrait {
+            fn needless_lifetime_trait_method<'a>(x: &'a u8) -> &'a u8;
+        }
+    }
+
+    // no lint on external macro (extra unused lifetimes in function)
+    external! {
+        fn extra_unused_lifetime<'a>(x: u8) {}
     }
 
     inline! {

--- a/tests/ui/needless_lifetimes.rs
+++ b/tests/ui/needless_lifetimes.rs
@@ -470,11 +470,34 @@ mod in_macro {
         }
     }
 
-    // no lint on external macro
+    // no lint on external macro (standalone function)
     external! {
         fn needless_lifetime<'a>(x: &'a u8) -> &'a u8 {
             unimplemented!()
         }
+    }
+
+    // no lint on external macro (method in impl block)
+    external! {
+        struct ExternalStruct;
+
+        impl ExternalStruct {
+            fn needless_lifetime_method<'a>(x: &'a u8) -> &'a u8 {
+                unimplemented!()
+            }
+        }
+    }
+
+    // no lint on external macro (trait method)
+    external! {
+        trait ExternalTrait {
+            fn needless_lifetime_trait_method<'a>(x: &'a u8) -> &'a u8;
+        }
+    }
+
+    // no lint on external macro (extra unused lifetimes in function)
+    external! {
+        fn extra_unused_lifetime<'a>(x: u8) {}
     }
 
     inline! {


### PR DESCRIPTION
When linting code generated by proc macros (like `derivative`), the `elidable_lifetime_names` lint can produce fix suggestions with overlapping spans. This causes `cargo clippy --fix` to fail with "cannot replace slice of data that was already replaced".

This change adds `is_from_proc_macro` checks to the three lint entry points (`check_item`, `check_impl_item`, `check_trait_item`) to skip linting proc-macro generated code entirely.

Fixes rust-lang/rust-clippy#16316

---

changelog: [`elidable_lifetime_names`]: skip linting proc-macro generated code to avoid broken fix suggestions