### PR TITLE
rhs of short-circuit expression doesn't always run

### DIFF
--- a/clippy_lints/src/loops/never_loop.rs
+++ b/clippy_lints/src/loops/never_loop.rs
@@ -6,6 +6,7 @@ use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::source::{snippet, snippet_with_context};
 use clippy_utils::visitors::{Descend, for_each_expr_without_closures};
 use clippy_utils::{contains_return, sym};
+use rustc_ast::BinOpKind;
 use rustc_errors::Applicability;
 use rustc_hir::{
     Block, Closure, Destination, Expr, ExprKind, HirId, InlineAsm, InlineAsmOperand, Node, Pat, Stmt, StmtKind,
@@ -305,6 +306,9 @@ fn never_loop_expr<'tcx>(
             }
         },
         ExprKind::Call(e, es) => never_loop_expr_all(cx, once(e).chain(es.iter()), local_labels, main_loop_id),
+        ExprKind::Binary(op, e1, _) if matches!(op.node, BinOpKind::And | BinOpKind::Or) => {
+            never_loop_expr(cx, e1, local_labels, main_loop_id)
+        },
         ExprKind::Binary(_, e1, e2)
         | ExprKind::Assign(e1, e2, _)
         | ExprKind::AssignOp(_, e1, e2)

--- a/tests/ui/never_loop.rs
+++ b/tests/ui/never_loop.rs
@@ -546,3 +546,13 @@ fn issue15673() {
         return;
     }
 }
+
+#[expect(clippy::diverging_sub_expression, clippy::short_circuit_statement)]
+fn issue16462() {
+    let mut n = 10;
+    loop {
+        println!("{n}");
+        n -= 1;
+        n >= 0 || break;
+    }
+}


### PR DESCRIPTION
changelog: [`never_loop`]: rhs of short-circuit expression doesn't always run

Fixes rust-lang/rust-clippy#16462 