### PR TITLE
Add new lint `static_mut_vars`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7461,6 +7461,7 @@ Released 2018-09-13
 [`slow_vector_initialization`]: https://rust-lang.github.io/rust-clippy/master/index.html#slow_vector_initialization
 [`some_filter`]: https://rust-lang.github.io/rust-clippy/master/index.html#some_filter
 [`stable_sort_primitive`]: https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive
+[`static_mut_vars`]: https://rust-lang.github.io/rust-clippy/master/index.html#static_mut_vars
 [`std_instead_of_alloc`]: https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_alloc
 [`std_instead_of_core`]: https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_core
 [`str_split_at_newline`]: https://rust-lang.github.io/rust-clippy/master/index.html#str_split_at_newline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7581,6 +7581,7 @@ Released 2018-09-13
 [`slow_vector_initialization`]: https://rust-lang.github.io/rust-clippy/main/index.html#slow_vector_initialization
 [`some_filter`]: https://rust-lang.github.io/rust-clippy/main/index.html#some_filter
 [`stable_sort_primitive`]: https://rust-lang.github.io/rust-clippy/main/index.html#stable_sort_primitive
+[`static_mut_vars`]: https://rust-lang.github.io/rust-clippy/main/index.html#static_mut_vars
 [`std_instead_of_alloc`]: https://rust-lang.github.io/rust-clippy/main/index.html#std_instead_of_alloc
 [`std_instead_of_core`]: https://rust-lang.github.io/rust-clippy/main/index.html#std_instead_of_core
 [`str_split_at_newline`]: https://rust-lang.github.io/rust-clippy/main/index.html#str_split_at_newline

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -716,6 +716,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::size_of_in_element_count::SIZE_OF_IN_ELEMENT_COUNT_INFO,
     crate::size_of_ref::SIZE_OF_REF_INFO,
     crate::slow_vector_initialization::SLOW_VECTOR_INITIALIZATION_INFO,
+    crate::static_mut_vars::STATIC_MUT_VARS_INFO,
     crate::std_instead_of_core::ALLOC_INSTEAD_OF_CORE_INFO,
     crate::std_instead_of_core::STD_INSTEAD_OF_ALLOC_INFO,
     crate::std_instead_of_core::STD_INSTEAD_OF_CORE_INFO,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -714,6 +714,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::size_of_in_element_count::SIZE_OF_IN_ELEMENT_COUNT_INFO,
     crate::size_of_ref::SIZE_OF_REF_INFO,
     crate::slow_vector_initialization::SLOW_VECTOR_INITIALIZATION_INFO,
+    crate::static_mut_vars::STATIC_MUT_VARS_INFO,
     crate::std_instead_of_core::ALLOC_INSTEAD_OF_CORE_INFO,
     crate::std_instead_of_core::STD_INSTEAD_OF_ALLOC_INFO,
     crate::std_instead_of_core::STD_INSTEAD_OF_CORE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -350,6 +350,7 @@ mod single_range_in_vec_init;
 mod size_of_in_element_count;
 mod size_of_ref;
 mod slow_vector_initialization;
+mod static_mut_vars;
 mod std_instead_of_core;
 mod string_patterns;
 mod strings;
