### PR TITLE
Resolve false positive `useless_asref` on `Result`

### DIFF
--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -158,4 +158,11 @@ fn main() {
         let y = Some(&x);
         let _z = y.map(RcWeak::clone);
     }
+
+    // Issue #16529
+    {
+        let r: Result<i32, i64> = Ok(1);
+        let _r = r.as_ref().copied();
+        //~^ map_clone
+    }
 }

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -158,4 +158,11 @@ fn main() {
         let y = Some(&x);
         let _z = y.map(RcWeak::clone);
     }
+
+    // Issue #16529
+    {
+        let r: Result<i32, i64> = Ok(1);
+        let _r = r.as_ref().map(Clone::clone);
+        //~^ map_clone
+    }
 }

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -91,5 +91,11 @@ error: you are explicitly cloning with `.map()`
 LL |     let y = x.map(|x| Clone::clone(x));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `x.copied()`
 
-error: aborting due to 15 previous errors
+error: you are explicitly cloning with `.map()`
+  --> tests/ui/map_clone.rs:165:18
+   |
+LL |         let _r = r.as_ref().map(Clone::clone);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `r.as_ref().copied()`
+
+error: aborting due to 16 previous errors
 

--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -293,4 +293,9 @@ fn issue16098(exts: Vec<&str>) {
     //~^ useless_asref
 }
 
+fn issue_16529() {
+    let r: Result<i32, i64> = Ok(1);
+    let _r = r.as_ref().map(Clone::clone);
+}
+
 fn main() {}

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -293,4 +293,9 @@ fn issue16098(exts: Vec<&str>) {
     //~^ useless_asref
 }
 
+fn issue_16529() {
+    let r: Result<i32, i64> = Ok(1);
+    let _r = r.as_ref().map(Clone::clone);
+}
+
 fn main() {}


### PR DESCRIPTION
Eliminated the overlap `useless_asref` with `map_clone`, giving preference to `map_clone` on `Result<T, E>`.

Fixes rust-lang/rust-clippy#16529.

changelog: [`useless_asref`, `map_clone`].