### PR TITLE
Fix panic/assert message detection in edition 2015/2018

### DIFF
--- a/clippy_lints/src/assertions_on_result_states.rs
+++ b/clippy_lints/src/assertions_on_result_states.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::macros::{PanicExpn, find_assert_args, root_macro_call_first_node};
+use clippy_utils::macros::{find_assert_args, root_macro_call_first_node};
 use clippy_utils::res::{MaybeDef, MaybeResPath};
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::sym;
@@ -52,7 +52,7 @@ impl<'tcx> LateLintPass<'tcx> for AssertionsOnResultStates {
         if let Some(macro_call) = root_macro_call_first_node(cx, e)
             && matches!(cx.tcx.get_diagnostic_name(macro_call.def_id), Some(sym::assert_macro))
             && let Some((condition, panic_expn)) = find_assert_args(cx, e, macro_call.expn)
-            && matches!(panic_expn, PanicExpn::Empty)
+            && panic_expn.is_default_message()
             && let ExprKind::MethodCall(method_segment, recv, [], _) = condition.kind
             && let result_type_with_refs = cx.typeck_results().expr_ty(recv)
             && let result_type = result_type_with_refs.peel_refs()

--- a/clippy_lints/src/missing_assert_message.rs
+++ b/clippy_lints/src/missing_assert_message.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_in_test;
-use clippy_utils::macros::{PanicExpn, find_assert_args, find_assert_eq_args, root_macro_call_first_node};
+use clippy_utils::macros::{find_assert_args, find_assert_eq_args, root_macro_call_first_node};
 use rustc_hir::Expr;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
@@ -78,7 +78,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingAssertMessage {
             panic_expn
         };
 
-        if let PanicExpn::Empty = panic_expn {
+        if panic_expn.is_default_message() {
             #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
             span_lint_and_then(
                 cx,

--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -228,19 +228,30 @@ pub fn is_assert_macro(cx: &LateContext<'_>, def_id: DefId) -> bool {
     matches!(name, sym::assert_macro | sym::debug_assert_macro)
 }
 
+/// A call to a function in [`std::rt`] or [`core::panicking`] that results in a panic, typically
+/// part of a `panic!()` expansion (often wrapped in a block) but may be called directly by other
+/// macros such as `assert`.
 #[derive(Debug)]
-pub enum PanicExpn<'a> {
-    /// No arguments - `panic!()`
-    Empty,
-    /// A string literal or any `&str` - `panic!("message")` or `panic!(message)`
-    Str(&'a Expr<'a>),
-    /// A single argument that implements `Display` - `panic!("{}", object)`
+pub enum PanicCall<'a> {
+    // The default message - `panic!()`, `assert!(true)`, etc.
+    DefaultMessage,
+    /// A string literal or any `&str` in edition 2015/2018 - `panic!("message")` or
+    /// `panic!(message)`.
+    ///
+    /// In edition 2021+ `panic!("message")` will be a [`PanicCall::Format`] and `panic!(message)` a
+    /// compile error.
+    Str2015(&'a Expr<'a>),
+    /// A single argument that implements `Display` - `panic!("{}", object)`.
+    ///
+    /// `panic!("{object}")` will still be a [`PanicCall::Format`].
     Display(&'a Expr<'a>),
-    /// Anything else - `panic!("error {}: {}", a, b)`
+    /// Anything else - `panic!("error {}: {}", a, b)`, `panic!("on edition 2021+")`.
+    ///
+    /// See [`FormatArgsStorage::get`] to examine the contents of the formatting.
     Format(&'a Expr<'a>),
 }
 
-impl<'a> PanicExpn<'a> {
+impl<'a> PanicCall<'a> {
     pub fn parse(expr: &'a Expr<'a>) -> Option<Self> {
         let ExprKind::Call(callee, args) = &expr.kind else {
             return None;
@@ -254,8 +265,13 @@ impl<'a> PanicExpn<'a> {
             return None;
         };
         let result = match name {
-            sym::panic if arg.span.eq_ctxt(expr.span) => Self::Empty,
-            sym::panic | sym::panic_str => Self::Str(arg),
+            sym::panic | sym::begin_panic | sym::panic_str_2015 => {
+                if arg.span.eq_ctxt(expr.span) || arg.span.is_dummy() {
+                    Self::DefaultMessage
+                } else {
+                    Self::Str2015(arg)
+                }
+            },
             sym::panic_display => {
                 let ExprKind::AddrOf(_, _, e) = &arg.kind else {
                     return None;
@@ -275,12 +291,16 @@ impl<'a> PanicExpn<'a> {
                 let msg_arg = &rest[2];
                 match msg_arg.kind {
                     ExprKind::Call(_, [fmt_arg]) => Self::Format(fmt_arg),
-                    _ => Self::Empty,
+                    _ => Self::DefaultMessage,
                 }
             },
             _ => return None,
         };
         Some(result)
+    }
+
+    pub fn is_default_message(&self) -> bool {
+        matches!(self, Self::DefaultMessage)
     }
 }
 
@@ -289,18 +309,8 @@ pub fn find_assert_args<'a>(
     cx: &LateContext<'_>,
     expr: &'a Expr<'a>,
     expn: ExpnId,
-) -> Option<(&'a Expr<'a>, PanicExpn<'a>)> {
-    find_assert_args_inner(cx, expr, expn).map(|([e], mut p)| {
-        // `assert!(..)` expands to `core::panicking::panic("assertion failed: ...")` (which we map to
-        // `PanicExpn::Str(..)`) and `assert!(.., "..")` expands to
-        // `core::panicking::panic_fmt(format_args!(".."))` (which we map to `PanicExpn::Format(..)`).
-        // So even we got `PanicExpn::Str(..)` that means there is no custom message provided
-        if let PanicExpn::Str(_) = p {
-            p = PanicExpn::Empty;
-        }
-
-        (e, p)
-    })
+) -> Option<(&'a Expr<'a>, PanicCall<'a>)> {
+    find_assert_args_inner(cx, expr, expn).map(|([e], p)| (e, p))
 }
 
 /// Finds the arguments of an `assert_eq!` or `debug_assert_eq!` macro call within the macro
@@ -309,7 +319,7 @@ pub fn find_assert_eq_args<'a>(
     cx: &LateContext<'_>,
     expr: &'a Expr<'a>,
     expn: ExpnId,
-) -> Option<(&'a Expr<'a>, &'a Expr<'a>, PanicExpn<'a>)> {
+) -> Option<(&'a Expr<'a>, &'a Expr<'a>, PanicCall<'a>)> {
     find_assert_args_inner(cx, expr, expn).map(|([a, b], p)| (a, b, p))
 }
 
@@ -317,7 +327,7 @@ fn find_assert_args_inner<'a, const N: usize>(
     cx: &LateContext<'_>,
     expr: &'a Expr<'a>,
     expn: ExpnId,
-) -> Option<([&'a Expr<'a>; N], PanicExpn<'a>)> {
+) -> Option<([&'a Expr<'a>; N], PanicCall<'a>)> {
     let macro_id = expn.expn_data().macro_def_id?;
     let (expr, expn) = match cx.tcx.item_name(macro_id).as_str().strip_prefix("debug_") {
         None => (expr, expn),
@@ -326,7 +336,7 @@ fn find_assert_args_inner<'a, const N: usize>(
     let mut args = ArrayVec::new();
     let panic_expn = for_each_expr_without_closures(expr, |e| {
         if args.is_full() {
-            match PanicExpn::parse(e) {
+            match PanicCall::parse(e) {
                 Some(expn) => ControlFlow::Break(expn),
                 None => ControlFlow::Continue(Descend::Yes),
             }
@@ -338,10 +348,7 @@ fn find_assert_args_inner<'a, const N: usize>(
         }
     });
     let args = args.into_inner().ok()?;
-    // if no `panic!(..)` is found, use `PanicExpn::Empty`
-    // to indicate that the default assertion message is used
-    let panic_expn = panic_expn.unwrap_or(PanicExpn::Empty);
-    Some((args, panic_expn))
+    Some((args, panic_expn?))
 }
 
 fn find_assert_within_debug_assert<'a>(

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -269,7 +269,6 @@ generate! {
     or_insert,
     or_insert_with,
     outer_expn,
-    panic_str,
     parse,
     partition,
     paths,

--- a/tests/ui/missing_assert_message.edition2015.stderr
+++ b/tests/ui/missing_assert_message.edition2015.stderr
@@ -1,5 +1,5 @@
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:12:5
+  --> tests/ui/missing_assert_message.rs:15:5
    |
 LL |     assert!(foo());
    |     ^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     assert!(foo());
    = help: to override `-D warnings` add `#[allow(clippy::missing_assert_message)]`
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:14:5
+  --> tests/ui/missing_assert_message.rs:17:5
    |
 LL |     assert_eq!(foo(), foo());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     assert_eq!(foo(), foo());
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:16:5
+  --> tests/ui/missing_assert_message.rs:19:5
    |
 LL |     assert_ne!(foo(), foo());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     assert_ne!(foo(), foo());
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:18:5
+  --> tests/ui/missing_assert_message.rs:21:5
    |
 LL |     debug_assert!(foo());
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     debug_assert!(foo());
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:20:5
+  --> tests/ui/missing_assert_message.rs:23:5
    |
 LL |     debug_assert_eq!(foo(), foo());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |     debug_assert_eq!(foo(), foo());
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:22:5
+  --> tests/ui/missing_assert_message.rs:25:5
    |
 LL |     debug_assert_ne!(foo(), foo());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     debug_assert_ne!(foo(), foo());
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:28:5
+  --> tests/ui/missing_assert_message.rs:31:5
    |
 LL |     assert!(bar!(true));
    |     ^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL |     assert!(bar!(true));
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:30:5
+  --> tests/ui/missing_assert_message.rs:33:5
    |
 LL |     assert!(bar!(true, false));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     assert!(bar!(true, false));
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:32:5
+  --> tests/ui/missing_assert_message.rs:35:5
    |
 LL |     assert_eq!(bar!(true), foo());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     assert_eq!(bar!(true), foo());
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:34:5
+  --> tests/ui/missing_assert_message.rs:37:5
    |
 LL |     assert_ne!(bar!(true, true), bar!(true));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     assert_ne!(bar!(true, true), bar!(true));
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:40:5
+  --> tests/ui/missing_assert_message.rs:43:5
    |
 LL |     assert!(foo(),);
    |     ^^^^^^^^^^^^^^^
@@ -89,7 +89,7 @@ LL |     assert!(foo(),);
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:42:5
+  --> tests/ui/missing_assert_message.rs:45:5
    |
 LL |     assert_eq!(foo(), foo(),);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL |     assert_eq!(foo(), foo(),);
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:44:5
+  --> tests/ui/missing_assert_message.rs:47:5
    |
 LL |     assert_ne!(foo(), foo(),);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +105,7 @@ LL |     assert_ne!(foo(), foo(),);
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:46:5
+  --> tests/ui/missing_assert_message.rs:49:5
    |
 LL |     debug_assert!(foo(),);
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +113,7 @@ LL |     debug_assert!(foo(),);
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:48:5
+  --> tests/ui/missing_assert_message.rs:51:5
    |
 LL |     debug_assert_eq!(foo(), foo(),);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     debug_assert_eq!(foo(), foo(),);
    = help: consider describing why the failing assert is problematic
 
 error: assert without any message
-  --> tests/ui/missing_assert_message.rs:50:5
+  --> tests/ui/missing_assert_message.rs:53:5
    |
 LL |     debug_assert_ne!(foo(), foo(),);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/missing_assert_message.edition2021.stderr
+++ b/tests/ui/missing_assert_message.edition2021.stderr
@@ -1,0 +1,132 @@
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:15:5
+   |
+LL |     assert!(foo());
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+   = note: `-D clippy::missing-assert-message` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_assert_message)]`
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:17:5
+   |
+LL |     assert_eq!(foo(), foo());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:19:5
+   |
+LL |     assert_ne!(foo(), foo());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:21:5
+   |
+LL |     debug_assert!(foo());
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:23:5
+   |
+LL |     debug_assert_eq!(foo(), foo());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:25:5
+   |
+LL |     debug_assert_ne!(foo(), foo());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:31:5
+   |
+LL |     assert!(bar!(true));
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:33:5
+   |
+LL |     assert!(bar!(true, false));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:35:5
+   |
+LL |     assert_eq!(bar!(true), foo());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:37:5
+   |
+LL |     assert_ne!(bar!(true, true), bar!(true));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:43:5
+   |
+LL |     assert!(foo(),);
+   |     ^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:45:5
+   |
+LL |     assert_eq!(foo(), foo(),);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:47:5
+   |
+LL |     assert_ne!(foo(), foo(),);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:49:5
+   |
+LL |     debug_assert!(foo(),);
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:51:5
+   |
+LL |     debug_assert_eq!(foo(), foo(),);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: assert without any message
+  --> tests/ui/missing_assert_message.rs:53:5
+   |
+LL |     debug_assert_ne!(foo(), foo(),);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why the failing assert is problematic
+
+error: aborting due to 16 previous errors
+

--- a/tests/ui/missing_assert_message.rs
+++ b/tests/ui/missing_assert_message.rs
@@ -1,4 +1,7 @@
-#![allow(unused)]
+//@revisions: edition2015 edition2021
+//@[edition2015] edition:2015
+//@[edition2021] edition:2021
+
 #![warn(clippy::missing_assert_message)]
 
 macro_rules! bar {


### PR DESCRIPTION
changelog: fix FP: [`assertions_on_result_states`], [`missing_assert_message`] on edition 2015 and 2018

Fixes https://github.com/rust-lang/rust-clippy/issues/13490