### PR TITLE
Clear collection reassignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ document.
 
 [88f787...master](https://github.com/rust-lang/rust-clippy/compare/88f787...master)
 
+### New Lints
+
+* Added [`new_instead_of_clear`] to `perf`
+  [#16549](https://github.com/rust-lang/rust-clippy/pull/16549)
+
 ## Rust 1.96
 
 Current stable, released 2026-05-28
@@ -7151,6 +7156,7 @@ Released 2018-09-13
 [`neg_multiply`]: https://rust-lang.github.io/rust-clippy/master/index.html#neg_multiply
 [`negative_feature_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#negative_feature_names
 [`never_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#never_loop
+[`new_instead_of_clear`]: https://rust-lang.github.io/rust-clippy/master/index.html#new_instead_of_clear
 [`new_ret_no_self`]: https://rust-lang.github.io/rust-clippy/master/index.html#new_ret_no_self
 [`new_without_default`]: https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
 [`new_without_default_derive`]: https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default_derive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7389,6 +7389,7 @@ Released 2018-09-13
 [`neg_multiply`]: https://rust-lang.github.io/rust-clippy/main/index.html#neg_multiply
 [`negative_feature_names`]: https://rust-lang.github.io/rust-clippy/main/index.html#negative_feature_names
 [`never_loop`]: https://rust-lang.github.io/rust-clippy/main/index.html#never_loop
+[`new_instead_of_clear`]: https://rust-lang.github.io/rust-clippy/main/index.html#new_instead_of_clear
 [`new_ret_no_self`]: https://rust-lang.github.io/rust-clippy/main/index.html#new_ret_no_self
 [`new_without_default`]: https://rust-lang.github.io/rust-clippy/main/index.html#new_without_default
 [`new_without_default_derive`]: https://rust-lang.github.io/rust-clippy/main/index.html#new_without_default_derive

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -620,6 +620,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::operators::MODULO_ARITHMETIC_INFO,
     crate::operators::MODULO_ONE_INFO,
     crate::operators::NEEDLESS_BITWISE_BOOL_INFO,
+    crate::operators::NEW_INSTEAD_OF_CLEAR_INFO,
     crate::operators::OP_REF_INFO,
     crate::operators::REDUNDANT_COMPARISONS_INFO,
     crate::operators::SELF_ASSIGNMENT_INFO,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -630,6 +630,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::operators::MODULO_ARITHMETIC_INFO,
     crate::operators::MODULO_ONE_INFO,
     crate::operators::NEEDLESS_BITWISE_BOOL_INFO,
+    crate::operators::NEW_INSTEAD_OF_CLEAR_INFO,
     crate::operators::OP_REF_INFO,
     crate::operators::REDUNDANT_COMPARISONS_INFO,
     crate::operators::SELF_ASSIGNMENT_INFO,

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -22,6 +22,7 @@ mod misrefactored_assign_op;
 mod modulo_arithmetic;
 mod modulo_one;
 mod needless_bitwise_bool;
+mod new_instead_of_clear;
 mod numeric_arithmetic;
 mod op_ref;
 mod self_assignment;
@@ -884,6 +885,38 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for assignments of `Collection::new()` or `vec![]` to a collection
+    /// variable that was already initialized.
+    ///
+    /// ### Why is this bad?
+    /// The existing allocation is thrown away. `.clear()` empties the collection
+    /// without freeing the memory, so the next push/insert won't need to allocate.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # fn f(v: &Vec<i32>) {}
+    /// let mut v = Vec::new();
+    /// v.push(1);
+    /// f(&v);
+    /// v = Vec::new();
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// # fn f(v: &Vec<i32>) {}
+    /// let mut v = Vec::new();
+    /// v.push(1);
+    /// f(&v);
+    /// v.clear();
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub NEW_INSTEAD_OF_CLEAR,
+    perf,
+    "creating a new collection instead of calling `.clear()`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for arguments to `==` which have their address
     /// taken to satisfy a bound
     /// and suggests to dereference the other argument instead
@@ -1021,6 +1054,7 @@ impl_lint_pass!(Operators => [
     MODULO_ARITHMETIC,
     MODULO_ONE,
     NEEDLESS_BITWISE_BOOL,
+    NEW_INSTEAD_OF_CLEAR,
     OP_REF,
     REDUNDANT_COMPARISONS,
     SELF_ASSIGNMENT,
@@ -1099,6 +1133,7 @@ impl<'tcx> LateLintPass<'tcx> for Operators {
             ExprKind::Assign(lhs, rhs, _) => {
                 assign_op_pattern::check(cx, e, lhs, rhs, self.msrv);
                 self_assignment::check(cx, e, lhs, rhs);
+                new_instead_of_clear::check(cx, e);
             },
             ExprKind::Unary(op, arg) =>
             {

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -22,6 +22,7 @@ mod misrefactored_assign_op;
 mod modulo_arithmetic;
 mod modulo_one;
 mod needless_bitwise_bool;
+mod new_instead_of_clear;
 mod numeric_arithmetic;
 mod op_ref;
 mod self_assignment;
@@ -883,6 +884,38 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for assignments of `Collection::new()` or `vec![]` to a collection
+    /// variable that was already initialized.
+    ///
+    /// ### Why is this bad?
+    /// The existing allocation is thrown away. `.clear()` empties the collection
+    /// without freeing the memory, so the next push/insert won't need to allocate.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # fn f(v: &Vec<i32>) {}
+    /// let mut v = Vec::new();
+    /// v.push(1);
+    /// f(&v);
+    /// v = Vec::new();
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// # fn f(v: &Vec<i32>) {}
+    /// let mut v = Vec::new();
+    /// v.push(1);
+    /// f(&v);
+    /// v.clear();
+    /// ```
+    #[clippy::version = "1.100.0"]
+    pub NEW_INSTEAD_OF_CLEAR,
+    perf,
+    "creating a new collection instead of calling `.clear()`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for arguments to `==` which have their address
     /// taken to satisfy a bound
     /// and suggests to dereference the other argument instead
@@ -1020,6 +1053,7 @@ impl_lint_pass!(Operators => [
     MODULO_ARITHMETIC,
     MODULO_ONE,
     NEEDLESS_BITWISE_BOOL,
+    NEW_INSTEAD_OF_CLEAR,
     OP_REF,
     REDUNDANT_COMPARISONS,
     SELF_ASSIGNMENT,
@@ -1100,6 +1134,7 @@ impl<'tcx> LateLintPass<'tcx> for Operators {
             ExprKind::Assign(lhs, rhs, _) => {
                 assign_op_pattern::check(cx, e, lhs, rhs, self.msrv);
                 self_assignment::check(cx, e, lhs, rhs);
+                new_instead_of_clear::check(cx, e);
             },
             ExprKind::Unary(op, arg) =>
             {

--- a/clippy_lints/src/operators/new_instead_of_clear.rs
+++ b/clippy_lints/src/operators/new_instead_of_clear.rs
@@ -1,0 +1,111 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::higher::VecArgs;
+use clippy_utils::res::{MaybeDef, MaybeResPath};
+use clippy_utils::{eq_expr_value, is_integer_literal, local_is_initialized, peel_ref_operators, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, LangItem, QPath, TyKind};
+use rustc_lint::LateContext;
+use rustc_span::Symbol;
+
+use super::NEW_INSTEAD_OF_CLEAR;
+
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
+    if let ExprKind::Assign(lhs, rhs, _) = expr.kind
+        && !expr.span.from_expansion()
+    {
+        check_collection_new(cx, expr, lhs, rhs);
+        check_vec_macro(cx, expr, lhs, rhs);
+    }
+}
+
+fn check_collection_new(cx: &LateContext<'_>, expr: &Expr<'_>, lhs: &Expr<'_>, rhs: &Expr<'_>) {
+    if !rhs.span.from_expansion()
+        && let ExprKind::Call(func, []) = rhs.kind
+        && let ExprKind::Path(QPath::TypeRelative(ty, method)) = func.kind
+        && method.ident.name == sym::new
+        // turbofish on the type (e.g. `Vec::<i32>::new()`) changes type inference,
+        // so replacing with `.clear()` could be wrong
+        && !has_type_args(ty)
+        && let rhs_ty = cx.typeck_results().node_type(ty.hir_id)
+        // `.clear()` only keeps the backing allocation for contiguously allocated types;
+        // node-based collections (`BTreeMap`, `BTreeSet`, `LinkedList`) don't preallocate,
+        // so the note about retained memory must not be shown for them
+        && let Some(retains_allocation) = match rhs_ty.opt_diag_name(cx) {
+            Some(sym::Vec | sym::HashMap | sym::HashSet | sym::VecDeque | sym::BinaryHeap) => Some(true),
+            Some(sym::BTreeMap | sym::BTreeSet | sym::LinkedList) => Some(false),
+            _ if rhs_ty.is_lang_item(cx, LangItem::String) => Some(true),
+            _ => None,
+        }
+        && let Some(name) = local_name(cx, lhs)
+    {
+        emit_lint(cx, expr, name, retains_allocation, None);
+    }
+}
+
+fn check_vec_macro(cx: &LateContext<'_>, expr: &Expr<'_>, lhs: &Expr<'_>, rhs: &Expr<'_>) {
+    // `VecArgs::hir` already verifies that the `vec!` macro is used
+    let discarded_init = match VecArgs::hir(cx, rhs) {
+        Some(VecArgs::Vec([])) => None,
+        Some(VecArgs::Repeat(init, count)) if is_integer_literal(count, 0) => Some(init),
+        _ => return,
+    };
+    if let Some(name) = local_name(cx, lhs) {
+        // an empty `vec![]` is a `Vec`, which keeps its allocation on `.clear()`
+        emit_lint(cx, expr, name, true, discarded_init);
+    }
+}
+
+fn emit_lint(
+    cx: &LateContext<'_>,
+    expr: &Expr<'_>,
+    name: Symbol,
+    retains_allocation: bool,
+    discarded_init: Option<&Expr<'_>>,
+) {
+    span_lint_and_then(
+        cx,
+        NEW_INSTEAD_OF_CLEAR,
+        expr.span,
+        "assigning a new empty collection",
+        |diag| {
+            diag.span_suggestion(
+                expr.span,
+                "consider using `.clear()` instead",
+                format!("{name}.clear()"),
+                Applicability::MaybeIncorrect,
+            );
+            if retains_allocation {
+                diag.note("`.clear()` retains the allocated memory for reuse");
+            }
+            // for `vec![init; 0]`, `init` is evaluated once but would be skipped by `.clear()`
+            if let Some(init) = discarded_init
+                && !eq_expr_value(cx, expr.span.ctxt(), init, init)
+            {
+                diag.span_note(init.span, "side effects of this expression will no longer be executed");
+            }
+        },
+    );
+}
+
+/// Returns `true` if the type-relative path `ty` carries explicit type arguments,
+/// e.g. `Vec::<i32>` in `Vec::<i32>::new()`.
+fn has_type_args(ty: &rustc_hir::Ty<'_>) -> bool {
+    if let TyKind::Path(QPath::Resolved(_, path)) = ty.kind {
+        path.segments.last().is_some_and(|seg| seg.args.is_some())
+    } else {
+        false
+    }
+}
+
+/// If `expr` is a path to an initialized local, returns the local's name.
+///
+/// Reference operators (`&`/`*` on references) are peeled, but smart-pointer `Deref`s
+/// such as `Box` are deliberately left in place: a `*boxed = Vec::new()` must not be
+/// rewritten to `boxed.clear()`, since the smart pointer may have its own `clear` with
+/// different semantics.
+fn local_name(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<Symbol> {
+    peel_ref_operators(cx, expr)
+        .res_local_id_and_ident()
+        .filter(|(hir_id, _)| local_is_initialized(cx, *hir_id))
+        .map(|(_, ident)| ident.name)
+}

--- a/clippy_lints/src/operators/new_instead_of_clear.rs
+++ b/clippy_lints/src/operators/new_instead_of_clear.rs
@@ -1,0 +1,109 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::higher::VecArgs;
+use clippy_utils::res::{MaybeDef as _, MaybeResPath as _};
+use clippy_utils::{eq_expr_value, is_integer_literal, local_is_initialized, peel_ref_operators, sym};
+use rustc_errors::Applicability;
+use rustc_hir::attrs::lang_items::LangItem;
+use rustc_hir::{Expr, ExprKind, QPath, TyKind};
+use rustc_lint::LateContext;
+use rustc_span::Symbol;
+
+use super::NEW_INSTEAD_OF_CLEAR;
+
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
+    if let ExprKind::Assign(lhs, rhs, _) = expr.kind
+        && !expr.span.from_expansion()
+    {
+        check_collection_new(cx, expr, lhs, rhs);
+        check_vec_macro(cx, expr, lhs, rhs);
+    }
+}
+
+fn check_collection_new(cx: &LateContext<'_>, expr: &Expr<'_>, lhs: &Expr<'_>, rhs: &Expr<'_>) {
+    if !rhs.span.from_expansion()
+        && let ExprKind::Call(func, []) = rhs.kind
+        && let ExprKind::Path(QPath::TypeRelative(ty, method)) = func.kind
+        && method.ident.name == sym::new
+        // turbofish on the type (e.g. `Vec::<i32>::new()`) changes type inference,
+        // so replacing with `.clear()` could be wrong
+        && !has_type_args(ty)
+        && let rhs_ty = cx.typeck_results().node_type(ty.hir_id)
+        // `.clear()` only keeps the backing allocation for contiguously allocated types;
+        // node-based collections (`BTreeMap`, `BTreeSet`, `LinkedList`) don't preallocate,
+        // so the note about retained memory must not be shown for them
+        && let Some(retains_allocation) = match rhs_ty.opt_diag_name(cx) {
+            Some(sym::Vec | sym::HashMap | sym::HashSet | sym::VecDeque | sym::BinaryHeap) => Some(true),
+            Some(sym::BTreeMap | sym::BTreeSet | sym::LinkedList) => Some(false),
+            _ if rhs_ty.is_lang_item(cx, LangItem::String) => Some(true),
+            _ => None,
+        }
+        && let Some(name) = local_name(cx, lhs)
+    {
+        emit_lint(cx, expr, name, retains_allocation, None);
+    }
+}
+
+fn check_vec_macro(cx: &LateContext<'_>, expr: &Expr<'_>, lhs: &Expr<'_>, rhs: &Expr<'_>) {
+    // `VecArgs::hir` already verifies that the `vec!` macro is used
+    let discarded_init = match VecArgs::hir(cx, rhs) {
+        Some(VecArgs::Vec([])) => None,
+        Some(VecArgs::Repeat(init, count)) if is_integer_literal(count, 0) => Some(init),
+        _ => return,
+    };
+    if let Some(name) = local_name(cx, lhs) {
+        // an empty `vec![]` is a `Vec`, which keeps its allocation on `.clear()`
+        emit_lint(cx, expr, name, true, discarded_init);
+    }
+}
+
+fn emit_lint(
+    cx: &LateContext<'_>,
+    expr: &Expr<'_>,
+    name: Symbol,
+    retains_allocation: bool,
+    discarded_init: Option<&Expr<'_>>,
+) {
+    span_lint_and_then(
+        cx,
+        NEW_INSTEAD_OF_CLEAR,
+        expr.span,
+        "assigning a new empty collection",
+        |diag| {
+            diag.span_suggestion(
+                expr.span,
+                "consider using `.clear()` instead",
+                format!("{name}.clear()"),
+                Applicability::MaybeIncorrect,
+            );
+            if retains_allocation {
+                diag.note("`.clear()` retains the allocated memory for reuse");
+            }
+            // for `vec![init; 0]`, `init` is evaluated once but would be skipped by `.clear()`
+            if let Some(init) = discarded_init
+                && !eq_expr_value(cx, expr.span.ctxt(), init, init)
+            {
+                diag.span_note(init.span, "side effects of this expression will no longer be executed");
+            }
+        },
+    );
+}
+
+/// Returns `true` if the type-relative path `ty` carries explicit type arguments,
+/// e.g. `Vec::<i32>` in `Vec::<i32>::new()`.
+fn has_type_args(ty: &rustc_hir::Ty<'_>) -> bool {
+    matches!(ty.kind, TyKind::Path(QPath::Resolved(_, path))
+             if path.segments.last().is_some_and(|seg| seg.args.is_some()))
+}
+
+/// If `expr` is a path to an initialized local, returns the local's name.
+///
+/// Reference operators (`&`/`*` on references) are peeled, but smart-pointer `Deref`s
+/// such as `Box` are deliberately left in place: a `*boxed = Vec::new()` must not be
+/// rewritten to `boxed.clear()`, since the smart pointer may have its own `clear` with
+/// different semantics.
+fn local_name(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<Symbol> {
+    peel_ref_operators(cx, expr)
+        .res_local_id_and_ident()
+        .filter(|(hir_id, _)| local_is_initialized(cx, *hir_id))
+        .map(|(_, ident)| ident.name)
+}

--- a/tests/ui/collection_is_never_read.rs
+++ b/tests/ui/collection_is_never_read.rs
@@ -1,4 +1,4 @@
-#![expect(clippy::useless_vec)]
+#![expect(clippy::useless_vec, clippy::new_instead_of_clear)]
 #![warn(clippy::collection_is_never_read)]
 
 use std::collections::{HashMap, HashSet};

--- a/tests/ui/collection_is_never_read.rs
+++ b/tests/ui/collection_is_never_read.rs
@@ -1,5 +1,5 @@
-#![expect(clippy::useless_vec)]
 #![warn(clippy::collection_is_never_read)]
+#![expect(clippy::new_instead_of_clear, clippy::useless_vec)]
 
 use std::collections::{HashMap, HashSet};
 

--- a/tests/ui/new_instead_of_clear.fixed
+++ b/tests/ui/new_instead_of_clear.fixed
@@ -1,0 +1,146 @@
+#![warn(clippy::new_instead_of_clear)]
+#![expect(clippy::vec_init_then_push)]
+#![allow(clippy::zero_repeat_side_effects)]
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
+
+fn use_vec(_: &Vec<i32>) {}
+fn use_map(_: &HashMap<i32, i32>) {}
+fn use_set(_: &HashSet<i32>) {}
+fn use_deque(_: &VecDeque<i32>) {}
+fn use_btree_map(_: &BTreeMap<i32, i32>) {}
+fn use_btree_set(_: &BTreeSet<i32>) {}
+fn use_heap(_: &BinaryHeap<i32>) {}
+fn use_list(_: &LinkedList<i32>) {}
+fn use_string(_: &String) {}
+
+fn side_effect() -> i32 {
+    println!("called");
+    0
+}
+
+fn main() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    v.clear();
+    //~^ new_instead_of_clear
+
+    let mut map: HashMap<i32, i32> = HashMap::new();
+    map.insert(1, 2);
+    use_map(&map);
+    map.clear();
+    //~^ new_instead_of_clear
+
+    let mut set: HashSet<i32> = HashSet::new();
+    set.insert(1);
+    use_set(&set);
+    set.clear();
+    //~^ new_instead_of_clear
+
+    let mut deque: VecDeque<i32> = VecDeque::new();
+    deque.push_back(1);
+    use_deque(&deque);
+    deque.clear();
+    //~^ new_instead_of_clear
+
+    let mut heap: BinaryHeap<i32> = BinaryHeap::new();
+    heap.push(1);
+    use_heap(&heap);
+    heap.clear();
+    //~^ new_instead_of_clear
+
+    let mut s = String::new();
+    s.push('a');
+    use_string(&s);
+    s.clear();
+    //~^ new_instead_of_clear
+
+    // node-based collections: still linted, but without the "retains memory" note
+    let mut btree_map: BTreeMap<i32, i32> = BTreeMap::new();
+    btree_map.insert(1, 2);
+    use_btree_map(&btree_map);
+    btree_map.clear();
+    //~^ new_instead_of_clear
+
+    let mut btree_set: BTreeSet<i32> = BTreeSet::new();
+    btree_set.insert(1);
+    use_btree_set(&btree_set);
+    btree_set.clear();
+    //~^ new_instead_of_clear
+
+    let mut list: LinkedList<i32> = LinkedList::new();
+    list.push_back(1);
+    use_list(&list);
+    list.clear();
+    //~^ new_instead_of_clear
+
+    let mut v2 = Vec::new();
+    v2.push(1);
+    use_vec(&v2);
+    v2.clear();
+    //~^ new_instead_of_clear
+
+    // `vec![init; 0]` is also empty; `0` has no side effect, so no extra note
+    let mut v3 = Vec::new();
+    v3.push(1);
+    use_vec(&v3);
+    v3.clear();
+    //~^ new_instead_of_clear
+
+    // here the discarded initializer has a side effect that would no longer run
+    let mut v4 = Vec::new();
+    v4.push(1);
+    use_vec(&v4);
+    v4.clear();
+    //~^ new_instead_of_clear
+}
+
+fn deref_through_reference() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    let r = &mut v;
+    r.clear();
+    //~^ new_instead_of_clear
+}
+
+fn block_expr() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    let _ = {
+        v.clear();
+        //~^ new_instead_of_clear
+        42
+    };
+}
+
+fn no_lint() {
+    // turbofish changes type inference, replacing with .clear() would be wrong
+    let mut v: Vec<i32> = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    v = Vec::<i32>::new();
+
+    // first assignment to an uninitialized binding, .clear() won't compile
+    let mut u: Vec<u8>;
+    u = Vec::new();
+    u.push(1u8);
+
+    // smart-pointer deref: `Box` could have a `clear` with different semantics
+    let mut boxed = Box::new(Vec::new());
+    boxed.push(1);
+    use_vec(&boxed);
+    *boxed = Vec::new();
+
+    // inside a macro expansion
+    macro_rules! reset {
+        ($x:ident) => {
+            $x = Vec::new()
+        };
+    }
+    let mut w = Vec::new();
+    w.push(1);
+    use_vec(&w);
+    reset!(w);
+}

--- a/tests/ui/new_instead_of_clear.fixed
+++ b/tests/ui/new_instead_of_clear.fixed
@@ -1,0 +1,159 @@
+#![warn(clippy::new_instead_of_clear)]
+#![expect(clippy::vec_init_then_push)]
+#![allow(clippy::zero_repeat_side_effects)]
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
+
+fn use_vec(_: &Vec<i32>) {}
+fn use_map(_: &HashMap<i32, i32>) {}
+fn use_set(_: &HashSet<i32>) {}
+fn use_deque(_: &VecDeque<i32>) {}
+fn use_btree_map(_: &BTreeMap<i32, i32>) {}
+fn use_btree_set(_: &BTreeSet<i32>) {}
+fn use_heap(_: &BinaryHeap<i32>) {}
+fn use_list(_: &LinkedList<i32>) {}
+fn use_string(_: &String) {}
+
+fn side_effect() -> i32 {
+    println!("called");
+    0
+}
+
+fn main() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    v.clear();
+    //~^ new_instead_of_clear
+
+    let mut map: HashMap<i32, i32> = HashMap::new();
+    map.insert(1, 2);
+    use_map(&map);
+    map.clear();
+    //~^ new_instead_of_clear
+
+    let mut set: HashSet<i32> = HashSet::new();
+    set.insert(1);
+    use_set(&set);
+    set.clear();
+    //~^ new_instead_of_clear
+
+    let mut deque: VecDeque<i32> = VecDeque::new();
+    deque.push_back(1);
+    use_deque(&deque);
+    deque.clear();
+    //~^ new_instead_of_clear
+
+    let mut heap: BinaryHeap<i32> = BinaryHeap::new();
+    heap.push(1);
+    use_heap(&heap);
+    heap.clear();
+    //~^ new_instead_of_clear
+
+    let mut s = String::new();
+    s.push('a');
+    use_string(&s);
+    s.clear();
+    //~^ new_instead_of_clear
+
+    // node-based collections: still linted, but without the "retains memory" note
+    let mut btree_map: BTreeMap<i32, i32> = BTreeMap::new();
+    btree_map.insert(1, 2);
+    use_btree_map(&btree_map);
+    btree_map.clear();
+    //~^ new_instead_of_clear
+
+    let mut btree_set: BTreeSet<i32> = BTreeSet::new();
+    btree_set.insert(1);
+    use_btree_set(&btree_set);
+    btree_set.clear();
+    //~^ new_instead_of_clear
+
+    let mut list: LinkedList<i32> = LinkedList::new();
+    list.push_back(1);
+    use_list(&list);
+    list.clear();
+    //~^ new_instead_of_clear
+
+    let mut v2 = Vec::new();
+    v2.push(1);
+    use_vec(&v2);
+    v2.clear();
+    //~^ new_instead_of_clear
+
+    // `vec![init; 0]` is also empty; `0` has no side effect, so no extra note
+    let mut v3 = Vec::new();
+    v3.push(1);
+    use_vec(&v3);
+    v3.clear();
+    //~^ new_instead_of_clear
+
+    // here the discarded initializer has a side effect that would no longer run
+    let mut v4 = Vec::new();
+    v4.push(1);
+    use_vec(&v4);
+    v4.clear();
+    //~^ new_instead_of_clear
+}
+
+fn deref_through_reference() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    let r = &mut v;
+    r.clear();
+    //~^ new_instead_of_clear
+}
+
+fn block_expr() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    let _ = {
+        v.clear();
+        //~^ new_instead_of_clear
+        42
+    };
+}
+
+fn no_lint() {
+    // turbofish changes type inference, replacing with .clear() would be wrong
+    let mut v: Vec<i32> = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    v = Vec::<i32>::new();
+
+    // first assignment to an uninitialized binding, .clear() won't compile
+    let mut u: Vec<u8>;
+    u = Vec::new();
+    u.push(1u8);
+
+    // smart-pointer deref: `Box` could have a `clear` with different semantics
+    let mut boxed = Box::new(Vec::new());
+    boxed.push(1);
+    use_vec(&boxed);
+    *boxed = Vec::new();
+
+    // inside a macro expansion
+    macro_rules! reset {
+        ($x:ident) => {
+            $x = Vec::new()
+        };
+    }
+    let mut w = Vec::new();
+    w.push(1);
+    use_vec(&w);
+    reset!(w);
+
+    // the turbofish pins the element type: `.clear()` would make the `push` below
+    // infer `i32` and overflow
+    let mut n = Vec::new();
+    n.push(2147483647);
+    *n.last_mut().unwrap() += 10;
+    println!("{n:?}");
+    n = Vec::<u64>::new();
+
+    // uninitialized binding with no type annotation, `.clear()` won't compile
+    let mut e;
+    e = Vec::new();
+    e.push(1u8);
+}

--- a/tests/ui/new_instead_of_clear.rs
+++ b/tests/ui/new_instead_of_clear.rs
@@ -1,0 +1,146 @@
+#![warn(clippy::new_instead_of_clear)]
+#![expect(clippy::vec_init_then_push)]
+#![allow(clippy::zero_repeat_side_effects)]
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
+
+fn use_vec(_: &Vec<i32>) {}
+fn use_map(_: &HashMap<i32, i32>) {}
+fn use_set(_: &HashSet<i32>) {}
+fn use_deque(_: &VecDeque<i32>) {}
+fn use_btree_map(_: &BTreeMap<i32, i32>) {}
+fn use_btree_set(_: &BTreeSet<i32>) {}
+fn use_heap(_: &BinaryHeap<i32>) {}
+fn use_list(_: &LinkedList<i32>) {}
+fn use_string(_: &String) {}
+
+fn side_effect() -> i32 {
+    println!("called");
+    0
+}
+
+fn main() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    v = Vec::new();
+    //~^ new_instead_of_clear
+
+    let mut map: HashMap<i32, i32> = HashMap::new();
+    map.insert(1, 2);
+    use_map(&map);
+    map = HashMap::new();
+    //~^ new_instead_of_clear
+
+    let mut set: HashSet<i32> = HashSet::new();
+    set.insert(1);
+    use_set(&set);
+    set = HashSet::new();
+    //~^ new_instead_of_clear
+
+    let mut deque: VecDeque<i32> = VecDeque::new();
+    deque.push_back(1);
+    use_deque(&deque);
+    deque = VecDeque::new();
+    //~^ new_instead_of_clear
+
+    let mut heap: BinaryHeap<i32> = BinaryHeap::new();
+    heap.push(1);
+    use_heap(&heap);
+    heap = BinaryHeap::new();
+    //~^ new_instead_of_clear
+
+    let mut s = String::new();
+    s.push('a');
+    use_string(&s);
+    s = String::new();
+    //~^ new_instead_of_clear
+
+    // node-based collections: still linted, but without the "retains memory" note
+    let mut btree_map: BTreeMap<i32, i32> = BTreeMap::new();
+    btree_map.insert(1, 2);
+    use_btree_map(&btree_map);
+    btree_map = BTreeMap::new();
+    //~^ new_instead_of_clear
+
+    let mut btree_set: BTreeSet<i32> = BTreeSet::new();
+    btree_set.insert(1);
+    use_btree_set(&btree_set);
+    btree_set = BTreeSet::new();
+    //~^ new_instead_of_clear
+
+    let mut list: LinkedList<i32> = LinkedList::new();
+    list.push_back(1);
+    use_list(&list);
+    list = LinkedList::new();
+    //~^ new_instead_of_clear
+
+    let mut v2 = Vec::new();
+    v2.push(1);
+    use_vec(&v2);
+    v2 = vec![];
+    //~^ new_instead_of_clear
+
+    // `vec![init; 0]` is also empty; `0` has no side effect, so no extra note
+    let mut v3 = Vec::new();
+    v3.push(1);
+    use_vec(&v3);
+    v3 = vec![0; 0];
+    //~^ new_instead_of_clear
+
+    // here the discarded initializer has a side effect that would no longer run
+    let mut v4 = Vec::new();
+    v4.push(1);
+    use_vec(&v4);
+    v4 = vec![side_effect(); 0];
+    //~^ new_instead_of_clear
+}
+
+fn deref_through_reference() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    let r = &mut v;
+    *r = Vec::new();
+    //~^ new_instead_of_clear
+}
+
+fn block_expr() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    let _ = {
+        v = Vec::new();
+        //~^ new_instead_of_clear
+        42
+    };
+}
+
+fn no_lint() {
+    // turbofish changes type inference, replacing with .clear() would be wrong
+    let mut v: Vec<i32> = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    v = Vec::<i32>::new();
+
+    // first assignment to an uninitialized binding, .clear() won't compile
+    let mut u: Vec<u8>;
+    u = Vec::new();
+    u.push(1u8);
+
+    // smart-pointer deref: `Box` could have a `clear` with different semantics
+    let mut boxed = Box::new(Vec::new());
+    boxed.push(1);
+    use_vec(&boxed);
+    *boxed = Vec::new();
+
+    // inside a macro expansion
+    macro_rules! reset {
+        ($x:ident) => {
+            $x = Vec::new()
+        };
+    }
+    let mut w = Vec::new();
+    w.push(1);
+    use_vec(&w);
+    reset!(w);
+}

--- a/tests/ui/new_instead_of_clear.rs
+++ b/tests/ui/new_instead_of_clear.rs
@@ -1,0 +1,159 @@
+#![warn(clippy::new_instead_of_clear)]
+#![expect(clippy::vec_init_then_push)]
+#![allow(clippy::zero_repeat_side_effects)]
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
+
+fn use_vec(_: &Vec<i32>) {}
+fn use_map(_: &HashMap<i32, i32>) {}
+fn use_set(_: &HashSet<i32>) {}
+fn use_deque(_: &VecDeque<i32>) {}
+fn use_btree_map(_: &BTreeMap<i32, i32>) {}
+fn use_btree_set(_: &BTreeSet<i32>) {}
+fn use_heap(_: &BinaryHeap<i32>) {}
+fn use_list(_: &LinkedList<i32>) {}
+fn use_string(_: &String) {}
+
+fn side_effect() -> i32 {
+    println!("called");
+    0
+}
+
+fn main() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    v = Vec::new();
+    //~^ new_instead_of_clear
+
+    let mut map: HashMap<i32, i32> = HashMap::new();
+    map.insert(1, 2);
+    use_map(&map);
+    map = HashMap::new();
+    //~^ new_instead_of_clear
+
+    let mut set: HashSet<i32> = HashSet::new();
+    set.insert(1);
+    use_set(&set);
+    set = HashSet::new();
+    //~^ new_instead_of_clear
+
+    let mut deque: VecDeque<i32> = VecDeque::new();
+    deque.push_back(1);
+    use_deque(&deque);
+    deque = VecDeque::new();
+    //~^ new_instead_of_clear
+
+    let mut heap: BinaryHeap<i32> = BinaryHeap::new();
+    heap.push(1);
+    use_heap(&heap);
+    heap = BinaryHeap::new();
+    //~^ new_instead_of_clear
+
+    let mut s = String::new();
+    s.push('a');
+    use_string(&s);
+    s = String::new();
+    //~^ new_instead_of_clear
+
+    // node-based collections: still linted, but without the "retains memory" note
+    let mut btree_map: BTreeMap<i32, i32> = BTreeMap::new();
+    btree_map.insert(1, 2);
+    use_btree_map(&btree_map);
+    btree_map = BTreeMap::new();
+    //~^ new_instead_of_clear
+
+    let mut btree_set: BTreeSet<i32> = BTreeSet::new();
+    btree_set.insert(1);
+    use_btree_set(&btree_set);
+    btree_set = BTreeSet::new();
+    //~^ new_instead_of_clear
+
+    let mut list: LinkedList<i32> = LinkedList::new();
+    list.push_back(1);
+    use_list(&list);
+    list = LinkedList::new();
+    //~^ new_instead_of_clear
+
+    let mut v2 = Vec::new();
+    v2.push(1);
+    use_vec(&v2);
+    v2 = vec![];
+    //~^ new_instead_of_clear
+
+    // `vec![init; 0]` is also empty; `0` has no side effect, so no extra note
+    let mut v3 = Vec::new();
+    v3.push(1);
+    use_vec(&v3);
+    v3 = vec![0; 0];
+    //~^ new_instead_of_clear
+
+    // here the discarded initializer has a side effect that would no longer run
+    let mut v4 = Vec::new();
+    v4.push(1);
+    use_vec(&v4);
+    v4 = vec![side_effect(); 0];
+    //~^ new_instead_of_clear
+}
+
+fn deref_through_reference() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    let r = &mut v;
+    *r = Vec::new();
+    //~^ new_instead_of_clear
+}
+
+fn block_expr() {
+    let mut v = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    let _ = {
+        v = Vec::new();
+        //~^ new_instead_of_clear
+        42
+    };
+}
+
+fn no_lint() {
+    // turbofish changes type inference, replacing with .clear() would be wrong
+    let mut v: Vec<i32> = Vec::new();
+    v.push(1);
+    use_vec(&v);
+    v = Vec::<i32>::new();
+
+    // first assignment to an uninitialized binding, .clear() won't compile
+    let mut u: Vec<u8>;
+    u = Vec::new();
+    u.push(1u8);
+
+    // smart-pointer deref: `Box` could have a `clear` with different semantics
+    let mut boxed = Box::new(Vec::new());
+    boxed.push(1);
+    use_vec(&boxed);
+    *boxed = Vec::new();
+
+    // inside a macro expansion
+    macro_rules! reset {
+        ($x:ident) => {
+            $x = Vec::new()
+        };
+    }
+    let mut w = Vec::new();
+    w.push(1);
+    use_vec(&w);
+    reset!(w);
+
+    // the turbofish pins the element type: `.clear()` would make the `push` below
+    // infer `i32` and overflow
+    let mut n = Vec::new();
+    n.push(2147483647);
+    *n.last_mut().unwrap() += 10;
+    println!("{n:?}");
+    n = Vec::<u64>::new();
+
+    // uninitialized binding with no type annotation, `.clear()` won't compile
+    let mut e;
+    e = Vec::new();
+    e.push(1u8);
+}

