### PR TITLE
chore: remove unnecessary trailing commas in format strings

### DIFF
--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -167,9 +167,9 @@ fn add_lint(lint: &LintData<'_>, enable_msrv: bool) -> io::Result<()> {
     let camel_name = to_camel_case(lint.name);
 
     let new_lint = if enable_msrv {
-        format!("Box::new(move |{ctor_arg}| Box::new({module_name}::{camel_name}::new(conf))),\n        ",)
+        format!("Box::new(move |{ctor_arg}| Box::new({module_name}::{camel_name}::new(conf))),\n        ")
     } else {
-        format!("Box::new(|{ctor_arg}| Box::new({module_name}::{camel_name})),\n        ",)
+        format!("Box::new(|{ctor_arg}| Box::new({module_name}::{camel_name})),\n        ")
     };
 
     lib_rs.insert_str(comment_start, &new_lint);

--- a/clippy_lints/src/cargo/lint_groups_priority.rs
+++ b/clippy_lints/src/cargo/lint_groups_priority.rs
@@ -100,7 +100,7 @@ fn check_table(cx: &LateContext<'_>, table: &DeTable<'_>, known_groups: &FxHashS
                             "to have lints override the group set `{}` to a lower priority",
                             group.as_ref()
                         ),
-                        format!("{{ level = {:?}, priority = {low_priority} }}", group_config.level,),
+                        format!("{{ level = {:?}, priority = {low_priority} }}", group_config.level),
                         Applicability::MaybeIncorrect,
                     );
                 },

--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -117,7 +117,7 @@ pub(super) fn check(
                 return;
             }
 
-            format!("casting `{cast_from}` to `{cast_to}` may truncate the value{suffix}",)
+            format!("casting `{cast_from}` to `{cast_to}` may truncate the value{suffix}")
         },
 
         (ty::Adt(def, _), Some(to_nbits)) if def.is_enum() => {

--- a/clippy_lints/src/doc/doc_suspicious_footnotes.rs
+++ b/clippy_lints/src/doc/doc_suspicious_footnotes.rs
@@ -91,7 +91,7 @@ pub fn check(cx: &LateContext<'_>, doc: &str, range: Range<usize>, fragments: &F
                             diag.span_suggestion_verbose(
                                 this_fragment.span.shrink_to_hi(),
                                 "add footnote definition",
-                                format!("\n\n{label}: <!-- description -->", label = &doc[start..end],),
+                                format!("\n\n{label}: <!-- description -->", label = &doc[start..end]),
                                 Applicability::HasPlaceholders,
                             );
                         } else {

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -337,7 +337,7 @@ fn check_missing_else(cx: &EarlyContext<'_>, first: &Expr, second: &Expr) {
             else_span,
             format!("this looks like {looks_like} but the `else` is missing"),
             None,
-            format!("to remove this lint, add the missing `else` or add a new line before {next_thing}",),
+            format!("to remove this lint, add the missing `else` or add a new line before {next_thing}"),
         );
     }
 }

--- a/clippy_lints/src/implicit_hasher.rs
+++ b/clippy_lints/src/implicit_hasher.rs
@@ -92,7 +92,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitHasher {
                 ),
                 (
                     target.span(),
-                    format!("{}<{}, S>", target.type_name(), target.type_arguments(),),
+                    format!("{}<{}, S>", target.type_name(), target.type_arguments()),
                 ),
             ];
             suggestions.extend(vis.suggestions);
@@ -352,7 +352,7 @@ impl<'tcx> Visitor<'tcx> for ImplicitHasherConstructorVisitor<'_, '_, 'tcx> {
                     );
                     self.suggestions.insert(
                         e.span,
-                        format!("{container_name}::with_capacity_and_hasher({arg_snippet}, Default::default())",),
+                        format!("{container_name}::with_capacity_and_hasher({arg_snippet}, Default::default())"),
                     );
                 },
                 _ => {},

