### PR TITLE
`clippy_dev` parsing revamp part 6/N

### DIFF
--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -337,20 +337,20 @@ pub fn run(update_mode: UpdateMode) {
 
     new_parse_cx(|cx| {
         let mut data = cx.parse_lint_decls();
-        let (mut lints, passes) = data.split_by_lint_file();
-        let mut updater = FileUpdater::default();
-        let mut ranges = VecBuf::with_capacity(256);
 
-        for passes in passes {
-            let path = passes[0].path.clone();
-            let mut lints = lints.remove(&*path);
+        let mut updater = FileUpdater::default();
+
+        let mut lints = data.mk_file_to_lint_decl_map();
+        let mut ranges = VecBuf::with_capacity(256);
+        for passes in data.iter_passes_by_file_mut() {
+            let path = passes[0].file.path.get();
+            let mut lints = lints.remove(path);
             let lints = lints.as_deref_mut().unwrap_or_default();
-            updater.update_file_checked("cargo dev fmt", update_mode, &path, &mut |_, src, dst| {
+            updater.update_file_checked("cargo dev fmt", update_mode, path, &mut |_, src, dst| {
                 gen_sorted_lints_file(src, dst, lints, passes, &mut ranges);
                 UpdateStatus::from_changed(src != dst)
             });
         }
-
         for (&path, lints) in &mut lints {
             updater.update_file_checked("cargo dev fmt", update_mode, path, &mut |_, src, dst| {
                 gen_sorted_lints_file(src, dst, lints, &mut [], &mut ranges);

--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -340,19 +340,20 @@ pub fn run(update_mode: UpdateMode) {
 
         let mut updater = FileUpdater::default();
 
+        #[expect(clippy::mutable_key_type)]
         let mut lints = data.mk_file_to_lint_decl_map();
         let mut ranges = VecBuf::with_capacity(256);
         for passes in data.iter_passes_by_file_mut() {
-            let path = passes[0].file.path.get();
-            let mut lints = lints.remove(path);
+            let file = passes[0].file;
+            let mut lints = lints.remove(file);
             let lints = lints.as_deref_mut().unwrap_or_default();
-            updater.update_file_checked("cargo dev fmt", update_mode, path, &mut |_, src, dst| {
+            updater.update_loaded_file_checked("cargo dev fmt", update_mode, file, &mut |_, src, dst| {
                 gen_sorted_lints_file(src, dst, lints, passes, &mut ranges);
                 UpdateStatus::from_changed(src != dst)
             });
         }
-        for (&path, lints) in &mut lints {
-            updater.update_file_checked("cargo dev fmt", update_mode, path, &mut |_, src, dst| {
+        for (&file, lints) in &mut lints {
+            updater.update_loaded_file_checked("cargo dev fmt", update_mode, file, &mut |_, src, dst| {
                 gen_sorted_lints_file(src, dst, lints, &mut [], &mut ranges);
                 UpdateStatus::from_changed(src != dst)
             });

--- a/clippy_dev/src/generate.rs
+++ b/clippy_dev/src/generate.rs
@@ -66,10 +66,10 @@ impl LintData<'_> {
             }),
         );
 
-        updater.update_file_checked(
+        updater.update_loaded_file_checked(
             "cargo dev update_lints",
             update_mode,
-            "clippy_lints/src/deprecated_lints.rs",
+            self.deprecated_file,
             &mut |_, src, dst| {
                 let mut cursor = Cursor::new(src);
                 assert!(

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -14,7 +14,7 @@
     unused_lifetimes,
     unused_qualifications
 )]
-#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::case_sensitive_file_extension_comparisons, clippy::missing_panics_doc)]
 
 extern crate rustc_arena;
 extern crate rustc_data_structures;


### PR DESCRIPTION
Based on rust-lang/rust-clippy#15979

This part keeps all the parsed source files in memory. These are then borrowed from to avoid allocations and reused when generating which avoids reloading the files. The next PR will also use this when reporting errors.

changelog: none
