### PR TITLE
Extend `manual_filter` to cover `and_then`

### DIFF
--- a/clippy_lints/src/matches/manual_filter.rs
+++ b/clippy_lints/src/matches/manual_filter.rs
@@ -1,12 +1,15 @@
 use clippy_utils::as_some_expr;
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::res::{MaybeDef, MaybeQPath, MaybeResPath};
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::sugg::Sugg;
+use clippy_utils::ty::is_copy;
 use clippy_utils::visitors::contains_unsafe_block;
-
+use rustc_errors::Applicability;
 use rustc_hir::LangItem::OptionNone;
 use rustc_hir::{Arm, Expr, ExprKind, HirId, Pat, PatKind};
 use rustc_lint::LateContext;
-use rustc_span::{SyntaxContext, sym};
+use rustc_span::{Span, SyntaxContext, sym};
 
 use super::MANUAL_FILTER;
 use super::manual_utils::{SomeExpr, check_with};
@@ -21,8 +24,8 @@ fn get_cond_expr<'tcx>(
     expr: &'tcx Expr<'_>,
     ctxt: SyntaxContext,
 ) -> Option<SomeExpr<'tcx>> {
-    if let Some(block_expr) = peels_blocks_incl_unsafe_opt(expr)
-        && let ExprKind::If(cond, then_expr, Some(else_expr)) = block_expr.kind
+    let block_expr = peels_blocks_incl_unsafe(expr);
+    if let ExprKind::If(cond, then_expr, Some(else_expr)) = block_expr.kind
         && let PatKind::Binding(_, target, ..) = pat.kind
         && (is_some_expr(cx, target, ctxt, then_expr) && is_none_expr(cx, else_expr)
             || is_none_expr(cx, then_expr) && is_some_expr(cx, target, ctxt, else_expr))
@@ -86,6 +89,66 @@ fn add_ampersand_if_copy(body_str: String, has_copy_trait: bool) -> String {
         with_ampersand
     } else {
         body_str
+    }
+}
+
+/// Checks for the following pattern:
+/// `opt.and_then(|x| if /* predicate on x */ { Some(x) } else { None })`
+/// and suggests replacing with:
+/// `opt.filter(|&x| /* predicate on x */ )`
+pub(crate) fn check_and_then_method<'tcx>(
+    cx: &LateContext<'tcx>,
+    scrutinee: &'tcx Expr<'_>,
+    arg: &'tcx Expr<'_>,
+    call_span: Span,
+    expr: &'tcx Expr<'_>,
+) {
+    let ty = cx.typeck_results().expr_ty(scrutinee);
+    if ty.is_diag_item(cx, sym::Option)
+        && let ExprKind::Closure(closure) = arg.kind
+        && let body = cx.tcx.hir_body(closure.body)
+        && let Some(fn_arg_span) = closure.fn_arg_span
+        && let [param] = body.params
+        && let expr_span_ctxt = expr.span.ctxt()
+        && let Some(some_expr) = get_cond_expr(cx, param.pat, body.value, expr_span_ctxt)
+    {
+        span_lint_and_then(
+            cx,
+            MANUAL_FILTER,
+            call_span,
+            "manual implementation of `Option::filter`",
+            |diag| {
+                let mut applicability = Applicability::MachineApplicable;
+
+                let mut cond_snip =
+                    Sugg::hir_with_context(cx, some_expr.expr, expr_span_ctxt, "..", &mut applicability);
+                if some_expr.needs_unsafe_block {
+                    cond_snip = cond_snip.unsafeify();
+                }
+                if some_expr.needs_negated {
+                    cond_snip = !cond_snip;
+                }
+
+                let (prefix_snip, _) = snippet_with_context(
+                    cx,
+                    closure.fn_decl_span.until(fn_arg_span),
+                    expr_span_ctxt,
+                    "..",
+                    &mut applicability,
+                );
+                let (param_snip, _) =
+                    snippet_with_context(cx, param.pat.span, expr_span_ctxt, "..", &mut applicability);
+                diag.span_suggestion(
+                    call_span,
+                    "try",
+                    format!(
+                        "filter({prefix_snip}|{}{param_snip}| {cond_snip})",
+                        if is_copy(cx, ty) { "&" } else { "" }
+                    ),
+                    applicability,
+                );
+            },
+        );
     }
 }
 

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -1,6 +1,6 @@
 mod collapsible_match;
 mod infallible_destructuring_match;
