### PR TITLE
Fix collapsible_match false negative on if let chains (#16570)

### DIFF
--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -31,9 +31,10 @@ pub(super) fn check_if_let<'tcx>(
     body: &'tcx Expr<'_>,
     else_expr: Option<&'tcx Expr<'_>>,
     let_expr: &'tcx Expr<'_>,
+    outer_guard: Option<&'tcx Expr<'tcx>>,
     msrv: Msrv,
 ) {
-    check_arm(cx, false, pat, let_expr, body, None, else_expr, msrv);
+    check_arm(cx, false, pat, let_expr, body, outer_guard, else_expr, msrv);
 }
 
 #[expect(clippy::too_many_arguments, clippy::too_many_lines)]

--- a/clippy_lints/src/option_if_let_else.rs
+++ b/clippy_lints/src/option_if_let_else.rs
@@ -329,7 +329,7 @@ fn try_get_inner_pat_and_is_result<'tcx>(cx: &LateContext<'tcx>, pat: &Pat<'tcx>
 /// If this expression is the option if let/else construct we're detecting, then
 /// this function returns an `OptionOccurrence` struct with details if
 /// this construct is found, or None if this construct is not found.
-fn detect_option_if_let_else<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) -> Option<OptionOccurrence> {
+fn detect_option_if_let_else<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> Option<OptionOccurrence> {
     if let Some(higher::IfLet {
         let_pat,
         let_expr,
@@ -391,7 +391,7 @@ fn is_none_or_err_arm(cx: &LateContext<'_>, arm: &Arm<'_>) -> bool {
 }
 
 impl<'tcx> LateLintPass<'tcx> for OptionIfLetElse {
-    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         // Don't lint macros and constants
         if expr.span.from_expansion() || is_in_const_context(cx) {
             return;

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -466,7 +466,7 @@ fn check_if_try_match<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
     }
 }
 
-fn check_if_let_some_or_err_and_early_return<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+fn check_if_let_some_or_err_and_early_return<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
     if let Some(higher::IfLet {
         let_pat,
         let_expr,

--- a/tests/ui/issue_16570.rs
+++ b/tests/ui/issue_16570.rs
@@ -1,0 +1,30 @@
+#![allow(clippy::collapsible_else_if, stable_features)]
+#![allow(dead_code)]
+
+fn main() {
+    let opt = Some(Some(1));
+
+    // This should trigger collapsible_match
+    let _ = if true && let Some(inner) = opt {
+        match inner {
+            //~^ ERROR: this `match` can be collapsed into the outer `if let`
+            Some(_) => 0,
+            _ => 1,
+        }
+    } else {
+        1
+    };
+
+    // Another case with multiple let chains
+    let _ = if let Some(inner_opt) = opt
+        && let Some(inner) = inner_opt
+    {
+        match inner {
+            //~^ ERROR: this `match` can be collapsed into the outer `if let`
+            1 => 0,
+            _ => 1,
+        }
+    } else {
+        1
+    };
+}

--- a/tests/ui/issue_16570.stderr
+++ b/tests/ui/issue_16570.stderr
@@ -1,0 +1,42 @@
+error: this `match` can be collapsed into the outer `if let`
+  --> tests/ui/issue_16570.rs:9:9
+   |
+LL | /         match inner {
+LL | |
+LL | |             Some(_) => 0,
+LL | |             _ => 1,
+LL | |         }
+   | |_________^
+   |
+help: the outer pattern can be modified to include the inner pattern
+  --> tests/ui/issue_16570.rs:8:33
+   |
+LL |     let _ = if true && let Some(inner) = opt {
+   |                                 ^^^^^ replace this binding
+...
+LL |             Some(_) => 0,
+   |             ^^^^^^^ with this pattern
+   = note: `-D clippy::collapsible-match` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::collapsible_match)]`
+
+error: this `match` can be collapsed into the outer `if let`
+  --> tests/ui/issue_16570.rs:22:9
+   |
+LL | /         match inner {
+LL | |
+LL | |             1 => 0,
+LL | |             _ => 1,
+LL | |         }
+   | |_________^
+   |
+help: the outer pattern can be modified to include the inner pattern
+  --> tests/ui/issue_16570.rs:20:21
+   |
+LL |         && let Some(inner) = inner_opt
+   |                     ^^^^^ replace this binding
+...
+LL |             1 => 0,
+   |             ^ with this pattern
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fix `collapsible_match` false negative when the outer match is inside an `if let` chain.

Previously, `collapsible_match` only checked simple `if let` expressions. This PR adds support for [let](cci:1://file:///home/pankaj/turbine/rust-foundation/rust-clippy/clippy_utils/src/higher.rs:557:0-565:1) chains (e.g., `if true && let Some(x) = opt { match x { ... } }`) by:

- Adding `IfLet::hir_all()` to [clippy_utils/src/higher.rs](cci:7://file:///home/pankaj/turbine/rust-foundation/rust-clippy/clippy_utils/src/higher.rs:0:0-0:0) to parse all [let](cci:1://file:///home/pankaj/turbine/rust-foundation/rust-clippy/clippy_utils/src/higher.rs:557:0-565:1) bindings in an [if](cci:1://file:///home/pankaj/turbine/rust-foundation/rust-clippy/clippy_lints/src/matches/collapsible_match.rs:27:0-37:1) condition
- Updating [matches/mod.rs](cci:7://file:///home/pankaj/turbine/rust-foundation/rust-clippy/clippy_lints/src/matches/mod.rs:0:0-0:0) to iterate over all [let](cci:1://file:///home/pankaj/turbine/rust-foundation/rust-clippy/clippy_utils/src/higher.rs:557:0-565:1) bindings in a chain
- Passing the full [if](cci:1://file:///home/pankaj/turbine/rust-foundation/rust-clippy/clippy_lints/src/matches/collapsible_match.rs:27:0-37:1) condition as an `outer_guard` to [check_if_let](cci:1://file:///home/pankaj/turbine/rust-foundation/rust-clippy/clippy_lints/src/matches/collapsible_match.rs:27:0-37:1) so the binding isn't incorrectly collapsed when used elsewhere in the chain

fixes rust-lang/rust-clippy#16570

@profetia 

changelog: [`collapsible_match`]: Fix false negative when match is inside an `if let` chain
