### PR TITLE
Fix `cmp_owned` suggests wrongly on `PathBuf`

### DIFF
--- a/clippy_lints/src/operators/cmp_owned.rs
+++ b/clippy_lints/src/operators/cmp_owned.rs
@@ -100,10 +100,10 @@ fn check_op(cx: &LateContext<'_>, outer: &Expr<'_>, expr: &Expr<'_>, other: &Exp
 
             let mut applicability = Applicability::MachineApplicable;
             let (arg_snip, _) = snippet_with_context(cx, arg_span, expr.span.ctxt(), "..", &mut applicability);
-            let (expr_snip, eq_impl) = if with_deref.is_implemented() && !arg_ty.peel_refs().is_str() {
-                (format!("*{arg_snip}"), with_deref)
-            } else {
+            let (expr_snip, eq_impl) = if without_deref.is_implemented() {
                 (arg_snip.to_string(), without_deref)
+            } else {
+                (format!("*{arg_snip}"), with_deref)
             };
 
             let (span, hint) = if (eq_impl.ty_eq_other && left) || (eq_impl.other_eq_ty && !left) {

--- a/tests/ui/cmp_owned/with_suggestion.fixed
+++ b/tests/ui/cmp_owned/with_suggestion.fixed
@@ -150,3 +150,11 @@ fn issue16458() {
         required_version: String, m!().to_string();
     }
 }
+
+fn issue16564(path: std::path::PathBuf) {
+    const ROOT: &str = "root";
+    if path != *ROOT {
+        //~^ cmp_owned
+        todo!()
+    }
+}

--- a/tests/ui/cmp_owned/with_suggestion.rs
+++ b/tests/ui/cmp_owned/with_suggestion.rs
@@ -150,3 +150,11 @@ fn issue16458() {
         required_version: String, m!().to_string();
     }
 }
+
+fn issue16564(path: std::path::PathBuf) {
+    const ROOT: &str = "root";
+    if path != std::path::PathBuf::from(ROOT) {
+        //~^ cmp_owned
+        todo!()
+    }
+}

--- a/tests/ui/cmp_owned/with_suggestion.stderr
+++ b/tests/ui/cmp_owned/with_suggestion.stderr
@@ -68,5 +68,11 @@ LL | |     }
    |
    = note: this error originates in the macro `all_comes_from_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 10 previous errors
+error: this creates an owned instance just for comparison
+  --> tests/ui/cmp_owned/with_suggestion.rs:156:16
+   |
+LL |     if path != std::path::PathBuf::from(ROOT) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `*ROOT`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16448
Closes rust-lang/rust-clippy#16564

The previous implementation hardcoded bans on `str` to avoid adding `*` when comparing with `String`, which becomes a problem for `Pathbuf` as `PartialEq<&str>` is not yet implemented on it.

changelog: [`cmp_owned`] fix wrong suggestions on `PathBuf`
