### PR TITLE
Add f16 and f128 test cases to manual_float_methods

### DIFF
--- a/tests/ui/manual_float_methods.rs
+++ b/tests/ui/manual_float_methods.rs
@@ -1,9 +1,11 @@
 //@no-rustfix: overlapping suggestions
 //@aux-build:proc_macros.rs
+#![feature(f16)]
+#![feature(f128)]
 #![allow(clippy::needless_ifs, unused)]
 #![warn(clippy::manual_is_infinite, clippy::manual_is_finite)]
 
-// FIXME(f16_f128): add tests for these types once constants are available
+// Tests for f16 and f128 types
 
 #[macro_use]
 extern crate proc_macros;
@@ -27,7 +29,19 @@ fn main() {
     //~^ manual_is_infinite
     if x != f64::INFINITY && x != f64::NEG_INFINITY {}
     //~^ manual_is_finite
-    // Don't lint
+
+    // f16 tests
+    let x = 1.0f16;
+    if x == f16::INFINITY || x == f16::NEG_INFINITY {}
+    if x != f16::INFINITY && x != f16::NEG_INFINITY {}
+
+    // f128 tests
+    let x = 1.0f128;
+    if x == f128::INFINITY || x == f128::NEG_INFINITY {}
+    if x != f128::INFINITY && x != f128::NEG_INFINITY {}
+
+    // Don't lint - f64 tests
+    let x = 1.0f64;
     if x.is_infinite() {}
     if x.is_finite() {}
     if x.abs() < f64::INFINITY {}
@@ -42,6 +56,14 @@ fn main() {
         let x = 1.0f64;
         if x == f64::INFINITY || x == f64::NEG_INFINITY {}
         //~^ manual_is_infinite
+    }
+    const {
+        let x = 1.0f16;
+        if x == f16::INFINITY || x == f16::NEG_INFINITY {}
+    }
+    const {
+        let x = 1.0f128;
+        if x == f128::INFINITY || x == f128::NEG_INFINITY {}
     }
     const X: f64 = 1.0f64;
     if const { X == f64::INFINITY || X == f64::NEG_INFINITY } {}
@@ -62,6 +84,22 @@ fn main() {
         let x = 1.0f32;
         const X: f32 = f32::INFINITY;
         const Y: f32 = f32::NEG_INFINITY;
+        if x == X || x == Y {}
+        if x != X && x != Y {}
+    }
+
+    {
+        let x = 1.0f16;
+        const X: f16 = f16::INFINITY;
+        const Y: f16 = f16::NEG_INFINITY;
+        if x == X || x == Y {}
+        if x != X && x != Y {}
+    }
+
+    {
+        let x = 1.0f128;
+        const X: f128 = f128::INFINITY;
+        const Y: f128 = f128::NEG_INFINITY;
         if x == X || x == Y {}
         if x != X && x != Y {}
     }

--- a/tests/ui/manual_float_methods.stderr
+++ b/tests/ui/manual_float_methods.stderr
@@ -1,5 +1,5 @@
 error: manually checking if a float is infinite
-  --> tests/ui/manual_float_methods.rs:21:8
+  --> tests/ui/manual_float_methods.rs:23:8
    |
 LL |     if x == f32::INFINITY || x == f32::NEG_INFINITY {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the dedicated method instead: `x.is_infinite()`
@@ -8,7 +8,7 @@ LL |     if x == f32::INFINITY || x == f32::NEG_INFINITY {}
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_infinite)]`
 
 error: manually checking if a float is finite
-  --> tests/ui/manual_float_methods.rs:23:8
+  --> tests/ui/manual_float_methods.rs:25:8
    |
 LL |     if x != f32::INFINITY && x != f32::NEG_INFINITY {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,13 +32,13 @@ LL +     if !x.is_infinite() {}
    |
 
 error: manually checking if a float is infinite
-  --> tests/ui/manual_float_methods.rs:26:8
+  --> tests/ui/manual_float_methods.rs:28:8
    |
 LL |     if x == f64::INFINITY || x == f64::NEG_INFINITY {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the dedicated method instead: `x.is_infinite()`
 
 error: manually checking if a float is finite
-  --> tests/ui/manual_float_methods.rs:28:8
+  --> tests/ui/manual_float_methods.rs:30:8
    |
 LL |     if x != f64::INFINITY && x != f64::NEG_INFINITY {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL +     if !x.is_infinite() {}
    |
 
 error: manually checking if a float is infinite
-  --> tests/ui/manual_float_methods.rs:43:12
+  --> tests/ui/manual_float_methods.rs:57:12
    |
 LL |         if x == f64::INFINITY || x == f64::NEG_INFINITY {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the dedicated method instead: `x.is_infinite()`


### PR DESCRIPTION
This PR adds test cases for f16 and f128 types to the `manual_float_methods` test suite. While the lint doesn't currently detect these patterns (which is expected since f16/f128 support may need to be implemented), these test cases serve as:

1. Documentation of the expected behavior
2. Preparation for future f16/f128 support
3. Regression prevention

The test cases include both `manual_is_infinite` and `manual_is_finite` patterns for both f16 and f128 types, with the necessary feature flags enabled.

changelog: none