--- a/clippy_lints/src/matches/manual_unwrap_or.rs
+++ b/clippy_lints/src/matches/manual_unwrap_or.rs
@@ -173,7 +173,7 @@ fn handle(
                 expr.span,
                 format!("this pattern reimplements `{ty_name}::unwrap_or`"),
                 "replace with",
-                format!("{suggestion}.unwrap_or({reindented_or_body})",),
+                format!("{suggestion}.unwrap_or({reindented_or_body})"),
                 app,
             );
         }

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -187,7 +187,7 @@ pub(super) fn check_match<'tcx>(
                 diag.span_suggestion_verbose(
                     e.span,
                     "use `matches!` directly",
-                    format!("{}matches!({snippet}, {pat_and_guard})", if b0 { "" } else { "!" },),
+                    format!("{}matches!({snippet}, {pat_and_guard})", if b0 { "" } else { "!" }),
                     applicability,
                 );
             },

--- a/clippy_lints/src/methods/bytes_nth.rs
+++ b/clippy_lints/src/methods/bytes_nth.rs
@@ -34,7 +34,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, recv: &'tcx E
             parent.span,
             format!("called `.bytes().nth().unwrap()` on a `{caller_type}`"),
             "try",
-            format!("{receiver}.as_bytes()[{n}]",),
+            format!("{receiver}.as_bytes()[{n}]"),
             applicability,
         );
     } else {

--- a/clippy_lints/src/methods/into_iter_on_ref.rs
+++ b/clippy_lints/src/methods/into_iter_on_ref.rs
@@ -20,7 +20,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, method_span: Spa
             cx,
             INTO_ITER_ON_REF,
             method_span,
-            format!("this `.into_iter()` call is equivalent to `.{method_name}()` and will not consume the `{kind}`",),
+            format!("this `.into_iter()` call is equivalent to `.{method_name}()` and will not consume the `{kind}`"),
             "call directly",
             method_name.to_string(),
             Applicability::MachineApplicable,

--- a/clippy_lints/src/methods/manual_try_fold.rs
+++ b/clippy_lints/src/methods/manual_try_fold.rs
@@ -47,7 +47,7 @@ pub(super) fn check<'tcx>(
             fold_span,
             "usage of `Iterator::fold` on a type that implements `Try`",
             "use `try_fold` instead",
-            format!("try_fold({init_snip}, {args_snip} ...)",),
+            format!("try_fold({init_snip}, {args_snip} ...)"),
             Applicability::HasPlaceholders,
         );
     }

--- a/clippy_lints/src/methods/unit_hash.rs
+++ b/clippy_lints/src/methods/unit_hash.rs
@@ -19,7 +19,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'
                 diag.span_suggestion(
                     expr.span,
                     "remove the call to `hash` or consider using",
-                    format!("0_u8.hash({})", snippet(cx, arg.span, ".."),),
+                    format!("0_u8.hash({})", snippet(cx, arg.span, "..")),
                     Applicability::MaybeIncorrect,
                 );
                 diag.note("the implementation of `Hash` for `()` is a no-op");

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -364,15 +364,15 @@ fn report_indexes(cx: &LateContext<'_>, map: UnindexMap<u64, Vec<IndexEntry<'_>>
                         // `v.len() < 5` and `v.len() <= 5` does nothing in terms of bounds checks.
                         // The user probably meant `v.len() > 5`
                         LengthComparison::LengthLessThanInt | LengthComparison::LengthLessThanOrEqualInt => {
-                            Some(format!("assert!({slice_str}.len() > {highest_index})",))
+                            Some(format!("assert!({slice_str}.len() > {highest_index})"))
                         },
                         // `5 < v.len()` == `v.len() > 5`
                         LengthComparison::IntLessThanLength if asserted_len < highest_index => {
-                            Some(format!("assert!({slice_str}.len() > {highest_index})",))
+                            Some(format!("assert!({slice_str}.len() > {highest_index})"))
                         },
                         // `5 <= v.len() == `v.len() >= 5`
                         LengthComparison::IntLessThanOrEqualLength if asserted_len <= highest_index => {
-                            Some(format!("assert!({slice_str}.len() > {highest_index})",))
+                            Some(format!("assert!({slice_str}.len() > {highest_index})"))
                         },
                         // `highest_index` here is rather a length, so we need to add 1 to it
                         LengthComparison::LengthEqualInt if asserted_len < highest_index + 1 => match macro_call {

--- a/clippy_lints/src/missing_enforced_import_rename.rs
+++ b/clippy_lints/src/missing_enforced_import_rename.rs
@@ -97,7 +97,7 @@ impl LateLintPass<'_> for ImportRename {
                         span_without_semi,
                         "this import should be renamed",
                         "try",
-                        format!("{import} as {name}",),
+                        format!("{import} as {name}"),
                         Applicability::MachineApplicable,
                     );
                 }

