### PR TITLE
Fix the compile-test tests when setting Cargo's `build.build-dir` setting to a path that's distinct from `target-dir`

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -197,10 +197,6 @@ impl TestContext {
             defaults.set_custom("diagnostic-collector", collector);
         }
         config.with_args(&self.args);
-        let current_exe_path = env::current_exe().unwrap();
-        let deps_path = current_exe_path.parent().unwrap();
-        let profile_path = deps_path.parent().unwrap();
-
         config.program.args.extend(
             [
                 "--emit=metadata",
@@ -224,6 +220,7 @@ impl TestContext {
             config.program.args.push(format!("--sysroot={sysroot}").into());
         }
 
+        let profile_path = target_dir.join(env!("PROFILE"));
         config.program.program = profile_path.join(if cfg!(windows) {
             "clippy-driver.exe"
         } else {


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16567.

Fix the compile-test tests when Cargo's `build.build-dir` is set to a path that's distinct from `target-dir`. Right now, the uitest harness assumes that `clippy-driver` (a final build artifact) is located in the parent directory of `compile_test-…` (an intermediate artifact or, rather, a dependency's final artifact), and that doesn't hold when `build-dir` is configured independently from `target-dir`, like so (in ~/.cargo/config.toml):

```toml
[build]
build-dir = "{cargo-cache-home}/build-artifacts/{workspace-path-hash}"
```

changelog: none
