### PR TITLE
Add `must_use_without_reason` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7223,6 +7223,7 @@ Released 2018-09-13
 [`multiple_unsafe_ops_per_block`]: https://rust-lang.github.io/rust-clippy/master/index.html#multiple_unsafe_ops_per_block
 [`must_use_candidate`]: https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
 [`must_use_unit`]: https://rust-lang.github.io/rust-clippy/master/index.html#must_use_unit
+[`must_use_without_reason`]: https://rust-lang.github.io/rust-clippy/master/index.html#must_use_without_reason
 [`mut_from_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#mut_from_ref
 [`mut_mut`]: https://rust-lang.github.io/rust-clippy/master/index.html#mut_mut
 [`mut_mutex_lock`]: https://rust-lang.github.io/rust-clippy/master/index.html#mut_mutex_lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7341,6 +7341,7 @@ Released 2018-09-13
 [`multiple_unsafe_ops_per_block`]: https://rust-lang.github.io/rust-clippy/main/index.html#multiple_unsafe_ops_per_block
 [`must_use_candidate`]: https://rust-lang.github.io/rust-clippy/main/index.html#must_use_candidate
 [`must_use_unit`]: https://rust-lang.github.io/rust-clippy/main/index.html#must_use_unit
+[`must_use_without_reason`]: https://rust-lang.github.io/rust-clippy/main/index.html#must_use_without_reason
 [`mut_from_ref`]: https://rust-lang.github.io/rust-clippy/main/index.html#mut_from_ref
 [`mut_mut`]: https://rust-lang.github.io/rust-clippy/main/index.html#mut_mut
 [`mut_mutex_lock`]: https://rust-lang.github.io/rust-clippy/main/index.html#mut_mutex_lock

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -200,6 +200,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::functions::MISNAMED_GETTERS_INFO,
     crate::functions::MUST_USE_CANDIDATE_INFO,
     crate::functions::MUST_USE_UNIT_INFO,
+    crate::functions::MUST_USE_WITHOUT_REASON_INFO,
     crate::functions::NOT_UNSAFE_PTR_ARG_DEREF_INFO,
     crate::functions::REF_OPTION_INFO,
     crate::functions::RENAMED_FUNCTION_PARAMS_INFO,

--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -196,6 +196,30 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for `#[must_use]` attributes without a reason.
+    ///
+    /// ### Why restrict this?
+    /// A reason explains why the return value must be used. Without it,
+    /// users only see a generic "unused must-use value" message which is less helpful.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #[must_use]
+    /// fn compute() -> i32 { 42 }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// #[must_use = "computation is expensive"]
+    /// fn compute() -> i32 { 42 }
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub MUST_USE_WITHOUT_REASON,
+    restriction,
+    "`#[must_use]` attribute without a reason"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for public functions that dereference raw pointer
     /// arguments but are not marked `unsafe`.
     ///
@@ -487,6 +511,7 @@ impl_lint_pass!(Functions => [
     MISNAMED_GETTERS,
     MUST_USE_CANDIDATE,
     MUST_USE_UNIT,
+    MUST_USE_WITHOUT_REASON,
     NOT_UNSAFE_PTR_ARG_DEREF,
     REF_OPTION,
     RENAMED_FUNCTION_PARAMS,

--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -6,19 +6,18 @@ use rustc_hir::{self as hir, Attribute, QPath, find_attr};
 use rustc_lint::unused::must_use::MustUsePath;
 use rustc_lint::{LateContext, LintContext as _};
 use rustc_middle::ty::{self, Ty};
-use rustc_span::{Span, sym};
+use rustc_span::{Span, Symbol, sym};
 
 use clippy_utils::attrs::is_proc_macro;
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::snippet_indent;
 use clippy_utils::ty::{describe_must_use_type, opt_must_use_path};
 use clippy_utils::visitors::for_each_expr_without_closures;
-use clippy_utils::{is_entrypoint_fn, return_ty, trait_ref_of_method};
-use rustc_span::Symbol;
+use clippy_utils::{is_entrypoint_fn, is_lint_allowed, return_ty, trait_ref_of_method};
 
 use core::ops::ControlFlow;
 
-use super::{DOUBLE_MUST_USE, MUST_USE_CANDIDATE, MUST_USE_UNIT};
+use super::{DOUBLE_MUST_USE, MUST_USE_CANDIDATE, MUST_USE_UNIT, MUST_USE_WITHOUT_REASON};
 
 pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
     let attrs = cx.tcx.hir_attrs(item.hir_id());
@@ -29,21 +28,24 @@ pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>
         ident,
         ..
     } = item.kind
+        && !item.span.in_external_macro(cx.sess().source_map())
     {
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
         if let Some((attr_span, reason)) = attr {
-            check_needless_must_use(
+            let is_needless_must_use = check_needless_must_use(
                 cx,
                 sig.decl,
                 item.owner_id,
-                item.span,
                 fn_header_span,
                 *attr_span,
                 *reason,
                 attrs,
                 sig,
             );
+            if !is_needless_must_use {
+                check_must_use_without_reason(cx, *attr_span, *reason);
+            }
         } else if is_public && !is_proc_macro(attrs) && !find_attr!(attrs, NoMangle(..)) {
             check_must_use_candidate(
                 cx,
@@ -59,23 +61,27 @@ pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>
 }
 
 pub(super) fn check_impl_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::ImplItem<'_>) {
-    if let hir::ImplItemKind::Fn(ref sig, ref body_id) = item.kind {
+    if let hir::ImplItemKind::Fn(ref sig, ref body_id) = item.kind
+        && !item.span.in_external_macro(cx.sess().source_map())
+    {
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
         let attrs = cx.tcx.hir_attrs(item.hir_id());
         let attr = find_attr!(cx.tcx, item.hir_id(), MustUse { span, reason } => (span, reason));
         if let Some((attr_span, reason)) = attr {
-            check_needless_must_use(
+            let is_needless_must_use = check_needless_must_use(
                 cx,
                 sig.decl,
                 item.owner_id,
-                item.span,
                 fn_header_span,
                 *attr_span,
                 *reason,
                 attrs,
                 sig,
             );
+            if !is_needless_must_use {
+                check_must_use_without_reason(cx, *attr_span, *reason);
+            }
         } else if is_public && !is_proc_macro(attrs) && trait_ref_of_method(cx, item.owner_id).is_none() {
             check_must_use_candidate(
                 cx,
@@ -91,24 +97,28 @@ pub(super) fn check_impl_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Imp
 }
 
 pub(super) fn check_trait_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::TraitItem<'_>) {
-    if let hir::TraitItemKind::Fn(ref sig, ref eid) = item.kind {
+    if let hir::TraitItemKind::Fn(ref sig, ref eid) = item.kind
+        && !item.span.in_external_macro(cx.sess().source_map())
+    {
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
 
         let attrs = cx.tcx.hir_attrs(item.hir_id());
         let attr = find_attr!(cx.tcx, item.hir_id(), MustUse { span, reason } => (span, reason));
         if let Some((attr_span, reason)) = attr {
-            check_needless_must_use(
+            let is_needless_must_use = check_needless_must_use(
                 cx,
                 sig.decl,
                 item.owner_id,
-                item.span,
                 fn_header_span,
                 *attr_span,
                 *reason,
                 attrs,
                 sig,
             );
+            if !is_needless_must_use {
+                check_must_use_without_reason(cx, *attr_span, *reason);
+            }
         } else if let hir::TraitFn::Provided(eid) = *eid {
             let body = cx.tcx.hir_body(eid);
             if attr.is_none() && is_public && !is_proc_macro(attrs) {
@@ -132,16 +142,12 @@ fn check_needless_must_use(
     cx: &LateContext<'_>,
     decl: &hir::FnDecl<'_>,
     item_id: hir::OwnerId,
-    item_span: Span,
     fn_header_span: Span,
     attr_span: Span,
     reason: Option<Symbol>,
     attrs: &[Attribute],
     sig: &FnSig<'_>,
-) {
-    if item_span.in_external_macro(cx.sess().source_map()) {
-        return;
-    }
+) -> bool {
     if returns_unit(decl) {
         span_lint_and_then(
             cx,
@@ -161,6 +167,7 @@ fn check_needless_must_use(
                 }
             },
         );
+        return true;
     } else if reason.is_none()
         && let Some(return_must_use_path) = opt_must_use_path(cx, return_ty(cx, item_id))
     {
@@ -169,7 +176,7 @@ fn check_needless_must_use(
             && let Some(future_ty) = cx.tcx.get_impl_future_output_ty(return_ty(cx, item_id))
             && opt_must_use_path(cx, future_ty).is_none()
         {
-            return;
+            return false;
         }
 
         span_lint_and_then(
@@ -201,7 +208,27 @@ fn check_needless_must_use(
                 diag.note("alternatively, you may add an explicit reason to the `must_use` attribute");
             },
         );
+        return true;
     }
+
+    false
+}
+
+/// Checks for `must_use` usage without a reason
+fn check_must_use_without_reason(cx: &LateContext<'_>, attr_span: Span, reason: Option<Symbol>) {
+    if reason.is_some() {
+        return;
+    }
+
+    span_lint_and_sugg(
+        cx,
+        MUST_USE_WITHOUT_REASON,
+        attr_span,
+        "`#[must_use]` attribute without a reason",
+        "add a reason why the value must be used",
+        "#[must_use = \"<REASON>\"]".to_string(),
+        Applicability::HasPlaceholders,
+    );
 }
 
 fn check_must_use_candidate<'tcx>(
@@ -215,7 +242,6 @@ fn check_must_use_candidate<'tcx>(
 ) {
     if has_mutable_arg(cx, body)
         || mutates_static(cx, body)
-        || item_span.in_external_macro(cx.sess().source_map())
         || returns_unit(decl)
         || !cx.effective_visibilities.is_exported(item_id.def_id)
         || opt_must_use_path(cx, return_ty(cx, item_id)).is_some()
@@ -224,14 +250,19 @@ fn check_must_use_candidate<'tcx>(
     {
         return;
     }
+    let hir_id = cx.tcx.local_def_id_to_hir_id(item_id.def_id);
     span_lint_and_then(cx, MUST_USE_CANDIDATE, ident_span, msg, |diag| {
         let indent = snippet_indent(cx, item_span).unwrap_or_default();
-        diag.span_suggestion(
-            item_span.shrink_to_lo(),
-            "add the attribute",
-            format!("#[must_use]\n{indent}"),
-            Applicability::MachineApplicable,
-        );
+        // Suggest a reason as well, otherwise `must_use_without_reason` fires on the result.
+        let (sugg, applicability) = if is_lint_allowed(cx, MUST_USE_WITHOUT_REASON, hir_id) {
+            (format!("#[must_use]\n{indent}"), Applicability::MachineApplicable)
+        } else {
+            (
+                format!("#[must_use = \"<REASON>\"]\n{indent}"),
+                Applicability::HasPlaceholders,
+            )
+        };
+        diag.span_suggestion(item_span.shrink_to_lo(), "add the attribute", sugg, applicability);
     });
 }
 

--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -6,19 +6,18 @@ use rustc_hir::{self as hir, Attribute, QPath, find_attr};
 use rustc_lint::unused::must_use::MustUsePath;
 use rustc_lint::{LateContext, LintContext as _};
 use rustc_middle::ty::{self, Ty};
-use rustc_span::{Span, sym};
+use rustc_span::{Span, Symbol, sym};
 
 use clippy_utils::attrs::is_proc_macro;
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::snippet_indent;
 use clippy_utils::ty::{describe_must_use_type, opt_must_use_path};
 use clippy_utils::visitors::for_each_expr_without_closures;
-use clippy_utils::{is_entrypoint_fn, return_ty, trait_ref_of_method};
-use rustc_span::Symbol;
+use clippy_utils::{is_entrypoint_fn, is_lint_allowed, return_ty, trait_ref_of_method};
 
 use core::ops::ControlFlow;
 
-use super::{DOUBLE_MUST_USE, MUST_USE_CANDIDATE, MUST_USE_UNIT};
+use super::{DOUBLE_MUST_USE, MUST_USE_CANDIDATE, MUST_USE_UNIT, MUST_USE_WITHOUT_REASON};
 
 pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
     let attrs = cx.tcx.hir_attrs(item.hir_id());
@@ -29,21 +28,24 @@ pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>
         ident,
         ..
     } = item.kind
+        && !item.span.in_external_macro(cx.sess().source_map())
     {
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
         if let Some((attr_span, reason)) = attr {
-            check_needless_must_use(
+            let is_needless_must_use = check_needless_must_use(
                 cx,
                 sig.decl,
                 item.owner_id,
-                item.span,
                 fn_header_span,
                 *attr_span,
                 *reason,
                 attrs,
                 sig,
             );
+            if !is_needless_must_use {
+                check_must_use_without_reason(cx, *attr_span, *reason);
+            }
         } else if is_public && !is_proc_macro(attrs) && !find_attr!(attrs, NoMangle(..)) {
             check_must_use_candidate(
                 cx,
@@ -59,23 +61,27 @@ pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>
 }
 
 pub(super) fn check_impl_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::ImplItem<'_>) {
-    if let hir::ImplItemKind::Fn(ref sig, ref body_id) = item.kind {
+    if let hir::ImplItemKind::Fn(ref sig, ref body_id) = item.kind
+        && !item.span.in_external_macro(cx.sess().source_map())
+    {
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
         let attrs = cx.tcx.hir_attrs(item.hir_id());
         let attr = find_attr!(cx.tcx, item.hir_id(), MustUse { span, reason } => (span, reason));
         if let Some((attr_span, reason)) = attr {
-            check_needless_must_use(
+            let is_needless_must_use = check_needless_must_use(
                 cx,
                 sig.decl,
                 item.owner_id,
-                item.span,
                 fn_header_span,
                 *attr_span,
                 *reason,
                 attrs,
                 sig,
             );
+            if !is_needless_must_use {
+                check_must_use_without_reason(cx, *attr_span, *reason);
+            }
         } else if is_public && !is_proc_macro(attrs) && trait_ref_of_method(cx, item.owner_id).is_none() {
             check_must_use_candidate(
                 cx,
@@ -91,24 +97,28 @@ pub(super) fn check_impl_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Imp
 }
 
 pub(super) fn check_trait_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::TraitItem<'_>) {
-    if let hir::TraitItemKind::Fn(ref sig, ref eid) = item.kind {
+    if let hir::TraitItemKind::Fn(ref sig, ref eid) = item.kind
+        && !item.span.in_external_macro(cx.sess().source_map())
+    {
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
 
         let attrs = cx.tcx.hir_attrs(item.hir_id());
         let attr = find_attr!(cx.tcx, item.hir_id(), MustUse { span, reason } => (span, reason));
         if let Some((attr_span, reason)) = attr {
-            check_needless_must_use(
+            let is_needless_must_use = check_needless_must_use(
                 cx,
                 sig.decl,
                 item.owner_id,
-                item.span,
                 fn_header_span,
                 *attr_span,
                 *reason,
                 attrs,
                 sig,
             );
+            if !is_needless_must_use {
+                check_must_use_without_reason(cx, *attr_span, *reason);
+            }
         } else if let hir::TraitFn::Provided(eid) = *eid {
             let body = cx.tcx.hir_body(eid);
             if attr.is_none() && is_public && !is_proc_macro(attrs) {
@@ -132,15 +142,14 @@ fn check_needless_must_use(
     cx: &LateContext<'_>,
     decl: &hir::FnDecl<'_>,
     item_id: hir::OwnerId,
-    item_span: Span,
     fn_header_span: Span,
     attr_span: Span,
     reason: Option<Symbol>,
     attrs: &[Attribute],
     sig: &FnSig<'_>,
-) {
-    if item_span.in_external_macro(cx.sess().source_map()) || attr_span.from_expansion() {
-        return;
+) -> bool {
+    if attr_span.from_expansion() {
+        return false;
     }
     if returns_unit(decl) {
         span_lint_and_then(
@@ -161,6 +170,7 @@ fn check_needless_must_use(
                 }
             },
         );
+        return true;
     } else if reason.is_none()
         && let Some(return_must_use_path) = opt_must_use_path(cx, return_ty(cx, item_id))
     {
@@ -169,7 +179,7 @@ fn check_needless_must_use(
             && let Some(future_ty) = cx.tcx.get_impl_future_output_ty(return_ty(cx, item_id))
             && opt_must_use_path(cx, future_ty).is_none()
         {
-            return;
+            return false;
         }
 
         span_lint_and_then(
@@ -201,7 +211,27 @@ fn check_needless_must_use(
                 diag.note("alternatively, you may add an explicit reason to the `must_use` attribute");
             },
         );
+        return true;
     }
+
+    false
+}
+
+/// Checks for `must_use` usage without a reason
+fn check_must_use_without_reason(cx: &LateContext<'_>, attr_span: Span, reason: Option<Symbol>) {
+    if reason.is_some() || attr_span.from_expansion() {
+        return;
+    }
+
+    span_lint_and_sugg(
+        cx,
+        MUST_USE_WITHOUT_REASON,
+        attr_span,
+        "`#[must_use]` attribute without a reason",
+        "add a reason why the value must be used",
+        "#[must_use = \"<REASON>\"]".to_string(),
+        Applicability::HasPlaceholders,
+    );
 }
 
 fn check_must_use_candidate<'tcx>(
@@ -215,7 +245,6 @@ fn check_must_use_candidate<'tcx>(
 ) {
     if has_mutable_arg(cx, body)
         || mutates_static(cx, body)
-        || item_span.in_external_macro(cx.sess().source_map())
         || returns_unit(decl)
         || !cx.effective_visibilities.is_exported(item_id.def_id)
         || opt_must_use_path(cx, return_ty(cx, item_id)).is_some()
@@ -224,14 +253,19 @@ fn check_must_use_candidate<'tcx>(
     {
         return;
     }
+    let hir_id = cx.tcx.local_def_id_to_hir_id(item_id.def_id);
     span_lint_and_then(cx, MUST_USE_CANDIDATE, ident_span, msg, |diag| {
         let indent = snippet_indent(cx, item_span).unwrap_or_default();
-        diag.span_suggestion(
-            item_span.shrink_to_lo(),
-            "add the attribute",
-            format!("#[must_use]\n{indent}"),
-            Applicability::MachineApplicable,
-        );
+        // Suggest a reason as well, otherwise `must_use_without_reason` fires on the result.
+        let (sugg, applicability) = if is_lint_allowed(cx, MUST_USE_WITHOUT_REASON, hir_id) {
+            (format!("#[must_use]\n{indent}"), Applicability::MachineApplicable)
+        } else {
+            (
+                format!("#[must_use = \"<REASON>\"]\n{indent}"),
+                Applicability::HasPlaceholders,
+            )
+        };
+        diag.span_suggestion(item_span.shrink_to_lo(), "add the attribute", sugg, applicability);
     });
 }
 

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -122,3 +122,22 @@ pub fn result_uninhabited_2() -> Result<T, std::convert::Infallible> {
 pub fn with_box() -> Box<T> {
     todo!()
 }
+
+pub mod with_reason_lint {
+    // With `must_use_without_reason` enabled the suggestion carries a reason placeholder,
+    // so applying it does not immediately trip that lint.
+    #![warn(clippy::must_use_without_reason)]
+
+    //~v must_use_candidate
+    #[must_use = "<REASON>"]
+    pub fn pure(i: u8) -> u8 {
+        i
+    }
+
+    #[allow(clippy::must_use_without_reason)]
+    //~v must_use_candidate
+    #[must_use]
+    pub fn reason_lint_allowed(i: u8) -> u8 {
+        i
+    }
+}

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -116,3 +116,20 @@ pub fn result_uninhabited_2() -> Result<T, std::convert::Infallible> {
 pub fn with_box() -> Box<T> {
     todo!()
 }
+
+pub mod with_reason_lint {
+    // With `must_use_without_reason` enabled the suggestion carries a reason placeholder,
+    // so applying it does not immediately trip that lint.
+    #![warn(clippy::must_use_without_reason)]
+
+    //~v must_use_candidate
+    pub fn pure(i: u8) -> u8 {
+        i
+    }
+
+    #[allow(clippy::must_use_without_reason)]
+    //~v must_use_candidate
+    pub fn reason_lint_allowed(i: u8) -> u8 {
+        i
+    }
+}

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -72,5 +72,29 @@ LL + #[must_use]
 LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
    |
 
-error: aborting due to 6 previous errors
+error: this function could have a `#[must_use]` attribute
+  --> tests/ui/must_use_candidates.rs:126:12
+   |
+LL |     pub fn pure(i: u8) -> u8 {
+   |            ^^^^
+   |
+help: add the attribute
+   |
+LL ~     #[must_use = "<REASON>"]
+LL ~     pub fn pure(i: u8) -> u8 {
+   |
+
+error: this function could have a `#[must_use]` attribute
+  --> tests/ui/must_use_candidates.rs:132:12
+   |
+LL |     pub fn reason_lint_allowed(i: u8) -> u8 {
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+help: add the attribute
+   |
+LL ~     #[must_use]
+LL ~     pub fn reason_lint_allowed(i: u8) -> u8 {
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/must_use_without_reason.fixed
+++ b/tests/ui/must_use_without_reason.fixed
@@ -1,0 +1,64 @@
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::must_use_without_reason)]
+#![allow(clippy::must_use_unit)]
+
+extern crate proc_macros;
+use proc_macros::external;
+
+// Should trigger lint
+#[must_use = "<REASON>"]
+//~^ ERROR: `#[must_use]` attribute without a reason
+fn no_note() -> i32 {
+    42
+}
+
+// Should NOT trigger lint - has a note
+#[must_use = "expensive operation"]
+fn with_note() -> i32 {
+    42
+}
+
+struct MyStruct;
+
+impl MyStruct {
+    // Should trigger lint
+    #[must_use = "<REASON>"]
+    //~^ ERROR: `#[must_use]` attribute without a reason
+    fn method_no_note(&self) -> i32 {
+        42
+    }
+
+    // Should NOT trigger lint
+    #[must_use = "important result"]
+    fn method_with_note(&self) -> i32 {
+        42
+    }
+}
+
+trait MyTrait {
+    // Should trigger lint
+    #[must_use = "<REASON>"]
+    //~^ ERROR: `#[must_use]` attribute without a reason
+    fn trait_method_no_note(&self) -> i32;
+
+    // Should NOT trigger lint
+    #[must_use = "trait method note"]
+    fn trait_method_with_note(&self) -> i32;
+}
+
+// Should NOT trigger lint - external macro
+external! {
+    #[must_use]
+    fn external_macro_no_note() -> i32 {
+        42
+    }
+}
+
+fn main() {
+    let _ = no_note();
+    let _ = with_note();
+    let s = MyStruct;
+    let _ = s.method_no_note();
+    let _ = s.method_with_note();
+}

--- a/tests/ui/must_use_without_reason.rs
+++ b/tests/ui/must_use_without_reason.rs
@@ -1,0 +1,64 @@
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::must_use_without_reason)]
+#![allow(clippy::must_use_unit)]
+
+extern crate proc_macros;
+use proc_macros::external;
+
+// Should trigger lint
+#[must_use]
+//~^ ERROR: `#[must_use]` attribute without a reason
+fn no_note() -> i32 {
+    42
+}
+
+// Should NOT trigger lint - has a note
+#[must_use = "expensive operation"]
+fn with_note() -> i32 {
+    42
+}
+
+struct MyStruct;
+
+impl MyStruct {
+    // Should trigger lint
+    #[must_use]
+    //~^ ERROR: `#[must_use]` attribute without a reason
+    fn method_no_note(&self) -> i32 {
+        42
+    }
+
+    // Should NOT trigger lint
+    #[must_use = "important result"]
+    fn method_with_note(&self) -> i32 {
+        42
+    }
+}
+
+trait MyTrait {
+    // Should trigger lint
+    #[must_use]
+    //~^ ERROR: `#[must_use]` attribute without a reason
+    fn trait_method_no_note(&self) -> i32;
+
+    // Should NOT trigger lint
+    #[must_use = "trait method note"]
+    fn trait_method_with_note(&self) -> i32;
+}
+
+// Should NOT trigger lint - external macro
+external! {
+    #[must_use]
+    fn external_macro_no_note() -> i32 {
+        42
+    }
+}
+
+fn main() {
+    let _ = no_note();
+    let _ = with_note();
+    let s = MyStruct;
+    let _ = s.method_no_note();
+    let _ = s.method_with_note();
+}

--- a/tests/ui/must_use_without_reason.stderr
+++ b/tests/ui/must_use_without_reason.stderr
@@ -1,0 +1,23 @@
+error: `#[must_use]` attribute without a reason
+  --> tests/ui/must_use_without_reason.rs:10:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^ help: add a reason why the value must be used: `#[must_use = "<REASON>"]`
+   |
+   = note: `-D clippy::must-use-without-reason` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::must_use_without_reason)]`
+
+error: `#[must_use]` attribute without a reason
+  --> tests/ui/must_use_without_reason.rs:26:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^ help: add a reason why the value must be used: `#[must_use = "<REASON>"]`
+
+error: `#[must_use]` attribute without a reason
+  --> tests/ui/must_use_without_reason.rs:41:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^ help: add a reason why the value must be used: `#[must_use = "<REASON>"]`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16592)*

PR addresses [proposal](https://github.com/rust-lang/rust-clippy/issues/16466) for adding a lint that warns about a `#[must_use]` attribute that lacks a reason.
Fixes rust-lang/rust-clippy#16466

---

### Updated after review

Rebased onto current master and addressed all review feedback. The branch is now a single commit.

- **Category `style` → `restriction`** — the lint is opinionated and restricts an otherwise valid attribute.
- **Renamed `must_use_without_note` → `must_use_without_reason`**, matching `allow_attributes_without_reason`. Diagnostic wording uses "reason" throughout.
- **Suggestion placeholder is now `#[must_use = "<REASON>"]`** instead of `"/* reason */"`.
- **`must_use_candidate` now suggests a message based on `is_lint_allowed`.** By default it is unchanged from master — plain `#[must_use]`, `MachineApplicable`. Only when `must_use_without_reason` is enabled at that node does it suggest `#[must_use = "<REASON>"]`, so applying the fix does not immediately trip the other lint. Covered by a scoped module in `tests/ui/must_use_candidates.rs`, which keeps the existing cases and their `.fixed` output untouched.
- **`in_external_macro` guard moved after the item-kind check** in all three entry points.

changelog: [`must_use_without_reason`]: add a lint that warns on `#[must_use]` attributes without a reason
