### PR TITLE
Do not suggest removing reborrow of a captured upvar

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1144,6 +1144,27 @@ pub fn get_enclosing_block<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Optio
     })
 }
 
+/// Returns the [`Closure`] enclosing `hir_id`, if any.
+pub fn get_enclosing_closure<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Option<&'tcx Closure<'tcx>> {
+    cx.tcx.hir_parent_iter(hir_id).find_map(|(_, node)| {
+        if let Node::Expr(expr) = node
+            && let ExprKind::Closure(closure) = expr.kind
+        {
+            Some(closure)
+        } else {
+            None
+        }
+    })
+}
+
+/// Checks whether a local identified by `local_id` is captured as an upvar by the given `closure`.
+pub fn is_upvar_in_closure(cx: &LateContext<'_>, closure: &Closure<'_>, local_id: HirId) -> bool {
+    cx.typeck_results()
+        .closure_min_captures
+        .get(&closure.def_id)
+        .is_some_and(|x| x.contains_key(&local_id))
+}
+
 /// Gets the loop or closure enclosing the given expression, if any.
 pub fn get_enclosing_loop_or_multi_call_closure<'tcx>(
     cx: &LateContext<'tcx>,

--- a/tests/ui/borrow_deref_ref.fixed
+++ b/tests/ui/borrow_deref_ref.fixed
@@ -171,3 +171,27 @@ fn issue_14934() {
         //~^ borrow_deref_ref
     }
 }
+
+mod issue16556 {
+    use std::pin::Pin;
+
+    async fn async_main() {
+        for_each_city(|city| {
+            Box::pin(async {
+                // Do not lint, as it would not compile without reborrowing
+                let city = &*city;
+                println!("{city}")
+            })
+        })
+        .await;
+    }
+
+    async fn for_each_city<F>(mut f: F)
+    where
+        F: for<'c> FnMut(&'c str) -> Pin<Box<dyn Future<Output = ()> + Send + 'c>>,
+    {
+        for x in ["New York", "London", "Tokyo"] {
+            f(x).await;
+        }
+    }
+}

--- a/tests/ui/borrow_deref_ref.rs
+++ b/tests/ui/borrow_deref_ref.rs
@@ -171,3 +171,27 @@ fn issue_14934() {
         //~^ borrow_deref_ref
     }
 }
+
+mod issue16556 {
+    use std::pin::Pin;
+
+    async fn async_main() {
+        for_each_city(|city| {
+            Box::pin(async {
+                // Do not lint, as it would not compile without reborrowing
+                let city = &*city;
+                println!("{city}")
+            })
+        })
+        .await;
+    }
+
+    async fn for_each_city<F>(mut f: F)
+    where
+        F: for<'c> FnMut(&'c str) -> Pin<Box<dyn Future<Output = ()> + Send + 'c>>,
+    {
+        for x in ["New York", "London", "Tokyo"] {
+            f(x).await;
+        }
+    }
+}


### PR DESCRIPTION
changelog: [`borrow_deref_ref`]: do not suggest removing an explicit reborrow when it targets an upvar captured by a closure

Fixes rust-lang/rust-clippy#16556 

r? Jarcho