### PR TITLE
Fix stale metadata output comment in compile-test

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -466,7 +466,7 @@ enum DiagnosticOrMessage {
 }
 
 /// Collects applicabilities from the diagnostics produced for each UI test, producing the
-/// `util/gh-pages/lints.json` file used by <https://rust-lang.github.io/rust-clippy/>
+/// `util/gh-pages/index.html` file used by <https://rust-lang.github.io/rust-clippy/>
 #[derive(Debug, Clone)]
 struct DiagnosticCollector {
     sender: Sender<Vec<u8>>,


### PR DESCRIPTION
This fixes a stale doc comment in `tests/compile-test.rs`.

`DiagnosticCollector` currently writes `util/gh-pages/index.html`, but the
comment still referenced `util/gh-pages/lints.json`.

The drift came from b522e7a94 ("Generate lint list in HTML directly instead
of JS"), which changed the output from JSON to HTML while leaving this comment
unchanged.

changelog: none
