### PR TITLE
feat: make `unused_format_specs` catch width issues

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 
 use arrayvec::ArrayVec;
 use clippy_config::Conf;
-use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg, span_lint_and_then};
+use clippy_utils::diagnostics::{span_lint, span_lint_and_help, span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::macros::{
     FormatArgsStorage, FormatParamUsage, MacroCall, find_format_arg_expr, format_arg_removal_span,
     format_placeholder_format_span, is_assert_macro, is_format_macro, is_panic, matching_root_macro_call,
@@ -14,9 +14,10 @@ use clippy_utils::source::{SpanRangeExt, snippet, snippet_opt};
 use clippy_utils::ty::implements_trait;
 use clippy_utils::{is_from_proc_macro, is_in_test, peel_hir_expr_while, sym, trait_ref_of_method};
 use itertools::Itertools;
+use rustc_ast::FormatTrait::{Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex};
 use rustc_ast::{
     BorrowKind, FormatArgPosition, FormatArgPositionKind, FormatArgsPiece, FormatArgumentKind, FormatCount,
-    FormatOptions, FormatPlaceholder, FormatTrait,
+    FormatOptions, FormatPlaceholder,
 };
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::Applicability;
@@ -171,6 +172,11 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for `Debug` formatting (`{:?}`) applied to an `OsStr` or `Path`.
     ///
+    /// This includes:
+    /// - Format specifiers on `format_args!()` (width, precision have no effect)
+    /// - Format width too small for the format trait (e.g. `{:#02x}` outputs "0x1"
+    ///   so width 2 has no effect; minimum is 4 for alternate hex/octal/binary)
+    ///
     /// ### Why is this bad?
     /// Rust doesn't guarantee what `Debug` formatting looks like, and it could
     /// change in the future. `OsStr`s and `Path`s can be `Display` formatted
@@ -231,6 +237,11 @@ declare_clippy_lint! {
     /// Detects [formatting parameters] that have no effect on the output of
     /// `format!()`, `println!()` or similar macros.
     ///
+    /// This includes:
+    /// - Format specifiers on `format_args!()` (width, precision have no effect)
+    /// - Format width too small for the format trait (e.g. `{:#02x}` outputs "0x1"
+    ///   so width 2 has no effect; minimum is 4 for alternate hex/octal/binary)
+    ///
     /// ### Why is this bad?
     /// Shorter format specifiers are easier to read, it may also indicate that
     /// an expected formatting operation such as adding padding isn't happening.
@@ -240,6 +251,9 @@ declare_clippy_lint! {
     /// println!("{:.}", 1.0);
     ///
     /// println!("not padded: {:5}", format_args!("..."));
+    ///
+    /// // width 2 has no effect for alternate hex (outputs "0x1")
+    /// format!("{:#02x}", 1_u8);
     /// ```
     /// Use instead:
     /// ```no_run
@@ -248,6 +262,8 @@ declare_clippy_lint! {
     /// println!("not padded: {}", format_args!("..."));
     /// // OR
     /// println!("padded: {:5}", format!("..."));
+    ///
+    /// format!("{:#04x}", 1_u8);  // width 4 for two-digit zero-padded hex
     /// ```
     ///
     /// [formatting parameters]: https://doc.rust-lang.org/std/fmt/index.html#formatting-parameters
@@ -392,6 +408,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                 && let Some(arg_expr) = find_format_arg_expr(self.expr, arg)
             {
                 self.check_unused_format_specifier(placeholder, arg_expr);
+                self.check_useless_format_width(placeholder);
                 self.check_useless_borrows_in_formatting(placeholder, arg_expr);
 
                 // Check width and precision arguments the same way as the value
@@ -405,7 +422,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                     }
                 }
 
-                if placeholder.format_trait == FormatTrait::Display
+                if placeholder.format_trait == Display
                     && placeholder.format_options == FormatOptions::default()
                     && !self.is_aliased(index)
                 {
@@ -414,7 +431,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                     self.check_to_string_in_format_args(name, arg_expr);
                 }
 
-                if placeholder.format_trait == FormatTrait::Debug {
+                if placeholder.format_trait == Debug {
                     let name = self.cx.tcx.item_name(self.macro_call.def_id);
                     self.check_unnecessary_debug_formatting(name, arg_expr);
                     if let Some(span) = placeholder.span
@@ -424,7 +441,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                     }
                 }
 
-                if placeholder.format_trait == FormatTrait::Pointer
+                if placeholder.format_trait == Pointer
                     && let Some(span) = placeholder.span
                 {
                     span_lint(self.cx, POINTER_FORMAT, span, "pointer formatting detected");
@@ -437,8 +454,8 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
         if !arg_expr.span.from_expansion()
             && !is_from_proc_macro(self.cx, arg_expr)
             && let Some(fmt_trait) = match placeholder.format_trait {
-                FormatTrait::Display => self.cx.tcx.get_diagnostic_item(sym::Display),
-                FormatTrait::Debug => self.cx.tcx.get_diagnostic_item(sym::Debug),
+                Display => self.cx.tcx.get_diagnostic_item(sym::Display),
+                Debug => self.cx.tcx.get_diagnostic_item(sym::Debug),
                 _ => None,
             }
             && let Some(sized_trait) = self.cx.tcx.lang_items().sized_trait()
@@ -516,6 +533,30 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
                         );
                     }
                 },
+            );
+        }
+    }
+
+    /// Lint when format width has no effect on the output because the format trait's
+    /// minimum output is larger (e.g. `{:#02X}` outputs "0x1" so width 2 has no effect).
+    fn check_useless_format_width(&self, placeholder: &FormatPlaceholder) {
+        let min_width = match placeholder.format_trait {
+            // 0x prefix, e.g. 0x1, 0o1, 0b1
+            LowerHex | UpperHex | Octal | Binary if placeholder.format_options.alternate => 4,
+            LowerExp | UpperExp | Pointer => 4, // e.g. 1e0 with exponent, 0x1 for pointer
+            _ => return,
+        };
+        if let Some(FormatCount::Literal(width_value)) = placeholder.format_options.width
+            && width_value < min_width
+            && let Some(placeholder_span) = placeholder.span
+        {
+            span_lint_and_help(
+                self.cx,
+                UNUSED_FORMAT_SPECS,
+                placeholder_span,
+                "format width has no effect on the output for this format trait",
+                None,
+                format!("consider removing the width or increasing it to at least {min_width}"),
             );
         }
     }

