### PR TITLE
Fix `needless_borrows_for_generic_args` FP for mutable borrows of arrays

### DIFF
--- a/tests/ui/needless_borrows_for_generic_args.fixed
+++ b/tests/ui/needless_borrows_for_generic_args.fixed
@@ -355,3 +355,16 @@ fn main() {
         }
     }
 }
+
+#[clippy::msrv = "1.53.0"]
+fn issue16538() {
+    fn use_mut<I>(data: I)
+    where
+        I: IntoIterator<Item: AsMut<[i32]>>,
+    {
+        data.into_iter().for_each(|mut s| s.as_mut()[0] *= 10);
+    }
+
+    let mut data = [[10, 20, 30], [40, 50, 60]];
+    use_mut(&mut data);
+}

--- a/tests/ui/needless_borrows_for_generic_args.rs
+++ b/tests/ui/needless_borrows_for_generic_args.rs
@@ -355,3 +355,16 @@ fn main() {
         }
     }
 }
+
+#[clippy::msrv = "1.53.0"]
+fn issue16538() {
+    fn use_mut<I>(data: I)
+    where
+        I: IntoIterator<Item: AsMut<[i32]>>,
+    {
+        data.into_iter().for_each(|mut s| s.as_mut()[0] *= 10);
+    }
+
+    let mut data = [[10, 20, 30], [40, 50, 60]];
+    use_mut(&mut data);
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16538

This lint should not warn on mutable borrows of arrays because unlike immutable borrows, the function may change the borrowed array and thus changing it will alter the intended behavior of the program.

changelog: [`needless_borrows_for_generic_args`] fix FP for mutable borrows of arrays
