### PR TITLE
allow `deprecated(since = "CURRENT_RUSTC_VERSION")`

### DIFF
--- a/clippy_lints/src/attrs/deprecated_semver.rs
+++ b/clippy_lints/src/attrs/deprecated_semver.rs
@@ -2,13 +2,14 @@ use super::DEPRECATED_SEMVER;
 use clippy_utils::diagnostics::span_lint;
 use clippy_utils::sym;
 use rustc_ast::{LitKind, MetaItemLit};
+use rustc_hir::VERSION_PLACEHOLDER;
 use rustc_lint::EarlyContext;
 use rustc_span::Span;
 use semver::Version;
 
 pub(super) fn check(cx: &EarlyContext<'_>, span: Span, lit: &MetaItemLit) {
     if let LitKind::Str(is, _) = lit.kind
-        && (is == sym::TBD || Version::parse(is.as_str()).is_ok())
+        && (is == sym::TBD || is.as_str() == VERSION_PLACEHOLDER || Version::parse(is.as_str()).is_ok())
     {
         return;
     }


### PR DESCRIPTION
Motivated by https://github.com/rust-lang/rust/pull/149978 and https://github.com/rust-lang/rust/pull/152488.

changelog: none