### PR TITLE
Mention `cast_signed` in docs of `cast_possible_wrap`

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -145,6 +145,12 @@ declare_clippy_lint! {
     /// let _ = i32::try_from(u32::MAX).ok();
     /// ```
     ///
+    /// If the wrapping is intended, you can use:
+    /// ```no_run
+    /// let _ = u32::MAX.cast_signed();
+    /// let _ = (-1i32).cast_unsigned();
+    /// ```
+    ///
     #[clippy::version = "pre 1.29.0"]
     pub CAST_POSSIBLE_WRAP,
     pedantic,


### PR DESCRIPTION
I was evaluating this lint recently, and accepted using it because these methods exist.
But the docs on the lint don't mention it, so I thought it would be prudent to include it in the docs.

See also https://github.com/rust-lang/rust-clippy/pull/15384

changelog: [`cast_possible_wrap`]: mention `cast_{un,}signed()` methods in the documentation