-mod manual_filter;
+pub(crate) mod manual_filter;
 mod manual_map;
 mod manual_ok_err;
 mod manual_unwrap_or;

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -163,6 +163,8 @@ use rustc_middle::ty::TraitRef;
 use rustc_session::impl_lint_pass;
 use rustc_span::{Span, Symbol};
 
+use crate::matches::manual_filter;
+
 declare_clippy_lint! {
     /// ### What it does
     /// Checks for usage of `_.and_then(|x| Some(y))`, `_.and_then(|x| Ok(y))`
@@ -5154,6 +5156,8 @@ impl Methods {
                             return_and_then::check(cx, expr, recv, arg);
                         }
                     }
+
+                    manual_filter::check_and_then_method(cx, recv, arg, call_span, expr);
                 },
                 (sym::any, [arg]) => {
                     needless_character_iteration::check(cx, expr, recv, arg, false);

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -335,6 +335,11 @@ impl<'a> Sugg<'a> {
         Sugg::NonParen(Cow::Owned(format!("{{ {self} }}")))
     }
 
+    /// Convenience method to wrap the expression in an `unsafe` block.
+    pub fn unsafeify(self) -> Sugg<'static> {
+        Sugg::NonParen(Cow::Owned(format!("unsafe {{ {self} }}")))
+    }
+
     /// Convenience method to prefix the expression with the `async` keyword.
     /// Can be used after `blockify` to create an async block.
     pub fn asyncify(self) -> Sugg<'static> {

--- a/tests/ui/bind_instead_of_map.fixed
+++ b/tests/ui/bind_instead_of_map.fixed
@@ -1,4 +1,5 @@
 #![deny(clippy::bind_instead_of_map)]
