### PR TITLE
Fix `unnecessary_safety_comment` FP on code blocks inside inner docs

### DIFF
--- a/clippy_lints/src/undocumented_unsafe_blocks.rs
+++ b/clippy_lints/src/undocumented_unsafe_blocks.rs
@@ -822,7 +822,9 @@ fn text_has_safety_comment(
             // Don't lint if the safety comment is part of a codeblock in a doc comment.
             // It may or may not be required, and we can't very easily check it (and we shouldn't, since
             // the safety comment isn't referring to the node we're currently checking)
-            if line.trim_start_matches("///").trim_start().starts_with("```") {
+            if let Some(doc) = line.strip_prefix("///").or_else(|| line.strip_prefix("//!"))
+                && doc.trim_start().starts_with("```")
+            {
                 in_codeblock = !in_codeblock;
             }
 

--- a/tests/ui/unnecessary_safety_comment.rs
+++ b/tests/ui/unnecessary_safety_comment.rs
@@ -100,3 +100,13 @@ mod issue_12048 {
 }
 
 fn main() {}
+
+mod issue16553 {
+    //! ```
+    //! // SAFETY: All is well.
+    //! unsafe {
+    //!    foo()
+    //! }
+    //! ```
+    mod blah {}
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16553 

changelog: [`unnecessary_safety_comment`] fix FP on code blocks inside inner docs