--- a/tests/ui/new_instead_of_clear.stderr
+++ b/tests/ui/new_instead_of_clear.stderr
@@ -1,0 +1,115 @@
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:25:5
+   |
+LL |     v = Vec::new();
+   |     ^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `v.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+   = note: `-D clippy::new-instead-of-clear` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::new_instead_of_clear)]`
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:31:5
+   |
+LL |     map = HashMap::new();
+   |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `map.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:37:5
+   |
+LL |     set = HashSet::new();
+   |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `set.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:43:5
+   |
+LL |     deque = VecDeque::new();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `deque.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:49:5
+   |
+LL |     heap = BinaryHeap::new();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `heap.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:55:5
+   |
+LL |     s = String::new();
+   |     ^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `s.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:62:5
+   |
+LL |     btree_map = BTreeMap::new();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `btree_map.clear()`
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:68:5
+   |
+LL |     btree_set = BTreeSet::new();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `btree_set.clear()`
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:74:5
+   |
+LL |     list = LinkedList::new();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `list.clear()`
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:80:5
+   |
+LL |     v2 = vec![];
+   |     ^^^^^^^^^^^ help: consider using `.clear()` instead: `v2.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:87:5
+   |
+LL |     v3 = vec![0; 0];
+   |     ^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `v3.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:94:5
+   |
+LL |     v4 = vec![side_effect(); 0];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `v4.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+note: side effects of this expression will no longer be executed
+  --> tests/ui/new_instead_of_clear.rs:94:15
+   |
+LL |     v4 = vec![side_effect(); 0];
+   |               ^^^^^^^^^^^^^
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:103:5
+   |
+LL |     *r = Vec::new();
+   |     ^^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `r.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: assigning a new empty collection
+  --> tests/ui/new_instead_of_clear.rs:112:9
+   |
+LL |         v = Vec::new();
+   |         ^^^^^^^^^^^^^^ help: consider using `.clear()` instead: `v.clear()`
+   |
+   = note: `.clear()` retains the allocated memory for reuse
+
+error: aborting due to 14 previous errors
+

--- a/tests/ui/reserve_after_initialization.fixed
+++ b/tests/ui/reserve_after_initialization.fixed
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::reserve_after_initialization)]
+#![allow(clippy::new_instead_of_clear)]
 #![no_main]
 
 extern crate proc_macros;

--- a/tests/ui/reserve_after_initialization.rs
+++ b/tests/ui/reserve_after_initialization.rs
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::reserve_after_initialization)]
+#![allow(clippy::new_instead_of_clear)]
 #![no_main]
 
 extern crate proc_macros;

--- a/tests/ui/reserve_after_initialization.stderr
+++ b/tests/ui/reserve_after_initialization.stderr
@@ -1,5 +1,5 @@
 error: call to `reserve` immediately after creation
-  --> tests/ui/reserve_after_initialization.rs:10:5
+  --> tests/ui/reserve_after_initialization.rs:11:5
    |
 LL | /     let mut v1: Vec<usize> = vec![];
 LL | |
@@ -10,7 +10,7 @@ LL | |     v1.reserve(10);
    = help: to override `-D warnings` add `#[allow(clippy::reserve_after_initialization)]`
 
 error: call to `reserve` immediately after creation
