### PR TITLE
Fix `redundant_closure` suggests wrongly when local is derefed to callable

### DIFF
--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -216,6 +216,18 @@ fn check_closure<'tcx>(cx: &LateContext<'tcx>, outer_receiver: Option<&Expr<'tcx
                     "redundant closure",
                     |diag| {
                         if let Some(mut snippet) = snippet_opt(cx, callee.span) {
+                            let n_refs = callee_ty_adjustments
+                                .iter()
+                                .rev()
+                                .fold(0, |acc, adjustment| match adjustment.kind {
+                                    Adjust::Deref(DerefAdjustKind::Overloaded(_)) => acc + 1,
+                                    Adjust::Deref(_) if acc > 0 => acc + 1,
+                                    _ => acc,
+                                });
+                            if n_refs > 0 {
+                                snippet = format!("{}{snippet}", "*".repeat(n_refs));
+                            }
+
                             if callee.res_local_id().is_some_and(|l| {
                                 // FIXME: Do we really need this `local_used_in` check?
                                 // Isn't it checking something like... `callee(callee)`?
@@ -231,18 +243,6 @@ fn check_closure<'tcx>(cx: &LateContext<'tcx>, outer_receiver: Option<&Expr<'tcx
                                     },
                                     _ => (),
                                 }
-                            } else if let n_refs =
-                                callee_ty_adjustments
-                                    .iter()
-                                    .rev()
-                                    .fold(0, |acc, adjustment| match adjustment.kind {
-                                        Adjust::Deref(DerefAdjustKind::Overloaded(_)) => acc + 1,
-                                        Adjust::Deref(_) if acc > 0 => acc + 1,
-                                        _ => acc,
-                                    })
-                                && n_refs > 0
-                            {
-                                snippet = format!("{}{snippet}", "*".repeat(n_refs));
                             }
 
                             let replace_with = match callee_ty_adjusted.kind() {

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -652,3 +652,12 @@ trait Issue16360: Sized {
         //~^ redundant_closure_for_method_calls
     }
 }
+
+fn issue16641() {
+    use std::cell::LazyCell;
+
+    let closure = LazyCell::new(|| |x: usize| println!("{x}"));
+
+    (0..10).flat_map(|x| (0..10).map(&*closure)).count();
+    //~^ redundant_closure
+}

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -652,3 +652,12 @@ trait Issue16360: Sized {
         //~^ redundant_closure_for_method_calls
     }
 }
+
+fn issue16641() {
+    use std::cell::LazyCell;
+
+    let closure = LazyCell::new(|| |x: usize| println!("{x}"));
+
+    (0..10).flat_map(|x| (0..10).map(|y| closure(y))).count();
+    //~^ redundant_closure
+}

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -262,5 +262,11 @@ error: redundant closure
 LL |         array.iter().for_each(|item| item.method());
    |                               ^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `Self::method`
 
-error: aborting due to 43 previous errors
+error: redundant closure
+  --> tests/ui/eta.rs:661:38
+   |
+LL |     (0..10).flat_map(|x| (0..10).map(|y| closure(y))).count();
+   |                                      ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&*closure`
+
+error: aborting due to 44 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16641 

changelog: [`redundant_closure`] fix wrong suggestions when local is derefed to callable
