### PR TITLE
`doc_paragraphs_missing_punctuation`: allow some non-punctuated paragraphs

### DIFF
--- a/tests/ui/doc/doc_paragraphs_missing_punctuation.fixed
+++ b/tests/ui/doc/doc_paragraphs_missing_punctuation.fixed
@@ -46,13 +46,6 @@ enum Exceptions {
     /// | -------------- | ----- |
     /// | Markdown table | A-ok  |
     MarkdownTable,
-    /// Here is a snippet.
-    //~^ doc_paragraphs_missing_punctuation
-    ///
-    /// ```
-    /// // Code blocks are no issues.
-    /// ```
-    CodeBlock,
 }
 
 // Check the lint can be expected on a whole enum at once.
@@ -128,6 +121,24 @@ enum OrderedLists {
     Dot,
     /// 42) A list item
     Paren,
+}
+
+/// Some elements do not have to be introduced by an independent clause.
+enum NotIndependentClause {
+    /// Lists are allowed to be introduced by a clause that is not independent: this usually
+    /// requires that
+    ///
+    /// - items end with a comma or a semicolon, which is not enforced;
+    /// - the last item end with a period, which is also not enforced.
+    List,
+    /// For instance, the function
+    ///
+    /// ```
+    /// fn answer() {}
+    /// ```
+    ///
+    /// returns the Answer to the Ultimate Question of Life, the Universe, and Everything.
+    CodeBlock,
 }
 
 /// Doc comments with trailing blank lines are supported.

--- a/tests/ui/doc/doc_paragraphs_missing_punctuation.rs
+++ b/tests/ui/doc/doc_paragraphs_missing_punctuation.rs
@@ -46,13 +46,6 @@ enum Exceptions {
     /// | -------------- | ----- |
     /// | Markdown table | A-ok  |
     MarkdownTable,
-    /// Here is a snippet
-    //~^ doc_paragraphs_missing_punctuation
-    ///
-    /// ```
-    /// // Code blocks are no issues.
-    /// ```
-    CodeBlock,
 }
 
 // Check the lint can be expected on a whole enum at once.
@@ -128,6 +121,24 @@ enum OrderedLists {
     Dot,
     /// 42) A list item
     Paren,
+}
+
+/// Some elements do not have to be introduced by an independent clause.
+enum NotIndependentClause {
+    /// Lists are allowed to be introduced by a clause that is not independent: this usually
+    /// requires that
+    ///
+    /// - items end with a comma or a semicolon, which is not enforced;
+    /// - the last item end with a period, which is also not enforced.
+    List,
+    /// For instance, the function
+    ///
+    /// ```
+    /// fn answer() {}
+    /// ```
+    ///
+    /// returns the Answer to the Ultimate Question of Life, the Universe, and Everything.
+    CodeBlock,
 }
 
 /// Doc comments with trailing blank lines are supported

--- a/tests/ui/doc/doc_paragraphs_missing_punctuation.stderr
+++ b/tests/ui/doc/doc_paragraphs_missing_punctuation.stderr
@@ -32,82 +32,76 @@ LL |     /// <https://spec.commonmark.org/0.31.2/#autolinks>
    |                                                        ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:49:26
-   |
-LL |     /// Here is a snippet
-   |                          ^ help: end the paragraph with some punctuation: `.`
-
-error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:72:15
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:65:15
    |
 LL |     /// U+0001
    |               ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:79:29
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:72:29
    |
 LL |     //! inner attributes too
    |                             ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:90:47
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:83:47
    |
 LL |     /// **But sometimes it is missing a period**
    |                                               ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:95:46
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:88:46
    |
 LL |     /// _But sometimes it is missing a period_
    |                                              ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:104:56
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:97:56
    |
 LL | /// Doc comments can end with an [inline link](#anchor)
    |                                                        ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:108:65
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:101:65
    |
 LL | /// Some doc comments contain [link reference definitions][spec]
    |                                                                 ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:133:57
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:144:57
    |
 LL | /// Doc comments with trailing blank lines are supported
    |                                                         ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:139:48
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:150:48
    |
 LL | /// This first paragraph is missing punctuation
    |                                                ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:143:34
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:154:34
    |
 LL | /// And it has multiple sentences
    |                                  ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:146:37
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:157:37
    |
 LL | /// Same for this third and last one
    |                                     ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:153:33
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:164:33
    |
 LL | /// This ends with a code `span`
    |                                 ^ help: end the paragraph with some punctuation: `.`
 
 error: doc paragraphs should end with a terminal punctuation mark
-  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:162:27
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation.rs:173:27
    |
 LL |  * Block doc comments work
    |                           ^ help: end the paragraph with some punctuation: `.`
 
-error: aborting due to 18 previous errors
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
This fixes an FP in `doc_paragraphs_missing_punctuation` which prevented having lists (and code blocks) as parts of sentences. Even though it was often possible to rephrase to make the lint happy, it likely makes the lint more acceptable if we just allow these (at the risk of some false negatives).

This fix might be a bit ad hoc, but it should make the exception pretty explicit and easy to follow.

- Fixes rust-lang/rust-clippy#16370

changelog: [`doc_paragraphs_missing_punctuation`]: allow unpunctuated paragraphs before lists and code blocks

---

Feel free to push to this branch as needed.