### PR TITLE
fix(manual_let_else): add trailing comma to struct patterns ending with `..`

### DIFF
--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -301,7 +301,7 @@ fn replace_in_pattern(
                     .collect::<Vec<_>>();
                 let fields_string = fields.join(", ");
 
-                let dot_dot_str = if dot_dot.is_some() { " .." } else { "" };
+                let dot_dot_str = if dot_dot.is_some() { ", .." } else { "" };
                 let (sn_pth, _) = snippet_with_context(cx, path.span(), span.ctxt(), "", app);
                 return format!("{sn_pth} {{ {fields_string}{dot_dot_str} }}");
             },

--- a/tests/ui/manual_let_else_match.fixed
+++ b/tests/ui/manual_let_else_match.fixed
@@ -1,4 +1,4 @@
-#![allow(unused_braces, unused_variables, dead_code)]
+#![allow(unused_braces, unused_variables, dead_code, irrefutable_let_patterns)]
 #![allow(
     clippy::collapsible_else_if,
     clippy::let_unit_value,
@@ -181,4 +181,17 @@ fn issue9939b() {
     // with shadowing
     let Some(Issue9939b { earthquake: erosion, hurricane: _x }) = issue else { unreachable!("can't happen") };
     assert!(erosion);
+}
+
+mod issue16433 {
+    // https://github.com/rust-lang/rust-clippy/issues/16433
+    struct A {
+        a: u32,
+        b: u32,
+    }
+
+    fn foo() {
+        let a = A { a: 1, b: 1 };
+        let A { a: first_arg, .. } = a else { return };
+    }
 }

--- a/tests/ui/manual_let_else_match.rs
+++ b/tests/ui/manual_let_else_match.rs
@@ -1,4 +1,4 @@
-#![allow(unused_braces, unused_variables, dead_code)]
+#![allow(unused_braces, unused_variables, dead_code, irrefutable_let_patterns)]
 #![allow(
     clippy::collapsible_else_if,
     clippy::let_unit_value,
@@ -249,4 +249,21 @@ fn issue9939b() {
         None => unreachable!("can't happen"),
     };
     assert!(erosion);
+}
+
+mod issue16433 {
+    // https://github.com/rust-lang/rust-clippy/issues/16433
+    struct A {
+        a: u32,
+        b: u32,
+    }
+
+    fn foo() {
+        let a = A { a: 1, b: 1 };
+        let first_arg = match a {
+            //~^ manual_let_else
+            A { a, .. } => a,
+            _ => return,
+        };
+    }
 }

--- a/tests/ui/manual_let_else_match.stderr
+++ b/tests/ui/manual_let_else_match.stderr
@@ -171,5 +171,15 @@ LL | |         None => unreachable!("can't happen"),
 LL | |     };
    | |______^ help: consider writing: `let Some(Issue9939b { earthquake: erosion, hurricane: _x }) = issue else { unreachable!("can't happen") };`
 
-error: aborting due to 17 previous errors
+error: this could be rewritten as `let...else`
+  --> tests/ui/manual_let_else_match.rs:263:9
+   |
+LL | /         let first_arg = match a {
+LL | |
+LL | |             A { a, .. } => a,
+LL | |             _ => return,
+LL | |         };
+   | |__________^ help: consider writing: `let A { a: first_arg, .. } = a else { return };`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16433

Adds a trailing comma to the last field of a struct pattern if it ends with a `..` to avoid an invalid suggestion. A test was added as well.

changelog: [`manual_let_else`] fix suggestion for `..` patterns