### PR TITLE
Trigger `single_element_loop` if the block contains only a final expression

### DIFF
--- a/clippy_lints/src/loops/single_element_loop.rs
+++ b/clippy_lints/src/loops/single_element_loop.rs
@@ -1,5 +1,5 @@
 use super::SINGLE_ELEMENT_LOOP;
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg};
 use clippy_utils::source::{indent_of, snippet, snippet_with_applicability};
 use clippy_utils::visitors::contains_break_or_continue;
 use rustc_ast::Mutability;
@@ -66,7 +66,7 @@ pub(super) fn check<'tcx>(
         _ => return,
     };
     if let ExprKind::Block(block, _) = body.kind
-        && !block.stmts.is_empty()
+        && (!block.stmts.is_empty() || block.expr.is_some())
         && !contains_break_or_continue(body)
     {
         let mut applicability = Applicability::MachineApplicable;
@@ -78,7 +78,13 @@ pub(super) fn check<'tcx>(
         let mut block_str = snippet_with_applicability(cx, block.span, "..", &mut applicability).into_owned();
         block_str.remove(0);
         block_str.pop();
-        let indent = " ".repeat(indent_of(cx, block.stmts[0].span).unwrap_or(0));
+        let indent = if let Some(first_stmt) = block.stmts.first() {
+            " ".repeat(indent_of(cx, first_stmt.span).unwrap_or(0))
+        } else if let Some(block_expr) = block.expr {
+            " ".repeat(indent_of(cx, block_expr.span).unwrap_or(0))
+        } else {
+            String::new()
+        };
 
         // Reference iterator from `&(mut) []` or `[].iter(_mut)()`.
         if !prefix.is_empty()
@@ -90,19 +96,23 @@ pub(super) fn check<'tcx>(
             arg_snip = format!("({arg_snip})").into();
         }
 
