### PR TITLE
Fix: non_canonical_partial_ord_impl allows constant Ordering for ZSTs (#16423)

### DIFF
--- a/tests/ui/non_canonical_partial_ord_impl.fixed
+++ b/tests/ui/non_canonical_partial_ord_impl.fixed
@@ -283,7 +283,7 @@ impl PartialOrd for L {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
 }
 
-// #16508, do not lint -- ZST returns constant Ordering
+// #16423, do not lint -- ZST returns constant Ordering
 
 #[derive(PartialEq, Eq)]
 pub struct Zst;

--- a/tests/ui/non_canonical_partial_ord_impl.rs
+++ b/tests/ui/non_canonical_partial_ord_impl.rs
@@ -293,7 +293,7 @@ impl PartialOrd for L {
     }
 }
 
-// #16508, do not lint -- ZST returns constant Ordering
+// #16423, do not lint -- ZST returns constant Ordering
 
 #[derive(PartialEq, Eq)]
 pub struct Zst;


### PR DESCRIPTION
changelog: [`non_canonical_partial_ord_impl`]: Don't lint ZSTs returning constant Ordering variants like `Some(Ordering::Equal)`

fixes rust-lang/rust-clippy#16423 