### PR TITLE
feat: add lint for ignored format precision on non-float types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7374,6 +7374,7 @@ Released 2018-09-13
 [`unused_async`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_async
 [`unused_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_collect
 [`unused_enumerate_index`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_enumerate_index
+[`unused_format_precision`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_format_precision
 [`unused_format_specs`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_format_specs
 [`unused_io_amount`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount
 [`unused_label`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7719,6 +7719,7 @@ Released 2018-09-13
 [`unused_async_trait_impl`]: https://rust-lang.github.io/rust-clippy/main/index.html#unused_async_trait_impl
 [`unused_collect`]: https://rust-lang.github.io/rust-clippy/main/index.html#unused_collect
 [`unused_enumerate_index`]: https://rust-lang.github.io/rust-clippy/main/index.html#unused_enumerate_index
+[`unused_format_precision`]: https://rust-lang.github.io/rust-clippy/main/index.html#unused_format_precision
 [`unused_format_specs`]: https://rust-lang.github.io/rust-clippy/main/index.html#unused_format_specs
 [`unused_io_amount`]: https://rust-lang.github.io/rust-clippy/main/index.html#unused_io_amount
 [`unused_label`]: https://rust-lang.github.io/rust-clippy/main/index.html#unused_label

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -175,6 +175,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::format_args::UNINLINED_FORMAT_ARGS_INFO,
     crate::format_args::UNNECESSARY_DEBUG_FORMATTING_INFO,
     crate::format_args::UNNECESSARY_TRAILING_COMMA_INFO,
+    crate::format_args::UNUSED_FORMAT_PRECISION_INFO,
     crate::format_args::UNUSED_FORMAT_SPECS_INFO,
     crate::format_args::USELESS_BORROWS_IN_FORMATTING_INFO,
     crate::format_impl::PRINT_IN_FORMAT_IMPL_INFO,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -180,6 +180,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::format_args::UNINLINED_FORMAT_ARGS_INFO,
     crate::format_args::UNNECESSARY_DEBUG_FORMATTING_INFO,
     crate::format_args::UNNECESSARY_TRAILING_COMMA_INFO,
+    crate::format_args::UNUSED_FORMAT_PRECISION_INFO,
     crate::format_args::UNUSED_FORMAT_SPECS_INFO,
     crate::format_args::USELESS_BORROWS_IN_FORMATTING_INFO,
     crate::format_impl::PRINT_IN_FORMAT_IMPL_INFO,

--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -234,6 +234,26 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for format precision for standard non-float types where it has no effect
+    /// (integers, bool, char, pointers). Precision is meaningful for floats, `str` (truncation), or user types.
+    ///
+    /// ### Why is this bad?
+    /// Specifying precision for these types is misleading and may indicate a bug. The value is ignored by the formatter.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// println!("{:.5}", 42);   // precision ignored for integers
+    /// println!("{:.3}", true); // precision ignored for bool
+    /// println!("{:.2}", 'x');  // precision ignored for char
+    /// ```
+    #[clippy::version = "1.95.0"]
+    pub UNUSED_FORMAT_PRECISION,
+    correctness,
+    "precision has no effect for this type"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Detects [formatting parameters] that have no effect on the output of
     /// `format!()`, `println!()` or similar macros.
     ///
@@ -308,6 +328,7 @@ impl_lint_pass!(FormatArgs<'_> => [
     UNINLINED_FORMAT_ARGS,
     UNNECESSARY_DEBUG_FORMATTING,
     UNNECESSARY_TRAILING_COMMA,
+    UNUSED_FORMAT_PRECISION,
     UNUSED_FORMAT_SPECS,
     USELESS_BORROWS_IN_FORMATTING,
 ]);
@@ -408,6 +429,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                 && let Some(arg_expr) = find_format_arg_expr(self.expr, arg)
             {
                 self.check_unused_format_specifier(placeholder, arg_expr);
+                self.check_unused_format_precision(placeholder, arg_expr);
                 self.check_useless_format_width(placeholder);
                 self.check_useless_borrows_in_formatting(placeholder, arg_expr);
 
@@ -533,6 +555,26 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                         );
                     }
                 },
+            );
+        }
+    }
+
+    /// Lint when precision is specified but the argument type is a standard non-float type
+    /// (integer, bool, char, pointer) where precision has no effect.
+    fn check_unused_format_precision(&self, placeholder: &FormatPlaceholder, arg_expr: &Expr<'_>) {
+        if placeholder.format_options.precision.is_some()
+            && let Some(placeholder_span) = placeholder.span
+            && let ty = self.cx.typeck_results().expr_ty(arg_expr).peel_refs()
+            && matches!(
+                ty.kind(),
+                ty::Int(..) | ty::Uint(..) | ty::Char | ty::RawPtr(..) | ty::FnPtr(..)
+            )
+        {
+            span_lint(
+                self.cx,
+                UNUSED_FORMAT_PRECISION,
+                placeholder_span,
+                format!("precision has no effect for type `{ty}`"),
             );
         }
     }

--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -235,6 +235,26 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for format precision for standard non-float types where it has no effect
+    /// (integers, bool, char, pointers). Precision is meaningful for floats, `str` (truncation), or user types.
+    ///
+    /// ### Why is this bad?
+    /// Specifying precision for these types is misleading and may indicate a bug. The value is ignored by the formatter.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// println!("{:.5}", 42);   // precision ignored for integers
+    /// println!("{:.3}", true); // precision ignored for bool
+    /// println!("{:.2}", 'x');  // precision ignored for char
+    /// ```
+    #[clippy::version = "1.95.0"]
+    pub UNUSED_FORMAT_PRECISION,
+    correctness,
+    "precision has no effect for this type"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Detects [formatting parameters] that have no effect on the output of
     /// `format!()`, `println!()` or similar macros.
     ///
@@ -309,6 +329,7 @@ impl_lint_pass!(FormatArgs<'_> => [
     UNINLINED_FORMAT_ARGS,
     UNNECESSARY_DEBUG_FORMATTING,
     UNNECESSARY_TRAILING_COMMA,
+    UNUSED_FORMAT_PRECISION,
     UNUSED_FORMAT_SPECS,
     USELESS_BORROWS_IN_FORMATTING,
 ]);