-  --> tests/ui/reserve_after_initialization.rs:18:5
+  --> tests/ui/reserve_after_initialization.rs:19:5
    |
 LL | /     let mut v2: Vec<usize> = vec![];
 LL | |
@@ -18,7 +18,7 @@ LL | |     v2.reserve(capacity);
    | |_________________________^ help: consider using `Vec::with_capacity(/* Space hint */)`: `let mut v2: Vec<usize> = Vec::with_capacity(capacity);`
 
 error: call to `reserve` immediately after creation
-  --> tests/ui/reserve_after_initialization.rs:37:5
+  --> tests/ui/reserve_after_initialization.rs:38:5
    |
 LL | /     v5 = Vec::new();
 LL | |

--- a/tests/ui/slow_vector_initialization.fixed
+++ b/tests/ui/slow_vector_initialization.fixed
@@ -1,4 +1,4 @@
-#![allow(clippy::useless_vec, clippy::manual_repeat_n)]
+#![allow(clippy::useless_vec, clippy::manual_repeat_n, clippy::new_instead_of_clear)]
 
 use std::iter::repeat;
 

--- a/tests/ui/slow_vector_initialization.fixed
+++ b/tests/ui/slow_vector_initialization.fixed
@@ -1,6 +1,6 @@
 #![warn(clippy::slow_vector_initialization)]
 #![allow(clippy::useless_vec)]
