### PR TITLE
Do not materialize snippets when it is not needed to

### DIFF
--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -1,5 +1,4 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::source::HasSession;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{higher, is_else_clause, is_in_const_context, span_contains_comment};
 use rustc_ast::LitKind;
@@ -60,7 +59,7 @@ impl<'tcx> LateLintPass<'tcx> for BoolToIntWithIf {
             && !is_in_const_context(cx)
         {
             let ty = cx.typeck_results().expr_ty(then);
-            let mut applicability = if span_contains_comment(cx.sess().source_map(), expr.span) {
+            let mut applicability = if span_contains_comment(cx, expr.span) {
                 Applicability::MaybeIncorrect
             } else {
                 Applicability::MachineApplicable

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -1,7 +1,7 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::msrvs::Msrv;
-use clippy_utils::source::{IntoSpan as _, SpanRangeExt, snippet, snippet_block_with_applicability};
+use clippy_utils::source::{HasSession, IntoSpan as _, SpanRangeExt, snippet, snippet_block_with_applicability};
 use clippy_utils::{can_use_if_let_chains, span_contains_non_whitespace, sym, tokenize_with_text};
 use rustc_ast::{BinOpKind, MetaItemInner};
 use rustc_errors::Applicability;
@@ -9,7 +9,6 @@ use rustc_hir::{Block, Expr, ExprKind, StmtKind};
 use rustc_lexer::TokenKind;
 use rustc_lint::{LateContext, LateLintPass, Level};
 use rustc_session::impl_lint_pass;
-use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span, Symbol};
 
 declare_clippy_lint! {
@@ -111,10 +110,8 @@ impl CollapsibleIf {
                     let up_to_else = then_span.between(else_block.span);
                     let else_before_if = else_.span.shrink_to_lo().with_hi(else_if_cond.span.lo() - BytePos(1));
                     if self.lint_commented_code
-                        && let Some(else_keyword_span) =
-                            span_extract_keyword(cx.tcx.sess.source_map(), up_to_else, "else")
-                        && let Some(else_if_keyword_span) =
-                            span_extract_keyword(cx.tcx.sess.source_map(), else_before_if, "if")
+                        && let Some(else_keyword_span) = span_extract_keyword(cx, up_to_else, "else")
+                        && let Some(else_if_keyword_span) = span_extract_keyword(cx, else_before_if, "if")
                     {
                         let else_keyword_span = else_keyword_span.with_leading_whitespace(cx).into_span();
                         let else_open_bracket = else_block.span.split_at(1).0.with_leading_whitespace(cx).into_span();
@@ -139,7 +136,7 @@ impl CollapsibleIf {
                     }
 
                     // Peel off any parentheses.
-                    let (_, else_block_span, _) = peel_parens(cx.tcx.sess.source_map(), else_.span);
+                    let (_, else_block_span, _) = peel_parens(cx, else_.span);
 
                     // Prevent "elseif"
                     // Check that the "else" is followed by whitespace
@@ -187,7 +184,7 @@ impl CollapsibleIf {
                             .with_leading_whitespace(cx)
                             .into_span()
                     };
-                    let (paren_start, inner_if_span, paren_end) = peel_parens(cx.tcx.sess.source_map(), inner.span);
+                    let (paren_start, inner_if_span, paren_end) = peel_parens(cx, inner.span);
                     let inner_if = inner_if_span.split_at(2).0;
                     let mut sugg = vec![
                         // Remove the outer then block `{`
@@ -320,33 +317,36 @@ pub(super) fn parens_around(expr: &Expr<'_>) -> Vec<(Span, String)> {
     }
 }
 
-fn span_extract_keyword(sm: &SourceMap, span: Span, keyword: &str) -> Option<Span> {
-    let snippet = sm.span_to_snippet(span).ok()?;
-    tokenize_with_text(&snippet)
-        .filter(|(t, s, _)| matches!(t, TokenKind::Ident if *s == keyword))
-        .map(|(_, _, inner)| {
-            span.split_at(u32::try_from(inner.start).unwrap())
-                .1
-                .split_at(u32::try_from(inner.end - inner.start).unwrap())
-                .0
-        })
-        .next()
+fn span_extract_keyword(cx: &impl HasSession, span: Span, keyword: &str) -> Option<Span> {
+    span.with_source_text(cx, |snippet| {
+        tokenize_with_text(snippet)
+            .filter(|(t, s, _)| matches!(t, TokenKind::Ident if *s == keyword))
+            .map(|(_, _, inner)| {
+                span.split_at(u32::try_from(inner.start).unwrap())
+                    .1
+                    .split_at(u32::try_from(inner.end - inner.start).unwrap())
+                    .0
+            })
+            .next()
+    })
+    .flatten()
 }
 
 /// Peel the parentheses from an `if` expression, e.g. `((if true {} else {}))`.
-pub(super) fn peel_parens(sm: &SourceMap, mut span: Span) -> (Span, Span, Span) {
+pub(super) fn peel_parens(cx: &impl HasSession, mut span: Span) -> (Span, Span, Span) {
     use crate::rustc_span::Pos;
 
     let start = span.shrink_to_lo();
     let end = span.shrink_to_hi();
 
-    let snippet = sm.span_to_snippet(span).unwrap();
-    if let Some((trim_start, _, trim_end)) = peel_parens_str(&snippet) {
-        let mut data = span.data();
-        data.lo = data.lo + BytePos::from_usize(trim_start);
-        data.hi = data.hi - BytePos::from_usize(trim_end);
-        span = data.span();
-    }
+    span.with_source_text(cx, |snippet| {
+        if let Some((trim_start, _, trim_end)) = peel_parens_str(snippet) {
+            let mut data = span.data();
+            data.lo = data.lo + BytePos::from_usize(trim_start);
+            data.hi = data.hi - BytePos::from_usize(trim_end);
+            span = data.span();
+        }
+    });
 
     (start.with_hi(span.lo()), span, end.with_lo(span.hi()))
 }

--- a/clippy_lints/src/loops/manual_flatten.rs
+++ b/clippy_lints/src/loops/manual_flatten.rs
@@ -3,7 +3,7 @@ use super::utils::make_iterator_snippet;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeResPath;
-use clippy_utils::source::{HasSession, indent_of, reindent_multiline, snippet_with_applicability};
+use clippy_utils::source::{indent_of, reindent_multiline, snippet_with_applicability};
 use clippy_utils::visitors::is_local_used;
 use clippy_utils::{higher, is_refutable, peel_blocks_with_stmt, span_contains_comment};
 use rustc_errors::Applicability;
@@ -50,7 +50,7 @@ pub(super) fn check<'tcx>(
             format!("unnecessary `if let` since only the `{if_let_type}` variant of the iterator element is used");
 
         // Prepare the help message
-        let mut applicability = if span_contains_comment(cx.sess().source_map(), body.span) {
+        let mut applicability = if span_contains_comment(cx, body.span) {
             Applicability::MaybeIncorrect
         } else {
             Applicability::MachineApplicable

--- a/clippy_lints/src/loops/manual_slice_fill.rs
+++ b/clippy_lints/src/loops/manual_slice_fill.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::eager_or_lazy::switch_to_eager_eval;
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::source::{HasSession, snippet_with_applicability};
+use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::{implements_trait, is_slice_like};
 use clippy_utils::visitors::is_local_used;
 use clippy_utils::{higher, peel_blocks_with_stmt, span_contains_comment};
@@ -94,7 +94,7 @@ fn sugg<'tcx>(
     slice_span: rustc_span::Span,
     assignval_span: rustc_span::Span,
 ) {
-    let mut app = if span_contains_comment(cx.sess().source_map(), body.span) {
+    let mut app = if span_contains_comment(cx, body.span) {
         Applicability::MaybeIncorrect // Comments may be informational.
     } else {
         Applicability::MachineApplicable

--- a/clippy_lints/src/manual_abs_diff.rs
+++ b/clippy_lints/src/manual_abs_diff.rs
@@ -3,7 +3,6 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::higher::If;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
-use clippy_utils::source::HasSession as _;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::peel_and_count_ty_refs;
 use clippy_utils::{eq_expr_value, peel_blocks, span_contains_comment, sym};
@@ -76,10 +75,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualAbsDiff {
                         (a, b) = (b, a);
                     }
                     let applicability = {
-                        let source_map = cx.sess().source_map();
-                        if span_contains_comment(source_map, if_expr.then.span)
-                            || span_contains_comment(source_map, r#else.span)
-                        {
+                        if span_contains_comment(cx, if_expr.then.span) || span_contains_comment(cx, r#else.span) {
                             Applicability::MaybeIncorrect
                         } else {
                             Applicability::MachineApplicable

--- a/clippy_lints/src/manual_assert.rs
+++ b/clippy_lints/src/manual_assert.rs
@@ -58,7 +58,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualAssert {
                 "only a `panic!` in `if`-then statement",
                 |diag| {
                     let mut applicability = Applicability::MachineApplicable;
-                    let mut comments = span_extract_comment(cx.sess().source_map(), expr.span);
+                    let mut comments = span_extract_comment(cx, expr.span);
                     if !comments.is_empty() {
                         comments += "\n";
                     }

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -154,7 +154,7 @@ fn check_arm<'tcx>(
                 } else {
                     outer_pat.span.shrink_to_hi()
                 };
-                let (paren_start, inner_if_span, paren_end) = peel_parens(cx.tcx.sess.source_map(), inner_expr.span);
+                let (paren_start, inner_if_span, paren_end) = peel_parens(cx, inner_expr.span);
                 let inner_if = inner_if_span.split_at(2).0;
                 let mut sugg = vec![
                     (inner.then.span.shrink_to_lo(), "=> ".to_string()),

--- a/clippy_lints/src/matches/manual_ok_err.rs
+++ b/clippy_lints/src/matches/manual_ok_err.rs
@@ -9,7 +9,7 @@ use rustc_errors::Applicability;
 use rustc_hir::LangItem::ResultErr;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Arm, Expr, ExprKind, Pat, PatExpr, PatExprKind, PatKind, Path, QPath};
-use rustc_lint::{LateContext, LintContext};
+use rustc_lint::LateContext;
 use rustc_middle::ty::Ty;
 use rustc_span::symbol::Ident;
 
@@ -130,7 +130,7 @@ fn is_none(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
 /// `err`, depending on `is_ok`.
 fn apply_lint(cx: &LateContext<'_>, expr: &Expr<'_>, scrutinee: &Expr<'_>, is_ok: bool) {
     let method = if is_ok { "ok" } else { "err" };
-    let mut app = if span_contains_comment(cx.sess().source_map(), expr.span) {
+    let mut app = if span_contains_comment(cx, expr.span) {
         Applicability::MaybeIncorrect
     } else {
         Applicability::MachineApplicable

--- a/clippy_lints/src/matches/manual_unwrap_or.rs
+++ b/clippy_lints/src/matches/manual_unwrap_or.rs
@@ -5,7 +5,7 @@ use rustc_ast::{BindingMode, ByRef};
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
 use rustc_hir::{Arm, Expr, ExprKind, HirId, LangItem, Pat, PatExpr, PatExprKind, PatKind, QPath};
-use rustc_lint::{LateContext, LintContext};
+use rustc_lint::LateContext;
 use rustc_middle::ty::{GenericArgKind, Ty};
 use rustc_span::sym;
 
@@ -101,7 +101,7 @@ fn handle(
         && local_id == binding_id
     {
         // Machine applicable only if there are no comments present
-        let mut applicability = if span_contains_comment(cx.sess().source_map(), expr.span) {
+        let mut applicability = if span_contains_comment(cx, expr.span) {
             Applicability::MaybeIncorrect
         } else {
             Applicability::MachineApplicable

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -8,7 +8,7 @@ use clippy_utils::{is_lint_allowed, is_wild, span_contains_comment};
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::{Arm, BorrowKind, Expr, ExprKind, Pat, PatKind, QPath};
-use rustc_lint::{LateContext, LintContext};
+use rustc_lint::LateContext;
 use rustc_middle::ty;
 use rustc_span::source_map::Spanned;
 
@@ -22,7 +22,7 @@ pub(crate) fn check_if_let<'tcx>(
     then_expr: &'tcx Expr<'_>,
     else_expr: &'tcx Expr<'_>,
 ) {
-    if !span_contains_comment(cx.sess().source_map(), expr.span)
+    if !span_contains_comment(cx, expr.span)
         && cx.typeck_results().expr_ty(expr).is_bool()
         && let Some(b0) = find_bool_lit(then_expr)
         && let Some(b1) = find_bool_lit(else_expr)
@@ -71,7 +71,7 @@ pub(super) fn check_match<'tcx>(
 ) -> bool {
     if let Some((last_arm, arms_without_last)) = arms.split_last()
         && let Some((first_arm, middle_arms)) = arms_without_last.split_first()
-        && !span_contains_comment(cx.sess().source_map(), e.span)
+        && !span_contains_comment(cx, e.span)
         && cx.typeck_results().expr_ty(e).is_bool()
         && let Some(b0) = find_bool_lit(first_arm.body)
         && let Some(b1) = find_bool_lit(last_arm.body)

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -1093,12 +1093,11 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                     }
 
                     redundant_pattern_match::check_match(cx, expr, ex, arms);
-                    let source_map = cx.tcx.sess.source_map();
-                    let mut match_comments = span_extract_comments(source_map, expr.span);
+                    let mut match_comments = span_extract_comments(cx, expr.span);
                     // We remove comments from inside arms block.
                     if !match_comments.is_empty() {
                         for arm in arms {
-                            for comment in span_extract_comments(source_map, arm.body.span) {
+                            for comment in span_extract_comments(cx, arm.body.span) {
                                 if let Some(index) = match_comments
                                     .iter()
                                     .enumerate()

--- a/clippy_lints/src/methods/iter_filter.rs
+++ b/clippy_lints/src/methods/iter_filter.rs
@@ -1,7 +1,7 @@
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::ty::get_iterator_item_ty;
 use hir::ExprKind;
-use rustc_lint::{LateContext, LintContext};
+use rustc_lint::LateContext;
 
 use super::{ITER_FILTER_IS_OK, ITER_FILTER_IS_SOME};
 
@@ -144,7 +144,7 @@ fn expression_type(
 ) -> Option<FilterType> {
     if !cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator)
         || parent_is_map(cx, expr)
-        || span_contains_comment(cx.sess().source_map(), filter_span.with_hi(expr.span.hi()))
+        || span_contains_comment(cx, filter_span.with_hi(expr.span.hi()))
     {
         return None;
     }

--- a/clippy_lints/src/methods/map_flatten.rs
+++ b/clippy_lints/src/methods/map_flatten.rs
@@ -19,7 +19,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, map_
         let closure_snippet = snippet_with_applicability(cx, map_arg.span, "..", &mut applicability);
         let span = expr.span.with_lo(map_span.lo());
         // If the methods are separated with comments, we don't apply suggestion automatically.
-        if span_contains_comment(cx.tcx.sess.source_map(), span) {
+        if span_contains_comment(cx, span) {
             applicability = Applicability::Unspecified;
         }
         span_lint_and_sugg(

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -108,7 +108,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
                 then,
                 r#else: Some(else_expr),
             }) = higher::If::hir(e)
-            && !span_contains_comment(cx.tcx.sess.source_map(), e.span)
+            && !span_contains_comment(cx, e.span)
         {
             let reduce = |ret, not| {
                 let mut applicability = Applicability::MachineApplicable;

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -143,7 +143,7 @@ fn check_let_some_else_return_none(cx: &LateContext<'_>, stmt: &Stmt<'_>) {
         && init_expr_can_use_question_mark(cx, init_expr)
         && let Some(ret) = find_let_else_ret_expression(els)
         && let Some(inner_pat) = pat_and_expr_can_be_question_mark(cx, pat, ret)
-        && !span_contains_comment(cx.tcx.sess.source_map(), els.span)
+        && !span_contains_comment(cx, els.span)
         && !span_contains_cfg(cx, els.span)
     {
         let mut applicability = Applicability::MaybeIncorrect;

--- a/clippy_lints/src/slow_vector_initialization.rs
+++ b/clippy_lints/src/slow_vector_initialization.rs
@@ -208,7 +208,7 @@ impl SlowVectorInit {
             .with_lo(vec_alloc.allocation_expr.span.source_callsite().lo());
 
         // If there is no comment in `span_to_replace`, Clippy can automatically fix the code.
-        let app = if span_contains_comment(cx.tcx.sess.source_map(), span_to_replace) {
+        let app = if span_contains_comment(cx, span_to_replace) {
             Applicability::Unspecified
         } else {
             Applicability::MachineApplicable

--- a/clippy_lints/src/useless_vec.rs
+++ b/clippy_lints/src/useless_vec.rs
@@ -251,7 +251,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessVec {
                     let help_msg = format!("you can use {} directly", suggest_ty.desc());
                     // If the `vec!` macro contains comment, better not make the suggestion machine applicable as it
                     // would remove them.
-                    let applicability = if span_contains_comment(cx.tcx.sess.source_map(), span) {
+                    let applicability = if span_contains_comment(cx, span) {
                         Applicability::Unspecified
                     } else {
                         Applicability::MachineApplicable

--- a/clippy_lints/src/write/empty_string.rs
+++ b/clippy_lints/src/write/empty_string.rs
@@ -22,7 +22,7 @@ pub(super) fn check(cx: &LateContext<'_>, format_args: &FormatArgs, macro_call: 
             macro_call.span,
             format!("empty string literal in `{name}!`"),
             |diag| {
-                if span_extract_comments(cx.sess().source_map(), macro_call.span).is_empty() {
+                if span_extract_comments(cx, macro_call.span).is_empty() {
                     let closing_paren = cx.sess().source_map().span_extend_to_prev_char_before(
                         macro_call.span.shrink_to_hi(),
                         ')',

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2764,16 +2764,15 @@ pub fn tokenize_with_text(s: &str) -> impl Iterator<Item = (TokenKind, &str, Inn
 
 /// Checks whether a given span has any comment token
 /// This checks for all types of comment: line "//", block "/**", doc "///" "//!"
-pub fn span_contains_comment(sm: &SourceMap, span: Span) -> bool {
-    let Ok(snippet) = sm.span_to_snippet(span) else {
-        return false;
-    };
-    return tokenize(&snippet, FrontmatterAllowed::No).any(|token| {
-        matches!(
-            token.kind,
-            TokenKind::BlockComment { .. } | TokenKind::LineComment { .. }
-        )
-    });
+pub fn span_contains_comment(cx: &impl source::HasSession, span: Span) -> bool {
+    span.check_source_text(cx, |snippet| {
+        tokenize(snippet, FrontmatterAllowed::No).any(|token| {
+            matches!(
+                token.kind,
+                TokenKind::BlockComment { .. } | TokenKind::LineComment { .. }
+            )
+        })
+    })
 }
 
 /// Checks whether a given span has any significant token. A significant token is a non-whitespace
@@ -2781,30 +2780,32 @@ pub fn span_contains_comment(sm: &SourceMap, span: Span) -> bool {
 /// This is useful to determine if there are any actual code tokens in the span that are omitted in
 /// the late pass, such as platform-specific code.
 pub fn span_contains_non_whitespace(cx: &impl source::HasSession, span: Span, skip_comments: bool) -> bool {
-    matches!(span.get_source_text(cx), Some(snippet) if tokenize_with_text(&snippet).any(|(token, _, _)|
-        match token {
+    span.check_source_text(cx, |snippet| {
+        tokenize_with_text(snippet).any(|(token, _, _)| match token {
             TokenKind::Whitespace => false,
             TokenKind::BlockComment { .. } | TokenKind::LineComment { .. } => !skip_comments,
             _ => true,
-        }
-    ))
+        })
+    })
 }
 /// Returns all the comments a given span contains
 ///
 /// Comments are returned wrapped with their relevant delimiters
-pub fn span_extract_comment(sm: &SourceMap, span: Span) -> String {
-    span_extract_comments(sm, span).join("\n")
+pub fn span_extract_comment(cx: &impl source::HasSession, span: Span) -> String {
+    span_extract_comments(cx, span).join("\n")
 }
 
 /// Returns all the comments a given span contains.
 ///
 /// Comments are returned wrapped with their relevant delimiters.
-pub fn span_extract_comments(sm: &SourceMap, span: Span) -> Vec<String> {
-    let snippet = sm.span_to_snippet(span).unwrap_or_default();
-    tokenize_with_text(&snippet)
-        .filter(|(t, ..)| matches!(t, TokenKind::BlockComment { .. } | TokenKind::LineComment { .. }))
-        .map(|(_, s, _)| s.to_string())
-        .collect::<Vec<_>>()
+pub fn span_extract_comments(cx: &impl source::HasSession, span: Span) -> Vec<String> {
+    span.with_source_text(cx, |snippet| {
+        tokenize_with_text(snippet)
+            .filter(|(t, ..)| matches!(t, TokenKind::BlockComment { .. } | TokenKind::LineComment { .. }))
+            .map(|(_, s, _)| s.to_string())
+            .collect::<Vec<_>>()
+    })
+    .unwrap_or_default()
 }
 
 pub fn span_find_starting_semi(sm: &SourceMap, span: Span) -> Span {


### PR DESCRIPTION
It is not necessary to materialize snippets into `String` objects just to check if they contain comments for example.

changelog: none

r? @blyxyas 
(for perf measurements)