### PR TITLE
Add `allow-unwrap-types` configuration for `unwrap_used` and `expect_used`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7234,6 +7234,7 @@ Released 2018-09-13
 [`allow-renamed-params-for`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-renamed-params-for
 [`allow-unwrap-in-consts`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-unwrap-in-consts
 [`allow-unwrap-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-unwrap-in-tests
+[`allow-unwrap-types`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-unwrap-types
 [`allow-useless-vec-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-useless-vec-in-tests
 [`allowed-dotfiles`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allowed-dotfiles
 [`allowed-duplicate-crates`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allowed-duplicate-crates

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -214,6 +214,23 @@ Whether `unwrap` should be allowed in test functions or `#[cfg(test)]`
 * [`unwrap_used`](https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_used)
 
 
+## `allow-unwrap-types`
+List of types to allow `unwrap()` and `expect()` on.
+
+#### Example
+
+```toml
+allow-unwrap-types = [ "std::sync::LockResult" ]
+```
+
+**Default Value:** `[]`
+
+---
+**Affected lints:**
+* [`expect_used`](https://rust-lang.github.io/rust-clippy/master/index.html#expect_used)
+* [`unwrap_used`](https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_used)
+
+
 ## `allow-useless-vec-in-tests`
 Whether `useless_vec` should ignore test functions or `#[cfg(test)]`
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -413,6 +413,15 @@ define_Conf! {
     /// Whether `unwrap` should be allowed in test functions or `#[cfg(test)]`
     #[lints(unwrap_used)]
     allow_unwrap_in_tests: bool = false,
+    /// List of types to allow `unwrap()` and `expect()` on.
+    ///
+    /// #### Example
+    ///
+    /// ```toml
+    /// allow-unwrap-types = [ "std::sync::LockResult" ]
+    /// ```
+    #[lints(expect_used, unwrap_used)]
+    allow_unwrap_types: Vec<String> = Vec::new(),
     /// Whether `useless_vec` should ignore test functions or `#[cfg(test)]`
     #[lints(useless_vec)]
     allow_useless_vec_in_tests: bool = false,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4760,6 +4760,7 @@ pub struct Methods {
     allow_unwrap_in_consts: bool,
     allowed_dotfiles: FxHashSet<&'static str>,
     format_args: FormatArgsStorage,
+    allow_unwrap_types: Vec<String>,
 }
 
 impl Methods {
@@ -4776,6 +4777,7 @@ impl Methods {
             allow_unwrap_in_consts: conf.allow_unwrap_in_consts,
             allowed_dotfiles,
             format_args,
+            allow_unwrap_types: conf.allow_unwrap_types.clone(),
         }
     }
 }
@@ -4974,6 +4976,7 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
                     self.allow_expect_in_tests,
                     self.allow_unwrap_in_consts,
                     self.allow_expect_in_consts,
+                    &self.allow_unwrap_types,
                 );
             },
             ExprKind::MethodCall(..) => {
@@ -5722,6 +5725,7 @@ impl Methods {
                         false,
                         self.allow_expect_in_consts,
                         self.allow_expect_in_tests,
+                        &self.allow_unwrap_types,
                         unwrap_expect_used::Variant::Expect,
                     );
                     expect_fun_call::check(cx, &self.format_args, expr, method_span, recv, arg);
@@ -5734,6 +5738,7 @@ impl Methods {
                         true,
                         self.allow_expect_in_consts,
                         self.allow_expect_in_tests,
+                        &self.allow_unwrap_types,
                         unwrap_expect_used::Variant::Expect,
                     );
                 },
@@ -5754,6 +5759,7 @@ impl Methods {
                         false,
                         self.allow_unwrap_in_consts,
                         self.allow_unwrap_in_tests,
+                        &self.allow_unwrap_types,
                         unwrap_expect_used::Variant::Unwrap,
                     );
                 },
@@ -5765,6 +5771,7 @@ impl Methods {
                         true,
                         self.allow_unwrap_in_consts,
                         self.allow_unwrap_in_tests,
+                        &self.allow_unwrap_types,
                         unwrap_expect_used::Variant::Unwrap,
                     );
                 },

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -18,6 +18,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            allow-renamed-params-for
            allow-unwrap-in-consts
            allow-unwrap-in-tests
+           allow-unwrap-types
            allow-useless-vec-in-tests
            allowed-dotfiles
            allowed-duplicate-crates
@@ -118,6 +119,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            allow-renamed-params-for
            allow-unwrap-in-consts
            allow-unwrap-in-tests
+           allow-unwrap-types
            allow-useless-vec-in-tests
            allowed-dotfiles
            allowed-duplicate-crates
@@ -218,6 +220,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            allow-renamed-params-for
            allow-unwrap-in-consts
            allow-unwrap-in-tests
+           allow-unwrap-types
            allow-useless-vec-in-tests
            allowed-dotfiles
            allowed-duplicate-crates

--- a/tests/ui-toml/unwrap_used_allowed/clippy.toml
+++ b/tests/ui-toml/unwrap_used_allowed/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-types = ["std::sync::LockResult"]

--- a/tests/ui-toml/unwrap_used_allowed/unwrap_used_allowed.rs
+++ b/tests/ui-toml/unwrap_used_allowed/unwrap_used_allowed.rs
@@ -1,0 +1,20 @@
+#![warn(clippy::unwrap_used)]
+#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(unused_variables)]
+use std::sync::Mutex;
+
+fn main() {
+    let m = Mutex::new(0);
+    // This is allowed because `LockResult` is configured!
+    let _guard = m.lock().unwrap();
+
+    let optional: Option<i32> = Some(1);
+    // This is not allowed!
+    let _opt = optional.unwrap();
+    //~^ ERROR: used `unwrap()` on an `Option` value
+
+    let result: Result<i32, ()> = Ok(1);
+    // This is not allowed!
+    let _res = result.unwrap();
+    //~^ ERROR: used `unwrap()` on a `Result` value
+}

--- a/tests/ui-toml/unwrap_used_allowed/unwrap_used_allowed.stderr
+++ b/tests/ui-toml/unwrap_used_allowed/unwrap_used_allowed.stderr
@@ -1,0 +1,22 @@
+error: used `unwrap()` on an `Option` value
+  --> tests/ui-toml/unwrap_used_allowed/unwrap_used_allowed.rs:13:16
+   |
+LL |     let _opt = optional.unwrap();
+   |                ^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+   = help: consider using `expect()` to provide a better panic message
+   = note: `-D clippy::unwrap-used` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unwrap_used)]`
+
+error: used `unwrap()` on a `Result` value
+  --> tests/ui-toml/unwrap_used_allowed/unwrap_used_allowed.rs:18:16
+   |
+LL |     let _res = result.unwrap();
+   |                ^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Err`, it will panic
+   = help: consider using `expect()` to provide a better panic message
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION

rust-lang/rust-clippy#16535 

This PR introduces a new configuration option, `allow-unwrap-types`, which accepts a list of type paths (e.g., `["std::sync::LockResult"]`). When configured, calling `.unwrap()` or `.expect()` on values of these types will no longer trigger the `unwrap_used` or `expect_used` lints.

This is particularly useful for reducing noisy lints on patterns where unwrapping is widely considered acceptable or expected by design, such as obtaining a `std::sync::LockResult` from `Mutex::lock()`.

**Changes Made**
Introduced the `allow_unwrap_types: Vec<String>` field in `clippy_config`.
Updated the `unwrap_expect_used` lint to check the underlying evaluated expression `ty` against the configured allowed types.
Handled robust type alias resolution so that aliases like `std::sync::LockResult` accurately map to their underlying `Adt` types during lint evaluation.
Added UI tests in `tests/ui-toml/unwrap_used_allowed/` to verify both allowed and disallowed cases.


----

changelog: [`unwrap_used`], [`expect_used`]: Add `allow-unwrap-types` configuration to allow unwrapping specified types.