-#![expect(clippy::manual_repeat_n)]
+#![expect(clippy::manual_repeat_n, clippy::new_instead_of_clear)]
 
 use std::iter::repeat;
 

--- a/tests/ui/slow_vector_initialization.rs
+++ b/tests/ui/slow_vector_initialization.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::useless_vec, clippy::manual_repeat_n)]
+#![allow(clippy::useless_vec, clippy::manual_repeat_n, clippy::new_instead_of_clear)]
 
 use std::iter::repeat;
 

--- a/tests/ui/slow_vector_initialization.rs
+++ b/tests/ui/slow_vector_initialization.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::slow_vector_initialization)]
 #![allow(clippy::useless_vec)]
-#![expect(clippy::manual_repeat_n)]
+#![expect(clippy::manual_repeat_n, clippy::new_instead_of_clear)]
 
 use std::iter::repeat;
 

--- a/tests/ui/swap_with_temporary.fixed
+++ b/tests/ui/swap_with_temporary.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::swap_with_temporary)]
+#![allow(clippy::new_instead_of_clear)]
 
 use std::mem::swap;
 

--- a/tests/ui/swap_with_temporary.rs
+++ b/tests/ui/swap_with_temporary.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::swap_with_temporary)]
+#![allow(clippy::new_instead_of_clear)]
 
 use std::mem::swap;
 

