### PR TITLE
Do not lint main function in `must_use_candidates`

### DIFF
--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -13,7 +13,7 @@ use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::source::snippet_indent;
 use clippy_utils::ty::is_must_use_ty;
 use clippy_utils::visitors::for_each_expr_without_closures;
-use clippy_utils::{return_ty, trait_ref_of_method};
+use clippy_utils::{is_entrypoint_fn, return_ty, trait_ref_of_method};
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::find_attr;
 use rustc_span::Symbol;
@@ -211,6 +211,7 @@ fn check_must_use_candidate<'tcx>(
         || !cx.effective_visibilities.is_exported(item_id.def_id)
         || is_must_use_ty(cx, return_ty(cx, item_id))
         || item_span.from_expansion()
+        || is_entrypoint_fn(cx, item_id.def_id.to_def_id())
     {
         return;
     }

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -104,6 +104,7 @@ pub extern "C" fn unmangled(i: bool) -> bool {
     !i
 }
 
-fn main() {
+pub fn main() -> std::process::ExitCode {
     assert_eq!(1, pure(1));
+    std::process::ExitCode::SUCCESS
 }

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -99,6 +99,7 @@ pub extern "C" fn unmangled(i: bool) -> bool {
     !i
 }
 
-fn main() {
+pub fn main() -> std::process::ExitCode {
     assert_eq!(1, pure(1));
+    std::process::ExitCode::SUCCESS
 }


### PR DESCRIPTION
Marking the `main` function as `#[must_use]` is nonsensical, as it is not really supposed to be called anyway.

changelog: [`must_use_candidates`]: No longer lints `main` functions with return values
