### PR TITLE
Enable triagebot new `[view-all-comments-link]` feature

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -55,6 +55,11 @@ labels = ["S-waiting-on-concerns"]
 # Amend a review to include a link to what was changed since the review
 [review-changes-since]
 
+# Adds a "View all comments" link on the issue/PR body that shows all the comments of it
+# Documentation at: https://forge.rust-lang.org/triagebot/view-all-comments-link.html
+[view-all-comments-link]
+threshold = 20
+
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
 users_on_vacation = [


### PR DESCRIPTION
Triagebot implemented a GitHub comments viewer, it loads and shows all the comments (and review comments) of an issue or pull-request.

In order to facilitate it's usage we also added a feature to automatically have triagebot add a "View all comments" link to that viewer, which this PR enables for this repository with a threshold of 20 comments minimum.

See [this link](https://triage.rust-lang.org/gh-comments/rust-lang/rust-clippy/issues/15006) for an example of the result looks like.

cc @samueltardieu 
r? @flip1995 

changelog: none
