### PR TITLE
test: don't call test functions in `main`

### DIFF
--- a/tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs
+++ b/tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.rs
@@ -39,9 +39,4 @@ fn block_bad() -> impl std::future::Future<Output = u32> {
     }
 }
 
-fn main() {
-    good();
-    bad();
-    bad_reason();
-    block_bad();
-}
+fn main() {}

--- a/tests/ui-toml/expect_used/expect_used.rs
+++ b/tests/ui-toml/expect_used/expect_used.rs
@@ -15,9 +15,6 @@ fn expect_result() {
 }
 
 fn main() {
-    expect_option();
-    expect_result();
-
     const SOME: Option<i32> = Some(3);
     const UNWRAPPED: i32 = SOME.expect("Not three?");
     //~^ expect_used

--- a/tests/ui-toml/expect_used/expect_used.stderr
+++ b/tests/ui-toml/expect_used/expect_used.stderr
@@ -17,7 +17,7 @@ LL |     let _ = res.expect("");
    = note: if this value is an `Err`, it will panic
 
 error: used `expect()` on an `Option` value
-  --> tests/ui-toml/expect_used/expect_used.rs:22:28
+  --> tests/ui-toml/expect_used/expect_used.rs:19:28
    |
 LL |     const UNWRAPPED: i32 = SOME.expect("Not three?");
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     const UNWRAPPED: i32 = SOME.expect("Not three?");
    = note: if this value is `None`, it will panic
 
 error: used `expect()` on an `Option` value
-  --> tests/ui-toml/expect_used/expect_used.rs:25:9
+  --> tests/ui-toml/expect_used/expect_used.rs:22:9
    |
 LL |         SOME.expect("Still not three?");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/lint_decimal_readability/test.fixed
+++ b/tests/ui-toml/lint_decimal_readability/test.fixed
@@ -7,8 +7,6 @@ fn allow_inconsistent_digit_grouping() {
 }
 
 fn main() {
-    allow_inconsistent_digit_grouping();
-
     let _pass1 = 100_200_300.100_200_300;
     let _pass2 = 1.123456789;
     let _pass3 = 1.0;

--- a/tests/ui-toml/lint_decimal_readability/test.rs
+++ b/tests/ui-toml/lint_decimal_readability/test.rs
@@ -7,8 +7,6 @@ fn allow_inconsistent_digit_grouping() {
 }
 
 fn main() {
-    allow_inconsistent_digit_grouping();
-
     let _pass1 = 100_200_300.100_200_300;
     let _pass2 = 1.123456789;
     let _pass3 = 1.0;

--- a/tests/ui-toml/lint_decimal_readability/test.stderr
+++ b/tests/ui-toml/lint_decimal_readability/test.stderr
@@ -1,5 +1,5 @@
 error: digits grouped inconsistently by underscores
-  --> tests/ui-toml/lint_decimal_readability/test.rs:19:18
+  --> tests/ui-toml/lint_decimal_readability/test.rs:17:18
    |
 LL |     let _fail1 = 100_200_300.123456789;
    |                  ^^^^^^^^^^^^^^^^^^^^^ help: consider: `100_200_300.123_456_789`
@@ -8,7 +8,7 @@ LL |     let _fail1 = 100_200_300.123456789;
    = help: to override `-D warnings` add `#[allow(clippy::inconsistent_digit_grouping)]`
 
 error: long literal lacking separators
-  --> tests/ui-toml/lint_decimal_readability/test.rs:23:18
+  --> tests/ui-toml/lint_decimal_readability/test.rs:21:18
    |
 LL |     let _fail2 = 100200300.300200100;
    |                  ^^^^^^^^^^^^^^^^^^^ help: consider: `100_200_300.300_200_100`

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.fixed
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.fixed
@@ -18,7 +18,4 @@ fn above_limit() {
     }
 }
 
-fn main() {
-    below_limit();
-    above_limit();
-}
+fn main() {}

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
@@ -18,7 +18,4 @@ fn above_limit() {
     }
 }
 
-fn main() {
-    below_limit();
-    above_limit();
-}
+fn main() {}

--- a/tests/ui-toml/min_rust_version/min_rust_version.fixed
+++ b/tests/ui-toml/min_rust_version/min_rust_version.fixed
@@ -88,12 +88,4 @@ fn manual_bits() {
     size_of_val(&0u32) * 8;
 }
 
-fn main() {
-    option_as_ref_deref();
-    match_like_matches();
-    match_same_arms();
-    match_same_arms2();
-    manual_strip_msrv();
-    check_index_refutable_slice();
-    borrow_as_ptr();
-}
+fn main() {}

--- a/tests/ui-toml/min_rust_version/min_rust_version.rs
+++ b/tests/ui-toml/min_rust_version/min_rust_version.rs
@@ -88,12 +88,4 @@ fn manual_bits() {
     size_of_val(&0u32) * 8;
 }
 
-fn main() {
-    option_as_ref_deref();
-    match_like_matches();
-    match_same_arms();
-    match_same_arms2();
-    manual_strip_msrv();
-    check_index_refutable_slice();
-    borrow_as_ptr();
-}
+fn main() {}

--- a/tests/ui-toml/mut_key/mut_key.rs
+++ b/tests/ui-toml/mut_key/mut_key.rs
@@ -56,7 +56,4 @@ fn should_not_take_this_arg(_v: HashSet<Counted<String>>) {}
 
 fn indirect(_: HashMap<ContainsCounted, usize>) {}
 
-fn main() {
-    should_not_take_this_arg(HashSet::new());
-    indirect(HashMap::new());
-}
+fn main() {}

--- a/tests/ui/attrs.rs
+++ b/tests/ui/attrs.rs
@@ -37,15 +37,4 @@ pub const YET_ANOTHER_CONST: u8 = 0;
 #[deprecated(since = "TBD")]
 pub const GONNA_DEPRECATE_THIS_LATER: u8 = 0;
 
-fn main() {
-    test_attr_lint();
-    if false {
-        false_positive_expr()
-    }
-    if false {
-        false_positive_stmt()
-    }
-    if false {
-        empty_and_false_positive_stmt()
-    }
-}
+fn main() {}

--- a/tests/ui/crashes/returns.rs
+++ b/tests/ui/crashes/returns.rs
@@ -18,7 +18,4 @@ fn cfg_let_and_return() -> i32 {
     x
 }
 
-fn main() {
-    cfg_return();
-    cfg_let_and_return();
-}
+fn main() {}

--- a/tests/ui/debug_assert_with_mut_call.rs
+++ b/tests/ui/debug_assert_with_mut_call.rs
@@ -179,12 +179,4 @@ async fn debug_await() {
     }.await);
 }
 
-fn main() {
-    func_non_mutable();
-    func_mutable();
-    method_non_mutable();
-    method_mutable();
-
-    misc();
-    debug_await();
-}
+fn main() {}