--- a/tests/ui/swap_with_temporary.stderr
+++ b/tests/ui/swap_with_temporary.stderr
@@ -1,11 +1,11 @@
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:22:5
+  --> tests/ui/swap_with_temporary.rs:23:5
    |
 LL |     swap(&mut func(), &mut y);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `y = func()`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:22:15
+  --> tests/ui/swap_with_temporary.rs:23:15
    |
 LL |     swap(&mut func(), &mut y);
    |               ^^^^^^
@@ -13,121 +13,121 @@ LL |     swap(&mut func(), &mut y);
    = help: to override `-D warnings` add `#[allow(clippy::swap_with_temporary)]`
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:25:5
+  --> tests/ui/swap_with_temporary.rs:26:5
    |
 LL |     swap(&mut x, &mut func());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `x = func()`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:25:23
+  --> tests/ui/swap_with_temporary.rs:26:23
    |
 LL |     swap(&mut x, &mut func());
    |                       ^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:28:5
+  --> tests/ui/swap_with_temporary.rs:29:5
    |
 LL |     swap(z, &mut func());
    |     ^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `*z = func()`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:28:18
+  --> tests/ui/swap_with_temporary.rs:29:18
    |
 LL |     swap(z, &mut func());
    |                  ^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:36:5
+  --> tests/ui/swap_with_temporary.rs:37:5
    |
 LL |     swap(&mut func(), z);
    |     ^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `*z = func()`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:36:15