@@ -409,6 +430,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                 && let Some(arg_expr) = find_format_arg_expr(self.expr, arg)
             {
                 self.check_unused_format_specifier(placeholder, arg_expr);
+                self.check_unused_format_precision(placeholder, arg_expr);
                 self.check_useless_format_width(placeholder);
                 self.check_useless_borrows_in_formatting(placeholder, arg_expr);
 
@@ -547,6 +569,26 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                         );
                     }
                 },
+            );
+        }
+    }
+
+    /// Lint when precision is specified but the argument type is a standard non-float type
+    /// (integer, bool, char, pointer) where precision has no effect.
+    fn check_unused_format_precision(&self, placeholder: &FormatPlaceholder, arg_expr: &Expr<'_>) {
+        if placeholder.format_options.precision.is_some()
+            && let Some(placeholder_span) = placeholder.span
+            && let ty = self.cx.typeck_results().expr_ty(arg_expr).peel_refs()
+            && matches!(
+                ty.kind(),
+                ty::Int(..) | ty::Uint(..) | ty::Char | ty::RawPtr(..) | ty::FnPtr(..)
+            )
+        {
+            span_lint(
+                self.cx,
+                UNUSED_FORMAT_PRECISION,
+                placeholder_span,
+                format!("precision has no effect for type `{ty}`"),
             );
         }
     }

--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -236,21 +236,22 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     /// ### What it does
     /// Checks for format precision for standard non-float types where it has no effect
-    /// (integers, bool, char, pointers). Precision is meaningful for floats, `str` (truncation), or user types.
+    /// (integers, `char`, pointers). Precision is meaningful for floats, `str` and `bool`
+    /// (truncation), or user types.
     ///
     /// ### Why is this bad?
     /// Specifying precision for these types is misleading and may indicate a bug. The value is ignored by the formatter.
     ///
     /// ### Example
     /// ```no_run
-    /// println!("{:.5}", 42);   // precision ignored for integers
-    /// println!("{:.3}", true); // precision ignored for bool
-    /// println!("{:.2}", 'x');  // precision ignored for char
+    /// println!("{:.5}", 42); // precision ignored for integers
+    /// println!("{:.2}", 'x'); // precision ignored for char
+    /// println!("{:.2p}", &42 as *const i32); // precision ignored for pointers
     /// ```
     #[clippy::version = "1.95.0"]
     pub UNUSED_FORMAT_PRECISION,
     correctness,
-    "precision has no effect for this type"
+    "format precision specified for a type that ignores it, such as an integer, `char` or a pointer"
 }
 
 declare_clippy_lint! {
@@ -574,7 +575,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
     }
 
     /// Lint when precision is specified but the argument type is a standard non-float type
