### PR TITLE
Configure triagebot to add a backlink to Zulip when nominating a lint

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -63,6 +63,11 @@ threshold = 20
 [notify-zulip."lint-nominated"]
 zulip_stream = 577190 # #clippy/fcp
 topic = "FCP rust-clippy#{number}: {title}"
+github_comment = """\
+This lint has been nominated for inclusion.
+
+[A FCP topic has been created on Zulip]({zulip_topic_url}).
+"""
 # Zulip polls may not be preceded by any other text and pings & short links inside
 # the title of a poll don't get recognized. Therefore we need to send two messages.
 message_on_add = [


### PR DESCRIPTION
As asked in https://github.com/rust-lang/rust-clippy/pull/16614#issuecomment-3998600387, triagebot has been updated to able to add a comment to GitHub when opening the nomination Zulip topic.

This PR therefore configures the nomination with the suggested text and link to the Zulip topic. 

cc @samueltardieu 
r? @flip1995

---

changelog: none
