### PR TITLE
Fix outdated doc comments

### DIFF
--- a/book/src/development/type_checking.md
+++ b/book/src/development/type_checking.md
@@ -154,7 +154,7 @@ in this chapter:
 [expr_ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TypeckResults.html#method.expr_ty
 [node_type]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TypeckResults.html#method.node_type
 [is_char]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.Ty.html#method.is_char
-[is_char_source]: https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_middle/ty/sty.rs.html#1429-1432
+[is_char_source]: https://github.com/rust-lang/rust/blob/d34f1f931489618efffc4007e6b6bdb9e10f6467/compiler/rustc_middle/src/ty/sty.rs#L1429-L1432
 [kind]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.Ty.html#method.kind
 [LateContext]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/struct.LateContext.html
 [LateLintPass]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/trait.LateLintPass.html

--- a/tests/ui/unconditional_recursion.rs
+++ b/tests/ui/unconditional_recursion.rs
@@ -334,7 +334,7 @@ mod issue12154 {
     }
 
     // Not necessarily related to the issue but another FP from the http crate that was fixed with it:
-    // https://docs.rs/http/latest/src/http/header/name.rs.html#1408
+    // https://github.com/hyperium/http/blob/5f0c86642f1dc86f156da82b62aceb2f4fab20e1/src/header/name.rs#L1408-L1420
     // We used to simply peel refs from the LHS and RHS, so we couldn't differentiate
     // between `PartialEq<T> for &T` and `PartialEq<&T> for T` impls.
     #[derive(PartialEq)]


### PR DESCRIPTION
Replace the links to more recent materials in the docs.

changelog: none