### PR TITLE
Trigger `integer_division_remainder_used` on `DivAssign`/`RemAssign`

### DIFF
--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -1096,6 +1096,7 @@ impl<'tcx> LateLintPass<'tcx> for Operators {
                 self.arithmetic_context.check_binary(cx, e, bin_op, lhs, rhs);
                 misrefactored_assign_op::check(cx, e, bin_op, lhs, rhs);
                 modulo_arithmetic::check(cx, e, bin_op, lhs, rhs, false);
+                integer_division_remainder_used::check(cx, bin_op, lhs, rhs, e.span);
             },
             ExprKind::Assign(lhs, rhs, _) => {
                 assign_op_pattern::check(cx, e, lhs, rhs, self.msrv);

--- a/tests/ui/integer_division_remainder_used.rs
+++ b/tests/ui/integer_division_remainder_used.rs
@@ -38,6 +38,13 @@ fn main() {
     let i = a / &4;
     //~^ integer_division_remainder_used
 
+    // should trigger on DivAssign and RemAssign
+    let mut j = 10;
+    j /= 2;
+    //~^ integer_division_remainder_used
+    j %= 3;
+    //~^ integer_division_remainder_used
+
     // should not trigger on custom Div and Rem
     let w = CustomOps(3);
     let x = CustomOps(4);

--- a/tests/ui/integer_division_remainder_used.stderr
+++ b/tests/ui/integer_division_remainder_used.stderr
@@ -55,5 +55,17 @@ error: use of `/` has been disallowed in this context
 LL |     let i = a / &4;
    |             ^^^^^^
 
-error: aborting due to 9 previous errors
+error: use of `/` has been disallowed in this context
+  --> tests/ui/integer_division_remainder_used.rs:43:5
+   |
+LL |     j /= 2;
+   |     ^^^^^^
+
+error: use of `%` has been disallowed in this context
+  --> tests/ui/integer_division_remainder_used.rs:45:5
+   |
+LL |     j %= 3;
+   |     ^^^^^^
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16490

----

changelog: [`integer_division_remainder_used`]: also triggers on `DivAssign`/`RemAssign`