### PR TITLE
fix(single_range_in_vec_init): detect all range types

### DIFF
--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -1,15 +1,14 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::higher::VecArgs;
+use clippy_utils::higher::{Range, VecArgs};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::source::{SpanRangeExt, snippet_with_context};
 use clippy_utils::ty::implements_trait;
 use clippy_utils::{is_no_std_crate, sym};
-use rustc_ast::{LitIntType, LitKind, UintTy};
+use rustc_ast::{LitIntType, LitKind, RangeLimits, UintTy};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, StructTailExpr};
+use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
-use rustc_span::DesugaringKind;
 use std::fmt::{self, Display, Formatter};
 
 declare_clippy_lint! {
@@ -87,66 +86,114 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
             return;
         };
 
-        let ExprKind::Struct(_, [start, end], StructTailExpr::None) = inner_expr.kind else {
+        let Some(range) = Range::hir(cx, inner_expr) else {
             return;
         };
 
-        if inner_expr.span.is_desugaring(DesugaringKind::RangeExpr)
-            && let ty = cx.typeck_results().expr_ty(start.expr)
-            && let Some(snippet) = span.get_source_text(cx)
-            // `is_from_proc_macro` will skip any `vec![]`. Let's not!
-            && snippet.starts_with(suggested_type.starts_with())
-            && snippet.ends_with(suggested_type.ends_with())
+        let Some(snippet) = span.get_source_text(cx) else {
+            return;
+        };
+
+        // `is_from_proc_macro` will skip any `vec![]`. Let's not!
+        if !snippet.starts_with(suggested_type.starts_with()) || !snippet.ends_with(suggested_type.ends_with()) {
+            return;
+        }
+
+        // Get the type from whichever bound is available
+        let ty = if let Some(start) = range.start {
+            cx.typeck_results().expr_ty(start)
+        } else if let Some(end) = range.end {
+            cx.typeck_results().expr_ty(end)
+        } else {
+            // RangeFull `..` - no type to infer, skip
+            return;
+        };
+
+        let mut applicability = Applicability::MaybeIncorrect;
+
+        let start_snippet = range.start.map(|start| {
+            snippet_with_context(cx, start.span, span.ctxt(), "..", &mut applicability).0
+        });
+        let end_snippet = range.end.map(|end| {
+            snippet_with_context(cx, end.span, span.ctxt(), "..", &mut applicability).0
+        });
+
+        let should_emit_every_value = if let Some(step_def_id) = cx.tcx.get_diagnostic_item(sym::range_step)
+            && implements_trait(cx, ty, step_def_id, &[])
         {
-            let mut applicability = Applicability::MaybeIncorrect;
-            let (start_snippet, _) = snippet_with_context(cx, start.expr.span, span.ctxt(), "..", &mut applicability);
-            let (end_snippet, _) = snippet_with_context(cx, end.expr.span, span.ctxt(), "..", &mut applicability);
+            true
+        } else {
+            false
+        };
 
-            let should_emit_every_value = if let Some(step_def_id) = cx.tcx.get_diagnostic_item(sym::range_step)
-                && implements_trait(cx, ty, step_def_id, &[])
-            {
-                true
-            } else {
-                false
+        // Only emit the "of len" suggestion for ranges with both start and end (a..b or a..=b)
+        // and when the end is an integer literal
+        let should_emit_of_len = if let Some(copy_def_id) = cx.tcx.lang_items().copy_trait()
+            && implements_trait(cx, ty, copy_def_id, &[])
+            && range.start.is_some()
+            && let Some(end_expr) = range.end
+            && let ExprKind::Lit(lit_kind) = end_expr.kind
+            && let LitKind::Int(.., suffix_type) = lit_kind.node
+            && let LitIntType::Unsigned(UintTy::Usize) | LitIntType::Unsuffixed = suffix_type
+            // Don't suggest `[start; end]` for inclusive ranges since it's confusing
+            && range.limits == RangeLimits::HalfOpen
+        {
+            true
+        } else {
+            false
+        };
+
+        if should_emit_every_value || should_emit_of_len {
+            // Format the range type name for the error message
+            let range_type = match (range.start.is_some(), range.end.is_some(), range.limits) {
+                (true, true, RangeLimits::HalfOpen) => "Range",
+                (true, true, RangeLimits::Closed) => "RangeInclusive",
+                (true, false, _) => "RangeFrom",
+                (false, true, RangeLimits::HalfOpen) => "RangeTo",
+                (false, true, RangeLimits::Closed) => "RangeToInclusive",
+                (false, false, _) => "RangeFull",
             };
-            let should_emit_of_len = if let Some(copy_def_id) = cx.tcx.lang_items().copy_trait()
-                && implements_trait(cx, ty, copy_def_id, &[])
-                && let ExprKind::Lit(lit_kind) = end.expr.kind
-                && let LitKind::Int(.., suffix_type) = lit_kind.node
-                && let LitIntType::Unsigned(UintTy::Usize) | LitIntType::Unsuffixed = suffix_type
-            {
-                true
-            } else {
-                false
-            };
 
-            if should_emit_every_value || should_emit_of_len {
-                span_lint_and_then(
-                    cx,
-                    SINGLE_RANGE_IN_VEC_INIT,
-                    span,
-                    format!("{suggested_type} of `Range` that is only one element"),
-                    |diag| {
-                        if should_emit_every_value && !is_no_std_crate(cx) {
-                            diag.span_suggestion(
-                                span,
-                                "if you wanted a `Vec` that contains the entire range, try",
-                                format!("({start_snippet}..{end_snippet}).collect::<std::vec::Vec<{ty}>>()"),
-                                applicability,
-                            );
-                        }
+            span_lint_and_then(
+                cx,
+                SINGLE_RANGE_IN_VEC_INIT,
+                span,
+                format!("{suggested_type} of `{range_type}` that is only one element"),
+                |diag| {
+                    if should_emit_every_value && !is_no_std_crate(cx) {
+                        // Format the range syntax for the suggestion
+                        let range_op = if range.limits == RangeLimits::Closed {
+                            "..="
+                        } else {
+                            ".."
+                        };
+                        let range_str = match (&start_snippet, &end_snippet) {
+                            (Some(start), Some(end)) => format!("{start}{range_op}{end}"),
+                            (Some(start), None) => format!("{start}.."),
+                            (None, Some(end)) => format!("{range_op}{end}"),
+                            (None, None) => "..".to_string(),
+                        };
 
-                        if should_emit_of_len {
+                        diag.span_suggestion(
+                            span,
+                            "if you wanted a `Vec` that contains the entire range, try",
+                            format!("({range_str}).collect::<std::vec::Vec<{ty}>>()"),
+                            applicability,
+                        );
+                    }
+
+                    if should_emit_of_len {
+                        if let (Some(start), Some(end)) = (&start_snippet, &end_snippet) {
                             diag.span_suggestion(
                                 inner_expr.span,
-                                format!("if you wanted {suggested_type} of len {end_snippet}, try"),
-                                format!("{start_snippet}; {end_snippet}"),
+                                format!("if you wanted {suggested_type} of len {end}, try"),
+                                format!("{start}; {end}"),
                                 applicability,
                             );
                         }
-                    },
-                );
-            }
+                    }
+                },
+            );
         }
     }
 }

--- a/tests/ui/single_range_in_vec_init.rs
+++ b/tests/ui/single_range_in_vec_init.rs
@@ -82,3 +82,34 @@ fn issue16044() {
     let input = vec![0..as_i32!(10)];
     //~^ single_range_in_vec_init
 }
+
+// Issue #16508: detect all kinds of ranges
+fn issue16508() {
+    // RangeTo: ..b
+    [..10i32];
+    //~^ single_range_in_vec_init
+    vec![..10i32];
+    //~^ single_range_in_vec_init
+
+    // RangeFrom: a..
+    [0i32..];
+    //~^ single_range_in_vec_init
+    vec![0i32..];
+    //~^ single_range_in_vec_init
+
+    // RangeInclusive: a..=b
+    [0..=10i32];
+    //~^ single_range_in_vec_init
+    vec![0..=10i32];
+    //~^ single_range_in_vec_init
+
+    // RangeToInclusive: ..=b
+    [..=10i32];
+    //~^ single_range_in_vec_init
+    vec![..=10i32];
+    //~^ single_range_in_vec_init
+
+    // RangeFull should NOT lint (no type to infer)
+    [..];
+    vec![..];
+}


### PR DESCRIPTION
## Summary

This PR extends the `single_range_in_vec_init` lint to detect all kinds of ranges, not just `Range` (`a..b`).

Fixes rust-lang/rust-clippy#16508

### Changes

- Uses `clippy_utils::higher::Range::hir()` as suggested in the issue to handle all range types uniformly
- Now detects:
  - `RangeTo` (`..b`)
  - `RangeFrom` (`a..`)
  - `RangeInclusive` (`a..=b`)
  - `RangeToInclusive` (`..=b`)
- Updates error messages to show the specific range type name
- Adapts suggestions appropriately for each range type
- `RangeFull` (`..`) is intentionally not linted as there's no type information to infer

### Example

Before this PR, the following would not trigger the lint:
```rust
[..10];      // RangeTo - now linted
[0..];       // RangeFrom - now linted
[0..=10];    // RangeInclusive - now linted
[..=10];     // RangeToInclusive - now linted
```

After this PR, all of the above will be caught with appropriate suggestions.

---

changelog: [`single_range_in_vec_init`]: Now detects all range types (`..b`, `a..`, `a..=b`, `..=b`), not just `a..b`

---

> [!NOTE]
> This PR was authored with AI assistance (Claude claude-opus-4-5). The implementation follows the guidance in issue #16508 to use `clippy_utils::higher::Range`.