-        if clippy_utils::higher::Range::hir(cx, arg_expression).is_some() {
-            let range_expr = snippet(cx, arg_expression.span, "?").to_string();
-
-            let sugg = snippet(cx, arg_expression.span, "..");
-            span_lint_and_sugg(
-                cx,
-                SINGLE_ELEMENT_LOOP,
-                arg.span,
-                format!("this loops only once with `{pat_snip}` being `{range_expr}`"),
-                "did you mean to iterate over the range instead?",
-                sugg.to_string(),
-                Applicability::Unspecified,
-            );
+        if let Some(range) = clippy_utils::higher::Range::hir(cx, arg_expression) {
+            if range.start.is_some() {
+                // Only suggest iterating over ranges that have a start value.
+                let range_expr = snippet(cx, arg_expression.span, "?").to_string();
+                let sugg = snippet(cx, arg_expression.span, "..");
+                span_lint_and_sugg(
+                    cx,
+                    SINGLE_ELEMENT_LOOP,
+                    arg.span,
+                    format!("this loops only once with `{pat_snip}` being `{range_expr}`"),
+                    "did you mean to iterate over the range instead?",
+                    sugg.to_string(),
+                    Applicability::Unspecified,
+                );
+            } else {
+                span_lint(cx, SINGLE_ELEMENT_LOOP, expr.span, "for loop over a single element");
+            }
         } else {
             span_lint_and_sugg(
                 cx,

--- a/clippy_lints/src/loops/single_element_loop.rs
+++ b/clippy_lints/src/loops/single_element_loop.rs
@@ -17,112 +17,134 @@ pub(super) fn check<'tcx>(
     body: &'tcx Expr<'_>,
     expr: &'tcx Expr<'_>,
 ) {
-    let (arg_expression, prefix) = match arg.kind {
-        ExprKind::AddrOf(
-            BorrowKind::Ref,
-            Mutability::Not,
-            Expr {
-                kind: ExprKind::Array([arg]),
-                ..
-            },
-        ) => (arg, "&"),
-        ExprKind::AddrOf(
-            BorrowKind::Ref,
-            Mutability::Mut,
-            Expr {
-                kind: ExprKind::Array([arg]),
-                ..
-            },
-        ) => (arg, "&mut "),
-        ExprKind::MethodCall(
-            method,
-            Expr {
-                kind: ExprKind::Array([arg]),
-                ..
-            },
-            [],
-            _,
-        ) if method.ident.name == sym::iter => (arg, "&"),
-        ExprKind::MethodCall(
-            method,
-            Expr {
-                kind: ExprKind::Array([arg]),
-                ..
-            },
-            [],
-            _,
-        ) if method.ident.name == sym::iter_mut => (arg, "&mut "),
-        ExprKind::MethodCall(
-            method,
-            Expr {
-                kind: ExprKind::Array([arg]),
-                ..
-            },
-            [],
-            _,
-        ) if method.ident.name == sym::into_iter => (arg, ""),
-        // Only check for arrays edition 2021 or later, as this case will trigger a compiler error otherwise.
-        ExprKind::Array([arg]) if cx.tcx.sess.edition() >= Edition::Edition2021 => (arg, ""),
-        _ => return,
+    let Some((arg_expression, prefix)) = extract_single_element(cx, arg) else {
+        return;
     };
+
     if let ExprKind::Block(block, _) = body.kind
         && (!block.stmts.is_empty() || block.expr.is_some())
         && !contains_break_or_continue(body)
     {
-        let mut applicability = Applicability::MachineApplicable;
-        let mut pat_snip = snippet_with_applicability(cx, pat.span, "..", &mut applicability);
-        if matches!(pat.kind, PatKind::Or(..)) {
-            pat_snip = format!("({pat_snip})").into();
-        }
-        let mut arg_snip = snippet_with_applicability(cx, arg_expression.span, "..", &mut applicability);
-        let mut block_str = snippet_with_applicability(cx, block.span, "..", &mut applicability).into_owned();
-        block_str.remove(0);
-        block_str.pop();
-        let indent = if let Some(first_stmt) = block.stmts.first() {
-            " ".repeat(indent_of(cx, first_stmt.span).unwrap_or(0))
-        } else if let Some(block_expr) = block.expr {
-            " ".repeat(indent_of(cx, block_expr.span).unwrap_or(0))
-        } else {
-            String::new()
-        };
+        emit_lint(cx, pat, arg, expr, arg_expression, prefix, block);
+    }
+}
 
-        // Reference iterator from `&(mut) []` or `[].iter(_mut)()`.
-        if !prefix.is_empty()
-            && (
-                // Precedence of internal expression is less than or equal to precedence of `&expr`.
-                cx.precedence(arg_expression) <= ExprPrecedence::Prefix || is_range_literal(arg_expression)
-            )
-        {
-            arg_snip = format!("({arg_snip})").into();
-        }
+fn extract_single_element<'tcx>(
+    cx: &LateContext<'tcx>,
+    arg: &'tcx Expr<'_>,
+) -> Option<(&'tcx Expr<'tcx>, &'static str)> {
+    match arg.kind {
+        ExprKind::AddrOf(
+            BorrowKind::Ref,
+            Mutability::Not,
+            Expr {
+                kind: ExprKind::Array([inner]),
+                ..
+            },
+        ) => Some((inner, "&")),
+        ExprKind::AddrOf(
+            BorrowKind::Ref,
+            Mutability::Mut,
+            Expr {
+                kind: ExprKind::Array([inner]),
+                ..
+            },
+        ) => Some((inner, "&mut ")),
+        ExprKind::MethodCall(
+            method,
+            Expr {
+                kind: ExprKind::Array([inner]),
+                ..
+            },
+            [],
+            _,
+        ) if method.ident.name == sym::iter => Some((inner, "&")),
+        ExprKind::MethodCall(
+            method,
+            Expr {
+                kind: ExprKind::Array([inner]),
+                ..
+            },
+            [],
+            _,
+        ) if method.ident.name == sym::iter_mut => Some((inner, "&mut ")),
+        ExprKind::MethodCall(
+            method,
+            Expr {
+                kind: ExprKind::Array([inner]),
+                ..
+            },
+            [],
+            _,
+        ) if method.ident.name == sym::into_iter => Some((inner, "")),
+        // Only check for arrays edition 2021 or later, as this case will trigger a compiler error otherwise.
+        ExprKind::Array([inner]) if cx.tcx.sess.edition() >= Edition::Edition2021 => Some((inner, "")),
+        _ => None,
+    }
+}
 
-        if let Some(range) = clippy_utils::higher::Range::hir(cx, arg_expression) {
-            if range.start.is_some() {
-                // Only suggest iterating over ranges that have a start value.
-                let range_expr = snippet(cx, arg_expression.span, "?").to_string();
-                let sugg = snippet(cx, arg_expression.span, "..");
-                span_lint_and_sugg(
-                    cx,
-                    SINGLE_ELEMENT_LOOP,
-                    arg.span,
-                    format!("this loops only once with `{pat_snip}` being `{range_expr}`"),
-                    "did you mean to iterate over the range instead?",
-                    sugg.to_string(),
-                    Applicability::Unspecified,
-                );
-            } else {
-                span_lint(cx, SINGLE_ELEMENT_LOOP, expr.span, "for loop over a single element");
-            }
-        } else {
+fn emit_lint<'tcx>(
+    cx: &LateContext<'tcx>,
+    pat: &'tcx Pat<'_>,
+    arg: &'tcx Expr<'_>,
+    expr: &'tcx Expr<'_>,
+    arg_expression: &'tcx Expr<'_>,
+    prefix: &str,
+    block: &rustc_hir::Block<'_>,
+) {
+    let mut applicability = Applicability::MachineApplicable;
+    let mut pat_snip = snippet_with_applicability(cx, pat.span, "..", &mut applicability);
+    if matches!(pat.kind, PatKind::Or(..)) {
+        pat_snip = format!("({pat_snip})").into();
+    }
+    let mut arg_snip = snippet_with_applicability(cx, arg_expression.span, "..", &mut applicability);
+    let mut block_str = snippet_with_applicability(cx, block.span, "..", &mut applicability).into_owned();
+    block_str.remove(0);
+    block_str.pop();
+    let indent = if let Some(first_stmt) = block.stmts.first() {
+        " ".repeat(indent_of(cx, first_stmt.span).unwrap_or(0))
+    } else if let Some(block_expr) = block.expr {
+        " ".repeat(indent_of(cx, block_expr.span).unwrap_or(0))
+    } else {
+        String::new()
+    };
+
+    // Reference iterator from `&(mut) []` or `[].iter(_mut)()`.
+    if !prefix.is_empty()
+        && (
+            // Precedence of internal expression is less than or equal to precedence of `&expr`.
+            cx.precedence(arg_expression) <= ExprPrecedence::Prefix || is_range_literal(arg_expression)
+        )
+    {
+        arg_snip = format!("({arg_snip})").into();
+    }
+
+    if let Some(range) = clippy_utils::higher::Range::hir(cx, arg_expression) {
+        if range.start.is_some() {
+            // Only suggest iterating over ranges that have a start value.
+            let range_expr = snippet(cx, arg_expression.span, "?").to_string();
+            let sugg = snippet(cx, arg_expression.span, "..");
             span_lint_and_sugg(
                 cx,
                 SINGLE_ELEMENT_LOOP,
-                expr.span,
-                "for loop over a single element",
-                "try",
-                format!("{{\n{indent}let {pat_snip} = {prefix}{arg_snip};{block_str}}}"),
-                applicability,
+                arg.span,
+                format!("this loops only once with `{pat_snip}` being `{range_expr}`"),
+                "did you mean to iterate over the range instead?",
+                sugg.to_string(),
+                Applicability::Unspecified,
             );
+        } else {
+            span_lint(cx, SINGLE_ELEMENT_LOOP, expr.span, "for loop over a single element");
         }
+    } else {
+        span_lint_and_sugg(
+            cx,
+            SINGLE_ELEMENT_LOOP,
+            expr.span,
+            "for loop over a single element",
+            "try",
+            format!("{{\n{indent}let {pat_snip} = {prefix}{arg_snip};{block_str}}}"),
+            applicability,
+        );
     }
 }

--- a/tests/ui/single_element_loop.fixed
+++ b/tests/ui/single_element_loop.fixed
@@ -73,4 +73,11 @@ fn main() {
         //~^ single_element_loop
         let ptr: *const bool = std::ptr::null();
     }
+
+    for _ in 3..5 {
+        //~^ single_element_loop
+        if true {
+            println!("aaa");
+        }
+    }
 }

--- a/tests/ui/single_element_loop.rs
+++ b/tests/ui/single_element_loop.rs
@@ -69,4 +69,11 @@ fn main() {
         //~^ single_element_loop
         let ptr: *const bool = std::ptr::null();
     }
+
+    for _ in [3..5] {
+        //~^ single_element_loop
+        if true {
+            println!("aaa");
+        }
+    }
 }

