### PR TITLE
fix: `RustcCallbacks::config()` in `clippy-driver`

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -126,6 +126,7 @@ impl rustc_driver::Callbacks for RustcCallbacks {
         config.psess_created = Some(Box::new(move |psess| {
             track_clippy_args(psess, clippy_args_var.as_deref());
         }));
+        config.extra_symbols = sym::EXTRA_SYMBOLS.into();
     }
 }
 


### PR DESCRIPTION
The `RustcCallbacks::config()` function used by `clippy-driver` was not setting `config.extra_symbols`, so when interned symbols were computed, such as `sym::CLIPPY_ARGS`, it was using some random string in the binary. The fix is to set 

```rust
config.extra_symbols = sym::EXTRA_SYMBOLS.into();
```

in the config() function. This mirrors what is done in the `ClippyCallbacks::config()` function, which did not show a problem.

# Steps to repro the problem (WITHOUT this PR):

I'm on a mac laptop now, but I repro'd this on Linux too:

```console
❯ cargo -V
cargo 1.95.0-nightly (fe2f314ae 2026-01-30)
```

1. Create a dummy project
```console
❯ cargo new --lib /tmp/foo
```

2. Run `clippy-driver` from this repo on `/tmp/foo/src/lib.rs`. You must specify `--cap-lints allow` in order for the `RustcCallbacks` to be used; otherwise, the `ClippyCallbacks` are used and you won't see the problem.
```console
❯ cargo run --bin clippy-driver -- rustc --crate-name foo --edition=2024 /tmp/foo/src/lib.rs --crate-type lib --emit=dep-info --out-dir /tmp/foo --cap-lints allow
```

3. **The problem**: The problem is the `env-dep:macos` line. It is _incorrectly_ recording that the "macos" environment variable is relevant for this build. On Linux it showed the string "linux". I've also seen other random strings, like "128". I believe these strings are arbitrary.

   The problem is that the `sym::CLIPPY_ARGS` symbol is read without the `exta_symbols` table being set.
```console
❯ cat /tmp/foo/foo.d
/tmp/foo/foo.d: /tmp/foo/src/lib.rs

/tmp/foo/src/lib.rs:

# env-dep:macos
```

# The fix:

With this fix in this PR, we can re-run the `clippy-driver` invocation in step 2 above and see the expected dep-info showing `env-dep:CLIPPY_ARGS` instead of `env-dep:macos`.

```console

❯ cargo run --bin clippy-driver -- rustc --crate-name foo --edition=2024 /tmp/foo/src/lib.rs --crate-type lib --emit=dep-info --out-dir /tmp/foo --cap-lints allow

❯ cat /tmp/foo/foo.d
/tmp/foo/foo.d: /tmp/foo/src/lib.rs

/tmp/foo/src/lib.rs:

# env-dep:CLIPPY_ARGS
```

Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`lint_name`]: your change
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none