-    /// (integer, bool, char, pointer) where precision has no effect.
+    /// (integer, char, pointer) where precision has no effect.
     fn check_unused_format_precision(&self, placeholder: &FormatPlaceholder, arg_expr: &Expr<'_>) {
         if placeholder.format_options.precision.is_some()
             && let Some(placeholder_span) = placeholder.span

--- a/tests/ui/print_literal.fixed
+++ b/tests/ui/print_literal.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::print_literal)]
-#![allow(clippy::uninlined_format_args, clippy::literal_string_with_formatting_args)]
+#![allow(
+    clippy::literal_string_with_formatting_args,
+    clippy::uninlined_format_args,
+    clippy::unused_format_precision
+)]
 
 fn main() {
     // these should be fine

--- a/tests/ui/print_literal.fixed
+++ b/tests/ui/print_literal.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::print_literal)]
-#![expect(clippy::literal_string_with_formatting_args, clippy::uninlined_format_args)]
+#![expect(
+    clippy::literal_string_with_formatting_args,
+    clippy::uninlined_format_args,
+    clippy::unused_format_precision
+)]
 
 fn main() {
     // these should be fine

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::print_literal)]
-#![allow(clippy::uninlined_format_args, clippy::literal_string_with_formatting_args)]
+#![allow(
+    clippy::literal_string_with_formatting_args,
+    clippy::uninlined_format_args,
+    clippy::unused_format_precision
+)]
 
 fn main() {
     // these should be fine

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::print_literal)]
-#![expect(clippy::literal_string_with_formatting_args, clippy::uninlined_format_args)]
+#![expect(
+    clippy::literal_string_with_formatting_args,
+    clippy::uninlined_format_args,
+    clippy::unused_format_precision
+)]
 
 fn main() {
     // these should be fine

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -1,5 +1,5 @@
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:27:24
+  --> tests/ui/print_literal.rs:31:24
    |
 LL |     print!("Hello {}", "world");
    |                        ^^^^^^^
@@ -13,7 +13,7 @@ LL +     print!("Hello world");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:30:36
+  --> tests/ui/print_literal.rs:34:36
    |
 LL |     println!("Hello {} {}", world, "world");
    |                                    ^^^^^^^
@@ -25,7 +25,7 @@ LL +     println!("Hello {} world", world);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:33:26
+  --> tests/ui/print_literal.rs:37:26
    |
 LL |     println!("Hello {}", "world");
    |                          ^^^^^^^
@@ -37,7 +37,7 @@ LL +     println!("Hello world");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:36:26
+  --> tests/ui/print_literal.rs:40:26
    |
 LL |     println!("{} {:.4}", "a literal", 5);
    |                          ^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +     println!("a literal {:.4}", 5);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:42:25
+  --> tests/ui/print_literal.rs:46:25
    |
 LL |     println!("{0} {1}", "hello", "world");
    |                         ^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL +     println!("hello world");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:45:25
+  --> tests/ui/print_literal.rs:49:25
    |
 LL |     println!("{1} {0}", "hello", "world");
    |                         ^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +     println!("world hello");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:49:35
+  --> tests/ui/print_literal.rs:53:35
    |
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                   ^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +     println!("hello world");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:52:35
+  --> tests/ui/print_literal.rs:56:35
    |
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                   ^^^^^^^^^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL +     println!("world hello");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:60:20
+  --> tests/ui/print_literal.rs:64:20
    |
 LL |     println!("{}", "{} \x00 \u{ab123} \\\u{ab123} {:?}");
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL +     println!("{{}} \x00 \u{ab123} \\\u{ab123} {{:?}}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:62:20
+  --> tests/ui/print_literal.rs:66:20
    |
 LL |     println!("{}", "\\\u{1234}");
    |                    ^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL +     println!("\\\u{1234}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:67:20
+  --> tests/ui/print_literal.rs:71:20
    |
 LL |     println!("{}", r"\u{ab123} \u{{");
    |                    ^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL +     println!("\\u{{ab123}} \\u{{{{");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:69:21
+  --> tests/ui/print_literal.rs:73:21
    |
 LL |     println!(r"{}", r"\u{ab123} \u{{");
    |                     ^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL +     println!(r"\u{{ab123}} \u{{{{");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:71:20
+  --> tests/ui/print_literal.rs:75:20
    |
 LL |     println!("{}", r"\{ab123} \u{{");
    |                    ^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     println!("\\{{ab123}} \\u{{{{");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:73:20
+  --> tests/ui/print_literal.rs:77:20
    |
 LL |     println!("{}", "\\u{ab123}");
    |                    ^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL +     println!("\\u{{ab123}}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:75:20
+  --> tests/ui/print_literal.rs:79:20
    |
 LL |     println!("{}", "\\\\u{1234}");
    |                    ^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     println!("\\\\u{{1234}}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:78:35
+  --> tests/ui/print_literal.rs:82:35
    |
 LL |     println!("mixed: {} {world}", "{hello}");
    |                                   ^^^^^^^^^
@@ -193,7 +193,7 @@ LL +     println!("mixed: {{hello}} {world}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:83:20
+  --> tests/ui/print_literal.rs:87:20
    |
 LL |     println!("{}", r#"""#);
    |                    ^^^^^^
@@ -205,7 +205,7 @@ LL +     println!("\"");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:87:9
+  --> tests/ui/print_literal.rs:91:9
    |
 LL | /         r#"
 LL | |
@@ -230,7 +230,7 @@ LL ~ "
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:100:52
+  --> tests/ui/print_literal.rs:104:52
    |
 LL |     println!("Hello {3} is {0:2$.1$}", 0.01, 2, 3, "x");
    |                                                    ^^^
@@ -242,7 +242,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:102:49
+  --> tests/ui/print_literal.rs:106:49
    |
 LL |     println!("Hello {2} is {0:3$.1$}", 0.01, 2, "x", 3);
    |                                                 ^^^
@@ -254,7 +254,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:104:46
+  --> tests/ui/print_literal.rs:108:46
    |
 LL |     println!("Hello {1} is {0:3$.2$}", 0.01, "x", 2, 3);
    |                                              ^^^
@@ -266,7 +266,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:106:40
+  --> tests/ui/print_literal.rs:110:40
    |
 LL |     println!("Hello {0} is {1:3$.2$}", "x", 0.01, 2, 3);
    |                                        ^^^
@@ -278,7 +278,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:111:36
+  --> tests/ui/print_literal.rs:115:36
    |
 LL |     println!("Hello {} is {2:.*}", "x", 5, 0.01);
    |                                    ^^^
@@ -290,7 +290,7 @@ LL +     println!("Hello x is {1:.*}", 5, 0.01);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:114:36
+  --> tests/ui/print_literal.rs:118:36
    |
 LL |     println!("Hello {} is {:.p$}", "x", 0.01, p = 5);
    |                                    ^^^
@@ -302,7 +302,7 @@ LL +     println!("Hello x is {:.p$}", 0.01, p = 5);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:119:9
+  --> tests/ui/print_literal.rs:123:9
    |
 LL |         "name", 5, "x", 0.01
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/uninlined_format_args.fixed
+++ b/tests/ui/uninlined_format_args.fixed
@@ -6,9 +6,9 @@
     clippy::eq_op,
     clippy::format_in_format_args,
     clippy::print_literal,
-    clippy::unnecessary_literal_unwrap
+    clippy::unnecessary_literal_unwrap,
+    clippy::unused_format_precision
 )]
-
 extern crate proc_macros;
 use proc_macros::with_span;
 

--- a/tests/ui/uninlined_format_args.fixed
+++ b/tests/ui/uninlined_format_args.fixed
@@ -5,9 +5,9 @@
 #![expect(
     clippy::format_in_format_args,
     clippy::print_literal,
-    clippy::unnecessary_literal_unwrap
+    clippy::unnecessary_literal_unwrap,
+    clippy::unused_format_precision
 )]
-
 extern crate proc_macros;
 use proc_macros::with_span;
 

--- a/tests/ui/uninlined_format_args.rs
+++ b/tests/ui/uninlined_format_args.rs
@@ -6,9 +6,9 @@
     clippy::eq_op,
     clippy::format_in_format_args,
     clippy::print_literal,
-    clippy::unnecessary_literal_unwrap
+    clippy::unnecessary_literal_unwrap,
+    clippy::unused_format_precision
 )]
-
 extern crate proc_macros;
 use proc_macros::with_span;
 

--- a/tests/ui/uninlined_format_args.rs
+++ b/tests/ui/uninlined_format_args.rs
@@ -5,9 +5,9 @@
 #![expect(
     clippy::format_in_format_args,
     clippy::print_literal,
-    clippy::unnecessary_literal_unwrap
+    clippy::unnecessary_literal_unwrap,
+    clippy::unused_format_precision
 )]
-
 extern crate proc_macros;
 use proc_macros::with_span;
 

