### PR TITLE
Update `bytes` dependency in `clippy_test_deps` to avoid CVE warning

### DIFF
--- a/clippy_test_deps/Cargo.lock
+++ b/clippy_test_deps/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"


### PR DESCRIPTION
Pull-requests get a warning because of
[RUSTSEC-2026-0007](https://rustsec.org/advisories/RUSTSEC-2026-0007.html). Bumping `bytes` will silence the warning.

changelog: none

r? flip1995