### PR TITLE
Remove extra space in `must_use_candidate` lint output

### DIFF
--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -221,7 +221,7 @@ fn check_must_use_candidate<'tcx>(
         diag.span_suggestion(
             item_span.shrink_to_lo(),
             "add the attribute",
-            format!("#[must_use] \n{indent}"),
+            format!("#[must_use]\n{indent}"),
             Applicability::MachineApplicable,
         );
         if let Some(msg) = match return_ty(cx, item_id).opt_diag_name(cx) {

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -13,14 +13,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub struct MyAtomic(AtomicBool);
 pub struct MyPure;
 
-#[must_use] 
+#[must_use]
 pub fn pure(i: u8) -> u8 {
     //~^ must_use_candidate
     i
 }
 
 impl MyPure {
-    #[must_use] 
+    #[must_use]
     pub fn inherent_pure(&self) -> u8 {
         //~^ must_use_candidate
         0
@@ -53,7 +53,7 @@ pub fn with_callback<F: Fn(u32) -> bool>(f: &F) -> bool {
     f(0)
 }
 
-#[must_use] 
+#[must_use]
 pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
     //~^ must_use_candidate
     true
@@ -67,7 +67,7 @@ pub fn atomics(b: &AtomicBool) -> bool {
     b.load(Ordering::SeqCst)
 }
 
-#[must_use] 
+#[must_use]
 pub fn rcd(_x: Rc<u32>) -> bool {
     //~^ must_use_candidate
     true
@@ -77,7 +77,7 @@ pub fn rcmut(_x: Rc<&mut u32>) -> bool {
     true
 }
 
-#[must_use] 
+#[must_use]
 pub fn arcd(_x: Arc<u32>) -> bool {
     //~^ must_use_candidate
     false
@@ -110,13 +110,13 @@ pub fn main() -> std::process::ExitCode {
 }
 
 //~v must_use_candidate
-#[must_use] 
+#[must_use]
 pub fn result_uninhabited() -> Result<i32, std::convert::Infallible> {
     todo!()
 }
 
 //~v must_use_candidate
-#[must_use] 
+#[must_use]
 pub fn controlflow_uninhabited() -> std::ops::ControlFlow<std::convert::Infallible, i32> {
     todo!()
 }

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -8,7 +8,7 @@ LL | pub fn pure(i: u8) -> u8 {
    = help: to override `-D warnings` add `#[allow(clippy::must_use_candidate)]`
 help: add the attribute
    |
-LL + #[must_use] 
+LL + #[must_use]
 LL | pub fn pure(i: u8) -> u8 {
    |
 
@@ -20,7 +20,7 @@ LL |     pub fn inherent_pure(&self) -> u8 {
    |
 help: add the attribute
    |
-LL ~     #[must_use] 
+LL ~     #[must_use]
 LL ~     pub fn inherent_pure(&self) -> u8 {
    |
 
@@ -32,7 +32,7 @@ LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    |
 help: add the attribute
    |
-LL + #[must_use] 
+LL + #[must_use]
 LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    |
 
@@ -44,7 +44,7 @@ LL | pub fn rcd(_x: Rc<u32>) -> bool {
    |
 help: add the attribute
    |
-LL + #[must_use] 
+LL + #[must_use]
 LL | pub fn rcd(_x: Rc<u32>) -> bool {
    |
 
@@ -56,7 +56,7 @@ LL | pub fn arcd(_x: Arc<u32>) -> bool {
    |
 help: add the attribute
    |
-LL + #[must_use] 
+LL + #[must_use]
 LL | pub fn arcd(_x: Arc<u32>) -> bool {
    |
 
@@ -69,7 +69,7 @@ LL | pub fn result_uninhabited() -> Result<i32, std::convert::Infallible> {
    = note: a future version of Rust will treat `Result<T, E>` as `T` when `E` is uninhabited wrt `#[must_use]`
 help: add the attribute
    |
-LL + #[must_use] 
+LL + #[must_use]
 LL | pub fn result_uninhabited() -> Result<i32, std::convert::Infallible> {
    |
 
@@ -82,7 +82,7 @@ LL | pub fn controlflow_uninhabited() -> std::ops::ControlFlow<std::convert::Inf
    = note: a future version of Rust will treat `ControlFlow<B, C>` as `C` when `B` is uninhabited wrt `#[must_use]`
 help: add the attribute
    |
-LL + #[must_use] 
+LL + #[must_use]
 LL | pub fn controlflow_uninhabited() -> std::ops::ControlFlow<std::convert::Infallible, i32> {
    |
 


### PR DESCRIPTION
changelog: none

Fixes rust-lang/rust-clippy#16650 