### PR TITLE
Fix `useless_attribute` FP on `exported_private_dependencies` lint attributes

### DIFF
--- a/clippy_lints/src/attrs/useless_attribute.rs
+++ b/clippy_lints/src/attrs/useless_attribute.rs
@@ -31,6 +31,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, item: &Item, attrs: &[Attribute]) {
                                     | sym::dead_code
                                     | sym::deprecated
                                     | sym::deprecated_in_future
+                                    | sym::exported_private_dependencies
                                     | sym::hidden_glob_reexports
                                     | sym::unreachable_pub
                                     | sym::unused

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -147,6 +147,7 @@ generate! {
     exp,
     expect_err,
     expn_data,
+    exported_private_dependencies,
     extend,
     filter,
     filter_map,

--- a/tests/ui/useless_attribute.fixed
+++ b/tests/ui/useless_attribute.fixed
@@ -42,6 +42,10 @@ mod foo {
 #[allow(deprecated)]
 pub use foo::Bar;
 
+// don't lint on exported_private_dependencies for `use` items
+#[allow(exported_private_dependencies)]
+use {};
+
 // This should not trigger the lint. There's lint level definitions inside the external derive
 // that would trigger the useless_attribute lint.
 #[derive(DeriveSomething)]

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -42,6 +42,10 @@ mod foo {
 #[allow(deprecated)]
 pub use foo::Bar;
 
+// don't lint on exported_private_dependencies for `use` items
+#[allow(exported_private_dependencies)]
+use {};
+
 // This should not trigger the lint. There's lint level definitions inside the external derive
 // that would trigger the useless_attribute lint.
 #[derive(DeriveSomething)]


### PR DESCRIPTION
The `exported_private_dependencies` lint can fire on any mention of an item from a private dependency, including mentions inside of `use`. Therefore, `useless_attribute` should not fire on lint attributes mentioning `exported_private_dependencies` attached to a `use`.

changelog: [`useless_attribute`]: fix false positive on `exported_private_dependencies` lint attributes

PR rust-lang/rust-clippy#15645 was used as an example for preparing this PR.