### PR TITLE
Add brackets around unsafe or labeled block used in `else`

### DIFF
--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -9,7 +9,9 @@ use rustc_ast::BindingMode;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::Applicability;
 use rustc_hir::def::{CtorOf, DefKind, Res};
-use rustc_hir::{Arm, Expr, ExprKind, MatchSource, Pat, PatExpr, PatExprKind, PatKind, QPath, Stmt, StmtKind};
+use rustc_hir::{
+    Arm, BlockCheckMode, Expr, ExprKind, MatchSource, Pat, PatExpr, PatExprKind, PatKind, QPath, Stmt, StmtKind,
+};
 use rustc_lint::{LateContext, LintContext};
 use rustc_span::Span;
 use rustc_span::symbol::{Symbol, sym};
@@ -177,7 +179,10 @@ fn emit_manual_let_else(
             let (sn_expr, _) = snippet_with_context(cx, expr.span, span.ctxt(), "", &mut app);
             let (sn_else, else_is_mac_call) = snippet_with_context(cx, else_body.span, span.ctxt(), "", &mut app);
 
-            let else_bl = if matches!(else_body.kind, ExprKind::Block(..)) && !else_is_mac_call {
+            let else_bl = if let ExprKind::Block(block, None) = else_body.kind
+                && matches!(block.rules, BlockCheckMode::DefaultBlock)
+                && !else_is_mac_call
+            {
                 sn_else.into_owned()
             } else {
                 format!("{{ {sn_else} }}")

--- a/tests/ui/manual_let_else.rs
+++ b/tests/ui/manual_let_else.rs
@@ -571,3 +571,21 @@ mod issue15914 {
         };
     }
 }
+
+fn issue16602(i: Result<i32, i32>) {
+    //~v manual_let_else
+    _ = match i {
+        Ok(i) => i,
+        Err(_) => unsafe {
+            core::hint::unreachable_unchecked();
+        },
+    };
+
+    //~v manual_let_else
+    _ = match i {
+        Ok(i) => i,
+        Err(_) => 'useless_label: {
+            panic!();
+        },
+    };
+}

--- a/tests/ui/manual_let_else.stderr
+++ b/tests/ui/manual_let_else.stderr
@@ -585,5 +585,41 @@ LL +             return;
 LL +         };
    |
 
-error: aborting due to 37 previous errors
+error: this could be rewritten as `let...else`
+  --> tests/ui/manual_let_else.rs:577:5
+   |
+LL | /     _ = match i {
+LL | |         Ok(i) => i,
+LL | |         Err(_) => unsafe {
+LL | |             core::hint::unreachable_unchecked();
+LL | |         },
+LL | |     };
+   | |_____^
+   |
+help: consider writing
+   |
+LL ~     let Ok(_) = i else { unsafe {
+LL +             core::hint::unreachable_unchecked();
+LL ~         } };;
+   |
+
+error: this could be rewritten as `let...else`
+  --> tests/ui/manual_let_else.rs:585:5
+   |
+LL | /     _ = match i {
+LL | |         Ok(i) => i,
+LL | |         Err(_) => 'useless_label: {
+LL | |             panic!();
+LL | |         },
+LL | |     };
+   | |_____^
+   |
+help: consider writing
+   |
+LL ~     let Ok(_) = i else { 'useless_label: {
+LL +             panic!();
+LL ~         } };;
+   |
+
+error: aborting due to 39 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16602 

----

changelog: [`manual_let_else`]: use brackets around unsafe or labeled block used in `else`