### PR TITLE
changelog_update.md: update name of rust primary branch

### DIFF
--- a/book/src/development/infrastructure/changelog_update.md
+++ b/book/src/development/infrastructure/changelog_update.md
@@ -28,8 +28,8 @@ bullet points might be helpful:
   check out the Clippy commit of the current Rust `beta` branch.
   [Link][rust_beta_tools]
 * When writing the release notes for the **upcoming beta release**, you need to
-  check out the Clippy commit of the current Rust `master`.
-  [Link][rust_master_tools]
+  check out the Clippy commit of the current Rust `main`.
+  [Link][rust_main_tools]
 * When writing the (forgotten) release notes for a **past stable release**, you
   need to check out the Rust release tag of the stable release.
   [Link][rust_stable_tools]
@@ -112,7 +112,7 @@ written for. If not, update the version to the changelog version.
 
 [changelog]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md
 [forge]: https://forge.rust-lang.org/
-[rust_master_tools]: https://github.com/rust-lang/rust/tree/HEAD/src/tools/clippy
+[rust_main_tools]: https://github.com/rust-lang/rust/tree/HEAD/src/tools/clippy
 [rust_beta_tools]: https://github.com/rust-lang/rust/tree/beta/src/tools/clippy
 [rust_stable_tools]: https://github.com/rust-lang/rust/releases
 [`beta-accepted`]: https://github.com/rust-lang/rust-clippy/issues?q=label%3Abeta-accepted+


### PR DESCRIPTION
Use `main` rather than `master` in the text explaining the link - the link was updated previously, but not the description. Also internally update the link name for consistency.

changelog: none
