### PR TITLE
Fix false positives in duration_suboptimal_units for small literals

### DIFF
--- a/clippy_lints/src/duration_suboptimal_units.rs
+++ b/clippy_lints/src/duration_suboptimal_units.rs
@@ -88,7 +88,7 @@ impl LateLintPass<'_> for DurationSuboptimalUnits {
             && value != 0
             && let Some((promoted_constructor, promoted_value)) = self.promote(cx, func_name.ident.name, value)
             // Does not promote for literals with resulting values <=10
-            && (!matches!(expr.kind, ExprKind::Call(_, [Expr { kind: ExprKind::Lit(_), .. }])) || promoted_value > 10)
+            && (!matches!(arg.kind, ExprKind::Lit(_)) || promoted_value > 10)
         {
             span_lint_and_then(
                 cx,

--- a/clippy_lints/src/duration_suboptimal_units.rs
+++ b/clippy_lints/src/duration_suboptimal_units.rs
@@ -18,6 +18,8 @@ declare_clippy_lint! {
     ///
     /// Checks for instances where a `std::time::Duration` is constructed using a smaller time unit
     /// when the value could be expressed more clearly using a larger unit.
+    /// For values that would convert to 10 or fewer of the larger unit,
+    /// this lint does not apply.
     ///
     /// ### Why is this bad?
     ///
@@ -29,8 +31,8 @@ declare_clippy_lint! {
     /// ```
     /// use std::time::Duration;
     ///
-    /// let dur = Duration::from_millis(5_000);
-    /// let dur = Duration::from_secs(180);
+    /// let dur = Duration::from_millis(50_000);
+    /// let dur = Duration::from_secs(1800);
     /// let dur = Duration::from_mins(10 * 60);
     /// ```
     ///
@@ -38,8 +40,8 @@ declare_clippy_lint! {
     /// ```
     /// use std::time::Duration;
     ///
-    /// let dur = Duration::from_secs(5);
-    /// let dur = Duration::from_mins(3);
+    /// let dur = Duration::from_secs(50);
+    /// let dur = Duration::from_mins(30);
     /// let dur = Duration::from_hours(10);
     /// ```
     #[clippy::version = "1.95.0"]
@@ -80,8 +82,8 @@ impl LateLintPass<'_> for DurationSuboptimalUnits {
             // We intentionally don't want to evaluate referenced constants, as we don't want to
             // recommend a literal value over using constants:
             //
-            // let dur = Duration::from_secs(SIXTY);
-            //           ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Duration::from_mins(1)`
+            // let dur = Duration::from_millis(TWELVE_THOUSAND);
+            //           ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Duration::from_secs(12)`
             && let Some(Constant::Int(value)) = ConstEvalCtxt::new(cx).eval_local(arg, expr.span.ctxt())
             && let Ok(value) = u64::try_from(value) // Cannot fail
             // There is no need to promote e.g. 0 seconds to 0 hours

--- a/clippy_lints/src/duration_suboptimal_units.rs
+++ b/clippy_lints/src/duration_suboptimal_units.rs
@@ -87,6 +87,8 @@ impl LateLintPass<'_> for DurationSuboptimalUnits {
             // There is no need to promote e.g. 0 seconds to 0 hours
             && value != 0
             && let Some((promoted_constructor, promoted_value)) = self.promote(cx, func_name.ident.name, value)
+            // Does not promote for literals with resulting values <=10
+            && (!matches!(expr.kind, ExprKind::Call(_, [Expr { kind: ExprKind::Lit(_), .. }])) || promoted_value > 10)
         {
             span_lint_and_then(
                 cx,

--- a/tests/ui/duration_suboptimal_units.fixed
+++ b/tests/ui/duration_suboptimal_units.fixed
@@ -7,7 +7,7 @@ const SIXTY: u64 = 60;
 
 macro_rules! mac {
     (slow_rythm) => {
-        3600
+        60 * 60
     };
     (duration) => {
         Duration::from_mins(5)
@@ -23,14 +23,17 @@ fn main() {
     let dur = Duration::from_secs(42);
     let dur = Duration::from_hours(3);
 
+    let dur = Duration::from_secs(60);
     let dur = Duration::from_mins(1);
     //~^ duration_suboptimal_units
+    let dur = Duration::from_secs(180);
     let dur = Duration::from_mins(3);
     //~^ duration_suboptimal_units
     let dur = Duration::from_mins(10);
     //~^ duration_suboptimal_units
     let dur = Duration::from_hours(24);
     //~^ duration_suboptimal_units
+    let dur = Duration::from_millis(5_000);
     let dur = Duration::from_secs(5);
     //~^ duration_suboptimal_units
     let dur = Duration::from_hours(13);
@@ -44,7 +47,15 @@ fn main() {
 
     const {
         let dur = Duration::from_secs(0);
+        let dur = Duration::from_millis(5_000);
         let dur = Duration::from_secs(5);
+        //~^ duration_suboptimal_units
+        let dur = Duration::from_secs(11);
+        //~^ duration_suboptimal_units
+
+        let dur = Duration::from_secs(180);
+        // 39600 secs = 3 hours
+        let dur = Duration::from_hours(11);
         //~^ duration_suboptimal_units
         let dur = Duration::from_mins(3);
         //~^ duration_suboptimal_units
@@ -54,11 +65,8 @@ fn main() {
         let dur = Duration::from_secs(SIXTY);
     }
 
-    // Qualified Durations must be kept
-    std::time::Duration::from_mins(1);
-    //~^ duration_suboptimal_units
-
     // We lint in normal macros
+    assert_eq!(Duration::from_secs(3_600), Duration::from_mins(6));
     assert_eq!(Duration::from_hours(1), Duration::from_mins(6));
     //~^ duration_suboptimal_units
 
@@ -66,10 +74,10 @@ fn main() {
     let dur = mac!(duration);
 
     // We don't lint in macros if duration comes from outside
-    let dur = mac!(arg => 3600);
+    let dur = mac!(arg => 60 * 60);
 
     // We don't lint in external macros
-    let dur = proc_macros::external! { Duration::from_secs(3_600) };
+    let dur = proc_macros::external! { Duration::from_secs(60 * 60) };
 
     // We don't lint values coming from macros
     let dur = Duration::from_secs(mac!(slow_rythm));

--- a/tests/ui/duration_suboptimal_units.rs
+++ b/tests/ui/duration_suboptimal_units.rs
@@ -7,10 +7,10 @@ const SIXTY: u64 = 60;
 
 macro_rules! mac {
     (slow_rythm) => {
-        3600
+        60 * 60
     };
     (duration) => {
-        Duration::from_secs(300)
+        Duration::from_secs(60 * 5)
         //~^ duration_suboptimal_units
     };
     (arg => $e:expr) => {
@@ -24,14 +24,17 @@ fn main() {
     let dur = Duration::from_hours(3);
 
     let dur = Duration::from_secs(60);
+    let dur = Duration::from_secs(59 + 1);
     //~^ duration_suboptimal_units
     let dur = Duration::from_secs(180);
+    let dur = Duration::from_secs(60 * 3);
     //~^ duration_suboptimal_units
     let dur = Duration::from_secs(10 * 60);
     //~^ duration_suboptimal_units
     let dur = Duration::from_mins(24 * 60);
     //~^ duration_suboptimal_units
     let dur = Duration::from_millis(5_000);
+    let dur = Duration::from_millis(5 * 1000);
     //~^ duration_suboptimal_units
     let dur = Duration::from_nanos(13 * 60 * 60 * 1_000 * 1_000 * 1_000);
     //~^ duration_suboptimal_units
@@ -45,8 +48,16 @@ fn main() {
     const {
         let dur = Duration::from_secs(0);
         let dur = Duration::from_millis(5_000);
+        let dur = Duration::from_millis(1000 * 5);
         //~^ duration_suboptimal_units
+        let dur = Duration::from_millis(11000);
+        //~^ duration_suboptimal_units
+
         let dur = Duration::from_secs(180);
+        // 39600 secs = 3 hours
+        let dur = Duration::from_secs(39600);
+        //~^ duration_suboptimal_units
+        let dur = Duration::from_secs(3 * 60);
         //~^ duration_suboptimal_units
         let dur = Duration::from_mins(24 * 60);
         //~^ duration_suboptimal_units
@@ -54,22 +65,19 @@ fn main() {
         let dur = Duration::from_secs(SIXTY);
     }
 
-    // Qualified Durations must be kept
-    std::time::Duration::from_secs(60);
-    //~^ duration_suboptimal_units
-
     // We lint in normal macros
     assert_eq!(Duration::from_secs(3_600), Duration::from_mins(6));
+    assert_eq!(Duration::from_secs(60 * 60), Duration::from_mins(6));
     //~^ duration_suboptimal_units
 
     // We lint in normal macros (marker is in macro itself)
     let dur = mac!(duration);
 
     // We don't lint in macros if duration comes from outside
-    let dur = mac!(arg => 3600);
+    let dur = mac!(arg => 60 * 60);
 
     // We don't lint in external macros
-    let dur = proc_macros::external! { Duration::from_secs(3_600) };
+    let dur = proc_macros::external! { Duration::from_secs(60 * 60) };
 
     // We don't lint values coming from macros
     let dur = Duration::from_secs(mac!(slow_rythm));

--- a/tests/ui/duration_suboptimal_units.stderr
+++ b/tests/ui/duration_suboptimal_units.stderr
@@ -1,31 +1,31 @@
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:26:15
+  --> tests/ui/duration_suboptimal_units.rs:27:15
    |
-LL |     let dur = Duration::from_secs(60);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_secs(59 + 1);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::duration-suboptimal-units` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::duration_suboptimal_units)]`
 help: try using from_mins
    |
-LL -     let dur = Duration::from_secs(60);
+LL -     let dur = Duration::from_secs(59 + 1);
 LL +     let dur = Duration::from_mins(1);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:28:15
+  --> tests/ui/duration_suboptimal_units.rs:30:15
    |
-LL |     let dur = Duration::from_secs(180);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_secs(60 * 3);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_mins
    |
-LL -     let dur = Duration::from_secs(180);
+LL -     let dur = Duration::from_secs(60 * 3);
 LL +     let dur = Duration::from_mins(3);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:30:15
+  --> tests/ui/duration_suboptimal_units.rs:32:15
    |
 LL |     let dur = Duration::from_secs(10 * 60);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL +     let dur = Duration::from_mins(10);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:32:15
+  --> tests/ui/duration_suboptimal_units.rs:34:15
    |
 LL |     let dur = Duration::from_mins(24 * 60);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,19 +49,19 @@ LL +     let dur = Duration::from_hours(24);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:34:15
+  --> tests/ui/duration_suboptimal_units.rs:37:15
    |
-LL |     let dur = Duration::from_millis(5_000);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_millis(5 * 1000);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_secs
    |
-LL -     let dur = Duration::from_millis(5_000);
+LL -     let dur = Duration::from_millis(5 * 1000);
 LL +     let dur = Duration::from_secs(5);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:36:15
+  --> tests/ui/duration_suboptimal_units.rs:39:15
    |
 LL |     let dur = Duration::from_nanos(13 * 60 * 60 * 1_000 * 1_000 * 1_000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,31 +73,55 @@ LL +     let dur = Duration::from_hours(13);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:47:19
+  --> tests/ui/duration_suboptimal_units.rs:51:19
    |
-LL |         let dur = Duration::from_millis(5_000);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let dur = Duration::from_millis(1000 * 5);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_secs
    |
-LL -         let dur = Duration::from_millis(5_000);
+LL -         let dur = Duration::from_millis(1000 * 5);
 LL +         let dur = Duration::from_secs(5);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:49:19
+  --> tests/ui/duration_suboptimal_units.rs:53:19
    |
-LL |         let dur = Duration::from_secs(180);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let dur = Duration::from_millis(11000);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_secs
+   |
+LL -         let dur = Duration::from_millis(11000);
+LL +         let dur = Duration::from_secs(11);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:58:19
+   |
+LL |         let dur = Duration::from_secs(39600);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_hours
+   |
+LL -         let dur = Duration::from_secs(39600);
+LL +         let dur = Duration::from_hours(11);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:60:19
+   |
+LL |         let dur = Duration::from_secs(3 * 60);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_mins
    |
-LL -         let dur = Duration::from_secs(180);
+LL -         let dur = Duration::from_secs(3 * 60);
 LL +         let dur = Duration::from_mins(3);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:51:19
+  --> tests/ui/duration_suboptimal_units.rs:62:19
    |
 LL |         let dur = Duration::from_mins(24 * 60);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,34 +133,22 @@ LL +         let dur = Duration::from_hours(24);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:58:5
+  --> tests/ui/duration_suboptimal_units.rs:70:16
    |
-LL |     std::time::Duration::from_secs(60);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: try using from_mins
-   |
-LL -     std::time::Duration::from_secs(60);
-LL +     std::time::Duration::from_mins(1);
-   |
-
-error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:62:16
-   |
-LL |     assert_eq!(Duration::from_secs(3_600), Duration::from_mins(6));
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     assert_eq!(Duration::from_secs(60 * 60), Duration::from_mins(6));
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_hours
    |
-LL -     assert_eq!(Duration::from_secs(3_600), Duration::from_mins(6));
+LL -     assert_eq!(Duration::from_secs(60 * 60), Duration::from_mins(6));
 LL +     assert_eq!(Duration::from_hours(1), Duration::from_mins(6));
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
   --> tests/ui/duration_suboptimal_units.rs:13:9
    |
-LL |         Duration::from_secs(300)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         Duration::from_secs(60 * 5)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     let dur = mac!(duration);
    |               -------------- in this macro invocation
@@ -144,9 +156,9 @@ LL |     let dur = mac!(duration);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: try using from_mins
    |
-LL -         Duration::from_secs(300)
+LL -         Duration::from_secs(60 * 5)
 LL +         Duration::from_mins(5)
    |
 
-error: aborting due to 12 previous errors
+error: aborting due to 13 previous errors
 

--- a/tests/ui/duration_suboptimal_units_days_weeks.fixed
+++ b/tests/ui/duration_suboptimal_units_days_weeks.fixed
@@ -6,9 +6,11 @@
 use std::time::Duration;
 
 fn main() {
+    let dur = Duration::from_secs(60);
     let dur = Duration::from_mins(1);
     //~^ duration_suboptimal_units
 
+    let dur = Duration::from_hours(24);
     let dur = Duration::from_days(1);
     //~^ duration_suboptimal_units
 

--- a/tests/ui/duration_suboptimal_units_days_weeks.rs
+++ b/tests/ui/duration_suboptimal_units_days_weeks.rs
@@ -7,9 +7,11 @@ use std::time::Duration;
 
 fn main() {
     let dur = Duration::from_secs(60);
+    let dur = Duration::from_secs(61 - 1);
     //~^ duration_suboptimal_units
 
     let dur = Duration::from_hours(24);
+    let dur = Duration::from_hours(12 * 2);
     //~^ duration_suboptimal_units
 
     let dur = Duration::from_nanos(13 * 7 * 24 * 60 * 60 * 1_000 * 1_000 * 1_000);

--- a/tests/ui/duration_suboptimal_units_days_weeks.stderr
+++ b/tests/ui/duration_suboptimal_units_days_weeks.stderr
@@ -1,31 +1,31 @@
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units_days_weeks.rs:9:15
+  --> tests/ui/duration_suboptimal_units_days_weeks.rs:10:15
    |
-LL |     let dur = Duration::from_secs(60);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_secs(61 - 1);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::duration-suboptimal-units` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::duration_suboptimal_units)]`
 help: try using from_mins
    |
-LL -     let dur = Duration::from_secs(60);
+LL -     let dur = Duration::from_secs(61 - 1);
 LL +     let dur = Duration::from_mins(1);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units_days_weeks.rs:12:15
+  --> tests/ui/duration_suboptimal_units_days_weeks.rs:14:15
    |
-LL |     let dur = Duration::from_hours(24);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_hours(12 * 2);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_days
    |
-LL -     let dur = Duration::from_hours(24);
+LL -     let dur = Duration::from_hours(12 * 2);
 LL +     let dur = Duration::from_days(1);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units_days_weeks.rs:15:15
+  --> tests/ui/duration_suboptimal_units_days_weeks.rs:17:15
    |
 LL |     let dur = Duration::from_nanos(13 * 7 * 24 * 60 * 60 * 1_000 * 1_000 * 1_000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16532 

changelog: Fix [`duration_suboptimal_units`] false positive for small integer literals (at most 10).

