### PR TITLE
Assume that any external function might return a type alias

### DIFF
--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -1,13 +1,13 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::numeric_literal::NumericLiteral;
-use clippy_utils::res::MaybeResPath;
+use clippy_utils::res::MaybeResPath as _;
 use clippy_utils::source::{SpanRangeExt, snippet_opt};
 use clippy_utils::visitors::{Visitable, for_each_expr_without_closures};
 use clippy_utils::{get_parent_expr, is_hir_ty_cfg_dependant, is_ty_alias};
 use rustc_ast::{LitFloatType, LitIntType, LitKind};
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::{Expr, ExprKind, Lit, Node, Path, QPath, TyKind, UnOp};
+use rustc_hir::{Expr, ExprKind, FnRetTy, Lit, Node, Path, QPath, TyKind, UnOp};
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::adjustment::Adjust;
 use rustc_middle::ty::{self, FloatTy, InferTy, Ty};
@@ -97,7 +97,7 @@ pub(super) fn check<'tcx>(
 
     // skip cast of fn call that returns type alias
     if let ExprKind::Cast(inner, ..) = expr.kind
-        && is_cast_from_ty_alias(cx, inner, cast_from)
+        && is_cast_from_ty_alias(cx, inner)
     {
         return false;
     }
@@ -270,34 +270,25 @@ fn fp_ty_mantissa_nbits(typ: Ty<'_>) -> u32 {
 
 /// Finds whether an `Expr` returns a type alias.
 ///
-/// TODO: Maybe we should move this to `clippy_utils` so others won't need to go down this dark,
-/// dark path reimplementing this (or something similar).
-fn is_cast_from_ty_alias<'tcx>(cx: &LateContext<'tcx>, expr: impl Visitable<'tcx>, cast_from: Ty<'tcx>) -> bool {
+/// When in doubt, for example because it calls a non-local function that we don't have the
+/// declaration for, assume if might be a type alias.
+fn is_cast_from_ty_alias<'tcx>(cx: &LateContext<'tcx>, expr: impl Visitable<'tcx>) -> bool {
     for_each_expr_without_closures(expr, |expr| {
         // Calls are a `Path`, and usage of locals are a `Path`. So, this checks
         // - call() as i32
         // - local as i32
         if let ExprKind::Path(qpath) = expr.kind {
             let res = cx.qpath_res(&qpath, expr.hir_id);
-            // Function call
             if let Res::Def(DefKind::Fn, def_id) = res {
-                let Some(snippet) = cx.tcx.def_span(def_id).get_source_text(cx) else {
-                    return ControlFlow::Continue(());
+                let Some(def_id) = def_id.as_local() else {
+                    // External function, we can't know, better be safe
+                    return ControlFlow::Break(());
                 };
-                // This is the worst part of this entire function. This is the only way I know of to
-                // check whether a function returns a type alias. Sure, you can get the return type
-                // from a function in the current crate as an hir ty, but how do you get it for
-                // external functions?? Simple: It's impossible. So, we check whether a part of the
-                // function's declaration snippet is exactly equal to the `Ty`. That way, we can
-                // see whether it's a type alias.
-                //
-                // FIXME: This won't work if the type is given an alias through `use`, should we
-                // consider this a type alias as well?
-                if !snippet
-                    .split("->")
-                    .skip(1)
-                    .any(|s| snippet_eq_ty(s, cast_from) || s.split("where").any(|ty| snippet_eq_ty(ty, cast_from)))
+                if let Some(FnRetTy::Return(ty)) = cx.tcx.hir_get_fn_output(def_id)
+                    && let TyKind::Path(qpath) = ty.kind
+                    && is_ty_alias(&qpath)
                 {
+                    // Function call to a local function returning a type alias
                     return ControlFlow::Break(());
                 }
             // Local usage
@@ -305,7 +296,7 @@ fn is_cast_from_ty_alias<'tcx>(cx: &LateContext<'tcx>, expr: impl Visitable<'tcx
                 && let Node::LetStmt(l) = cx.tcx.parent_hir_node(hir_id)
             {
                 if let Some(e) = l.init
-                    && is_cast_from_ty_alias(cx, e, cast_from)
+                    && is_cast_from_ty_alias(cx, e)
                 {
                     return ControlFlow::Break::<()>(());
                 }
@@ -322,8 +313,4 @@ fn is_cast_from_ty_alias<'tcx>(cx: &LateContext<'tcx>, expr: impl Visitable<'tcx
         ControlFlow::Continue(())
     })
     .is_some()
-}
-
-fn snippet_eq_ty(snippet: &str, ty: Ty<'_>) -> bool {
-    snippet.trim() == ty.to_string() || snippet.trim().contains(&format!("::{ty}"))
 }

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -133,12 +133,13 @@ fn main() {
     aaa();
     //~^ unnecessary_cast
     let x = aaa();
-    aaa();
+    x;
     //~^ unnecessary_cast
-    // Will not lint currently.
-    bbb() as u32;
+    bbb();
+    //~^ unnecessary_cast
     let x = bbb();
-    bbb() as u32;
+    x;
+    //~^ unnecessary_cast
 
     let i8_ptr: *const i8 = &1;
     let u8_ptr: *const u8 = &1;

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -133,12 +133,13 @@ fn main() {
     aaa() as u32;
     //~^ unnecessary_cast
     let x = aaa();
-    aaa() as u32;
+    x as u32;
     //~^ unnecessary_cast
-    // Will not lint currently.
     bbb() as u32;
+    //~^ unnecessary_cast
     let x = bbb();
-    bbb() as u32;
+    x as u32;
+    //~^ unnecessary_cast
 
     let i8_ptr: *const i8 = &1;
     let u8_ptr: *const u8 = &1;

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -100,170 +100,182 @@ LL |     aaa() as u32;
 error: casting to the same type is unnecessary (`u32` -> `u32`)
   --> tests/ui/unnecessary_cast.rs:136:5
    |
-LL |     aaa() as u32;
-   |     ^^^^^^^^^^^^ help: try: `aaa()`
+LL |     x as u32;
+   |     ^^^^^^^^ help: try: `x`
+
+error: casting to the same type is unnecessary (`u32` -> `u32`)
+  --> tests/ui/unnecessary_cast.rs:138:5
+   |
+LL |     bbb() as u32;
+   |     ^^^^^^^^^^^^ help: try: `bbb()`
+
+error: casting to the same type is unnecessary (`u32` -> `u32`)
+  --> tests/ui/unnecessary_cast.rs:141:5
+   |
+LL |     x as u32;
+   |     ^^^^^^^^ help: try: `x`
 
 error: casting integer literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:173:9
+  --> tests/ui/unnecessary_cast.rs:174:9
    |
 LL |         100 as f32;
    |         ^^^^^^^^^^ help: try: `100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:175:9
+  --> tests/ui/unnecessary_cast.rs:176:9
    |
 LL |         100 as f64;
    |         ^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:177:9
+  --> tests/ui/unnecessary_cast.rs:178:9
    |
 LL |         100_i32 as f64;
    |         ^^^^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:179:17
+  --> tests/ui/unnecessary_cast.rs:180:17
    |
 LL |         let _ = -100 as f32;
    |                 ^^^^^^^^^^^ help: try: `-100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:181:17
+  --> tests/ui/unnecessary_cast.rs:182:17
    |
 LL |         let _ = -100 as f64;
    |                 ^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:183:17
+  --> tests/ui/unnecessary_cast.rs:184:17
    |
 LL |         let _ = -100_i32 as f64;
    |                 ^^^^^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:185:9
+  --> tests/ui/unnecessary_cast.rs:186:9
    |
 LL |         100. as f32;
    |         ^^^^^^^^^^^ help: try: `100_f32`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:187:9
+  --> tests/ui/unnecessary_cast.rs:188:9
    |
 LL |         100. as f64;
    |         ^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `u32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:200:9
+  --> tests/ui/unnecessary_cast.rs:201:9
    |
 LL |         1 as u32;
    |         ^^^^^^^^ help: try: `1_u32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:202:9
+  --> tests/ui/unnecessary_cast.rs:203:9
    |
 LL |         0x10 as i32;
    |         ^^^^^^^^^^^ help: try: `0x10_i32`
 
 error: casting integer literal to `usize` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:204:9
+  --> tests/ui/unnecessary_cast.rs:205:9
    |
 LL |         0b10 as usize;
    |         ^^^^^^^^^^^^^ help: try: `0b10_usize`
 
 error: casting integer literal to `u16` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:206:9
+  --> tests/ui/unnecessary_cast.rs:207:9
    |
 LL |         0o73 as u16;
    |         ^^^^^^^^^^^ help: try: `0o73_u16`
 
 error: casting integer literal to `u32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:208:9
+  --> tests/ui/unnecessary_cast.rs:209:9
    |
 LL |         1_000_000_000 as u32;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `1_000_000_000_u32`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:211:9
+  --> tests/ui/unnecessary_cast.rs:212:9
    |
 LL |         1.0 as f64;
    |         ^^^^^^^^^^ help: try: `1.0_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:213:9
+  --> tests/ui/unnecessary_cast.rs:214:9
    |
 LL |         0.5 as f32;
    |         ^^^^^^^^^^ help: try: `0.5_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:218:17
+  --> tests/ui/unnecessary_cast.rs:219:17
    |
 LL |         let _ = -1 as i32;
    |                 ^^^^^^^^^ help: try: `-1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:220:17
+  --> tests/ui/unnecessary_cast.rs:221:17
    |
 LL |         let _ = -1.0 as f32;
    |                 ^^^^^^^^^^^ help: try: `-1.0_f32`
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> tests/ui/unnecessary_cast.rs:227:18
+  --> tests/ui/unnecessary_cast.rs:228:18
    |
 LL |         let _ = &(x as i32);
    |                  ^^^^^^^^^^ help: try: `{ x }`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:234:22
+  --> tests/ui/unnecessary_cast.rs:235:22
    |
 LL |         let _: i32 = -(1) as i32;
    |                      ^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:237:22
+  --> tests/ui/unnecessary_cast.rs:238:22
    |
 LL |         let _: i64 = -(1) as i64;
    |                      ^^^^^^^^^^^ help: try: `-1_i64`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:245:22
+  --> tests/ui/unnecessary_cast.rs:246:22
    |
 LL |         let _: f64 = (-8.0 as f64).exp();
    |                      ^^^^^^^^^^^^^ help: try: `(-8.0_f64)`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:248:23
+  --> tests/ui/unnecessary_cast.rs:249:23
    |
 LL |         let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
    |                       ^^^^^^^^^^^^ help: try: `8.0_f64`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> tests/ui/unnecessary_cast.rs:258:20
+  --> tests/ui/unnecessary_cast.rs:259:20
    |
 LL |         let _num = foo() as f32;
    |                    ^^^^^^^^^^^^ help: try: `foo()`
 
 error: casting to the same type is unnecessary (`usize` -> `usize`)
-  --> tests/ui/unnecessary_cast.rs:269:9
+  --> tests/ui/unnecessary_cast.rs:270:9
    |
 LL |         (*x as usize).pow(2)
    |         ^^^^^^^^^^^^^ help: try: `(*x)`
 
 error: casting to the same type is unnecessary (`usize` -> `usize`)
-  --> tests/ui/unnecessary_cast.rs:277:31
+  --> tests/ui/unnecessary_cast.rs:278:31
    |
 LL |         assert_eq!(vec.len(), x as usize);
    |                               ^^^^^^^^^^ help: try: `x`
 
 error: casting to the same type is unnecessary (`i64` -> `i64`)
-  --> tests/ui/unnecessary_cast.rs:280:17
+  --> tests/ui/unnecessary_cast.rs:281:17
    |
 LL |         let _ = (5i32 as i64 as i64).abs();
    |                 ^^^^^^^^^^^^^^^^^^^^ help: try: `(5i32 as i64)`
 
 error: casting to the same type is unnecessary (`i64` -> `i64`)
-  --> tests/ui/unnecessary_cast.rs:283:17
+  --> tests/ui/unnecessary_cast.rs:284:17
    |
 LL |         let _ = 5i32 as i64 as i64;
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `5i32 as i64`
 
-error: aborting due to 44 previous errors
+error: aborting due to 46 previous errors
 


### PR DESCRIPTION
We might not have the declaration around if `extern crate` is used, or if rust-src is not installed for the standard library. Better err on the safe side rather than having a behavior depending on what happens to be available at compile time.

Fixes rust-lang/rust-clippy#14625

changelog: [`unnecessary_cast`]: do not warn on casts of external function return type