### PR TITLE
Make `manual_is_variant_and` to cover manual `is_none_or`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4978,6 +4978,9 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
                 };
                 lint_binary_expr_with_method_call(cx, &mut info);
             },
+            ExprKind::Binary(op, lhs, rhs) if op.node == hir::BinOpKind::Or => {
+                manual_is_variant_and::check_or(cx, expr, lhs, rhs, self.msrv);
+            },
             _ => (),
         }
     }

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -226,3 +226,22 @@ mod with_func {
         assert_eq!(a1, a2);
     }
 }
+
+fn issue16419() {
+    let then_fn = |s: &str| s.len() > 3;
+    let opt: Option<&str> = Some("test");
+    let _ = opt.is_none_or(then_fn);
+    //~^ manual_is_variant_and
+
+    let _ = opt.is_none_or(then_fn);
+    //~^ manual_is_variant_and
+}
+
+#[clippy::msrv = "1.75.0"]
+fn issue16419_msrv() {
+    let then_fn = |s: &str| s.len() > 3;
+    let opt: Option<&str> = Some("test");
+    let _ = opt.is_none() || opt.is_some_and(then_fn);
+
+    let _ = opt.is_some_and(then_fn) || opt.is_none();
+}

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -235,3 +235,22 @@ mod with_func {
         assert_eq!(a1, a2);
     }
 }
+
+fn issue16419() {
+    let then_fn = |s: &str| s.len() > 3;
+    let opt: Option<&str> = Some("test");
+    let _ = opt.is_none() || opt.is_some_and(then_fn);
+    //~^ manual_is_variant_and
+
+    let _ = opt.is_some_and(then_fn) || opt.is_none();
+    //~^ manual_is_variant_and
+}
+
+#[clippy::msrv = "1.75.0"]
+fn issue16419_msrv() {
+    let then_fn = |s: &str| s.len() > 3;
+    let opt: Option<&str> = Some("test");
+    let _ = opt.is_none() || opt.is_some_and(then_fn);
+
+    let _ = opt.is_some_and(then_fn) || opt.is_none();
+}

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -222,5 +222,17 @@ error: called `.map() != Ok()`
 LL |         let a1 = b.map(iad) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
 
-error: aborting due to 31 previous errors
+error: manual implementation of `Option::is_none_or`
+  --> tests/ui/manual_is_variant_and.rs:242:13
+   |
+LL |     let _ = opt.is_none() || opt.is_some_and(then_fn);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
+
+error: manual implementation of `Option::is_none_or`
+  --> tests/ui/manual_is_variant_and.rs:245:13
+   |
+LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
+
+error: aborting due to 33 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16419 

changelog: [`manual_is_variant_and`] enhance to cover manual `is_none_or`