--- a/tests/ui/unused_format_specs_width.rs
+++ b/tests/ui/unused_format_specs_width.rs
@@ -1,0 +1,41 @@
+//@no-rustfix
+// Format width has no effect for certain traits (issue #15039)
+
+#![warn(clippy::unused_format_specs)]
+#![allow(clippy::zero_ptr, clippy::manual_dangling_ptr)]
+
+fn main() {
+    // Integer formats with # (alternate): 0x/0o/0b prefix makes min width 4
+    println!("{:#02X}", 1u8); //~ ERROR: format width has no effect on the output
+    println!("{:#2X}", 1u8); //~ ERROR: format width has no effect on the output
+    println!("{:#02x}", 1u8); //~ ERROR: format width has no effect on the output
+    println!("{:#02o}", 1u8); //~ ERROR: format width has no effect on the output
+    println!("{:#02b}", 1u8); //~ ERROR: format width has no effect on the output
+
+    // Exponent formats: min width 4 (e.g. 1e0)
+    println!("{:02e}", 1u8); //~ ERROR: format width has no effect on the output
+    println!("{:02E}", 1u8); //~ ERROR: format width has no effect on the output
+    println!("{:2e}", 1.0); //~ ERROR: format width has no effect on the output
+    println!("{:2E}", 1.0); //~ ERROR: format width has no effect on the output
+    println!("{:2e}", 0.1); //~ ERROR: format width has no effect on the output
+    println!("{:2E}", 0.1); //~ ERROR: format width has no effect on the output
+
+    // Pointer: min width 4 (0x1)
+    println!("{:2p}", 0 as *const usize); //~ ERROR: format width has no effect on the output
+    println!("{:02p}", 1 as *const usize); //~ ERROR: format width has no effect on the output
+
+    // Width 2 still too small for exponent; precision+width
+    println!("{:2.2e}", 1.0); //~ ERROR: format width has no effect on the output
+    println!("{:2.2E}", 1.0); //~ ERROR: format width has no effect on the output
+    println!("{:2.2e}", 0.1); //~ ERROR: format width has no effect on the output
+    println!("{:2.2E}", 0.1); //~ ERROR: format width has no effect on the output
+
+    // Width 3 is exactly the minimum for alternate hex, still warn
+    println!("{:#03X}", 1u8); //~ ERROR: format width has no effect on the output
+
+    // Not linted: width more than 3, or no # for x/o/b
+    println!("{:#04X}", 1u8);
+    println!("{:2X}", 1u8); // no #, so no prefix
+    println!("{:2o}", 1u8);
+    println!("{}", 1);
+}

