### PR TITLE
Revert "Fix the compile-test tests when setting Cargo's `build.build-dir` setting to a path that's distinct from `target-dir`."

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -197,6 +197,10 @@ impl TestContext {
             defaults.set_custom("diagnostic-collector", collector);
         }
         config.with_args(&self.args);
+        let current_exe_path = env::current_exe().unwrap();
+        let deps_path = current_exe_path.parent().unwrap();
+        let profile_path = deps_path.parent().unwrap();
+
         config.program.args.extend(
             [
                 "--emit=metadata",
@@ -220,7 +224,6 @@ impl TestContext {
             config.program.args.push(format!("--sysroot={sysroot}").into());
         }
 
-        let profile_path = target_dir.join(env!("PROFILE"));
         config.program.program = profile_path.join(if cfg!(windows) {
             "clippy-driver.exe"
         } else {


### PR DESCRIPTION
This reverts commit 2737b26c2e5eee9229663552d0c70e2affbb8511 as it prevents Clippy tests from passing when running inside the compiler repository.

changelog: none

r? @flip1995 