### PR TITLE
Make `unnecessary_fold` commutative

### DIFF
--- a/tests/ui/unnecessary_fold.fixed
+++ b/tests/ui/unnecessary_fold.fixed
@@ -88,16 +88,6 @@ fn unnecessary_fold_should_ignore() {
     let _: i32 = (0..3).fold(0, FakeAdd::add);
     let _: i32 = (0..3).fold(1, FakeMul::mul);
 
-    // We only match against an accumulator on the left
-    // hand side. We could lint for .sum and .product when
-    // it's on the right, but don't for now (and this wouldn't
-    // be valid if we extended the lint to cover arbitrary numeric
-    // types).
-    let _ = (0..3).fold(false, |acc, x| x > 2 || acc);
-    let _ = (0..3).fold(true, |acc, x| x > 2 && acc);
-    let _ = (0..3).fold(0, |acc, x| x + acc);
-    let _ = (0..3).fold(1, |acc, x| x * acc);
-
     let _ = [(0..2), (0..3)].iter().fold(0, |a, b| a + b.len());
     let _ = [(0..2), (0..3)].iter().fold(1, |a, b| a * b.len());
 }
@@ -176,6 +166,26 @@ fn issue10000() {
         (0..3).product::<i32>()
         //~^ unnecessary_fold
     }
