### PR TITLE
Fix the compile-test tests for `build.build-dir` that's distinct from `target-dir`

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -197,9 +197,6 @@ impl TestContext {
             defaults.set_custom("diagnostic-collector", collector);
         }
         config.with_args(&self.args);
-        let current_exe_path = env::current_exe().unwrap();
-        let deps_path = current_exe_path.parent().unwrap();
-        let profile_path = deps_path.parent().unwrap();
 
         config.program.args.extend(
             [
@@ -224,11 +221,7 @@ impl TestContext {
             config.program.args.push(format!("--sysroot={sysroot}").into());
         }
 
-        config.program.program = profile_path.join(if cfg!(windows) {
-            "clippy-driver.exe"
-        } else {
-            "clippy-driver"
-        });
+        config.program.program = PathBuf::from(env!("CARGO_BIN_EXE_clippy-driver"));
 
         config
     }

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -3,11 +3,6 @@
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-pub static CARGO_CLIPPY_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
-    let mut path = std::env::current_exe().unwrap();
-    assert!(path.pop()); // deps
-    path.set_file_name("cargo-clippy");
-    path
-});
+pub static CARGO_CLIPPY_PATH: LazyLock<PathBuf> = LazyLock::new(|| PathBuf::from(env!("CARGO_BIN_EXE_cargo-clippy")));
 
 pub const IS_RUSTC_TEST_SUITE: bool = option_env!("RUSTC_TEST_SUITE").is_some();


### PR DESCRIPTION
Second attempt after the previous revert in https://github.com/rust-lang/rust-clippy/pull/16623.
Fixes rust-lang/rust-clippy#16567.

This time I'm using an env var of the `CARGO_BIN_EXE_*` class, to determine the correct path to the `clippy-driver` executable. This is a simpler change that, conveniently enough, also fixes the build within rust-lang/rust. I verified that it does.

Also, extend the fix to `CARGO_CLIPPY_PATH` in tests/test_utils, which also fixes the dogfood tests in environments with a custom `build.build-dir`.

Over all, this fixes the compile-test tests and dogfood tests, which presently don't run when Cargo's `build.build-dir` is set to a path that's distinct from `target-dir`. Right now, the uitest harness assumes that `clippy-driver` (a final build artifact) is located in the parent directory of `compile_test-…` (an intermediate artifact or, rather, a dependency's final artifact), and that doesn't hold when `build-dir` is configured independently from `target-dir`, like so (in ~/.cargo/config.toml):

```toml
[build]
build-dir = "{cargo-cache-home}/build-artifacts/{workspace-path-hash}"
```

changelog: none

r? @samueltardieu 