### PR TITLE
Do not trigger manual_is_multiple_of on literal divisors

### DIFF
--- a/clippy_lints/src/operators/manual_is_multiple_of.rs
+++ b/clippy_lints/src/operators/manual_is_multiple_of.rs
@@ -32,6 +32,11 @@ pub(super) fn check<'tcx>(
             ty::Uint(_)
         )
         && expr_type_is_certain(cx, operand_left)
+        // https://github.com/rust-lang/rust-clippy/issues/16537
+        && !matches!(
+            operand_right.kind,
+            ExprKind::Lit(_)
+        )
     {
         let mut app = Applicability::MachineApplicable;
         let divisor = deref_sugg(

--- a/tests/ui/manual_is_multiple_of.fixed
+++ b/tests/ui/manual_is_multiple_of.fixed
@@ -117,3 +117,13 @@ fn wrongly_unmangled_macros(a: u32, b: u32) {
         todo!()
     }
 }
+
+fn issue16537(v: u64) {
+    let _ = v % 2 == 0;
+    let _ = (v + 1) % 2 == 0;
+    let _ = v % 2 != 0;
+    let _ = (v + 1) % 2 != 0;
+
+    let _ = v % 2 > 0;
+    let _ = 0 < v % 2;
+}

--- a/tests/ui/manual_is_multiple_of.rs
+++ b/tests/ui/manual_is_multiple_of.rs
@@ -117,3 +117,13 @@ fn wrongly_unmangled_macros(a: u32, b: u32) {
         todo!()
     }
 }
+
+fn issue16537(v: u64) {
+    let _ = v % 2 == 0;
+    let _ = (v + 1) % 2 == 0;
+    let _ = v % 2 != 0;
+    let _ = (v + 1) % 2 != 0;
+
+    let _ = v % 2 > 0;
+    let _ = 0 < v % 2;
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16537.

changelog: [`manual_is_multiple_of`]: skip this lint if the divisor is an integer literal, because it is not necessary.
