### PR TITLE
Extend `question_mark` to cover `else if`

### DIFF
--- a/tests/ui/question_mark.fixed
+++ b/tests/ui/question_mark.fixed
@@ -515,3 +515,12 @@ fn wrongly_unmangled_macros() -> Option<i32> {
     test_expr!(42)?;
     test_expr!(42)
 }
+
+fn issue16429(b: i32) -> Option<i32> {
+    let a = Some(5);
+    let _ = if b == 1 {
+        b
+    } else { a? };
+
+    Some(0)
+}

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -635,3 +635,17 @@ fn wrongly_unmangled_macros() -> Option<i32> {
     }
     test_expr!(42)
 }
+
+fn issue16429(b: i32) -> Option<i32> {
+    let a = Some(5);
+    let _ = if b == 1 {
+        b
+    } else if let Some(x) = a {
+        //~^ question_mark
+        x
+    } else {
+        return None;
+    };
+
+    Some(0)
+}

--- a/tests/ui/question_mark.stderr
+++ b/tests/ui/question_mark.stderr
@@ -350,5 +350,17 @@ LL | |         return None;
 LL | |     }
    | |_____^ help: replace it with: `test_expr!(42)?;`
 
-error: aborting due to 37 previous errors
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:643:12
+   |
+LL |       } else if let Some(x) = a {
+   |  ____________^
+LL | |
+LL | |         x
+LL | |     } else {
+LL | |         return None;
+LL | |     };
+   | |_____^ help: replace it with: `{ a? }`
+
+error: aborting due to 38 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16429

changelog: [`question_mark`] enhance to cover `else if`
