### PR TITLE
New lint: `manual_clear`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6771,6 +6771,7 @@ Released 2018-09-13
 [`manual_c_str_literals`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals
 [`manual_checked_ops`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_checked_ops
 [`manual_clamp`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp
+[`manual_clear`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_clear
 [`manual_contains`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_contains
 [`manual_dangling_ptr`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_dangling_ptr
 [`manual_div_ceil`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -411,6 +411,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::JOIN_ABSOLUTE_PATHS_INFO,
     crate::methods::LINES_FILTER_MAP_OK_INFO,
     crate::methods::MANUAL_C_STR_LITERALS_INFO,
+    crate::methods::MANUAL_CLEAR_INFO,
     crate::methods::MANUAL_CONTAINS_INFO,
     crate::methods::MANUAL_FILTER_MAP_INFO,
     crate::methods::MANUAL_FIND_MAP_INFO,

--- a/clippy_lints/src/methods/manual_clear.rs
+++ b/clippy_lints/src/methods/manual_clear.rs
@@ -1,0 +1,30 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::res::MaybeDef;
+use clippy_utils::{is_integer_literal, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, LangItem};
+use rustc_lint::LateContext;
+use rustc_span::Span;
+
+use super::MANUAL_CLEAR;
+
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg: &Expr<'_>, method_span: Span) {
+    let ty = cx.typeck_results().expr_ty_adjusted(recv);
+    let ty = ty.peel_refs();
+
+    let diag_name = ty.ty_adt_def().and_then(|def| cx.tcx.get_diagnostic_name(def.did()));
+
+    if (matches!(diag_name, Some(sym::Vec | sym::VecDeque | sym::OsString)) || ty.is_lang_item(cx, LangItem::String))
+        && is_integer_literal(arg, 0)
+    {
+        span_lint_and_then(cx, MANUAL_CLEAR, expr.span, "truncating to zero length", |diag| {
+            // Keep the receiver as-is and only rewrite the method.
+            diag.span_suggestion_verbose(
+                method_span.with_hi(expr.span.hi()),
+                "use `clear()` instead",
+                "clear()",
+                Applicability::MachineApplicable,
+            );
+        });
+    }
+}

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -58,6 +58,7 @@ mod join_absolute_paths;
 mod lib;
 mod lines_filter_map_ok;
 mod manual_c_str_literals;
+mod manual_clear;
 mod manual_contains;
 mod manual_inspect;
 mod manual_is_variant_and;
@@ -1762,6 +1763,31 @@ declare_clippy_lint! {
     pub MANUAL_C_STR_LITERALS,
     complexity,
     r#"creating a `CStr` through functions when `c""` literals can be used"#
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `.truncate(0)` calls on standard library types where it can be replaced with `.clear()`.
+    ///
+    /// Currently this includes `Vec`, `VecDeque`, `String`, and `OsString`.
+    ///
+    /// ### Why is this bad?
+    /// `clear()` expresses the intent better and is likely to be more efficient than `truncate(0)`.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let mut v = vec![1, 2, 3];
+    /// v.truncate(0);
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let mut v = vec![1, 2, 3];
+    /// v.clear();
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub MANUAL_CLEAR,
+    perf,
+    "using `truncate(0)` instead of `clear()`"
 }
 
 declare_clippy_lint! {
@@ -4806,6 +4832,7 @@ impl_lint_pass!(Methods => [
     ITER_WITH_DRAIN,
     JOIN_ABSOLUTE_PATHS,
     LINES_FILTER_MAP_OK,
+    MANUAL_CLEAR,
     MANUAL_CONTAINS,
     MANUAL_C_STR_LITERALS,
     MANUAL_FILTER_MAP,
@@ -5774,6 +5801,9 @@ impl Methods {
                 },
                 (sym::to_string, []) => {
                     inefficient_to_string::check(cx, expr, recv, self.msrv);
+                },
+                (sym::truncate, [arg]) => {
+                    manual_clear::check(cx, expr, recv, arg, method_span);
                 },
                 (sym::unwrap, []) => {
                     unwrap_expect_used::check(

--- a/tests/ui/manual_clear.fixed
+++ b/tests/ui/manual_clear.fixed
@@ -1,0 +1,54 @@
+#![feature(os_string_truncate)]
+#![warn(clippy::manual_clear)]
+
+use std::collections::VecDeque;
+use std::ffi::OsString;
+
+struct CustomTruncate(String);
+
+impl CustomTruncate {
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
+fn main() {
+    let mut v = vec![1, 2, 3];
+    v.clear(); //~ manual_clear
+
+    let mut d: VecDeque<i32> = VecDeque::from([1, 2, 3]);
+    d.clear(); //~ manual_clear
+
+    // lint: macro receiver
+    macro_rules! get_vec {
+        ($e:expr) => {
+            $e
+        };
+    }
+    get_vec!(v).clear(); //~ manual_clear
+
+    // no lint: other args
+    v.truncate(1);
+
+    // no lint: `0` from a different context
+    {
+        // `0` inside a block expression should not be changed into `clear()`
+        v.truncate({ 0 });
+    }
+
+    // lint: String
+    let mut s = String::from("abc");
+    s.clear(); //~ manual_clear
+
+    // lint: OsString
+    let mut os = OsString::from("abc");
+    os.clear(); //~ manual_clear
+
+    // no lint: custom type
+    let mut c = CustomTruncate(String::from("abc"));
+    c.truncate(0);
+}

--- a/tests/ui/manual_clear.rs
+++ b/tests/ui/manual_clear.rs
@@ -1,0 +1,54 @@
+#![feature(os_string_truncate)]
+#![warn(clippy::manual_clear)]
+
+use std::collections::VecDeque;
+use std::ffi::OsString;
+
+struct CustomTruncate(String);
+
+impl CustomTruncate {
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
+fn main() {
+    let mut v = vec![1, 2, 3];
+    v.truncate(0); //~ manual_clear
+
+    let mut d: VecDeque<i32> = VecDeque::from([1, 2, 3]);
+    d.truncate(0); //~ manual_clear
+
+    // lint: macro receiver
+    macro_rules! get_vec {
+        ($e:expr) => {
+            $e
+        };
+    }
+    get_vec!(v).truncate(0); //~ manual_clear
+
+    // no lint: other args
+    v.truncate(1);
+
+    // no lint: `0` from a different context
+    {
+        // `0` inside a block expression should not be changed into `clear()`
+        v.truncate({ 0 });
+    }
+
+    // lint: String
+    let mut s = String::from("abc");
+    s.truncate(0); //~ manual_clear
+
+    // lint: OsString
+    let mut os = OsString::from("abc");
+    os.truncate(0); //~ manual_clear
+
+    // no lint: custom type
+    let mut c = CustomTruncate(String::from("abc"));
+    c.truncate(0);
+}

--- a/tests/ui/manual_clear.stderr
+++ b/tests/ui/manual_clear.stderr
@@ -1,0 +1,64 @@
+error: truncating to zero length
+  --> tests/ui/manual_clear.rs:21:5
+   |
+LL |     v.truncate(0);
+   |     ^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::manual-clear` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_clear)]`
+help: use `clear()` instead
+   |
+LL -     v.truncate(0);
+LL +     v.clear();
+   |
+
+error: truncating to zero length
+  --> tests/ui/manual_clear.rs:24:5
+   |
+LL |     d.truncate(0);
+   |     ^^^^^^^^^^^^^
+   |
+help: use `clear()` instead
+   |
+LL -     d.truncate(0);
+LL +     d.clear();
+   |
+
+error: truncating to zero length
+  --> tests/ui/manual_clear.rs:32:5
+   |
+LL |     get_vec!(v).truncate(0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `clear()` instead
+   |
+LL -     get_vec!(v).truncate(0);
+LL +     get_vec!(v).clear();
+   |
+
+error: truncating to zero length
+  --> tests/ui/manual_clear.rs:45:5
+   |
+LL |     s.truncate(0);
+   |     ^^^^^^^^^^^^^
+   |
+help: use `clear()` instead
+   |
+LL -     s.truncate(0);
+LL +     s.clear();
+   |
+
+error: truncating to zero length
+  --> tests/ui/manual_clear.rs:49:5
+   |
+LL |     os.truncate(0);
+   |     ^^^^^^^^^^^^^^
+   |
+help: use `clear()` instead
+   |
+LL -     os.truncate(0);
+LL +     os.clear();
+   |
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
This proposes replacing calls to `.truncate(0)` for types in the standard library by `.clear()`, as the specialized version might be more efficient.

changelog: [`manual_clear`]: new lint

Closes rust-lang/rust-clippy#16615