### PR TITLE
Improve `default_trait_access` suggestions

### DIFF
--- a/tests/ui/default_trait_access.fixed
+++ b/tests/ui/default_trait_access.fixed
@@ -33,7 +33,7 @@ fn main() {
 
     let s10 = DerivedDefault::default();
 
-    let s11: GenericDerivedDefault<String> = GenericDerivedDefault::default();
+    let s11: GenericDerivedDefault<String> = <GenericDerivedDefault<String>>::default();
     //~^ default_trait_access
 
     let s12 = GenericDerivedDefault::<String>::default();
@@ -67,6 +67,28 @@ fn main() {
         "[{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}]",
         s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20,
     );
+}
+
+fn issue16325() {
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+    use std::sync::{Arc, RwLock};
+
+    #[derive(Default, Clone)]
+    struct Foo;
+
+    let _: Arc<Foo> = <Arc<Foo>>::default();
+    //~^ default_trait_access
+
+    let _: Rc<Foo> = <Rc<Foo>>::default();
+    //~^ default_trait_access
+
+    let _: Cow<'_, Foo> = <Cow<'_, Foo>>::default();
+    //~^ default_trait_access
+
+    let _: Arc<RwLock<HashMap<String, Foo>>> = <Arc<RwLock<HashMap<String, Foo>>>>::default();
+    //~^ default_trait_access
 }
 
 struct DefaultFactory;

--- a/tests/ui/default_trait_access.rs
+++ b/tests/ui/default_trait_access.rs
@@ -69,6 +69,28 @@ fn main() {
     );
 }
 
+fn issue16325() {
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+    use std::sync::{Arc, RwLock};
+
+    #[derive(Default, Clone)]
+    struct Foo;
+
+    let _: Arc<Foo> = Default::default();
+    //~^ default_trait_access
+
+    let _: Rc<Foo> = Default::default();
+    //~^ default_trait_access
+
+    let _: Cow<'_, Foo> = Default::default();
+    //~^ default_trait_access
+
+    let _: Arc<RwLock<HashMap<String, Foo>>> = Default::default();
+    //~^ default_trait_access
+}
+
 struct DefaultFactory;
 
 impl DefaultFactory {

--- a/tests/ui/default_trait_access.stderr
+++ b/tests/ui/default_trait_access.stderr
@@ -28,11 +28,11 @@ error: calling `String::default()` is more clear than this expression
 LL |     let s6: String = default::Default::default();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `String::default()`
 
-error: calling `GenericDerivedDefault::default()` is more clear than this expression
+error: calling `<GenericDerivedDefault<String>>::default()` is more clear than this expression
   --> tests/ui/default_trait_access.rs:36:46
    |
 LL |     let s11: GenericDerivedDefault<String> = Default::default();
-   |                                              ^^^^^^^^^^^^^^^^^^ help: try: `GenericDerivedDefault::default()`
+   |                                              ^^^^^^^^^^^^^^^^^^ help: try: `<GenericDerivedDefault<String>>::default()`
 
 error: calling `TupleDerivedDefault::default()` is more clear than this expression
   --> tests/ui/default_trait_access.rs:43:36
@@ -52,5 +52,29 @@ error: calling `TupleStructDerivedDefault::default()` is more clear than this ex
 LL |     let s17: TupleStructDerivedDefault = Default::default();
    |                                          ^^^^^^^^^^^^^^^^^^ help: try: `TupleStructDerivedDefault::default()`
 
-error: aborting due to 8 previous errors
+error: calling `<Arc<Foo>>::default()` is more clear than this expression
+  --> tests/ui/default_trait_access.rs:81:23
+   |
+LL |     let _: Arc<Foo> = Default::default();
+   |                       ^^^^^^^^^^^^^^^^^^ help: try: `<Arc<Foo>>::default()`
+
+error: calling `<Rc<Foo>>::default()` is more clear than this expression
+  --> tests/ui/default_trait_access.rs:84:22
+   |
+LL |     let _: Rc<Foo> = Default::default();
+   |                      ^^^^^^^^^^^^^^^^^^ help: try: `<Rc<Foo>>::default()`
+
+error: calling `<Cow<'_, Foo>>::default()` is more clear than this expression
+  --> tests/ui/default_trait_access.rs:87:27
+   |
+LL |     let _: Cow<'_, Foo> = Default::default();
+   |                           ^^^^^^^^^^^^^^^^^^ help: try: `<Cow<'_, Foo>>::default()`
+
+error: calling `<Arc<RwLock<HashMap<String, Foo>>>>::default()` is more clear than this expression
+  --> tests/ui/default_trait_access.rs:90:48
+   |
+LL |     let _: Arc<RwLock<HashMap<String, Foo>>> = Default::default();
+   |                                                ^^^^^^^^^^^^^^^^^^ help: try: `<Arc<RwLock<HashMap<String, Foo>>>>::default()`
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16325.

changelog: [`default_trait_access`]: make suggestions more clear.