### PR TITLE
Use `#[must_use]` determination from the compiler

### DIFF
--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_must_use_func_call;
 use clippy_utils::res::MaybeDef as _;
-use clippy_utils::ty::{is_copy, is_must_use_ty};
+use clippy_utils::ty::{is_copy, opt_must_use_path};
 use rustc_hir::{Arm, Expr, ExprKind, LangItem, Node};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
@@ -98,7 +98,7 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetRef {
                 sym::mem_drop
                     if !(arg_ty.needs_drop(cx.tcx, cx.typing_env())
                         || is_must_use_func_call(cx, arg)
-                        || is_must_use_ty(cx, arg_ty)
+                        || opt_must_use_path(cx, arg_ty).is_some()
                         || drop_is_single_call_in_arm) =>
                 {
                     (DROP_NON_DROP, DROP_NON_DROP_SUMMARY.into(), Some(arg.span))

--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -25,7 +25,7 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for a `#[must_use]` attribute without
     /// further information on functions and methods that return a type already
-    /// marked as `#[must_use]`.
+    /// considered as `#[must_use]`.
     ///
     /// ### Why is this bad?
     /// The attribute isn't needed. Not using the result
@@ -38,6 +38,12 @@ declare_clippy_lint! {
     /// fn double_must_use() -> Result<(), ()> {
     ///     unimplemented!();
     /// }
+    /// ```
+    ///
+    /// ### Note
+    /// The compiler may consider a type as being indirectly `#[must_use]`. For
+    /// example, although `Box<_>` itself is not `#[must_use]`, `Box<T>` will be
+    /// considered `#[must_use]` if `T` is.
     /// ```
     #[clippy::version = "1.40.0"]
     pub DOUBLE_MUST_USE,

--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -3,6 +3,7 @@ use rustc_errors::Applicability;
 use rustc_hir::def::Res;
 use rustc_hir::def_id::DefIdSet;
 use rustc_hir::{self as hir, Attribute, QPath, find_attr};
+use rustc_lint::unused::must_use::MustUsePath;
 use rustc_lint::{LateContext, LintContext as _};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::{Span, sym};
@@ -10,7 +11,7 @@ use rustc_span::{Span, sym};
 use clippy_utils::attrs::is_proc_macro;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::snippet_indent;
-use clippy_utils::ty::is_must_use_ty;
+use clippy_utils::ty::{describe_must_use_type, opt_must_use_path};
 use clippy_utils::visitors::for_each_expr_without_closures;
 use clippy_utils::{is_entrypoint_fn, return_ty, trait_ref_of_method};
 use rustc_span::Symbol;
@@ -160,11 +161,13 @@ fn check_needless_must_use(
                 }
             },
         );
-    } else if reason.is_none() && is_must_use_ty(cx, return_ty(cx, item_id)) {
+    } else if reason.is_none()
+        && let Some(return_must_use_path) = opt_must_use_path(cx, return_ty(cx, item_id))
+    {
         // Ignore async functions unless Future::Output type is a must_use type
         if sig.header.is_async()
             && let Some(future_ty) = cx.tcx.get_impl_future_output_ty(return_ty(cx, item_id))
-            && !is_must_use_ty(cx, future_ty)
+            && opt_must_use_path(cx, future_ty).is_none()
         {
             return;
         }
@@ -175,6 +178,16 @@ fn check_needless_must_use(
             fn_header_span,
             "this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`",
             |diag| {
+                // Add info about the reason why the return type is `#[must_use]` if it is a compound type.
+                if !matches!(return_must_use_path, MustUsePath::Def(..)) {
+                    diag.span_note(
+                        sig.decl.output.span(),
+                        format!(
+                            "the return type is {}",
+                            describe_must_use_type(cx, &return_must_use_path)
+                        ),
+                    );
+                }
                 // When there are multiple attributes, it is not sufficient to simply make `must_use` empty, see
                 // issue #12320.
                 // FIXME(jdonszelmann): this used to give a machine-applicable fix. However, it was super fragile,
@@ -205,7 +218,7 @@ fn check_must_use_candidate<'tcx>(
         || item_span.in_external_macro(cx.sess().source_map())
         || returns_unit(decl)
         || !cx.effective_visibilities.is_exported(item_id.def_id)
-        || is_must_use_ty(cx, return_ty(cx, item_id))
+        || opt_must_use_path(cx, return_ty(cx, item_id)).is_some()
         || item_span.from_expansion()
         || is_entrypoint_fn(cx, item_id.def_id.to_def_id())
     {

--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -1,4 +1,3 @@
-use clippy_utils::res::MaybeDef as _;
 use hir::FnSig;
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
@@ -174,7 +173,7 @@ fn check_needless_must_use(
             cx,
             DOUBLE_MUST_USE,
             fn_header_span,
-            "this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`",
+            "this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`",
             |diag| {
                 // When there are multiple attributes, it is not sufficient to simply make `must_use` empty, see
                 // issue #12320.
@@ -220,13 +219,6 @@ fn check_must_use_candidate<'tcx>(
             format!("#[must_use]\n{indent}"),
             Applicability::MachineApplicable,
         );
-        if let Some(msg) = match return_ty(cx, item_id).opt_diag_name(cx) {
-            Some(sym::ControlFlow) => Some("`ControlFlow<B, C>` as `C` when `B` is uninhabited"),
-            Some(sym::Result) => Some("`Result<T, E>` as `T` when `E` is uninhabited"),
-            _ => None,
-        } {
-            diag.note(format!("a future version of Rust will treat {msg} wrt `#[must_use]`"));
-        }
     });
 }
 

--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::ty::{implements_trait, is_must_use_ty};
+use clippy_utils::ty::{describe_must_use_type, implements_trait, opt_must_use_path};
 use clippy_utils::{is_from_proc_macro, is_must_use_func_call, paths};
 use rustc_hir::{LetStmt, LocalSource, PatKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -176,8 +176,7 @@ impl<'tcx> LateLintPass<'tcx> for LetUnderscore {
                         diag.help("consider awaiting the future or dropping explicitly with `std::mem::drop`");
                     },
                 );
-            } else if is_must_use_ty(cx, cx.typeck_results().expr_ty(init)) {
-                #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+            } else if let Some(must_use_path) = opt_must_use_path(cx, cx.typeck_results().expr_ty(init)) {
                 span_lint_and_then(
                     cx,
                     LET_UNDERSCORE_MUST_USE,
@@ -185,6 +184,11 @@ impl<'tcx> LateLintPass<'tcx> for LetUnderscore {
                     "non-binding `let` on an expression with `#[must_use]` type",
                     |diag| {
                         diag.help("consider explicitly using expression value");
+                        let ty_span = local.ty.map_or(init.span, |ty| ty.span);
+                        diag.span_note(
+                            ty_span,
+                            format!("type is {}", describe_must_use_type(cx, &must_use_path)),
+                        );
                     },
                 );
             } else if is_must_use_func_call(cx, init) {

--- a/clippy_lints/src/return_self_not_must_use.rs
+++ b/clippy_lints/src/return_self_not_must_use.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_help;
-use clippy_utils::ty::is_must_use_ty;
+use clippy_utils::ty::opt_must_use_path;
 use clippy_utils::{nth_arg, return_ty};
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::FnKind;
@@ -87,7 +87,7 @@ fn check_method(cx: &LateContext<'_>, decl: &FnDecl<'_>, fn_def: LocalDefId, spa
         // there is one, we shouldn't emit a warning!
         && self_arg.peel_refs() == ret_ty
         // If `Self` is already considered as `#[must_use]`, no need for the attribute here.
-        && !is_must_use_ty(cx, ret_ty)
+        && opt_must_use_path(cx, ret_ty).is_none()
     {
         span_lint_and_help(
             cx,

--- a/clippy_lints/src/return_self_not_must_use.rs
+++ b/clippy_lints/src/return_self_not_must_use.rs
@@ -86,7 +86,7 @@ fn check_method(cx: &LateContext<'_>, decl: &FnDecl<'_>, fn_def: LocalDefId, spa
         // For this check, we don't want to remove the reference on the returned type because if
         // there is one, we shouldn't emit a warning!
         && self_arg.peel_refs() == ret_ty
-        // If `Self` is already marked as `#[must_use]`, no need for the attribute here.
+        // If `Self` is already considered as `#[must_use]`, no need for the attribute here.
         && !is_must_use_ty(cx, ret_ty)
     {
         span_lint_and_help(

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -9,10 +9,11 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, FnDecl, LangItem, find_attr};
+use rustc_hir::{Expr, ExprKind, FnDecl, LangItem};
 use rustc_hir_analysis::lower_ty;
 use rustc_infer::infer::TyCtxtInferExt as _;
 use rustc_lint::LateContext;
+use rustc_lint::unused::must_use::{IsTyMustUse, is_ty_must_use};
 use rustc_middle::mir::ConstValue;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::traits::EvaluationResult;
@@ -319,55 +320,22 @@ pub fn has_drop<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
     }
 }
 
-// Returns whether the `ty` has `#[must_use]` attribute. If `ty` is a `Result`/`ControlFlow`
-// whose `Err`/`Break` payload is an uninhabited type, the `Ok`/`Continue` payload type
-// will be used instead. See <https://github.com/rust-lang/rust/pull/148214>.
+/// Returns whether the `ty` has `#[must_use]` attribute, or acts like it does according to the
+/// compiler determination. For example, if `ty` is a `Result`/`ControlFlow` whose `Err`/`Break`
+/// payload is an uninhabited type, the `Ok`/`Continue` payload type will be used instead.
 pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-    match ty.kind() {
-        ty::Adt(adt, args) => match cx.tcx.get_diagnostic_name(adt.did()) {
-            Some(sym::Result) if args.type_at(1).is_privately_uninhabited(cx.tcx, cx.typing_env()) => {
-                is_must_use_ty(cx, args.type_at(0))
-            },
-            Some(sym::ControlFlow) if args.type_at(0).is_privately_uninhabited(cx.tcx, cx.typing_env()) => {
-                is_must_use_ty(cx, args.type_at(1))
-            },
-            _ => find_attr!(cx.tcx, adt.did(), MustUse { .. }),
-        },
-        ty::Foreign(did) => find_attr!(cx.tcx, *did, MustUse { .. }),
-        ty::Slice(ty) | ty::Array(ty, _) | ty::RawPtr(ty, _) | ty::Ref(_, ty, _) => {
-            // for the Array case we don't need to care for the len == 0 case
-            // because we don't want to lint functions returning empty arrays
-            is_must_use_ty(cx, *ty)
-        },
-        ty::Tuple(args) => args.iter().any(|ty| is_must_use_ty(cx, ty)),
-        ty::Alias(
-            _,
-            AliasTy {
-                kind: ty::Opaque { def_id },
-                ..
-            },
-        ) => {
-            for (predicate, _) in cx.tcx.explicit_item_self_bounds(*def_id).skip_binder() {
-                if let ty::ClauseKind::Trait(trait_predicate) = predicate.kind().skip_binder()
-                    && find_attr!(cx.tcx, trait_predicate.trait_ref.def_id, MustUse { .. })
-                {
-                    return true;
-                }
-            }
-            false
-        },
-        ty::Dynamic(binder, _) => {
-            for predicate in *binder {
-                if let ty::ExistentialPredicate::Trait(ref trait_ref) = predicate.skip_binder()
-                    && find_attr!(cx.tcx, trait_ref.def_id, MustUse { .. })
-                {
-                    return true;
-                }
-            }
-            false
-        },
-        _ => false,
-    }
+    // `is_ty_must_use` requires an expression, whose `hir_id` will be used to determine whether
+    // certain types are visibly uninhabited from the module containing the expression.
+    // `cx.last_node_with_lint_attrs` is initialized to the crate/module `hir_id` when linting
+    // a new crate/module. If it is overriden, it is with an `hir_id` pertaining to the same
+    // create/module. We can use this in a dummy expression instead of asking all callers
+    // to provide a local `hir_id` which would not add more information.
+    let dummy_expr = Expr {
+        hir_id: cx.last_node_with_lint_attrs,
+        span: DUMMY_SP,
+        kind: ExprKind::Ret(None),
+    };
+    matches!(is_ty_must_use(cx, ty, &dummy_expr), IsTyMustUse::Yes(_))
 }
 
 /// Returns `true` if the given type is a non aggregate primitive (a `bool` or `char`, any

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -3,9 +3,11 @@
 #![allow(clippy::module_name_repetitions)]
 
 use core::ops::ControlFlow;
+use itertools::Itertools as _;
 use rustc_abi::{BackendRepr, FieldsShape, VariantIdx, Variants};
 use rustc_ast::ast::Mutability;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_errors::pluralize;
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
@@ -13,7 +15,7 @@ use rustc_hir::{Expr, ExprKind, FnDecl, LangItem};
 use rustc_hir_analysis::lower_ty;
 use rustc_infer::infer::TyCtxtInferExt as _;
 use rustc_lint::LateContext;
-use rustc_lint::unused::must_use::{IsTyMustUse, is_ty_must_use};
+use rustc_lint::unused::must_use::{IsTyMustUse, MustUsePath, is_ty_must_use};
 use rustc_middle::mir::ConstValue;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::traits::EvaluationResult;
@@ -323,7 +325,9 @@ pub fn has_drop<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
 /// Returns whether the `ty` has `#[must_use]` attribute, or acts like it does according to the
 /// compiler determination. For example, if `ty` is a `Result`/`ControlFlow` whose `Err`/`Break`
 /// payload is an uninhabited type, the `Ok`/`Continue` payload type will be used instead.
-pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+///
+/// The [`MustUsePath`] can be used to describe the type through [`describe_must_use_type`].
+pub fn opt_must_use_path<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<MustUsePath> {
     // `is_ty_must_use` requires an expression, whose `hir_id` will be used to determine whether
     // certain types are visibly uninhabited from the module containing the expression.
     // `cx.last_node_with_lint_attrs` is initialized to the crate/module `hir_id` when linting
@@ -335,7 +339,96 @@ pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
         span: DUMMY_SP,
         kind: ExprKind::Ret(None),
     };
-    matches!(is_ty_must_use(cx, ty, &dummy_expr), IsTyMustUse::Yes(_))
+    match is_ty_must_use(cx, ty, &dummy_expr) {
+        IsTyMustUse::Yes(path) => Some(path),
+        _ => None,
+    }
+}
+
+/// Describe a [`MustUsePath`] returned by [`is_must_use_ty`].
+pub fn describe_must_use_type(cx: &LateContext<'_>, path: &MustUsePath) -> String {
+    describe_must_use_type_inner(cx, path, "", "", 1)
+}
+
+// This is a rip-off from the compiler's `rustc_lint/src/unused/must_use.rs`
+fn describe_must_use_type_inner(
+    cx: &LateContext<'_>,
+    path: &MustUsePath,
+    descr_pre: &str,
+    descr_post: &str,
+    plural_len: usize,
+) -> String {
+    let plural_suffix = pluralize!(plural_len);
+
+    match path {
+        MustUsePath::Boxed(path) => {
+            let descr_pre = &format!("{descr_pre}boxed ");
+            describe_must_use_type_inner(cx, path, descr_pre, descr_post, plural_len)
+        },
+        MustUsePath::Pinned(path) => {
+            let descr_pre = &format!("{descr_pre}pinned ");
+            describe_must_use_type_inner(cx, path, descr_pre, descr_post, plural_len)
+        },
+        MustUsePath::Opaque(path) => {
+            let descr_pre = &format!("{descr_pre}implementer{plural_suffix} of ");
+            describe_must_use_type_inner(cx, path, descr_pre, descr_post, plural_len)
+        },
+        MustUsePath::TraitObject(path) => {
+            let descr_post = &format!(" trait object{plural_suffix}{descr_post}");
+            describe_must_use_type_inner(cx, path, descr_pre, descr_post, plural_len)
+        },
+        MustUsePath::TupleElement(elems) => elems
+            .iter()
+            .map(|(index, path)| {
+                let descr_post = &format!(" in tuple element {index}");
+                describe_must_use_type_inner(cx, path, descr_pre, descr_post, plural_len)
+            })
+            .join(", "),
+        MustUsePath::Result(path) => {
+            let descr_post = &format!(" in a `Result` with an uninhabited error{descr_post}");
+            describe_must_use_type_inner(cx, path, descr_pre, descr_post, plural_len)
+        },
+        MustUsePath::ControlFlow(path) => {
+            let descr_post = &format!(" in a `ControlFlow` with an uninhabited break{descr_post}");
+            describe_must_use_type_inner(cx, path, descr_pre, descr_post, plural_len)
+        },
+        MustUsePath::Array(path, len) => {
+            let descr_pre = &format!("{descr_pre}array{plural_suffix} of ");
+            describe_must_use_type_inner(
+                cx,
+                path,
+                descr_pre,
+                descr_post,
+                plural_len.saturating_add(usize::try_from(*len).unwrap_or(usize::MAX)),
+            )
+        },
+        MustUsePath::Closure(_) => {
+            format!(
+                "{descr_pre}{} closure{plural_suffix}{descr_post}",
+                if plural_len == 1 {
+                    "one".to_string()
+                } else {
+                    plural_len.to_string()
+                }
+            )
+        },
+        MustUsePath::Coroutine(_) => {
+            format!(
+                "{descr_pre}{} coroutine{plural_suffix}{descr_post}",
+                if plural_len == 1 {
+                    "one".to_string()
+                } else {
+                    plural_len.to_string()
+                }
+            )
+        },
+        MustUsePath::Def(_, def_id, _) => {
+            format!(
+                "{descr_pre}`{}`{plural_suffix}{descr_post}",
+                cx.tcx.def_path_str(*def_id)
+            )
+        },
+    }
 }
 
 /// Returns `true` if the given type is a non aggregate primitive (a `bool` or `char`, any

--- a/tests/ui/double_must_use.stderr
+++ b/tests/ui/double_must_use.stderr
@@ -1,4 +1,4 @@
-error: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
   --> tests/ui/double_must_use.rs:8:1
    |
 LL | #[must_use]
@@ -10,7 +10,7 @@ LL | pub fn must_use_result() -> Result<(), ()> {
    = note: `-D clippy::double-must-use` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::double_must_use)]`
 
-error: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
   --> tests/ui/double_must_use.rs:15:1
    |
 LL | #[must_use]
@@ -20,7 +20,7 @@ LL | pub fn must_use_tuple() -> (Result<(), ()>, u8) {
    |
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
-error: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
   --> tests/ui/double_must_use.rs:22:1
    |
 LL | #[must_use]
@@ -30,7 +30,7 @@ LL | pub fn must_use_array() -> [Result<(), ()>; 1] {
    |
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
-error: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
   --> tests/ui/double_must_use.rs:40:1
    |
 LL | #[must_use]
@@ -40,7 +40,7 @@ LL | async fn async_must_use_result() -> Result<(), ()> {
    |
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
-error: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
   --> tests/ui/double_must_use.rs:55:1
    |
 LL | #[must_use]
@@ -50,7 +50,7 @@ LL | pub fn must_use_result_with_uninhabited_2() -> Result<T, !> {
    |
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
-error: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
   --> tests/ui/double_must_use.rs:66:1
    |
 LL | #[must_use]

--- a/tests/ui/double_must_use.stderr
+++ b/tests/ui/double_must_use.stderr
@@ -18,6 +18,11 @@ LL | #[must_use]
 LL | pub fn must_use_tuple() -> (Result<(), ()>, u8) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: the return type is `std::result::Result` in tuple element 0
+  --> tests/ui/double_must_use.rs:15:28
+   |
+LL | pub fn must_use_tuple() -> (Result<(), ()>, u8) {
+   |                            ^^^^^^^^^^^^^^^^^^^^
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
 error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
@@ -28,6 +33,11 @@ LL | #[must_use]
 LL | pub fn must_use_array() -> [Result<(), ()>; 1] {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: the return type is array of `std::result::Result`s
+  --> tests/ui/double_must_use.rs:22:28
+   |
+LL | pub fn must_use_array() -> [Result<(), ()>; 1] {
+   |                            ^^^^^^^^^^^^^^^^^^^
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
 error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
@@ -38,6 +48,11 @@ LL | #[must_use]
 LL | async fn async_must_use_result() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: the return type is implementer of `std::future::Future`
+  --> tests/ui/double_must_use.rs:40:37
+   |
+LL | async fn async_must_use_result() -> Result<(), ()> {
+   |                                     ^^^^^^^^^^^^^^
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
 error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
@@ -48,6 +63,11 @@ LL | #[must_use]
 LL | pub fn must_use_result_with_uninhabited_2() -> Result<T, !> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: the return type is `T` in a `Result` with an uninhabited error
+  --> tests/ui/double_must_use.rs:55:48
+   |
+LL | pub fn must_use_result_with_uninhabited_2() -> Result<T, !> {
+   |                                                ^^^^^^^^^^^^
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
 error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
@@ -58,6 +78,11 @@ LL | #[must_use]
 LL | pub fn must_use_controlflow_with_uninhabited_2() -> ControlFlow<std::convert::Infallible, T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: the return type is `T` in a `ControlFlow` with an uninhabited break
+  --> tests/ui/double_must_use.rs:66:53
+   |
+LL | pub fn must_use_controlflow_with_uninhabited_2() -> ControlFlow<std::convert::Infallible, T> {
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
 
 error: aborting due to 6 previous errors

--- a/tests/ui/double_must_use_unfixable.stderr
+++ b/tests/ui/double_must_use_unfixable.stderr
@@ -1,4 +1,4 @@
-error: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
   --> tests/ui/double_must_use_unfixable.rs:6:1
    |
 LL | pub fn issue_12320() -> Result<(), ()> {
@@ -13,7 +13,7 @@ LL | #[cfg_attr(all(), must_use, deprecated)]
    = note: `-D clippy::double-must-use` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::double_must_use)]`
 
-error: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
   --> tests/ui/double_must_use_unfixable.rs:12:1
    |
 LL | pub fn issue_12320_2() -> Result<(), ()> {

--- a/tests/ui/let_underscore_must_use.rs
+++ b/tests/ui/let_underscore_must_use.rs
@@ -96,6 +96,9 @@ fn main() {
     let _ = if true { Ok(()) } else { Err(()) };
     //~^ let_underscore_must_use
 
+    let _: Result<(), ()> = if true { Ok(()) } else { Err(()) };
+    //~^ let_underscore_must_use
+
     let a = Result::<(), ()>::Ok(());
 
     let _ = a.is_ok();

--- a/tests/ui/let_underscore_must_use.stderr
+++ b/tests/ui/let_underscore_must_use.stderr
@@ -15,6 +15,11 @@ LL |     let _ = g();
    |     ^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
+note: type is `std::result::Result`
+  --> tests/ui/let_underscore_must_use.rs:70:13
+   |
+LL |     let _ = g();
+   |             ^^^
 
 error: non-binding `let` on a result of a `#[must_use]` function
   --> tests/ui/let_underscore_must_use.rs:74:5
@@ -39,6 +44,11 @@ LL |     let _ = s.g();
    |     ^^^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
+note: type is `std::result::Result`
+  --> tests/ui/let_underscore_must_use.rs:82:13
+   |
+LL |     let _ = s.g();
+   |             ^^^^^
 
 error: non-binding `let` on a result of a `#[must_use]` function
   --> tests/ui/let_underscore_must_use.rs:87:5
@@ -55,6 +65,11 @@ LL |     let _ = S::p();
    |     ^^^^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
+note: type is `std::result::Result`
+  --> tests/ui/let_underscore_must_use.rs:90:13
+   |
+LL |     let _ = S::p();
+   |             ^^^^^^
 
 error: non-binding `let` on a result of a `#[must_use]` function
   --> tests/ui/let_underscore_must_use.rs:93:5
@@ -71,9 +86,27 @@ LL |     let _ = if true { Ok(()) } else { Err(()) };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
+note: type is `std::result::Result`
+  --> tests/ui/let_underscore_must_use.rs:96:13
+   |
+LL |     let _ = if true { Ok(()) } else { Err(()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: non-binding `let` on an expression with `#[must_use]` type
+  --> tests/ui/let_underscore_must_use.rs:99:5
+   |
+LL |     let _: Result<(), ()> = if true { Ok(()) } else { Err(()) };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider explicitly using expression value
+note: type is `std::result::Result`
+  --> tests/ui/let_underscore_must_use.rs:99:12
+   |
+LL |     let _: Result<(), ()> = if true { Ok(()) } else { Err(()) };
+   |            ^^^^^^^^^^^^^^
 
 error: non-binding `let` on a result of a `#[must_use]` function
-  --> tests/ui/let_underscore_must_use.rs:101:5
+  --> tests/ui/let_underscore_must_use.rs:104:5
    |
 LL |     let _ = a.is_ok();
    |     ^^^^^^^^^^^^^^^^^^
@@ -81,28 +114,43 @@ LL |     let _ = a.is_ok();
    = help: consider explicitly using function result
 
 error: non-binding `let` on an expression with `#[must_use]` type
-  --> tests/ui/let_underscore_must_use.rs:104:5
+  --> tests/ui/let_underscore_must_use.rs:107:5
    |
 LL |     let _ = a.map(|_| ());
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
+note: type is `std::result::Result`
+  --> tests/ui/let_underscore_must_use.rs:107:13
+   |
+LL |     let _ = a.map(|_| ());
+   |             ^^^^^^^^^^^^^
 
 error: non-binding `let` on an expression with `#[must_use]` type
-  --> tests/ui/let_underscore_must_use.rs:107:5
+  --> tests/ui/let_underscore_must_use.rs:110:5
    |
 LL |     let _ = a;
    |     ^^^^^^^^^^
    |
    = help: consider explicitly using expression value
+note: type is `std::result::Result`
+  --> tests/ui/let_underscore_must_use.rs:110:13
+   |
+LL |     let _ = a;
+   |             ^
 
 error: non-binding `let` on an expression with `#[must_use]` type
-  --> tests/ui/let_underscore_must_use.rs:120:5
+  --> tests/ui/let_underscore_must_use.rs:123:5
    |
 LL |     let _ = Result::<_, std::convert::Infallible>::Ok(T);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
+note: type is `main::T` in a `Result` with an uninhabited error
+  --> tests/ui/let_underscore_must_use.rs:123:13
+   |
+LL |     let _ = Result::<_, std::convert::Infallible>::Ok(T);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 14 previous errors
 

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -105,12 +105,20 @@ pub fn main() -> std::process::ExitCode {
 
 //~v must_use_candidate
 #[must_use]
-pub fn result_uninhabited() -> Result<i32, std::convert::Infallible> {
+pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
     todo!()
 }
 
-//~v must_use_candidate
 #[must_use]
-pub fn controlflow_uninhabited() -> std::ops::ControlFlow<std::convert::Infallible, i32> {
+pub struct T;
+
+// Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
+pub fn result_uninhabited_2() -> Result<T, std::convert::Infallible> {
+    todo!()
+}
+
+// Do not lint: even though `Box` itself is not `#[must_use]`, if the content is (which is
+// the case of `T`), the compiler will treat the box as a `#[must_use]` type already.
+pub fn with_box() -> Box<T> {
     todo!()
 }

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -99,11 +99,20 @@ pub fn main() -> std::process::ExitCode {
 }
 
 //~v must_use_candidate
-pub fn result_uninhabited() -> Result<i32, std::convert::Infallible> {
+pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
     todo!()
 }
 
-//~v must_use_candidate
-pub fn controlflow_uninhabited() -> std::ops::ControlFlow<std::convert::Infallible, i32> {
+#[must_use]
+pub struct T;
+
+// Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
+pub fn result_uninhabited_2() -> Result<T, std::convert::Infallible> {
+    todo!()
+}
+
+// Do not lint: even though `Box` itself is not `#[must_use]`, if the content is (which is
+// the case of `T`), the compiler will treat the box as a `#[must_use]` type already.
+pub fn with_box() -> Box<T> {
     todo!()
 }

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -63,28 +63,14 @@ LL | pub fn arcd(_x: Arc<u32>) -> bool {
 error: this function could have a `#[must_use]` attribute
   --> tests/ui/must_use_candidates.rs:102:8
    |
-LL | pub fn result_uninhabited() -> Result<i32, std::convert::Infallible> {
-   |        ^^^^^^^^^^^^^^^^^^
+LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+   |        ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: a future version of Rust will treat `Result<T, E>` as `T` when `E` is uninhabited wrt `#[must_use]`
 help: add the attribute
    |
 LL + #[must_use]
-LL | pub fn result_uninhabited() -> Result<i32, std::convert::Infallible> {
+LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
    |
 
-error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:107:8
-   |
-LL | pub fn controlflow_uninhabited() -> std::ops::ControlFlow<std::convert::Infallible, i32> {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a future version of Rust will treat `ControlFlow<B, C>` as `C` when `B` is uninhabited wrt `#[must_use]`
-help: add the attribute
-   |
-LL + #[must_use]
-LL | pub fn controlflow_uninhabited() -> std::ops::ControlFlow<std::convert::Infallible, i32> {
-   |
-
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16633)*

changelog: [`double_must_use`, `let_underscore_must_use`, `must_use_candidates`]: better determination of `#[must_use]` needs by directly using the compiler algorithm

For example, `Box<T>` is considered `#[must_use]` when `T` is.