### PR TITLE
Remove `env` macro use from ui tests.

### DIFF
--- a/tests/ui/cmp_owned/with_suggestion.fixed
+++ b/tests/ui/cmp_owned/with_suggestion.fixed
@@ -114,6 +114,12 @@ fn issue16322(item: String) {
 }
 
 fn issue16458() {
+    macro_rules! m {
+        () => {
+            ""
+        };
+    }
+
     macro_rules! partly_comes_from_macro {
         ($i:ident: $ty:ty, $def:expr) => {
             let _ = {
@@ -125,7 +131,7 @@ fn issue16458() {
     }
 
     partly_comes_from_macro! {
-        required_version: String, env!("HOME").to_string()
+        required_version: String, m!().to_string()
     }
 
     macro_rules! all_comes_from_macro {
@@ -141,6 +147,6 @@ fn issue16458() {
         };
     }
     all_comes_from_macro! {
-        required_version: String, env!("HOME").to_string();
+        required_version: String, m!().to_string();
     }
 }

--- a/tests/ui/cmp_owned/with_suggestion.rs
+++ b/tests/ui/cmp_owned/with_suggestion.rs
@@ -114,6 +114,12 @@ fn issue16322(item: String) {
 }
 
 fn issue16458() {
+    macro_rules! m {
+        () => {
+            ""
+        };
+    }
+
     macro_rules! partly_comes_from_macro {
         ($i:ident: $ty:ty, $def:expr) => {
             let _ = {
@@ -125,7 +131,7 @@ fn issue16458() {
     }
 
     partly_comes_from_macro! {
-        required_version: String, env!("HOME").to_string()
+        required_version: String, m!().to_string()
     }
 
     macro_rules! all_comes_from_macro {
@@ -141,6 +147,6 @@ fn issue16458() {
         };
     }
     all_comes_from_macro! {
-        required_version: String, env!("HOME").to_string();
+        required_version: String, m!().to_string();
     }
 }

--- a/tests/ui/cmp_owned/with_suggestion.stderr
+++ b/tests/ui/cmp_owned/with_suggestion.stderr
@@ -56,13 +56,13 @@ LL |     if item == t!(frohes_neu_Jahr).to_string() {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t!(frohes_neu_Jahr)`
 
 error: this creates an owned instance just for comparison
-  --> tests/ui/cmp_owned/with_suggestion.rs:135:51
+  --> tests/ui/cmp_owned/with_suggestion.rs:141:51
    |
 LL |                       let res = <$ty>::default() == "$def".to_string();
    |                                                     ^^^^^^^^^^^^^^^^^^ help: try: `"$def"`
 ...
 LL | /     all_comes_from_macro! {
-LL | |         required_version: String, env!("HOME").to_string();
+LL | |         required_version: String, m!().to_string();
 LL | |     }
    | |_____- in this macro invocation
    |


### PR DESCRIPTION
`env` requires that the test machine has the variable defined.

changelog: none
