### PR TITLE
fix: `question_mark` suggestion caused error

### DIFF
--- a/tests/ui/question_mark.fixed
+++ b/tests/ui/question_mark.fixed
@@ -524,3 +524,16 @@ fn issue16429(b: i32) -> Option<i32> {
 
     Some(0)
 }
+
+fn issue16654() -> Result<(), i32> {
+    let result = func_returning_result();
+
+    #[allow(clippy::collapsible_if)]
+    if true {
+        result?;
+    }
+
+    _ = [{ result?; }];
+
+    Ok(())
+}

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -649,3 +649,22 @@ fn issue16429(b: i32) -> Option<i32> {
 
     Some(0)
 }
+
+fn issue16654() -> Result<(), i32> {
+    let result = func_returning_result();
+
+    #[allow(clippy::collapsible_if)]
+    if true {
+        if let Err(err) = result {
+            //~^ question_mark
+            return Err(err);
+        }
+    }
+
+    _ = [if let Err(err) = result {
+        //~^ question_mark
+        return Err(err);
+    }];
+
+    Ok(())
+}

--- a/tests/ui/question_mark.stderr
+++ b/tests/ui/question_mark.stderr
@@ -362,5 +362,24 @@ LL | |         return None;
 LL | |     };
    | |_____^ help: replace it with: `{ a? }`
 
-error: aborting due to 38 previous errors
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:658:9
+   |
+LL | /         if let Err(err) = result {
+LL | |
+LL | |             return Err(err);
+LL | |         }
+   | |_________^ help: replace it with: `result?;`
+
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:664:10
+   |
+LL |       _ = [if let Err(err) = result {
+   |  __________^
+LL | |
+LL | |         return Err(err);
+LL | |     }];
+   | |_____^ help: replace it with: `{ result?; }`
+
+error: aborting due to 40 previous errors
 


### PR DESCRIPTION
Closes: rust-lang/rust-clippy#16654

changelog: [`question_mark`]: fix suggestion-caused-error caused by semicolon inference relying only on parent-node shape.