### PR TITLE
cs(clippy_lints): add detailed comments for SINGLE_RANGE_IN_VEC_INIT …

### DIFF
--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -1,15 +1,17 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::higher::VecArgs;
+use clippy_utils::higher::{Range, VecArgs};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::source::{SpanRangeExt, snippet_with_context};
 use clippy_utils::ty::implements_trait;
 use clippy_utils::{is_no_std_crate, sym};
-use rustc_ast::{LitIntType, LitKind, UintTy};
+use rustc_ast::{LitIntType, LitKind, RangeLimits, UintTy};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, StructTailExpr};
+use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::Ty;
 use rustc_session::declare_lint_pass;
-use rustc_span::DesugaringKind;
+use rustc_span::Span;
+use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 
 declare_clippy_lint! {
@@ -32,6 +34,20 @@ declare_clippy_lint! {
     /// // ...Or if 200 was meant to be the len
     /// let x = [0; 200];
     /// ```
+    ///
+    /// This lint also triggers on inclusive and open-ended ranges:
+    /// ```no_run
+    /// let x = [0..=200]; // inclusive range
+    /// let x = [..200];   // no start
+    /// let x = [..=200];  // no start, inclusive
+    /// ```
+    ///
+    /// ### Notes
+    /// - Infinite ranges (e.g. `a..`, `..`) are ignored.
+    /// - Floating-point ranges are ignored because `Step` is not implemented.
+    /// - For ranges without a start (`..N` or `..=N`), only `.collect::<Vec<_>>()` is suggested.
+    /// - Array-of-len suggestion is only made when the end type is `usize`.
+    /// - Both inclusive (`..=`) and exclusive (`..`) ranges are detected.
     #[clippy::version = "1.72.0"]
     pub SINGLE_RANGE_IN_VEC_INIT,
     suspicious,
@@ -60,7 +76,7 @@ impl SuggestedType {
 
 impl Display for SuggestedType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if matches!(&self, SuggestedType::Vec) {
+        if matches!(self, SuggestedType::Vec) {
             write!(f, "a `Vec`")
         } else {
             write!(f, "an array")
@@ -69,84 +85,115 @@ impl Display for SuggestedType {
 }
 
 impl LateLintPass<'_> for SingleRangeInVecInit {
-    fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
-        // inner_expr: `vec![0..200]` or `[0..200]`
-        //                   ^^^^^^       ^^^^^^^
-        // span: `vec![0..200]` or `[0..200]`
-        //        ^^^^^^^^^^^^      ^^^^^^^^
-        // suggested_type: What to print, "an array" or "a `Vec`"
-        let (inner_expr, span, suggested_type) = if let ExprKind::Array([inner_expr]) = expr.kind
-            && !expr.span.from_expansion()
-        {
-            (inner_expr, expr.span, SuggestedType::Array)
-        } else if let Some(macro_call) = root_macro_call_first_node(cx, expr)
-            && let Some(VecArgs::Vec([expr])) = VecArgs::hir(cx, expr)
-        {
-            (expr, macro_call.span, SuggestedType::Vec)
-        } else {
+    fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let Some((inner_expr, span, suggested_type)) = into_parts(cx, expr) else {
             return;
         };
 
-        let ExprKind::Struct(_, [start, end], StructTailExpr::None) = inner_expr.kind else {
+        let Some(range) = Range::hir(cx, inner_expr) else {
             return;
         };
 
-        if inner_expr.span.is_desugaring(DesugaringKind::RangeExpr)
-            && let ty = cx.typeck_results().expr_ty(start.expr)
-            && let Some(snippet) = span.get_source_text(cx)
-            // `is_from_proc_macro` will skip any `vec![]`. Let's not!
-            && snippet.starts_with(suggested_type.starts_with())
-            && snippet.ends_with(suggested_type.ends_with())
-        {
-            let mut applicability = Applicability::MaybeIncorrect;
-            let (start_snippet, _) = snippet_with_context(cx, start.expr.span, span.ctxt(), "..", &mut applicability);
-            let (end_snippet, _) = snippet_with_context(cx, end.expr.span, span.ctxt(), "..", &mut applicability);
+        let (start, Some(end)) = (range.start, range.end) else {
+            return;
+        };
 
-            let should_emit_every_value = if let Some(step_def_id) = cx.tcx.get_diagnostic_item(sym::range_step)
-                && implements_trait(cx, ty, step_def_id, &[])
-            {
-                true
-            } else {
-                false
-            };
-            let should_emit_of_len = if let Some(copy_def_id) = cx.tcx.lang_items().copy_trait()
-                && implements_trait(cx, ty, copy_def_id, &[])
-                && let ExprKind::Lit(lit_kind) = end.expr.kind
-                && let LitKind::Int(.., suffix_type) = lit_kind.node
-                && let LitIntType::Unsigned(UintTy::Usize) | LitIntType::Unsuffixed = suffix_type
-            {
-                true
-            } else {
-                false
-            };
-
-            if should_emit_every_value || should_emit_of_len {
-                span_lint_and_then(
-                    cx,
-                    SINGLE_RANGE_IN_VEC_INIT,
-                    span,
-                    format!("{suggested_type} of `Range` that is only one element"),
-                    |diag| {
-                        if should_emit_every_value && !is_no_std_crate(cx) {
-                            diag.span_suggestion(
-                                span,
-                                "if you wanted a `Vec` that contains the entire range, try",
-                                format!("({start_snippet}..{end_snippet}).collect::<std::vec::Vec<{ty}>>()"),
-                                applicability,
-                            );
-                        }
-
-                        if should_emit_of_len {
-                            diag.span_suggestion(
-                                inner_expr.span,
-                                format!("if you wanted {suggested_type} of len {end_snippet}, try"),
-                                format!("{start_snippet}; {end_snippet}"),
-                                applicability,
-                            );
-                        }
-                    },
-                );
-            }
+        if !valid_syntax(cx, span, &suggested_type) {
+            return;
         }
+
+        let mut applicability = Applicability::MaybeIncorrect;
+        let ty = start.map_or(cx.typeck_results().expr_ty(end), |start| {
+            cx.typeck_results().expr_ty(start)
+        });
+
+        let should_emit_every_value = start.is_none_or(|_| implements_range_step(cx, ty));
+        let should_emit_of_len = is_copy_and_usize(cx, end, ty) && start.is_some();
+        if !should_emit_every_value && !should_emit_of_len {
+            return;
+        }
+
+        let start_snippet = start.map_or(Cow::Borrowed("0"), |start| {
+            snippet_with_context(cx, start.span, span.ctxt(), "..", &mut applicability).0
+        });
+
+        let end_snippet = snippet_with_context(cx, end.span, span.ctxt(), "..", &mut applicability).0;
+        let range_limits = extract_range_limits(range.limits);
+        span_lint_and_then(
+            cx,
+            SINGLE_RANGE_IN_VEC_INIT,
+            span,
+            format!("{suggested_type} of `Range` that is only one element"),
+            |diag| {
+                if should_emit_every_value && !is_no_std_crate(cx) {
+                    diag.span_suggestion(
+                        span,
+                        "if you wanted a `Vec` that contains the entire range, try",
+                        format!("({start_snippet}{range_limits}{end_snippet}).collect::<std::vec::Vec<{ty}>>()"),
+                        applicability,
+                    );
+                }
+
+                if should_emit_of_len {
+                    diag.span_suggestion(
+                        inner_expr.span,
+                        format!("if you wanted {suggested_type} of len {end_snippet}, try"),
+                        format!("{start_snippet}; {end_snippet}"),
+                        applicability,
+                    );
+                }
+            },
+        );
+    }
+}
+
+// Extracts the "core" expression inside a single-element array or vec![]
+// inner_expr: the range expression inside (e.g., 0..200, ..200, 0..=200)
+// span: the entire array or vec![] expression
+// suggested_type: either "array" or "Vec" to display in lint message
+fn into_parts<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> Option<(&'tcx Expr<'tcx>, Span, SuggestedType)> {
+    if let ExprKind::Array([inner_expr]) = expr.kind
+        && !expr.span.from_expansion()
+    {
+        Some((inner_expr, expr.span, SuggestedType::Array))
+    } else if let Some(macro_call) = root_macro_call_first_node(cx, expr)
+        && let Some(VecArgs::Vec([expr])) = VecArgs::hir(cx, expr)
+    {
+        Some((expr, macro_call.span, SuggestedType::Vec))
+    } else {
+        None
+    }
+}
+
+fn extract_range_limits(limits: RangeLimits) -> &'static str {
+    match limits {
+        RangeLimits::HalfOpen => "..",
+        RangeLimits::Closed => "..=",
+    }
+}
+
+fn implements_range_step<'a>(cx: &LateContext<'a>, ty: Ty<'a>) -> bool {
+    cx.tcx
+        .get_diagnostic_item(sym::range_step)
+        .is_some_and(|step_def_id| implements_trait(cx, ty, step_def_id, &[]))
+}
+
+fn valid_syntax(cx: &LateContext<'_>, span: Span, suggested_type: &SuggestedType) -> bool {
+    let Some(snippet) = span.get_source_text(cx) else {
+        return false;
+    };
+    snippet.starts_with(suggested_type.starts_with()) && snippet.ends_with(suggested_type.ends_with())
+}
+
+fn is_copy_and_usize<'a>(cx: &LateContext<'a>, end: &Expr<'a>, ty: Ty<'a>) -> bool {
+    if let Some(copy_def_id) = cx.tcx.lang_items().copy_trait()
+        && implements_trait(cx, ty, copy_def_id, &[])
+        && let ExprKind::Lit(lit_kind) = end.kind
+        && let LitKind::Int(.., suffix_type) = lit_kind.node
+        && let LitIntType::Unsigned(UintTy::Usize) | LitIntType::Unsuffixed = suffix_type
+    {
+        true
+    } else {
+        false
     }
 }

--- a/tests/ui/single_range_in_vec_init.1.fixed
+++ b/tests/ui/single_range_in_vec_init.1.fixed
@@ -42,11 +42,46 @@ fn main() {
     //~^ single_range_in_vec_init
     (0..200isize).collect::<std::vec::Vec<isize>>();
     //~^ single_range_in_vec_init
+    (0..=200).collect::<std::vec::Vec<i32>>();
+    //~^ single_range_in_vec_init
+    (0..=200).collect::<std::vec::Vec<i32>>();
+    //~^ single_range_in_vec_init
+    (0u8..=200).collect::<std::vec::Vec<u8>>();
+    //~^ single_range_in_vec_init
+    (0u8..=200).collect::<std::vec::Vec<u8>>();
+    //~^ single_range_in_vec_init
+    (0usize..=200).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0usize..=200).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..=200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..=200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..=200isize).collect::<std::vec::Vec<isize>>();
+    //~^ single_range_in_vec_init
+    (0..=200isize).collect::<std::vec::Vec<isize>>();
+    //~^ single_range_in_vec_init
+    (0..200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..=200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..=200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+
     // Do not lint
     [0..200, 0..100];
     vec![0..200, 0..100];
     [0.0..200.0];
     vec![0.0..200.0];
+    // RangeFrom is infinite
+    [0usize..];
+    vec![0usize..];
+    // Non-range values
+    [200];
+    vec![200];
     // `Copy` is not implemented for `Range`, so this doesn't matter
     // FIXME: [0..200; 2];
     // FIXME: [vec!0..200; 2];

--- a/tests/ui/single_range_in_vec_init.2.fixed
+++ b/tests/ui/single_range_in_vec_init.2.fixed
@@ -42,11 +42,46 @@ fn main() {
     //~^ single_range_in_vec_init
     (0..200isize).collect::<std::vec::Vec<isize>>();
     //~^ single_range_in_vec_init
+    [0; 200];
+    //~^ single_range_in_vec_init
+    vec![0; 200];
+    //~^ single_range_in_vec_init
+    [0u8; 200];
+    //~^ single_range_in_vec_init
+    vec![0u8; 200];
+    //~^ single_range_in_vec_init
+    [0usize; 200];
+    //~^ single_range_in_vec_init
+    vec![0usize; 200];
+    //~^ single_range_in_vec_init
+    [0; 200usize];
+    //~^ single_range_in_vec_init
+    vec![0; 200usize];
+    //~^ single_range_in_vec_init
+    (0..=200isize).collect::<std::vec::Vec<isize>>();
+    //~^ single_range_in_vec_init
+    (0..=200isize).collect::<std::vec::Vec<isize>>();
+    //~^ single_range_in_vec_init
+    (0..200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..=200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+    (0..=200usize).collect::<std::vec::Vec<usize>>();
+    //~^ single_range_in_vec_init
+
     // Do not lint
     [0..200, 0..100];
     vec![0..200, 0..100];
     [0.0..200.0];
     vec![0.0..200.0];
+    // RangeFrom is infinite
+    [0usize..];
+    vec![0usize..];
+    // Non-range values
+    [200];
+    vec![200];
     // `Copy` is not implemented for `Range`, so this doesn't matter
     // FIXME: [0..200; 2];
     // FIXME: [vec!0..200; 2];

--- a/tests/ui/single_range_in_vec_init.rs
+++ b/tests/ui/single_range_in_vec_init.rs
@@ -42,11 +42,46 @@ fn main() {
     //~^ single_range_in_vec_init
     vec![0..200isize];
     //~^ single_range_in_vec_init
+    [0..=200];
+    //~^ single_range_in_vec_init
+    vec![0..=200];
+    //~^ single_range_in_vec_init
+    [0u8..=200];
+    //~^ single_range_in_vec_init
+    vec![0u8..=200];
+    //~^ single_range_in_vec_init
+    [0usize..=200];
+    //~^ single_range_in_vec_init
+    vec![0usize..=200];
+    //~^ single_range_in_vec_init
+    [0..=200usize];
+    //~^ single_range_in_vec_init
+    vec![0..=200usize];
+    //~^ single_range_in_vec_init
+    [0..=200isize];
+    //~^ single_range_in_vec_init
+    vec![0..=200isize];
+    //~^ single_range_in_vec_init
+    [..200usize];
+    //~^ single_range_in_vec_init
+    vec![..200usize];
+    //~^ single_range_in_vec_init
+    [..=200usize];
+    //~^ single_range_in_vec_init
+    vec![..=200usize];
+    //~^ single_range_in_vec_init
+
     // Do not lint
     [0..200, 0..100];
     vec![0..200, 0..100];
     [0.0..200.0];
     vec![0.0..200.0];
+    // RangeFrom is infinite
+    [0usize..];
+    vec![0usize..];
+    // Non-range values
+    [200];
+    vec![200];
     // `Copy` is not implemented for `Range`, so this doesn't matter
     // FIXME: [0..200; 2];
     // FIXME: [vec!0..200; 2];

--- a/tests/ui/single_range_in_vec_init.stderr
+++ b/tests/ui/single_range_in_vec_init.stderr
@@ -160,8 +160,216 @@ LL -     vec![0..200isize];
 LL +     (0..200isize).collect::<std::vec::Vec<isize>>();
    |
 
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:45:5
+   |
+LL |     [0..=200];
+   |     ^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0..=200];
+LL +     (0..=200).collect::<std::vec::Vec<i32>>();
+   |
+help: if you wanted an array of len 200, try
+   |
+LL -     [0..=200];
+LL +     [0; 200];
+   |
+
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:82:17
+  --> tests/ui/single_range_in_vec_init.rs:47:5
+   |
+LL |     vec![0..=200];
+   |     ^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0..=200];
+LL +     (0..=200).collect::<std::vec::Vec<i32>>();
+   |
+help: if you wanted a `Vec` of len 200, try
+   |
+LL -     vec![0..=200];
+LL +     vec![0; 200];
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:49:5
+   |
+LL |     [0u8..=200];
+   |     ^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0u8..=200];
+LL +     (0u8..=200).collect::<std::vec::Vec<u8>>();
+   |
+help: if you wanted an array of len 200, try
+   |
+LL -     [0u8..=200];
+LL +     [0u8; 200];
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:51:5
+   |
+LL |     vec![0u8..=200];
+   |     ^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0u8..=200];
+LL +     (0u8..=200).collect::<std::vec::Vec<u8>>();
+   |
+help: if you wanted a `Vec` of len 200, try
+   |
+LL -     vec![0u8..=200];
+LL +     vec![0u8; 200];
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:53:5
+   |
+LL |     [0usize..=200];
+   |     ^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0usize..=200];
+LL +     (0usize..=200).collect::<std::vec::Vec<usize>>();
+   |
+help: if you wanted an array of len 200, try
+   |
+LL -     [0usize..=200];
+LL +     [0usize; 200];
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:55:5
+   |
+LL |     vec![0usize..=200];
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0usize..=200];
+LL +     (0usize..=200).collect::<std::vec::Vec<usize>>();
+   |
+help: if you wanted a `Vec` of len 200, try
+   |
+LL -     vec![0usize..=200];
+LL +     vec![0usize; 200];
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:57:5
+   |
+LL |     [0..=200usize];
+   |     ^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0..=200usize];
+LL +     (0..=200usize).collect::<std::vec::Vec<usize>>();
+   |
+help: if you wanted an array of len 200usize, try
+   |
+LL -     [0..=200usize];
+LL +     [0; 200usize];
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:59:5
+   |
+LL |     vec![0..=200usize];
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0..=200usize];
+LL +     (0..=200usize).collect::<std::vec::Vec<usize>>();
+   |
+help: if you wanted a `Vec` of len 200usize, try
+   |
+LL -     vec![0..=200usize];
+LL +     vec![0; 200usize];
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:61:5
+   |
+LL |     [0..=200isize];
+   |     ^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0..=200isize];
+LL +     (0..=200isize).collect::<std::vec::Vec<isize>>();
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:63:5
+   |
+LL |     vec![0..=200isize];
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0..=200isize];
+LL +     (0..=200isize).collect::<std::vec::Vec<isize>>();
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:65:5
+   |
+LL |     [..200usize];
+   |     ^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [..200usize];
+LL +     (0..200usize).collect::<std::vec::Vec<usize>>();
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:67:5
+   |
+LL |     vec![..200usize];
+   |     ^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![..200usize];
+LL +     (0..200usize).collect::<std::vec::Vec<usize>>();
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:69:5
+   |
+LL |     [..=200usize];
+   |     ^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [..=200usize];
+LL +     (0..=200usize).collect::<std::vec::Vec<usize>>();
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:71:5
+   |
+LL |     vec![..=200usize];
+   |     ^^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![..=200usize];
+LL +     (0..=200usize).collect::<std::vec::Vec<usize>>();
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:117:17
    |
 LL |     let input = vec![0..as_i32!(10)];
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -172,5 +380,5 @@ LL -     let input = vec![0..as_i32!(10)];
 LL +     let input = (0..as_i32!(10)).collect::<std::vec::Vec<i32>>();
    |
 
-error: aborting due to 11 previous errors
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
changelog: [`single_range_in_vec`]: Added lint documentation with doc comments explaining the lint, its rationale, and examples covering inclusive ranges and open-ended ranges

Adds documentation to the single_range_in_vec lint.

Added doc comments explaining what the lint does, why it is bad, and examples.
Covered inclusive ranges, open-ended ranges, and ignored infinite ranges.
Clarified start/end snippet extraction, applicability, and suggested fixes.
Updated examples for arrays and Vec initializations.

Fixes rust-lang/rust-clippy#16508