@@ -872,6 +873,7 @@ rustc_lint::late_lint_methods!(
         RestWhenDestructuringStruct: rest_when_destructuring_struct::RestWhenDestructuringStruct = rest_when_destructuring_struct::RestWhenDestructuringStruct,
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
+        StaticMutVars: static_mut_vars::StaticMutVars = static_mut_vars::StaticMutVars,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -348,6 +348,7 @@ mod single_range_in_vec_init;
 mod size_of_in_element_count;
 mod size_of_ref;
 mod slow_vector_initialization;
+mod static_mut_vars;
 mod std_instead_of_core;
 mod string_patterns;
 mod strings;
@@ -870,6 +871,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        StaticMutVars: static_mut_vars::StaticMutVars = static_mut_vars::StaticMutVars,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/static_mut_vars.rs
+++ b/clippy_lints/src/static_mut_vars.rs
@@ -1,0 +1,146 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::source::{IntoSpan as _, SpanExt as _, snippet};
+use clippy_utils::sugg::Sugg;
+use clippy_utils::ty::ty_from_hir_ty;
+use rustc_ast::{IntTy, UintTy};
+use rustc_errors::Applicability;
+use rustc_hir::{Item, ItemKind, MutTy, Mutability, Ty, TyKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
+use rustc_middle::ty::Ty as MidTy;
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for usage of `static mut` variables.
+    ///
+    /// ### Why is this bad?
+    /// `static mut` allows mutable global state without synchronization.
+    /// Accessing it is `unsafe` because it can cause:
+    ///
+    /// * Data races in multithreaded contexts
+    /// * Undefined behavior
+    /// * Violations of Rust’s aliasing guarantees
+    /// * Hard-to-debug global state bugs
+    ///
+    /// Also, since Rust 2024, the built-in lint `static_mut_refs` denies by default `&` or `&mut`
+    /// references to a `static mut`.
+    ///
+    /// ### Alternatives
+    /// Prefer one of:
+    /// * `Atomic*` for integer types, booleans and pointers
+    /// * `Mutex<T>` or `RwLock<T>` synchronization primitives for interior mutability
+    /// * `OnceLock<T>` or `LazyLock<T>` for one-time initialization
+    /// * `UnsafeCell<T>` with wrapper implementing `Sync` (or nightly `SyncUnsafeCell<T>`)
+    ///
+    /// ### Example
+    /// ```no_run
+    /// static mut A: i32 = 0i32;
+    /// static mut B: (u64, u64) = (0u64, 0u64);
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// use std::sync::atomic::AtomicI32;
+    /// use std::sync::RwLock;
+    ///
+    /// static A: AtomicI32 = AtomicI32::new(0i32);
+    /// static B: RwLock<(u64, u64)> = RwLock::new((0u64, 0u64));
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub STATIC_MUT_VARS,
+    correctness,
+    "using a static mutable variable"
+}
+
+declare_lint_pass!(StaticMutVars => [STATIC_MUT_VARS]);
+
+enum Replacement<'tcx> {
+    AtomicPrimTy(&'static str),
+    AtomicPtr(&'tcx Ty<'tcx>),
+}
+
+impl Replacement<'_> {
+    fn new<'tcx>(hir_ty: &Ty<'tcx>, mid_ty: MidTy<'tcx>) -> Option<Replacement<'tcx>> {
+        match mid_ty.kind() {
+            ty::Int(int_ty) => match int_ty {
+                IntTy::Isize => Some(Replacement::AtomicPrimTy("AtomicIsize")),
+                IntTy::I8 => Some(Replacement::AtomicPrimTy("AtomicI8")),
+                IntTy::I16 => Some(Replacement::AtomicPrimTy("AtomicI16")),
+                IntTy::I32 => Some(Replacement::AtomicPrimTy("AtomicI32")),
+                IntTy::I64 => Some(Replacement::AtomicPrimTy("AtomicI64")),
+                IntTy::I128 => None,
+            },
+
+            ty::Uint(uint_ty) => match uint_ty {
+                UintTy::Usize => Some(Replacement::AtomicPrimTy("AtomicUsize")),
+                UintTy::U8 => Some(Replacement::AtomicPrimTy("AtomicU8")),
+                UintTy::U16 => Some(Replacement::AtomicPrimTy("AtomicU16")),
+                UintTy::U32 => Some(Replacement::AtomicPrimTy("AtomicU32")),
+                UintTy::U64 => Some(Replacement::AtomicPrimTy("AtomicU64")),
+                UintTy::U128 => None,
+            },
+
+            ty::Bool => Some(Replacement::AtomicPrimTy("AtomicBool")),
+
+            ty::RawPtr(_, Mutability::Mut) => match hir_ty.kind {
+                TyKind::Ptr(MutTy { ty: ptr_ty, .. }) => Some(Replacement::AtomicPtr(ptr_ty)),
+                _ => None,
+            },
+
+            _ => None,
+        }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for StaticMutVars {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if let ItemKind::Static(Mutability::Mut, ref ident, hir_ty, body_id) = item.kind {
+            span_lint_and_then(
+                cx,
+                STATIC_MUT_VARS,
+                item.span,
+                format!("static `{}` is declared as mutable", ident.name),
+                |diag| match Replacement::new(hir_ty, ty_from_hir_ty(cx, hir_ty)) {
+                    Some(repl) => {
+                        let mut applicability = Applicability::MaybeIncorrect;
+
+                        let body = cx.tcx.hir_body(body_id).value.peel_blocks();
+                        let arg = Sugg::hir_with_context(cx, body, item.span.ctxt(), "_", &mut applicability);
+
+                        let (sugg_ty, sugg_body) = match repl {
+                            Replacement::AtomicPrimTy(ty) => (
+                                format!("std::sync::atomic::{ty}"),
+                                format!("std::sync::atomic::{ty}::new({arg})"),
+                            ),
+
+                            Replacement::AtomicPtr(ty) => {
+                                let ty_snippet = snippet(cx, ty.span, "..");
+                                (
+                                    format!("std::sync::atomic::AtomicPtr<{ty_snippet}>"),
+                                    format!("std::sync::atomic::AtomicPtr::<{ty_snippet}>::new({arg})"),
+                                )
+                            },
+                        };
+
+                        diag.multipart_suggestion(
+                            "try",
+                            vec![
+                                (
+                                    item.span.until(ident.span.with_leading_whitespace(cx).into_span()),
+                                    "static".to_string(),
+                                ),
+                                (hir_ty.span, sugg_ty),
+                                (body.span, sugg_body),
+                            ],
+                            applicability,
+                        );
+                    },
+
+                    None => {
+                        diag.help("consider using a safer alternative");
+                    },
+                },
+            );
+        }
+    }
+}

--- a/clippy_lints/src/static_mut_vars.rs
+++ b/clippy_lints/src/static_mut_vars.rs
@@ -1,0 +1,145 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::source::{IntoSpan as _, SpanExt as _, snippet};
+use clippy_utils::sugg::Sugg;
+use clippy_utils::ty::ty_from_hir_ty;
+use rustc_ast::{IntTy, UintTy};
+use rustc_errors::Applicability;
+use rustc_hir::{Item, ItemKind, MutTy, Mutability, Ty, TyKind};
+use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
+use rustc_middle::ty;
+use rustc_middle::ty::Ty as MidTy;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for usage of `static mut` variables.
+    ///
+    /// ### Why is this bad?
+    /// `static mut` allows mutable global state without synchronization.
+    /// Accessing it is `unsafe` because it can cause:
+    ///
+    /// * Data races in multithreaded contexts
+    /// * Undefined behavior
+    /// * Violations of Rust’s aliasing guarantees
+    /// * Hard-to-debug global state bugs
+    ///
+    /// Also, since Rust 2024, the built-in lint `static_mut_refs` denies by default `&` or `&mut`
+    /// references to a `static mut`.
+    ///
+    /// ### Alternatives
+    /// Prefer one of:
+    /// * `Atomic*` for integer types, booleans and pointers
+    /// * `Mutex<T>` or `RwLock<T>` synchronization primitives for interior mutability
+    /// * `OnceLock<T>` or `LazyLock<T>` for one-time initialization
+    /// * `UnsafeCell<T>` with wrapper implementing `Sync` (or nightly `SyncUnsafeCell<T>`)
+    ///
+    /// ### Example
+    /// ```no_run
+    /// static mut A: i32 = 0i32;
+    /// static mut B: (u64, u64) = (0u64, 0u64);
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// use std::sync::atomic::AtomicI32;
+    /// use std::sync::RwLock;
+    ///
+    /// static A: AtomicI32 = AtomicI32::new(0i32);
+    /// static B: RwLock<(u64, u64)> = RwLock::new((0u64, 0u64));
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub STATIC_MUT_VARS,
+    correctness,
+    "using a static mutable variable"
+}
+
+declare_lint_pass!(StaticMutVars => [STATIC_MUT_VARS]);
+
+enum Replacement<'tcx> {
+    AtomicPrimTy(&'static str),
+    AtomicPtr(&'tcx Ty<'tcx>),
+}
+
+impl Replacement<'_> {
+    fn new<'tcx>(hir_ty: &Ty<'tcx>, mid_ty: MidTy<'tcx>) -> Option<Replacement<'tcx>> {
+        match mid_ty.kind() {
+            ty::Int(int_ty) => match int_ty {
+                IntTy::Isize => Some(Replacement::AtomicPrimTy("AtomicIsize")),
+                IntTy::I8 => Some(Replacement::AtomicPrimTy("AtomicI8")),
+                IntTy::I16 => Some(Replacement::AtomicPrimTy("AtomicI16")),
+                IntTy::I32 => Some(Replacement::AtomicPrimTy("AtomicI32")),
+                IntTy::I64 => Some(Replacement::AtomicPrimTy("AtomicI64")),
+                IntTy::I128 => None,
+            },
+
+            ty::Uint(uint_ty) => match uint_ty {
+                UintTy::Usize => Some(Replacement::AtomicPrimTy("AtomicUsize")),
+                UintTy::U8 => Some(Replacement::AtomicPrimTy("AtomicU8")),
+                UintTy::U16 => Some(Replacement::AtomicPrimTy("AtomicU16")),
+                UintTy::U32 => Some(Replacement::AtomicPrimTy("AtomicU32")),
+                UintTy::U64 => Some(Replacement::AtomicPrimTy("AtomicU64")),
+                UintTy::U128 => None,
+            },
+
+            ty::Bool => Some(Replacement::AtomicPrimTy("AtomicBool")),
+
+            ty::RawPtr(_, Mutability::Mut) => match hir_ty.kind {
+                TyKind::Ptr(MutTy { ty: ptr_ty, .. }) => Some(Replacement::AtomicPtr(ptr_ty)),
+                _ => None,
+            },
+
+            _ => None,
+        }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for StaticMutVars {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if let ItemKind::Static(Mutability::Mut, ref ident, hir_ty, body_id) = item.kind {
+            span_lint_and_then(
+                cx,
+                STATIC_MUT_VARS,
+                item.span,
+                format!("static `{}` is declared as mutable", ident.name),
+                |diag| match Replacement::new(hir_ty, ty_from_hir_ty(cx, hir_ty)) {
+                    Some(repl) => {
+                        let mut applicability = Applicability::MaybeIncorrect;
+
+                        let body = cx.tcx.hir_body(body_id).value.peel_blocks();
+                        let arg = Sugg::hir_with_context(cx, body, item.span.ctxt(), "_", &mut applicability);
+
+                        let (sugg_ty, sugg_body) = match repl {
+                            Replacement::AtomicPrimTy(ty) => (
+                                format!("std::sync::atomic::{ty}"),
+                                format!("std::sync::atomic::{ty}::new({arg})"),
+                            ),
+
+                            Replacement::AtomicPtr(ty) => {
+                                let ty_snippet = snippet(cx, ty.span, "..");
+                                (
+                                    format!("std::sync::atomic::AtomicPtr<{ty_snippet}>"),
+                                    format!("std::sync::atomic::AtomicPtr::<{ty_snippet}>::new({arg})"),
+                                )
+                            },
+                        };
+
+                        diag.multipart_suggestion(
+                            "try",
+                            vec![
+                                (
+                                    item.span.until(ident.span.with_leading_whitespace(cx).into_span()),
+                                    "static".to_string(),
+                                ),
+                                (hir_ty.span, sugg_ty),
+                                (body.span, sugg_body),
+                            ],
+                            applicability,
+                        );
+                    },
+
+                    None => {
+                        diag.help("consider using a safer alternative");
+                    },
+                },
+            );
+        }
+    }
+}

--- a/tests/ui-toml/excessive_precision/excessive_precision.fixed
+++ b/tests/ui-toml/excessive_precision/excessive_precision.fixed
@@ -1,5 +1,10 @@
 #![warn(clippy::excessive_precision)]
