### PR TITLE
book: describe Clippy walk up directory tree behavior when searching config

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -2,12 +2,16 @@
 
 > **Note:** The configuration file is unstable and may be deprecated in the future.
 
-Some lints can be configured in a TOML file named `clippy.toml` or `.clippy.toml`, which is searched for in:
+Some lints can be configured in a TOML file named `clippy.toml` or `.clippy.toml`, which is searched for starting in the
+first defined directory according to the following priority order:
 
 1. The directory specified by the `CLIPPY_CONF_DIR` environment variable, or
 2. The directory specified by the
 [CARGO_MANIFEST_DIR](https://doc.rust-lang.org/cargo/reference/environment-variables.html) environment variable, or
 3. The current directory.
+
+If the chosen directory does not contain a configuration file, Clippy will walk up the directory tree, searching each
+parent directory until it finds one or reaches the filesystem root.
 
 It contains a basic `variable = value` mapping e.g.
 


### PR DESCRIPTION
Reading the source code at
https://github.com/rust-lang/rust-clippy/blob/b3188b8a9f0f2df2ba58bfe9001fe4fe711cff74/clippy_config/src/conf.rs#L928-L974 clearly shows that Clippy also searches parent directories when looking for a configuration file. However, this behavior is not documented anywhere I could see in the Clippy book, despite being useful to end users. For example, end users can leverage this to share a single configuration file across all member packages of a Cargo workspace.

This change adds documentation for this behavior to the Clippy book.

changelog: none