### PR TITLE
Only `Duration` constructors taking `u64` are covered

### DIFF
--- a/clippy_lints/src/duration_suboptimal_units.rs
+++ b/clippy_lints/src/duration_suboptimal_units.rs
@@ -9,7 +9,7 @@ use clippy_utils::sym;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, QPath, RustcVersion};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{self, TyCtxt, UintTy};
 use rustc_session::impl_lint_pass;
 use rustc_span::Symbol;
 
@@ -76,13 +76,14 @@ impl LateLintPass<'_> for DurationSuboptimalUnits {
                 .typeck_results()
                 .node_type(func_ty.hir_id)
                 .is_diag_item(cx, sym::Duration)
+            && matches!(cx.typeck_results().expr_ty_adjusted(arg).kind(), ty::Uint(UintTy::U64))
             // We intentionally don't want to evaluate referenced constants, as we don't want to
             // recommend a literal value over using constants:
             //
             // let dur = Duration::from_secs(SIXTY);
             //           ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Duration::from_mins(1)`
             && let Some(Constant::Int(value)) = ConstEvalCtxt::new(cx).eval_local(arg, expr.span.ctxt())
-            && let value = u64::try_from(value).expect("All Duration::from_<time-unit> constructors take a u64")
+            && let Ok(value) = u64::try_from(value) // Cannot fail
             // There is no need to promote e.g. 0 seconds to 0 hours
             && value != 0
             && let Some((promoted_constructor, promoted_value)) = self.promote(cx, func_name.ident.name, value)

--- a/tests/ui/duration_suboptimal_units.fixed
+++ b/tests/ui/duration_suboptimal_units.fixed
@@ -89,3 +89,8 @@ mod my_duration {
         let dur = Duration::from_secs(60);
     }
 }
+
+fn issue16457() {
+    // Methods taking something else than `u64` are not covered
+    _ = Duration::from_nanos_u128(1 << 90);
+}

--- a/tests/ui/duration_suboptimal_units.rs
+++ b/tests/ui/duration_suboptimal_units.rs
@@ -89,3 +89,8 @@ mod my_duration {
         let dur = Duration::from_secs(60);
     }
 }
+
+fn issue16457() {
+    // Methods taking something else than `u64` are not covered
+    _ = Duration::from_nanos_u128(1 << 90);
+}


### PR DESCRIPTION
changelog: none
(lint introduced in 1.95)

Fixes rust-lang/rust-clippy#16457 