### PR TITLE
Fix `unwrap_used` and `expect_used` FN when using fully qualified syntax

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4965,6 +4965,16 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
                 io_other_error::check(cx, expr, func, args, self.msrv);
                 swap_with_temporary::check(cx, expr, func, args);
                 ip_constant::check(cx, expr, func, args);
+                unwrap_expect_used::check_call(
+                    cx,
+                    expr,
+                    func,
+                    args,
+                    self.allow_unwrap_in_tests,
+                    self.allow_expect_in_tests,
+                    self.allow_unwrap_in_consts,
+                    self.allow_expect_in_consts,
+                );
             },
             ExprKind::MethodCall(..) => {
                 self.check_methods(cx, expr);

--- a/tests/ui/unwrap_expect_used.rs
+++ b/tests/ui/unwrap_expect_used.rs
@@ -83,3 +83,15 @@ mod with_expansion {
         let _ = open!(file).expect_err("can open"); //~ expect_used
     }
 }
+
+fn issue16484() {
+    let opt = Some(());
+    Option::unwrap(opt); //~ unwrap_used
+    Option::expect(opt, "error message"); //~ expect_used
+
+    let res: Result<(), i32> = Ok(());
+    Result::unwrap(res); //~ unwrap_used
+    Result::expect(res, "error message"); //~ expect_used
+    Result::unwrap_err(res); //~ unwrap_used
+    Result::expect_err(res, "error message"); //~ expect_used
+}

--- a/tests/ui/unwrap_expect_used.stderr
+++ b/tests/ui/unwrap_expect_used.stderr
@@ -82,5 +82,53 @@ LL |         let _ = open!(file).expect_err("can open");
    |
    = note: if this value is an `Ok`, it will panic
 
-error: aborting due to 10 previous errors
+error: used `unwrap()` on an `Option` value
+  --> tests/ui/unwrap_expect_used.rs:89:5
+   |
+LL |     Option::unwrap(opt);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+
+error: used `expect()` on an `Option` value
+  --> tests/ui/unwrap_expect_used.rs:90:5
+   |
+LL |     Option::expect(opt, "error message");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+
+error: used `unwrap()` on a `Result` value
+  --> tests/ui/unwrap_expect_used.rs:93:5
+   |
+LL |     Result::unwrap(res);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Err`, it will panic
+
+error: used `expect()` on a `Result` value
+  --> tests/ui/unwrap_expect_used.rs:94:5
+   |
+LL |     Result::expect(res, "error message");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Err`, it will panic
+
+error: used `unwrap_err()` on a `Result` value
+  --> tests/ui/unwrap_expect_used.rs:95:5
+   |
+LL |     Result::unwrap_err(res);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Ok`, it will panic
+
+error: used `expect_err()` on a `Result` value
+  --> tests/ui/unwrap_expect_used.rs:96:5
+   |
+LL |     Result::expect_err(res, "error message");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Ok`, it will panic
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16484 

changelog: [`unwrap_used`] fix FN when using fully qualified syntax
changelog: [`expect_used`] fix FN when using fully qualified syntax