--- a/tests/ui/unused_format_specs_width.stderr
+++ b/tests/ui/unused_format_specs_width.stderr
@@ -1,0 +1,148 @@
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:9:15
+   |
+LL |     println!("{:#02X}", 1u8);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+   = note: `-D clippy::unused-format-specs` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_format_specs)]`
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:10:15
+   |
+LL |     println!("{:#2X}", 1u8);
+   |               ^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:11:15
+   |
+LL |     println!("{:#02x}", 1u8);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:12:15
+   |
+LL |     println!("{:#02o}", 1u8);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:13:15
+   |
+LL |     println!("{:#02b}", 1u8);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:16:15
+   |
+LL |     println!("{:02e}", 1u8);
+   |               ^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:17:15
+   |
+LL |     println!("{:02E}", 1u8);
+   |               ^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:18:15
+   |
+LL |     println!("{:2e}", 1.0);
+   |               ^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:19:15
+   |
+LL |     println!("{:2E}", 1.0);
+   |               ^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:20:15
+   |
+LL |     println!("{:2e}", 0.1);
+   |               ^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:21:15
+   |
+LL |     println!("{:2E}", 0.1);
+   |               ^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:24:15
+   |
+LL |     println!("{:2p}", 0 as *const usize);
+   |               ^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:25:15
+   |
+LL |     println!("{:02p}", 1 as *const usize);
+   |               ^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:28:15
+   |
+LL |     println!("{:2.2e}", 1.0);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:29:15
+   |
+LL |     println!("{:2.2E}", 1.0);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:30:15
+   |
+LL |     println!("{:2.2e}", 0.1);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:31:15
+   |
+LL |     println!("{:2.2E}", 0.1);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: format width has no effect on the output for this format trait
+  --> tests/ui/unused_format_specs_width.rs:34:15
+   |
+LL |     println!("{:#03X}", 1u8);
+   |               ^^^^^^^
+   |
+   = help: consider removing the width or increasing it to at least 4
+
+error: aborting due to 18 previous errors
+


### PR DESCRIPTION
implements rust-lang/rust-clippy#15039

Improve [`unused_format_specs`] lint to detect format width that is below the minimum output size for certain format traits (e.g. `{:#02x}` outputs "0x1", so width 2 is ignored). The lint suggests removing the width or increasing it above the minimum.

```
error: format width has no effect on the output for this format trait
  --> tests/ui/unused_format_specs_width.rs:9:15
   |
LL |     println!("{:#02X}", 1u8);
   |               ^^^^^^^
   |
   = help: consider removing the width or increasing it to at least 4
   = note: `-D clippy::unused-format-specs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::unused_format_specs)]`
```

---

changelog: [`unused_format_specs`]: detect format width below minimum output size for #x/#o/#b, exponent, and pointer