### PR TITLE
Automate lint FCP Zulip topic creation with triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -61,7 +61,7 @@ labels = ["S-waiting-on-concerns"]
 threshold = 20
 
 [notify-zulip."lint-nominated"]
-zulip_stream = 257328 # #clippy
+zulip_stream = 577190 # #clippy/fcp
 topic = "FCP rust-clippy#{number}: {title}"
 # Zulip polls may not be preceded by any other text and pings & short links inside
 # the title of a poll don't get recognized. Therefore we need to send two messages.


### PR DESCRIPTION
As discussed in [#clippy > Automatic creation of FCP Zulip topics](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/Automatic.20creation.20of.20FCP.20Zulip.20topics/with/575155235), this PR configures triagebot to automatically create a Zulip topic in `#clippy` for lint nomination.

It is triggered by the `lint-nominated` label (need to be created).

In addition to containing a link to the pull request, the topic will also contain a Zulip poll with three per-determined answers: approve, decline, don't know.

cc @samueltardieu
r? @flip1995

changelog: none
