### PR TITLE
Add `cast_lossless` lints for `char` to uint, small int to `usize`/`isize`, and float casts

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -347,7 +347,7 @@ impl SuggestContext<'_, '_, '_> {
                     self.output.push(')');
                 },
                 Term(n) => {
-                    let terminal = self.terminals[n as usize];
+                    let terminal = self.terminals[usize::from(n)];
                     if let Some(str) = simplify_not(self.cx, self.msrv, terminal) {
                         self.output.push_str(&str);
                     } else {
@@ -389,7 +389,7 @@ impl SuggestContext<'_, '_, '_> {
             },
             &Term(n) => {
                 self.output.push_str(
-                    &self.terminals[n as usize]
+                    &self.terminals[usize::from(n)]
                         .span
                         .source_callsite()
                         .get_source_text(self.cx)?,
@@ -527,7 +527,7 @@ fn terminal_stats(b: &Bool) -> Stats {
                     recurse(inner, stats);
                 }
             },
-            &Term(n) => stats.terminals[n as usize] += 1,
+            &Term(n) => stats.terminals[usize::from(n)] += 1,
         }
     }
     use quine_mc_cluskey::Bool::{And, False, Not, Or, Term, True};

--- a/clippy_lints/src/casts/cast_lossless.rs
+++ b/clippy_lints/src/casts/cast_lossless.rs
@@ -1,13 +1,12 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_in_const_context;
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::source::SpanRangeExt;
+use clippy_utils::source::{SpanRangeExt, walk_span_to_context};
 use clippy_utils::sugg::Sugg;
-use clippy_utils::ty::is_isize_or_usize;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, QPath, TyKind};
 use rustc_lint::LateContext;
-use rustc_middle::ty::{self, FloatTy, Ty};
+use rustc_middle::ty::{self, FloatTy, IntTy, Ty, UintTy};
 use rustc_span::hygiene;
 
 use super::{CAST_LOSSLESS, utils};
