### PR TITLE
fix: handle false negative for `str_to_string`

### DIFF
--- a/tests/ui/str_to_string.fixed
+++ b/tests/ui/str_to_string.fixed
@@ -22,3 +22,32 @@ fn issue16271(key: &[u8]) {
     let _value = t!(str::from_utf8(key)).to_owned();
     //~^ str_to_string
 }
+
+struct GenericWrapper<T>(T);
+
+impl<T> GenericWrapper<T> {
+    fn mapper<U, F: FnOnce(T) -> U>(self, f: F) -> U {
+        f(self.0)
+    }
+}
+
+fn issue16511(x: Option<&str>) {
+    let _ = x.map(ToOwned::to_owned);
+    //~^ str_to_string
+
+    let _ = x.map(ToOwned::to_owned);
+    //~^ str_to_string
+
+    let _ = ["a", "b"].iter().map(ToOwned::to_owned);
+    //~^ str_to_string
+
+    fn mapper<F: Fn(&str) -> String>(f: F) -> String {
+        f("hello")
+    }
+    let _ = mapper(ToOwned::to_owned);
+    //~^ str_to_string
+
+    let w = GenericWrapper("hello");
+    let _ = w.mapper(ToOwned::to_owned);
+    //~^ str_to_string
+}

--- a/tests/ui/str_to_string.rs
+++ b/tests/ui/str_to_string.rs
@@ -22,3 +22,32 @@ fn issue16271(key: &[u8]) {
     let _value = t!(str::from_utf8(key)).to_string();
     //~^ str_to_string
 }
+
+struct GenericWrapper<T>(T);
+
+impl<T> GenericWrapper<T> {
+    fn mapper<U, F: FnOnce(T) -> U>(self, f: F) -> U {
+        f(self.0)
+    }
+}
+
+fn issue16511(x: Option<&str>) {
+    let _ = x.map(ToString::to_string);
+    //~^ str_to_string
+
+    let _ = x.map(str::to_string);
+    //~^ str_to_string
+
+    let _ = ["a", "b"].iter().map(ToString::to_string);
+    //~^ str_to_string
+
+    fn mapper<F: Fn(&str) -> String>(f: F) -> String {
+        f("hello")
+    }
+    let _ = mapper(ToString::to_string);
+    //~^ str_to_string
+
+    let w = GenericWrapper("hello");
+    let _ = w.mapper(ToString::to_string);
+    //~^ str_to_string
+}

--- a/tests/ui/str_to_string.stderr
+++ b/tests/ui/str_to_string.stderr
@@ -19,5 +19,35 @@ error: `to_string()` called on a `&str`
 LL |     let _value = t!(str::from_utf8(key)).to_string();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t!(str::from_utf8(key)).to_owned()`
 
-error: aborting due to 3 previous errors
+error: `ToString::to_string` used as `&str` to `String` converter
+  --> tests/ui/str_to_string.rs:35:19
+   |
+LL |     let _ = x.map(ToString::to_string);
+   |                   ^^^^^^^^^^^^^^^^^^^ help: try: `ToOwned::to_owned`
+
+error: `ToString::to_string` used as `&str` to `String` converter
+  --> tests/ui/str_to_string.rs:38:19
+   |
+LL |     let _ = x.map(str::to_string);
+   |                   ^^^^^^^^^^^^^^ help: try: `ToOwned::to_owned`
+
+error: `ToString::to_string` used as `&str` to `String` converter
+  --> tests/ui/str_to_string.rs:41:35
+   |
+LL |     let _ = ["a", "b"].iter().map(ToString::to_string);
+   |                                   ^^^^^^^^^^^^^^^^^^^ help: try: `ToOwned::to_owned`
+
+error: `ToString::to_string` used as `&str` to `String` converter
+  --> tests/ui/str_to_string.rs:47:20
+   |
+LL |     let _ = mapper(ToString::to_string);
+   |                    ^^^^^^^^^^^^^^^^^^^ help: try: `ToOwned::to_owned`
+
+error: `ToString::to_string` used as `&str` to `String` converter
+  --> tests/ui/str_to_string.rs:51:22
+   |
+LL |     let _ = w.mapper(ToString::to_string);
+   |                      ^^^^^^^^^^^^^^^^^^^ help: try: `ToOwned::to_owned`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Replace `ToString::to_string` with `ToOwned::to_owned` when it is passed as a function parameter.

```rust
fn issue16511(x: Option<&str>) -> Option<String> {
    // Replace with ToOwned::to_owned
    x.map(ToString::to_string)
}
```

fixes rust-lang/rust-clippy#16511

---

changelog: [`str_to_string`]: handle a case when `ToString::to_string` is passed as function parameter