+  --> tests/ui/swap_with_temporary.rs:37:15
    |
 LL |     swap(&mut func(), z);
    |               ^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:53:5
+  --> tests/ui/swap_with_temporary.rs:54:5
    |
 LL |     swap(&mut mac!(funcall func), z);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `*z = mac!(funcall func)`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:53:15
+  --> tests/ui/swap_with_temporary.rs:54:15
    |
 LL |     swap(&mut mac!(funcall func), z);
    |               ^^^^^^^^^^^^^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:55:5
+  --> tests/ui/swap_with_temporary.rs:56:5
    |
 LL |     swap(&mut mac!(funcall func), mac!(ident z));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `*mac!(ident z) = mac!(funcall func)`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:55:15
+  --> tests/ui/swap_with_temporary.rs:56:15
    |
 LL |     swap(&mut mac!(funcall func), mac!(ident z));
    |               ^^^^^^^^^^^^^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:57:5
+  --> tests/ui/swap_with_temporary.rs:58:5
    |
 LL |     swap(mac!(ident z), &mut mac!(funcall func));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `*mac!(ident z) = mac!(funcall func)`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:57:30
+  --> tests/ui/swap_with_temporary.rs:58:30
    |
 LL |     swap(mac!(ident z), &mut mac!(funcall func));
    |                              ^^^^^^^^^^^^^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:59:5
