### PR TITLE
Add new lint `unnecessary_dedup_by`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7333,6 +7333,7 @@ Released 2018-09-13
 [`unnecessary_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
 [`unnecessary_clippy_cfg`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_clippy_cfg
 [`unnecessary_debug_formatting`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting
+[`unnecessary_dedup_by`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_dedup_by
 [`unnecessary_fallible_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fallible_conversions
 [`unnecessary_filter_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_filter_map
 [`unnecessary_find_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_find_map

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -491,6 +491,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::UNBUFFERED_BYTES_INFO,
     crate::methods::UNINIT_ASSUMED_INIT_INFO,
     crate::methods::UNIT_HASH_INFO,
+    crate::methods::UNNECESSARY_DEDUP_BY_INFO,
     crate::methods::UNNECESSARY_FALLIBLE_CONVERSIONS_INFO,
     crate::methods::UNNECESSARY_FILTER_MAP_INFO,
     crate::methods::UNNECESSARY_FIND_MAP_INFO,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -127,6 +127,7 @@ mod type_id_on_box;
 mod unbuffered_bytes;
 mod uninit_assumed_init;
 mod unit_hash;
+mod unnecessary_dedup_by;
 mod unnecessary_fallible_conversions;
 mod unnecessary_filter_map;
 mod unnecessary_first_then_check;
@@ -4105,6 +4106,49 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for usage of `Vec::dedup_by` passing in a closure
+    /// that is equivalent to a simple key extraction and could be
+    /// written more idiomatically using `Vec::dedup_by_key` or
+    /// `Vec::dedup`
+    ///
+    /// ### Why is this bad?
+    /// It is more clear to use `Vec::dedup_by_key` or `Vec::dedup`
+    /// (when comparing whole elements) than to use
+    /// `Vec::dedup_by` and a more complicated closure.
+    ///
+    /// ### Examples
+    /// ```no_run
+    /// let mut v = vec![1, 1, 2, 3];
+    /// v.dedup_by(|a, b| a == b);
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let mut v = vec![1, 1, 2, 3];
+    /// v.dedup();
+    /// ```
+    ///
+    /// Or when comparing by a key:
+    /// ```no_run
+    /// pub fn m1(mut v: Vec<(i64, i64)>) -> Vec<(i64, i64)> {
+    ///     v.dedup_by(|(sym1, _), (sym2, _)| sym1 == sym2);
+    ///     v
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// pub fn m2(mut v: Vec<(i64, i64)>) -> Vec<(i64, i64)> {
+    ///     v.dedup_by_key(|(sym, _)| *sym);
+    ///     v
+    /// }
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub UNNECESSARY_DEDUP_BY,
+    complexity,
+    "use of `Vec::dedup_by` when `Vec::dedup_by_key` or `Vec::dedup` would be clearer"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for calls to `TryInto::try_into` and `TryFrom::try_from` when their infallible counterparts
     /// could be used.
     ///
@@ -4966,6 +5010,7 @@ impl_lint_pass!(Methods => [
     UNBUFFERED_BYTES,
     UNINIT_ASSUMED_INIT,
     UNIT_HASH,
+    UNNECESSARY_DEDUP_BY,
     UNNECESSARY_FALLIBLE_CONVERSIONS,
     UNNECESSARY_FILTER_MAP,
     UNNECESSARY_FIND_MAP,
@@ -5309,6 +5354,9 @@ impl Methods {
                 },
                 (sym::min | sym::max, [arg]) => {
                     unnecessary_min_or_max::check(cx, expr, name, recv, arg);
+                },
+                (sym::dedup_by, [arg]) => {
+                    unnecessary_dedup_by::check(cx, expr, call_span, arg);
                 },
                 (sym::drain, ..) => {
                     if let Node::Stmt(Stmt { hir_id: _, kind, .. }) = cx.tcx.parent_hir_node(expr.hir_id)

--- a/clippy_lints/src/methods/unnecessary_dedup_by.rs
+++ b/clippy_lints/src/methods/unnecessary_dedup_by.rs
@@ -1,0 +1,115 @@
+use super::utils::{
+    BindingKey, BindingSource, expr_borrows, expr_is_field_access, mapping_of_mirrored_pats, mirrored_exprs,
+};
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::res::MaybeDef;
+use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::ty::{is_copy, peel_n_ty_refs};
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Closure, Expr, ExprKind, Param, Path, PathSegment, QPath};
+use rustc_lint::LateContext;
+use rustc_span::{Span, sym};
+
+use super::UNNECESSARY_DEDUP_BY;
+
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, call_span: Span, arg: &'tcx Expr<'_>) {
+    if let Some(method_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
+        && let Some(impl_id) = cx.tcx.impl_of_assoc(method_id)
+        && cx
+            .tcx
+            .type_of(impl_id)
+            .instantiate_identity()
+            .skip_norm_wip()
+            .is_diag_item(cx, sym::Vec)
+        && let ExprKind::Closure(&Closure { body, .. }) = arg.kind
+        && let closure_body = cx.tcx.hir_body(body)
+        && let &[Param { pat: l_pat, .. }, Param { pat: r_pat, .. }] = closure_body.params
+        && let Some(binding_map) = mapping_of_mirrored_pats(l_pat, r_pat)
+        && let ExprKind::Binary(op, left_expr, right_expr) = closure_body.value.kind
+        && op.node == BinOpKind::Eq
+    {
+        let (key_expr, key_pat, binding_source) =
+            if mirrored_exprs(left_expr, right_expr, &binding_map, BindingSource::Left) {
+                (left_expr, l_pat, BindingSource::Left)
+            } else if mirrored_exprs(left_expr, right_expr, &binding_map, BindingSource::Right) {
+                (left_expr, r_pat, BindingSource::Right)
+            } else {
+                return;
+            };
+        let mut applicability = Applicability::MachineApplicable;
+        if let ExprKind::Path(QPath::Resolved(
+            _,
+            Path {
+                segments: [PathSegment { ident: key_name, .. }],
+                ..
+            },
+        )) = key_expr.kind
+        {
+            let key_name_n_refs = binding_map
+                .get(&BindingKey {
+                    ident: *key_name,
+                    source: binding_source,
+                })
+                .map_or(0, |value| value.n_refs);
+
+            // check the whole element is the key → suggest dedup()
+            if let rustc_hir::PatKind::Binding(_, _, param_ident, _) = key_pat.kind
+                && param_ident == *key_name
+            {
+                span_lint_and_then(cx, UNNECESSARY_DEDUP_BY, expr.span, "consider using `dedup`", |diag| {
+                    diag.span_suggestion_verbose(call_span, "try", "dedup()", Applicability::MachineApplicable);
+                });
+                return;
+            }
+
+            let mut key_expr_ty = cx.typeck_results().expr_ty(key_expr);
+            if key_name_n_refs == 0 {
+                (key_expr_ty, _) = peel_n_ty_refs(key_expr_ty, 1);
+            }
+            if is_copy(cx, key_expr_ty) {
+                let mut key_body = snippet_with_applicability(cx, key_expr.span, "_", &mut applicability).to_string();
+                if key_name_n_refs == 0 {
+                    key_body = format!("*{key_body}");
+                }
+
+                let key_pat_snippet = snippet_with_applicability(cx, key_pat.span, "_", &mut applicability);
+
+                span_lint_and_then(
+                    cx,
+                    UNNECESSARY_DEDUP_BY,
+                    expr.span,
+                    "consider using `dedup_by_key`",
+                    |diag| {
+                        diag.span_suggestion_verbose(
+                            call_span,
+                            "try",
+                            format!("dedup_by_key(|{key_pat_snippet}| {key_body})"),
+                            applicability,
+                        );
+                    },
+                );
+            }
+        } else {
+            let key_expr_ty = cx.typeck_results().expr_ty(key_expr);
+            if !expr_borrows(key_expr_ty) && (!expr_is_field_access(key_expr) || is_copy(cx, key_expr_ty)) {
+                let key_body = snippet_with_applicability(cx, key_expr.span, "_", &mut applicability).to_string();
+                let key_pat_snippet = snippet_with_applicability(cx, key_pat.span, "_", &mut applicability);
+
+                span_lint_and_then(
+                    cx,
+                    UNNECESSARY_DEDUP_BY,
+                    expr.span,
+                    "consider using `dedup_by_key`",
+                    |diag| {
+                        diag.span_suggestion_verbose(
+                            call_span,
+                            "try",
+                            format!("dedup_by_key(|{key_pat_snippet}| {key_body})"),
+                            applicability,
+                        );
+                    },
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/methods/unnecessary_sort_by.rs
+++ b/clippy_lints/src/methods/unnecessary_sort_by.rs
@@ -1,18 +1,16 @@
+use super::utils::{
+    BindingKey, BindingSource, expr_borrows, expr_is_field_access, mapping_of_mirrored_pats, mirrored_exprs,
+};
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::std_or_core;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::{implements_trait, is_copy, peel_n_ty_refs};
-use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::Applicability;
-use rustc_hir::{Closure, Expr, ExprKind, Mutability, Param, Pat, PatKind, Path, PathSegment, QPath};
+use rustc_hir::{Closure, Expr, ExprKind, Param, PatKind, Path, PathSegment, QPath};
 use rustc_lint::LateContext;
-use rustc_middle::ty::{self, GenericArgKind, Ty};
-use rustc_span::symbol::Ident;
 use rustc_span::{Span, sym};
-use std::iter;
-use std::ops::Not;
 
 use super::UNNECESSARY_SORT_BY;
 
@@ -26,218 +24,6 @@ struct SortByKeyDetection {
     closure_body: String,
     reverse: bool,
     applicability: Applicability,
-}
-
-/// Detect if the two expressions are mirrored (identical, except one
-/// contains a and the other replaces it with b)
-fn mirrored_exprs(
-    a_expr: &Expr<'_>,
-    b_expr: &Expr<'_>,
-    binding_map: &BindingMap,
-    binding_source: BindingSource,
-) -> bool {
-    match (a_expr.kind, b_expr.kind) {
-        // Two arrays with mirrored contents
-        (ExprKind::Array(left_exprs), ExprKind::Array(right_exprs)) => iter::zip(left_exprs, right_exprs)
-            .all(|(left, right)| mirrored_exprs(left, right, binding_map, binding_source)),
-        // The two exprs are function calls.
-        // Check to see that the function itself and its arguments are mirrored
-        (ExprKind::Call(left_expr, left_args), ExprKind::Call(right_expr, right_args)) => {
-            mirrored_exprs(left_expr, right_expr, binding_map, binding_source)
-                && iter::zip(left_args, right_args)
-                    .all(|(left, right)| mirrored_exprs(left, right, binding_map, binding_source))
-        },
-        // The two exprs are method calls.
-        // Check to see that the function is the same and the arguments and receivers are mirrored
-        (
-            ExprKind::MethodCall(left_segment, left_receiver, left_args, _),
-            ExprKind::MethodCall(right_segment, right_receiver, right_args, _),
-        ) => {
-            left_segment.ident == right_segment.ident
-                && iter::zip(left_args, right_args)
-                    .all(|(left, right)| mirrored_exprs(left, right, binding_map, binding_source))
-                && mirrored_exprs(left_receiver, right_receiver, binding_map, binding_source)
-        },
-        // Two tuples with mirrored contents
-        (ExprKind::Tup(left_exprs), ExprKind::Tup(right_exprs)) => iter::zip(left_exprs, right_exprs)
-            .all(|(left, right)| mirrored_exprs(left, right, binding_map, binding_source)),
-        // Two binary ops, which are the same operation and which have mirrored arguments
-        (ExprKind::Binary(left_op, left_left, left_right), ExprKind::Binary(right_op, right_left, right_right)) => {
-            left_op.node == right_op.node
-                && mirrored_exprs(left_left, right_left, binding_map, binding_source)
-                && mirrored_exprs(left_right, right_right, binding_map, binding_source)
-        },
-        // Two unary ops, which are the same operation and which have the same argument
-        (ExprKind::Unary(left_op, left_expr), ExprKind::Unary(right_op, right_expr)) => {
-            left_op == right_op && mirrored_exprs(left_expr, right_expr, binding_map, binding_source)
-        },
-        // The two exprs are literals of some kind
-        (ExprKind::Lit(left_lit), ExprKind::Lit(right_lit)) => left_lit.node == right_lit.node,
-        (ExprKind::Cast(left, _), ExprKind::Cast(right, _)) => mirrored_exprs(left, right, binding_map, binding_source),
-        (ExprKind::DropTemps(left_block), ExprKind::DropTemps(right_block)) => {
-            mirrored_exprs(left_block, right_block, binding_map, binding_source)
-        },
-        (ExprKind::Field(left_expr, left_ident), ExprKind::Field(right_expr, right_ident)) => {
-            left_ident.name == right_ident.name && mirrored_exprs(left_expr, right_expr, binding_map, binding_source)
-        },
-        // Two paths: either one is a and the other is b, or they're identical to each other
-        (
-            ExprKind::Path(QPath::Resolved(
-                _,
-                &Path {
-                    segments: left_segments,
-                    ..
-                },
-            )),
-            ExprKind::Path(QPath::Resolved(
-                _,
-                &Path {
-                    segments: right_segments,
-                    ..
-                },
-            )),
-        ) => {
-            (iter::zip(left_segments, right_segments).all(|(left, right)| left.ident == right.ident)
-                && left_segments.iter().all(|seg| {
-                    !binding_map.contains_key(&BindingKey {
-                        ident: seg.ident,
-                        source: BindingSource::Left,
-                    }) && !binding_map.contains_key(&BindingKey {
-                        ident: seg.ident,
-                        source: BindingSource::Right,
-                    })
-                }))
-                || (left_segments.len() == 1
-                    && right_segments.len() == 1
-                    && binding_map
-                        .get(&BindingKey {
-                            ident: left_segments[0].ident,
-                            source: binding_source,
-                        })
-                        .is_some_and(|value| value.mirrored.ident == right_segments[0].ident))
-        },
-        // Matching expressions, but one or both is borrowed
-        (
-            ExprKind::AddrOf(left_kind, Mutability::Not, left_expr),
-            ExprKind::AddrOf(right_kind, Mutability::Not, right_expr),
-        ) => left_kind == right_kind && mirrored_exprs(left_expr, right_expr, binding_map, binding_source),
-        (_, ExprKind::AddrOf(_, Mutability::Not, right_expr)) => {
-            mirrored_exprs(a_expr, right_expr, binding_map, binding_source)
-        },
-        (ExprKind::AddrOf(_, Mutability::Not, left_expr), _) => {
-            mirrored_exprs(left_expr, b_expr, binding_map, binding_source)
-        },
-        _ => false,
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
-enum BindingSource {
-    Left,
-    Right,
-}
-
-impl Not for BindingSource {
-    type Output = BindingSource;
-
-    fn not(self) -> Self::Output {
-        match self {
-            BindingSource::Left => BindingSource::Right,
-            BindingSource::Right => BindingSource::Left,
-        }
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
-struct BindingKey {
-    /// The identifier of the binding.
-    ident: Ident,
-    /// The source of the binding.
-    source: BindingSource,
-}
-
-struct BindingValue {
-    /// The mirrored binding.
-    mirrored: BindingKey,
-    /// The number of refs the binding is wrapped in.
-    n_refs: usize,
-}
-
-/// A map from binding info to the number of refs the binding is wrapped in.
-type BindingMap = FxHashMap<BindingKey, BindingValue>;
-/// Extract the binding pairs, if the two patterns are mirrored. The pats are assumed to be used in
-/// closure inputs and thus irrefutable.
-fn mapping_of_mirrored_pats(a_pat: &Pat<'_>, b_pat: &Pat<'_>) -> Option<BindingMap> {
-    fn mapping_of_mirrored_pats_inner(
-        a_pat: &Pat<'_>,
-        b_pat: &Pat<'_>,
-        mapping: &mut BindingMap,
-        n_refs: usize,
-    ) -> bool {
-        match (&a_pat.kind, &b_pat.kind) {
-            (PatKind::Tuple(a_pats, a_dots), PatKind::Tuple(b_pats, b_dots)) => {
-                a_dots == b_dots
-                    && a_pats.len() == b_pats.len()
-                    && iter::zip(a_pats.iter(), b_pats.iter())
-                        .all(|(a, b)| mapping_of_mirrored_pats_inner(a, b, mapping, n_refs))
-            },
-            (PatKind::Binding(_, _, a_ident, _), PatKind::Binding(_, _, b_ident, _)) => {
-                let a_key = BindingKey {
-                    ident: *a_ident,
-                    source: BindingSource::Left,
-                };
-                let b_key = BindingKey {
-                    ident: *b_ident,
-                    source: BindingSource::Right,
-                };
-                let a_value = BindingValue {
-                    mirrored: b_key,
-                    n_refs,
-                };
-                let b_value = BindingValue {
-                    mirrored: a_key,
-                    n_refs,
-                };
-                mapping.insert(a_key, a_value);
-                mapping.insert(b_key, b_value);
-                true
-            },
-            (PatKind::Wild, PatKind::Wild) => true,
-            (PatKind::TupleStruct(_, a_pats, a_dots), PatKind::TupleStruct(_, b_pats, b_dots)) => {
-                a_dots == b_dots
-                    && a_pats.len() == b_pats.len()
-                    && iter::zip(a_pats.iter(), b_pats.iter())
-                        .all(|(a, b)| mapping_of_mirrored_pats_inner(a, b, mapping, n_refs))
-            },
-            (PatKind::Struct(_, a_fields, a_rest), PatKind::Struct(_, b_fields, b_rest)) => {
-                a_rest == b_rest
-                    && a_fields.len() == b_fields.len()
-                    && iter::zip(a_fields.iter(), b_fields.iter()).all(|(a_field, b_field)| {
-                        a_field.ident == b_field.ident
-                            && mapping_of_mirrored_pats_inner(a_field.pat, b_field.pat, mapping, n_refs)
-                    })
-            },
-            (PatKind::Ref(a_inner, _, _), PatKind::Ref(b_inner, _, _)) => {
-                mapping_of_mirrored_pats_inner(a_inner, b_inner, mapping, n_refs + 1)
-            },
-            (PatKind::Slice(a_elems, None, a_rest), PatKind::Slice(b_elems, None, b_rest)) => {
-                a_elems.len() == b_elems.len()
-                    && iter::zip(a_elems.iter(), b_elems.iter())
-                        .all(|(a, b)| mapping_of_mirrored_pats_inner(a, b, mapping, n_refs))
-                    && a_rest.len() == b_rest.len()
-                    && iter::zip(a_rest.iter(), b_rest.iter())
-                        .all(|(a, b)| mapping_of_mirrored_pats_inner(a, b, mapping, n_refs))
-            },
-            _ => false,
-        }
-    }
-
-    let mut mapping = FxHashMap::default();
-    if mapping_of_mirrored_pats_inner(a_pat, b_pat, &mut mapping, 0) {
-        return Some(mapping);
-    }
-
-    None
 }
 
 fn detect_lint(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>) -> Option<LintTrigger> {
@@ -331,18 +117,6 @@ fn detect_lint(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>) -> Option<
     }
 
     None
-}
-
-fn expr_borrows(ty: Ty<'_>) -> bool {
-    matches!(ty.kind(), ty::Ref(..)) || ty.walk().any(|arg| matches!(arg.kind(), GenericArgKind::Lifetime(_)))
-}
-
-fn expr_is_field_access(expr: &Expr<'_>) -> bool {
-    match expr.kind {
-        ExprKind::Field(_, _) => true,
-        ExprKind::AddrOf(_, Mutability::Not, inner) => expr_is_field_access(inner),
-        _ => false,
-    }
 }
 
 pub(super) fn check<'tcx>(

--- a/clippy_lints/src/methods/utils.rs
+++ b/clippy_lints/src/methods/utils.rs
@@ -1,12 +1,15 @@
 use clippy_utils::res::{MaybeDef, MaybeResPath};
 use clippy_utils::{get_parent_expr, usage};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::intravisit::{Visitor, walk_expr};
-use rustc_hir::{BorrowKind, Expr, ExprKind, HirId, Mutability, Pat, QPath, Stmt, StmtKind};
+use rustc_hir::{BorrowKind, Expr, ExprKind, HirId, Mutability, Pat, PatKind, Path, QPath, Stmt, StmtKind};
 use rustc_lint::LateContext;
 use rustc_middle::hir::nested_filter;
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::{self, GenericArgKind, Ty};
 use rustc_span::Span;
-use rustc_span::symbol::sym;
+use rustc_span::symbol::{Ident, sym};
+use std::iter;
+use std::ops::Not;
 
 /// Checks if `expr`, of type `ty`, corresponds to a slice or can be dereferenced to a slice, or if
 /// `expr` is a method call to `.iter()` on such a type. In these cases, return the slice-like
@@ -153,4 +156,229 @@ pub(super) fn get_last_chain_binding_hir_id(mut hir_id: HirId, statements: &[Stm
         }
     }
     Some(hir_id)
+}
+
+// Core logic for `unnecessary_sort_by.rs` and `unnecessary_dedup_by.rs`
+/// Detect if the two expressions are mirrored (identical, except one
+/// contains a and the other replaces it with b)
+pub(super) fn mirrored_exprs(
+    a_expr: &Expr<'_>,
+    b_expr: &Expr<'_>,
+    binding_map: &BindingMap,
+    binding_source: BindingSource,
+) -> bool {
+    match (a_expr.kind, b_expr.kind) {
+        // Two arrays with mirrored contents
+        (ExprKind::Array(left_exprs), ExprKind::Array(right_exprs)) => iter::zip(left_exprs, right_exprs)
+            .all(|(left, right)| mirrored_exprs(left, right, binding_map, binding_source)),
+        // The two exprs are function calls.
+        // Check to see that the function itself and its arguments are mirrored
+        (ExprKind::Call(left_expr, left_args), ExprKind::Call(right_expr, right_args)) => {
+            mirrored_exprs(left_expr, right_expr, binding_map, binding_source)
+                && iter::zip(left_args, right_args)
+                    .all(|(left, right)| mirrored_exprs(left, right, binding_map, binding_source))
+        },
+        // The two exprs are method calls.
+        // Check to see that the function is the same and the arguments and receivers are mirrored
+        (
+            ExprKind::MethodCall(left_segment, left_receiver, left_args, _),
+            ExprKind::MethodCall(right_segment, right_receiver, right_args, _),
+        ) => {
+            left_segment.ident == right_segment.ident
+                && iter::zip(left_args, right_args)
+                    .all(|(left, right)| mirrored_exprs(left, right, binding_map, binding_source))
+                && mirrored_exprs(left_receiver, right_receiver, binding_map, binding_source)
+        },
+        // Two tuples with mirrored contents
+        (ExprKind::Tup(left_exprs), ExprKind::Tup(right_exprs)) => iter::zip(left_exprs, right_exprs)
+            .all(|(left, right)| mirrored_exprs(left, right, binding_map, binding_source)),
+        // Two binary ops, which are the same operation and which have mirrored arguments
+        (ExprKind::Binary(left_op, left_left, left_right), ExprKind::Binary(right_op, right_left, right_right)) => {
+            left_op.node == right_op.node
+                && mirrored_exprs(left_left, right_left, binding_map, binding_source)
+                && mirrored_exprs(left_right, right_right, binding_map, binding_source)
+        },
+        // Two unary ops, which are the same operation and which have the same argument
+        (ExprKind::Unary(left_op, left_expr), ExprKind::Unary(right_op, right_expr)) => {
+            left_op == right_op && mirrored_exprs(left_expr, right_expr, binding_map, binding_source)
+        },
+        // The two exprs are literals of some kind
+        (ExprKind::Lit(left_lit), ExprKind::Lit(right_lit)) => left_lit.node == right_lit.node,
+        (ExprKind::Cast(left, _), ExprKind::Cast(right, _)) => mirrored_exprs(left, right, binding_map, binding_source),
+        (ExprKind::DropTemps(left_block), ExprKind::DropTemps(right_block)) => {
+            mirrored_exprs(left_block, right_block, binding_map, binding_source)
+        },
+        (ExprKind::Field(left_expr, left_ident), ExprKind::Field(right_expr, right_ident)) => {
+            left_ident.name == right_ident.name && mirrored_exprs(left_expr, right_expr, binding_map, binding_source)
+        },
+        // Two paths: either one is a and the other is b, or they're identical to each other
+        (
+            ExprKind::Path(QPath::Resolved(
+                _,
+                &Path {
+                    segments: left_segments,
+                    ..
+                },
+            )),
+            ExprKind::Path(QPath::Resolved(
+                _,
+                &Path {
+                    segments: right_segments,
+                    ..
+                },
+            )),
+        ) => {
+            (iter::zip(left_segments, right_segments).all(|(left, right)| left.ident == right.ident)
+                && left_segments.iter().all(|seg| {
+                    !binding_map.contains_key(&BindingKey {
+                        ident: seg.ident,
+                        source: BindingSource::Left,
+                    }) && !binding_map.contains_key(&BindingKey {
+                        ident: seg.ident,
+                        source: BindingSource::Right,
+                    })
+                }))
+                || (left_segments.len() == 1
+                    && right_segments.len() == 1
+                    && binding_map
+                        .get(&BindingKey {
+                            ident: left_segments[0].ident,
+                            source: binding_source,
+                        })
+                        .is_some_and(|value| value.mirrored.ident == right_segments[0].ident))
+        },
+        // Matching expressions, but one or both is borrowed
+        (
+            ExprKind::AddrOf(left_kind, Mutability::Not, left_expr),
+            ExprKind::AddrOf(right_kind, Mutability::Not, right_expr),
+        ) => left_kind == right_kind && mirrored_exprs(left_expr, right_expr, binding_map, binding_source),
+        (_, ExprKind::AddrOf(_, Mutability::Not, right_expr)) => {
+            mirrored_exprs(a_expr, right_expr, binding_map, binding_source)
+        },
+        (ExprKind::AddrOf(_, Mutability::Not, left_expr), _) => {
+            mirrored_exprs(left_expr, b_expr, binding_map, binding_source)
+        },
+        _ => false,
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub(super) enum BindingSource {
+    Left,
+    Right,
+}
+
+impl Not for BindingSource {
+    type Output = BindingSource;
+
+    fn not(self) -> Self::Output {
+        match self {
+            BindingSource::Left => BindingSource::Right,
+            BindingSource::Right => BindingSource::Left,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub(super) struct BindingKey {
+    /// The identifier of the binding.
+    pub ident: Ident,
+    /// The source of the binding.
+    pub source: BindingSource,
+}
+
+pub(super) struct BindingValue {
+    /// The mirrored binding.
+    pub mirrored: BindingKey,
+    /// The number of refs the binding is wrapped in.
+    pub n_refs: usize,
+}
+
+/// A map from binding info to the number of refs the binding is wrapped in.
+pub(super) type BindingMap = FxHashMap<BindingKey, BindingValue>;
+/// Extract the binding pairs, if the two patterns are mirrored. The pats are assumed to be used in
+/// closure inputs and thus irrefutable.
+pub(super) fn mapping_of_mirrored_pats(a_pat: &Pat<'_>, b_pat: &Pat<'_>) -> Option<BindingMap> {
+    fn mapping_of_mirrored_pats_inner(
+        a_pat: &Pat<'_>,
+        b_pat: &Pat<'_>,
+        mapping: &mut BindingMap,
+        n_refs: usize,
+    ) -> bool {
+        match (&a_pat.kind, &b_pat.kind) {
+            (PatKind::Tuple(a_pats, a_dots), PatKind::Tuple(b_pats, b_dots)) => {
+                a_dots == b_dots
+                    && a_pats.len() == b_pats.len()
+                    && iter::zip(a_pats.iter(), b_pats.iter())
+                        .all(|(a, b)| mapping_of_mirrored_pats_inner(a, b, mapping, n_refs))
+            },
+            (PatKind::Binding(_, _, a_ident, _), PatKind::Binding(_, _, b_ident, _)) => {
+                let a_key = BindingKey {
+                    ident: *a_ident,
+                    source: BindingSource::Left,
+                };
+                let b_key = BindingKey {
+                    ident: *b_ident,
+                    source: BindingSource::Right,
+                };
+                let a_value = BindingValue {
+                    mirrored: b_key,
+                    n_refs,
+                };
+                let b_value = BindingValue {
+                    mirrored: a_key,
+                    n_refs,
+                };
+                mapping.insert(a_key, a_value);
+                mapping.insert(b_key, b_value);
+                true
+            },
+            (PatKind::Wild, PatKind::Wild) => true,
+            (PatKind::TupleStruct(_, a_pats, a_dots), PatKind::TupleStruct(_, b_pats, b_dots)) => {
+                a_dots == b_dots
+                    && a_pats.len() == b_pats.len()
+                    && iter::zip(a_pats.iter(), b_pats.iter())
+                        .all(|(a, b)| mapping_of_mirrored_pats_inner(a, b, mapping, n_refs))
+            },
+            (PatKind::Struct(_, a_fields, a_rest), PatKind::Struct(_, b_fields, b_rest)) => {
+                a_rest == b_rest
+                    && a_fields.len() == b_fields.len()
+                    && iter::zip(a_fields.iter(), b_fields.iter()).all(|(a_field, b_field)| {
+                        a_field.ident == b_field.ident
+                            && mapping_of_mirrored_pats_inner(a_field.pat, b_field.pat, mapping, n_refs)
+                    })
+            },
+            (PatKind::Ref(a_inner, _, _), PatKind::Ref(b_inner, _, _)) => {
+                mapping_of_mirrored_pats_inner(a_inner, b_inner, mapping, n_refs + 1)
+            },
+            (PatKind::Slice(a_elems, None, a_rest), PatKind::Slice(b_elems, None, b_rest)) => {
+                a_elems.len() == b_elems.len()
+                    && iter::zip(a_elems.iter(), b_elems.iter())
+                        .all(|(a, b)| mapping_of_mirrored_pats_inner(a, b, mapping, n_refs))
+                    && a_rest.len() == b_rest.len()
+                    && iter::zip(a_rest.iter(), b_rest.iter())
+                        .all(|(a, b)| mapping_of_mirrored_pats_inner(a, b, mapping, n_refs))
+            },
+            _ => false,
+        }
+    }
+
+    let mut mapping = FxHashMap::default();
+    if mapping_of_mirrored_pats_inner(a_pat, b_pat, &mut mapping, 0) {
+        return Some(mapping);
+    }
+
+    None
+}
+
+pub(super) fn expr_borrows(ty: Ty<'_>) -> bool {
+    matches!(ty.kind(), ty::Ref(..)) || ty.walk().any(|arg| matches!(arg.kind(), GenericArgKind::Lifetime(_)))
+}
+
+pub(super) fn expr_is_field_access(expr: &Expr<'_>) -> bool {
+    match expr.kind {
+        ExprKind::Field(_, _) => true,
+        ExprKind::AddrOf(_, Mutability::Not, inner) => expr_is_field_access(inner),
+        _ => false,
+    }
 }

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -204,6 +204,7 @@ generate! {
     cyclomatic_complexity,
     de,
     debug_struct,
+    dedup_by,
     deprecated_in_future,
     deref_mut_method,
     diagnostics,

--- a/tests/ui/unnecessary_dedup_by.fixed
+++ b/tests/ui/unnecessary_dedup_by.fixed
@@ -1,0 +1,81 @@
+#![warn(clippy::unnecessary_dedup_by)]
+
+struct Inner {
+    x: i32,
+}
+struct Outer {
+    inner: Inner,
+    y: i32,
+}
+
+struct Wrapper(i32);
+impl Wrapper {
+    fn key(&self) -> i32 {
+        self.0
+    }
+}
+
+struct Named(String);
+impl Named {
+    fn name(&self) -> &String {
+        &self.0
+    }
+}
+
+fn unnecessary_dedup_by() {
+    let mut v1 = vec![1, 2, 2, 3, 3, 4, 4, 5];
+    let mut v2 = vec![(1, 2, 3), (1, 2, 3), (4, 5, 6), (4, 5, 6)];
+    let mut v3 = vec!["name1".to_string(), "name1".to_string(), "name2".to_string()];
+    let mut v4 = vec![
+        Outer {
+            inner: Inner { x: 1 },
+            y: 10,
+        },
+        Outer {
+            inner: Inner { x: 1 },
+            y: 20,
+        },
+        Outer {
+            inner: Inner { x: 2 },
+            y: 30,
+        },
+    ];
+    let mut v5 = vec![Wrapper(1), Wrapper(1), Wrapper(2)];
+    let mut v6 = vec![Named("a".to_string()), Named("a".to_string())];
+
+    let mut v7 = vec![&1, &1, &2];
+
+    v1.dedup();
+    //~^ unnecessary_dedup_by
+
+    v2.dedup_by_key(|a| a.0);
+    //~^ unnecessary_dedup_by
+
+    v2.dedup_by(|a, b| a.0 == b.1);
+
+    v2.dedup_by(|a, b| a.0 == b.0 / 10);
+
+    v2.dedup_by_key(|b| b.0);
+    //~^ unnecessary_dedup_by
+
+    v2.dedup_by_key(|b| b.0 * 2);
+    //~^ unnecessary_dedup_by
+
+    v3.dedup();
+    //~^ unnecessary_dedup_by
+
+    v4.dedup_by_key(|a| a.inner.x);
+    //~^ unnecessary_dedup_by
+
+    // Test with Struct destructuring
+    v4.dedup_by_key(|Outer { inner: _, y: y1 }| *y1);
+    //~^ unnecessary_dedup_by
+
+    v5.dedup_by_key(|a| a.key());
+    //~^ unnecessary_dedup_by
+
+    v6.dedup_by(|a, b| a.name() == b.name());
+
+    v7.dedup();
+    //~^ unnecessary_dedup_by
+}

--- a/tests/ui/unnecessary_dedup_by.rs
+++ b/tests/ui/unnecessary_dedup_by.rs
@@ -1,0 +1,81 @@
+#![warn(clippy::unnecessary_dedup_by)]
+
+struct Inner {
+    x: i32,
+}
+struct Outer {
+    inner: Inner,
+    y: i32,
+}
+
+struct Wrapper(i32);
+impl Wrapper {
+    fn key(&self) -> i32 {
+        self.0
+    }
+}
+
+struct Named(String);
+impl Named {
+    fn name(&self) -> &String {
+        &self.0
+    }
+}
+
+fn unnecessary_dedup_by() {
+    let mut v1 = vec![1, 2, 2, 3, 3, 4, 4, 5];
+    let mut v2 = vec![(1, 2, 3), (1, 2, 3), (4, 5, 6), (4, 5, 6)];
+    let mut v3 = vec!["name1".to_string(), "name1".to_string(), "name2".to_string()];
+    let mut v4 = vec![
+        Outer {
+            inner: Inner { x: 1 },
+            y: 10,
+        },
+        Outer {
+            inner: Inner { x: 1 },
+            y: 20,
+        },
+        Outer {
+            inner: Inner { x: 2 },
+            y: 30,
+        },
+    ];
+    let mut v5 = vec![Wrapper(1), Wrapper(1), Wrapper(2)];
+    let mut v6 = vec![Named("a".to_string()), Named("a".to_string())];
+
+    let mut v7 = vec![&1, &1, &2];
+
+    v1.dedup_by(|a, b| a == b);
+    //~^ unnecessary_dedup_by
+
+    v2.dedup_by(|a, b| a.0 == b.0);
+    //~^ unnecessary_dedup_by
+
+    v2.dedup_by(|a, b| a.0 == b.1);
+
+    v2.dedup_by(|a, b| a.0 == b.0 / 10);
+
+    v2.dedup_by(|a, b| b.0 == a.0);
+    //~^ unnecessary_dedup_by
+
+    v2.dedup_by(|a, b| b.0 * 2 == a.0 * 2);
+    //~^ unnecessary_dedup_by
+
+    v3.dedup_by(|a, b| a == b);
+    //~^ unnecessary_dedup_by
+
+    v4.dedup_by(|a, b| a.inner.x == b.inner.x);
+    //~^ unnecessary_dedup_by
+
+    // Test with Struct destructuring
+    v4.dedup_by(|Outer { inner: _, y: y1 }, Outer { inner: _, y: y2 }| y1 == y2);
+    //~^ unnecessary_dedup_by
+
+    v5.dedup_by(|a, b| a.key() == b.key());
+    //~^ unnecessary_dedup_by
+
+    v6.dedup_by(|a, b| a.name() == b.name());
+
+    v7.dedup_by(|a, b| a == b);
+    //~^ unnecessary_dedup_by
+}

--- a/tests/ui/unnecessary_dedup_by.stderr
+++ b/tests/ui/unnecessary_dedup_by.stderr
@@ -1,0 +1,112 @@
+error: consider using `dedup`
+  --> tests/ui/unnecessary_dedup_by.rs:48:5
+   |
+LL |     v1.dedup_by(|a, b| a == b);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::unnecessary-dedup-by` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_dedup_by)]`
+help: try
+   |
+LL -     v1.dedup_by(|a, b| a == b);
+LL +     v1.dedup();
+   |
+
+error: consider using `dedup_by_key`
+  --> tests/ui/unnecessary_dedup_by.rs:51:5
+   |
+LL |     v2.dedup_by(|a, b| a.0 == b.0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     v2.dedup_by(|a, b| a.0 == b.0);
+LL +     v2.dedup_by_key(|a| a.0);
+   |
+
+error: consider using `dedup_by_key`
+  --> tests/ui/unnecessary_dedup_by.rs:58:5
+   |
+LL |     v2.dedup_by(|a, b| b.0 == a.0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     v2.dedup_by(|a, b| b.0 == a.0);
+LL +     v2.dedup_by_key(|b| b.0);
+   |
+
+error: consider using `dedup_by_key`
+  --> tests/ui/unnecessary_dedup_by.rs:61:5
+   |
+LL |     v2.dedup_by(|a, b| b.0 * 2 == a.0 * 2);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     v2.dedup_by(|a, b| b.0 * 2 == a.0 * 2);
+LL +     v2.dedup_by_key(|b| b.0 * 2);
+   |
+
+error: consider using `dedup`
+  --> tests/ui/unnecessary_dedup_by.rs:64:5
+   |
+LL |     v3.dedup_by(|a, b| a == b);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     v3.dedup_by(|a, b| a == b);
+LL +     v3.dedup();
+   |
+
+error: consider using `dedup_by_key`
+  --> tests/ui/unnecessary_dedup_by.rs:67:5
+   |
+LL |     v4.dedup_by(|a, b| a.inner.x == b.inner.x);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     v4.dedup_by(|a, b| a.inner.x == b.inner.x);
+LL +     v4.dedup_by_key(|a| a.inner.x);
+   |
+
+error: consider using `dedup_by_key`
+  --> tests/ui/unnecessary_dedup_by.rs:71:5
+   |
+LL |     v4.dedup_by(|Outer { inner: _, y: y1 }, Outer { inner: _, y: y2 }| y1 == y2);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     v4.dedup_by(|Outer { inner: _, y: y1 }, Outer { inner: _, y: y2 }| y1 == y2);
+LL +     v4.dedup_by_key(|Outer { inner: _, y: y1 }| *y1);
+   |
+
+error: consider using `dedup_by_key`
+  --> tests/ui/unnecessary_dedup_by.rs:74:5
+   |
+LL |     v5.dedup_by(|a, b| a.key() == b.key());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     v5.dedup_by(|a, b| a.key() == b.key());
+LL +     v5.dedup_by_key(|a| a.key());
+   |
+
+error: consider using `dedup`
+  --> tests/ui/unnecessary_dedup_by.rs:79:5
+   |
+LL |     v7.dedup_by(|a, b| a == b);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     v7.dedup_by(|a, b| a == b);
+LL +     v7.dedup();
+   |
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION

This PR adds a new lint, `unnecessary_dedup_by`, which suggests using Vec::dedup_by_key instead of Vec::dedup_by,
 when the comparison is equivalent to a simple key extraction.

The implementation is adapted from `unnecessary_sort_by` and copies the same helper logic.

changelog: [`unnecessary_dedup_by`]: add new lint

fixes rust-lang/rust-clippy#16481
