### PR TITLE
Fix grammar in doc comments in `conf.rs`

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -246,7 +246,7 @@ A list of crate names to allow duplicates of
 
 ## `allowed-idents-below-min-chars`
 Allowed names below the minimum allowed characters. The value `".."` can be used as part of
-the list to indicate, that the configured values should be appended to the default
+the list to indicate that the configured values should be appended to the default
 configuration of Clippy. By default, any configuration will replace the default value.
 
 **Default Value:** `["i", "j", "x", "y", "z", "w", "n"]`
@@ -570,7 +570,7 @@ The list of disallowed types, written as fully qualified paths.
 
 ## `doc-valid-idents`
 The list of words this lint should not consider as identifiers needing ticks. The value
-`".."` can be used as part of the list to indicate, that the configured values should be appended to the
+`".."` can be used as part of the list to indicate that the configured values should be appended to the
 default configuration of Clippy. By default, any configuration will replace the default value. For example:
 * `doc-valid-idents = ["ClipPy"]` would replace the default list with `["ClipPy"]`.
 * `doc-valid-idents = ["ClipPy", ".."]` would append `ClipPy` to the default list.

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -423,7 +423,7 @@ define_Conf! {
     #[lints(multiple_crate_versions)]
     allowed_duplicate_crates: Vec<String> = Vec::new(),
     /// Allowed names below the minimum allowed characters. The value `".."` can be used as part of
-    /// the list to indicate, that the configured values should be appended to the default
+    /// the list to indicate that the configured values should be appended to the default
     /// configuration of Clippy. By default, any configuration will replace the default value.
     #[lints(min_ident_chars)]
     allowed_idents_below_min_chars: Vec<String> =
@@ -620,7 +620,7 @@ define_Conf! {
     #[lints(disallowed_types)]
     disallowed_types: Vec<DisallowedPath> = Vec::new(),
     /// The list of words this lint should not consider as identifiers needing ticks. The value
-    /// `".."` can be used as part of the list to indicate, that the configured values should be appended to the
+    /// `".."` can be used as part of the list to indicate that the configured values should be appended to the
     /// default configuration of Clippy. By default, any configuration will replace the default value. For example:
     /// * `doc-valid-idents = ["ClipPy"]` would replace the default list with `["ClipPy"]`.
     /// * `doc-valid-idents = ["ClipPy", ".."]` would append `ClipPy` to the default list.


### PR DESCRIPTION
Fix incorrect "to indicate, that" -> "to indicate that" in doc comments for `allowed_idents_below_min_chars` and `doc_valid_idents` configuration options.

changelog: none