### PR TITLE
New lint: `drop_for_static` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -622,7 +622,7 @@ Current stable, released 2025-12-11
 * Added [`self_only_used_in_recursion`] to `pedantic`
   [#14787](https://github.com/rust-lang/rust-clippy/pull/14787)
 * Added [`redundant_iter_cloned`] to `perf`
-  [#15277](https://github.com/rust-lang/rust-clippy/pull/15277)  
+  [#15277](https://github.com/rust-lang/rust-clippy/pull/15277)
 
 ### Moves and Deprecations
 
@@ -705,7 +705,7 @@ Current stable, released 2025-10-30
 
 * [`excessive_precision`] added `const_literal_digits_threshold` option to suppress overly precise constants.
   [#15193](https://github.com/rust-lang/rust-clippy/pull/15193)
-* [`unwrap_in_result`] rewritten for better accuracy; now lints on `.unwrap()` and `.expect()` 
+* [`unwrap_in_result`] rewritten for better accuracy; now lints on `.unwrap()` and `.expect()`
   directly and no longer mixes `Result` and `Option`.
   [#15445](https://github.com/rust-lang/rust-clippy/pull/15445)
 * [`panic`] now works in `const` contexts.
@@ -722,7 +722,7 @@ Current stable, released 2025-10-30
   [#15438](https://github.com/rust-lang/rust-clippy/pull/15438)
 * [`float_equality_without_abs`] now checks `f16` and `f128` types.
   [#15054](https://github.com/rust-lang/rust-clippy/pull/15054)
-* [`doc_markdown`] expanded whitelist (`InfiniBand`, `RoCE`, `PowerPC`) and improved handling of 
+* [`doc_markdown`] expanded whitelist (`InfiniBand`, `RoCE`, `PowerPC`) and improved handling of
   identifiers like NixOS.
   [#15558](https://github.com/rust-lang/rust-clippy/pull/15558)
 * [`clone_on_ref_ptr`] now suggests fully qualified paths to avoid resolution errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6886,6 +6886,7 @@ Released 2018-09-13
 [`drain_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#drain_collect
 [`drop_bounds`]: https://rust-lang.github.io/rust-clippy/master/index.html#drop_bounds
 [`drop_copy`]: https://rust-lang.github.io/rust-clippy/master/index.html#drop_copy
+[`drop_for_static`]: https://rust-lang.github.io/rust-clippy/master/index.html#drop_for_static
 [`drop_non_drop`]: https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop
 [`drop_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#drop_ref
 [`duplicate_mod`]: https://rust-lang.github.io/rust-clippy/master/index.html#duplicate_mod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7004,6 +7004,7 @@ Released 2018-09-13
 [`drain_collect`]: https://rust-lang.github.io/rust-clippy/main/index.html#drain_collect
 [`drop_bounds`]: https://rust-lang.github.io/rust-clippy/main/index.html#drop_bounds
 [`drop_copy`]: https://rust-lang.github.io/rust-clippy/main/index.html#drop_copy
+[`drop_for_static`]: https://rust-lang.github.io/rust-clippy/main/index.html#drop_for_static
 [`drop_non_drop`]: https://rust-lang.github.io/rust-clippy/main/index.html#drop_non_drop
 [`drop_ref`]: https://rust-lang.github.io/rust-clippy/main/index.html#drop_ref
 [`duplicate_mod`]: https://rust-lang.github.io/rust-clippy/main/index.html#duplicate_mod

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -137,6 +137,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::doc::TOO_LONG_FIRST_DOC_PARAGRAPH_INFO,
     crate::doc::UNNECESSARY_SAFETY_DOC_INFO,
     crate::double_parens::DOUBLE_PARENS_INFO,
+    crate::drop_for_static::DROP_FOR_STATIC_INFO,
     crate::drop_forget_ref::DROP_NON_DROP_INFO,
     crate::drop_forget_ref::FORGET_NON_DROP_INFO,
     crate::drop_forget_ref::MEM_FORGET_INFO,

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -65,23 +65,6 @@ impl LateLintPass<'_> for DropForStatic {
                 );
             }
         }
-        // if let ItemKind::Static(_, ident, ty, _) = item.kind
-        //     && let Some(ty_amb) = ty.try_as_ambig_ty()
-        // {
-        //     let mut visitor = DropForStaticVisitor::new(cx);
-        //     visitor.visit_ty(ty_amb);
-        //     if let Some(type_with_drop_span) = visitor.type_with_drop_span {
-        //         span_lint_and_then(
-        //             cx,
-        //             DROP_FOR_STATIC,
-        //             ident.span,
-        //             "static items with drop implementation",
-        //             |diag| {
-        //                 diag.span_label(type_with_drop_span, "type with drop implementation
-        // here");             },
-        //         );
-        //     }
-        // }
     }
 }
 
@@ -102,12 +85,7 @@ impl<'tcx> Visitor<'tcx> for DropForStaticVisitor<'_, 'tcx> {
     type NestedFilter = nested_filter::All;
 
     fn visit_path(&mut self, path: &Path<'tcx>, _: HirId) {
-        if let Res::Def(def_kind, def_id) = path.res
-            && matches!(
-                def_kind,
-                DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::TyAlias
-            )
-        {
+        if let Res::Def(DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::TyAlias, def_id) = path.res {
             let ty = self.cx.tcx.type_of(def_id).instantiate_identity();
             if has_drop(self.cx, ty) {
                 self.type_with_drop_span = Some(path.span);

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -1,7 +1,8 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::ty::has_drop;
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::{Visitor, walk_path};
-use rustc_hir::{HirId, Item, ItemKind, Path, def::{Res, DefKind}};
+use rustc_hir::{HirId, Item, ItemKind, Path};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::hir::nested_filter;
 use rustc_session::declare_lint_pass;
@@ -83,7 +84,7 @@ impl<'tcx> Visitor<'tcx> for DropForStaticVisitor<'_, 'tcx> {
 
     fn visit_path(&mut self, path: &Path<'tcx>, _: HirId) {
         if let Res::Def(def_kind, def_id) = path.res
-            &&  matches!(def_kind, DefKind::Struct | DefKind::Union | DefKind::Enum)
+            && matches!(def_kind, DefKind::Struct | DefKind::Union | DefKind::Enum)
         {
             let ty = self.cx.tcx.type_of(def_id).instantiate_identity();
             if has_drop(self.cx, ty) {

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -45,7 +45,9 @@ declare_lint_pass!(DropForStatic => [DROP_FOR_STATIC]);
 
 impl LateLintPass<'_> for DropForStatic {
     fn check_item<'a>(&mut self, cx: &LateContext<'a>, item: &'a Item<'a>) {
-        if let ItemKind::Static(_, ident, ty, _) = item.kind && let Some(ty_amb) = ty.try_as_ambig_ty(){
+        if let ItemKind::Static(_, ident, ty, _) = item.kind
+            && let Some(ty_amb) = ty.try_as_ambig_ty()
+        {
             let mut visitor = DropForStaticVisitor::new(cx);
             visitor.visit_ty(ty_amb);
             if let Some(type_with_drop_span) = visitor.type_with_drop_span {
@@ -54,7 +56,9 @@ impl LateLintPass<'_> for DropForStatic {
                     DROP_FOR_STATIC,
                     ident.span,
                     "static items with drop implementation",
-                    |diag|{ diag.span_label(type_with_drop_span, "type with drop implementation here"); },
+                    |diag| {
+                        diag.span_label(type_with_drop_span, "type with drop implementation here");
+                    },
                 );
             }
         }

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -58,8 +58,7 @@ impl LateLintPass<'_> for DropForStatic {
                         walk_kinds.push(&ty.kind);
                     },
                     TyKind::Tup(ty) => walk_kinds.extend(ty.iter().map(|ty| &ty.kind)),
-                    _ => {
-                    },
+                    _ => {},
                 }
             }
         }

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -44,11 +44,11 @@ declare_lint_pass!(DropForStatic => [DROP_FOR_STATIC]);
 
 impl LateLintPass<'_> for DropForStatic {
     fn check_item<'a>(&mut self, cx: &LateContext<'a>, item: &'a Item<'a>) {
-        if let ItemKind::Static(_, _, _, _) = item.kind {
+        if let ItemKind::Static(_, ident, _, _) = item.kind {
             let mut visitor = DropForStaticVisitor::new(cx);
             visitor.visit_item(item);
             if visitor.drop_for_static_found {
-                span_lint(cx, DROP_FOR_STATIC, item.span, "static items with drop implementation");
+                span_lint(cx, DROP_FOR_STATIC, ident.span, "static items with drop implementation");
             }
         }
     }

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -1,6 +1,9 @@
 use clippy_utils::diagnostics::span_lint;
-use rustc_hir::{Item, ItemKind, MutTy, Ty, TyKind};
+use rustc_hir::def_id::DefId;
+use rustc_hir::intravisit::{Visitor, walk_path};
+use rustc_hir::{HirId, Item, ItemKind, MutTy, Path, Ty, TyKind};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::hir::nested_filter;
 use rustc_session::declare_lint_pass;
 
 declare_clippy_lint! {
@@ -40,19 +43,19 @@ declare_clippy_lint! {
 declare_lint_pass!(DropForStatic => [DROP_FOR_STATIC]);
 
 impl LateLintPass<'_> for DropForStatic {
-    fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
+    fn check_item<'a>(&mut self, cx: &LateContext<'a>, item: &Item<'a>) {
         if let Some(drop_trait_def_id) = cx.tcx.lang_items().drop_trait()
-            && let ItemKind::Static(_, _, Ty { kind, hir_id, .. }, _) = item.kind
+            && let ItemKind::Static(_, _, Ty { kind, hir_id, span }, _) = item.kind
         {
             let mut walk_kinds = vec![kind];
             while let Some(kind) = walk_kinds.pop() {
                 match kind {
-                    TyKind::Path(path) => {
-                        let def_id = cx.qpath_res(path, *hir_id).def_id();
-                        let ty = cx.tcx.type_of(def_id).instantiate_identity();
-                        cx.tcx.for_each_relevant_impl(drop_trait_def_id, ty, |_| {
+                    TyKind::Path(qpath) => {
+                        let mut visitor = PathVisitor::new(cx, drop_trait_def_id);
+                        visitor.visit_qpath(&qpath, *hir_id, *span);
+                        if visitor.drop_for_static_found {
                             span_lint(cx, DROP_FOR_STATIC, item.span, "static items with drop implementation");
-                        });
+                        }
                     },
                     TyKind::Array(ty, _) | TyKind::Slice(ty) | TyKind::Ref(_, MutTy { ty, .. }) => {
                         walk_kinds.push(&ty.kind);
@@ -62,5 +65,38 @@ impl LateLintPass<'_> for DropForStatic {
                 }
             }
         }
+    }
+}
+
+struct PathVisitor<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    drop_trait_def_id: DefId,
+    drop_for_static_found: bool,
+}
+impl<'tcx> PathVisitor<'_, 'tcx> {
+    fn new<'a>(cx: &'a LateContext<'tcx>, drop_trait_def_id: DefId) -> PathVisitor<'a, 'tcx> {
+        PathVisitor {
+            cx,
+            drop_trait_def_id,
+            drop_for_static_found: false,
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for PathVisitor<'_, 'tcx> {
+    type NestedFilter = nested_filter::All;
+
+    fn visit_path(&mut self, path: &Path<'tcx>, _: HirId) {
+        if let Some(def_id) = path.res.opt_def_id() {
+            let ty = self.cx.tcx.type_of(def_id).instantiate_identity();
+            self.cx.tcx.for_each_relevant_impl(self.drop_trait_def_id, ty, |_| {
+                self.drop_for_static_found = true;
+            });
+        }
+        walk_path(self, path);
+    }
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.cx.tcx
     }
 }

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -11,7 +11,7 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for `static` variables whose types implement `Drop`.
     ///
-    /// ### Why restrict this?
+    /// ### Why is this bad?
     /// Rust does not call `Drop::drop` for `static` variables at the end of a program's
     /// execution. If a type relies on its `Drop` implementation to release resources
     /// (like closing files, releasing locks, or deleting temporary files), these

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -1,0 +1,66 @@
+use clippy_utils::diagnostics::span_lint;
+use rustc_hir::{Item, ItemKind, Ty, TyKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `static` variables whose types implement `Drop`.
+    ///
+    /// ### Why restrict this?
+    /// Rust does not call `Drop::drop` for `static` variables at the end of a program's
+    /// execution. If a type relies on its `Drop` implementation to release resources
+    /// (like closing files, releasing locks, or deleting temporary files), these
+    /// actions will never occur for a `static` instance, potentially leading to
+    /// resource leaks or inconsistent state.
+    ///
+    /// ### Example
+    /// ```rust
+    /// struct Logger;
+    ///
+    /// impl Drop for Logger {
+    ///     fn drop(&mut self) {
+    ///         println!("Closing log file...");
+    ///     }
+    /// }
+    ///
+    /// static GLOBAL_LOGGER: Logger = Logger;
+    /// ```
+    ///
+    /// ### Known problems
+    /// If the type is intended to exist for the lifetime of the program and the
+    /// resource is automatically reclaimed by the operating system (like memory),
+    /// this lint may be noisy. However, it still serves as a useful reminder that
+    /// the `drop` logic will not execute.
+    #[clippy::version = "1.93.0"]
+    pub DROP_FOR_STATIC,
+    nursery,
+    "static items with a type that implements 'Drop'"
+}
+declare_lint_pass!(DropForStatic => [DROP_FOR_STATIC]);
+
+impl LateLintPass<'_> for DropForStatic {
+    fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
+        if let Some(drop_trait_def_id) = cx.tcx.lang_items().drop_trait()
+            && let ItemKind::Static(_, _, Ty { kind, hir_id, .. }, _) = item.kind
+        {
+            let mut walk_kind = Some(kind);
+            while let Some(kind) = walk_kind {
+                match kind {
+                    TyKind::Path(path) => {
+                        let def_id = cx.qpath_res(path, *hir_id).def_id();
+                        let ty = cx.tcx.type_of(def_id).instantiate_identity();
+                        cx.tcx.for_each_relevant_impl(drop_trait_def_id, ty, |_| {
+                            span_lint(cx, DROP_FOR_STATIC, item.span, "static items with drop implementation");
+                        });
+                        walk_kind = None;
+                    },
+                    TyKind::Array(ty, _) => walk_kind = Some(&ty.kind),
+                    _ => {
+                        walk_kind = None;
+                    },
+                }
+            }
+        }
+    }
+}

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -79,10 +79,6 @@ impl<'tcx> Visitor<'tcx> for DropForStaticVisitor<'_, 'tcx> {
                 walk_path(self, path);
             }
         }
-        // we already found, stop looking
-        if !self.drop_for_static_found {
-            walk_path(self, path);
-        }
     }
 
     fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -37,12 +37,17 @@ declare_clippy_lint! {
     nursery,
     "static items with a type that implements 'Drop'"
 }
+
 declare_lint_pass!(DropForStatic => [DROP_FOR_STATIC]);
 
 impl LateLintPass<'_> for DropForStatic {
     fn check_item<'a>(&mut self, cx: &LateContext<'a>, item: &'a Item<'a>) {
         if let ItemKind::Static(_, ident, _, _) = item.kind
-            && let ty = cx.tcx.type_of(item.owner_id.def_id).instantiate_identity()
+            && let ty = cx
+                .tcx
+                .type_of(item.owner_id.def_id)
+                .instantiate_identity()
+                .skip_normalization()
             && ty.needs_drop(cx.tcx, cx.typing_env())
         {
             span_lint(cx, DROP_FOR_STATIC, ident.span, "static items with drop implementation");

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -7,12 +7,18 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for `static` variables whose types implement `Drop`.
     ///
-    /// ### Why is this bad?
+    /// ### Why restrict this?
     /// Rust does not call `Drop::drop` for `static` variables at the end of a program's
-    /// execution. If a type relies on its `Drop` implementation to release resources
-    /// (like closing files, releasing locks, or deleting temporary files), these
-    /// actions will never occur for a `static` instance, potentially leading to
-    /// resource leaks or inconsistent state.
+    /// execution. If a type relies on its `Drop` implementation to perform actions with
+    /// observable side effects beyond process exit — such as flushing buffered
+    /// writes to a file or cleanly terminating a network connection — those
+    /// actions will never occur for a `static` instance.
+    ///
+    /// ### Known problems
+    /// If the type is intended to exist for the lifetime of the program and the
+    /// resource is automatically reclaimed by the operating system (like memory),
+    /// this lint may be noisy. However, it still serves as a useful reminder that
+    /// the `drop` logic will not execute.
     ///
     /// ### Example
     /// ```rust
@@ -26,15 +32,9 @@ declare_clippy_lint! {
     ///
     /// static GLOBAL_LOGGER: Logger = Logger;
     /// ```
-    ///
-    /// ### Known problems
-    /// If the type is intended to exist for the lifetime of the program and the
-    /// resource is automatically reclaimed by the operating system (like memory),
-    /// this lint may be noisy. However, it still serves as a useful reminder that
-    /// the `drop` logic will not execute.
     #[clippy::version = "1.93.0"]
     pub DROP_FOR_STATIC,
-    nursery,
+    restriction,
     "static items with a type that implements 'Drop'"
 }
 
@@ -47,7 +47,7 @@ impl LateLintPass<'_> for DropForStatic {
                 .tcx
                 .type_of(item.owner_id.def_id)
                 .instantiate_identity()
-                .skip_normalization()
+                .skip_norm_wip()
             && ty.needs_drop(cx.tcx, cx.typing_env())
         {
             span_lint(cx, DROP_FOR_STATIC, ident.span, "static items with drop implementation");

--- a/clippy_lints/src/drop_for_static.rs
+++ b/clippy_lints/src/drop_for_static.rs
@@ -1,7 +1,6 @@
 use clippy_utils::diagnostics::span_lint;
 use rustc_hir::{Item, ItemKind};
-use rustc_lint::{LateContext, LateLintPass};
-use rustc_session::declare_lint_pass;
+use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
 
 declare_clippy_lint! {
     /// ### What it does

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -872,6 +872,7 @@ rustc_lint::late_lint_methods!(
         RestWhenDestructuringStruct: rest_when_destructuring_struct::RestWhenDestructuringStruct = rest_when_destructuring_struct::RestWhenDestructuringStruct,
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
+        DropForStatic: drop_for_static::DropForStatic = drop_for_static::DropForStatic,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -114,6 +114,7 @@ mod disallowed_script_idents;
 mod disallowed_types;
 mod doc;
 mod double_parens;
+mod drop_for_static;
 mod drop_forget_ref;
 mod duplicate_mod;
 mod duration_suboptimal_units;

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -871,6 +871,8 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        UnnecessaryNonzeroGet: unnecessary_nonzero_get::UnnecessaryNonzeroGet = unnecessary_nonzero_get::UnnecessaryNonzeroGet::new(conf),
+        DropForStatic: drop_for_static::DropForStatic = drop_for_static::DropForStatic,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -117,6 +117,7 @@ mod disallowed_script_idents;
 mod disallowed_types;
 mod doc;
 mod double_parens;
+mod drop_for_static;
 mod drop_forget_ref;
 mod duplicate_mod;
 mod duration_suboptimal_units;

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -871,7 +871,6 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
-        UnnecessaryNonzeroGet: unnecessary_nonzero_get::UnnecessaryNonzeroGet = unnecessary_nonzero_get::UnnecessaryNonzeroGet::new(conf),
         DropForStatic: drop_for_static::DropForStatic = drop_for_static::DropForStatic,
         // add late passes here, used by `cargo dev new_lint`
     ]]

--- a/tests/ui/drop_for_static.rs
+++ b/tests/ui/drop_for_static.rs
@@ -29,8 +29,7 @@ static A9: &[FooWithDrop] = &[FooWithDrop];
 static A10: &[FooWithoutDrop] = &[FooWithoutDrop];
 
 struct Nested<T>(T);
-static B9: Nested::<FooWithDrop> = Nested(FooWithDrop);
-static B10: Nested::<FooWithoutDrop> = Nested(FooWithoutDrop);
-
+static B9: Nested<FooWithDrop> = Nested(FooWithDrop);
+static B10: Nested<FooWithoutDrop> = Nested(FooWithoutDrop);
 
 fn main() {}

--- a/tests/ui/drop_for_static.rs
+++ b/tests/ui/drop_for_static.rs
@@ -12,21 +12,13 @@ static A1: FooWithDrop = FooWithDrop;
 //~^ drop_for_static
 static A2: FooWithoutDrop = FooWithoutDrop;
 
-static A3: &FooWithDrop = &FooWithDrop;
+static A3: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
 //~^ drop_for_static
-static A4: &FooWithoutDrop = &FooWithoutDrop;
+static A4: (FooWithoutDrop, FooWithoutDrop) = (FooWithoutDrop, FooWithoutDrop);
 
-static A5: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
+static A5: [FooWithDrop; 1] = [FooWithDrop];
 //~^ drop_for_static
-static A6: (FooWithoutDrop, FooWithoutDrop) = (FooWithoutDrop, FooWithoutDrop);
-
-static A7: [FooWithDrop; 1] = [FooWithDrop];
-//~^ drop_for_static
-static A8: [FooWithoutDrop; 1] = [FooWithoutDrop];
-
-static A9: &[FooWithDrop] = &[FooWithDrop];
-//~^ drop_for_static
-static A10: &[FooWithoutDrop] = &[FooWithoutDrop];
+static A6: [FooWithoutDrop; 1] = [FooWithoutDrop];
 
 // ----------------------
 // nested types scenarios
@@ -41,20 +33,51 @@ static B3: Nested<FooWithoutDrop, Nested<FooWithDrop>> = Nested(FooWithoutDrop, 
 //~^ drop_for_static
 static B4: Nested<FooWithoutDrop, Nested<FooWithoutDrop>> = Nested(FooWithoutDrop, Nested(FooWithoutDrop, ()));
 
-static B5: Nested<&FooWithDrop> = Nested(&FooWithDrop, ());
+static B5: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
 //~^ drop_for_static
-static B6: Nested<&FooWithoutDrop> = Nested(&FooWithoutDrop, ());
+static B6: Nested<(FooWithoutDrop, FooWithoutDrop)> = Nested((FooWithoutDrop, FooWithoutDrop), ());
 
-static B7: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
+static B7: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
 //~^ drop_for_static
-static B8: Nested<(FooWithoutDrop, FooWithoutDrop)> = Nested((FooWithoutDrop, FooWithoutDrop), ());
+static B8: Nested<[FooWithoutDrop; 1]> = Nested([FooWithoutDrop], ());
 
-static B9: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
-//~^ drop_for_static
-static B10: Nested<[FooWithoutDrop; 1]> = Nested([FooWithoutDrop], ());
+// ----------------------
+// type alias
+// ----------------------
 
-static B11: Nested<&[FooWithDrop]> = Nested(&[FooWithDrop], ());
+type BarWithDrop = FooWithDrop;
+type BarWithoutDrop = FooWithoutDrop;
+
+static C1: BarWithDrop = FooWithDrop;
 //~^ drop_for_static
-static B12: Nested<&[FooWithoutDrop]> = Nested(&[FooWithoutDrop], ());
+static C2: BarWithoutDrop = FooWithoutDrop;
+
+static C3: (BarWithoutDrop, BarWithDrop) = (FooWithoutDrop, FooWithDrop);
+//~^ drop_for_static
+static C4: (BarWithoutDrop, BarWithoutDrop) = (FooWithoutDrop, FooWithoutDrop);
+
+static C5: [BarWithDrop; 1] = [FooWithDrop];
+//~^ drop_for_static
+static C6: [BarWithoutDrop; 1] = [FooWithoutDrop];
+
+// ----------------------
+// nested type alias
+// ----------------------
+
+static D1: Nested<BarWithDrop> = Nested(FooWithDrop, ());
+//~^ drop_for_static
+static D2: Nested<BarWithoutDrop> = Nested(FooWithoutDrop, ());
+
+static D3: Nested<BarWithoutDrop, Nested<BarWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
+//~^ drop_for_static
+static D4: Nested<BarWithoutDrop, Nested<BarWithoutDrop>> = Nested(FooWithoutDrop, Nested(FooWithoutDrop, ()));
+
+static D5: Nested<(BarWithoutDrop, BarWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
+//~^ drop_for_static
+static D6: Nested<(BarWithoutDrop, BarWithoutDrop)> = Nested((FooWithoutDrop, FooWithoutDrop), ());
+
+static D7: Nested<[BarWithDrop; 1]> = Nested([FooWithDrop], ());
+//~^ drop_for_static
+static D8: Nested<[BarWithoutDrop; 1]> = Nested([FooWithoutDrop], ());
 
 fn main() {}

--- a/tests/ui/drop_for_static.rs
+++ b/tests/ui/drop_for_static.rs
@@ -21,25 +21,25 @@ static A5: [FooWithDrop; 1] = [FooWithDrop];
 static A6: [FooWithoutDrop; 1] = [FooWithoutDrop];
 
 // ----------------------
-// nested types scenarios
+// generic type scenarios
 // ----------------------
 
-struct Nested<T1, T2 = ()>(T1, T2);
-static B1: Nested<FooWithDrop> = Nested(FooWithDrop, ());
+struct Generic<T1, T2 = ()>(T1, T2);
+static B1: Generic<FooWithDrop> = Generic(FooWithDrop, ());
 //~^ drop_for_static
-static B2: Nested<FooWithoutDrop> = Nested(FooWithoutDrop, ());
+static B2: Generic<FooWithoutDrop> = Generic(FooWithoutDrop, ());
 
-static B3: Nested<FooWithoutDrop, Nested<FooWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
+static B3: Generic<FooWithoutDrop, Generic<FooWithDrop>> = Generic(FooWithoutDrop, Generic(FooWithDrop, ()));
 //~^ drop_for_static
-static B4: Nested<FooWithoutDrop, Nested<FooWithoutDrop>> = Nested(FooWithoutDrop, Nested(FooWithoutDrop, ()));
+static B4: Generic<FooWithoutDrop, Generic<FooWithoutDrop>> = Generic(FooWithoutDrop, Generic(FooWithoutDrop, ()));
 
-static B5: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
+static B5: Generic<(FooWithoutDrop, FooWithDrop)> = Generic((FooWithoutDrop, FooWithDrop), ());
 //~^ drop_for_static
-static B6: Nested<(FooWithoutDrop, FooWithoutDrop)> = Nested((FooWithoutDrop, FooWithoutDrop), ());
+static B6: Generic<(FooWithoutDrop, FooWithoutDrop)> = Generic((FooWithoutDrop, FooWithoutDrop), ());
 
-static B7: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
+static B7: Generic<[FooWithDrop; 1]> = Generic([FooWithDrop], ());
 //~^ drop_for_static
-static B8: Nested<[FooWithoutDrop; 1]> = Nested([FooWithoutDrop], ());
+static B8: Generic<[FooWithoutDrop; 1]> = Generic([FooWithoutDrop], ());
 
 // ----------------------
 // type alias
@@ -61,23 +61,86 @@ static C5: [BarWithDrop; 1] = [FooWithDrop];
 static C6: [BarWithoutDrop; 1] = [FooWithoutDrop];
 
 // ----------------------
-// nested type alias
+// Generic type with alias
 // ----------------------
 
-static D1: Nested<BarWithDrop> = Nested(FooWithDrop, ());
+static D1: Generic<BarWithDrop> = Generic(FooWithDrop, ());
 //~^ drop_for_static
-static D2: Nested<BarWithoutDrop> = Nested(FooWithoutDrop, ());
+static D2: Generic<BarWithoutDrop> = Generic(FooWithoutDrop, ());
 
-static D3: Nested<BarWithoutDrop, Nested<BarWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
+static D3: Generic<BarWithoutDrop, Generic<BarWithDrop>> = Generic(FooWithoutDrop, Generic(FooWithDrop, ()));
 //~^ drop_for_static
-static D4: Nested<BarWithoutDrop, Nested<BarWithoutDrop>> = Nested(FooWithoutDrop, Nested(FooWithoutDrop, ()));
+static D4: Generic<BarWithoutDrop, Generic<BarWithoutDrop>> = Generic(FooWithoutDrop, Generic(FooWithoutDrop, ()));
 
-static D5: Nested<(BarWithoutDrop, BarWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
+static D5: Generic<(BarWithoutDrop, BarWithDrop)> = Generic((FooWithoutDrop, FooWithDrop), ());
 //~^ drop_for_static
-static D6: Nested<(BarWithoutDrop, BarWithoutDrop)> = Nested((FooWithoutDrop, FooWithoutDrop), ());
+static D6: Generic<(BarWithoutDrop, BarWithoutDrop)> = Generic((FooWithoutDrop, FooWithoutDrop), ());
 
-static D7: Nested<[BarWithDrop; 1]> = Nested([FooWithDrop], ());
+static D7: Generic<[BarWithDrop; 1]> = Generic([FooWithDrop], ());
 //~^ drop_for_static
-static D8: Nested<[BarWithoutDrop; 1]> = Nested([FooWithoutDrop], ());
+static D8: Generic<[BarWithoutDrop; 1]> = Generic([FooWithoutDrop], ());
+
+// ----------------------
+// associated type
+// ----------------------
+
+trait FooTrait {
+    type FooAssoc;
+}
+
+struct FooImplWithDrop;
+impl FooTrait for FooImplWithDrop {
+    type FooAssoc = FooWithDrop;
+}
+struct FooImplWithoutDrop;
+impl FooTrait for FooImplWithoutDrop {
+    type FooAssoc = FooWithoutDrop;
+}
+
+static F1: <FooImplWithDrop as FooTrait>::FooAssoc = FooWithDrop;
+//~^ drop_for_static
+static F2: <FooImplWithoutDrop as FooTrait>::FooAssoc = FooWithoutDrop;
+
+static F3: (
+    //~^ drop_for_static
+    <FooImplWithoutDrop as FooTrait>::FooAssoc,
+    <FooImplWithDrop as FooTrait>::FooAssoc,
+) = (FooWithoutDrop, FooWithDrop);
+static F4: (
+    <FooImplWithoutDrop as FooTrait>::FooAssoc,
+    <FooImplWithoutDrop as FooTrait>::FooAssoc,
+) = (FooWithoutDrop, FooWithoutDrop);
+
+static F5: [<FooImplWithDrop as FooTrait>::FooAssoc; 1] = [FooWithDrop];
+//~^ drop_for_static
+static F6: [<FooImplWithoutDrop as FooTrait>::FooAssoc; 1] = [FooWithoutDrop];
+
+// ----------------------
+// generic with associated type scenarios
+// ----------------------
+
+static E1: Generic<<FooImplWithDrop as FooTrait>::FooAssoc> = Generic(FooWithDrop, ());
+//~^ drop_for_static
+static E2: Generic<<FooImplWithoutDrop as FooTrait>::FooAssoc> = Generic(FooWithoutDrop, ());
+
+static E3: Generic<<FooImplWithoutDrop as FooTrait>::FooAssoc, Generic<<FooImplWithDrop as FooTrait>::FooAssoc>> =
+    //~^ drop_for_static
+    Generic(FooWithoutDrop, Generic(FooWithDrop, ()));
+static E4: Generic<<FooImplWithoutDrop as FooTrait>::FooAssoc, Generic<FooWithoutDrop>> =
+    Generic(FooWithoutDrop, Generic(FooWithoutDrop, ()));
+
+static E5: Generic<(
+    //~^ drop_for_static
+    <FooImplWithoutDrop as FooTrait>::FooAssoc,
+    <FooImplWithDrop as FooTrait>::FooAssoc,
+)> = Generic((FooWithoutDrop, FooWithDrop), ());
+static E6: Generic<(
+    <FooImplWithoutDrop as FooTrait>::FooAssoc,
+    <FooImplWithoutDrop as FooTrait>::FooAssoc,
+)> = Generic((FooWithoutDrop, FooWithoutDrop), ());
+
+static E7: Generic<[<FooImplWithDrop as FooTrait>::FooAssoc; 1]> = Generic([FooWithDrop], ());
+//~^ drop_for_static
+static E8: Generic<[<FooImplWithoutDrop as FooTrait>::FooAssoc; 1]> = Generic([FooWithoutDrop], ());
 
 fn main() {}

--- a/tests/ui/drop_for_static.rs
+++ b/tests/ui/drop_for_static.rs
@@ -28,8 +28,33 @@ static A9: &[FooWithDrop] = &[FooWithDrop];
 //~^ drop_for_static
 static A10: &[FooWithoutDrop] = &[FooWithoutDrop];
 
-struct Nested<T>(T);
-static B9: Nested<FooWithDrop> = Nested(FooWithDrop);
-static B10: Nested<FooWithoutDrop> = Nested(FooWithoutDrop);
+// ----------------------
+// nested types scenarios
+// ----------------------
+
+struct Nested<T1, T2 = ()>(T1, T2);
+static B1: Nested<FooWithDrop> = Nested(FooWithDrop, ());
+//~^ drop_for_static
+static B2: Nested<FooWithoutDrop> = Nested(FooWithoutDrop, ());
+
+static B3: Nested<FooWithoutDrop, Nested<FooWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
+//~^ drop_for_static
+static B4: Nested<FooWithoutDrop, Nested<FooWithoutDrop>> = Nested(FooWithoutDrop, Nested(FooWithoutDrop, ()));
+
+static B5: Nested<&FooWithDrop> = Nested(&FooWithDrop, ());
+//~^ drop_for_static
+static B6: Nested<&FooWithoutDrop> = Nested(&FooWithoutDrop, ());
+
+static B7: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
+//~^ drop_for_static
+static B8: Nested<(FooWithoutDrop, FooWithoutDrop)> = Nested((FooWithoutDrop, FooWithoutDrop), ());
+
+static B9: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
+//~^ drop_for_static
+static B10: Nested<[FooWithoutDrop; 1]> = Nested([FooWithoutDrop], ());
+
+static B11: Nested<&[FooWithDrop]> = Nested(&[FooWithDrop], ());
+//~^ drop_for_static
+static B12: Nested<&[FooWithoutDrop]> = Nested(&[FooWithoutDrop], ());
 
 fn main() {}

--- a/tests/ui/drop_for_static.rs
+++ b/tests/ui/drop_for_static.rs
@@ -1,0 +1,19 @@
+#![warn(clippy::drop_for_static)]
+#![allow(unused)]
+
+struct FooWithDrop;
+struct FooWithoutDrop;
+
+impl Drop for FooWithDrop {
+    fn drop(&mut self) {}
+}
+
+static A1: FooWithDrop = FooWithDrop;
+//~^ drop_for_static
+static A2: FooWithoutDrop = FooWithoutDrop;
+
+static A3: [FooWithDrop; 1] = [FooWithDrop];
+//~^ drop_for_static
+static A4: [FooWithoutDrop; 1] = [FooWithoutDrop];
+
+fn main() {}

--- a/tests/ui/drop_for_static.rs
+++ b/tests/ui/drop_for_static.rs
@@ -12,8 +12,25 @@ static A1: FooWithDrop = FooWithDrop;
 //~^ drop_for_static
 static A2: FooWithoutDrop = FooWithoutDrop;
 
-static A3: [FooWithDrop; 1] = [FooWithDrop];
+static A3: &FooWithDrop = &FooWithDrop;
 //~^ drop_for_static
-static A4: [FooWithoutDrop; 1] = [FooWithoutDrop];
+static A4: &FooWithoutDrop = &FooWithoutDrop;
+
+static A5: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
+//~^ drop_for_static
+static A6: (FooWithoutDrop, FooWithoutDrop) = (FooWithoutDrop, FooWithoutDrop);
+
+static A7: [FooWithDrop; 1] = [FooWithDrop];
+//~^ drop_for_static
+static A8: [FooWithoutDrop; 1] = [FooWithoutDrop];
+
+static A9: &[FooWithDrop] = &[FooWithDrop];
+//~^ drop_for_static
+static A10: &[FooWithoutDrop] = &[FooWithoutDrop];
+
+struct Nested<T>(T);
+static B9: Nested::<FooWithDrop> = Nested(FooWithDrop);
+static B10: Nested::<FooWithoutDrop> = Nested(FooWithoutDrop);
+
 
 fn main() {}

--- a/tests/ui/drop_for_static.stderr
+++ b/tests/ui/drop_for_static.stderr
@@ -8,7 +8,7 @@ LL | static A1: FooWithDrop = FooWithDrop;
    = help: to override `-D warnings` add `#[allow(clippy::drop_for_static)]`
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:16:1
+  --> tests/ui/drop_for_static.rs:15:1
    |
 LL | static A3: [FooWithDrop; 1] = [FooWithDrop];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/drop_for_static.stderr
+++ b/tests/ui/drop_for_static.stderr
@@ -2,7 +2,7 @@ error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:11:8
    |
 LL | static A1: FooWithDrop = FooWithDrop;
-   |        ^^
+   |        ^^  ----------- type with drop implementation here
    |
    = note: `-D clippy::drop-for-static` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::drop_for_static)]`
@@ -11,61 +11,61 @@ error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:15:8
    |
 LL | static A3: &FooWithDrop = &FooWithDrop;
-   |        ^^
+   |        ^^   ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:19:8
    |
 LL | static A5: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
-   |        ^^
+   |        ^^                   ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:23:8
    |
 LL | static A7: [FooWithDrop; 1] = [FooWithDrop];
-   |        ^^
+   |        ^^   ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:27:8
    |
 LL | static A9: &[FooWithDrop] = &[FooWithDrop];
-   |        ^^
+   |        ^^    ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:36:8
    |
 LL | static B1: Nested<FooWithDrop> = Nested(FooWithDrop, ());
-   |        ^^
+   |        ^^         ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:40:8
    |
 LL | static B3: Nested<FooWithoutDrop, Nested<FooWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
-   |        ^^
+   |        ^^                                ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:44:8
    |
 LL | static B5: Nested<&FooWithDrop> = Nested(&FooWithDrop, ());
-   |        ^^
+   |        ^^          ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:48:8
    |
 LL | static B7: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
-   |        ^^
+   |        ^^                          ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:52:8
    |
 LL | static B9: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
-   |        ^^
+   |        ^^          ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:56:8
    |
 LL | static B11: Nested<&[FooWithDrop]> = Nested(&[FooWithDrop], ());
-   |        ^^^
+   |        ^^^           ----------- type with drop implementation here
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/drop_for_static.stderr
+++ b/tests/ui/drop_for_static.stderr
@@ -2,7 +2,7 @@ error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:11:8
    |
 LL | static A1: FooWithDrop = FooWithDrop;
-   |        ^^  ----------- type with drop implementation here
+   |        ^^
    |
    = note: `-D clippy::drop-for-static` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::drop_for_static)]`
@@ -11,79 +11,121 @@ error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:15:8
    |
 LL | static A3: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
-   |        ^^                   ----------- type with drop implementation here
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:19:8
    |
 LL | static A5: [FooWithDrop; 1] = [FooWithDrop];
-   |        ^^   ----------- type with drop implementation here
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:28:8
    |
-LL | static B1: Nested<FooWithDrop> = Nested(FooWithDrop, ());
-   |        ^^         ----------- type with drop implementation here
+LL | static B1: Generic<FooWithDrop> = Generic(FooWithDrop, ());
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:32:8
    |
-LL | static B3: Nested<FooWithoutDrop, Nested<FooWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
-   |        ^^                                ----------- type with drop implementation here
+LL | static B3: Generic<FooWithoutDrop, Generic<FooWithDrop>> = Generic(FooWithoutDrop, Generic(FooWithDrop, ()));
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:36:8
    |
-LL | static B5: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
-   |        ^^                          ----------- type with drop implementation here
+LL | static B5: Generic<(FooWithoutDrop, FooWithDrop)> = Generic((FooWithoutDrop, FooWithDrop), ());
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:40:8
    |
-LL | static B7: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
-   |        ^^          ----------- type with drop implementation here
+LL | static B7: Generic<[FooWithDrop; 1]> = Generic([FooWithDrop], ());
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:51:8
    |
 LL | static C1: BarWithDrop = FooWithDrop;
-   |        ^^  ----------- type with drop implementation here
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:55:8
    |
 LL | static C3: (BarWithoutDrop, BarWithDrop) = (FooWithoutDrop, FooWithDrop);
-   |        ^^                   ----------- type with drop implementation here
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:59:8
    |
 LL | static C5: [BarWithDrop; 1] = [FooWithDrop];
-   |        ^^   ----------- type with drop implementation here
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:67:8
    |
-LL | static D1: Nested<BarWithDrop> = Nested(FooWithDrop, ());
-   |        ^^         ----------- type with drop implementation here
+LL | static D1: Generic<BarWithDrop> = Generic(FooWithDrop, ());
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:71:8
    |
-LL | static D3: Nested<BarWithoutDrop, Nested<BarWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
-   |        ^^                                ----------- type with drop implementation here
+LL | static D3: Generic<BarWithoutDrop, Generic<BarWithDrop>> = Generic(FooWithoutDrop, Generic(FooWithDrop, ()));
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:75:8
    |
-LL | static D5: Nested<(BarWithoutDrop, BarWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
-   |        ^^                          ----------- type with drop implementation here
+LL | static D5: Generic<(BarWithoutDrop, BarWithDrop)> = Generic((FooWithoutDrop, FooWithDrop), ());
+   |        ^^
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:79:8
    |
-LL | static D7: Nested<[BarWithDrop; 1]> = Nested([FooWithDrop], ());
-   |        ^^          ----------- type with drop implementation here
+LL | static D7: Generic<[BarWithDrop; 1]> = Generic([FooWithDrop], ());
+   |        ^^
 
-error: aborting due to 14 previous errors
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:100:8
+   |
+LL | static F1: <FooImplWithDrop as FooTrait>::FooAssoc = FooWithDrop;
+   |        ^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:104:8
+   |
+LL | static F3: (
+   |        ^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:114:8
+   |
+LL | static F5: [<FooImplWithDrop as FooTrait>::FooAssoc; 1] = [FooWithDrop];
+   |        ^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:122:8
+   |
+LL | static E1: Generic<<FooImplWithDrop as FooTrait>::FooAssoc> = Generic(FooWithDrop, ());
+   |        ^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:126:8
+   |
+LL | static E3: Generic<<FooImplWithoutDrop as FooTrait>::FooAssoc, Generic<<FooImplWithDrop as FooTrait>::FooAssoc>> =
+   |        ^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:132:8
+   |
+LL | static E5: Generic<(
+   |        ^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:142:8
+   |
+LL | static E7: Generic<[<FooImplWithDrop as FooTrait>::FooAssoc; 1]> = Generic([FooWithDrop], ());
+   |        ^^
+
+error: aborting due to 21 previous errors
 

--- a/tests/ui/drop_for_static.stderr
+++ b/tests/ui/drop_for_static.stderr
@@ -31,5 +31,41 @@ error: static items with drop implementation
 LL | static A9: &[FooWithDrop] = &[FooWithDrop];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:36:1
+   |
+LL | static B1: Nested<FooWithDrop> = Nested(FooWithDrop, ());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:40:1
+   |
+LL | static B3: Nested<FooWithoutDrop, Nested<FooWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:44:1
+   |
+LL | static B5: Nested<&FooWithDrop> = Nested(&FooWithDrop, ());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:48:1
+   |
+LL | static B7: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:52:1
+   |
+LL | static B9: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:56:1
+   |
+LL | static B11: Nested<&[FooWithDrop]> = Nested(&[FooWithDrop], ());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/drop_for_static.stderr
+++ b/tests/ui/drop_for_static.stderr
@@ -10,62 +10,80 @@ LL | static A1: FooWithDrop = FooWithDrop;
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:15:8
    |
-LL | static A3: &FooWithDrop = &FooWithDrop;
-   |        ^^   ----------- type with drop implementation here
+LL | static A3: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
+   |        ^^                   ----------- type with drop implementation here
 
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:19:8
    |
-LL | static A5: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
-   |        ^^                   ----------- type with drop implementation here
-
-error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:23:8
-   |
-LL | static A7: [FooWithDrop; 1] = [FooWithDrop];
+LL | static A5: [FooWithDrop; 1] = [FooWithDrop];
    |        ^^   ----------- type with drop implementation here
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:27:8
-   |
-LL | static A9: &[FooWithDrop] = &[FooWithDrop];
-   |        ^^    ----------- type with drop implementation here
-
-error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:36:8
+  --> tests/ui/drop_for_static.rs:28:8
    |
 LL | static B1: Nested<FooWithDrop> = Nested(FooWithDrop, ());
    |        ^^         ----------- type with drop implementation here
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:40:8
+  --> tests/ui/drop_for_static.rs:32:8
    |
 LL | static B3: Nested<FooWithoutDrop, Nested<FooWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
    |        ^^                                ----------- type with drop implementation here
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:44:8
+  --> tests/ui/drop_for_static.rs:36:8
    |
-LL | static B5: Nested<&FooWithDrop> = Nested(&FooWithDrop, ());
-   |        ^^          ----------- type with drop implementation here
-
-error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:48:8
-   |
-LL | static B7: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
+LL | static B5: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
    |        ^^                          ----------- type with drop implementation here
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:52:8
+  --> tests/ui/drop_for_static.rs:40:8
    |
-LL | static B9: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
+LL | static B7: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
    |        ^^          ----------- type with drop implementation here
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:56:8
+  --> tests/ui/drop_for_static.rs:51:8
    |
-LL | static B11: Nested<&[FooWithDrop]> = Nested(&[FooWithDrop], ());
-   |        ^^^           ----------- type with drop implementation here
+LL | static C1: BarWithDrop = FooWithDrop;
+   |        ^^  ----------- type with drop implementation here
 
-error: aborting due to 11 previous errors
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:55:8
+   |
+LL | static C3: (BarWithoutDrop, BarWithDrop) = (FooWithoutDrop, FooWithDrop);
+   |        ^^                   ----------- type with drop implementation here
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:59:8
+   |
+LL | static C5: [BarWithDrop; 1] = [FooWithDrop];
+   |        ^^   ----------- type with drop implementation here
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:67:8
+   |
+LL | static D1: Nested<BarWithDrop> = Nested(FooWithDrop, ());
+   |        ^^         ----------- type with drop implementation here
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:71:8
+   |
+LL | static D3: Nested<BarWithoutDrop, Nested<BarWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
+   |        ^^                                ----------- type with drop implementation here
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:75:8
+   |
+LL | static D5: Nested<(BarWithoutDrop, BarWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
+   |        ^^                          ----------- type with drop implementation here
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:79:8
+   |
+LL | static D7: Nested<[BarWithDrop; 1]> = Nested([FooWithDrop], ());
+   |        ^^          ----------- type with drop implementation here
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/drop_for_static.stderr
+++ b/tests/ui/drop_for_static.stderr
@@ -10,8 +10,26 @@ LL | static A1: FooWithDrop = FooWithDrop;
 error: static items with drop implementation
   --> tests/ui/drop_for_static.rs:15:1
    |
-LL | static A3: [FooWithDrop; 1] = [FooWithDrop];
+LL | static A3: &FooWithDrop = &FooWithDrop;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:19:1
+   |
+LL | static A5: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:23:1
+   |
+LL | static A7: [FooWithDrop; 1] = [FooWithDrop];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:27:1
+   |
+LL | static A9: &[FooWithDrop] = &[FooWithDrop];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/drop_for_static.stderr
+++ b/tests/ui/drop_for_static.stderr
@@ -1,71 +1,71 @@
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:11:1
+  --> tests/ui/drop_for_static.rs:11:8
    |
 LL | static A1: FooWithDrop = FooWithDrop;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
    |
    = note: `-D clippy::drop-for-static` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::drop_for_static)]`
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:15:1
+  --> tests/ui/drop_for_static.rs:15:8
    |
 LL | static A3: &FooWithDrop = &FooWithDrop;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:19:1
+  --> tests/ui/drop_for_static.rs:19:8
    |
 LL | static A5: (FooWithoutDrop, FooWithDrop) = (FooWithoutDrop, FooWithDrop);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:23:1
+  --> tests/ui/drop_for_static.rs:23:8
    |
 LL | static A7: [FooWithDrop; 1] = [FooWithDrop];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:27:1
+  --> tests/ui/drop_for_static.rs:27:8
    |
 LL | static A9: &[FooWithDrop] = &[FooWithDrop];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:36:1
+  --> tests/ui/drop_for_static.rs:36:8
    |
 LL | static B1: Nested<FooWithDrop> = Nested(FooWithDrop, ());
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:40:1
+  --> tests/ui/drop_for_static.rs:40:8
    |
 LL | static B3: Nested<FooWithoutDrop, Nested<FooWithDrop>> = Nested(FooWithoutDrop, Nested(FooWithDrop, ()));
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:44:1
+  --> tests/ui/drop_for_static.rs:44:8
    |
 LL | static B5: Nested<&FooWithDrop> = Nested(&FooWithDrop, ());
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:48:1
+  --> tests/ui/drop_for_static.rs:48:8
    |
 LL | static B7: Nested<(FooWithoutDrop, FooWithDrop)> = Nested((FooWithoutDrop, FooWithDrop), ());
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:52:1
+  --> tests/ui/drop_for_static.rs:52:8
    |
 LL | static B9: Nested<[FooWithDrop; 1]> = Nested([FooWithDrop], ());
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^
 
 error: static items with drop implementation
-  --> tests/ui/drop_for_static.rs:56:1
+  --> tests/ui/drop_for_static.rs:56:8
    |
 LL | static B11: Nested<&[FooWithDrop]> = Nested(&[FooWithDrop], ());
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/drop_for_static.stderr
+++ b/tests/ui/drop_for_static.stderr
@@ -1,0 +1,17 @@
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:11:1
+   |
+LL | static A1: FooWithDrop = FooWithDrop;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::drop-for-static` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::drop_for_static)]`
+
+error: static items with drop implementation
+  --> tests/ui/drop_for_static.rs:16:1
+   |
+LL | static A3: [FooWithDrop; 1] = [FooWithDrop];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16464)*

# Description

This PR introduces a new lint to notify users when a static item contains a type that implements the `Drop` trait.

As per the [Rust Reference](https://doc.rust-lang.org/reference/items/static-items.html#r-items.static.lifetime), static variables have a 'static lifetime and are never destroyed. Consequently, the`Drop::drop` method is never executed for these items.

# Rational

In scenarios where `drop` is used for critical resource management. Such as closing file handles, releasing external locks, or performing a "graceful" shutdown of a subsystem, relying on a static item can lead to subtle resource leaks or unexpected behaviour. Since the programmer might expect the destructor to run at the end of the program's execution, providing a diagnostic when this won't happen helps prevent "silent" failures in resource cleanup.

changelog: new lint: `drop_for_static` 