+}
+
+fn issue16581() {
+    let _ = (2..=3).product::<i32>();
+    //~^ unnecessary_fold
+    let _ = (1..=3).sum::<i32>();
+    //~^ unnecessary_fold
+    let _ = (2..=3).product::<i32>();
+    //~^ unnecessary_fold
+    let _ = (1..=3).sum::<i32>();
+    //~^ unnecessary_fold
+
+    let _ = (0..3).any(|x| x > 2);
+    //~^ unnecessary_fold
+    let _ = (0..3).all(|x| x > 2);
+    //~^ unnecessary_fold
+    let _ = (0..3).sum::<i32>();
+    //~^ unnecessary_fold
+    let _ = (0..3).product::<i32>();
+    //~^ unnecessary_fold
 }
 
 fn wrongly_unmangled_macros() {

--- a/tests/ui/unnecessary_fold.rs
+++ b/tests/ui/unnecessary_fold.rs
@@ -88,16 +88,6 @@ fn unnecessary_fold_should_ignore() {
     let _: i32 = (0..3).fold(0, FakeAdd::add);
     let _: i32 = (0..3).fold(1, FakeMul::mul);
 
-    // We only match against an accumulator on the left
-    // hand side. We could lint for .sum and .product when
-    // it's on the right, but don't for now (and this wouldn't
-    // be valid if we extended the lint to cover arbitrary numeric
-    // types).
-    let _ = (0..3).fold(false, |acc, x| x > 2 || acc);
-    let _ = (0..3).fold(true, |acc, x| x > 2 && acc);
-    let _ = (0..3).fold(0, |acc, x| x + acc);
-    let _ = (0..3).fold(1, |acc, x| x * acc);
-
     let _ = [(0..2), (0..3)].iter().fold(0, |a, b| a + b.len());
     let _ = [(0..2), (0..3)].iter().fold(1, |a, b| a * b.len());
 }
@@ -176,6 +166,26 @@ fn issue10000() {
         (0..3).fold(1, |acc, x| acc * x)
         //~^ unnecessary_fold
     }
+}
+
+fn issue16581() {
+    let _ = (2..=3).fold(1, |a, b| a * b);
+    //~^ unnecessary_fold
+    let _ = (1..=3).fold(0, |a, b| a + b);
+    //~^ unnecessary_fold
+    let _ = (2..=3).fold(1, |b, a| a * b);
+    //~^ unnecessary_fold
+    let _ = (1..=3).fold(0, |b, a| a + b);
+    //~^ unnecessary_fold
+
+    let _ = (0..3).fold(false, |acc, x| x > 2 || acc);
+    //~^ unnecessary_fold
+    let _ = (0..3).fold(true, |acc, x| x > 2 && acc);
+    //~^ unnecessary_fold
+    let _ = (0..3).fold(0, |acc, x| x + acc);
+    //~^ unnecessary_fold
+    let _ = (0..3).fold(1, |acc, x| x * acc);
+    //~^ unnecessary_fold
 }
 
 fn wrongly_unmangled_macros() {

--- a/tests/ui/unnecessary_fold.stderr
+++ b/tests/ui/unnecessary_fold.stderr
@@ -70,7 +70,7 @@ LL |     let _: bool = (0..3).map(|x| 2 * x).fold(false, |acc, x| acc || x > 2);
    = note: the `any` method is short circuiting and may change the program semantics if the iterator has side effects
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:110:10
+  --> tests/ui/unnecessary_fold.rs:100:10
    |
 LL |         .fold(false, |acc, x| acc || x > 2);
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `any(|x| x > 2)`
@@ -78,138 +78,190 @@ LL |         .fold(false, |acc, x| acc || x > 2);
    = note: the `any` method is short circuiting and may change the program semantics if the iterator has side effects
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:123:33
+  --> tests/ui/unnecessary_fold.rs:113:33
    |
 LL |         assert_eq!(map.values().fold(0, |x, y| x + y), 0);
    |                                 ^^^^^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:127:30
+  --> tests/ui/unnecessary_fold.rs:117:30
    |
 LL |         let _ = map.values().fold(0, |x, y| x + y);
    |                              ^^^^^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:129:30
+  --> tests/ui/unnecessary_fold.rs:119:30
    |
 LL |         let _ = map.values().fold(0, Add::add);
    |                              ^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:131:30
+  --> tests/ui/unnecessary_fold.rs:121:30
    |
 LL |         let _ = map.values().fold(1, |x, y| x * y);
    |                              ^^^^^^^^^^^^^^^^^^^^^ help: try: `product::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:133:30
+  --> tests/ui/unnecessary_fold.rs:123:30
    |
 LL |         let _ = map.values().fold(1, Mul::mul);
    |                              ^^^^^^^^^^^^^^^^^ help: try: `product::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:135:35
+  --> tests/ui/unnecessary_fold.rs:125:35
    |
 LL |         let _: i32 = map.values().fold(0, |x, y| x + y);
    |                                   ^^^^^^^^^^^^^^^^^^^^^ help: try: `sum()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:137:35
+  --> tests/ui/unnecessary_fold.rs:127:35
    |
 LL |         let _: i32 = map.values().fold(0, Add::add);
    |                                   ^^^^^^^^^^^^^^^^^ help: try: `sum()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:139:35
+  --> tests/ui/unnecessary_fold.rs:129:35
    |
 LL |         let _: i32 = map.values().fold(1, |x, y| x * y);
    |                                   ^^^^^^^^^^^^^^^^^^^^^ help: try: `product()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:141:35
+  --> tests/ui/unnecessary_fold.rs:131:35
    |
 LL |         let _: i32 = map.values().fold(1, Mul::mul);
    |                                   ^^^^^^^^^^^^^^^^^ help: try: `product()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:143:31
+  --> tests/ui/unnecessary_fold.rs:133:31
    |
 LL |         anything(map.values().fold(0, |x, y| x + y));
    |                               ^^^^^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:145:31
+  --> tests/ui/unnecessary_fold.rs:135:31
    |
 LL |         anything(map.values().fold(0, Add::add));
    |                               ^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:147:31
+  --> tests/ui/unnecessary_fold.rs:137:31
    |
 LL |         anything(map.values().fold(1, |x, y| x * y));
    |                               ^^^^^^^^^^^^^^^^^^^^^ help: try: `product::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:149:31
+  --> tests/ui/unnecessary_fold.rs:139:31
    |
 LL |         anything(map.values().fold(1, Mul::mul));
    |                               ^^^^^^^^^^^^^^^^^ help: try: `product::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:151:26
+  --> tests/ui/unnecessary_fold.rs:141:26
    |
 LL |         num(map.values().fold(0, |x, y| x + y));
    |                          ^^^^^^^^^^^^^^^^^^^^^ help: try: `sum()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:153:26
+  --> tests/ui/unnecessary_fold.rs:143:26
    |
 LL |         num(map.values().fold(0, Add::add));
    |                          ^^^^^^^^^^^^^^^^^ help: try: `sum()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:155:26
+  --> tests/ui/unnecessary_fold.rs:145:26
    |
 LL |         num(map.values().fold(1, |x, y| x * y));
    |                          ^^^^^^^^^^^^^^^^^^^^^ help: try: `product()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:157:26
+  --> tests/ui/unnecessary_fold.rs:147:26
    |
 LL |         num(map.values().fold(1, Mul::mul));
    |                          ^^^^^^^^^^^^^^^^^ help: try: `product()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:164:16
+  --> tests/ui/unnecessary_fold.rs:154:16
    |
 LL |         (0..3).fold(0, |acc, x| acc + x)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `sum()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:168:16
+  --> tests/ui/unnecessary_fold.rs:158:16
    |
 LL |         (0..3).fold(1, |acc, x| acc * x)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `product()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:172:16
+  --> tests/ui/unnecessary_fold.rs:162:16
    |
 LL |         (0..3).fold(0, |acc, x| acc + x)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:176:16
+  --> tests/ui/unnecessary_fold.rs:166:16
    |
 LL |         (0..3).fold(1, |acc, x| acc * x)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `product::<i32>()`
 
 error: this `.fold` can be written more succinctly using another method
-  --> tests/ui/unnecessary_fold.rs:188:20
+  --> tests/ui/unnecessary_fold.rs:172:21
+   |
+LL |     let _ = (2..=3).fold(1, |a, b| a * b);
+   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `product::<i32>()`
+
+error: this `.fold` can be written more succinctly using another method
+  --> tests/ui/unnecessary_fold.rs:174:21
+   |
+LL |     let _ = (1..=3).fold(0, |a, b| a + b);
+   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
+
+error: this `.fold` can be written more succinctly using another method
+  --> tests/ui/unnecessary_fold.rs:176:21
+   |
+LL |     let _ = (2..=3).fold(1, |b, a| a * b);
+   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `product::<i32>()`
+
+error: this `.fold` can be written more succinctly using another method
+  --> tests/ui/unnecessary_fold.rs:178:21
+   |
+LL |     let _ = (1..=3).fold(0, |b, a| a + b);
+   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
+
+error: this `.fold` can be written more succinctly using another method
+  --> tests/ui/unnecessary_fold.rs:181:20
+   |
+LL |     let _ = (0..3).fold(false, |acc, x| x > 2 || acc);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `any(|x| x > 2)`
+   |
+   = note: the `any` method is short circuiting and may change the program semantics if the iterator has side effects
+
+error: this `.fold` can be written more succinctly using another method
+  --> tests/ui/unnecessary_fold.rs:183:20
+   |
+LL |     let _ = (0..3).fold(true, |acc, x| x > 2 && acc);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `all(|x| x > 2)`
+   |
+   = note: the `all` method is short circuiting and may change the program semantics if the iterator has side effects
+
+error: this `.fold` can be written more succinctly using another method
+  --> tests/ui/unnecessary_fold.rs:185:20
+   |
+LL |     let _ = (0..3).fold(0, |acc, x| x + acc);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `sum::<i32>()`
+
+error: this `.fold` can be written more succinctly using another method
+  --> tests/ui/unnecessary_fold.rs:187:20
+   |
+LL |     let _ = (0..3).fold(1, |acc, x| x * acc);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `product::<i32>()`
+
+error: this `.fold` can be written more succinctly using another method
+  --> tests/ui/unnecessary_fold.rs:198:20
    |
 LL |     let _ = (0..3).fold(false, |acc: bool, x| acc || test_expr!(x));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `any(|x| test_expr!(x))`
    |
    = note: the `any` method is short circuiting and may change the program semantics if the iterator has side effects
 
-error: aborting due to 33 previous errors
+error: aborting due to 41 previous errors
 


### PR DESCRIPTION
To be honest, the changes are confusing. 

First of all, it has already been stated that it would be wrong if we extended the lint to cover both sides.
https://github.com/rust-lang/rust-clippy/blob/18e5b2db4a3f9de20aa472d5c46a855e3a31d5c4/tests/ui/unnecessary_fold.rs#L91-L95

Secondly, there is some monstrous expression in the `get_triggered_expr_span` function, and I think it could be rewritten more cleanly.

Anyway, even if it has to be implemented, I'm glad to rewrite it more thoroughly.

Fixes rust-lang/rust-clippy#16581.

----

changelog: [`unnecessary_fold`]: match against an accumulator on both sides.