+#![allow(clippy::manual_filter)]
 
 // need a main anyway, use it get rid of unused warnings too
 pub fn main() {

--- a/tests/ui/bind_instead_of_map.rs
+++ b/tests/ui/bind_instead_of_map.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::bind_instead_of_map)]
+#![allow(clippy::manual_filter)]
 
 // need a main anyway, use it get rid of unused warnings too
 pub fn main() {

--- a/tests/ui/bind_instead_of_map.stderr
+++ b/tests/ui/bind_instead_of_map.stderr
@@ -1,5 +1,5 @@
 error: using `Option.and_then(Some)`, which is a no-op
-  --> tests/ui/bind_instead_of_map.rs:7:13
+  --> tests/ui/bind_instead_of_map.rs:8:13
    |
 LL |     let _ = x.and_then(Some);
    |             ^^^^^^^^^^^^^^^^ help: use the expression directly: `x`
@@ -11,13 +11,13 @@ LL | #![deny(clippy::bind_instead_of_map)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
-  --> tests/ui/bind_instead_of_map.rs:9:13
+  --> tests/ui/bind_instead_of_map.rs:10:13
    |
 LL |     let _ = x.and_then(|o| Some(o + 1));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.map(|o| o + 1)`
 
 error: using `Result.and_then(Ok)`, which is a no-op
-  --> tests/ui/bind_instead_of_map.rs:16:13
+  --> tests/ui/bind_instead_of_map.rs:17:13
    |
 LL |     let _ = x.and_then(Ok);
    |             ^^^^^^^^^^^^^^ help: use the expression directly: `x`

--- a/tests/ui/if_then_some_else_none.fixed
+++ b/tests/ui/if_then_some_else_none.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::if_then_some_else_none)]
-#![allow(clippy::redundant_pattern_matching, clippy::unnecessary_lazy_evaluations)]
+#![allow(
+    clippy::redundant_pattern_matching,
+    clippy::unnecessary_lazy_evaluations,
+    clippy::manual_filter
+)]
 
 fn main() {
     // Should issue an error.

--- a/tests/ui/if_then_some_else_none.rs
+++ b/tests/ui/if_then_some_else_none.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::if_then_some_else_none)]
-#![allow(clippy::redundant_pattern_matching, clippy::unnecessary_lazy_evaluations)]
+#![allow(
+    clippy::redundant_pattern_matching,
+    clippy::unnecessary_lazy_evaluations,
+    clippy::manual_filter
+)]
 
 fn main() {
     // Should issue an error.

--- a/tests/ui/if_then_some_else_none.stderr
+++ b/tests/ui/if_then_some_else_none.stderr
@@ -1,5 +1,5 @@
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:6:13
+  --> tests/ui/if_then_some_else_none.rs:10:13
    |
 LL |       let _ = if foo() {
    |  _____________^
@@ -24,7 +24,7 @@ LL ~     });
    |
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:16:13
+  --> tests/ui/if_then_some_else_none.rs:20:13
    |
 LL |       let _ = if matches!(true, true) {
    |  _____________^
@@ -47,19 +47,19 @@ LL ~     });
    |
 
 error: this could be simplified with `bool::then_some`
-  --> tests/ui/if_then_some_else_none.rs:27:28
+  --> tests/ui/if_then_some_else_none.rs:31:28
    |
 LL |     let _ = x.and_then(|o| if o < 32 { Some(o) } else { None });
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(o < 32).then_some(o)`
 
 error: this could be simplified with `bool::then_some`
-  --> tests/ui/if_then_some_else_none.rs:32:13
+  --> tests/ui/if_then_some_else_none.rs:36:13
    |
 LL |     let _ = if !x { Some(0) } else { None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(!x).then_some(0)`
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:88:13
+  --> tests/ui/if_then_some_else_none.rs:92:13
    |
 LL |       let _ = if foo() {
    |  _____________^
@@ -82,13 +82,13 @@ LL ~     });
    |
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:138:5
+  --> tests/ui/if_then_some_else_none.rs:142:5
    |
 LL |     if s == "1" { Some(true) } else { None }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(s == "1").then(|| true)`
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:154:9
+  --> tests/ui/if_then_some_else_none.rs:158:9
    |
 LL | /         if rs.len() == 1 && rs[0].start == rs[0].end {
 LL | |
@@ -99,7 +99,7 @@ LL | |         }
    | |_________^ help: try: `(rs.len() == 1 && rs[0].start == rs[0].end).then(|| vec![rs[0].start])`
 
 error: this could be simplified with `bool::then_some`
-  --> tests/ui/if_then_some_else_none.rs:164:9
+  --> tests/ui/if_then_some_else_none.rs:168:9
    |
 LL | /         if modulo == 0 {
 LL | |
@@ -110,7 +110,7 @@ LL | |         }
    | |_________^ help: try: `(modulo == 0).then_some(i)`
 
 error: this could be simplified with `bool::then_some`
-  --> tests/ui/if_then_some_else_none.rs:181:22
+  --> tests/ui/if_then_some_else_none.rs:185:22
    |
 LL |           do_something(if i % 2 == 0 {
    |  ______________________^
@@ -122,7 +122,7 @@ LL | |         });
    | |_________^ help: try: `(i % 2 == 0).then_some(item_fn)`
 
 error: this could be simplified with `bool::then_some`
-  --> tests/ui/if_then_some_else_none.rs:198:22
+  --> tests/ui/if_then_some_else_none.rs:202:22
    |
 LL |           do_something(if i % 2 == 0 {
    |  ______________________^
@@ -134,7 +134,7 @@ LL | |         });
    | |_________^ help: try: `(i % 2 == 0).then_some(item_fn)`
 
 error: this could be simplified with `bool::then_some`
-  --> tests/ui/if_then_some_else_none.rs:206:22
+  --> tests/ui/if_then_some_else_none.rs:210:22
    |
 LL |           do_something(if i % 2 == 0 {
    |  ______________________^
@@ -146,7 +146,7 @@ LL | |         });
    | |_________^ help: try: `(i % 2 == 0).then_some(closure_fn)`
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:231:13
+  --> tests/ui/if_then_some_else_none.rs:235:13
    |
 LL | /             if self.count < 5 {
 LL | |                 self.count += 1;
@@ -165,7 +165,7 @@ LL +             })
    |
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:249:13
+  --> tests/ui/if_then_some_else_none.rs:253:13
    |
 LL |       let _ = if true {
    |  _____________^
@@ -185,7 +185,7 @@ LL ~     });
    |
 
 error: this could be simplified with `bool::then`
