### PR TITLE
fix(doc_paragraphs_missing_punctuation): Trim picture symbols

### DIFF
--- a/tests/ui/doc/doc_paragraphs_missing_punctuation_emoji.rs
+++ b/tests/ui/doc/doc_paragraphs_missing_punctuation_emoji.rs
@@ -1,0 +1,12 @@
+#![feature(custom_inner_attributes)]
+#![rustfmt::skip]
+#![warn(clippy::doc_paragraphs_missing_punctuation)]
+//@no-rustfix
+
+enum EmojiTrailers {
+    /// Sometimes the doc comment ends with an emoji! 😅
+    ExistingPunctuationBeforeEmoji,
+    /// But it may still be missing punctuation 😢
+    //~^ doc_paragraphs_missing_punctuation
+    MissingPunctuationBeforeEmoji,
+}

--- a/tests/ui/doc/doc_paragraphs_missing_punctuation_emoji.stderr
+++ b/tests/ui/doc/doc_paragraphs_missing_punctuation_emoji.stderr
@@ -1,0 +1,11 @@
+error: doc paragraphs should end with a terminal punctuation mark
+  --> tests/ui/doc/doc_paragraphs_missing_punctuation_emoji.rs:9:50
+   |
+LL |     /// But it may still be missing punctuation 😢
+   |                                                   ^ help: end the paragraph with some punctuation: `.`
+   |
+   = note: `-D clippy::doc-paragraphs-missing-punctuation` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::doc_paragraphs_missing_punctuation)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
FIxes rust-lang/rust-clippy#16482 

changelog: [`doc_paragraphs_missing_punctuation`]: fix: No longer lints for punctuated paragraphs with a trailing emoji.