+  --> tests/ui/swap_with_temporary.rs:60:5
    |
 LL |     swap(mac!(refmut y), &mut func());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `*mac!(refmut y) = func()`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:59:31
+  --> tests/ui/swap_with_temporary.rs:60:31
    |
 LL |     swap(mac!(refmut y), &mut func());
    |                               ^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:92:13
+  --> tests/ui/swap_with_temporary.rs:93:13
    |
 LL |             swap(&mut vec![42], &mut self.thing.lock().unwrap());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `*self.thing.lock().unwrap() = vec![42]`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:92:23
+  --> tests/ui/swap_with_temporary.rs:93:23
    |
 LL |             swap(&mut vec![42], &mut self.thing.lock().unwrap());
    |                       ^^^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:100:5
+  --> tests/ui/swap_with_temporary.rs:101:5
    |
 LL |     swap(&mut ***v1, &mut vec![]);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `***v1 = vec![]`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:100:27
+  --> tests/ui/swap_with_temporary.rs:101:27
    |
 LL |     swap(&mut ***v1, &mut vec![]);
    |                           ^^^^^^
 
 error: swapping with a temporary value is inefficient
-  --> tests/ui/swap_with_temporary.rs:118:5
+  --> tests/ui/swap_with_temporary.rs:119:5
    |
 LL |     swap(&mut vec![], &mut v1.lock().unwrap());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use assignment instead: `***v1.lock().unwrap() = vec![]`
    |
 note: this expression returns a temporary value