--- a/tests/ui/single_element_loop.stderr
+++ b/tests/ui/single_element_loop.stderr
@@ -106,5 +106,11 @@ LL +         let ptr: *const bool = std::ptr::null();
 LL +     }
    |
 
-error: aborting due to 8 previous errors
+error: this loops only once with `_` being `3..5`
+  --> tests/ui/single_element_loop.rs:73:14
+   |
+LL |     for _ in [3..5] {
+   |              ^^^^^^ help: did you mean to iterate over the range instead?: `3..5`
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/single_element_loop_nofix.rs
+++ b/tests/ui/single_element_loop_nofix.rs
@@ -1,0 +1,12 @@
+//@no-rustfix
+#![warn(clippy::single_element_loop)]
+#![allow(clippy::single_range_in_vec_init)]
+
+fn f(print: bool) {
+    for _ in [..5] {
+        //~^ single_element_loop
+        if print {
+            println!("Hello from f");
+        }
+    }
+}

--- a/tests/ui/single_element_loop_nofix.stderr
+++ b/tests/ui/single_element_loop_nofix.stderr
@@ -1,0 +1,16 @@
+error: for loop over a single element
+  --> tests/ui/single_element_loop_nofix.rs:6:5
+   |
+LL | /     for _ in [..5] {
+LL | |
+LL | |         if print {
+LL | |             println!("Hello from f");
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::single-element-loop` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::single_element_loop)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/16510

changelog: [`single_element_loop`]: Also trigger if the block contains only a final expression