--- a/clippy_lints/src/ptr/cmp_null.rs
+++ b/clippy_lints/src/ptr/cmp_null.rs
@@ -32,7 +32,7 @@ pub(super) fn check<'tcx>(
         expr.span,
         "comparing with null is better expressed by the `.is_null()` method",
         "try",
-        format!("{invert}{non_null_path_snippet}.is_null()",),
+        format!("{invert}{non_null_path_snippet}.is_null()"),
         applicability,
     );
     true

--- a/clippy_lints/src/toplevel_ref_arg.rs
+++ b/clippy_lints/src/toplevel_ref_arg.rs
@@ -109,7 +109,7 @@ impl<'tcx> LateLintPass<'tcx> for ToplevelRefArg {
                     diag.span_suggestion(
                         stmt.span,
                         "try",
-                        format!("let {name}{tyopt} = {initref};", name = snippet(cx, name.span, ".."),),
+                        format!("let {name}{tyopt} = {initref};", name = snippet(cx, name.span, "..")),
                         app,
                     );
                 },

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -56,7 +56,7 @@ impl<'tcx> LateLintPass<'tcx> for ZeroDiv {
                 expr.span,
                 "constant division of `0.0` with `0.0` will always result in NaN",
                 None,
-                format!("consider using `{float_type}::NAN` if you would like a constant representing NaN",),
+                format!("consider using `{float_type}::NAN` if you would like a constant representing NaN"),
             );
         }
     }

--- a/clippy_lints/src/zero_repeat_side_effects.rs
+++ b/clippy_lints/src/zero_repeat_side_effects.rs
@@ -168,7 +168,7 @@ fn assign_expr_suggestion(
     let indent = snippet_indent(cx, outer_expr.span).unwrap_or_default();
     let var_name = snippet(cx, assign_expr_span.source_callsite(), "..");
     if needs_curly {
-        format!("{{\n    {indent}{inner_expr};\n    {indent}{var_name} = {vec_str}[] as {return_type}\n{indent}}}",)
+        format!("{{\n    {indent}{inner_expr};\n    {indent}{var_name} = {vec_str}[] as {return_type}\n{indent}}}")
     } else {
         format!("{inner_expr};\n{indent}{var_name} = {vec_str}[] as {return_type}")
     }

--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -91,7 +91,7 @@ impl std::fmt::Debug for VersionInfo {
             self.crate_name, self.major, self.minor, self.patch,
         )?;
         if let Some(ref commit_hash) = self.commit_hash {
-            write!(f, ", commit_hash: \"{}\"", commit_hash.trim(),)?;
+            write!(f, ", commit_hash: \"{}\"", commit_hash.trim())?;
         }
         if let Some(ref commit_date) = self.commit_date {
             write!(f, ", commit_date: \"{}\"", commit_date.trim())?;


### PR DESCRIPTION
This noop PR makes the new comma-removing lint PR less noisy, allowing it focus only on the new functionality

See rust-lang/rust-clippy#16530

changelog: none