-  --> tests/ui/if_then_some_else_none.rs:292:5
+  --> tests/ui/if_then_some_else_none.rs:296:5
    |
 LL | /     if 1 <= 3 {
 LL | |         let a = UnsafeCell::new(1);

--- a/tests/ui/manual_filter.fixed
+++ b/tests/ui/manual_filter.fixed
@@ -1,5 +1,10 @@
 #![warn(clippy::manual_filter)]
-#![allow(unused_variables, clippy::question_mark, clippy::useless_vec)]
+#![allow(
+    unused_variables,
+    clippy::question_mark,
+    clippy::useless_vec,
+    clippy::nonminimal_bool
+)]
 
 fn main() {
     Some(0).filter(|&x| x <= 0);
@@ -155,4 +160,25 @@ fn main() {
 
 fn maybe_some() -> Option<u32> {
     Some(0)
+}
+
+fn issue14440(opt: Option<i32>) {
+    opt.filter(|&x| x != 0);
+    //~^ manual_filter
+
+    let y = 1i32;
+    opt.filter(move |&x| x == y);
+    //~^ manual_filter
+
+    let opt1 = Some("123".to_string());
+    opt1.filter(|s| s.len() > 2);
+    //~^ manual_filter
+
+    unsafe fn f(x: u32) -> bool {
+        true
+    }
+    opt.filter(|&x| unsafe { f(x as u32) });
+    //~^ manual_filter
+    opt.filter(|&x| unsafe { f(x as u32) });
+    //~^ manual_filter
 }

--- a/tests/ui/manual_filter.rs
+++ b/tests/ui/manual_filter.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::manual_filter)]
-#![allow(unused_variables, clippy::question_mark, clippy::useless_vec)]
+#![allow(
+    unused_variables,
+    clippy::question_mark,
+    clippy::useless_vec,
+    clippy::nonminimal_bool
+)]
 
 fn main() {
     match Some(0) {
@@ -292,4 +297,25 @@ fn main() {
 
 fn maybe_some() -> Option<u32> {
     Some(0)
+}
+
+fn issue14440(opt: Option<i32>) {
+    opt.and_then(|x| if x == 0 { None } else { Some(x) });
+    //~^ manual_filter
+
+    let y = 1i32;
+    opt.and_then(move |x| if x == y { Some(x) } else { None });
+    //~^ manual_filter
+
+    let opt1 = Some("123".to_string());
+    opt1.and_then(|s| if s.len() > 2 { Some(s) } else { None });
+    //~^ manual_filter
+
+    unsafe fn f(x: u32) -> bool {
+        true
+    }
+    opt.and_then(|x| if unsafe { f(x as u32) } { Some(x) } else { None });
+    //~^ manual_filter
+    opt.and_then(|x| unsafe { if f(x as u32) { Some(x) } else { None } });
+    //~^ manual_filter
 }

--- a/tests/ui/manual_filter.stderr
+++ b/tests/ui/manual_filter.stderr
@@ -1,5 +1,5 @@
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:5:5
+  --> tests/ui/manual_filter.rs:10:5
    |
 LL | /     match Some(0) {
 LL | |
@@ -14,7 +14,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::manual_filter)]`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:17:5
+  --> tests/ui/manual_filter.rs:22:5
    |
 LL | /     match Some(1) {
 LL | |
@@ -26,7 +26,7 @@ LL | |     };
    | |_____^ help: try: `Some(1).filter(|&x| x <= 0)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:29:5
+  --> tests/ui/manual_filter.rs:34:5
    |
 LL | /     match Some(2) {
 LL | |
@@ -38,7 +38,7 @@ LL | |     };
    | |_____^ help: try: `Some(2).filter(|&x| x <= 0)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:41:5
+  --> tests/ui/manual_filter.rs:46:5
    |
 LL | /     match Some(3) {
 LL | |
@@ -50,7 +50,7 @@ LL | |     };
    | |_____^ help: try: `Some(3).filter(|&x| x > 0)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:54:5
+  --> tests/ui/manual_filter.rs:59:5
    |
 LL | /     match y {
 LL | |
@@ -62,7 +62,7 @@ LL | |     };
    | |_____^ help: try: `y.filter(|&x| x <= 0)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:67:5
+  --> tests/ui/manual_filter.rs:72:5
    |
 LL | /     match Some(5) {
 LL | |
@@ -74,7 +74,7 @@ LL | |     };
    | |_____^ help: try: `Some(5).filter(|&x| x > 0)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:79:5
+  --> tests/ui/manual_filter.rs:84:5
    |
 LL | /     match Some(6) {
 LL | |
@@ -86,7 +86,7 @@ LL | |     };
    | |_____^ help: try: `Some(6).as_ref().filter(|&x| x > &0)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:92:5
+  --> tests/ui/manual_filter.rs:97:5
    |
 LL | /     match Some(String::new()) {
 LL | |
@@ -98,7 +98,7 @@ LL | |     };
    | |_____^ help: try: `Some(String::new()).filter(|x| external_cond)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:104:5
+  --> tests/ui/manual_filter.rs:109:5
    |
 LL | /     if let Some(x) = Some(7) {
 LL | |
@@ -109,7 +109,7 @@ LL | |     };
    | |_____^ help: try: `Some(7).filter(|&x| external_cond)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:111:5
+  --> tests/ui/manual_filter.rs:116:5
    |
 LL | /     match &Some(8) {
 LL | |
@@ -121,7 +121,7 @@ LL | |     };
    | |_____^ help: try: `Some(8).filter(|&x| x != 0)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:123:5
+  --> tests/ui/manual_filter.rs:128:5
    |
 LL | /     match Some(9) {
 LL | |
@@ -133,7 +133,7 @@ LL | |     };
    | |_____^ help: try: `Some(9).filter(|&x| x > 10 && x < 100)`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:150:5
+  --> tests/ui/manual_filter.rs:155:5
    |
 LL | /     match Some(11) {
 LL | |
@@ -153,7 +153,7 @@ LL ~             });
    |
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:195:13
+  --> tests/ui/manual_filter.rs:200:13
    |
 LL |       let _ = match Some(14) {
    |  _____________^
@@ -166,7 +166,7 @@ LL | |     };
    | |_____^ help: try: `Some(14).filter(|&x| unsafe { f(x) })`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:206:13
+  --> tests/ui/manual_filter.rs:211:13
    |
 LL |       let _ = match Some(15) {
    |  _____________^
@@ -177,7 +177,7 @@ LL | |     };
    | |_____^ help: try: `Some(15).filter(|&x| unsafe { f(x) })`
 
 error: manual implementation of `Option::filter`
-  --> tests/ui/manual_filter.rs:215:12
+  --> tests/ui/manual_filter.rs:220:12
    |
 LL |       } else if let Some(x) = Some(16) {
    |  ____________^
@@ -189,5 +189,35 @@ LL | |         None
 LL | |     };
    | |_____^ help: try: `{ Some(16).filter(|&x| x % 2 == 0) }`
 