--- a/tests/ui/unused_format_precision.rs
+++ b/tests/ui/unused_format_precision.rs
@@ -1,0 +1,119 @@
+#![warn(clippy::unused_format_precision)]
+#![allow(clippy::zero_ptr, clippy::manual_dangling_ptr, clippy::useless_borrows_in_formatting)]
+
+fn main() {
+    let v = 42_u8;
+    println!("{:.1}", 42_u8); //~ ERROR: precision has no effect for type `u8`
+    println!("{:.1?}", 42_u8); //~ ERROR: precision has no effect for type `u8`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `u8`
+
+    let prec = 1;
+    println!("{:.prec$}", 42_u8); //~ ERROR: precision has no effect for type `u8`
+    println!("{0:.1$}", 42_u8, prec); //~ ERROR: precision has no effect for type `u8`
+    println!("{:.*}", prec, 42_u8); //~ ERROR: precision has no effect for type `u8`
+    println!("{:.prec$?}", 42_u8); //~ ERROR: precision has no effect for type `u8`
+    println!("{v:.prec$}"); //~ ERROR: precision has no effect for type `u8`
+    println!("{:.prec$}", &v); //~ ERROR: precision has no effect for type `u8`
+
+    let v = 42_i8;
+    println!("{:.1}", 42_i8); //~ ERROR: precision has no effect for type `i8`
+    println!("{:.1?}", 42_i8); //~ ERROR: precision has no effect for type `i8`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `i8`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `i8`
+
+    let v = 42_u16;
+    println!("{:.1}", 42_u16); //~ ERROR: precision has no effect for type `u16`
+    println!("{:.1?}", 42_u16); //~ ERROR: precision has no effect for type `u16`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `u16`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `u16`
+
+    let v = 42_i16;
+    println!("{:.1}", 42_i16); //~ ERROR: precision has no effect for type `i16`
+    println!("{:.1?}", 42_i16); //~ ERROR: precision has no effect for type `i16`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `i16`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `i16`
+
+    let v = 42_u32;
+    println!("{:.1}", 42_u32); //~ ERROR: precision has no effect for type `u32`
+    println!("{:.1?}", 42_u32); //~ ERROR: precision has no effect for type `u32`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `u32`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `u32`
+
+    let v = 42_i32;
+    println!("{:.1}", 42_i32); //~ ERROR: precision has no effect for type `i32`
+    println!("{:.1?}", 42_i32); //~ ERROR: precision has no effect for type `i32`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `i32`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `i32`
+
+    let v = 42_u64;
+    println!("{:.1}", 42_u64); //~ ERROR: precision has no effect for type `u64`
+    println!("{:.1?}", 42_u64); //~ ERROR: precision has no effect for type `u64`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `u64`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `u64`
+
+    let v = 42_i64;
+    println!("{:.1}", 42_i64); //~ ERROR: precision has no effect for type `i64`
+    println!("{:.1?}", 42_i64); //~ ERROR: precision has no effect for type `i64`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `i64`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `i64`
+
+    let v = 42_usize;
+    println!("{:.1}", 42_usize); //~ ERROR: precision has no effect for type `usize`
+    println!("{:.1?}", 42_usize); //~ ERROR: precision has no effect for type `usize`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `usize`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `usize`
+
+    let v = 42_isize;
+    println!("{:.1}", 42_isize); //~ ERROR: precision has no effect for type `isize`
+    println!("{:.1?}", 42_isize); //~ ERROR: precision has no effect for type `isize`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `isize`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `isize`
+
+    let v = 'x';
+    println!("{:.1}", 'x'); //~ ERROR: precision has no effect for type `char`
+    println!("{:.1?}", 'x'); //~ ERROR: precision has no effect for type `char`
+    println!("{v:.1}"); //~ ERROR: precision has no effect for type `char`
+    println!("{:.1}", &v); //~ ERROR: precision has no effect for type `char`
+
+    let v = 0x123456789 as *const usize;
+    println!("{:.1p}", 0x123456789 as *const u8); //~ ERROR: precision has no effect for type `*const u8`
+    println!("{v:.1p}"); //~ ERROR: precision has no effect for type `*const usize`
+
+    fn dummy() {}
+    let v = dummy as fn();
+    println!("{:.1p}", dummy as fn()); //~ ERROR: precision has no effect for type `fn()`
+    println!("{v:.1p}"); //~ ERROR: precision has no effect for type `fn()`
+
+    // Not linted - precision used for truncation
+    println!("{:.1}", "hello");
+    println!("{:.1}", &"hello");
+
+    let v = true;
+    println!("{:.1}", true);
+    println!("{:.1?}", true);
+    println!("{v:.1}");
+    println!("{:.1}", &v);
+
+    // Not linted: floats (precision used)
+    println!("{:.1}", 1.0f32);
+    println!("{:.1}", 1.0f64);
+
+    // Not linted: no precision specified
+    println!("{}", 1u8);
+    println!("{:?}", 42);
+
+    // Not linted: custom types (ignored by design)
+    struct S;
+    impl std::fmt::Display for S {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ABC")
+        }
+    }
+    println!("{:.1}", S);
+
+    // Generics: not linted, since we don't know the type
+    fn generic<T: std::fmt::Display>(x: T) {
+        println!("{:.1}", x);
+    }
+}

--- a/tests/ui/unused_format_precision.rs
+++ b/tests/ui/unused_format_precision.rs
@@ -1,5 +1,10 @@
+//@aux-build:proc_macros.rs
 #![warn(clippy::unused_format_precision)]
