### PR TITLE
Do not consider binary operators as commutative by default

### DIFF
--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -11,6 +11,8 @@
     unreachable_code
 )]
 
+use std::ops::*;
+
 struct Foo {
     bar: u8,
 }
@@ -133,18 +135,6 @@ fn func() {
 
 fn f(val: &[u8]) {}
 
-mod issue_5698 {
-    fn mul_not_always_commutative(x: i32, y: i32) -> i32 {
-        if x == 42 {
-            x * y
-        } else if x == 21 {
-            y * x
-        } else {
-            0
-        }
-    }
-}
-
 mod issue_8836 {
     fn do_not_lint() {
         if true {
@@ -245,3 +235,73 @@ mod issue_11213 {
 }
 
 fn main() {}
+
+fn issue16416<T>(x: bool, a: T, b: T)
+where
+    T: Add + Sub + Mul + Div + Rem + BitAnd + BitOr + BitXor + PartialEq + Eq + PartialOrd + Ord + Shr + Shl + Copy,
+{
+    // Non-guaranteed-commutative operators
+    _ = if x { a * b } else { b * a };
+    _ = if x { a + b } else { b + a };
+    _ = if x { a - b } else { b - a };
+    _ = if x { a / b } else { b / a };
+    _ = if x { a % b } else { b % a };
+    _ = if x { a << b } else { b << a };
+    _ = if x { a >> b } else { b >> a };
+    _ = if x { a & b } else { b & a };
+    _ = if x { a ^ b } else { b ^ a };
+    _ = if x { a | b } else { b | a };
+
+    // Guaranteed commutative operators
+    //~v if_same_then_else
+    _ = if x { a == b } else { b == a };
+    //~v if_same_then_else
+    _ = if x { a != b } else { b != a };
+
+    // Symetric operators
+    //~v if_same_then_else
+    _ = if x { a < b } else { b > a };
+    //~v if_same_then_else
+    _ = if x { a <= b } else { b >= a };
+    //~v if_same_then_else
+    _ = if x { a > b } else { b < a };
+    //~v if_same_then_else
+    _ = if x { a >= b } else { b <= a };
+}
+
+fn issue16416_prim(x: bool, a: u32, b: u32) {
+    // Non-commutative operators
+    _ = if x { a - b } else { b - a };
+    _ = if x { a / b } else { b / a };
+    _ = if x { a % b } else { b % a };
+    _ = if x { a << b } else { b << a };
+    _ = if x { a >> b } else { b >> a };
+
+    // Commutative operators on primitive types
+    //~v if_same_then_else
+    _ = if x { a * b } else { b * a };
+    //~v if_same_then_else
+    _ = if x { a + b } else { b + a };
+    //~v if_same_then_else
+    _ = if x { a & b } else { b & a };
+    //~v if_same_then_else
+    _ = if x { a ^ b } else { b ^ a };
+    //~v if_same_then_else
+    _ = if x { a | b } else { b | a };
+
+    // Always commutative operators
+    //~v if_same_then_else
+    _ = if x { a == b } else { b == a };
+    //~v if_same_then_else
+    _ = if x { a != b } else { b != a };
+
+    // Symetric operators
+    //~v if_same_then_else
+    _ = if x { a < b } else { b > a };
+    //~v if_same_then_else
+    _ = if x { a <= b } else { b >= a };
+    //~v if_same_then_else
+    _ = if x { a > b } else { b < a };
+    //~v if_same_then_else
+    _ = if x { a >= b } else { b <= a };
+}

--- a/tests/ui/if_same_then_else.stderr
+++ b/tests/ui/if_same_then_else.stderr
@@ -1,5 +1,5 @@
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else.rs:23:13
+  --> tests/ui/if_same_then_else.rs:25:13
    |
 LL |       if true {
    |  _____________^
@@ -12,7 +12,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> tests/ui/if_same_then_else.rs:31:12
+  --> tests/ui/if_same_then_else.rs:33:12
    |
 LL |       } else {
    |  ____________^
@@ -27,43 +27,43 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::if_same_then_else)]`
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else.rs:67:21
+  --> tests/ui/if_same_then_else.rs:69:21
    |
 LL |     let _ = if true { 0.0 } else { 0.0 };
    |                     ^^^^^^^
    |
 note: same as this
-  --> tests/ui/if_same_then_else.rs:67:34
+  --> tests/ui/if_same_then_else.rs:69:34
    |
 LL |     let _ = if true { 0.0 } else { 0.0 };
    |                                  ^^^^^^^
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else.rs:70:21
+  --> tests/ui/if_same_then_else.rs:72:21
    |
 LL |     let _ = if true { -0.0 } else { -0.0 };
    |                     ^^^^^^^^
    |
 note: same as this
-  --> tests/ui/if_same_then_else.rs:70:35
+  --> tests/ui/if_same_then_else.rs:72:35
    |
 LL |     let _ = if true { -0.0 } else { -0.0 };
    |                                   ^^^^^^^^
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else.rs:82:21
+  --> tests/ui/if_same_then_else.rs:84:21
    |
 LL |     let _ = if true { 42 } else { 42 };
    |                     ^^^^^^
    |
 note: same as this
-  --> tests/ui/if_same_then_else.rs:82:33
+  --> tests/ui/if_same_then_else.rs:84:33
    |
 LL |     let _ = if true { 42 } else { 42 };
    |                                 ^^^^^^
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else.rs:85:13
+  --> tests/ui/if_same_then_else.rs:87:13
    |
 LL |       if true {
    |  _____________^
@@ -76,7 +76,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> tests/ui/if_same_then_else.rs:92:12
+  --> tests/ui/if_same_then_else.rs:94:12
    |
 LL |       } else {
    |  ____________^
@@ -89,7 +89,7 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else.rs:238:14
+  --> tests/ui/if_same_then_else.rs:228:14
    |
 LL |           if x {
    |  ______________^
@@ -98,7 +98,7 @@ LL | |         } else {
    | |_________^
    |
 note: same as this
-  --> tests/ui/if_same_then_else.rs:240:16
+  --> tests/ui/if_same_then_else.rs:230:16
    |
 LL |           } else {
    |  ________________^
@@ -106,5 +106,209 @@ LL | |             0_u8.is_power_of_two()
 LL | |         }
    | |_________^
 
-error: aborting due to 6 previous errors
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:257:14
+   |
+LL |     _ = if x { a == b } else { b == a };
+   |              ^^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:257:30
+   |
+LL |     _ = if x { a == b } else { b == a };
+   |                              ^^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:259:14
+   |
+LL |     _ = if x { a != b } else { b != a };
+   |              ^^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:259:30
+   |
+LL |     _ = if x { a != b } else { b != a };
+   |                              ^^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:263:14
+   |
+LL |     _ = if x { a < b } else { b > a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:263:29
+   |
+LL |     _ = if x { a < b } else { b > a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:265:14
+   |
+LL |     _ = if x { a <= b } else { b >= a };
+   |              ^^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:265:30
+   |
+LL |     _ = if x { a <= b } else { b >= a };
+   |                              ^^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:267:14
+   |
+LL |     _ = if x { a > b } else { b < a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:267:29
+   |
+LL |     _ = if x { a > b } else { b < a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:269:14
+   |
+LL |     _ = if x { a >= b } else { b <= a };
+   |              ^^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:269:30
+   |
+LL |     _ = if x { a >= b } else { b <= a };
+   |                              ^^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:282:14
+   |
+LL |     _ = if x { a * b } else { b * a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:282:29
+   |
+LL |     _ = if x { a * b } else { b * a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:284:14
+   |
+LL |     _ = if x { a + b } else { b + a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:284:29
+   |
+LL |     _ = if x { a + b } else { b + a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:286:14
+   |
+LL |     _ = if x { a & b } else { b & a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:286:29
+   |
+LL |     _ = if x { a & b } else { b & a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:288:14
+   |
+LL |     _ = if x { a ^ b } else { b ^ a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:288:29
+   |
+LL |     _ = if x { a ^ b } else { b ^ a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:290:14
+   |
+LL |     _ = if x { a | b } else { b | a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:290:29
+   |
+LL |     _ = if x { a | b } else { b | a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:294:14
+   |
+LL |     _ = if x { a == b } else { b == a };
+   |              ^^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:294:30
+   |
+LL |     _ = if x { a == b } else { b == a };
+   |                              ^^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:296:14
+   |
+LL |     _ = if x { a != b } else { b != a };
+   |              ^^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:296:30
+   |
+LL |     _ = if x { a != b } else { b != a };
+   |                              ^^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:300:14
+   |
+LL |     _ = if x { a < b } else { b > a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:300:29
+   |
+LL |     _ = if x { a < b } else { b > a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:302:14
+   |
+LL |     _ = if x { a <= b } else { b >= a };
+   |              ^^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:302:30
+   |
+LL |     _ = if x { a <= b } else { b >= a };
+   |                              ^^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:304:14
+   |
+LL |     _ = if x { a > b } else { b < a };
+   |              ^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:304:29
+   |
+LL |     _ = if x { a > b } else { b < a };
+   |                             ^^^^^^^^^
+
+error: this `if` has identical blocks
+  --> tests/ui/if_same_then_else.rs:306:14
+   |
+LL |     _ = if x { a >= b } else { b <= a };
+   |              ^^^^^^^^^^
+   |
+note: same as this
+  --> tests/ui/if_same_then_else.rs:306:30
+   |
+LL |     _ = if x { a >= b } else { b <= a };
+   |                              ^^^^^^^^^^
+
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
Only `==` (and thus `!=`) are supposed to be commutative according to Rust's documentation. Do not make assumptions about other operators whose meaning may depend on the types on which they apply. However, special-case operators known to be commutative for primitive types such as addition or multiplication.

changelog: [`if_same_then_else`]: do not consider binary operators commutative by default

Fixes rust-lang/rust-clippy#16416