### PR TITLE
Add MSRV-based tests to `duration_suboptimal_units` lint

### DIFF
--- a/tests/ui/duration_suboptimal_units.fixed
+++ b/tests/ui/duration_suboptimal_units.fixed
@@ -94,3 +94,14 @@ fn issue16457() {
     // Methods taking something else than `u64` are not covered
     _ = Duration::from_nanos_u128(1 << 90);
 }
+
+#[clippy::msrv = "1.90"]
+fn insufficient_msrv() {
+    _ = Duration::from_secs(67_768_040_922_076_800);
+}
+
+#[clippy::msrv = "1.91"]
+fn sufficient_msrv() {
+    _ = Duration::from_hours(18824455811688);
+    //~^ duration_suboptimal_units
+}

--- a/tests/ui/duration_suboptimal_units.rs
+++ b/tests/ui/duration_suboptimal_units.rs
@@ -94,3 +94,14 @@ fn issue16457() {
     // Methods taking something else than `u64` are not covered
     _ = Duration::from_nanos_u128(1 << 90);
 }
+
+#[clippy::msrv = "1.90"]
+fn insufficient_msrv() {
+    _ = Duration::from_secs(67_768_040_922_076_800);
+}
+
+#[clippy::msrv = "1.91"]
+fn sufficient_msrv() {
+    _ = Duration::from_secs(67_768_040_922_076_800);
+    //~^ duration_suboptimal_units
+}

--- a/tests/ui/duration_suboptimal_units.stderr
+++ b/tests/ui/duration_suboptimal_units.stderr
@@ -148,5 +148,17 @@ LL -         Duration::from_secs(300)
 LL +         Duration::from_mins(5)
    |
 
-error: aborting due to 12 previous errors
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:105:9
+   |
+LL |     _ = Duration::from_secs(67_768_040_922_076_800);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_hours
+   |
+LL -     _ = Duration::from_secs(67_768_040_922_076_800);
+LL +     _ = Duration::from_hours(18824455811688);
+   |
+
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Noticed because of rust-lang/rust-clippy#16525

changelog: none