### PR TITLE
Fix `manual_dangling_ptr` FP when pointee type is not `Sized`

### DIFF
--- a/clippy_lints/src/casts/manual_dangling_ptr.rs
+++ b/clippy_lints/src/casts/manual_dangling_ptr.rs
@@ -15,6 +15,8 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, from: &Expr<'_>, to: 
         let init_expr = expr_or_init(cx, from);
         if is_expr_const_aligned(cx, init_expr, ptr_ty.ty)
             && let Some(std_or_core) = std_or_core(cx)
+            && let pointee_ty = cx.typeck_results().node_type(ptr_ty.ty.hir_id)
+            && pointee_ty.is_sized(cx.tcx, cx.typing_env())
         {
             let sugg_fn = match ptr_ty.mutbl {
                 Mutability::Not => "ptr::dangling",

--- a/tests/ui/manual_dangling_ptr.fixed
+++ b/tests/ui/manual_dangling_ptr.fixed
@@ -1,3 +1,4 @@
+#![feature(extern_types)]
 #![warn(clippy::manual_dangling_ptr)]
 use std::mem;
 
@@ -41,4 +42,15 @@ fn _msrv_1_84() {
     foo(std::ptr::dangling(), std::ptr::dangling_mut());
     //~^ manual_dangling_ptr
     //~| manual_dangling_ptr
+}
+
+fn issue16459() {
+    unsafe extern "C" {
+        type Extern;
+    }
+    let _ = unsafe { &mut *(1 as *mut Extern) };
+
+    struct Empty;
+    let _ = unsafe { &mut *std::ptr::dangling_mut::<Empty>() };
+    //~^ manual_dangling_ptr
 }

--- a/tests/ui/manual_dangling_ptr.rs
+++ b/tests/ui/manual_dangling_ptr.rs
@@ -1,3 +1,4 @@
+#![feature(extern_types)]
 #![warn(clippy::manual_dangling_ptr)]
 use std::mem;
 
@@ -41,4 +42,15 @@ fn _msrv_1_84() {
     foo(4 as *const _, 4 as *mut _);
     //~^ manual_dangling_ptr
     //~| manual_dangling_ptr
+}
+
+fn issue16459() {
+    unsafe extern "C" {
+        type Extern;
+    }
+    let _ = unsafe { &mut *(1 as *mut Extern) };
+
+    struct Empty;
+    let _ = unsafe { &mut *(1 as *mut Empty) };
+    //~^ manual_dangling_ptr
 }

--- a/tests/ui/manual_dangling_ptr.stderr
+++ b/tests/ui/manual_dangling_ptr.stderr
@@ -1,5 +1,5 @@
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:7:24
+  --> tests/ui/manual_dangling_ptr.rs:8:24
    |
 LL |     let _: *const u8 = 1 as *const _;
    |                        ^^^^^^^^^^^^^ help: use: `std::ptr::dangling()`
@@ -8,58 +8,64 @@ LL |     let _: *const u8 = 1 as *const _;
    = help: to override `-D warnings` add `#[allow(clippy::manual_dangling_ptr)]`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:9:13
+  --> tests/ui/manual_dangling_ptr.rs:10:13
    |
 LL |     let _ = 2 as *const u32;
    |             ^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling::<u32>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:11:13
+  --> tests/ui/manual_dangling_ptr.rs:12:13
    |
 LL |     let _ = 4 as *mut f32;
    |             ^^^^^^^^^^^^^ help: use: `std::ptr::dangling_mut::<f32>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:14:13
+  --> tests/ui/manual_dangling_ptr.rs:15:13
    |
 LL |     let _ = mem::align_of::<u8>() as *const u8;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling::<u8>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:16:13
+  --> tests/ui/manual_dangling_ptr.rs:17:13
    |
 LL |     let _ = mem::align_of::<u32>() as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling::<u32>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:18:13
+  --> tests/ui/manual_dangling_ptr.rs:19:13
    |
 LL |     let _ = mem::align_of::<usize>() as *const usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling::<usize>()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:21:9
+  --> tests/ui/manual_dangling_ptr.rs:22:9
    |
 LL |     foo(4 as *const _, 4 as *mut _);
    |         ^^^^^^^^^^^^^ help: use: `std::ptr::dangling()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:21:24
+  --> tests/ui/manual_dangling_ptr.rs:22:24
    |
 LL |     foo(4 as *const _, 4 as *mut _);
    |                        ^^^^^^^^^^^ help: use: `std::ptr::dangling_mut()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:41:9
+  --> tests/ui/manual_dangling_ptr.rs:42:9
    |
 LL |     foo(4 as *const _, 4 as *mut _);
    |         ^^^^^^^^^^^^^ help: use: `std::ptr::dangling()`
 
 error: manual creation of a dangling pointer
-  --> tests/ui/manual_dangling_ptr.rs:41:24
+  --> tests/ui/manual_dangling_ptr.rs:42:24
    |
 LL |     foo(4 as *const _, 4 as *mut _);
    |                        ^^^^^^^^^^^ help: use: `std::ptr::dangling_mut()`
 
-error: aborting due to 10 previous errors
+error: manual creation of a dangling pointer
+  --> tests/ui/manual_dangling_ptr.rs:54:28
+   |
+LL |     let _ = unsafe { &mut *(1 as *mut Empty) };
+   |                            ^^^^^^^^^^^^^^^^^ help: use: `std::ptr::dangling_mut::<Empty>()`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16459 

changelog: [`manual_dangling_ptr`] fix FP when pointee type is not `Sized`
