### PR TITLE
Preserve parentheses in suggestion in presence of cascaded casts

### DIFF
--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -1,11 +1,12 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::numeric_literal::NumericLiteral;
 use clippy_utils::res::MaybeResPath as _;
-use clippy_utils::source::{SpanRangeExt, snippet_with_applicability};
+use clippy_utils::source::{SpanRangeExt, snippet, snippet_with_applicability};
+use clippy_utils::sugg::has_enclosing_paren;
 use clippy_utils::visitors::{Visitable, for_each_expr_without_closures};
 use clippy_utils::{get_parent_expr, is_hir_ty_cfg_dependant, is_ty_alias, sym};
 use rustc_ast::{LitFloatType, LitIntType, LitKind};
-use rustc_errors::{Applicability, DiagMessage};
+use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Expr, ExprKind, FnRetTy, Lit, Node, Path, QPath, TyKind, UnOp};
 use rustc_lint::{LateContext, LintContext};
@@ -48,6 +49,14 @@ pub(super) fn check<'tcx>(
             _ => {},
         }
 
+        // Preserve parentheses around `expr` in case of cascaded casts
+        let surrounding =
+            if matches!(cast_expr.kind, ExprKind::Cast(..)) && has_enclosing_paren(snippet(cx, expr.span, "")) {
+                MaybeParenOrBlock::Paren
+            } else {
+                MaybeParenOrBlock::Nothing
+            };
+
         emit_lint(
             cx,
             expr,
@@ -55,7 +64,7 @@ pub(super) fn check<'tcx>(
                 "casting raw pointers to the same type and constness is unnecessary (`{cast_from}` -> `{cast_to}`)"
             ),
             &cast_str,
-            MaybeParenOrBlock::Nothing,
+            surrounding,
             app.max(Applicability::MaybeIncorrect),
         );
     }
@@ -312,7 +321,7 @@ enum MaybeParenOrBlock {
 fn emit_lint(
     cx: &LateContext<'_>,
     expr: &Expr<'_>,
-    msg: impl Into<DiagMessage>,
+    msg: String,
     sugg: &str,
     surrounding: MaybeParenOrBlock,
     applicability: Applicability,

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -285,3 +285,11 @@ mod fixable {
         //~^ unnecessary_cast
     }
 }
+
+fn issue16475() -> *const u8 {
+    static NONE: Option<((), &'static u8)> = None;
+    unsafe {
+        *(&NONE as *const _ as *const _ as *const *const u8)
+        //~^ unnecessary_cast
+    }
+}

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -285,3 +285,11 @@ mod fixable {
         //~^ unnecessary_cast
     }
 }
+
+fn issue16475() -> *const u8 {
+    static NONE: Option<((), &'static u8)> = None;
+    unsafe {
+        *(&NONE as *const _ as *const _ as *const *const u8 as *const *const u8)
+        //~^ unnecessary_cast
+    }
+}

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -277,5 +277,11 @@ error: casting to the same type is unnecessary (`i64` -> `i64`)
 LL |         let _ = 5i32 as i64 as i64;
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `5i32 as i64`
 
-error: aborting due to 46 previous errors
+error: casting raw pointers to the same type and constness is unnecessary (`*const *const u8` -> `*const *const u8`)
+  --> tests/ui/unnecessary_cast.rs:292:10
+   |
+LL |         *(&NONE as *const _ as *const _ as *const *const u8 as *const *const u8)
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&NONE as *const _ as *const _ as *const *const u8)`
+
+error: aborting due to 47 previous errors
 


### PR DESCRIPTION
changelog: [`unnecessary_cast`]: preserve parentheses in presence of cascaded casts

Fixes rust-lang/rust-clippy#16475
