### PR TITLE
Also ignore cases with comments in `let_and_return`

### DIFF
--- a/clippy_lints/src/returns/let_and_return.rs
+++ b/clippy_lints/src/returns/let_and_return.rs
@@ -27,7 +27,7 @@ pub(super) fn check_block<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'_>) 
         && !initexpr.span.in_external_macro(cx.sess().source_map())
         && !retexpr.span.in_external_macro(cx.sess().source_map())
         && !local.span.from_expansion()
-        && !span_contains_non_whitespace(cx, stmt.span.between(retexpr.span), true)
+        && !span_contains_non_whitespace(cx, stmt.span.between(retexpr.span), false)
     {
         span_lint_hir_and_then(
             cx,

--- a/tests/ui/let_and_return.edition2021.fixed
+++ b/tests/ui/let_and_return.edition2021.fixed
@@ -271,4 +271,12 @@ fn issue15987() -> i32 {
     r
 }
 
+fn has_comment() -> Vec<usize> {
+    let v = Vec::new();
+
+    // TODO: stuff
+
+    v
+}
+
 fn main() {}

--- a/tests/ui/let_and_return.edition2024.fixed
+++ b/tests/ui/let_and_return.edition2024.fixed
@@ -271,4 +271,12 @@ fn issue15987() -> i32 {
     r
 }
 
+fn has_comment() -> Vec<usize> {
+    let v = Vec::new();
+
+    // TODO: stuff
+
+    v
+}
+
 fn main() {}

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -271,4 +271,12 @@ fn issue15987() -> i32 {
     r
 }
 
+fn has_comment() -> Vec<usize> {
+    let v = Vec::new();
+
+    // TODO: stuff
+
+    v
+}
+
 fn main() {}


### PR DESCRIPTION
Related to the example in https://github.com/rust-lang/rust-clippy/issues/16451 but doesn't fix the issue itself

changelog: [`let_and_return`]: No longer lints when there's a comment between the `let` and return