@@ -28,6 +27,10 @@ pub(super) fn check(
     // If the `as` is from a macro and the casting type is from macro input, whether it is lossless is
     // dependent on the input
     if expr.span.from_expansion() && !cast_to_hir.span.eq_ctxt(expr.span) {
+        return;
+    }
+
+    if walk_span_to_context(cast_from_expr.span, expr.span.ctxt()).is_none() {
         return;
     }
 
@@ -82,28 +85,26 @@ fn should_lint(cx: &LateContext<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>, msrv: M
         return false;
     }
 
-    match (
-        utils::int_ty_to_nbits(cx.tcx, cast_from),
-        utils::int_ty_to_nbits(cx.tcx, cast_to),
-    ) {
-        (Some(from_nbits), Some(to_nbits)) => {
-            let cast_signed_to_unsigned = cast_from.is_signed() && !cast_to.is_signed();
-            !is_isize_or_usize(cast_from)
-                && !is_isize_or_usize(cast_to)
-                && from_nbits < to_nbits
-                && !cast_signed_to_unsigned
+    match (cast_from.kind(), cast_to.kind()) {
+        (ty::Bool, ty::Uint(_) | ty::Int(_)) => msrv.meets(cx, msrvs::FROM_BOOL),
+        (ty::Uint(_), ty::Uint(UintTy::Usize)) | (ty::Uint(UintTy::U8) | ty::Int(_), ty::Int(IntTy::Isize)) => {
+            matches!(utils::int_ty_to_nbits(cx.tcx, cast_from), Some(n) if n <= 16)
         },
-
-        (Some(from_nbits), None) => {
-            // FIXME: handle `f16` and `f128`
-            let to_nbits = if let ty::Float(FloatTy::F32) = cast_to.kind() {
-                32
-            } else {
-                64
-            };
-            !is_isize_or_usize(cast_from) && from_nbits < to_nbits
+        // No `f16` to `f32`: https://github.com/rust-lang/rust/issues/123831
+        (ty::Float(FloatTy::F16), ty::Float(FloatTy::F32)) | (ty::Uint(UintTy::Usize) | ty::Int(IntTy::Isize), _) | (_, ty::Uint(UintTy::Usize) | ty::Int(IntTy::Isize)) => {
+            false
         },
-        (None, Some(_)) if cast_from.is_bool() && msrv.meets(cx, msrvs::FROM_BOOL) => true,
-        _ => matches!(cast_from.kind(), ty::Float(FloatTy::F32)) && matches!(cast_to.kind(), ty::Float(FloatTy::F64)),
+        (ty::Uint(_) | ty::Int(_), ty::Int(_)) | (ty::Uint(_), ty::Uint(_)) => {
+            matches!(
+                (utils::int_ty_to_nbits(cx.tcx, cast_from), utils::int_ty_to_nbits(cx.tcx, cast_to)),
+                (Some(from_bits), Some(to_bits)) if from_bits < to_bits
+            )
+        },
+        (ty::Uint(_) | ty::Int(_), ty::Float(fl)) => {
+            matches!(utils::int_ty_to_nbits(cx.tcx, cast_from), Some(from_bits) if from_bits < fl.bit_width())
+        },
+        (ty::Char, ty::Uint(_)) => matches!(utils::int_ty_to_nbits(cx.tcx, cast_to), Some(to_bits) if to_bits >= 32),
+        (ty::Float(fl_from), ty::Float(fl_to)) => fl_from.bit_width() < fl_to.bit_width(),
+        _ => false,
     }
 }

--- a/clippy_lints/src/casts/cast_lossless.rs
+++ b/clippy_lints/src/casts/cast_lossless.rs
@@ -91,9 +91,9 @@ fn should_lint(cx: &LateContext<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>, msrv: M
             matches!(utils::int_ty_to_nbits(cx.tcx, cast_from), Some(n) if n <= 16)
         },
         // No `f16` to `f32`: https://github.com/rust-lang/rust/issues/123831
-        (ty::Float(FloatTy::F16), ty::Float(FloatTy::F32)) | (ty::Uint(UintTy::Usize) | ty::Int(IntTy::Isize), _) | (_, ty::Uint(UintTy::Usize) | ty::Int(IntTy::Isize)) => {
-            false
-        },
+        (ty::Float(FloatTy::F16), ty::Float(FloatTy::F32))
+        | (ty::Uint(UintTy::Usize) | ty::Int(IntTy::Isize), _)
+        | (_, ty::Uint(UintTy::Usize) | ty::Int(IntTy::Isize)) => false,
         (ty::Uint(_) | ty::Int(_), ty::Int(_)) | (ty::Uint(_), ty::Uint(_)) => {
             matches!(
                 (utils::int_ty_to_nbits(cx.tcx, cast_from), utils::int_ty_to_nbits(cx.tcx, cast_to)),

--- a/clippy_lints/src/literal_string_with_formatting_args.rs
+++ b/clippy_lints/src/literal_string_with_formatting_args.rs
@@ -89,7 +89,7 @@ impl<'tcx> LateLintPass<'tcx> for LiteralStringWithFormattingArg {
                 LitKind::Str(symbol, style) => {
                     let add = match style {
                         StrStyle::Cooked => 1,
-                        StrStyle::Raw(nb) =>  usize::from(nb) + 2,
+                        StrStyle::Raw(nb) => usize::from(nb) + 2,
                     };
                     (add, symbol)
                 },

--- a/clippy_lints/src/literal_string_with_formatting_args.rs
+++ b/clippy_lints/src/literal_string_with_formatting_args.rs
@@ -89,7 +89,7 @@ impl<'tcx> LateLintPass<'tcx> for LiteralStringWithFormattingArg {
                 LitKind::Str(symbol, style) => {
                     let add = match style {
                         StrStyle::Cooked => 1,
-                        StrStyle::Raw(nb) => nb as usize + 2,
+                        StrStyle::Raw(nb) =>  usize::from(nb) + 2,
                     };
                     (add, symbol)
                 },

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -191,7 +191,7 @@ fn lint_syntax_error(cx: &LateContext<'_>, error: &regex_syntax::Error, unescape
 
     if let Some((primary, auxiliary, kind)) = parts
         && let Some(literal_snippet) = base.get_source_text(cx)
-        && let Some(inner) = literal_snippet.get(offset as usize..)
+        && let Some(inner) = literal_snippet.get(usize::from(offset)..)
         // Only convert to native rustc spans if the parsed regex matches the
         // source snippet exactly, to ensure the span offsets are correct
         && inner.get(..unescaped.len()) == Some(unescaped)

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -87,7 +87,7 @@ impl LateLintPass<'_> for Unicode {
 fn escape<T: Iterator<Item = char>>(s: T) -> String {
     let mut result = String::new();
     for c in s {
-        if c as u32 > 0x7F {
+        if u32::from(c) > 0x7F {
             for d in c.escape_unicode() {
                 result.push(d);
             }
@@ -119,7 +119,7 @@ fn check_str(cx: &LateContext<'_>, span: Span, id: HirId) {
         });
     }
 
-    if string.chars().any(|c| c as u32 > 0x7F) {
+    if string.chars().any(|c| u32::from(c) > 0x7F) {
         #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
         span_lint_and_then(
             cx,

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -779,7 +779,7 @@ pub fn str_literal_to_char_literal(
     {
         let snip = snippet_with_applicability(sess, expr.span, string, applicability);
         let ch = if let StrStyle::Raw(nhash) = style {
-            let nhash =  usize::from(nhash);
+            let nhash = usize::from(nhash);
             // for raw string: r##"a"##
             &snip[(nhash + 2)..(snip.len() - 1 - nhash)]
         } else {

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -779,7 +779,7 @@ pub fn str_literal_to_char_literal(
     {
         let snip = snippet_with_applicability(sess, expr.span, string, applicability);
         let ch = if let StrStyle::Raw(nhash) = style {
-            let nhash = nhash as usize;
+            let nhash =  usize::from(nhash);
             // for raw string: r##"a"##
             &snip[(nhash + 2)..(snip.len() - 1 - nhash)]
         } else {

--- a/tests/ui/cast_lossless_char.fixed
+++ b/tests/ui/cast_lossless_char.fixed
@@ -1,31 +1,30 @@
 #![allow(clippy::char_lit_as_u8)]
 #![warn(clippy::cast_lossless)]
 
-
 type I32 = i32;
 type U32 = u32;
 
 fn main() {
-  let _ = u32::from('|');
-  //~^ cast_lossless
-  let _ = '|' as i32;
-  
-  let _ = u64::from('|');
-  //~^ cast_lossless
-  let _ = '|' as i64;
+    let _ = u32::from('|');
+    //~^ cast_lossless
+    let _ = '|' as i32;
 
-  let _ = u128::from('|');
-  //~^ cast_lossless
-  let _ = '|' as i128;
-  
-  let _ = U32::from('|');
-  //~^ cast_lossless
-  let _ = '|' as I32;
+    let _ = u64::from('|');
+    //~^ cast_lossless
+    let _ = '|' as i64;
 
-  let _ = '|' as usize;
-  let _ = '|' as isize;
-  let _ = '|' as i8;
-  let _ = '|' as u8;
-  let _ = '|' as i16;
-  let _ = '|' as u16;
+    let _ = u128::from('|');
+    //~^ cast_lossless
+    let _ = '|' as i128;
+
+    let _ = U32::from('|');
+    //~^ cast_lossless
+    let _ = '|' as I32;
+
+    let _ = '|' as usize;
+    let _ = '|' as isize;
+    let _ = '|' as i8;
+    let _ = '|' as u8;
+    let _ = '|' as i16;
+    let _ = '|' as u16;
 }

--- a/tests/ui/cast_lossless_char.fixed
+++ b/tests/ui/cast_lossless_char.fixed
@@ -1,0 +1,31 @@
+#![allow(clippy::char_lit_as_u8)]
+#![warn(clippy::cast_lossless)]
+
+
+type I32 = i32;
+type U32 = u32;
+
+fn main() {
+  let _ = u32::from('|');
+  //~^ cast_lossless
+  let _ = '|' as i32;
+  
+  let _ = u64::from('|');
+  //~^ cast_lossless
+  let _ = '|' as i64;
+
+  let _ = u128::from('|');
+  //~^ cast_lossless
+  let _ = '|' as i128;
+  
+  let _ = U32::from('|');
+  //~^ cast_lossless
+  let _ = '|' as I32;
+
+  let _ = '|' as usize;
+  let _ = '|' as isize;
+  let _ = '|' as i8;
+  let _ = '|' as u8;
+  let _ = '|' as i16;
+  let _ = '|' as u16;
+}

--- a/tests/ui/cast_lossless_char.rs
+++ b/tests/ui/cast_lossless_char.rs
@@ -1,0 +1,31 @@
+#![allow(clippy::char_lit_as_u8)]
+#![warn(clippy::cast_lossless)]
+
+
+type I32 = i32;
+type U32 = u32;
+
+fn main() {
+  let _ = '|' as u32;
+  //~^ cast_lossless
+  let _ = '|' as i32;
+  
+  let _ = '|' as u64;
+  //~^ cast_lossless
+  let _ = '|' as i64;
+
+  let _ = '|' as u128;
+  //~^ cast_lossless
+  let _ = '|' as i128;
+  
+  let _ = '|' as U32;
+  //~^ cast_lossless
+  let _ = '|' as I32;
+
+  let _ = '|' as usize;
+  let _ = '|' as isize;
+  let _ = '|' as i8;
+  let _ = '|' as u8;
+  let _ = '|' as i16;
+  let _ = '|' as u16;
+}

--- a/tests/ui/cast_lossless_char.rs
+++ b/tests/ui/cast_lossless_char.rs
@@ -1,31 +1,30 @@
 #![allow(clippy::char_lit_as_u8)]
 #![warn(clippy::cast_lossless)]
 
-
 type I32 = i32;
 type U32 = u32;
 
 fn main() {
-  let _ = '|' as u32;
-  //~^ cast_lossless
-  let _ = '|' as i32;
-  
-  let _ = '|' as u64;
-  //~^ cast_lossless
-  let _ = '|' as i64;
+    let _ = '|' as u32;
+    //~^ cast_lossless
+    let _ = '|' as i32;
 
-  let _ = '|' as u128;
-  //~^ cast_lossless
-  let _ = '|' as i128;
-  
-  let _ = '|' as U32;
-  //~^ cast_lossless
-  let _ = '|' as I32;
+    let _ = '|' as u64;
+    //~^ cast_lossless
+    let _ = '|' as i64;
 
-  let _ = '|' as usize;
-  let _ = '|' as isize;
-  let _ = '|' as i8;
-  let _ = '|' as u8;
-  let _ = '|' as i16;
-  let _ = '|' as u16;
+    let _ = '|' as u128;
+    //~^ cast_lossless
+    let _ = '|' as i128;
+
+    let _ = '|' as U32;
+    //~^ cast_lossless
+    let _ = '|' as I32;
+
+    let _ = '|' as usize;
+    let _ = '|' as isize;
+    let _ = '|' as i8;
+    let _ = '|' as u8;
+    let _ = '|' as i16;
+    let _ = '|' as u16;
 }

--- a/tests/ui/cast_lossless_char.stderr
+++ b/tests/ui/cast_lossless_char.stderr
@@ -1,0 +1,56 @@
+error: casts from `char` to `u32` can be expressed infallibly using `From`
+  --> tests/ui/cast_lossless_char.rs:9:11
+   |
+LL |   let _ = '|' as u32;
+   |           ^^^^^^^^^^
+   |
+   = help: an `as` cast can become silently lossy if the types change in the future
+   = note: `-D clippy::cast-lossless` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::cast_lossless)]`
+help: use `u32::from` instead
+   |
+LL -   let _ = '|' as u32;
+LL +   let _ = u32::from('|');
+   |
+
+error: casts from `char` to `u64` can be expressed infallibly using `From`
+  --> tests/ui/cast_lossless_char.rs:13:11
+   |
+LL |   let _ = '|' as u64;
+   |           ^^^^^^^^^^
+   |
+   = help: an `as` cast can become silently lossy if the types change in the future
+help: use `u64::from` instead
+   |
+LL -   let _ = '|' as u64;
+LL +   let _ = u64::from('|');
+   |
+
+error: casts from `char` to `u128` can be expressed infallibly using `From`
+  --> tests/ui/cast_lossless_char.rs:17:11
+   |
+LL |   let _ = '|' as u128;
+   |           ^^^^^^^^^^^
+   |
+   = help: an `as` cast can become silently lossy if the types change in the future
+help: use `u128::from` instead
+   |
+LL -   let _ = '|' as u128;
+LL +   let _ = u128::from('|');
+   |
+
+error: casts from `char` to `u32` can be expressed infallibly using `From`
+  --> tests/ui/cast_lossless_char.rs:21:11
+   |
+LL |   let _ = '|' as U32;
+   |           ^^^^^^^^^^
+   |
+   = help: an `as` cast can become silently lossy if the types change in the future
+help: use `U32::from` instead
+   |
+LL -   let _ = '|' as U32;
+LL +   let _ = U32::from('|');
+   |
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/cast_lossless_char.stderr
+++ b/tests/ui/cast_lossless_char.stderr
@@ -1,55 +1,55 @@
 error: casts from `char` to `u32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_char.rs:9:11
+  --> tests/ui/cast_lossless_char.rs:8:13
    |
-LL |   let _ = '|' as u32;
-   |           ^^^^^^^^^^
+LL |     let _ = '|' as u32;
+   |             ^^^^^^^^^^
    |
    = help: an `as` cast can become silently lossy if the types change in the future
    = note: `-D clippy::cast-lossless` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::cast_lossless)]`
 help: use `u32::from` instead
    |
-LL -   let _ = '|' as u32;
-LL +   let _ = u32::from('|');
+LL -     let _ = '|' as u32;
+LL +     let _ = u32::from('|');
    |
 
 error: casts from `char` to `u64` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_char.rs:13:11
+  --> tests/ui/cast_lossless_char.rs:12:13
    |
-LL |   let _ = '|' as u64;
-   |           ^^^^^^^^^^
+LL |     let _ = '|' as u64;
+   |             ^^^^^^^^^^
    |
    = help: an `as` cast can become silently lossy if the types change in the future
 help: use `u64::from` instead
    |
-LL -   let _ = '|' as u64;
-LL +   let _ = u64::from('|');
+LL -     let _ = '|' as u64;
+LL +     let _ = u64::from('|');
    |
 
 error: casts from `char` to `u128` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_char.rs:17:11
+  --> tests/ui/cast_lossless_char.rs:16:13
    |
-LL |   let _ = '|' as u128;
-   |           ^^^^^^^^^^^
+LL |     let _ = '|' as u128;
+   |             ^^^^^^^^^^^
    |
    = help: an `as` cast can become silently lossy if the types change in the future
 help: use `u128::from` instead
    |
-LL -   let _ = '|' as u128;
-LL +   let _ = u128::from('|');
+LL -     let _ = '|' as u128;
+LL +     let _ = u128::from('|');
    |
 
 error: casts from `char` to `u32` can be expressed infallibly using `From`
-  --> tests/ui/cast_lossless_char.rs:21:11
+  --> tests/ui/cast_lossless_char.rs:20:13
    |
-LL |   let _ = '|' as U32;
-   |           ^^^^^^^^^^
+LL |     let _ = '|' as U32;
+   |             ^^^^^^^^^^
    |
    = help: an `as` cast can become silently lossy if the types change in the future
 help: use `U32::from` instead
    |
-LL -   let _ = '|' as U32;
-LL +   let _ = U32::from('|');
+LL -     let _ = '|' as U32;
+LL +     let _ = U32::from('|');
    |
 
 error: aborting due to 4 previous errors

--- a/tests/ui/cast_lossless_integer.fixed
+++ b/tests/ui/cast_lossless_integer.fixed
@@ -176,3 +176,29 @@ fn ty_from_macro() {
 }
 
 const IN_CONST: u64 = 0u8 as u64;
+
+#[allow(clippy::unnecessary_cast)]
+fn from_expr_macro() {
+    macro_rules! foo {
+        () => {
+            0u8
+        };
+    }
+    foo!() as u8;
+    u32::from(foo!());
+    //~^ cast_lossless
+}
+
+fn cast_using_macro() {
+    macro_rules! mac {
+        (to_i32 $x:expr) => { $x as u32 };
+        (zero_as $t:ty) => { 0u8 as $t };
+        ($x:expr => $t:ty) => { $x as $t };
+        ($x:expr, $k:ident, $t:ty) => { $x $k $t };
+    }
+    let _ = mac!(to_i32 0u16);
+    let _ = mac!(zero_as u32);
+    let _ = mac!(0u8 => u32);
+    let _ = mac!(0u8, as, u32);
+}
+

--- a/tests/ui/cast_lossless_integer.fixed
+++ b/tests/ui/cast_lossless_integer.fixed
@@ -201,4 +201,3 @@ fn cast_using_macro() {
     let _ = mac!(0u8 => u32);
     let _ = mac!(0u8, as, u32);
 }
-

--- a/tests/ui/cast_lossless_integer.rs
+++ b/tests/ui/cast_lossless_integer.rs
@@ -201,4 +201,3 @@ fn cast_using_macro() {
     let _ = mac!(0u8 => u32);
     let _ = mac!(0u8, as, u32);
 }
-

--- a/tests/ui/cast_lossless_integer.rs
+++ b/tests/ui/cast_lossless_integer.rs
@@ -176,3 +176,29 @@ fn ty_from_macro() {
 }
 
 const IN_CONST: u64 = 0u8 as u64;
+
+#[allow(clippy::unnecessary_cast)]
+fn from_expr_macro() {
+    macro_rules! foo {
+        () => {
+            0u8
+        };
+    }
+    foo!() as u8;
+    foo!() as u32;
+    //~^ cast_lossless
+}
+
+fn cast_using_macro() {
+    macro_rules! mac {
+        (to_i32 $x:expr) => { $x as u32 };
+        (zero_as $t:ty) => { 0u8 as $t };
+        ($x:expr => $t:ty) => { $x as $t };
+        ($x:expr, $k:ident, $t:ty) => { $x $k $t };
+    }
+    let _ = mac!(to_i32 0u16);
+    let _ = mac!(zero_as u32);
+    let _ = mac!(0u8 => u32);
+    let _ = mac!(0u8, as, u32);
+}
+

--- a/tests/ui/cast_lossless_integer.stderr
+++ b/tests/ui/cast_lossless_integer.stderr
@@ -524,5 +524,18 @@ LL -     let _ = 0u8 as ty!();
 LL +     let _ = <ty!()>::from(0u8);
    |
 
-error: aborting due to 40 previous errors
+error: casts from `u8` to `u32` can be expressed infallibly using `From`
+  --> tests/ui/cast_lossless_integer.rs:188:5
+   |
+LL |     foo!() as u32;
+   |     ^^^^^^^^^^^^^
+   |
+   = help: an `as` cast can become silently lossy if the types change in the future
+help: use `u32::from` instead
+   |
+LL -     foo!() as u32;
+LL +     u32::from(foo!());
+   |
+
+error: aborting due to 41 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#14469

changelog: [`cast_lossless`]: new lints on `char` to uint casts (u32/u64/u128), small ints (<=16 bits) to `usize`/`isize` and smaller floats to `f128`(if available). Also improves macro handling.