### PR TITLE
Remove known problems from `comparison_chain`

### DIFF
--- a/clippy_lints/src/comparison_chain.rs
+++ b/clippy_lints/src/comparison_chain.rs
@@ -17,10 +17,6 @@ declare_clippy_lint! {
     /// `if` is not guaranteed to be exhaustive and conditionals can get
     /// repetitive
     ///
-    /// ### Known problems
-    /// The match statement may be slower due to the compiler
-    /// not inlining the call to cmp. See issue [#5354](https://github.com/rust-lang/rust-clippy/issues/5354)
-    ///
     /// ### Example
     /// ```rust,ignore
     /// # fn a() {}


### PR DESCRIPTION
The current statement is incorrect as the call to `cmp` is inlined in _optimised_ builds. See https://github.com/rust-lang/rust-clippy/issues/5354#issuecomment-3762246553.

Revert https://github.com/rust-lang/rust-clippy/pull/6390