-#![allow(overflowing_literals, clippy::print_literal, clippy::useless_vec)]
+#![allow(
+    overflowing_literals,
+    clippy::print_literal,
+    clippy::useless_vec,
+    clippy::static_mut_vars
+)]
 
 fn main() {
     // Overly specified constants

--- a/tests/ui-toml/excessive_precision/excessive_precision.fixed
+++ b/tests/ui-toml/excessive_precision/excessive_precision.fixed
@@ -1,5 +1,10 @@
 #![warn(clippy::excessive_precision)]
-#![allow(overflowing_literals, clippy::print_literal, clippy::useless_vec)]
+#![allow(
+    overflowing_literals,
+    clippy::print_literal,
+    clippy::static_mut_vars,
+    clippy::useless_vec
+)]
 
 fn main() {
     // Overly specified constants

--- a/tests/ui-toml/excessive_precision/excessive_precision.rs
+++ b/tests/ui-toml/excessive_precision/excessive_precision.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::excessive_precision)]
-#![allow(overflowing_literals, clippy::print_literal, clippy::useless_vec)]
+#![allow(
+    overflowing_literals,
+    clippy::print_literal,
+    clippy::useless_vec,
+    clippy::static_mut_vars
+)]
 
 fn main() {
     // Overly specified constants

--- a/tests/ui-toml/excessive_precision/excessive_precision.rs
+++ b/tests/ui-toml/excessive_precision/excessive_precision.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::excessive_precision)]
-#![allow(overflowing_literals, clippy::print_literal, clippy::useless_vec)]
+#![allow(
+    overflowing_literals,
+    clippy::print_literal,
+    clippy::static_mut_vars,
+    clippy::useless_vec
+)]
 
 fn main() {
     // Overly specified constants

--- a/tests/ui-toml/excessive_precision/excessive_precision.stderr
+++ b/tests/ui-toml/excessive_precision/excessive_precision.stderr
@@ -1,11 +1,11 @@
 error: float has excessive precision
-  --> tests/ui-toml/excessive_precision/excessive_precision.rs:6:18
+  --> tests/ui-toml/excessive_precision/excessive_precision.rs:11:18
    |
 LL |     let _: f32 = 1.012345678901234567890;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: consider making it a `const` item
-  --> tests/ui-toml/excessive_precision/excessive_precision.rs:6:5
+  --> tests/ui-toml/excessive_precision/excessive_precision.rs:11:5
    |
 LL |     let _: f32 = 1.012345678901234567890;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,13 +18,13 @@ LL +     let _: f32 = 1.012_345_7;
    |
 
 error: float has excessive precision
-  --> tests/ui-toml/excessive_precision/excessive_precision.rs:8:18
+  --> tests/ui-toml/excessive_precision/excessive_precision.rs:13:18
    |
 LL |     let _: f64 = 1.012345678901234567890;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: consider making it a `const` item
-  --> tests/ui-toml/excessive_precision/excessive_precision.rs:8:5
+  --> tests/ui-toml/excessive_precision/excessive_precision.rs:13:5
    |
 LL |     let _: f64 = 1.012345678901234567890;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/checked_unwrap/simple_conditionals.rs
+++ b/tests/ui/checked_unwrap/simple_conditionals.rs
@@ -157,6 +157,7 @@ fn issue11371() {
     }
 
     // This should not lint and suggest `if let Some(..) = X {}`, as `X` is being mutated
+    #[expect(clippy::static_mut_vars)]
     static mut X: Option<i32> = Some(123);
     unsafe {
         #[expect(static_mut_refs)]

--- a/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -226,7 +226,7 @@ LL |         result.as_mut().unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:184:17
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:185:17
    |
 LL |     if option.is_some() {
    |     ------------------- help: try: `if let Some(<item>) = &option`
@@ -234,7 +234,7 @@ LL |         let _ = option.as_ref().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:187:17
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:188:17
    |
 LL |     if option.is_some() {
    |        ---------------- because of this check
@@ -243,7 +243,7 @@ LL |         let _ = option.as_ref().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `result` after checking its variant with `is_ok`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:195:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:196:9
    |
 LL |     if result.is_ok() {
    |     ----------------- help: try: `if let Ok(<item>) = &result`
@@ -252,7 +252,7 @@ LL |         result.as_ref().unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:199:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:200:9
    |
 LL |     if result.is_ok() {
    |        -------------- because of this check
@@ -261,7 +261,7 @@ LL |         result.as_ref().unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `x` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:225:17
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:226:17
    |
 LL |         if x.is_some() {
    |         -------------- help: try: `if let Some(<item>) = x`
@@ -269,7 +269,7 @@ LL |             _ = x.unwrap();
    |                 ^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:228:17
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:229:17
    |
 LL |         if x.is_some() {
    |            ----------- because of this check
@@ -278,7 +278,7 @@ LL |             _ = x.unwrap();
    |                 ^^^^^^^^^^
 
 error: called `unwrap` on `r` after checking its variant with `is_ok`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:234:17
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:235:17
    |
 LL |         if r.is_ok() {
    |         ------------ help: try: `if let Ok(<item>) = &r`
@@ -286,7 +286,7 @@ LL |             _ = r.as_ref().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:237:17
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:238:17
    |
 LL |         if r.is_ok() {
    |            --------- because of this check
@@ -295,7 +295,7 @@ LL |             _ = r.as_ref().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `x` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:246:17
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:247:17
    |
 LL |         if x.is_some() {
    |         -------------- help: try: `if let Some(<item>) = x`
@@ -303,7 +303,7 @@ LL |             _ = x.unwrap();
    |                 ^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:249:17
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:250:17
    |
 LL |         if x.is_some() {
    |            ----------- because of this check
@@ -312,7 +312,7 @@ LL |             _ = x.unwrap();
    |                 ^^^^^^^^^^
 
 error: called `unwrap` on `option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:259:26
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:260:26
    |
 LL |     if option.is_some() {
    |     ------------------- help: try: `if let Some(<item>) = option`
@@ -320,7 +320,7 @@ LL |         println!("{:?}", option.unwrap());
    |                          ^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:262:26
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:263:26
    |
 LL |     if option.is_some() {
    |        ---------------- because of this check
@@ -329,7 +329,7 @@ LL |         println!("{:?}", option.unwrap());
    |                          ^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `result` after checking its variant with `is_ok`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:269:26
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:270:26
    |
 LL |     if result.is_ok() {
    |     ----------------- help: try: `if let Ok(<item>) = result`
@@ -337,7 +337,7 @@ LL |         println!("{:?}", result.unwrap());
    |                          ^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:272:26
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:273:26
    |
 LL |     if result.is_ok() {
    |        -------------- because of this check
@@ -346,7 +346,7 @@ LL |         println!("{:?}", result.unwrap());
    |                          ^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `x` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:299:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:300:9
    |
 LL |     if x.is_some() {
    |     -------------- help: try: `if let Some(<item>) = x`
@@ -355,7 +355,7 @@ LL |         x.unwrap();
    |         ^^^^^^^^^^
 
 error: called `unwrap` on `x` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:305:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:306:9
    |
 LL |     if x.is_some() {
    |     -------------- help: try: `if let Some(<item>) = &x`
@@ -364,7 +364,7 @@ LL |         x.as_ref().unwrap();
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `sopt.option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:321:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:322:9
    |
 LL |     let _res = if sopt.option.is_some() {
    |                ------------------------ help: try: `if let Some(<item>) = sopt.option`
@@ -372,7 +372,7 @@ LL |         sopt.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:324:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:325:9
    |
 LL |     let _res = if sopt.option.is_some() {
    |                   --------------------- because of this check
@@ -381,7 +381,7 @@ LL |         sopt.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `sopt.option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:330:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:331:9
    |
 LL |     let _res = if sopt.option.is_some() {
    |                ------------------------ help: try: `if let Some(<item>) = sopt.option`
@@ -390,7 +390,7 @@ LL |         sopt.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:334:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:335:9
    |
 LL |     let _res = if sopt.option.is_some() {
    |                   --------------------- because of this check
@@ -399,7 +399,7 @@ LL |         sopt.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `topt.0` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:358:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:359:9
    |
 LL |     let _res = if topt.0.is_some() {
    |                ------------------- help: try: `if let Some(<item>) = topt.0`
@@ -407,7 +407,7 @@ LL |         topt.0.unwrap()
    |         ^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:361:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:362:9
    |
 LL |     let _res = if topt.0.is_some() {
    |                   ---------------- because of this check
@@ -416,7 +416,7 @@ LL |         topt.0.unwrap()
    |         ^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `topt.0` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:367:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:368:9
    |
 LL |     let _res = if topt.0.is_some() {
    |                ------------------- help: try: `if let Some(<item>) = topt.0`
@@ -425,7 +425,7 @@ LL |         topt.0.unwrap()
    |         ^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:371:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:372:9
    |
 LL |     let _res = if topt.0.is_some() {
    |                   ---------------- because of this check
@@ -434,7 +434,7 @@ LL |         topt.0.unwrap()
    |         ^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `sopt2.option.option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:405:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:406:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                -------------------------------- help: try: `if let Some(<item>) = sopt2.option.option`
@@ -442,7 +442,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:408:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:409:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                   ----------------------------- because of this check
@@ -451,7 +451,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `sopt2.option.option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:415:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:416:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                -------------------------------- help: try: `if let Some(<item>) = sopt2.option.option`
@@ -460,7 +460,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:419:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:420:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                   ----------------------------- because of this check
@@ -469,7 +469,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `sopt2.option.option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:425:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:426:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                -------------------------------- help: try: `if let Some(<item>) = sopt2.option.option`
@@ -478,7 +478,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:429:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:430:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                   ----------------------------- because of this check
@@ -487,7 +487,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `topt.0` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:465:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:466:9
    |
 LL |     if topt.0.is_some() {
    |     ------------------- help: try: `if let Some(<item>) = topt.0`
@@ -496,7 +496,7 @@ LL |         topt.0.unwrap();
    |         ^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `topt.0` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:471:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:472:9
    |
 LL |     if topt.0.is_some() {
    |     ------------------- help: try: `if let Some(<item>) = &topt.0`

--- a/tests/ui/crashes/issues_loop_mut_cond.rs
+++ b/tests/ui/crashes/issues_loop_mut_cond.rs
@@ -1,5 +1,7 @@
 //@ check-pass
 
+#![expect(clippy::static_mut_vars)]
+
 /// Issue: https://github.com/rust-lang/rust-clippy/issues/2596
 pub fn loop_on_block_condition(u: &mut isize) {
     while { *u < 0 } {

--- a/tests/ui/excessive_precision.fixed
+++ b/tests/ui/excessive_precision.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::excessive_precision)]
-#![expect(overflowing_literals, clippy::approx_constant)]
+#![expect(overflowing_literals, clippy::approx_constant, clippy::static_mut_vars)]
 
 macro_rules! make_pi {
     ($i:ident : $t:ty) => {

--- a/tests/ui/excessive_precision.rs
+++ b/tests/ui/excessive_precision.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::excessive_precision)]
-#![expect(overflowing_literals, clippy::approx_constant)]
+#![expect(overflowing_literals, clippy::approx_constant, clippy::static_mut_vars)]
 
 macro_rules! make_pi {
     ($i:ident : $t:ty) => {

--- a/tests/ui/multiple_unsafe_ops_per_block.rs
+++ b/tests/ui/multiple_unsafe_ops_per_block.rs
@@ -32,6 +32,7 @@ union U {
     u: u32,
 }
 
+#[allow(clippy::static_mut_vars)]
 static mut STATIC: i32 = 0;
 
 fn test1() {

--- a/tests/ui/multiple_unsafe_ops_per_block.rs
+++ b/tests/ui/multiple_unsafe_ops_per_block.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::multiple_unsafe_ops_per_block)]
 #![expect(
     dropping_copy_types,
+    clippy::static_mut_vars,
     clippy::unnecessary_literal_unwrap,
     clippy::unnecessary_operation
 )]

--- a/tests/ui/multiple_unsafe_ops_per_block.stderr
+++ b/tests/ui/multiple_unsafe_ops_per_block.stderr
@@ -1,5 +1,5 @@
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:38:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:39:5
    |
 LL | /     unsafe {
 LL | |
@@ -9,12 +9,12 @@ LL | |     }
    | |_____^
    |
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:40:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:41:9
    |
 LL |         STATIC += 1;
    |         ^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:41:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:42:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |         not_very_safe();
    = help: to override `-D warnings` add `#[allow(clippy::multiple_unsafe_ops_per_block)]`
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:48:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:49:5
    |
 LL | /     unsafe {
 LL | |
@@ -32,18 +32,18 @@ LL | |     }
    | |_____^
    |
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:51:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:52:9
    |
 LL |         *raw_ptr();
    |         ^^^^^^^^^^
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:50:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:51:14
    |
 LL |         drop(u.u);
    |              ^^^
 
 error: this `unsafe` block contains 3 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:56:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:57:5
    |
 LL | /     unsafe {
 LL | |
@@ -54,23 +54,23 @@ LL | |     }
    | |_____^
    |
 note: inline assembly used here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:58:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:59:9
    |
 LL |         asm!("nop");
    |         ^^^^^^^^^^^
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:60:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:61:9
    |
 LL |         STATIC = 0;
    |         ^^^^^^^^^^
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:59:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:60:9
    |
 LL |         sample.not_very_safe();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 6 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:66:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:67:5
    |
 LL | /     unsafe {
 LL | |
@@ -82,38 +82,38 @@ LL | |     }
    | |_____^
    |
 note: access of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:69:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:70:14
    |
 LL |         drop(STATIC);
    |              ^^^^^^
 note: inline assembly used here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:73:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:74:9
    |
 LL |         asm!("nop");
    |         ^^^^^^^^^^^
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:72:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:73:9
    |
 LL |         *raw_ptr();
    |         ^^^^^^^^^^
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:68:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:69:14
    |
 LL |         drop(u.u);
    |              ^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:71:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:72:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:70:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:71:9
    |
 LL |         sample.not_very_safe();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:109:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:110:5
    |
 LL | /     unsafe {
 LL | |
@@ -123,35 +123,35 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:111:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:112:9
    |
 LL |         f();
    |         ^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:112:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:113:9
    |
 LL |         f();
    |         ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:9
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:43
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:43
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |                                           ^^^^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:18
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:18
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:139:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:140:9
    |
 LL | /         unsafe {
 LL | |
@@ -161,18 +161,18 @@ LL | |         }
    | |_________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:141:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:142:13
    |
 LL |             x();
    |             ^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:142:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:143:13
    |
 LL |             x();
    |             ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:151:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:152:13
    |
 LL | /             unsafe {
 LL | |
@@ -182,18 +182,18 @@ LL | |             }
    | |_____________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:153:17
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:154:17
    |
 LL |                 T::X();
    |                 ^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:154:17
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:155:17
    |
 LL |                 T::X();
    |                 ^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:162:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:163:9
    |
 LL | /         unsafe {
 LL | |
@@ -203,18 +203,18 @@ LL | |         }
    | |_________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:164:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:165:13
    |
 LL |             x.0();
    |             ^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:165:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:166:13
    |
 LL |             x.0();
    |             ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:192:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:193:5
    |
 LL | /     unsafe {
 LL | |
@@ -225,18 +225,18 @@ LL | |     }
    | |_____^
    |
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:195:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:196:9
    |
 LL |         STATIC += 1;
    |         ^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:194:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:195:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:207:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:208:5
    |
 LL | /     unsafe {
 LL | |
@@ -246,18 +246,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:209:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:210:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:210:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:211:9
    |
 LL |         foo_unchecked().await;
    |         ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:214:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:215:5
    |
 LL | /     unsafe {
 LL | |
@@ -266,18 +266,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:216:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:217:14
    |
 LL |         Some(foo_unchecked()).unwrap_unchecked().await;
    |              ^^^^^^^^^^^^^^^
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:216:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:217:9
    |
 LL |         Some(foo_unchecked()).unwrap_unchecked().await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:236:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:237:5
    |
 LL | /     unsafe {
 LL | |
@@ -286,19 +286,19 @@ LL | |         _ = &u.i;
 LL | |     }
    | |_____^
    |
-note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:238:14
-   |
-LL |         _ = &u.i;
-   |              ^^^
 note: union field access occurs here
   --> tests/ui/multiple_unsafe_ops_per_block.rs:239:14
    |
 LL |         _ = &u.i;
    |              ^^^
+note: union field access occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:240:14
+   |
+LL |         _ = &u.i;
+   |              ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:244:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:245:5
    |
 LL | /     unsafe {
 LL | |
@@ -307,19 +307,19 @@ LL | |         _ = &raw const (*&raw const u).i;
 LL | |     }
    | |_____^
    |
-note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:246:24
-   |
-LL |         _ = &raw const (*&raw const u).i;
-   |                        ^^^^^^^^^^^^^^^
 note: raw pointer dereference occurs here
   --> tests/ui/multiple_unsafe_ops_per_block.rs:247:24
    |
 LL |         _ = &raw const (*&raw const u).i;
    |                        ^^^^^^^^^^^^^^^
+note: raw pointer dereference occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:248:24
+   |
+LL |         _ = &raw const (*&raw const u).i;
+   |                        ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:294:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:295:5
    |
 LL | /     unsafe {
 LL | |
@@ -329,18 +329,18 @@ LL | |     }
    | |_____^
    |
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:296:24
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:297:24
    |
 LL |         _ = &raw const w.s.i;
    |                        ^^^
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:297:24
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:298:24
    |
 LL |         _ = &raw const w.s.i;
    |                        ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:309:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:310:5
    |
 LL | /     unsafe {
 LL | |
@@ -349,18 +349,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:311:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:312:9
    |
 LL |         apply(|| f(0));
    |         ^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:311:18
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:312:18
    |
 LL |         apply(|| f(0));
    |                  ^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:326:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:327:5
    |
 LL | /     unsafe {
 LL | |
@@ -370,18 +370,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:328:31
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:329:31
    |
 LL |         let _ = format!("{}", foo());
    |                               ^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:329:31
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:330:31
    |
 LL |         let _ = format!("{}", foo());
    |                               ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:338:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:339:5
    |
 LL | /     unsafe {
 LL | |
@@ -390,18 +390,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:340:20
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:341:20
    |
 LL |         assert_eq!(foo(), 0, "{}", foo()); // One unsafe operation
    |                    ^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:340:36
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:341:36
    |
 LL |         assert_eq!(foo(), 0, "{}", foo()); // One unsafe operation
    |                                    ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:356:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:357:5
    |
 LL | /     unsafe {
 LL | |
@@ -410,19 +410,19 @@ LL | |         twice!(foo());
 LL | |     }
    | |_____^
    |
-note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:358:16
-   |
-LL |         twice!(foo());
-   |                ^^^^^
 note: unsafe function call occurs here
   --> tests/ui/multiple_unsafe_ops_per_block.rs:359:16
    |
 LL |         twice!(foo());
    |                ^^^^^
+note: unsafe function call occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:360:16
+   |
+LL |         twice!(foo());
+   |                ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:362:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:363:5
    |
 LL | /     unsafe {
 LL | |
@@ -431,19 +431,19 @@ LL | |         assert_eq!(foo(), 0, "{}", 1 + 2);
 LL | |     }
    | |_____^
    |
-note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:364:20
-   |
-LL |         assert_eq!(foo(), 0, "{}", 1 + 2);
-   |                    ^^^^^
 note: unsafe function call occurs here
   --> tests/ui/multiple_unsafe_ops_per_block.rs:365:20
    |
 LL |         assert_eq!(foo(), 0, "{}", 1 + 2);
    |                    ^^^^^
+note: unsafe function call occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:366:20
+   |
+LL |         assert_eq!(foo(), 0, "{}", 1 + 2);
+   |                    ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:396:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:397:5
    |
 LL | /     unsafe {
 LL | |
@@ -452,19 +452,19 @@ LL | |         double_non_arg_unsafe!();
 LL | |     }
    | |_____^
    |
-note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:398:9
-   |
-LL |         double_non_arg_unsafe!();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
 note: this macro call expands into one or more unsafe operations
   --> tests/ui/multiple_unsafe_ops_per_block.rs:399:9
    |
 LL |         double_non_arg_unsafe!();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
+note: this macro call expands into one or more unsafe operations
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:400:9
+   |
+LL |         double_non_arg_unsafe!();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:407:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:408:5
    |
 LL | /     unsafe {
 LL | |
@@ -474,18 +474,18 @@ LL | |     }
    | |_____^
    |
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:409:20
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:410:20
    |
 LL |         assert_eq!(double_non_arg_unsafe!(), ());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:410:20
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:411:20
    |
 LL |         assert_eq!(double_non_arg_unsafe!(), ());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:413:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:414:5
    |
 LL | /     unsafe {
 LL | |
@@ -494,18 +494,18 @@ LL | |     }
    | |_____^
    |
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:415:21
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:416:21
    |
 LL |         assert_eq!((double_non_arg_unsafe!(), double_non_arg_unsafe!()), ((), ()));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:415:47
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:416:47
    |
 LL |         assert_eq!((double_non_arg_unsafe!(), double_non_arg_unsafe!()), ((), ()));
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:430:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:431:5
    |
 LL | /     unsafe {
 LL | |
@@ -514,12 +514,12 @@ LL | |     }
    | |_____^
    |
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:432:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:433:9
    |
 LL |         unsafe_with_arg!(foo());
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:432:26
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:433:26
    |
 LL |         unsafe_with_arg!(foo());
    |                          ^^^^^

--- a/tests/ui/multiple_unsafe_ops_per_block.stderr
+++ b/tests/ui/multiple_unsafe_ops_per_block.stderr
@@ -1,5 +1,5 @@
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:38:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:39:5
    |
 LL | /     unsafe {
 LL | |
@@ -9,12 +9,12 @@ LL | |     }
    | |_____^
    |
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:40:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:41:9
    |
 LL |         STATIC += 1;
    |         ^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:41:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:42:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |         not_very_safe();
    = help: to override `-D warnings` add `#[allow(clippy::multiple_unsafe_ops_per_block)]`
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:48:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:49:5
    |
 LL | /     unsafe {
 LL | |
@@ -32,18 +32,18 @@ LL | |     }
    | |_____^
    |
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:51:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:52:9
    |
 LL |         *raw_ptr();
    |         ^^^^^^^^^^
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:50:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:51:14
    |
 LL |         drop(u.u);
    |              ^^^
 
 error: this `unsafe` block contains 3 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:56:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:57:5
    |
 LL | /     unsafe {
 LL | |
@@ -54,23 +54,23 @@ LL | |     }
    | |_____^
    |
 note: inline assembly used here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:58:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:59:9
    |
 LL |         asm!("nop");
    |         ^^^^^^^^^^^
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:60:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:61:9
    |
 LL |         STATIC = 0;
    |         ^^^^^^^^^^
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:59:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:60:9
    |
 LL |         sample.not_very_safe();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 6 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:66:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:67:5
    |
 LL | /     unsafe {
 LL | |
@@ -82,38 +82,38 @@ LL | |     }
    | |_____^
    |
 note: access of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:69:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:70:14
    |
 LL |         drop(STATIC);
    |              ^^^^^^
 note: inline assembly used here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:73:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:74:9
    |
 LL |         asm!("nop");
    |         ^^^^^^^^^^^
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:72:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:73:9
    |
 LL |         *raw_ptr();
    |         ^^^^^^^^^^
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:68:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:69:14
    |
 LL |         drop(u.u);
    |              ^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:71:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:72:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:70:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:71:9
    |
 LL |         sample.not_very_safe();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:109:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:110:5
    |
 LL | /     unsafe {
 LL | |
@@ -123,35 +123,35 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:111:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:112:9
    |
 LL |         f();
    |         ^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:112:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:113:9
    |
 LL |         f();
    |         ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:9
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:43
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:43
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |                                           ^^^^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:118:18
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:119:18
    |
 LL |         unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:139:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:140:9
    |
 LL | /         unsafe {
 LL | |
@@ -161,18 +161,18 @@ LL | |         }
    | |_________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:141:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:142:13
    |
 LL |             x();
    |             ^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:142:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:143:13
    |
 LL |             x();
    |             ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:151:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:152:13
    |
 LL | /             unsafe {
 LL | |
@@ -182,18 +182,18 @@ LL | |             }
    | |_____________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:153:17
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:154:17
    |
 LL |                 T::X();
    |                 ^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:154:17
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:155:17
    |
 LL |                 T::X();
    |                 ^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:162:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:163:9
    |
 LL | /         unsafe {
 LL | |
@@ -203,18 +203,18 @@ LL | |         }
    | |_________^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:164:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:165:13
    |
 LL |             x.0();
    |             ^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:165:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:166:13
    |
 LL |             x.0();
    |             ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:192:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:193:5
    |
 LL | /     unsafe {
 LL | |
@@ -225,18 +225,18 @@ LL | |     }
    | |_____^
    |
 note: modification of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:195:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:196:9
    |
 LL |         STATIC += 1;
    |         ^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:194:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:195:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:207:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:208:5
    |
 LL | /     unsafe {
 LL | |
@@ -246,18 +246,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:209:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:210:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:210:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:211:9
    |
 LL |         foo_unchecked().await;
    |         ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:214:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:215:5
    |
 LL | /     unsafe {
 LL | |
@@ -266,18 +266,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:216:14
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:217:14
    |
 LL |         Some(foo_unchecked()).unwrap_unchecked().await;
    |              ^^^^^^^^^^^^^^^
 note: unsafe method call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:216:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:217:9
    |
 LL |         Some(foo_unchecked()).unwrap_unchecked().await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:236:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:237:5
    |
 LL | /     unsafe {
 LL | |
@@ -286,19 +286,19 @@ LL | |         _ = &u.i;
 LL | |     }
    | |_____^
    |
-note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:238:14
-   |
-LL |         _ = &u.i;
-   |              ^^^
 note: union field access occurs here
   --> tests/ui/multiple_unsafe_ops_per_block.rs:239:14
    |
 LL |         _ = &u.i;
    |              ^^^
+note: union field access occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:240:14
+   |
+LL |         _ = &u.i;
+   |              ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:244:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:245:5
    |
 LL | /     unsafe {
 LL | |
@@ -307,19 +307,19 @@ LL | |         _ = &raw const (*&raw const u).i;
 LL | |     }
    | |_____^
    |
-note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:246:24
-   |
-LL |         _ = &raw const (*&raw const u).i;
-   |                        ^^^^^^^^^^^^^^^
 note: raw pointer dereference occurs here
   --> tests/ui/multiple_unsafe_ops_per_block.rs:247:24
    |
 LL |         _ = &raw const (*&raw const u).i;
    |                        ^^^^^^^^^^^^^^^
+note: raw pointer dereference occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:248:24
+   |
+LL |         _ = &raw const (*&raw const u).i;
+   |                        ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:294:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:295:5
    |
 LL | /     unsafe {
 LL | |
@@ -329,18 +329,18 @@ LL | |     }
    | |_____^
    |
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:296:24
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:297:24
    |
 LL |         _ = &raw const w.s.i;
    |                        ^^^
 note: union field access occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:297:24
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:298:24
    |
 LL |         _ = &raw const w.s.i;
    |                        ^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:309:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:310:5
    |
 LL | /     unsafe {
 LL | |
@@ -349,18 +349,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:311:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:312:9
    |
 LL |         apply(|| f(0));
    |         ^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:311:18
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:312:18
    |
 LL |         apply(|| f(0));
    |                  ^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:326:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:327:5
    |
 LL | /     unsafe {
 LL | |
@@ -370,18 +370,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:328:31
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:329:31
    |
 LL |         let _ = format!("{}", foo());
    |                               ^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:329:31
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:330:31
    |
 LL |         let _ = format!("{}", foo());
    |                               ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:338:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:339:5
    |
 LL | /     unsafe {
 LL | |
@@ -390,18 +390,18 @@ LL | |     }
    | |_____^
    |
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:340:20
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:341:20
    |
 LL |         assert_eq!(foo(), 0, "{}", foo()); // One unsafe operation
    |                    ^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:340:36
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:341:36
    |
 LL |         assert_eq!(foo(), 0, "{}", foo()); // One unsafe operation
    |                                    ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:356:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:357:5
    |
 LL | /     unsafe {
 LL | |
@@ -410,19 +410,19 @@ LL | |         twice!(foo());
 LL | |     }
    | |_____^
    |
-note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:358:16
-   |
-LL |         twice!(foo());
-   |                ^^^^^
 note: unsafe function call occurs here
   --> tests/ui/multiple_unsafe_ops_per_block.rs:359:16
    |
 LL |         twice!(foo());
    |                ^^^^^
+note: unsafe function call occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:360:16
+   |
+LL |         twice!(foo());
+   |                ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:362:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:363:5
    |
 LL | /     unsafe {
 LL | |
@@ -431,19 +431,19 @@ LL | |         assert_eq!(foo(), 0, "{}", 1 + 2);
 LL | |     }
    | |_____^
    |
-note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:364:20
-   |
-LL |         assert_eq!(foo(), 0, "{}", 1 + 2);
-   |                    ^^^^^
 note: unsafe function call occurs here
   --> tests/ui/multiple_unsafe_ops_per_block.rs:365:20
    |
 LL |         assert_eq!(foo(), 0, "{}", 1 + 2);
    |                    ^^^^^
+note: unsafe function call occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:366:20
+   |
+LL |         assert_eq!(foo(), 0, "{}", 1 + 2);
+   |                    ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:396:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:397:5
    |
 LL | /     unsafe {
 LL | |
@@ -452,19 +452,19 @@ LL | |         double_non_arg_unsafe!();
 LL | |     }
    | |_____^
    |
-note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:398:9
-   |
-LL |         double_non_arg_unsafe!();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
 note: this macro call expands into one or more unsafe operations
   --> tests/ui/multiple_unsafe_ops_per_block.rs:399:9
    |
 LL |         double_non_arg_unsafe!();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
+note: this macro call expands into one or more unsafe operations
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:400:9
+   |
+LL |         double_non_arg_unsafe!();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:407:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:408:5
    |
 LL | /     unsafe {
 LL | |
@@ -474,18 +474,18 @@ LL | |     }
    | |_____^
    |
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:409:20
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:410:20
    |
 LL |         assert_eq!(double_non_arg_unsafe!(), ());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:410:20
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:411:20
    |
 LL |         assert_eq!(double_non_arg_unsafe!(), ());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:413:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:414:5
    |
 LL | /     unsafe {
 LL | |
@@ -494,18 +494,18 @@ LL | |     }
    | |_____^
    |
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:415:21
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:416:21
    |
 LL |         assert_eq!((double_non_arg_unsafe!(), double_non_arg_unsafe!()), ((), ()));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:415:47
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:416:47
    |
 LL |         assert_eq!((double_non_arg_unsafe!(), double_non_arg_unsafe!()), ((), ()));
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:430:5
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:431:5
    |
 LL | /     unsafe {
 LL | |
@@ -514,18 +514,18 @@ LL | |     }
    | |_____^
    |
 note: this macro call expands into one or more unsafe operations
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:432:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:433:9
    |
 LL |         unsafe_with_arg!(foo());
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:432:26
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:433:26
    |
 LL |         unsafe_with_arg!(foo());
    |                          ^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:475:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:476:9
    |
 LL | /         unsafe {
 LL | |
@@ -535,18 +535,18 @@ LL | |         }
    | |_________^
    |
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:478:30
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:479:30
    |
 LL |             let _ = &raw mut (*value).x;
    |                              ^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:477:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:478:13
    |
 LL |             not_very_safe();
    |             ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:497:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:498:9
    |
 LL | /         unsafe {
 LL | |
@@ -556,18 +556,18 @@ LL | |         }
    | |_________^
    |
 note: access of a mutable static occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:500:30
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:501:30
    |
 LL |             let _ = &raw mut GLOBAL_STRUCT.s.x;
    |                              ^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:499:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:500:13
    |
 LL |             not_very_safe();
    |             ^^^^^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:506:9
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:507:9
    |
 LL | /         unsafe {
 LL | |
@@ -577,12 +577,12 @@ LL | |         }
    | |_________^
    |
 note: raw pointer dereference occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:509:30
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:510:30
    |
 LL |             let _ = &raw mut (*ptr).s.x;
    |                              ^^^^^^
 note: unsafe function call occurs here
-  --> tests/ui/multiple_unsafe_ops_per_block.rs:508:13
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:509:13
    |
 LL |             not_very_safe();
    |             ^^^^^^^^^^^^^^^

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -1,4 +1,5 @@
 #![feature(never_type)]
+#![expect(clippy::static_mut_vars)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;
 use std::sync::Arc;

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -1,3 +1,4 @@
+#![expect(clippy::static_mut_vars)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;
 use std::sync::Arc;

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -1,4 +1,5 @@
 #![feature(never_type)]
+#![expect(clippy::static_mut_vars)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;
 use std::sync::Arc;

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::static_mut_vars)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;
 use std::sync::Arc;

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -1,5 +1,5 @@
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:10:8
+  --> tests/ui/must_use_candidates.rs:11:8
    |
 LL | pub fn pure(i: u8) -> u8 {
    |        ^^^^
@@ -13,7 +13,7 @@ LL | pub fn pure(i: u8) -> u8 {
    |
 
 error: this method could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:16:12
+  --> tests/ui/must_use_candidates.rs:17:12
    |
 LL |     pub fn inherent_pure(&self) -> u8 {
    |            ^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL ~     pub fn inherent_pure(&self) -> u8 {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:48:8
+  --> tests/ui/must_use_candidates.rs:49:8
    |
 LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    |        ^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:61:8
+  --> tests/ui/must_use_candidates.rs:62:8
    |
 LL | pub fn rcd(_x: Rc<u32>) -> bool {
    |        ^^^
@@ -49,7 +49,7 @@ LL | pub fn rcd(_x: Rc<u32>) -> bool {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:70:8
+  --> tests/ui/must_use_candidates.rs:71:8
    |
 LL | pub fn arcd(_x: Arc<u32>) -> bool {
    |        ^^^^
@@ -61,7 +61,7 @@ LL | pub fn arcd(_x: Arc<u32>) -> bool {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:102:8
+  --> tests/ui/must_use_candidates.rs:103:8
    |
 LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
    |        ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -1,5 +1,5 @@
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:9:8
+  --> tests/ui/must_use_candidates.rs:10:8
    |
 LL | pub fn pure(i: u8) -> u8 {
    |        ^^^^
@@ -13,7 +13,7 @@ LL | pub fn pure(i: u8) -> u8 {
    |
 
 error: this method could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:15:12
+  --> tests/ui/must_use_candidates.rs:16:12
    |
 LL |     pub fn inherent_pure(&self) -> u8 {
    |            ^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL ~     pub fn inherent_pure(&self) -> u8 {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:47:8
+  --> tests/ui/must_use_candidates.rs:48:8
    |
 LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    |        ^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:60:8
+  --> tests/ui/must_use_candidates.rs:61:8
    |
 LL | pub fn rcd(_x: Rc<u32>) -> bool {
    |        ^^^
@@ -49,7 +49,7 @@ LL | pub fn rcd(_x: Rc<u32>) -> bool {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:69:8
+  --> tests/ui/must_use_candidates.rs:70:8
    |
 LL | pub fn arcd(_x: Arc<u32>) -> bool {
    |        ^^^^
@@ -61,7 +61,7 @@ LL | pub fn arcd(_x: Arc<u32>) -> bool {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:101:8
+  --> tests/ui/must_use_candidates.rs:102:8
    |
 LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
    |        ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.fixed
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.fixed
@@ -2,7 +2,7 @@
 //@aux-build:lazy_static.rs
 
 #![warn(clippy::non_std_lazy_statics)]
-#![expect(static_mut_refs)]
+#![expect(static_mut_refs, clippy::static_mut_vars)]
 
 use once_cell::sync::Lazy;
 

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs
@@ -2,7 +2,7 @@
 //@aux-build:lazy_static.rs
 
 #![warn(clippy::non_std_lazy_statics)]
-#![expect(static_mut_refs)]
+#![expect(static_mut_refs, clippy::static_mut_vars)]
 
 use once_cell::sync::Lazy;
 

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs
@@ -3,7 +3,7 @@
 //@no-rustfix
 
 #![warn(clippy::non_std_lazy_statics)]
-#![expect(static_mut_refs)]
+#![expect(static_mut_refs, clippy::static_mut_vars)]
 
 mod once_cell_lazy {
     use once_cell::sync::Lazy;

--- a/tests/ui/redundant_static_lifetimes.fixed
+++ b/tests/ui/redundant_static_lifetimes.fixed
@@ -1,6 +1,6 @@
 #![warn(clippy::redundant_static_lifetimes)]
 // FIXME(static_mut_refs): use raw pointers instead of references
-#![allow(static_mut_refs)]
+#![allow(static_mut_refs, clippy::static_mut_vars)]
 
 #[derive(Debug)]
 struct Foo;

--- a/tests/ui/redundant_static_lifetimes.rs
+++ b/tests/ui/redundant_static_lifetimes.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::redundant_static_lifetimes)]
 // FIXME(static_mut_refs): use raw pointers instead of references
-#![allow(static_mut_refs)]
+#![allow(static_mut_refs, clippy::static_mut_vars)]
 
 #[derive(Debug)]
 struct Foo;

--- a/tests/ui/ref_as_ptr.fixed
+++ b/tests/ui/ref_as_ptr.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::ref_as_ptr)]
-#![allow(clippy::unnecessary_mut_passed)]
+#![allow(clippy::unnecessary_mut_passed, clippy::static_mut_vars)]
 
 fn f<T>(_: T) {}
 

--- a/tests/ui/ref_as_ptr.fixed
+++ b/tests/ui/ref_as_ptr.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::ref_as_ptr)]
-#![allow(clippy::unnecessary_mut_passed)]
+#![allow(clippy::static_mut_vars, clippy::unnecessary_mut_passed)]
 
 fn f<T>(_: T) {}
 

--- a/tests/ui/ref_as_ptr.rs
+++ b/tests/ui/ref_as_ptr.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::ref_as_ptr)]
-#![allow(clippy::unnecessary_mut_passed)]
+#![allow(clippy::unnecessary_mut_passed, clippy::static_mut_vars)]
 
 fn f<T>(_: T) {}
 

--- a/tests/ui/ref_as_ptr.rs
+++ b/tests/ui/ref_as_ptr.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::ref_as_ptr)]
-#![allow(clippy::unnecessary_mut_passed)]
+#![allow(clippy::static_mut_vars, clippy::unnecessary_mut_passed)]
 
 fn f<T>(_: T) {}
 

--- a/tests/ui/static_mut_vars/static_mut_vars_fixable.fixed
+++ b/tests/ui/static_mut_vars/static_mut_vars_fixable.fixed
@@ -1,0 +1,37 @@
+#![warn(clippy::static_mut_vars)]
+
+unsafe extern "C" {
+    pub safe static mut EXTERN_VAR: [u8; 5];
+}
+
+static BOOL_VAR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+//~^ static_mut_vars
+
+static ISIZE_VAR: std::sync::atomic::AtomicIsize = std::sync::atomic::AtomicIsize::new(0isize);
+//~^ static_mut_vars
+static I8_VAR: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(0i8);
+//~^ static_mut_vars
+static I16_VAR: std::sync::atomic::AtomicI16 = std::sync::atomic::AtomicI16::new(0i16);
+//~^ static_mut_vars
+static I32_VAR: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(1i32);
+//~^ static_mut_vars
+static I64_VAR: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1i64);
+//~^ static_mut_vars
+
+static USIZE_VAR: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0usize);
+//~^ static_mut_vars
+static U8_VAR: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0u8);
+//~^ static_mut_vars
+static U16_VAR: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(0u16);
+//~^ static_mut_vars
+static U32_VAR: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0u32);
+//~^ static_mut_vars
+static U64_VAR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0u64);
+//~^ static_mut_vars
+
+static MUT_PTR_VAR: std::sync::atomic::AtomicPtr<i32> = std::sync::atomic::AtomicPtr::<i32>::new(std::ptr::null_mut());
+//~^ static_mut_vars
+
+static VAL: u8 = 0u8;
+
+fn main() {}

--- a/tests/ui/static_mut_vars/static_mut_vars_fixable.rs
+++ b/tests/ui/static_mut_vars/static_mut_vars_fixable.rs
@@ -1,0 +1,37 @@
+#![warn(clippy::static_mut_vars)]
+
+unsafe extern "C" {
+    pub safe static mut EXTERN_VAR: [u8; 5];
+}
+
+static mut BOOL_VAR: bool = false;
+//~^ static_mut_vars
+
+static mut ISIZE_VAR: isize = 0isize;
+//~^ static_mut_vars
+static mut I8_VAR: i8 = 0i8;
+//~^ static_mut_vars
+static mut I16_VAR: i16 = 0i16;
+//~^ static_mut_vars
+static mut I32_VAR: i32 = 1i32;
+//~^ static_mut_vars
+static mut I64_VAR: i64 = 1i64;
+//~^ static_mut_vars
+
+static mut USIZE_VAR: usize = 0usize;
+//~^ static_mut_vars
+static mut U8_VAR: u8 = 0u8;
+//~^ static_mut_vars
+static mut U16_VAR: u16 = 0u16;
+//~^ static_mut_vars
+static mut U32_VAR: u32 = 0u32;
+//~^ static_mut_vars
+static mut U64_VAR: u64 = 0u64;
+//~^ static_mut_vars
+
+static mut MUT_PTR_VAR: *mut i32 = std::ptr::null_mut();
+//~^ static_mut_vars
+
+static VAL: u8 = 0u8;
+
+fn main() {}

--- a/tests/ui/static_mut_vars/static_mut_vars_fixable.stderr
+++ b/tests/ui/static_mut_vars/static_mut_vars_fixable.stderr
@@ -1,0 +1,148 @@
+error: static `BOOL_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:7:1
+   |
+LL | static mut BOOL_VAR: bool = false;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::static-mut-vars` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::static_mut_vars)]`
+help: try
+   |
+LL - static mut BOOL_VAR: bool = false;
+LL + static BOOL_VAR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+   |
+
+error: static `ISIZE_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:10:1
+   |
+LL | static mut ISIZE_VAR: isize = 0isize;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut ISIZE_VAR: isize = 0isize;
+LL + static ISIZE_VAR: std::sync::atomic::AtomicIsize = std::sync::atomic::AtomicIsize::new(0isize);
+   |
+
+error: static `I8_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:12:1
+   |
+LL | static mut I8_VAR: i8 = 0i8;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut I8_VAR: i8 = 0i8;
+LL + static I8_VAR: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(0i8);
+   |
+
+error: static `I16_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:14:1
+   |
+LL | static mut I16_VAR: i16 = 0i16;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut I16_VAR: i16 = 0i16;
+LL + static I16_VAR: std::sync::atomic::AtomicI16 = std::sync::atomic::AtomicI16::new(0i16);
+   |
+
+error: static `I32_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:16:1
+   |
+LL | static mut I32_VAR: i32 = 1i32;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut I32_VAR: i32 = 1i32;
+LL + static I32_VAR: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(1i32);
+   |
+
+error: static `I64_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:18:1
+   |
+LL | static mut I64_VAR: i64 = 1i64;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut I64_VAR: i64 = 1i64;
+LL + static I64_VAR: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1i64);
+   |
+
+error: static `USIZE_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:21:1
+   |
+LL | static mut USIZE_VAR: usize = 0usize;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut USIZE_VAR: usize = 0usize;
+LL + static USIZE_VAR: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0usize);
+   |
+
+error: static `U8_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:23:1
+   |
+LL | static mut U8_VAR: u8 = 0u8;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut U8_VAR: u8 = 0u8;
+LL + static U8_VAR: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0u8);
+   |
+
+error: static `U16_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:25:1
+   |
+LL | static mut U16_VAR: u16 = 0u16;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut U16_VAR: u16 = 0u16;
+LL + static U16_VAR: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(0u16);
+   |
+
+error: static `U32_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:27:1
+   |
+LL | static mut U32_VAR: u32 = 0u32;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut U32_VAR: u32 = 0u32;
+LL + static U32_VAR: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0u32);
+   |
+
+error: static `U64_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:29:1
+   |
+LL | static mut U64_VAR: u64 = 0u64;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut U64_VAR: u64 = 0u64;
+LL + static U64_VAR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0u64);
+   |
+
+error: static `MUT_PTR_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_fixable.rs:32:1
+   |
+LL | static mut MUT_PTR_VAR: *mut i32 = std::ptr::null_mut();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL - static mut MUT_PTR_VAR: *mut i32 = std::ptr::null_mut();
+LL + static MUT_PTR_VAR: std::sync::atomic::AtomicPtr<i32> = std::sync::atomic::AtomicPtr::<i32>::new(std::ptr::null_mut());
+   |
+
+error: aborting due to 12 previous errors
+

--- a/tests/ui/static_mut_vars/static_mut_vars_unfixable.rs
+++ b/tests/ui/static_mut_vars/static_mut_vars_unfixable.rs
@@ -1,0 +1,27 @@
+#![warn(clippy::static_mut_vars)]
+//@no-rustfix
+
+static mut F32_VAR: f32 = 1.0f32;
+//~^ static_mut_vars
+static mut F64_VAR: f64 = 1.0f64;
+//~^ static_mut_vars
+
+static mut CHAR_VAR: char = 'a';
+//~^ static_mut_vars
+
+static mut REF_VAR: &str = "foo";
+//~^ static_mut_vars
+
+static mut PTR_VAR: *const i32 = std::ptr::null();
+//~^ static_mut_vars
+
+static mut ARR_VAR: [u8; 3] = [0u8, 1u8, 2u8];
+//~^ static_mut_vars
+
+static mut TUPLE_VAR: (u8, u8) = (0u8, 0u8);
+//~^ static_mut_vars
+
+static mut FN_PTR_VAR: fn(i32) -> i32 = |x| x * x;
+//~^ static_mut_vars
+
+fn main() {}

--- a/tests/ui/static_mut_vars/static_mut_vars_unfixable.stderr
+++ b/tests/ui/static_mut_vars/static_mut_vars_unfixable.stderr
@@ -1,0 +1,68 @@
+error: static `F32_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_unfixable.rs:4:1
+   |
+LL | static mut F32_VAR: f32 = 1.0f32;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a safer alternative
+   = note: `-D clippy::static-mut-vars` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::static_mut_vars)]`
+
+error: static `F64_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_unfixable.rs:6:1
+   |
+LL | static mut F64_VAR: f64 = 1.0f64;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a safer alternative
+
+error: static `CHAR_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_unfixable.rs:9:1
+   |
+LL | static mut CHAR_VAR: char = 'a';
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a safer alternative
+
+error: static `REF_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_unfixable.rs:12:1
+   |
+LL | static mut REF_VAR: &str = "foo";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a safer alternative
+
+error: static `PTR_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_unfixable.rs:15:1
+   |
+LL | static mut PTR_VAR: *const i32 = std::ptr::null();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a safer alternative
+
+error: static `ARR_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_unfixable.rs:18:1
+   |
+LL | static mut ARR_VAR: [u8; 3] = [0u8, 1u8, 2u8];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a safer alternative
+
+error: static `TUPLE_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_unfixable.rs:21:1
+   |
+LL | static mut TUPLE_VAR: (u8, u8) = (0u8, 0u8);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a safer alternative
+
+error: static `FN_PTR_VAR` is declared as mutable
+  --> tests/ui/static_mut_vars/static_mut_vars_unfixable.rs:24:1
+   |
+LL | static mut FN_PTR_VAR: fn(i32) -> i32 = |x| x * x;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a safer alternative
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -1,6 +1,6 @@
 #![warn(clippy::useless_conversion)]
 // FIXME(static_mut_refs): use raw pointers instead of references
-#![expect(static_mut_refs)]
+#![expect(static_mut_refs, clippy::static_mut_vars)]
 #![allow(clippy::into_iter_on_ref)]
 
 use std::ops::ControlFlow;

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::useless_conversion)]
 // FIXME(static_mut_refs): use raw pointers instead of references
-#![expect(static_mut_refs)]
+#![expect(static_mut_refs, clippy::static_mut_vars)]
 #![allow(clippy::into_iter_on_ref)]
 
 use std::ops::ControlFlow;


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16646)*

*implements lint for checking `static mut` variables usage*

changelog: [`static_mut_vars`]

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Fixes rust-lang/rust-clippy#4070.