-error: aborting due to 15 previous errors
+error: manual implementation of `Option::filter`
+  --> tests/ui/manual_filter.rs:303:9
+   |
+LL |     opt.and_then(|x| if x == 0 { None } else { Some(x) });
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter(|&x| x != 0)`
+
+error: manual implementation of `Option::filter`
+  --> tests/ui/manual_filter.rs:307:9
+   |
+LL |     opt.and_then(move |x| if x == y { Some(x) } else { None });
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter(move |&x| x == y)`
+
+error: manual implementation of `Option::filter`
+  --> tests/ui/manual_filter.rs:311:10
+   |
+LL |     opt1.and_then(|s| if s.len() > 2 { Some(s) } else { None });
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter(|s| s.len() > 2)`
+
+error: manual implementation of `Option::filter`
+  --> tests/ui/manual_filter.rs:317:9
+   |
+LL |     opt.and_then(|x| if unsafe { f(x as u32) } { Some(x) } else { None });
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter(|&x| unsafe { f(x as u32) })`
+
+error: manual implementation of `Option::filter`
+  --> tests/ui/manual_filter.rs:319:9
+   |
+LL |     opt.and_then(|x| unsafe { if f(x as u32) { Some(x) } else { None } });
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter(|&x| unsafe { f(x as u32) })`
+
+error: aborting due to 20 previous errors
 

--- a/tests/ui/map_flatten.fixed
+++ b/tests/ui/map_flatten.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::map_flatten)]
-#![allow(clippy::unnecessary_filter_map)]
+#![allow(clippy::unnecessary_filter_map, clippy::manual_filter)]
 
 // issue #8506, multi-line
 #[rustfmt::skip]

--- a/tests/ui/map_flatten.rs
+++ b/tests/ui/map_flatten.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::map_flatten)]
-#![allow(clippy::unnecessary_filter_map)]
+#![allow(clippy::unnecessary_filter_map, clippy::manual_filter)]
 
 // issue #8506, multi-line
 #[rustfmt::skip]

--- a/tests/ui/return_and_then.fixed
+++ b/tests/ui/return_and_then.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::return_and_then)]
+#![allow(clippy::manual_filter)]
 
 fn main() {
     fn test_opt_block(opt: Option<i32>) -> Option<i32> {

--- a/tests/ui/return_and_then.rs
+++ b/tests/ui/return_and_then.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::return_and_then)]
+#![allow(clippy::manual_filter)]
 
 fn main() {
     fn test_opt_block(opt: Option<i32>) -> Option<i32> {

--- a/tests/ui/return_and_then.stderr
+++ b/tests/ui/return_and_then.stderr
@@ -1,5 +1,5 @@
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:5:9
+  --> tests/ui/return_and_then.rs:6:9
    |
 LL | /         opt.and_then(|n| {
 LL | |
@@ -21,7 +21,7 @@ LL +         if n > 1 { Some(ret) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:14:9
+  --> tests/ui/return_and_then.rs:15:9
    |
 LL |         opt.and_then(|n| test_opt_block(Some(n)))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL +         test_opt_block(Some(n))
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:19:9
+  --> tests/ui/return_and_then.rs:20:9
    |
 LL |         gen_option(1).and_then(|n| test_opt_block(Some(n)))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL +         test_opt_block(Some(n))
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:24:9
+  --> tests/ui/return_and_then.rs:25:9
    |
 LL |         opt.and_then(|n| if n > 1 { Ok(n + 1) } else { Err(n) })
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL +         if n > 1 { Ok(n + 1) } else { Err(n) }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:29:9
+  --> tests/ui/return_and_then.rs:30:9
    |
 LL |         opt.and_then(|n| test_res_block(Ok(n)))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL +         test_res_block(Ok(n))
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:35:9
+  --> tests/ui/return_and_then.rs:36:9
    |
 LL |         Some("").and_then(|x| if x.len() > 2 { Some(3) } else { None })
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL +         if x.len() > 2 { Some(3) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:41:9
+  --> tests/ui/return_and_then.rs:42:9
    |
 LL | /         Some(match (vec![1, 2, 3], vec![1, 2, 4]) {
 LL | |
@@ -102,7 +102,7 @@ LL +         if x.len() > 2 { Some(3) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:69:13
+  --> tests/ui/return_and_then.rs:70:13
    |
 LL |             Some("").and_then(|x| if x.len() > 2 { Some(3) } else { None })
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL +             if x.len() > 2 { Some(3) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:77:20
+  --> tests/ui/return_and_then.rs:78:20
    |
 LL |             return Some("").and_then(|x| if x.len() > 2 { Some(3) } else { None });
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -128,7 +128,7 @@ LL ~             };
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:85:20
+  --> tests/ui/return_and_then.rs:86:20
    |
 LL |               return Some("").and_then(|mut x| {
    |  ____________________^
@@ -147,7 +147,7 @@ LL ~             };
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:97:20
+  --> tests/ui/return_and_then.rs:98:20
    |
 LL |             return Some("").and_then(|x| if x.len() > 2 { Some(3) } else { None }),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -161,7 +161,7 @@ LL ~             },
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:105:13
+  --> tests/ui/return_and_then.rs:106:13
    |
 LL |             i.and_then(|i| if i > 3 { Some(i) } else { None })
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +173,7 @@ LL +             if i > 3 { Some(i) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:114:22
+  --> tests/ui/return_and_then.rs:115:22
    |
 LL |             1 | 2 => i.and_then(|i| if i > 3 { Some(i) } else { None }),
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -187,7 +187,7 @@ LL ~             },
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:126:21
+  --> tests/ui/return_and_then.rs:127:21
    |
 LL |                     i.and_then(|i| if i > 3 { Some(i) } else { None })
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -199,7 +199,7 @@ LL +                     if i > 3 { Some(i) } else { None }
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:141:23
+  --> tests/ui/return_and_then.rs:142:23
    |
 LL |                 break i.and_then(|i| if i > 3 { Some(i) } else { None });
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +213,7 @@ LL ~                 });
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:146:32
+  --> tests/ui/return_and_then.rs:147:32
    |
 LL |                     break 'foo i.and_then(|i| if i > 3 { Some(i) } else { None });
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -227,7 +227,7 @@ LL ~                     });
    |
 
 error: use the `?` operator instead of an `and_then` call
-  --> tests/ui/return_and_then.rs:151:28
+  --> tests/ui/return_and_then.rs:152:28
    |
 LL |                 break 'bar i.and_then(|i| if i > 3 { Some(i) } else { None });
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16456)*

Closes rust-lang/rust-clippy#14440 

Implemented as enhancement to `manual_filter`

changelog: [`manual_filter`] enhance to cover `and_then`