--- a/tests/ui/doc/doc-fixable.fixed
+++ b/tests/ui/doc/doc-fixable.fixed
@@ -109,10 +109,6 @@ fn test_allowed() {
 /// `be_sure_we_got_to_the_end_of_it`
 //~^ doc_markdown
 fn main() {
-    foo_bar();
-    multiline_codeblock();
-    test_emphasis();
-    test_units();
 }
 
 /// ## `CamelCaseThing`

--- a/tests/ui/doc/doc-fixable.rs
+++ b/tests/ui/doc/doc-fixable.rs
@@ -109,10 +109,6 @@ fn test_allowed() {
 /// be_sure_we_got_to_the_end_of_it
 //~^ doc_markdown
 fn main() {
-    foo_bar();
-    multiline_codeblock();
-    test_emphasis();
-    test_units();
 }
 
 /// ## CamelCaseThing

--- a/tests/ui/doc/doc-fixable.stderr
+++ b/tests/ui/doc/doc-fixable.stderr
@@ -169,7 +169,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:118:8
+  --> tests/ui/doc/doc-fixable.rs:114:8
    |
 LL | /// ## CamelCaseThing
    |        ^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL + /// ## `CamelCaseThing`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:122:7
+  --> tests/ui/doc/doc-fixable.rs:118:7
    |
 LL | /// # CamelCaseThing
    |       ^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL + /// # `CamelCaseThing`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:125:22
+  --> tests/ui/doc/doc-fixable.rs:121:22
    |
 LL | /// Not a title #897 CamelCaseThing
    |                      ^^^^^^^^^^^^^^
@@ -205,7 +205,7 @@ LL + /// Not a title #897 `CamelCaseThing`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:127:5
+  --> tests/ui/doc/doc-fixable.rs:123:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +217,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:135:5
+  --> tests/ui/doc/doc-fixable.rs:131:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:149:5
+  --> tests/ui/doc/doc-fixable.rs:145:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +241,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:161:43
+  --> tests/ui/doc/doc-fixable.rs:157:43
    |
 LL | /** E.g., serialization of an empty list: FooBar
    |                                           ^^^^^^
@@ -253,7 +253,7 @@ LL + /** E.g., serialization of an empty list: `FooBar`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:166:5
+  --> tests/ui/doc/doc-fixable.rs:162:5
    |
 LL | And BarQuz too.
    |     ^^^^^^
@@ -265,7 +265,7 @@ LL + And `BarQuz` too.
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:167:1
+  --> tests/ui/doc/doc-fixable.rs:163:1
    |
 LL | be_sure_we_got_to_the_end_of_it
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,7 +277,7 @@ LL + `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:175:43
+  --> tests/ui/doc/doc-fixable.rs:171:43
    |
 LL | /** E.g., serialization of an empty list: FooBar
    |                                           ^^^^^^
@@ -289,7 +289,7 @@ LL + /** E.g., serialization of an empty list: `FooBar`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:180:5
+  --> tests/ui/doc/doc-fixable.rs:176:5
    |
 LL | And BarQuz too.
    |     ^^^^^^
@@ -301,7 +301,7 @@ LL + And `BarQuz` too.
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:181:1
+  --> tests/ui/doc/doc-fixable.rs:177:1
    |
 LL | be_sure_we_got_to_the_end_of_it
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -313,7 +313,7 @@ LL + `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:195:5
+  --> tests/ui/doc/doc-fixable.rs:191:5
    |
 LL | /// be_sure_we_got_to_the_end_of_it
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -325,7 +325,7 @@ LL + /// `be_sure_we_got_to_the_end_of_it`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:215:22
+  --> tests/ui/doc/doc-fixable.rs:211:22
    |
 LL | /// An iterator over mycrate::Collection's values.
    |                      ^^^^^^^^^^^^^^^^^^^
@@ -337,7 +337,7 @@ LL + /// An iterator over `mycrate::Collection`'s values.
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:240:34
+  --> tests/ui/doc/doc-fixable.rs:236:34
    |
 LL | /// Foo \[bar\] \[baz\] \[qux\]. DocMarkdownLint
    |                                  ^^^^^^^^^^^^^^^
@@ -349,7 +349,7 @@ LL + /// Foo \[bar\] \[baz\] \[qux\]. `DocMarkdownLint`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:264:22
+  --> tests/ui/doc/doc-fixable.rs:260:22
    |
 LL | /// There is no try (do() or do_not()).
    |                      ^^^^
@@ -361,7 +361,7 @@ LL + /// There is no try (`do()` or do_not()).
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:264:30
+  --> tests/ui/doc/doc-fixable.rs:260:30
    |
 LL | /// There is no try (do() or do_not()).
    |                              ^^^^^^^^
@@ -373,7 +373,7 @@ LL + /// There is no try (do() or `do_not()`).
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:269:5
+  --> tests/ui/doc/doc-fixable.rs:265:5
    |
 LL | /// ABes
    |     ^^^^
@@ -385,7 +385,7 @@ LL + /// `ABes`
    |
 
 error: item in documentation is missing backticks
-  --> tests/ui/doc/doc-fixable.rs:276:9
+  --> tests/ui/doc/doc-fixable.rs:272:9
    |
 LL |     /// foo()
    |         ^^^^^
@@ -397,7 +397,7 @@ LL +     /// `foo()`
    |
 
 error: you should put bare URLs between `<`/`>` or make a proper Markdown link
-  --> tests/ui/doc/doc-fixable.rs:281:5
+  --> tests/ui/doc/doc-fixable.rs:277:5
    |
 LL | /// https://github.com/rust-lang/rust-clippy/pull/12836
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `<https://github.com/rust-lang/rust-clippy/pull/12836>`

--- a/tests/ui/doc_link_with_quotes.rs
+++ b/tests/ui/doc_link_with_quotes.rs
@@ -1,8 +1,6 @@
 #![warn(clippy::doc_link_with_quotes)]
 
-fn main() {
-    foo()
-}
+fn main() {}
 
 /// Calls ['bar'] uselessly
 //~^ doc_link_with_quotes

--- a/tests/ui/doc_link_with_quotes.stderr
+++ b/tests/ui/doc_link_with_quotes.stderr
@@ -1,5 +1,5 @@
 error: possible intra-doc link using quotes instead of backticks
-  --> tests/ui/doc_link_with_quotes.rs:7:12
+  --> tests/ui/doc_link_with_quotes.rs:5:12
    |
 LL | /// Calls ['bar'] uselessly
    |            ^^^^^
@@ -8,7 +8,7 @@ LL | /// Calls ['bar'] uselessly
    = help: to override `-D warnings` add `#[allow(clippy::doc_link_with_quotes)]`
 
 error: possible intra-doc link using quotes instead of backticks
-  --> tests/ui/doc_link_with_quotes.rs:13:12
+  --> tests/ui/doc_link_with_quotes.rs:11:12
    |
 LL | /// Calls ["bar"] uselessly
    |            ^^^^^

--- a/tests/ui/double_must_use.rs
+++ b/tests/ui/double_must_use.rs
@@ -68,8 +68,4 @@ pub fn must_use_controlflow_with_uninhabited_2() -> ControlFlow<std::convert::In
     unimplemented!();
 }
 
-fn main() {
-    must_use_result();
-    must_use_tuple();
-    must_use_with_note();
-}
+fn main() {}

--- a/tests/ui/duplicate_underscore_argument.rs
+++ b/tests/ui/duplicate_underscore_argument.rs
@@ -5,7 +5,4 @@ fn join_the_dark_side(darth: i32, _darth: i32) {}
 
 fn join_the_light_side(knight: i32, _master: i32) {} // the Force is strong with this one
 
-fn main() {
-    join_the_dark_side(0, 0);
-    join_the_light_side(0, 0);
-}
+fn main() {}

--- a/tests/ui/erasing_op.rs
+++ b/tests/ui/erasing_op.rs
@@ -49,6 +49,4 @@ fn test(x: u8) {
     //~^ erasing_op
 }
 
-fn main() {
-    test(0)
-}
+fn main() {}

--- a/tests/ui/expect.rs
+++ b/tests/ui/expect.rs
@@ -34,8 +34,4 @@ fn issue_15247() {
     //~^ expect_used
 }
 
-fn main() {
-    expect_option();
-    expect_result();
-    issue_15247();
-}
+fn main() {}

--- a/tests/ui/floating_point_abs.fixed
+++ b/tests/ui/floating_point_abs.fixed
@@ -73,18 +73,4 @@ fn not_fake_abs5(a: A) -> f64 {
     if a.a > 0.0 { a.a } else { -a.b }
 }
 
-fn main() {
-    fake_abs1(5.0);
-    fake_abs2(5.0);
-    fake_abs3(A { a: 5.0, b: 5.0 });
-    fake_abs4(5.0);
-    fake_abs5(A { a: 5.0, b: 5.0 });
-    fake_nabs1(5.0);
-    fake_nabs2(5.0);
-    fake_nabs3(A { a: 5.0, b: 5.0 });
-    not_fake_abs1(5.0);
-    not_fake_abs2(5.0);
-    not_fake_abs3(5.0, 5.0);
-    not_fake_abs4(A { a: 5.0, b: 5.0 });
-    not_fake_abs5(A { a: 5.0, b: 5.0 });
-}
+fn main() {}

--- a/tests/ui/floating_point_abs.rs
+++ b/tests/ui/floating_point_abs.rs
@@ -73,18 +73,4 @@ fn not_fake_abs5(a: A) -> f64 {
     if a.a > 0.0 { a.a } else { -a.b }
 }
 
-fn main() {
-    fake_abs1(5.0);
-    fake_abs2(5.0);
-    fake_abs3(A { a: 5.0, b: 5.0 });
-    fake_abs4(5.0);
-    fake_abs5(A { a: 5.0, b: 5.0 });
-    fake_nabs1(5.0);
-    fake_nabs2(5.0);
-    fake_nabs3(A { a: 5.0, b: 5.0 });
-    not_fake_abs1(5.0);
-    not_fake_abs2(5.0);
-    not_fake_abs3(5.0, 5.0);
-    not_fake_abs4(A { a: 5.0, b: 5.0 });
-    not_fake_abs5(A { a: 5.0, b: 5.0 });
-}
+fn main() {}

--- a/tests/ui/infinite_iter.rs
+++ b/tests/ui/infinite_iter.rs
@@ -87,10 +87,7 @@ fn potential_infinite_iters() {
     repeat(42).take_while(|x| *x == 42).next();
 }
 
-fn main() {
-    infinite_iters();
-    potential_infinite_iters();
-}
+fn main() {}
 
 mod finite_collect {
     use std::collections::HashSet;

--- a/tests/ui/infinite_iter.stderr
+++ b/tests/ui/infinite_iter.stderr
@@ -100,7 +100,7 @@ LL |     (0..).all(|x| x == 24);
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: infinite iteration detected
-  --> tests/ui/infinite_iter.rs:107:31
+  --> tests/ui/infinite_iter.rs:104:31
    |
 LL |         let _: HashSet<i32> = (0..).collect();
    |                               ^^^^^^^^^^^^^^^

--- a/tests/ui/ip_constant_from_external.rs
+++ b/tests/ui/ip_constant_from_external.rs
@@ -7,6 +7,4 @@ fn external_constant_test() {
     // lint in external file `localhost.txt`
 }
 
-fn main() {
-    external_constant_test();
-}
+fn main() {}

--- a/tests/ui/iter_on_empty_collections.fixed
+++ b/tests/ui/iter_on_empty_collections.fixed
@@ -84,8 +84,4 @@ mod custom_option {
     }
 }
 
-fn main() {
-    array();
-    custom_option::custom_option();
-    in_macros!();
-}
+fn main() {}

--- a/tests/ui/iter_on_empty_collections.rs
+++ b/tests/ui/iter_on_empty_collections.rs
@@ -84,8 +84,4 @@ mod custom_option {
     }
 }
 
-fn main() {
-    array();
-    custom_option::custom_option();
-    in_macros!();
-}
+fn main() {}

--- a/tests/ui/iter_on_single_items.fixed
+++ b/tests/ui/iter_on_single_items.fixed
@@ -61,11 +61,7 @@ mod custom_option {
     }
 }
 
-fn main() {
-    array();
-    custom_option::custom_option();
-    in_macros!();
-}
+fn main() {}
 
 mod issue14981 {
     use std::option::IntoIter;

--- a/tests/ui/iter_on_single_items.rs
+++ b/tests/ui/iter_on_single_items.rs
@@ -61,11 +61,7 @@ mod custom_option {
     }
 }
 
-fn main() {
-    array();
-    custom_option::custom_option();
-    in_macros!();
-}
+fn main() {}
 
 mod issue14981 {
     use std::option::IntoIter;

--- a/tests/ui/iter_with_drain.fixed
+++ b/tests/ui/iter_with_drain.fixed
@@ -62,9 +62,4 @@ fn should_not_help_0(bomb: &mut Bomb) {
     let _: Vec<u8> = bomb.fire.drain(..).collect();
 }
 
-fn main() {
-    full();
-    closed();
-    should_not_help();
-    should_not_help_0(&mut Bomb::default());
-}
+fn main() {}

--- a/tests/ui/iter_with_drain.rs
+++ b/tests/ui/iter_with_drain.rs
@@ -62,9 +62,4 @@ fn should_not_help_0(bomb: &mut Bomb) {
     let _: Vec<u8> = bomb.fire.drain(..).collect();
 }
 
-fn main() {
-    full();
-    closed();
-    should_not_help();
-    should_not_help_0(&mut Bomb::default());
-}
+fn main() {}

--- a/tests/ui/let_if_seq.rs
+++ b/tests/ui/let_if_seq.rs
@@ -69,11 +69,6 @@ fn allow_works() -> i32 {
 }
 
 fn main() {
-    early_return();
-    issue975();
-    issue985();
-    issue985_alt();
-
     let mut foo = 0;
     //~^ useless_let_if_seq
 

--- a/tests/ui/let_if_seq.stderr
+++ b/tests/ui/let_if_seq.stderr
@@ -1,5 +1,5 @@
 error: `if _ { .. } else { .. }` is an expression
-  --> tests/ui/let_if_seq.rs:77:5
+  --> tests/ui/let_if_seq.rs:72:5
    |
 LL | /     let mut foo = 0;
 LL | |
@@ -14,7 +14,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::useless_let_if_seq)]`
 
 error: `if _ { .. } else { .. }` is an expression
-  --> tests/ui/let_if_seq.rs:84:5
+  --> tests/ui/let_if_seq.rs:79:5
    |
 LL | /     let mut bar = 0;
 LL | |
@@ -28,7 +28,7 @@ LL | |     }
    = note: you might not need `mut` at all
 
 error: `if _ { .. } else { .. }` is an expression
-  --> tests/ui/let_if_seq.rs:94:5
+  --> tests/ui/let_if_seq.rs:89:5
    |
 LL | /     let quz;
 LL | |
@@ -40,7 +40,7 @@ LL | |     }
    | |_____^ help: it is more idiomatic to write: `let quz = if f() { 42 } else { 0 };`
 
 error: `if _ { .. } else { .. }` is an expression
-  --> tests/ui/let_if_seq.rs:125:5
+  --> tests/ui/let_if_seq.rs:120:5
    |
 LL | /     let mut baz = 0;
 LL | |
@@ -53,7 +53,7 @@ LL | |     }
    = note: you might not need `mut` at all
 
 error: `if _ { .. } else { .. }` is an expression
-  --> tests/ui/let_if_seq.rs:144:5
+  --> tests/ui/let_if_seq.rs:139:5
    |
 LL | /     let foo;
 LL | |
@@ -65,7 +65,7 @@ LL | |     }
    | |_____^ help: it is more idiomatic to write: `let foo = if bar() { 42 } else { 0 };`
 
 error: `if _ { .. } else { .. }` is an expression
-  --> tests/ui/let_if_seq.rs:163:5
+  --> tests/ui/let_if_seq.rs:158:5
    |
 LL | /     let foo;
 LL | |

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -113,10 +113,7 @@ fn result_methods() {
     let _ = opt_map!(res2, |x| x == 'a').unwrap_or_default(); // should not lint
 }
 
-fn main() {
-    option_methods();
-    result_methods();
-}
+fn main() {}
 
 fn issue15202() {
     let xs = [None, Some(b'_'), Some(b'1')];

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -122,10 +122,7 @@ fn result_methods() {
     let _ = opt_map!(res2, |x| x == 'a').unwrap_or_default(); // should not lint
 }
 
-fn main() {
-    option_methods();
-    result_methods();
-}
+fn main() {}
 
 fn issue15202() {
     let xs = [None, Some(b'_'), Some(b'1')];

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -127,121 +127,121 @@ LL |     let _ = res2.map(char::is_alphanumeric).unwrap_or_default(); // should 
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `is_ok_and(char::is_alphanumeric)`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:133:18
+  --> tests/ui/manual_is_variant_and.rs:130:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:140:18
+  --> tests/ui/manual_is_variant_and.rs:137:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_none_or(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:147:18
+  --> tests/ui/manual_is_variant_and.rs:144:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:154:18
+  --> tests/ui/manual_is_variant_and.rs:151:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_some_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:162:18
+  --> tests/ui/manual_is_variant_and.rs:159:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:169:18
+  --> tests/ui/manual_is_variant_and.rs:166:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:176:18
+  --> tests/ui/manual_is_variant_and.rs:173:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| b.is_ascii_digit())`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:183:18
+  --> tests/ui/manual_is_variant_and.rs:180:18
    |
 LL |         let a1 = x.map(|b| b.is_ascii_digit()) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `x.is_ok_and(|b| !b.is_ascii_digit())`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:196:18
+  --> tests/ui/manual_is_variant_and.rs:193:18
    |
 LL |         let a1 = b.map(iad) == Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(iad)`
 
 error: called `.map() == Some()`
-  --> tests/ui/manual_is_variant_and.rs:201:18
+  --> tests/ui/manual_is_variant_and.rs:198:18
    |
 LL |         let a1 = b.map(iad) == Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_some_and(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:206:18
+  --> tests/ui/manual_is_variant_and.rs:203:18
    |
 LL |         let a1 = b.map(iad) != Some(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(|x| !iad(x))`
 
 error: called `.map() != Some()`
-  --> tests/ui/manual_is_variant_and.rs:211:18
+  --> tests/ui/manual_is_variant_and.rs:208:18
    |
 LL |         let a1 = b.map(iad) != Some(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_none_or(iad)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:218:18
+  --> tests/ui/manual_is_variant_and.rs:215:18
    |
 LL |         let a1 = b.map(iad) == Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(iad)`
 
 error: called `.map() == Ok()`
-  --> tests/ui/manual_is_variant_and.rs:223:18
+  --> tests/ui/manual_is_variant_and.rs:220:18
    |
 LL |         let a1 = b.map(iad) == Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.is_ok_and(|x| !iad(x))`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:228:18
+  --> tests/ui/manual_is_variant_and.rs:225:18
    |
 LL |         let a1 = b.map(iad) != Ok(true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(iad)`
 
 error: called `.map() != Ok()`
-  --> tests/ui/manual_is_variant_and.rs:233:18
+  --> tests/ui/manual_is_variant_and.rs:230:18
    |
 LL |         let a1 = b.map(iad) != Ok(false);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!b.is_ok_and(|x| !iad(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:243:13
+  --> tests/ui/manual_is_variant_and.rs:240:13
    |
 LL |     let _ = opt.is_none() || opt.is_some_and(then_fn);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:246:13
+  --> tests/ui/manual_is_variant_and.rs:243:13
    |
 LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
 error: manual implementation of `Option::is_some_and`
-  --> tests/ui/manual_is_variant_and.rs:262:5
+  --> tests/ui/manual_is_variant_and.rs:259:5
    |
 LL |     opt.filter(|x| condition(x)).is_some();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_some_and(|x| condition(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:264:5
+  --> tests/ui/manual_is_variant_and.rs:261:5
    |
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`

--- a/tests/ui/manual_option_as_slice.fixed
+++ b/tests/ui/manual_option_as_slice.fixed
@@ -56,7 +56,4 @@ fn check_msrv(x: Option<u32>) {
     _ = x.as_ref().map_or(&[][..], std::slice::from_ref);
 }
 
-fn main() {
-    check(Some(1));
-    check_msrv(Some(175));
-}
+fn main() {}

--- a/tests/ui/manual_option_as_slice.rs
+++ b/tests/ui/manual_option_as_slice.rs
@@ -66,7 +66,4 @@ fn check_msrv(x: Option<u32>) {
     _ = x.as_ref().map_or(&[][..], std::slice::from_ref);
 }
 
-fn main() {
-    check(Some(1));
-    check_msrv(Some(175));
-}
+fn main() {}

--- a/tests/ui/manual_retain.fixed
+++ b/tests/ui/manual_retain.fixed
@@ -2,22 +2,7 @@
 #![allow(unused, clippy::needless_borrowed_reference, clippy::redundant_clone)]
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 
-fn main() {
-    binary_heap_retain();
-    btree_set_retain();
-    btree_map_retain();
-    hash_set_retain();
-    hash_map_retain();
-    string_retain();
-    vec_deque_retain();
-    vec_retain();
-    _msrv_153();
-    _msrv_126();
-    _msrv_118();
-
-    issue_10393();
-    issue_12081();
-}
+fn main() {}
 
 fn binary_heap_retain() {
     let mut binary_heap = BinaryHeap::from([1, 2, 3]);

--- a/tests/ui/manual_retain.rs
+++ b/tests/ui/manual_retain.rs
@@ -2,22 +2,7 @@
 #![allow(unused, clippy::needless_borrowed_reference, clippy::redundant_clone)]
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 
-fn main() {
-    binary_heap_retain();
-    btree_set_retain();
-    btree_map_retain();
-    hash_set_retain();
-    hash_map_retain();
-    string_retain();
-    vec_deque_retain();
-    vec_retain();
-    _msrv_153();
-    _msrv_126();
-    _msrv_118();
-
-    issue_10393();
-    issue_12081();
-}
+fn main() {}
 
 fn binary_heap_retain() {
     let mut binary_heap = BinaryHeap::from([1, 2, 3]);

--- a/tests/ui/manual_retain.stderr
+++ b/tests/ui/manual_retain.stderr
@@ -1,5 +1,5 @@
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:25:5
+  --> tests/ui/manual_retain.rs:10:5
    |
 LL |     binary_heap = binary_heap.into_iter().filter(|x| x % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `binary_heap.retain(|x| x % 2 == 0)`
@@ -8,43 +8,43 @@ LL |     binary_heap = binary_heap.into_iter().filter(|x| x % 2 == 0).collect();
    = help: to override `-D warnings` add `#[allow(clippy::manual_retain)]`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:27:5
+  --> tests/ui/manual_retain.rs:12:5
    |
 LL |     binary_heap = binary_heap.iter().filter(|&x| x % 2 == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `binary_heap.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:29:5
+  --> tests/ui/manual_retain.rs:14:5
    |
 LL |     binary_heap = binary_heap.iter().filter(|&x| x % 2 == 0).cloned().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `binary_heap.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:34:5
+  --> tests/ui/manual_retain.rs:19:5
    |
 LL |     tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|&(ref x, ref y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:36:5
+  --> tests/ui/manual_retain.rs:21:5
    |
 LL |     tuples = tuples.iter().filter(|(x, y)| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(x, y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:67:5
+  --> tests/ui/manual_retain.rs:52:5
    |
 LL |     btree_map = btree_map.into_iter().filter(|(k, _)| k % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `btree_map.retain(|k, _| k % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:69:5
+  --> tests/ui/manual_retain.rs:54:5
    |
 LL |     btree_map = btree_map.into_iter().filter(|(_, v)| v % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `btree_map.retain(|_, &mut v| v % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:71:5
+  --> tests/ui/manual_retain.rs:56:5
    |
 LL | /     btree_map = btree_map
 LL | |
@@ -54,49 +54,49 @@ LL | |         .collect();
    | |__________________^ help: consider calling `.retain()` instead: `btree_map.retain(|k, &mut v| (k % 2 == 0) && (v % 2 == 0))`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:97:5
+  --> tests/ui/manual_retain.rs:82:5
    |
 LL |     btree_set = btree_set.iter().filter(|&x| x % 2 == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `btree_set.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:99:5
+  --> tests/ui/manual_retain.rs:84:5
    |
 LL |     btree_set = btree_set.iter().filter(|&x| x % 2 == 0).cloned().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `btree_set.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:101:5
+  --> tests/ui/manual_retain.rs:86:5
    |
 LL |     btree_set = btree_set.into_iter().filter(|x| x % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `btree_set.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:106:5
+  --> tests/ui/manual_retain.rs:91:5
    |
 LL |     tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|&(ref x, ref y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:108:5
+  --> tests/ui/manual_retain.rs:93:5
    |
 LL |     tuples = tuples.iter().filter(|(x, y)| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(x, y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:139:5
+  --> tests/ui/manual_retain.rs:124:5
    |
 LL |     hash_map = hash_map.into_iter().filter(|(k, _)| k % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `hash_map.retain(|k, _| k % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:141:5
+  --> tests/ui/manual_retain.rs:126:5
    |
 LL |     hash_map = hash_map.into_iter().filter(|(_, v)| v % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `hash_map.retain(|_, &mut v| v % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:143:5
+  --> tests/ui/manual_retain.rs:128:5
    |
 LL | /     hash_map = hash_map
 LL | |
@@ -106,133 +106,133 @@ LL | |         .collect();
    | |__________________^ help: consider calling `.retain()` instead: `hash_map.retain(|k, &mut v| (k % 2 == 0) && (v % 2 == 0))`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:168:5
+  --> tests/ui/manual_retain.rs:153:5
    |
 LL |     hash_set = hash_set.into_iter().filter(|x| x % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `hash_set.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:170:5
+  --> tests/ui/manual_retain.rs:155:5
    |
 LL |     hash_set = hash_set.iter().filter(|&x| x % 2 == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `hash_set.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:172:5
+  --> tests/ui/manual_retain.rs:157:5
    |
 LL |     hash_set = hash_set.iter().filter(|&x| x % 2 == 0).cloned().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `hash_set.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:177:5
+  --> tests/ui/manual_retain.rs:162:5
    |
 LL |     tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|&(ref x, ref y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:179:5
+  --> tests/ui/manual_retain.rs:164:5
    |
 LL |     tuples = tuples.iter().filter(|(x, y)| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(x, y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:209:5
+  --> tests/ui/manual_retain.rs:194:5
    |
 LL |     s = s.chars().filter(|&c| c != 'o').to_owned().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `s.retain(|c| c != 'o')`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:222:5
+  --> tests/ui/manual_retain.rs:207:5
    |
 LL |     vec = vec.iter().filter(|&x| x % 2 == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:224:5
+  --> tests/ui/manual_retain.rs:209:5
    |
 LL |     vec = vec.iter().filter(|&x| x % 2 == 0).cloned().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:226:5
+  --> tests/ui/manual_retain.rs:211:5
    |
 LL |     vec = vec.into_iter().filter(|x| x % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:231:5
+  --> tests/ui/manual_retain.rs:216:5
    |
 LL |     tuples = tuples.iter().filter(|&&(ref x, ref y)| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|&(ref x, ref y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:233:5
+  --> tests/ui/manual_retain.rs:218:5
    |
 LL |     tuples = tuples.iter().filter(|(x, y)| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(x, y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:256:5
+  --> tests/ui/manual_retain.rs:241:5
    |
 LL |     vec_deque = vec_deque.iter().filter(|&x| x % 2 == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec_deque.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:258:5
+  --> tests/ui/manual_retain.rs:243:5
    |
 LL |     vec_deque = vec_deque.iter().filter(|&x| x % 2 == 0).cloned().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec_deque.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:260:5
+  --> tests/ui/manual_retain.rs:245:5
    |
 LL |     vec_deque = vec_deque.into_iter().filter(|x| x % 2 == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec_deque.retain(|x| x % 2 == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:318:5
+  --> tests/ui/manual_retain.rs:303:5
    |
 LL |     vec = vec.into_iter().filter(|(x, y)| *x == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|(x, y)| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:323:5
+  --> tests/ui/manual_retain.rs:308:5
    |
 LL |     tuples = tuples.into_iter().filter(|(_, n)| *n > 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `tuples.retain(|(_, n)| *n > 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:341:5
+  --> tests/ui/manual_retain.rs:326:5
    |
 LL |     vec = vec.iter().filter(|&&x| x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|&x| x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:343:5
+  --> tests/ui/manual_retain.rs:328:5
    |
 LL |     vec = vec.iter().filter(|&&x| x == 0).cloned().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|&x| x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:345:5
+  --> tests/ui/manual_retain.rs:330:5
    |
 LL |     vec = vec.into_iter().filter(|&x| x == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|&x| x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:349:5
+  --> tests/ui/manual_retain.rs:334:5
    |
 LL |     vec = vec.iter().filter(|&x| *x == 0).copied().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|x| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:351:5
+  --> tests/ui/manual_retain.rs:336:5
    |
 LL |     vec = vec.iter().filter(|&x| *x == 0).cloned().collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|x| *x == 0)`
 
 error: this expression can be written more simply using `.retain()`
-  --> tests/ui/manual_retain.rs:353:5
+  --> tests/ui/manual_retain.rs:338:5
    |
 LL |     vec = vec.into_iter().filter(|x| *x == 0).collect();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling `.retain()` instead: `vec.retain(|x| *x == 0)`

--- a/tests/ui/manual_take.fixed
+++ b/tests/ui/manual_take.fixed
@@ -1,8 +1,6 @@
 #![warn(clippy::manual_take)]
 
 fn main() {
-    msrv_1_39();
-    msrv_1_40();
     let mut x = true;
     let mut y = false;
 

--- a/tests/ui/manual_take.rs
+++ b/tests/ui/manual_take.rs
@@ -1,8 +1,6 @@
 #![warn(clippy::manual_take)]
 
 fn main() {
-    msrv_1_39();
-    msrv_1_40();
     let mut x = true;
     let mut y = false;
 

--- a/tests/ui/manual_take.stderr
+++ b/tests/ui/manual_take.stderr
@@ -1,5 +1,5 @@
 error: manual implementation of `mem::take`
-  --> tests/ui/manual_take.rs:9:25
+  --> tests/ui/manual_take.rs:7:25
    |
 LL |       let _lint_negated = if x {
    |  _________________________^
@@ -26,7 +26,7 @@ LL +     let _lint_negated = !std::mem::take(&mut x);
    |
 
 error: manual implementation of `mem::take`
-  --> tests/ui/manual_take.rs:62:5
+  --> tests/ui/manual_take.rs:60:5
    |
 LL | /     if x {
 LL | |

--- a/tests/ui/map_flatten.fixed
+++ b/tests/ui/map_flatten.fixed
@@ -64,6 +64,4 @@ fn no_suggestion_if_comments_present() {
         .flat_map(|x| x.iter());
 }
 
-fn main() {
-    long_span();
-}
+fn main() {}

--- a/tests/ui/map_flatten.rs
+++ b/tests/ui/map_flatten.rs
@@ -71,6 +71,4 @@ fn no_suggestion_if_comments_present() {
         .flatten();
 }
 
-fn main() {
-    long_span();
-}
+fn main() {}

--- a/tests/ui/map_unwrap_or.rs
+++ b/tests/ui/map_unwrap_or.rs
@@ -92,10 +92,7 @@ fn result_methods() {
     let _ = opt_map!(res, |x| x + 1).unwrap_or_else(|_e| 0); // should not lint
 }
 
-fn main() {
-    option_methods();
-    result_methods();
-}
+fn main() {}
 
 #[clippy::msrv = "1.40"]
 fn msrv_1_40() {

--- a/tests/ui/map_unwrap_or.stderr
+++ b/tests/ui/map_unwrap_or.stderr
@@ -203,13 +203,13 @@ LL ~         }, |x| x + 1);
    |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
-  --> tests/ui/map_unwrap_or.rs:111:13
+  --> tests/ui/map_unwrap_or.rs:108:13
    |
 LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|_e| 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or_else(|_e| 0, |x| x + 1)`
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
-  --> tests/ui/map_unwrap_or.rs:119:13
+  --> tests/ui/map_unwrap_or.rs:116:13
    |
 LL |     let _ = opt.map(|x| x > 5).unwrap_or(false);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +221,7 @@ LL +     let _ = opt.map_or(false, |x| x > 5);
    |
 
 error: called `map(<f>).unwrap_or(false)` on an `Option` value
-  --> tests/ui/map_unwrap_or.rs:127:13
+  --> tests/ui/map_unwrap_or.rs:124:13
    |
 LL |     let _ = opt.map(|x| x > 5).unwrap_or(false);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -233,7 +233,7 @@ LL +     let _ = opt.is_some_and(|x| x > 5);
    |
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
-  --> tests/ui/map_unwrap_or.rs:164:5
+  --> tests/ui/map_unwrap_or.rs:161:5
    |
 LL |     x.map(|y| y.0).unwrap_or(&[]);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/map_unwrap_or_fixable.fixed
+++ b/tests/ui/map_unwrap_or_fixable.fixed
@@ -52,10 +52,7 @@ fn result_methods() {
     let _ = opt_map!(res, |x| x + 1).unwrap_or_else(|_e| 0); // should not lint
 }
 
-fn main() {
-    option_methods();
-    result_methods();
-}
+fn main() {}
 
 fn issue15714() {
     let o: Option<i32> = Some(3);

--- a/tests/ui/map_unwrap_or_fixable.rs
+++ b/tests/ui/map_unwrap_or_fixable.rs
@@ -58,10 +58,7 @@ fn result_methods() {
     let _ = opt_map!(res, |x| x + 1).unwrap_or_else(|_e| 0); // should not lint
 }
 
-fn main() {
-    option_methods();
-    result_methods();
-}
+fn main() {}
 
 fn issue15714() {
     let o: Option<i32> = Some(3);

--- a/tests/ui/map_unwrap_or_fixable.stderr
+++ b/tests/ui/map_unwrap_or_fixable.stderr
@@ -20,7 +20,7 @@ LL | |         .unwrap_or_else(|_e| 0);
    | |_______________________________^ help: try: `res.map_or_else(|_e| 0, |x| x + 1)`
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:69:20
+  --> tests/ui/map_unwrap_or_fixable.rs:66:20
    |
 LL |     println!("{}", o.map(|y| y + 1).unwrap_or(3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,13 +32,13 @@ LL +     println!("{}", o.map_or(3, |y| y + 1));
    |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:71:20
+  --> tests/ui/map_unwrap_or_fixable.rs:68:20
    |
 LL |     println!("{}", o.map(|y| y + 1).unwrap_or_else(|| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `o.map_or_else(|| 3, |y| y + 1)`
 
 error: called `map(<f>).unwrap_or(<a>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:73:20
+  --> tests/ui/map_unwrap_or_fixable.rs:70:20
    |
 LL |     println!("{}", r.map(|y| y + 1).unwrap_or(3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,13 +50,13 @@ LL +     println!("{}", r.map_or(3, |y| y + 1));
    |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:75:20
+  --> tests/ui/map_unwrap_or_fixable.rs:72:20
    |
 LL |     println!("{}", r.map(|y| y + 1).unwrap_or_else(|()| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `r.map_or_else(|()| 3, |y| y + 1)`
 
 error: called `map(<f>).unwrap_or(false)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:78:20
+  --> tests/ui/map_unwrap_or_fixable.rs:75:20
    |
 LL |     println!("{}", r.map(|y| y == 1).unwrap_or(false));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL +     println!("{}", r.is_ok_and(|y| y == 1));
    |
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:84:20
+  --> tests/ui/map_unwrap_or_fixable.rs:81:20
    |
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or(3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL +     println!("{}", x.map_or(3, |y| y + 1));
    |
 
 error: called `map(<f>).unwrap_or(<a>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:88:20
+  --> tests/ui/map_unwrap_or_fixable.rs:85:20
    |
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or(3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,13 +92,13 @@ LL +     println!("{}", x.map_or(3, |y| y + 1));
    |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value
-  --> tests/ui/map_unwrap_or_fixable.rs:92:20
+  --> tests/ui/map_unwrap_or_fixable.rs:89:20
    |
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or_else(|| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.map_or_else(|| 3, |y| y + 1)`
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
-  --> tests/ui/map_unwrap_or_fixable.rs:96:20
+  --> tests/ui/map_unwrap_or_fixable.rs:93:20
    |
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or_else(|_| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.map_or_else(|_| 3, |y| y + 1)`

--- a/tests/ui/mem_replace.fixed
+++ b/tests/ui/mem_replace.fixed
@@ -101,11 +101,7 @@ fn dont_lint_not_used() {
     std::mem::replace(&mut s, String::default());
 }
 
-fn main() {
-    replace_option_with_none();
-    replace_with_default();
-    dont_lint_primitive();
-}
+fn main() {}
 
 #[clippy::msrv = "1.39"]
 fn msrv_1_39() {

--- a/tests/ui/mem_replace.rs
+++ b/tests/ui/mem_replace.rs
@@ -101,11 +101,7 @@ fn dont_lint_not_used() {
     std::mem::replace(&mut s, String::default());
 }
 
-fn main() {
-    replace_option_with_none();
-    replace_with_default();
-    dont_lint_primitive();
-}
+fn main() {}
 
 #[clippy::msrv = "1.39"]
 fn msrv_1_39() {

--- a/tests/ui/mem_replace.stderr
+++ b/tests/ui/mem_replace.stderr
@@ -131,37 +131,37 @@ LL |     let _ = std::mem::replace(&mut slice, &[]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(&mut slice)`
 
 error: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
-  --> tests/ui/mem_replace.rs:119:13
+  --> tests/ui/mem_replace.rs:115:13
    |
 LL |     let _ = std::mem::replace(&mut s, String::default());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(&mut s)`
 
 error: replacing an `Option` with `None`
-  --> tests/ui/mem_replace.rs:150:13
+  --> tests/ui/mem_replace.rs:146:13
    |
 LL |     let _ = std::mem::replace(&mut f.0, None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `f.0.take()`
 
 error: replacing an `Option` with `None`
-  --> tests/ui/mem_replace.rs:152:13
+  --> tests/ui/mem_replace.rs:148:13
    |
 LL |     let _ = std::mem::replace(&mut *f, None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `(*f).take()`
 
 error: replacing an `Option` with `None`
-  --> tests/ui/mem_replace.rs:154:13
+  --> tests/ui/mem_replace.rs:150:13
    |
 LL |     let _ = std::mem::replace(&mut b.opt, None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `b.opt.take()`
 
 error: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
-  --> tests/ui/mem_replace.rs:157:13
+  --> tests/ui/mem_replace.rs:153:13
    |
 LL |     let _ = std::mem::replace(&mut b.val, String::default());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(&mut b.val)`
 
 error: replacing an `Option` with `Some(..)`
-  --> tests/ui/mem_replace.rs:164:20
+  --> tests/ui/mem_replace.rs:160:20
    |
 LL |     let replaced = mem::replace(&mut an_option, Some(1));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::replace()` instead: `an_option.replace(1)`
@@ -170,19 +170,19 @@ LL |     let replaced = mem::replace(&mut an_option, Some(1));
    = help: to override `-D warnings` add `#[allow(clippy::mem_replace_option_with_some)]`
 
 error: replacing an `Option` with `Some(..)`
-  --> tests/ui/mem_replace.rs:168:20
+  --> tests/ui/mem_replace.rs:164:20
    |
 LL |     let replaced = mem::replace(an_option, Some(1));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::replace()` instead: `an_option.replace(1)`
 
 error: replacing an `Option` with `Some(..)`
-  --> tests/ui/mem_replace.rs:173:20
+  --> tests/ui/mem_replace.rs:169:20
    |
 LL |     let replaced = mem::replace(if b { &mut opt1 } else { &mut opt2 }, Some(1));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::replace()` instead: `(if b { &mut opt1 } else { &mut opt2 }).replace(1)`
 
 error: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
-  --> tests/ui/mem_replace.rs:185:20
+  --> tests/ui/mem_replace.rs:181:20
    |
 LL |     let replaced = std::mem::replace(dbg!(&mut text), String::default());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(dbg!(&mut text))`

--- a/tests/ui/mem_replace_no_std.fixed
+++ b/tests/ui/mem_replace_no_std.fixed
@@ -47,11 +47,7 @@ fn dont_lint_primitive() {
     let _ = mem::replace(&mut pint, 0);
 }
 
-fn main() {
-    replace_option_with_none();
-    replace_with_default();
-    dont_lint_primitive();
-}
+fn main() {}
 
 fn issue9824() {
     struct Foo<'a>(Option<&'a str>);

--- a/tests/ui/mem_replace_no_std.rs
+++ b/tests/ui/mem_replace_no_std.rs
@@ -47,11 +47,7 @@ fn dont_lint_primitive() {
     let _ = mem::replace(&mut pint, 0);
 }
 
-fn main() {
-    replace_option_with_none();
-    replace_with_default();
-    dont_lint_primitive();
-}
+fn main() {}
 
 fn issue9824() {
     struct Foo<'a>(Option<&'a str>);

--- a/tests/ui/mem_replace_no_std.stderr
+++ b/tests/ui/mem_replace_no_std.stderr
@@ -29,19 +29,19 @@ LL |     let _ = mem::replace(&mut slice, &[]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `core::mem::take(&mut slice)`
 
 error: replacing an `Option` with `None`
-  --> tests/ui/mem_replace_no_std.rs:80:13
+  --> tests/ui/mem_replace_no_std.rs:76:13
    |
 LL |     let _ = mem::replace(&mut f.0, None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `f.0.take()`
 
 error: replacing an `Option` with `None`
-  --> tests/ui/mem_replace_no_std.rs:82:13
+  --> tests/ui/mem_replace_no_std.rs:78:13
    |
 LL |     let _ = mem::replace(&mut *f, None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `(*f).take()`
 
 error: replacing an `Option` with `None`
-  --> tests/ui/mem_replace_no_std.rs:84:13
+  --> tests/ui/mem_replace_no_std.rs:80:13
    |
 LL |     let _ = mem::replace(&mut b.opt, None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `b.opt.take()`

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -145,7 +145,7 @@ fn filter_next_back() {
                                 *x < 0
                             }
                    ).next_back();
-    
+
     // Check that we don't lint if the caller is not an `Iterator`.
     let foo = IteratorFalsePositives { foo: 0 };
     let _ = foo.filter().next_back();
@@ -154,7 +154,4 @@ fn filter_next_back() {
     let _ = foo.filter(42).next_back();
 }
 
-fn main() {
-    filter_next();
-    filter_next_back();
-}
+fn main() {}

--- a/tests/ui/methods_unfixable.rs
+++ b/tests/ui/methods_unfixable.rs
@@ -1,8 +1,6 @@
 #![warn(clippy::filter_next)]
 //@no-rustfix
-fn main() {
-    issue10029();
-}
+fn main() {}
 
 pub fn issue10029() {
     let iter = (0..10);

--- a/tests/ui/methods_unfixable.stderr
+++ b/tests/ui/methods_unfixable.stderr
@@ -1,11 +1,11 @@
 error: called `filter(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(..)` instead
-  --> tests/ui/methods_unfixable.rs:9:13
+  --> tests/ui/methods_unfixable.rs:7:13
    |
 LL |     let _ = iter.filter(|_| true).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `iter.find(|_| true)`
    |
 help: you will also need to make `iter` mutable, because `find` takes `&mut self`
-  --> tests/ui/methods_unfixable.rs:8:9
+  --> tests/ui/methods_unfixable.rs:6:9
    |
 LL |     let iter = (0..10);
    |         ^^^^

--- a/tests/ui/must_use_unit.fixed
+++ b/tests/ui/must_use_unit.fixed
@@ -15,14 +15,10 @@ pub fn must_use_unit() -> () {}
 pub fn must_use_with_note() {}
 //~^ must_use_unit
 
-fn main() {
-    must_use_default();
-    must_use_unit();
-    must_use_with_note();
+// We should not lint in external macros
+external!(
+    #[must_use]
+    fn foo() {}
+);
 
-    // We should not lint in external macros
-    external!(
-        #[must_use]
-        fn foo() {}
-    );
-}
+fn main() {}

--- a/tests/ui/must_use_unit.rs
+++ b/tests/ui/must_use_unit.rs
@@ -18,14 +18,10 @@ pub fn must_use_unit() -> () {}
 pub fn must_use_with_note() {}
 //~^ must_use_unit
 
-fn main() {
-    must_use_default();
-    must_use_unit();
-    must_use_with_note();
+// We should not lint in external macros
+external!(
+    #[must_use]
+    fn foo() {}
+);
 
-    // We should not lint in external macros
-    external!(
-        #[must_use]
-        fn foo() {}
-    );
-}
+fn main() {}

--- a/tests/ui/needless_doc_main.rs
+++ b/tests/ui/needless_doc_main.rs
@@ -134,7 +134,4 @@ fn no_false_positives() {}
 /// ```
 fn issue_6022() {}
 
-fn main() {
-    bad_doctests();
-    no_false_positives();
-}
+fn main() {}

--- a/tests/ui/never_loop.rs
+++ b/tests/ui/never_loop.rs
@@ -447,22 +447,7 @@ fn loop_label() {
     }
 }
 
-fn main() {
-    test1();
-    test2();
-    test3();
-    test4();
-    test5();
-    test6();
-    test7();
-    test8();
-    test9();
-    test10();
-    test11(|| 0);
-    test12(true, false);
-    test13();
-    test14();
-}
+fn main() {}
 
 fn issue15059() {
     'a: for _ in 0..1 {

--- a/tests/ui/never_loop.stderr
+++ b/tests/ui/never_loop.stderr
@@ -248,7 +248,7 @@ LL | |         }
    | |_________^
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:468:5
+  --> tests/ui/never_loop.rs:453:5
    |
 LL | /     'a: for _ in 0..1 {
 LL | |
@@ -264,7 +264,7 @@ LL ~
    |
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:474:5
+  --> tests/ui/never_loop.rs:459:5
    |
 LL | /     'a: for i in 0..1 {
 LL | |
@@ -288,7 +288,7 @@ LL ~
    |
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:489:5
+  --> tests/ui/never_loop.rs:474:5
    |
 LL | /     for v in 0..10 {
 LL | |
@@ -311,7 +311,7 @@ LL ~
    |
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:500:5
+  --> tests/ui/never_loop.rs:485:5
    |
 LL | /     'bar: for _ in 0..100 {
 LL | |
@@ -321,7 +321,7 @@ LL | |     }
    | |_____^
    |
 help: this code is unreachable. Consider moving the reachable parts out
-  --> tests/ui/never_loop.rs:502:9
+  --> tests/ui/never_loop.rs:487:9
    |
 LL | /         loop {
 LL | |
@@ -336,7 +336,7 @@ LL +     if let Some(_) = (0..100).next() {
    |
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:502:9
+  --> tests/ui/never_loop.rs:487:9
    |
 LL | /         loop {
 LL | |
@@ -346,7 +346,7 @@ LL | |         }
    | |_________^
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:509:5
+  --> tests/ui/never_loop.rs:494:5
    |
 LL | /     'foo: for _ in 0..100 {
 LL | |
@@ -356,7 +356,7 @@ LL | |     }
    | |_____^
    |
 help: this code is unreachable. Consider moving the reachable parts out
-  --> tests/ui/never_loop.rs:511:9
+  --> tests/ui/never_loop.rs:496:9
    |
 LL | /         loop {
 LL | |
@@ -372,7 +372,7 @@ LL +     if let Some(_) = (0..100).next() {
    |
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:511:9
+  --> tests/ui/never_loop.rs:496:9
    |
 LL | /         loop {
 LL | |
@@ -383,7 +383,7 @@ LL | |         }
    | |_________^
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:514:13
+  --> tests/ui/never_loop.rs:499:13
    |
 LL | /             loop {
 LL | |
@@ -393,7 +393,7 @@ LL | |             }
    | |_____________^
 
 error: this loop never actually loops
-  --> tests/ui/never_loop.rs:537:5
+  --> tests/ui/never_loop.rs:522:5
    |
 LL | /     loop {
 LL | |         unsafe {

--- a/tests/ui/panicking_macros.rs
+++ b/tests/ui/panicking_macros.rs
@@ -126,15 +126,4 @@ fn debug_assert_msg() {
     debug_assert_ne!(true, false, "test");
 }
 
-fn main() {
-    panic();
-    panic_const();
-    todo();
-    unimplemented();
-    unreachable();
-    core_versions();
-    assert();
-    assert_msg();
-    debug_assert();
-    debug_assert_msg();
-}
+fn main() {}

--- a/tests/ui/panicking_overflow_checks.rs
+++ b/tests/ui/panicking_overflow_checks.rs
@@ -28,6 +28,4 @@ fn test(a: u32, b: u32, c: u32) {
     if i - j < i {}
 }
 
-fn main() {
-    test(1, 2, 3)
-}
+fn main() {}

--- a/tests/ui/regex.rs
+++ b/tests/ui/regex.rs
@@ -152,8 +152,4 @@ fn regex_creation_in_loops() {
     }
 }
 
-fn main() {
-    syntax_error();
-    trivial_regex();
-    regex_creation_in_loops();
-}
+fn main() {}

--- a/tests/ui/set_contains_or_insert.rs
+++ b/tests/ui/set_contains_or_insert.rs
@@ -157,13 +157,7 @@ fn simply_true() -> bool {
     true
 }
 
-// This is placed last in order to be able to add new tests without changing line numbers
-fn main() {
-    should_warn_hashset();
-    should_warn_btreeset();
-    should_not_warn_hashset();
-    should_not_warn_btreeset();
-}
+fn main() {}
 
 fn issue15990(s: &mut HashSet<usize>, v: usize) {
     if !s.contains(&v) {

--- a/tests/ui/set_contains_or_insert.stderr
+++ b/tests/ui/set_contains_or_insert.stderr
@@ -128,7 +128,7 @@ LL |         borrow_set.insert(value);
    |                    ^^^^^^^^^^^^^
 
 error: usage of `HashSet::insert` after `HashSet::contains`
-  --> tests/ui/set_contains_or_insert.rs:182:11
+  --> tests/ui/set_contains_or_insert.rs:176:11
    |
 LL |     if !s.contains(&v) {
    |           ^^^^^^^^^^^^

--- a/tests/ui/skip_while_next.rs
+++ b/tests/ui/skip_while_next.rs
@@ -26,6 +26,4 @@ fn skip_while_next() {
     let _ = foo.skip_while().next();
 }
 
-fn main() {
-    skip_while_next();
-}
+fn main() {}

--- a/tests/ui/slow_vector_initialization.fixed
+++ b/tests/ui/slow_vector_initialization.fixed
@@ -1,12 +1,8 @@
 #![allow(clippy::useless_vec, clippy::manual_repeat_n)]
 
 use std::iter::repeat;
-fn main() {
-    resize_vector();
-    extend_vector();
-    mixed_extend_resize_vector();
-    from_empty_vec();
-}
+
+fn main() {}
 
 fn extend_vector() {
     // Extend with constant expression

--- a/tests/ui/slow_vector_initialization.rs
+++ b/tests/ui/slow_vector_initialization.rs
@@ -1,12 +1,8 @@
 #![allow(clippy::useless_vec, clippy::manual_repeat_n)]
 
 use std::iter::repeat;
-fn main() {
-    resize_vector();
-    extend_vector();
-    mixed_extend_resize_vector();
-    from_empty_vec();
-}
+
+fn main() {}
 
 fn extend_vector() {
     // Extend with constant expression

--- a/tests/ui/slow_vector_initialization.stderr
+++ b/tests/ui/slow_vector_initialization.stderr
@@ -1,5 +1,5 @@
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:14:20
+  --> tests/ui/slow_vector_initialization.rs:10:20
    |
 LL |       let mut vec1 = Vec::with_capacity(len);
    |  ____________________^
@@ -11,7 +11,7 @@ LL | |     vec1.extend(repeat(0).take(len));
    = help: to override `-D warnings` add `#[allow(clippy::slow_vector_initialization)]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:20:20
+  --> tests/ui/slow_vector_initialization.rs:16:20
    |
 LL |       let mut vec2 = Vec::with_capacity(len - 10);
    |  ____________________^
@@ -20,7 +20,7 @@ LL | |     vec2.extend(repeat(0).take(len - 10));
    | |_________________________________________^ help: consider replacing this with: `vec![0; len - 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:29:20
+  --> tests/ui/slow_vector_initialization.rs:25:20
    |
 LL |       let mut vec4 = Vec::with_capacity(len);
    |  ____________________^
@@ -29,7 +29,7 @@ LL | |     vec4.extend(repeat(0).take(vec4.capacity()));
    | |________________________________________________^ help: consider replacing this with: `vec![0; len]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:41:27
+  --> tests/ui/slow_vector_initialization.rs:37:27
    |
 LL |       let mut resized_vec = Vec::with_capacity(30);
    |  ___________________________^
@@ -38,7 +38,7 @@ LL | |     resized_vec.resize(30, 0);
    | |_____________________________^ help: consider replacing this with: `vec![0; 30]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:46:26
+  --> tests/ui/slow_vector_initialization.rs:42:26
    |
 LL |       let mut extend_vec = Vec::with_capacity(30);
    |  __________________________^
@@ -47,7 +47,7 @@ LL | |     extend_vec.extend(repeat(0).take(30));
    | |_________________________________________^ help: consider replacing this with: `vec![0; 30]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:55:20
+  --> tests/ui/slow_vector_initialization.rs:51:20
    |
 LL |       let mut vec1 = Vec::with_capacity(len);
    |  ____________________^
@@ -56,7 +56,7 @@ LL | |     vec1.resize(len, 0);
    | |_______________________^ help: consider replacing this with: `vec![0; len]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:65:20
+  --> tests/ui/slow_vector_initialization.rs:61:20
    |
 LL |       let mut vec3 = Vec::with_capacity(len - 10);
    |  ____________________^
@@ -65,7 +65,7 @@ LL | |     vec3.resize(len - 10, 0);
    | |____________________________^ help: consider replacing this with: `vec![0; len - 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:70:20
+  --> tests/ui/slow_vector_initialization.rs:66:20
    |
 LL |       let mut vec4 = Vec::with_capacity(len);
    |  ____________________^
@@ -74,7 +74,7 @@ LL | |     vec4.resize(vec4.capacity(), 0);
    | |___________________________________^ help: consider replacing this with: `vec![0; len]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:76:12
+  --> tests/ui/slow_vector_initialization.rs:72:12
    |
 LL |       vec1 = Vec::with_capacity(10);
    |  ____________^
@@ -83,7 +83,7 @@ LL | |     vec1.resize(10, 0);
    | |______________________^ help: consider replacing this with: `vec![0; 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:85:20
+  --> tests/ui/slow_vector_initialization.rs:81:20
    |
 LL |       let mut vec1 = Vec::new();
    |  ____________________^
@@ -92,7 +92,7 @@ LL | |     vec1.resize(len, 0);
    | |_______________________^ help: consider replacing this with: `vec![0; len]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:91:20
+  --> tests/ui/slow_vector_initialization.rs:87:20
    |
 LL |       let mut vec3 = Vec::new();
    |  ____________________^
@@ -101,7 +101,7 @@ LL | |     vec3.resize(len - 10, 0);
    | |____________________________^ help: consider replacing this with: `vec![0; len - 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:97:12
+  --> tests/ui/slow_vector_initialization.rs:93:12
    |
 LL |       vec1 = Vec::new();
    |  ____________^
@@ -110,7 +110,7 @@ LL | |     vec1.resize(10, 0);
    | |______________________^ help: consider replacing this with: `vec![0; 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:102:12
+  --> tests/ui/slow_vector_initialization.rs:98:12
    |
 LL |       vec1 = vec![];
    |  ____________^

--- a/tests/ui/transmute_null_to_fn.rs
+++ b/tests/ui/transmute_null_to_fn.rs
@@ -41,7 +41,4 @@ fn issue_11485() {
     }
 }
 
-fn main() {
-    one_liners();
-    transmute_const();
-}
+fn main() {}

--- a/tests/ui/transmuting_null.rs
+++ b/tests/ui/transmuting_null.rs
@@ -57,10 +57,4 @@ fn transmute_pointer_creators() {
     }
 }
 
-fn main() {
-    one_liners();
-    transmute_const();
-    transmute_const_int();
-    transumute_single_expr_blocks();
-    transmute_pointer_creators();
-}
+fn main() {}

--- a/tests/ui/try_err.fixed
+++ b/tests/ui/try_err.fixed
@@ -107,23 +107,16 @@ fn calling_macro() -> Result<i32, i32> {
     Ok(5)
 }
 
-fn main() {
-    basic_test().unwrap();
-    into_test().unwrap();
-    negative_test().unwrap();
-    closure_matches_test().unwrap();
-    closure_into_test().unwrap();
-    calling_macro().unwrap();
-
-    // We don't want to lint in external macros
-    external! {
-        pub fn try_err_fn() -> Result<i32, i32> {
-            let err: i32 = 1;
-            // To avoid warnings during rustfix
-            if true { Err(err)? } else { Ok(2) }
-        }
+// We don't want to lint in external macros
+external! {
+    pub fn try_err_fn() -> Result<i32, i32> {
+        let err: i32 = 1;
+        // To avoid warnings during rustfix
+        if true { Err(err)? } else { Ok(2) }
     }
 }
+
+fn main() {}
 
 #[inline_macros]
 pub fn macro_inside(fail: bool) -> Result<i32, String> {

--- a/tests/ui/try_err.rs
+++ b/tests/ui/try_err.rs
@@ -107,23 +107,16 @@ fn calling_macro() -> Result<i32, i32> {
     Ok(5)
 }
 
-fn main() {
-    basic_test().unwrap();
-    into_test().unwrap();
-    negative_test().unwrap();
-    closure_matches_test().unwrap();
-    closure_into_test().unwrap();
-    calling_macro().unwrap();
-
-    // We don't want to lint in external macros
-    external! {
-        pub fn try_err_fn() -> Result<i32, i32> {
-            let err: i32 = 1;
-            // To avoid warnings during rustfix
-            if true { Err(err)? } else { Ok(2) }
-        }
+// We don't want to lint in external macros
+external! {
+    pub fn try_err_fn() -> Result<i32, i32> {
+        let err: i32 = 1;
+        // To avoid warnings during rustfix
+        if true { Err(err)? } else { Ok(2) }
     }
 }
+
+fn main() {}
 
 #[inline_macros]
 pub fn macro_inside(fail: bool) -> Result<i32, String> {

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -45,31 +45,31 @@ LL |             Err(_) => Err(inline!(1))?,
    = note: this error originates in the macro `__inline_mac_fn_calling_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:131:9
+  --> tests/ui/try_err.rs:124:9
    |
 LL |         Err(inline!(inline!(String::from("aasdfasdfasdfa"))))?;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Err(inline!(inline!(String::from("aasdfasdfasdfa"))))`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:139:9
+  --> tests/ui/try_err.rs:132:9
    |
 LL |         Err(io::ErrorKind::WriteZero)?
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:142:9
+  --> tests/ui/try_err.rs:135:9
    |
 LL |         Err(io::Error::new(io::ErrorKind::InvalidInput, "error"))?
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidInput, "error")))`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:151:9
+  --> tests/ui/try_err.rs:144:9
    |
 LL |         Err(io::ErrorKind::NotFound)?
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Some(Err(io::ErrorKind::NotFound.into())))`
 
 error: returning an `Err(_)` with the `?` operator
-  --> tests/ui/try_err.rs:161:16
+  --> tests/ui/try_err.rs:154:16
    |
 LL |         return Err(42)?;
    |                ^^^^^^^^ help: try: `Err(42)`

--- a/tests/ui/unicode.fixed
+++ b/tests/ui/unicode.fixed
@@ -60,7 +60,4 @@ mod non_ascii_literal {
     }
 }
 
-fn main() {
-    zero();
-    canon();
-}
+fn main() {}

--- a/tests/ui/unicode.rs
+++ b/tests/ui/unicode.rs
@@ -60,7 +60,4 @@ mod non_ascii_literal {
     }
 }
 
-fn main() {
-    zero();
-    canon();
-}
+fn main() {}

--- a/tests/ui/uninlined_format_args.fixed
+++ b/tests/ui/uninlined_format_args.fixed
@@ -238,9 +238,7 @@ fn tester(fn_arg: i32) {
     }
 }
 
-fn main() {
-    tester(42);
-}
+fn main() {}
 
 #[clippy::msrv = "1.57"]
 fn _under_msrv() {

--- a/tests/ui/uninlined_format_args.rs
+++ b/tests/ui/uninlined_format_args.rs
@@ -243,9 +243,7 @@ fn tester(fn_arg: i32) {
     }
 }
 
-fn main() {
-    tester(42);
-}
+fn main() {}
 
 #[clippy::msrv = "1.57"]
 fn _under_msrv() {

--- a/tests/ui/uninlined_format_args.stderr
+++ b/tests/ui/uninlined_format_args.stderr
@@ -836,7 +836,7 @@ LL +         panic!("p3 {local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> tests/ui/uninlined_format_args.rs:259:5
+  --> tests/ui/uninlined_format_args.rs:257:5
    |
 LL |     println!("expand='{}'", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -848,7 +848,7 @@ LL +     println!("expand='{local_i32}'");
    |
 
 error: variables can be used directly in the `format!` string
-  --> tests/ui/uninlined_format_args.rs:362:5
+  --> tests/ui/uninlined_format_args.rs:360:5
    |
 LL |     usr_println!(true, "val='{}'", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -860,7 +860,7 @@ LL +     usr_println!(true, "val='{local_i32}'");
    |
 
 error: variables can be used directly in the `format!` string
-  --> tests/ui/uninlined_format_args.rs:364:5
+  --> tests/ui/uninlined_format_args.rs:362:5
    |
 LL |     usr_println!(true, "{}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -872,7 +872,7 @@ LL +     usr_println!(true, "{local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> tests/ui/uninlined_format_args.rs:366:5
+  --> tests/ui/uninlined_format_args.rs:364:5
    |
 LL |     usr_println!(true, "{:#010x}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -884,7 +884,7 @@ LL +     usr_println!(true, "{local_i32:#010x}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> tests/ui/uninlined_format_args.rs:368:5
+  --> tests/ui/uninlined_format_args.rs:366:5
    |
 LL |     usr_println!(true, "{:.1}", local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unit_arg.rs
+++ b/tests/ui/unit_arg.rs
@@ -147,10 +147,7 @@ fn proc_macro() {
     with_span!(span taking_multiple_units(unsafe { (); }, 'x: loop { break 'x (); }));
 }
 
-fn main() {
-    bad();
-    ok();
-}
+fn main() {}
 
 fn issue14857() {
     let fn_take_unit = |_: ()| {};

--- a/tests/ui/unit_arg.stderr
+++ b/tests/ui/unit_arg.stderr
@@ -200,19 +200,19 @@ LL +     Some(())
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:171:5
+  --> tests/ui/unit_arg.rs:168:5
    |
 LL |     fn_take_unit(mac!(def));
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:173:5
+  --> tests/ui/unit_arg.rs:170:5
    |
 LL |     fn_take_unit(mac!(func Default::default));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg.rs:175:5
+  --> tests/ui/unit_arg.rs:172:5
    |
 LL |     fn_take_unit(mac!(nonempty_block Default::default()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unit_arg_fixable.fixed
+++ b/tests/ui/unit_arg_fixable.fixed
@@ -29,9 +29,7 @@ fn bad() {
 fn taking_two_units(a: (), b: ()) {}
 fn taking_three_units(a: (), b: (), c: ()) {}
 
-fn main() {
-    bad();
-}
+fn main() {}
 
 fn issue14857() {
     let fn_take_unit = |_: ()| {};

--- a/tests/ui/unit_arg_fixable.rs
+++ b/tests/ui/unit_arg_fixable.rs
@@ -26,9 +26,7 @@ fn bad() {
 fn taking_two_units(a: (), b: ()) {}
 fn taking_three_units(a: (), b: (), c: ()) {}
 
-fn main() {
-    bad();
-}
+fn main() {}
 
 fn issue14857() {
     let fn_take_unit = |_: ()| {};

--- a/tests/ui/unit_arg_fixable.stderr
+++ b/tests/ui/unit_arg_fixable.stderr
@@ -43,7 +43,7 @@ LL ~     taking_three_units((), (), ());
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg_fixable.rs:35:5
+  --> tests/ui/unit_arg_fixable.rs:33:5
    |
 LL |     fn_take_unit(Default::default());
    |     ^^^^^^^^^^^^^------------------^
@@ -51,7 +51,7 @@ LL |     fn_take_unit(Default::default());
    |                  help: use a unit literal instead: `()`
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg_fixable.rs:49:5
+  --> tests/ui/unit_arg_fixable.rs:47:5
    |
 LL |     fn_take_unit(another_mac!());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ LL ~     fn_take_unit(());
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg_fixable.rs:51:5
+  --> tests/ui/unit_arg_fixable.rs:49:5
    |
 LL |     fn_take_unit(another_mac!(1));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL ~     fn_take_unit(());
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg_fixable.rs:60:5
+  --> tests/ui/unit_arg_fixable.rs:58:5
    |
 LL |     fn_take_unit(mac!(nondef Default::default()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^------------------^^
@@ -83,7 +83,7 @@ LL |     fn_take_unit(mac!(nondef Default::default()));
    |                              help: use a unit literal instead: `()`
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg_fixable.rs:62:5
+  --> tests/ui/unit_arg_fixable.rs:60:5
    |
 LL |     fn_take_unit(mac!(empty_block));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL ~     fn_take_unit(());
    |
 
 error: passing a unit value to a function
-  --> tests/ui/unit_arg_fixable.rs:69:5
+  --> tests/ui/unit_arg_fixable.rs:67:5
    |
 LL |     fn_take_unit(def());
    |     ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unnecessary_literal_unwrap.fixed
+++ b/tests/ui/unnecessary_literal_unwrap.fixed
@@ -152,12 +152,4 @@ fn unwrap_unchecked() {
     //~^ unnecessary_literal_unwrap
 }
 
-fn main() {
-    unwrap_option_some();
-    unwrap_option_none();
-    unwrap_result_ok();
-    unwrap_result_err();
-    unwrap_methods_option();
-    unwrap_methods_result();
-    unwrap_unchecked();
-}
+fn main() {}

--- a/tests/ui/unnecessary_literal_unwrap.rs
+++ b/tests/ui/unnecessary_literal_unwrap.rs
@@ -152,12 +152,4 @@ fn unwrap_unchecked() {
     //~^ unnecessary_literal_unwrap
 }
 
-fn main() {
-    unwrap_option_some();
-    unwrap_option_none();
-    unwrap_result_ok();
-    unwrap_result_err();
-    unwrap_methods_option();
-    unwrap_methods_result();
-    unwrap_unchecked();
-}
+fn main() {}

--- a/tests/ui/unnecessary_literal_unwrap_unfixable.rs
+++ b/tests/ui/unnecessary_literal_unwrap_unfixable.rs
@@ -191,16 +191,4 @@ fn unwrap_methods_result_context() {
     //~^ unnecessary_literal_unwrap
 }
 
-fn main() {
-    unwrap_option_some();
-    unwrap_option_some_context();
-    unwrap_option_none();
-    unwrap_result_ok();
-    unwrap_result_ok_context();
-    unwrap_result_err();
-    unwrap_result_err_context();
-    unwrap_methods_option();
-    unwrap_methods_option_context();
-    unwrap_methods_result();
-    unwrap_methods_result_context();
-}
+fn main() {}

--- a/tests/ui/unnecessary_sort_by.fixed
+++ b/tests/ui/unnecessary_sort_by.fixed
@@ -106,11 +106,7 @@ mod issue_6001 {
     }
 }
 
-fn main() {
-    unnecessary_sort_by();
-    issue_5754::test();
-    issue_6001::test();
-}
+fn main() {}
 
 fn issue16405() {
     let mut v: Vec<(i32, &str)> = vec![(1, "foo"), (2, "bar")];

--- a/tests/ui/unnecessary_sort_by.rs
+++ b/tests/ui/unnecessary_sort_by.rs
@@ -106,11 +106,7 @@ mod issue_6001 {
     }
 }
 
-fn main() {
-    unnecessary_sort_by();
-    issue_5754::test();
-    issue_6001::test();
-}
+fn main() {}
 
 fn issue16405() {
     let mut v: Vec<(i32, &str)> = vec![(1, "foo"), (2, "bar")];

--- a/tests/ui/unnecessary_sort_by.stderr
+++ b/tests/ui/unnecessary_sort_by.stderr
@@ -145,7 +145,7 @@ LL +         args.sort_unstable_by_key(|b| std::cmp::Reverse(b.name()));
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:118:5
+  --> tests/ui/unnecessary_sort_by.rs:114:5
    |
 LL |     v.sort_by(|a, b| a.0.cmp(&b.0));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     v.sort_by_key(|a| a.0);
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:136:5
+  --> tests/ui/unnecessary_sort_by.rs:132:5
    |
 LL |     items.sort_by(|item1, item2| item1.key.cmp(&item2.key));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL +     items.sort_by_key(|item1| item1.key);
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:141:5
+  --> tests/ui/unnecessary_sort_by.rs:137:5
    |
 LL |     items.sort_by(|item1, item2| item1.value.clone().cmp(&item2.value.clone()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     items.sort_by_key(|item1| item1.value.clone());
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:147:5
+  --> tests/ui/unnecessary_sort_by.rs:143:5
    |
 LL |     v.sort_by(|(_, s1), (_, s2)| s1.cmp(s2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL +     v.sort_by_key(|(_, s1)| *s1);
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:154:5
+  --> tests/ui/unnecessary_sort_by.rs:150:5
    |
 LL |     v.sort_by(|Foo { bar: b1 }, Foo { bar: b2 }| b1.cmp(b2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +205,7 @@ LL +     v.sort_by_key(|Foo { bar: b1 }| *b1);
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:159:5
+  --> tests/ui/unnecessary_sort_by.rs:155:5
    |
 LL |     v.sort_by(|Baz(b1), Baz(b2)| b1.cmp(b2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +217,7 @@ LL +     v.sort_by_key(|Baz(b1)| *b1);
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:162:5
+  --> tests/ui/unnecessary_sort_by.rs:158:5
    |
 LL |     v.sort_by(|&Baz(b1), &Baz(b2)| b1.cmp(&b2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ LL +     v.sort_by_key(|&Baz(b1)| b1);
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:166:5
+  --> tests/ui/unnecessary_sort_by.rs:162:5
    |
 LL |     v.sort_by(|&&b1, &&b2| b1.cmp(&b2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +241,7 @@ LL +     v.sort_by_key(|&&b1| b1);
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:170:5
+  --> tests/ui/unnecessary_sort_by.rs:166:5
    |
 LL |     v.sort_by(|[a1, b1], [a2, b2]| a1.cmp(a2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -253,7 +253,7 @@ LL +     v.sort_by_key(|[a1, b1]| *a1);
    |
 
 error: consider using `sort_by_key`
-  --> tests/ui/unnecessary_sort_by.rs:173:5
+  --> tests/ui/unnecessary_sort_by.rs:169:5
    |
 LL |     v.sort_by(|[a1, b1], [a2, b2]| (a1 - b1).cmp(&(a2 - b2)));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unused_async.rs
+++ b/tests/ui/unused_async.rs
@@ -115,10 +115,7 @@ macro_rules! async_trait_impl {
 }
 async_trait_impl!();
 
-fn main() {
-    foo();
-    bar();
-}
+fn main() {}
 
 mod issue14704 {
     use std::sync::Arc;

--- a/tests/ui/unused_peekable.rs
+++ b/tests/ui/unused_peekable.rs
@@ -3,10 +3,7 @@
 
 use std::iter::{Empty, Peekable};
 
-fn main() {
-    invalid();
-    valid();
-}
+fn main() {}
 
 #[allow(clippy::unused_unit)]
 fn invalid() {

--- a/tests/ui/unused_peekable.stderr
+++ b/tests/ui/unused_peekable.stderr
@@ -1,5 +1,5 @@
 error: `peek` never called on `Peekable` iterator
-  --> tests/ui/unused_peekable.rs:13:9
+  --> tests/ui/unused_peekable.rs:10:9
    |
 LL |     let peekable = std::iter::empty::<u32>().peekable();
    |         ^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let peekable = std::iter::empty::<u32>().peekable();
    = help: to override `-D warnings` add `#[allow(clippy::unused_peekable)]`
 
 error: `peek` never called on `Peekable` iterator
-  --> tests/ui/unused_peekable.rs:18:9
+  --> tests/ui/unused_peekable.rs:15:9
    |
 LL |     let new_local = old_local;
    |         ^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     let new_local = old_local;
    = help: consider removing the call to `peekable`
 
 error: `peek` never called on `Peekable` iterator
-  --> tests/ui/unused_peekable.rs:23:9
+  --> tests/ui/unused_peekable.rs:20:9
    |
 LL |     let by_mut_ref = &mut by_mut_ref_test;
    |         ^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     let by_mut_ref = &mut by_mut_ref_test;
    = help: consider removing the call to `peekable`
 
 error: `peek` never called on `Peekable` iterator
-  --> tests/ui/unused_peekable.rs:31:9
+  --> tests/ui/unused_peekable.rs:28:9
    |
 LL |     let peekable_from_fn = returns_peekable();
    |         ^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     let peekable_from_fn = returns_peekable();
    = help: consider removing the call to `peekable`
 
 error: `peek` never called on `Peekable` iterator
-  --> tests/ui/unused_peekable.rs:35:13
+  --> tests/ui/unused_peekable.rs:32:13
    |
 LL |     let mut peekable_using_iterator_method = std::iter::empty::<u32>().peekable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |     let mut peekable_using_iterator_method = std::iter::empty::<u32>().peek
    = help: consider removing the call to `peekable`
 
 error: `peek` never called on `Peekable` iterator
-  --> tests/ui/unused_peekable.rs:42:9
+  --> tests/ui/unused_peekable.rs:39:9
    |
 LL |     let passed_along_ref = std::iter::empty::<u32>().peekable();
    |         ^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     let passed_along_ref = std::iter::empty::<u32>().peekable();
    = help: consider removing the call to `peekable`
 
 error: `peek` never called on `Peekable` iterator
-  --> tests/ui/unused_peekable.rs:49:9
+  --> tests/ui/unused_peekable.rs:46:9
    |
 LL |     let _by_ref = by_ref_test.by_ref();
    |         ^^^^^^^
@@ -57,7 +57,7 @@ LL |     let _by_ref = by_ref_test.by_ref();
    = help: consider removing the call to `peekable`
 
 error: `peek` never called on `Peekable` iterator
-  --> tests/ui/unused_peekable.rs:52:13
+  --> tests/ui/unused_peekable.rs:49:13
    |
 LL |     let mut peekable_in_for_loop = std::iter::empty::<u32>().peekable();
    |             ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -293,7 +293,4 @@ fn issue16098(exts: Vec<&str>) {
     //~^ useless_asref
 }
 
-fn main() {
-    not_ok();
-    ok();
-}
+fn main() {}

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -293,7 +293,4 @@ fn issue16098(exts: Vec<&str>) {
     //~^ useless_asref
 }
 
-fn main() {
-    not_ok();
-    ok();
-}
+fn main() {}

--- a/tests/ui/useless_attribute.fixed
+++ b/tests/ui/useless_attribute.fixed
@@ -96,9 +96,7 @@ mod module {
 #[allow(unused_braces)]
 use module::{Struct};
 
-fn main() {
-    test_indented_attr();
-}
+fn main() {}
 
 // Regression test for https://github.com/rust-lang/rust-clippy/issues/4467
 #[allow(dead_code)]

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -96,9 +96,7 @@ mod module {
 #[allow(unused_braces)]
 use module::{Struct};
 
-fn main() {
-    test_indented_attr();
-}
+fn main() {}
 
 // Regression test for https://github.com/rust-lang/rust-clippy/issues/4467
 #[allow(dead_code)]

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -117,21 +117,6 @@ fn dont_lint_into_iter_on_static_copy_iter() {
 }
 
 fn main() {
-    test_generic(10i32);
-    test_generic2::<i32, i32>(10i32);
-    test_questionmark().unwrap();
-    test_issue_3913().unwrap();
-
-    dont_lint_on_type_alias();
-    dont_lint_into_iter_on_immutable_local_implementing_iterator_in_expr();
-    lint_into_iter_on_mutable_local_implementing_iterator_in_expr();
-    lint_into_iter_on_expr_implementing_iterator();
-    lint_into_iter_on_expr_implementing_iterator_2();
-    lint_into_iter_on_const_implementing_iterator();
-    lint_into_iter_on_const_implementing_iterator_2();
-    dont_lint_into_iter_on_copy_iter();
-    dont_lint_into_iter_on_static_copy_iter();
-
     {
         // triggers the IntoIterator trait
         fn consume(_: impl IntoIterator) {}

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -117,21 +117,6 @@ fn dont_lint_into_iter_on_static_copy_iter() {
 }
 
 fn main() {
-    test_generic(10i32);
-    test_generic2::<i32, i32>(10i32);
-    test_questionmark().unwrap();
-    test_issue_3913().unwrap();
-
-    dont_lint_on_type_alias();
-    dont_lint_into_iter_on_immutable_local_implementing_iterator_in_expr();
-    lint_into_iter_on_mutable_local_implementing_iterator_in_expr();
-    lint_into_iter_on_expr_implementing_iterator();
-    lint_into_iter_on_expr_implementing_iterator_2();
-    lint_into_iter_on_const_implementing_iterator();
-    lint_into_iter_on_const_implementing_iterator_2();
-    dont_lint_into_iter_on_copy_iter();
-    dont_lint_into_iter_on_static_copy_iter();
-
     {
         // triggers the IntoIterator trait
         fn consume(_: impl IntoIterator) {}

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -53,13 +53,13 @@ LL |     let mut n = NUMBERS.into_iter();
    |                 ^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `NUMBERS`
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:141:17
+  --> tests/ui/useless_conversion.rs:126:17
    |
 LL |         consume(items.into_iter());
    |                 ^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:137:28
+  --> tests/ui/useless_conversion.rs:122:28
    |
 LL |         fn consume(_: impl IntoIterator) {}
    |                            ^^^^^^^^^^^^
@@ -70,73 +70,73 @@ LL +         consume(*items);
    |
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:154:21
+  --> tests/ui/useless_conversion.rs:139:21
    |
 LL |     let _: String = "foo".to_string().into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `"foo".to_string()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:156:21
+  --> tests/ui/useless_conversion.rs:141:21
    |
 LL |     let _: String = From::from("foo".to_string());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `From::from()`: `"foo".to_string()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:158:13
+  --> tests/ui/useless_conversion.rs:143:13
    |
 LL |     let _ = String::from("foo".to_string());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `"foo".to_string()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:160:13
+  --> tests/ui/useless_conversion.rs:145:13
    |
 LL |     let _ = String::from(format!("A: {:04}", 123));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `format!("A: {:04}", 123)`
 
 error: useless conversion to the same type: `std::str::Lines<'_>`
-  --> tests/ui/useless_conversion.rs:162:13
+  --> tests/ui/useless_conversion.rs:147:13
    |
 LL |     let _ = "".lines().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `"".lines()`
 
 error: useless conversion to the same type: `std::vec::IntoIter<i32>`
-  --> tests/ui/useless_conversion.rs:164:13
+  --> tests/ui/useless_conversion.rs:149:13
    |
 LL |     let _ = vec![1, 2, 3].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2, 3].into_iter()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> tests/ui/useless_conversion.rs:166:21
+  --> tests/ui/useless_conversion.rs:151:21
    |
 LL |     let _: String = format!("Hello {}", "world").into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `format!("Hello {}", "world")`
 
 error: useless conversion to the same type: `i32`
-  --> tests/ui/useless_conversion.rs:172:13
+  --> tests/ui/useless_conversion.rs:157:13
    |
 LL |     let _ = i32::from(a + b) * 3;
    |             ^^^^^^^^^^^^^^^^ help: consider removing `i32::from()`: `(a + b)`
 
 error: useless conversion to the same type: `Foo<'a'>`
-  --> tests/ui/useless_conversion.rs:179:23
+  --> tests/ui/useless_conversion.rs:164:23
    |
 LL |     let _: Foo<'a'> = s2.into();
    |                       ^^^^^^^^^ help: consider removing `.into()`: `s2`
 
 error: useless conversion to the same type: `Foo<'a'>`
-  --> tests/ui/useless_conversion.rs:182:13
+  --> tests/ui/useless_conversion.rs:167:13
    |
 LL |     let _ = Foo::<'a'>::from(s3);
    |             ^^^^^^^^^^^^^^^^^^^^ help: consider removing `Foo::<'a'>::from()`: `s3`
 
 error: useless conversion to the same type: `std::vec::IntoIter<Foo<'a'>>`
-  --> tests/ui/useless_conversion.rs:185:13
+  --> tests/ui/useless_conversion.rs:170:13
    |
 LL |     let _ = vec![s4, s4, s4].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![s4, s4, s4].into_iter()`
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:218:7
+  --> tests/ui/useless_conversion.rs:203:7
    |
 LL |     b(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -144,13 +144,13 @@ LL |     b(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:208:13
+  --> tests/ui/useless_conversion.rs:193:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:220:7
+  --> tests/ui/useless_conversion.rs:205:7
    |
 LL |     c(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -158,13 +158,13 @@ LL |     c(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:209:18
+  --> tests/ui/useless_conversion.rs:194:18
    |
 LL |     fn c(_: impl IntoIterator<Item = i32>) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:222:7
+  --> tests/ui/useless_conversion.rs:207:7
    |
 LL |     d(vec![1, 2].into_iter());
    |       ^^^^^^^^^^------------
@@ -172,13 +172,13 @@ LL |     d(vec![1, 2].into_iter());
    |                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:212:12
+  --> tests/ui/useless_conversion.rs:197:12
    |
 LL |         T: IntoIterator<Item = i32>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:226:7
+  --> tests/ui/useless_conversion.rs:211:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter());
    |       ^^^^^^^^^^------------------------
@@ -186,13 +186,13 @@ LL |     b(vec![1, 2].into_iter().into_iter());
    |                 help: consider removing the `.into_iter()`s
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:208:13
+  --> tests/ui/useless_conversion.rs:193:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:228:7
+  --> tests/ui/useless_conversion.rs:213:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter().into_iter());
    |       ^^^^^^^^^^------------------------------------
@@ -200,13 +200,13 @@ LL |     b(vec![1, 2].into_iter().into_iter().into_iter());
    |                 help: consider removing the `.into_iter()`s
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:208:13
+  --> tests/ui/useless_conversion.rs:193:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:275:24
+  --> tests/ui/useless_conversion.rs:260:24
    |
 LL |         foo2::<i32, _>([1, 2, 3].into_iter());
    |                        ^^^^^^^^^------------
@@ -214,13 +214,13 @@ LL |         foo2::<i32, _>([1, 2, 3].into_iter());
    |                                 help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:254:12
+  --> tests/ui/useless_conversion.rs:239:12
    |
 LL |         I: IntoIterator<Item = i32> + Helper<X>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:284:14
+  --> tests/ui/useless_conversion.rs:269:14
    |
 LL |         foo3([1, 2, 3].into_iter());
    |              ^^^^^^^^^------------
@@ -228,13 +228,13 @@ LL |         foo3([1, 2, 3].into_iter());
    |                       help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:263:12
+  --> tests/ui/useless_conversion.rs:248:12
    |
 LL |         I: IntoIterator<Item = i32>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:294:16
+  --> tests/ui/useless_conversion.rs:279:16
    |
 LL |         S1.foo([1, 2].into_iter());
    |                ^^^^^^------------
@@ -242,13 +242,13 @@ LL |         S1.foo([1, 2].into_iter());
    |                      help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:291:27
+  --> tests/ui/useless_conversion.rs:276:27
    |
 LL |             pub fn foo<I: IntoIterator>(&self, _: I) {}
    |                           ^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:314:44
+  --> tests/ui/useless_conversion.rs:299:44
    |
 LL |         v0.into_iter().interleave_shortest(v1.into_iter());
    |                                            ^^------------
@@ -256,67 +256,67 @@ LL |         v0.into_iter().interleave_shortest(v1.into_iter());
    |                                              help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:301:20
+  --> tests/ui/useless_conversion.rs:286:20
    |
 LL |                 J: IntoIterator,
    |                    ^^^^^^^^^^^^
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:342:58
+  --> tests/ui/useless_conversion.rs:327:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map(Into::into);
    |                                                          ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `std::io::Error`
-  --> tests/ui/useless_conversion.rs:345:58
+  --> tests/ui/useless_conversion.rs:330:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map_err(Into::into);
    |                                                          ^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:348:58
+  --> tests/ui/useless_conversion.rs:333:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map(From::from);
    |                                                          ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `std::io::Error`
-  --> tests/ui/useless_conversion.rs:351:58
+  --> tests/ui/useless_conversion.rs:336:58
    |
 LL |     let _: Result<(), std::io::Error> = test_issue_3913().map_err(From::from);
    |                                                          ^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:355:31
+  --> tests/ui/useless_conversion.rs:340:31
    |
 LL |     let _: ControlFlow<()> = c.map_break(Into::into);
    |                               ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `()`
-  --> tests/ui/useless_conversion.rs:359:31
+  --> tests/ui/useless_conversion.rs:344:31
    |
 LL |     let _: ControlFlow<()> = c.map_continue(Into::into);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `u32`
-  --> tests/ui/useless_conversion.rs:373:41
+  --> tests/ui/useless_conversion.rs:358:41
    |
 LL |     let _: Vec<u32> = [1u32].into_iter().map(Into::into).collect();
    |                                         ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: useless conversion to the same type: `T`
-  --> tests/ui/useless_conversion.rs:384:18
+  --> tests/ui/useless_conversion.rs:369:18
    |
 LL |     x.into_iter().map(Into::into).collect()
    |                  ^^^^^^^^^^^^^^^^ help: consider removing
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:400:29
+  --> tests/ui/useless_conversion.rs:385:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:389:32
+  --> tests/ui/useless_conversion.rs:374:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -327,13 +327,13 @@ LL +             takes_into_iter(&self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:408:29
+  --> tests/ui/useless_conversion.rs:393:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:389:32
+  --> tests/ui/useless_conversion.rs:374:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -344,13 +344,13 @@ LL +             takes_into_iter(&mut self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:417:29
+  --> tests/ui/useless_conversion.rs:402:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:389:32
+  --> tests/ui/useless_conversion.rs:374:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -361,13 +361,13 @@ LL +             takes_into_iter(*self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:426:29
+  --> tests/ui/useless_conversion.rs:411:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:389:32
+  --> tests/ui/useless_conversion.rs:374:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -378,13 +378,13 @@ LL +             takes_into_iter(&*self.my_field);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:435:29
+  --> tests/ui/useless_conversion.rs:420:29
    |
 LL |             takes_into_iter(self.my_field.into_iter());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:389:32
+  --> tests/ui/useless_conversion.rs:374:32
    |
 LL |     fn takes_into_iter(_: impl IntoIterator<Item = String>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -395,25 +395,25 @@ LL +             takes_into_iter(&mut *self.my_field);
    |
 
 error: useless conversion to the same type: `std::ops::Range<u32>`
-  --> tests/ui/useless_conversion.rs:450:5
+  --> tests/ui/useless_conversion.rs:435:5
    |
 LL |     R.into_iter().for_each(|_x| {});
    |     ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
 error: useless conversion to the same type: `std::ops::Range<u32>`
-  --> tests/ui/useless_conversion.rs:452:13
+  --> tests/ui/useless_conversion.rs:437:13
    |
 LL |     let _ = R.into_iter().map(|_x| 0);
    |             ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
 error: useless conversion to the same type: `std::slice::Iter<'_, i32>`
-  --> tests/ui/useless_conversion.rs:463:14
+  --> tests/ui/useless_conversion.rs:448:14
    |
 LL |     for _ in mac!(iter [1, 2]).into_iter() {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `mac!(iter [1, 2])`
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:476:27
+  --> tests/ui/useless_conversion.rs:461:27
    |
 LL |     takes_into_iter_usize(b.into_iter());
    |                           ^------------
@@ -421,13 +421,13 @@ LL |     takes_into_iter_usize(b.into_iter());
    |                            help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:467:34
+  --> tests/ui/useless_conversion.rs:452:34
    |
 LL | fn takes_into_iter_usize(_: impl IntoIterator<Item = usize>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:485:31
+  --> tests/ui/useless_conversion.rs:470:31
    |
 LL |         takes_into_iter_usize(b.clone().into_iter());
    |                               ^^^^^^^^^------------
@@ -435,13 +435,13 @@ LL |         takes_into_iter_usize(b.clone().into_iter());
    |                                        help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:467:34
+  --> tests/ui/useless_conversion.rs:452:34
    |
 LL | fn takes_into_iter_usize(_: impl IntoIterator<Item = usize>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:493:34
+  --> tests/ui/useless_conversion.rs:478:34
    |
 LL |     takes_into_iter_usize_result(b.clone().into_iter())?;
    |                                  ^^^^^^^^^------------
@@ -449,7 +449,7 @@ LL |     takes_into_iter_usize_result(b.clone().into_iter())?;
    |                                           help: consider removing the `.into_iter()`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:468:41
+  --> tests/ui/useless_conversion.rs:453:41
    |
 LL | fn takes_into_iter_usize_result(_: impl IntoIterator<Item = usize>) -> Result<(), ()> {
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/while_immutable_condition.rs
+++ b/tests/ui/while_immutable_condition.rs
@@ -226,16 +226,4 @@ fn immutable_condition_false_positive(mut n: u64) -> u32 {
     count
 }
 
-fn main() {
-    immutable_condition();
-    unused_var();
-    used_immutable();
-    internally_mutable();
-    immutable_condition_false_positive(5);
-
-    let mut c = Counter { count: 0 };
-    c.inc_n(5);
-    c.print_n(2);
-
-    while_loop_with_break_and_return();
-}
+fn main() {}


### PR DESCRIPTION
seems to be a remnant of some older testing scheme that is completely
unnecessary now

changelog: none