-#![allow(clippy::zero_ptr, clippy::manual_dangling_ptr, clippy::useless_borrows_in_formatting)]
+#![allow(clippy::manual_dangling_ptr, clippy::useless_borrows_in_formatting, clippy::zero_ptr)]
+
+extern crate proc_macros;
+
+use std::fmt::Write as _;
 
 fn main() {
     let v = 42_u8;
@@ -115,5 +120,74 @@ fn main() {
     // Generics: not linted, since we don't know the type
     fn generic<T: std::fmt::Display>(x: T) {
         println!("{:.1}", x);
+    }
+
+    other_format_macros();
+    panicking_format_macros(42_u8);
+    inside_a_macro();
+}
+
+// All the other formatting macros are linted the same way as `println!`
+fn other_format_macros() {
+    let v = 42_u8;
+
+    let _ = format!("{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    print!("{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    eprint!("{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    eprintln!("{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+
+    let mut s = String::new();
+    let _ = write!(s, "{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    let _ = writeln!(s, "{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+
+    assert!(v == 42, "{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    assert_eq!(v, 42, "{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    assert_ne!(v, 0, "{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    debug_assert!(v == 42, "{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+
+    // Not linted for the same reasons as `println!`
+    let _ = format!("{:.1}", "hello");
+    let _ = format!("{:.1}", 1.0f64);
+    let _ = write!(s, "{:.1}", 1.0f64);
+    assert!(v == 42, "{:.1}", 1.0f64);
+}
+
+// Diverging formatting macros
+fn panicking_format_macros(v: u8) {
+    if v == 0 {
+        panic!("{v:.1}"); //~ ERROR: precision has no effect for type `u8`
+    }
+    // Not linted: `todo!` and `unimplemented!` wrap their arguments in a nested `format_args!`
+    // call, which none of the `format_args` lints look into
+    if v == 1 {
+        unimplemented!("{v:.1}");
+    }
+    todo!("{v:.1}");
+}
+
+// Not linted: the formatting macro is called from inside a macro, so the type of the
+// argument is not known at the macro definition site and nothing can be fixed there.
+macro_rules! print_with_precision {
+    ($e:expr) => {
+        println!("{:.1}", $e)
+    };
+}
+
+macro_rules! print_captured_with_precision {
+    () => {{
+        let v = 42_u8;
+        println!("{v:.1}");
+    }};
+}
+
+fn inside_a_macro() {
+    print_with_precision!(42_u8);
+    print_with_precision!("hello");
+    print_with_precision!(1.0f64);
+    print_captured_with_precision!();
+
+    // Not linted: code coming from an external macro
+    proc_macros::external! {
+        println!("{:.1}", 42_u8);
     }
 }

--- a/tests/ui/unused_format_precision.stderr
+++ b/tests/ui/unused_format_precision.stderr
@@ -1,0 +1,329 @@
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:6:15
+   |
+LL |     println!("{:.1}", 42_u8);
+   |               ^^^^^
+   |
+   = note: `-D clippy::unused-format-precision` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_format_precision)]`
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:7:15
+   |
+LL |     println!("{:.1?}", 42_u8);
+   |               ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:8:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:9:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:12:15
+   |
+LL |     println!("{:.prec$}", 42_u8);
+   |               ^^^^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:13:15
+   |
+LL |     println!("{0:.1$}", 42_u8, prec);
+   |               ^^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:14:15
+   |
+LL |     println!("{:.*}", prec, 42_u8);
+   |               ^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:15:15
+   |
+LL |     println!("{:.prec$?}", 42_u8);
+   |               ^^^^^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:16:15
+   |
+LL |     println!("{v:.prec$}");
+   |               ^^^^^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:17:15
+   |
+LL |     println!("{:.prec$}", &v);
+   |               ^^^^^^^^^
+
+error: precision has no effect for type `i8`
+  --> tests/ui/unused_format_precision.rs:20:15
+   |
+LL |     println!("{:.1}", 42_i8);
+   |               ^^^^^
+
+error: precision has no effect for type `i8`
+  --> tests/ui/unused_format_precision.rs:21:15
+   |
+LL |     println!("{:.1?}", 42_i8);
+   |               ^^^^^^
+
+error: precision has no effect for type `i8`
+  --> tests/ui/unused_format_precision.rs:22:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `i8`
+  --> tests/ui/unused_format_precision.rs:23:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `u16`
+  --> tests/ui/unused_format_precision.rs:26:15
+   |
+LL |     println!("{:.1}", 42_u16);
+   |               ^^^^^
+
+error: precision has no effect for type `u16`
+  --> tests/ui/unused_format_precision.rs:27:15
+   |
+LL |     println!("{:.1?}", 42_u16);
+   |               ^^^^^^
+
+error: precision has no effect for type `u16`
+  --> tests/ui/unused_format_precision.rs:28:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `u16`
+  --> tests/ui/unused_format_precision.rs:29:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `i16`
+  --> tests/ui/unused_format_precision.rs:32:15
+   |
+LL |     println!("{:.1}", 42_i16);
+   |               ^^^^^
+
+error: precision has no effect for type `i16`
+  --> tests/ui/unused_format_precision.rs:33:15
+   |
+LL |     println!("{:.1?}", 42_i16);
+   |               ^^^^^^
+
+error: precision has no effect for type `i16`
+  --> tests/ui/unused_format_precision.rs:34:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `i16`
+  --> tests/ui/unused_format_precision.rs:35:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `u32`
+  --> tests/ui/unused_format_precision.rs:38:15
+   |
+LL |     println!("{:.1}", 42_u32);
+   |               ^^^^^
+
+error: precision has no effect for type `u32`
+  --> tests/ui/unused_format_precision.rs:39:15
+   |
+LL |     println!("{:.1?}", 42_u32);
+   |               ^^^^^^
+
+error: precision has no effect for type `u32`
+  --> tests/ui/unused_format_precision.rs:40:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `u32`
+  --> tests/ui/unused_format_precision.rs:41:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `i32`
+  --> tests/ui/unused_format_precision.rs:44:15
+   |
+LL |     println!("{:.1}", 42_i32);
+   |               ^^^^^
+
+error: precision has no effect for type `i32`
+  --> tests/ui/unused_format_precision.rs:45:15
+   |
+LL |     println!("{:.1?}", 42_i32);
+   |               ^^^^^^
+
+error: precision has no effect for type `i32`
+  --> tests/ui/unused_format_precision.rs:46:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `i32`
+  --> tests/ui/unused_format_precision.rs:47:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `u64`
+  --> tests/ui/unused_format_precision.rs:50:15
+   |
+LL |     println!("{:.1}", 42_u64);
+   |               ^^^^^
+
+error: precision has no effect for type `u64`
+  --> tests/ui/unused_format_precision.rs:51:15
+   |
+LL |     println!("{:.1?}", 42_u64);
+   |               ^^^^^^
+
+error: precision has no effect for type `u64`
+  --> tests/ui/unused_format_precision.rs:52:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `u64`
+  --> tests/ui/unused_format_precision.rs:53:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `i64`
+  --> tests/ui/unused_format_precision.rs:56:15
+   |
+LL |     println!("{:.1}", 42_i64);
+   |               ^^^^^
+
+error: precision has no effect for type `i64`
+  --> tests/ui/unused_format_precision.rs:57:15
+   |
+LL |     println!("{:.1?}", 42_i64);
+   |               ^^^^^^
+
+error: precision has no effect for type `i64`
+  --> tests/ui/unused_format_precision.rs:58:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `i64`
+  --> tests/ui/unused_format_precision.rs:59:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `usize`
+  --> tests/ui/unused_format_precision.rs:62:15
+   |
+LL |     println!("{:.1}", 42_usize);
+   |               ^^^^^
+
+error: precision has no effect for type `usize`
+  --> tests/ui/unused_format_precision.rs:63:15
+   |
+LL |     println!("{:.1?}", 42_usize);
+   |               ^^^^^^
+
+error: precision has no effect for type `usize`
+  --> tests/ui/unused_format_precision.rs:64:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `usize`
+  --> tests/ui/unused_format_precision.rs:65:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `isize`
+  --> tests/ui/unused_format_precision.rs:68:15
+   |
+LL |     println!("{:.1}", 42_isize);
+   |               ^^^^^
+
+error: precision has no effect for type `isize`
+  --> tests/ui/unused_format_precision.rs:69:15
+   |
+LL |     println!("{:.1?}", 42_isize);
+   |               ^^^^^^
+
+error: precision has no effect for type `isize`
+  --> tests/ui/unused_format_precision.rs:70:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `isize`
+  --> tests/ui/unused_format_precision.rs:71:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `char`
+  --> tests/ui/unused_format_precision.rs:74:15
+   |
+LL |     println!("{:.1}", 'x');
+   |               ^^^^^
+
+error: precision has no effect for type `char`
+  --> tests/ui/unused_format_precision.rs:75:15
+   |
+LL |     println!("{:.1?}", 'x');
+   |               ^^^^^^
+
+error: precision has no effect for type `char`
+  --> tests/ui/unused_format_precision.rs:76:15
+   |
+LL |     println!("{v:.1}");
+   |               ^^^^^^
+
+error: precision has no effect for type `char`
+  --> tests/ui/unused_format_precision.rs:77:15
+   |
+LL |     println!("{:.1}", &v);
+   |               ^^^^^
+
+error: precision has no effect for type `*const u8`
+  --> tests/ui/unused_format_precision.rs:80:15
+   |
+LL |     println!("{:.1p}", 0x123456789 as *const u8);
+   |               ^^^^^^
+
+error: precision has no effect for type `*const usize`
+  --> tests/ui/unused_format_precision.rs:81:15
+   |
+LL |     println!("{v:.1p}");
+   |               ^^^^^^^
+
+error: precision has no effect for type `fn()`
+  --> tests/ui/unused_format_precision.rs:85:15
+   |
+LL |     println!("{:.1p}", dummy as fn());
+   |               ^^^^^^
+
+error: precision has no effect for type `fn()`
+  --> tests/ui/unused_format_precision.rs:86:15
+   |
+LL |     println!("{v:.1p}");
+   |               ^^^^^^^
+
+error: aborting due to 54 previous errors
+

--- a/tests/ui/unused_format_precision.stderr
+++ b/tests/ui/unused_format_precision.stderr
@@ -1,5 +1,5 @@
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:6:15
+  --> tests/ui/unused_format_precision.rs:11:15
    |
 LL |     println!("{:.1}", 42_u8);
    |               ^^^^^
@@ -8,322 +8,397 @@ LL |     println!("{:.1}", 42_u8);
    = help: to override `-D warnings` add `#[allow(clippy::unused_format_precision)]`
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:7:15
+  --> tests/ui/unused_format_precision.rs:12:15
    |
 LL |     println!("{:.1?}", 42_u8);
    |               ^^^^^^
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:8:15
+  --> tests/ui/unused_format_precision.rs:13:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:9:15
+  --> tests/ui/unused_format_precision.rs:14:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:12:15
+  --> tests/ui/unused_format_precision.rs:17:15
    |
 LL |     println!("{:.prec$}", 42_u8);
    |               ^^^^^^^^^
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:13:15
+  --> tests/ui/unused_format_precision.rs:18:15
    |
 LL |     println!("{0:.1$}", 42_u8, prec);
    |               ^^^^^^^
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:14:15
+  --> tests/ui/unused_format_precision.rs:19:15
    |
 LL |     println!("{:.*}", prec, 42_u8);
    |               ^^^^^
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:15:15
+  --> tests/ui/unused_format_precision.rs:20:15
    |
 LL |     println!("{:.prec$?}", 42_u8);
    |               ^^^^^^^^^^
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:16:15
+  --> tests/ui/unused_format_precision.rs:21:15
    |
 LL |     println!("{v:.prec$}");
    |               ^^^^^^^^^^
 
 error: precision has no effect for type `u8`
-  --> tests/ui/unused_format_precision.rs:17:15
+  --> tests/ui/unused_format_precision.rs:22:15
    |
 LL |     println!("{:.prec$}", &v);
    |               ^^^^^^^^^
 
 error: precision has no effect for type `i8`
-  --> tests/ui/unused_format_precision.rs:20:15
+  --> tests/ui/unused_format_precision.rs:25:15
    |
 LL |     println!("{:.1}", 42_i8);
    |               ^^^^^
 
 error: precision has no effect for type `i8`
-  --> tests/ui/unused_format_precision.rs:21:15
+  --> tests/ui/unused_format_precision.rs:26:15
    |
 LL |     println!("{:.1?}", 42_i8);
    |               ^^^^^^
 
 error: precision has no effect for type `i8`
-  --> tests/ui/unused_format_precision.rs:22:15
+  --> tests/ui/unused_format_precision.rs:27:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `i8`
-  --> tests/ui/unused_format_precision.rs:23:15
+  --> tests/ui/unused_format_precision.rs:28:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `u16`
-  --> tests/ui/unused_format_precision.rs:26:15
+  --> tests/ui/unused_format_precision.rs:31:15
    |
 LL |     println!("{:.1}", 42_u16);
    |               ^^^^^
 
 error: precision has no effect for type `u16`
-  --> tests/ui/unused_format_precision.rs:27:15
+  --> tests/ui/unused_format_precision.rs:32:15
    |
 LL |     println!("{:.1?}", 42_u16);
    |               ^^^^^^
 
 error: precision has no effect for type `u16`
-  --> tests/ui/unused_format_precision.rs:28:15
+  --> tests/ui/unused_format_precision.rs:33:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `u16`
-  --> tests/ui/unused_format_precision.rs:29:15
+  --> tests/ui/unused_format_precision.rs:34:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `i16`
-  --> tests/ui/unused_format_precision.rs:32:15
+  --> tests/ui/unused_format_precision.rs:37:15
    |
 LL |     println!("{:.1}", 42_i16);
    |               ^^^^^
 
 error: precision has no effect for type `i16`
-  --> tests/ui/unused_format_precision.rs:33:15
+  --> tests/ui/unused_format_precision.rs:38:15
    |
 LL |     println!("{:.1?}", 42_i16);
    |               ^^^^^^
 
 error: precision has no effect for type `i16`
-  --> tests/ui/unused_format_precision.rs:34:15
+  --> tests/ui/unused_format_precision.rs:39:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `i16`
-  --> tests/ui/unused_format_precision.rs:35:15
+  --> tests/ui/unused_format_precision.rs:40:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `u32`
-  --> tests/ui/unused_format_precision.rs:38:15
+  --> tests/ui/unused_format_precision.rs:43:15
    |
 LL |     println!("{:.1}", 42_u32);
    |               ^^^^^
 
 error: precision has no effect for type `u32`
-  --> tests/ui/unused_format_precision.rs:39:15
+  --> tests/ui/unused_format_precision.rs:44:15
    |
 LL |     println!("{:.1?}", 42_u32);
    |               ^^^^^^
 
 error: precision has no effect for type `u32`
-  --> tests/ui/unused_format_precision.rs:40:15
+  --> tests/ui/unused_format_precision.rs:45:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `u32`
-  --> tests/ui/unused_format_precision.rs:41:15
+  --> tests/ui/unused_format_precision.rs:46:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `i32`
-  --> tests/ui/unused_format_precision.rs:44:15
+  --> tests/ui/unused_format_precision.rs:49:15
    |
 LL |     println!("{:.1}", 42_i32);
    |               ^^^^^
 
 error: precision has no effect for type `i32`
-  --> tests/ui/unused_format_precision.rs:45:15
+  --> tests/ui/unused_format_precision.rs:50:15
    |
 LL |     println!("{:.1?}", 42_i32);
    |               ^^^^^^
 
 error: precision has no effect for type `i32`
-  --> tests/ui/unused_format_precision.rs:46:15
+  --> tests/ui/unused_format_precision.rs:51:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `i32`
-  --> tests/ui/unused_format_precision.rs:47:15
+  --> tests/ui/unused_format_precision.rs:52:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `u64`
-  --> tests/ui/unused_format_precision.rs:50:15
+  --> tests/ui/unused_format_precision.rs:55:15
    |
 LL |     println!("{:.1}", 42_u64);
    |               ^^^^^
 
 error: precision has no effect for type `u64`
-  --> tests/ui/unused_format_precision.rs:51:15
+  --> tests/ui/unused_format_precision.rs:56:15
    |
 LL |     println!("{:.1?}", 42_u64);
    |               ^^^^^^
 
 error: precision has no effect for type `u64`
-  --> tests/ui/unused_format_precision.rs:52:15
+  --> tests/ui/unused_format_precision.rs:57:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `u64`
-  --> tests/ui/unused_format_precision.rs:53:15
+  --> tests/ui/unused_format_precision.rs:58:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `i64`
-  --> tests/ui/unused_format_precision.rs:56:15
+  --> tests/ui/unused_format_precision.rs:61:15
    |
 LL |     println!("{:.1}", 42_i64);
    |               ^^^^^
 
 error: precision has no effect for type `i64`
-  --> tests/ui/unused_format_precision.rs:57:15
+  --> tests/ui/unused_format_precision.rs:62:15
    |
 LL |     println!("{:.1?}", 42_i64);
    |               ^^^^^^
 
 error: precision has no effect for type `i64`
-  --> tests/ui/unused_format_precision.rs:58:15
+  --> tests/ui/unused_format_precision.rs:63:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `i64`
-  --> tests/ui/unused_format_precision.rs:59:15
+  --> tests/ui/unused_format_precision.rs:64:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `usize`
-  --> tests/ui/unused_format_precision.rs:62:15
+  --> tests/ui/unused_format_precision.rs:67:15
    |
 LL |     println!("{:.1}", 42_usize);
    |               ^^^^^
 
 error: precision has no effect for type `usize`
-  --> tests/ui/unused_format_precision.rs:63:15
+  --> tests/ui/unused_format_precision.rs:68:15
    |
 LL |     println!("{:.1?}", 42_usize);
    |               ^^^^^^
 
 error: precision has no effect for type `usize`
-  --> tests/ui/unused_format_precision.rs:64:15
+  --> tests/ui/unused_format_precision.rs:69:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `usize`
-  --> tests/ui/unused_format_precision.rs:65:15
+  --> tests/ui/unused_format_precision.rs:70:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `isize`
-  --> tests/ui/unused_format_precision.rs:68:15
+  --> tests/ui/unused_format_precision.rs:73:15
    |
 LL |     println!("{:.1}", 42_isize);
    |               ^^^^^
 
 error: precision has no effect for type `isize`
-  --> tests/ui/unused_format_precision.rs:69:15
+  --> tests/ui/unused_format_precision.rs:74:15
    |
 LL |     println!("{:.1?}", 42_isize);
    |               ^^^^^^
 
 error: precision has no effect for type `isize`
-  --> tests/ui/unused_format_precision.rs:70:15
+  --> tests/ui/unused_format_precision.rs:75:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `isize`
-  --> tests/ui/unused_format_precision.rs:71:15
+  --> tests/ui/unused_format_precision.rs:76:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `char`
-  --> tests/ui/unused_format_precision.rs:74:15
+  --> tests/ui/unused_format_precision.rs:79:15
    |
 LL |     println!("{:.1}", 'x');
    |               ^^^^^
 
 error: precision has no effect for type `char`
-  --> tests/ui/unused_format_precision.rs:75:15
+  --> tests/ui/unused_format_precision.rs:80:15
    |
 LL |     println!("{:.1?}", 'x');
    |               ^^^^^^
 
 error: precision has no effect for type `char`
-  --> tests/ui/unused_format_precision.rs:76:15
+  --> tests/ui/unused_format_precision.rs:81:15
    |
 LL |     println!("{v:.1}");
    |               ^^^^^^
 
 error: precision has no effect for type `char`
-  --> tests/ui/unused_format_precision.rs:77:15
+  --> tests/ui/unused_format_precision.rs:82:15
    |
 LL |     println!("{:.1}", &v);
    |               ^^^^^
 
 error: precision has no effect for type `*const u8`
-  --> tests/ui/unused_format_precision.rs:80:15
+  --> tests/ui/unused_format_precision.rs:85:15
    |
 LL |     println!("{:.1p}", 0x123456789 as *const u8);
    |               ^^^^^^
 
 error: precision has no effect for type `*const usize`
-  --> tests/ui/unused_format_precision.rs:81:15
-   |
-LL |     println!("{v:.1p}");
-   |               ^^^^^^^
-
-error: precision has no effect for type `fn()`
-  --> tests/ui/unused_format_precision.rs:85:15
-   |
-LL |     println!("{:.1p}", dummy as fn());
-   |               ^^^^^^
-
-error: precision has no effect for type `fn()`
   --> tests/ui/unused_format_precision.rs:86:15
    |
 LL |     println!("{v:.1p}");
    |               ^^^^^^^
 
-error: aborting due to 54 previous errors
+error: precision has no effect for type `fn()`
+  --> tests/ui/unused_format_precision.rs:90:15
+   |
+LL |     println!("{:.1p}", dummy as fn());
+   |               ^^^^^^
+
+error: precision has no effect for type `fn()`
+  --> tests/ui/unused_format_precision.rs:91:15
+   |
+LL |     println!("{v:.1p}");
+   |               ^^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:134:22
+   |
+LL |     let _ = format!("{v:.1}");
+   |                      ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:135:13
+   |
+LL |     print!("{v:.1}");
+   |             ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:136:14
+   |
+LL |     eprint!("{v:.1}");
+   |              ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:137:16
+   |
+LL |     eprintln!("{v:.1}");
+   |                ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:140:24
+   |
+LL |     let _ = write!(s, "{v:.1}");
+   |                        ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:141:26
+   |
+LL |     let _ = writeln!(s, "{v:.1}");
+   |                          ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:143:23
+   |
+LL |     assert!(v == 42, "{v:.1}");
+   |                       ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:144:24
+   |
+LL |     assert_eq!(v, 42, "{v:.1}");
+   |                        ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:145:23
+   |
+LL |     assert_ne!(v, 0, "{v:.1}");
+   |                       ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:146:29
+   |
+LL |     debug_assert!(v == 42, "{v:.1}");
+   |                             ^^^^^^
+
+error: precision has no effect for type `u8`
+  --> tests/ui/unused_format_precision.rs:158:17
+   |
+LL |         panic!("{v:.1}");
+   |                 ^^^^^^
+
+error: this lint expectation is unfulfilled
+  --> tests/ui/unused_format_precision.rs:3:11
+   |
+LL | #![expect(clippy::manual_dangling_ptr, clippy::useless_borrows_in_formatting)]
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unfulfilled_lint_expectations)]`
+
+error: aborting due to 66 previous errors
 

--- a/tests/ui/write_literal.fixed
+++ b/tests/ui/write_literal.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::write_literal)]
-#![allow(clippy::uninlined_format_args, unused_must_use)]
+#![allow(clippy::uninlined_format_args, unused_must_use, clippy::unused_format_precision)]
 
 use std::io::Write;
 

--- a/tests/ui/write_literal.fixed
+++ b/tests/ui/write_literal.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::write_literal)]
-#![expect(clippy::uninlined_format_args)]
+#![expect(clippy::uninlined_format_args, clippy::unused_format_precision)]
 
 use std::io::Write;
 

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::write_literal)]
-#![allow(clippy::uninlined_format_args, unused_must_use)]
+#![allow(clippy::uninlined_format_args, unused_must_use, clippy::unused_format_precision)]
 
 use std::io::Write;
 

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::write_literal)]
-#![expect(clippy::uninlined_format_args, unused_must_use, clippy::unused_format_precision)]
+#![expect(clippy::uninlined_format_args, clippy::unused_format_precision)]
 
 use std::io::Write;
 

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::write_literal)]
-#![expect(clippy::uninlined_format_args)]
+#![expect(clippy::uninlined_format_args, unused_must_use, clippy::unused_format_precision)]
 
 use std::io::Write;
 


### PR DESCRIPTION
Introduce a new Clippy lint, `unused_format_precision`, which warns when a precision specifier is used in formatting macros for types where it has no effect, such as integers, bool, char, and pointers.  This helps catch misleading or potentially buggy formatting code.

### What it does
Detects use of format precision for standard non-float types where it has no effect
(integers, bool, char, pointers). Precision is meaningful for floats, `str` (truncation), or user types.

### Why is this bad?
Specifying precision for these types is misleading and may indicate a bug. The value is ignored by the formatter.

### Example
```rust
println!("{:.5}", 42);   // precision ignored for integers
println!("{:.3}", true); // precision ignored for bool
println!("{:.2}", 'x');  // precision ignored for char
```

### TODO
* [ ] I am not certain which of the lint groups applies best for this lint. All these seem somewhat appropriate:
  * `correctness` - code that is outright wrong or useless
  * `suspicious` - code that is most likely wrong or useless
  * `complexity` - code that does something simple but in a complex way

---

changelog: [`unused_format_precision`]: new lint to catch ignored format precision on non-float types