-  --> tests/ui/swap_with_temporary.rs:118:15
+  --> tests/ui/swap_with_temporary.rs:119:15
    |
 LL |     swap(&mut vec![], &mut v1.lock().unwrap());
    |               ^^^^^^

--- a/tests/ui/vec_init_then_push.rs
+++ b/tests/ui/vec_init_then_push.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![allow(unused_variables, clippy::new_instead_of_clear)]
 #![warn(clippy::vec_init_then_push)]
 //@no-rustfix
 fn main() {

--- a/tests/ui/vec_init_then_push.rs
+++ b/tests/ui/vec_init_then_push.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::vec_init_then_push)]
+#![expect(clippy::new_instead_of_clear)]
 //@no-rustfix
 fn main() {
     let mut def_err: Vec<u32> = Default::default();

--- a/tests/ui/vec_init_then_push.stderr
+++ b/tests/ui/vec_init_then_push.stderr
@@ -1,5 +1,5 @@
 error: calls to `push` immediately after creation
-  --> tests/ui/vec_init_then_push.rs:4:5
+  --> tests/ui/vec_init_then_push.rs:5:5
    |
 LL | /     let mut def_err: Vec<u32> = Default::default();
 ...  |
@@ -10,7 +10,7 @@ LL | |     def_err.push(0);
    = help: to override `-D warnings` add `#[allow(clippy::vec_init_then_push)]`
 
 error: calls to `push` immediately after creation
-  --> tests/ui/vec_init_then_push.rs:9:5
+  --> tests/ui/vec_init_then_push.rs:10:5
    |
 LL | /     let mut new_err = Vec::<u32>::new();
 ...  |
@@ -18,7 +18,7 @@ LL | |     new_err.push(1);
    | |____________________^ help: consider using the `vec![]` macro: `let mut new_err = vec![..];`
 
 error: calls to `push` immediately after creation
-  --> tests/ui/vec_init_then_push.rs:14:5
+  --> tests/ui/vec_init_then_push.rs:15:5
    |
 LL | /     let mut cap_err = Vec::with_capacity(2);
 LL | |
@@ -29,7 +29,7 @@ LL | |     cap_err.push(2);
    | |____________________^ help: consider using the `vec![]` macro: `let mut cap_err = vec![..];`
 
 error: calls to `push` immediately after creation
-  --> tests/ui/vec_init_then_push.rs:28:5
+  --> tests/ui/vec_init_then_push.rs:29:5
    |
 LL | /     new_err = Vec::new();
 ...  |
@@ -37,7 +37,7 @@ LL | |     new_err.push(0);
    | |____________________^ help: consider using the `vec![]` macro: `new_err = vec![..];`
 
 error: calls to `push` immediately after creation
-  --> tests/ui/vec_init_then_push.rs:80:5
+  --> tests/ui/vec_init_then_push.rs:81:5
    |
 LL | /     let mut v = Vec::new();
 LL | |
@@ -47,7 +47,7 @@ LL | |     v.push(1);
    | |______________^ help: consider using the `vec![]` macro: `let mut v = vec![..];`
 
 error: calls to `push` immediately after creation
-  --> tests/ui/vec_init_then_push.rs:90:5
+  --> tests/ui/vec_init_then_push.rs:91:5
    |
 LL | /     let mut v = Vec::new();
 LL | |
@@ -59,7 +59,7 @@ LL | |     v.push(0);
    | |______________^ help: consider using the `vec![]` macro: `let mut v = vec![..];`
 
 error: calls to `push` immediately after creation
-  --> tests/ui/vec_init_then_push.rs:105:5
+  --> tests/ui/vec_init_then_push.rs:106:5
    |
 LL | /     let mut v2 = Vec::new();
 LL | |
@@ -71,7 +71,7 @@ LL | |     v2.push(0);
    | |_______________^ help: consider using the `vec![]` macro: `let mut v2 = vec![..];`
 
 error: calls to `push` immediately after creation
-  --> tests/ui/vec_init_then_push.rs:122:5
+  --> tests/ui/vec_init_then_push.rs:123:5
    |
 LL | /     let mut v = Vec::new();
 ...  |


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16549)*

### Add clear_instead_of_new lint
### What does this PR do?
Adds a new perf lint that detects when a collection is reassigned to a new empty collection instead of calling .clear().
### Why?
Reassigning a collection with collection = CollectionType::new() is inefficient because it:-
1. Deallocates the existing collection
2. Loses any pre-allocated capacity
3. Allocates a new collection from scratch

### Advantage
Using .clear() is more efficient as it:-
1. Keeps the existing allocation and capacity
2. Only removes the elements
3. Avoids unnecessary deallocation/reallocation overhead

- This can lead to significant performance improvements in loops or many paths where collections are frequently reset.

### What collections are supported?
- Vec
- HashMap
- HashSet
- VecDeque
- BTreeMap
- BTreeSet
- BinaryHeap
- LinkedList

Example
Before:
```rust
let mut v = Vec::new();
v.push(1);
v = Vec::new(); // Inefficient: deallocates and reallocates
```

After:
```rust
let mut v = Vec::new();
v.push(1);
v.clear(); // Efficient: reuses existing allocation
```

Fixes rust-lang/rust-clippy#16520

changelog: [`clear_instead_of_new`]: new lint to suggest using .clear() instead of reassigning empty collections