### PR TITLE
`result-map-unit-fn`: use "a" before `Result`

### DIFF
--- a/tests/ui/result_map_unit_fn_fixable.stderr
+++ b/tests/ui/result_map_unit_fn_fixable.stderr
@@ -1,4 +1,4 @@
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a function that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:32:5
    |
 LL |     x.field.map(do_nothing);
@@ -12,7 +12,7 @@ LL -     x.field.map(do_nothing);
 LL +     if let Ok(x_field) = x.field { do_nothing(x_field) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a function that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:35:5
    |
 LL |     x.field.map(do_nothing);
@@ -24,7 +24,7 @@ LL -     x.field.map(do_nothing);
 LL +     if let Ok(x_field) = x.field { do_nothing(x_field) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a function that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:38:5
    |
 LL |     x.field.map(diverge);
@@ -36,7 +36,7 @@ LL -     x.field.map(diverge);
 LL +     if let Ok(x_field) = x.field { diverge(x_field) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:45:5
    |
 LL |     x.field.map(|value| x.do_result_nothing(value + captured));
@@ -48,7 +48,7 @@ LL -     x.field.map(|value| x.do_result_nothing(value + captured));
 LL +     if let Ok(value) = x.field { x.do_result_nothing(value + captured) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:48:5
    |
 LL |     x.field.map(|value| { x.do_result_plus_one(value + captured); });
@@ -60,7 +60,7 @@ LL -     x.field.map(|value| { x.do_result_plus_one(value + captured); });
 LL +     if let Ok(value) = x.field { x.do_result_plus_one(value + captured); }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:52:5
    |
 LL |     x.field.map(|value| do_nothing(value + captured));
@@ -72,7 +72,7 @@ LL -     x.field.map(|value| do_nothing(value + captured));
 LL +     if let Ok(value) = x.field { do_nothing(value + captured) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:55:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured) });
@@ -84,7 +84,7 @@ LL -     x.field.map(|value| { do_nothing(value + captured) });
 LL +     if let Ok(value) = x.field { do_nothing(value + captured) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:58:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured); });
@@ -96,7 +96,7 @@ LL -     x.field.map(|value| { do_nothing(value + captured); });
 LL +     if let Ok(value) = x.field { do_nothing(value + captured); }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:61:5
    |
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
@@ -108,7 +108,7 @@ LL -     x.field.map(|value| { { do_nothing(value + captured); } });
 LL +     if let Ok(value) = x.field { do_nothing(value + captured); }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:65:5
    |
 LL |     x.field.map(|value| diverge(value + captured));
@@ -120,7 +120,7 @@ LL -     x.field.map(|value| diverge(value + captured));
 LL +     if let Ok(value) = x.field { diverge(value + captured) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:68:5
    |
 LL |     x.field.map(|value| { diverge(value + captured) });
@@ -132,7 +132,7 @@ LL -     x.field.map(|value| { diverge(value + captured) });
 LL +     if let Ok(value) = x.field { diverge(value + captured) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:71:5
    |
 LL |     x.field.map(|value| { diverge(value + captured); });
@@ -144,7 +144,7 @@ LL -     x.field.map(|value| { diverge(value + captured); });
 LL +     if let Ok(value) = x.field { diverge(value + captured); }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:74:5
    |
 LL |     x.field.map(|value| { { diverge(value + captured); } });
@@ -156,7 +156,7 @@ LL -     x.field.map(|value| { { diverge(value + captured); } });
 LL +     if let Ok(value) = x.field { diverge(value + captured); }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:80:5
    |
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
@@ -168,7 +168,7 @@ LL -     x.field.map(|value| { let y = plus_one(value + captured); });
 LL +     if let Ok(value) = x.field { let y = plus_one(value + captured); }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:83:5
    |
 LL |     x.field.map(|value| { plus_one(value + captured); });
@@ -180,7 +180,7 @@ LL -     x.field.map(|value| { plus_one(value + captured); });
 LL +     if let Ok(value) = x.field { plus_one(value + captured); }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:86:5
    |
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
@@ -192,7 +192,7 @@ LL -     x.field.map(|value| { { plus_one(value + captured); } });
 LL +     if let Ok(value) = x.field { plus_one(value + captured); }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:90:5
    |
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });
@@ -204,7 +204,7 @@ LL -     x.field.map(|ref value| { do_nothing(value + captured) });
 LL +     if let Ok(ref value) = x.field { do_nothing(value + captured) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_fixable.rs:93:5
    |
 LL |     x.field.map(|value| println!("{value:?}"));

--- a/tests/ui/result_map_unit_fn_unfixable.stderr
+++ b/tests/ui/result_map_unit_fn_unfixable.stderr
@@ -1,4 +1,4 @@
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_unfixable.rs:24:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value) });
@@ -12,7 +12,7 @@ LL -     x.field.map(|value| { do_nothing(value); do_nothing(value) });
 LL +     if let Ok(value) = x.field { ... }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_unfixable.rs:29:5
    |
 LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value) });
@@ -24,7 +24,7 @@ LL -     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value)
 LL +     if let Ok(value) = x.field { ... }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_unfixable.rs:35:5
    |
 LL | /     x.field.map(|value| {
@@ -46,7 +46,7 @@ LL -     });
 LL +     if let Ok(value) = x.field { ... }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a closure that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_unfixable.rs:41:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value); });
@@ -58,7 +58,7 @@ LL -     x.field.map(|value| { do_nothing(value); do_nothing(value); });
 LL +     if let Ok(value) = x.field { ... }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a function that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_unfixable.rs:47:5
    |
 LL |     "12".parse::<i32>().map(diverge);
@@ -70,7 +70,7 @@ LL -     "12".parse::<i32>().map(diverge);
 LL +     if let Ok(a) = "12".parse::<i32>() { diverge(a) }
    |
 
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
+error: called `map(f)` on a `Result` value where `f` is a function that returns the unit type `()`
   --> tests/ui/result_map_unit_fn_unfixable.rs:55:5
    |
 LL |     y.map(do_nothing);


### PR DESCRIPTION
changelog: [`result-map-unit-fn`]: use "a" before `Result`