### PR TITLE
docs: add `<>` around Markdown link

### DIFF
--- a/book/src/development/the_team.md
+++ b/book/src/development/the_team.md
@@ -51,7 +51,7 @@ this group to help with triaging, which can include:
     busy or wants to abandon it. If the reviewer is busy, the PR can be
     reassigned to someone else.
 
-    Checkout: https://triage.rust-lang.org/triage/rust-lang/rust-clippy to
+    Checkout: <https://triage.rust-lang.org/triage/rust-lang/rust-clippy> to
     monitor PRs.
 
 While not part of their duties, contributors are encouraged to review PRs


### PR DESCRIPTION
changelog: none