### PR TITLE
Add new lint `suspicious_slice_copies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7480,6 +7480,7 @@ Released 2018-09-13
 [`suspicious_op_assign_impl`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_op_assign_impl
 [`suspicious_open_options`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_open_options
 [`suspicious_operation_groupings`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_operation_groupings
+[`suspicious_slice_copies`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_slice_copies
 [`suspicious_splitn`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_splitn
 [`suspicious_to_owned`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_to_owned
 [`suspicious_unary_op_formatting`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_unary_op_formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7607,6 +7607,7 @@ Released 2018-09-13
 [`suspicious_op_assign_impl`]: https://rust-lang.github.io/rust-clippy/main/index.html#suspicious_op_assign_impl
 [`suspicious_open_options`]: https://rust-lang.github.io/rust-clippy/main/index.html#suspicious_open_options
 [`suspicious_operation_groupings`]: https://rust-lang.github.io/rust-clippy/main/index.html#suspicious_operation_groupings
+[`suspicious_slice_copies`]: https://rust-lang.github.io/rust-clippy/main/index.html#suspicious_slice_copies
 [`suspicious_splitn`]: https://rust-lang.github.io/rust-clippy/main/index.html#suspicious_splitn
 [`suspicious_to_owned`]: https://rust-lang.github.io/rust-clippy/main/index.html#suspicious_to_owned
 [`suspicious_unary_op_formatting`]: https://rust-lang.github.io/rust-clippy/main/index.html#suspicious_unary_op_formatting

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -491,6 +491,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::SUSPICIOUS_COMMAND_ARG_SPACE_INFO,
     crate::methods::SUSPICIOUS_MAP_INFO,
     crate::methods::SUSPICIOUS_OPEN_OPTIONS_INFO,
+    crate::methods::SUSPICIOUS_SLICE_COPIES_INFO,
     crate::methods::SUSPICIOUS_SPLITN_INFO,
     crate::methods::SUSPICIOUS_TO_OWNED_INFO,
     crate::methods::SWAP_WITH_TEMPORARY_INFO,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -493,6 +493,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::SUSPICIOUS_COMMAND_ARG_SPACE_INFO,
     crate::methods::SUSPICIOUS_MAP_INFO,
     crate::methods::SUSPICIOUS_OPEN_OPTIONS_INFO,
+    crate::methods::SUSPICIOUS_SLICE_COPIES_INFO,
     crate::methods::SUSPICIOUS_SPLITN_INFO,
     crate::methods::SUSPICIOUS_TO_OWNED_INFO,
     crate::methods::SWAP_WITH_TEMPORARY_INFO,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -122,6 +122,7 @@ mod string_extend_chars;
 mod string_lit_chars_any;
 mod suspicious_command_arg_space;
 mod suspicious_map;
+mod suspicious_slice_copies;
 mod suspicious_splitn;
 mod suspicious_to_owned;
 mod swap_with_temporary;
@@ -3898,6 +3899,42 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for taking a mutable reference to a temporary array created by `arr[N..M].try_into()`
+    /// instead of borrowing the original slice data.
+    ///
+    /// ### Why is this bad?
+    /// Slices have two relevant implementations of the `TryInto` trait:
+    /// 1. `TryInto<[T; N]>`, which creates a new array by copying elements from the slice
+    /// 2. `TryInto<&'a mut [T; N]>`, which creates a mutable array reference from slice
+    ///
+    /// When writing `&mut arr[N..M].try_into().unwrap()`, the compiler selects the first implementation
+    /// and creates a new array. As a result, any mutations are applied to this temporary array, while
+    /// the original data remains unchanged. This is usually unintended.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let mut arr: [i32; 5] = [0; 5];
+    /// let arr_mut_ref: &mut [i32; 3] = &mut arr[..3].try_into().unwrap(); //copied
+    /// arr_mut_ref[0] = 1;
+    ///
+    /// assert_eq!(arr[0], 0);
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let mut arr: [i32; 5] = [0; 5];
+    /// let arr_mut_ref: &mut [i32; 3] = (&mut arr[..3]).try_into().unwrap(); //borrowed
+    /// arr_mut_ref[0] = 1;
+    ///
+    /// assert_eq!(arr[0], 1);
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub SUSPICIOUS_SLICE_COPIES,
+    suspicious,
+    "detects taking a `&mut` to a temporary array created from a slice"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for calls to [`splitn`]
     /// (https://doc.rust-lang.org/std/primitive.str.html#method.splitn) and
     /// related functions with either zero or one splits.
@@ -5049,6 +5086,7 @@ impl_lint_pass!(Methods => [
     SUSPICIOUS_COMMAND_ARG_SPACE,
     SUSPICIOUS_MAP,
     SUSPICIOUS_OPEN_OPTIONS,
+    SUSPICIOUS_SLICE_COPIES,
     SUSPICIOUS_SPLITN,
     SUSPICIOUS_TO_OWNED,
     SWAP_WITH_TEMPORARY,
@@ -5808,6 +5846,7 @@ impl Methods {
                 },
                 (sym::try_into, []) if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::TryInto) => {
                     unnecessary_fallible_conversions::check_method(cx, expr);
+                    suspicious_slice_copies::check(cx, expr, recv, call_span, self.msrv);
                 },
                 (sym::to_owned, []) => {
                     if !suspicious_to_owned::check(cx, expr, span) {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -124,6 +124,7 @@ mod string_extend_chars;
 mod string_lit_chars_any;
 mod suspicious_command_arg_space;
 mod suspicious_map;
+mod suspicious_slice_copies;
 mod suspicious_splitn;
 mod suspicious_to_owned;
 mod swap_with_temporary;
@@ -3923,6 +3924,42 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for taking a mutable reference to a temporary array created by `arr[N..M].try_into()`
+    /// instead of borrowing the original slice data.
+    ///
+    /// ### Why is this bad?
+    /// Slices have two relevant implementations of the `TryInto` trait:
+    /// 1. `TryInto<[T; N]>`, which creates a new array by copying elements from the slice
+    /// 2. `TryInto<&'a mut [T; N]>`, which creates a mutable array reference from slice
+    ///
+    /// When writing `&mut arr[N..M].try_into().unwrap()`, the compiler selects the first implementation
+    /// and creates a new array. As a result, any mutations are applied to this temporary array, while
+    /// the original data remains unchanged. This is usually unintended.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let mut arr: [i32; 5] = [0; 5];
+    /// let arr_mut_ref: &mut [i32; 3] = &mut arr[..3].try_into().unwrap(); //copied
+    /// arr_mut_ref[0] = 1;
+    ///
+    /// assert_eq!(arr[0], 0);
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let mut arr: [i32; 5] = [0; 5];
+    /// let arr_mut_ref: &mut [i32; 3] = (&mut arr[..3]).try_into().unwrap(); //borrowed
+    /// arr_mut_ref[0] = 1;
+    ///
+    /// assert_eq!(arr[0], 1);
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub SUSPICIOUS_SLICE_COPIES,
+    suspicious,
+    "detects taking a `&mut` to a temporary array created from a slice"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for calls to [`splitn`]
     /// (https://doc.rust-lang.org/std/primitive.str.html#method.splitn) and
     /// related functions with either zero or one splits.
@@ -5084,6 +5121,7 @@ impl_lint_pass!(Methods => [
     SUSPICIOUS_COMMAND_ARG_SPACE,
     SUSPICIOUS_MAP,
     SUSPICIOUS_OPEN_OPTIONS,
+    SUSPICIOUS_SLICE_COPIES,
     SUSPICIOUS_SPLITN,
     SUSPICIOUS_TO_OWNED,
     SWAP_WITH_TEMPORARY,
@@ -5844,6 +5882,7 @@ impl Methods {
                 },
                 (sym::try_into, []) if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::TryInto) => {
                     unnecessary_fallible_conversions::check_method(cx, expr);
+                    suspicious_slice_copies::check(cx, expr, recv, call_span, self.msrv);
                 },
                 (sym::to_owned, []) => {
                     if !suspicious_to_owned::check(cx, expr, span) {

--- a/clippy_lints/src/methods/suspicious_slice_copies.rs
+++ b/clippy_lints/src/methods/suspicious_slice_copies.rs
@@ -1,0 +1,195 @@
+use super::SUSPICIOUS_SLICE_COPIES;
+use crate::clippy_utils::source::SpanExt as _;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::Msrv;
+use clippy_utils::source::{IntoSpan as _, snippet_with_context};
+use clippy_utils::ty::implements_trait;
+use clippy_utils::{msrvs, sym};
+use rustc_ast::{BindingMode, BorrowKind, Mutability, UnOp};
+use rustc_errors::Applicability;
+use rustc_hir::def::Res;
+use rustc_hir::{Expr, ExprKind, Node, Param, PatKind, Path, QPath};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+use rustc_middle::ty::adjustment::{Adjust, DerefAdjustKind};
+use rustc_middle::ty::{GenericArgKind, Ty};
+use rustc_span::Span;
+
+enum TryIntoReceiver {
+    Slice,
+    SliceMutRef,
+}
+
+impl TryIntoReceiver {
+    fn from_ty(ty: Ty<'_>) -> Option<Self> {
+        match ty.kind() {
+            ty::Slice(_) => Some(TryIntoReceiver::Slice),
+            ty::Ref(_, ref_ty, Mutability::Mut) if let ty::Slice(_) = ref_ty.kind() => {
+                Some(TryIntoReceiver::SliceMutRef)
+            },
+            _ => None,
+        }
+    }
+}
+
+pub(super) fn check(
+    cx: &LateContext<'_>,
+    try_into_expr: &Expr<'_>,
+    recv_expr: &Expr<'_>,
+    try_into_span: Span,
+    msrv: Msrv,
+) {
+    if let Some(receiver) = TryIntoReceiver::from_ty(cx.typeck_results().expr_ty(recv_expr))
+
+        // try_into was instantiated with [T; N]
+        && let [_, dst_ty] = &**cx.typeck_results().node_args(try_into_expr.hir_id)
+        && let GenericArgKind::Type(arg_ty) = dst_ty.kind()
+        && let ty::Array(..) = arg_ty.kind()
+
+        && let mut parent_iter = cx.tcx.hir_parent_iter(try_into_expr.hir_id)
+
+        // calls unwrap() or expect()
+        && let Some((_, Node::Expr(unwrap_expr))) = parent_iter.next()
+        && let ExprKind::MethodCall(path, .., unwrap_span) = unwrap_expr.kind
+        && let sym::unwrap | sym::expect = path.ident.name
+
+        // use mut ref
+        && let Some((_, Node::Expr(mut_ref_expr))) = parent_iter.next()
+        && let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, inner_expr) = mut_ref_expr.kind
+
+        // check mutable borrow is possible
+        && (matches!(receiver, TryIntoReceiver::SliceMutRef) || slice_can_be_borrowed_mutably(cx, recv_expr))
+    {
+        let span = mut_ref_expr.span.with_hi(inner_expr.span.hi());
+
+        span_lint_and_then(
+            cx,
+            SUSPICIOUS_SLICE_COPIES,
+            span,
+            "using a mutable reference to temporary array",
+            |diag| {
+                let mut applicability = Applicability::MaybeIncorrect;
+
+                let (recv_snippet, _) =
+                    snippet_with_context(cx, recv_expr.span, try_into_span.ctxt(), "..", &mut applicability);
+                let (unwrap_snippet, _) =
+                    snippet_with_context(cx, unwrap_span, try_into_span.ctxt(), "..", &mut applicability);
+                let (mut_ref_snippet, _) = snippet_with_context(
+                    cx,
+                    mut_ref_expr
+                        .span
+                        .until(inner_expr.span.with_leading_whitespace(cx).into_span()),
+                    try_into_span.ctxt(),
+                    "..",
+                    &mut applicability,
+                );
+
+                let borrow_sugg = if msrv.meets(cx, msrvs::SLICE_AS_MUT_ARRAY) {
+                    format!("{recv_snippet}.as_mut_array().{unwrap_snippet}")
+                } else {
+                    match receiver {
+                        TryIntoReceiver::Slice => {
+                            format!("({mut_ref_snippet} {recv_snippet}).try_into().{unwrap_snippet}")
+                        },
+                        TryIntoReceiver::SliceMutRef => format!("{recv_snippet}.try_into().{unwrap_snippet}"),
+                    }
+                };
+
+                let copy_sugg = match receiver {
+                    TryIntoReceiver::Slice => {
+                        format!("{mut_ref_snippet} <[_; _]>::try_from(&{recv_snippet}).{unwrap_snippet}")
+                    },
+                    TryIntoReceiver::SliceMutRef => {
+                        format!("{mut_ref_snippet} <[_; _]>::try_from({recv_snippet}).{unwrap_snippet}")
+                    },
+                };
+
+                diag.span_suggestion(span, "borrow the slice as an array", borrow_sugg, applicability);
+                diag.span_suggestion(
+                    span,
+                    "explicitly create a new array using `TryFrom`",
+                    copy_sugg,
+                    applicability,
+                );
+            },
+        );
+    }
+}
+
+fn slice_can_be_borrowed_mutably(cx: &LateContext<'_>, recv_expr: &Expr<'_>) -> bool {
+    let deref_mut_trait = cx.tcx.lang_items().deref_mut_trait();
+    let index_mut_trait = cx.tcx.lang_items().index_mut_trait();
+
+    let impls_deref_mut_trait = |ty| deref_mut_trait.is_some_and(|trait_id| implements_trait(cx, ty, trait_id, &[]));
+    let impls_index_mut = |ty, idx| index_mut_trait.is_some_and(|trait_id| implements_trait(cx, ty, trait_id, &[idx]));
+
+    let mut cur_expr = recv_expr;
+
+    loop {
+        if cx
+            .typeck_results()
+            .expr_adjustments(cur_expr)
+            .iter()
+            .map_while(|adj| match adj.kind {
+                Adjust::Deref(k) => Some((adj.target, k)),
+                _ => None,
+            })
+            .try_fold(
+                cx.typeck_results().expr_ty(cur_expr),
+                |ty, (target, deref)| match deref {
+                    DerefAdjustKind::Builtin => (ty.ref_mutability() != Some(Mutability::Not)).then_some(target),
+                    DerefAdjustKind::Overloaded(_) => impls_deref_mut_trait(ty).then_some(target),
+                    DerefAdjustKind::Pin => None,
+                },
+            )
+            .is_none()
+        {
+            return false;
+        }
+
+        match cur_expr.kind {
+            ExprKind::Unary(UnOp::Deref, base) => {
+                if !impls_deref_mut_trait(cx.typeck_results().expr_ty_adjusted(base)) {
+                    return false;
+                }
+
+                cur_expr = base;
+            },
+
+            ExprKind::Index(base, idx, _) => {
+                let base_ty = cx.typeck_results().expr_ty(base);
+
+                cur_expr = if impls_index_mut(base_ty, cx.typeck_results().expr_ty(idx).into())
+                    || base_ty.ref_mutability() == Some(Mutability::Mut)
+                {
+                    base
+                } else {
+                    return false;
+                }
+            },
+
+            ExprKind::Field(base, _) => cur_expr = base,
+
+            ExprKind::Path(QPath::Resolved(
+                _,
+                Path {
+                    res: Res::Local(local), ..
+                },
+            )) => {
+                let node = cx.tcx.hir_node(*local);
+
+                return match node {
+                    Node::Pat(pat) | Node::Param(&Param { pat, .. }) => {
+                        matches!(pat.kind, PatKind::Binding(BindingMode::MUT, _, _, _))
+                            || cx.typeck_results().node_type(*local).ref_mutability() == Some(Mutability::Mut)
+                    },
+                    _ => false,
+                };
+            },
+
+            _ => {
+                return false;
+            },
+        }
+    }
+}

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -89,6 +89,7 @@ msrv_aliases! {
     1,15,0 { MAYBE_BOUND_IN_WHERE }
     1,13,0 { QUESTION_MARK_OPERATOR }
     1,3,0 { DURATION_FROM_MILLIS_SECS }
+    1,93,0 { SLICE_AS_MUT_ARRAY }
 }
 
 /// `#[clippy::msrv]` attributes are rarely used outside of Clippy's test suite, as a basic

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -92,6 +92,7 @@ msrv_aliases! {
     1,15,0 { MAYBE_BOUND_IN_WHERE }
     1,13,0 { QUESTION_MARK_OPERATOR }
     1,3,0 { DURATION_FROM_MILLIS_SECS }
+    1,93,0 { SLICE_AS_MUT_ARRAY }
 }
 
 /// `#[clippy::msrv]` attributes are rarely used outside of Clippy's test suite, as a basic

--- a/tests/ui/suspicious_slice_copies.1.fixed
+++ b/tests/ui/suspicious_slice_copies.1.fixed
@@ -1,0 +1,157 @@
+#![warn(clippy::suspicious_slice_copies)]
+
+const K: usize = 3;
+const N: usize = 5;
+
+fn arr_incr(arr: &mut [i32; K]) {
+    for x in arr.iter_mut() {
+        *x += 1;
+    }
+}
+
+struct ArrFieldStruct {
+    arr: [i32; N],
+}
+
+#[clippy::msrv = "1.92.0"]
+fn test_msrv_1_92(mut mut_arr: [i32; N], arr_mut_ref: &mut [i32; N]) {
+    let slice_mut_ref: &mut [i32; K] = (&mut mut_arr[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let slice_mut_ref: &mut [i32; K] = (&mut arr_mut_ref[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let arr_mut_ref = &mut [0; N];
+    let slice_mut_ref: &mut [i32; K] = (&mut arr_mut_ref[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = (&mut arr_mut_ref[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = (&mut (*arr_mut_ref)[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    #[allow(clippy::useless_vec)]
+    let mut mut_vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = (&mut mut_vec[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr: [i32; N] = [0; N];
+    let slice: &mut [i32] = &mut arr[..K];
+
+    let mut_arr_ref: &mut [i32; K] = slice.try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = (&mut arr[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = (&mut arr[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    arr_incr((&mut arr[..K]).try_into().expect("never happen"));
+    //~^ suspicious_slice_copies
+
+    let mut arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = (&mut arr_field_struct.arr[..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = (&mut arr_2d[0][..K]).try_into().unwrap();
+    //~^ suspicious_slice_copies
+}
+
+#[clippy::msrv = "1.93.0"]
+fn test_msrv_1_93(mut mut_arr: [i32; N], arr_mut_ref: &mut [i32; N]) {
+    let slice_mut_ref: &mut [i32; K] = mut_arr[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    let slice_mut_ref: &mut [i32; K] = arr_mut_ref[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    let arr_mut_ref = &mut [0; N];
+    let slice_mut_ref: &mut [i32; K] = arr_mut_ref[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = arr_mut_ref[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = (*arr_mut_ref)[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    #[allow(clippy::useless_vec)]
+    let mut mut_vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = mut_vec[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr: [i32; N] = [0; N];
+    let slice: &mut [i32] = &mut arr[..K];
+
+    let mut_arr_ref: &mut [i32; K] = slice.as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = arr[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = arr[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    arr_incr(arr[..K].as_mut_array().expect("never happen"));
+    //~^ suspicious_slice_copies
+
+    let mut arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = arr_field_struct.arr[..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = arr_2d[0][..K].as_mut_array().unwrap();
+    //~^ suspicious_slice_copies
+}
+
+fn test_params(arr: [i32; N], arr_ref: &[i32; K]) {
+    let slice_mut_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+}
+
+fn main() {
+    let arr_ref = &[0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+
+    let arr: [i32; N] = [0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_ref: &[i32; N] = &arr;
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_ref: &[i32; N] = &arr;
+    let slice_mut_ref: &mut [i32; K] = &mut (*arr_ref)[..K].try_into().unwrap();
+
+    #[allow(clippy::useless_vec)]
+    let vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = &mut vec[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; 5];
+
+    let slice_ref: &[i32; K] = &mut_arr[..K].try_into().unwrap();
+    let slice_mut_ref: &mut [i32; K] = (&mut mut_arr[..K]).try_into().unwrap();
+
+    let arr_copy: [i32; K] = mut_arr[..K].try_into().unwrap();
+
+    let slice: &[i32] = &mut_arr[..K];
+    let arr_mut_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+
+    let arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+
+    let arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+}

--- a/tests/ui/suspicious_slice_copies.2.fixed
+++ b/tests/ui/suspicious_slice_copies.2.fixed
@@ -1,0 +1,157 @@
+#![warn(clippy::suspicious_slice_copies)]
+
+const K: usize = 3;
+const N: usize = 5;
+
+fn arr_incr(arr: &mut [i32; K]) {
+    for x in arr.iter_mut() {
+        *x += 1;
+    }
+}
+
+struct ArrFieldStruct {
+    arr: [i32; N],
+}
+
+#[clippy::msrv = "1.92.0"]
+fn test_msrv_1_92(mut mut_arr: [i32; N], arr_mut_ref: &mut [i32; N]) {
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&mut_arr[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let arr_mut_ref = &mut [0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&(*arr_mut_ref)[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    #[allow(clippy::useless_vec)]
+    let mut mut_vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&mut_vec[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr: [i32; N] = [0; N];
+    let slice: &mut [i32] = &mut arr[..K];
+
+    let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(slice).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    arr_incr(&mut <[_; _]>::try_from(&arr[..K]).expect("never happen"));
+    //~^ suspicious_slice_copies
+
+    let mut arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_field_struct.arr[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_2d[0][..K]).unwrap();
+    //~^ suspicious_slice_copies
+}
+
+#[clippy::msrv = "1.93.0"]
+fn test_msrv_1_93(mut mut_arr: [i32; N], arr_mut_ref: &mut [i32; N]) {
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&mut_arr[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let arr_mut_ref = &mut [0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&(*arr_mut_ref)[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    #[allow(clippy::useless_vec)]
+    let mut mut_vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&mut_vec[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr: [i32; N] = [0; N];
+    let slice: &mut [i32] = &mut arr[..K];
+
+    let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(slice).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    arr_incr(&mut <[_; _]>::try_from(&arr[..K]).expect("never happen"));
+    //~^ suspicious_slice_copies
+
+    let mut arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_field_struct.arr[..K]).unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_2d[0][..K]).unwrap();
+    //~^ suspicious_slice_copies
+}
+
+fn test_params(arr: [i32; N], arr_ref: &[i32; K]) {
+    let slice_mut_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+}
+
+fn main() {
+    let arr_ref = &[0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+
+    let arr: [i32; N] = [0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_ref: &[i32; N] = &arr;
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_ref: &[i32; N] = &arr;
+    let slice_mut_ref: &mut [i32; K] = &mut (*arr_ref)[..K].try_into().unwrap();
+
+    #[allow(clippy::useless_vec)]
+    let vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = &mut vec[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; 5];
+
+    let slice_ref: &[i32; K] = &mut_arr[..K].try_into().unwrap();
+    let slice_mut_ref: &mut [i32; K] = (&mut mut_arr[..K]).try_into().unwrap();
+
+    let arr_copy: [i32; K] = mut_arr[..K].try_into().unwrap();
+
+    let slice: &[i32] = &mut_arr[..K];
+    let arr_mut_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+
+    let arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+
+    let arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+}

--- a/tests/ui/suspicious_slice_copies.rs
+++ b/tests/ui/suspicious_slice_copies.rs
@@ -1,0 +1,157 @@
+#![warn(clippy::suspicious_slice_copies)]
+
+const K: usize = 3;
+const N: usize = 5;
+
+fn arr_incr(arr: &mut [i32; K]) {
+    for x in arr.iter_mut() {
+        *x += 1;
+    }
+}
+
+struct ArrFieldStruct {
+    arr: [i32; N],
+}
+
+#[clippy::msrv = "1.92.0"]
+fn test_msrv_1_92(mut mut_arr: [i32; N], arr_mut_ref: &mut [i32; N]) {
+    let slice_mut_ref: &mut [i32; K] = &mut mut_arr[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let arr_mut_ref = &mut [0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = &mut (*arr_mut_ref)[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    #[allow(clippy::useless_vec)]
+    let mut mut_vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = &mut mut_vec[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr: [i32; N] = [0; N];
+    let slice: &mut [i32] = &mut arr[..K];
+
+    let mut_arr_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = &mut (arr[..K].try_into().unwrap());
+    //~^ suspicious_slice_copies
+
+    arr_incr(&mut arr[..K].try_into().expect("never happen"));
+    //~^ suspicious_slice_copies
+
+    let mut arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+}
+
+#[clippy::msrv = "1.93.0"]
+fn test_msrv_1_93(mut mut_arr: [i32; N], arr_mut_ref: &mut [i32; N]) {
+    let slice_mut_ref: &mut [i32; K] = &mut mut_arr[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let arr_mut_ref = &mut [0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_mut_ref: &mut [i32; N] = &mut mut_arr;
+    let slice_mut_ref: &mut [i32; K] = &mut (*arr_mut_ref)[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    #[allow(clippy::useless_vec)]
+    let mut mut_vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = &mut mut_vec[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr: [i32; N] = [0; N];
+    let slice: &mut [i32] = &mut arr[..K];
+
+    let mut_arr_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut_arr_ref: &mut [i32; K] = &mut (arr[..K].try_into().unwrap());
+    //~^ suspicious_slice_copies
+
+    arr_incr(&mut arr[..K].try_into().expect("never happen"));
+    //~^ suspicious_slice_copies
+
+    let mut arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+
+    let mut arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+    //~^ suspicious_slice_copies
+}
+
+fn test_params(arr: [i32; N], arr_ref: &[i32; K]) {
+    let slice_mut_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+}
+
+fn main() {
+    let arr_ref = &[0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+
+    let arr: [i32; N] = [0; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_ref: &[i32; N] = &arr;
+    let slice_mut_ref: &mut [i32; K] = &mut arr_ref[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; N];
+    let arr_ref: &[i32; N] = &arr;
+    let slice_mut_ref: &mut [i32; K] = &mut (*arr_ref)[..K].try_into().unwrap();
+
+    #[allow(clippy::useless_vec)]
+    let vec = vec![1, 2, 3, 4, 5];
+    let slice_mut_ref: &mut [i32; K] = &mut vec[..K].try_into().unwrap();
+
+    let mut mut_arr: [i32; N] = [0; 5];
+
+    let slice_ref: &[i32; K] = &mut_arr[..K].try_into().unwrap();
+    let slice_mut_ref: &mut [i32; K] = (&mut mut_arr[..K]).try_into().unwrap();
+
+    let arr_copy: [i32; K] = mut_arr[..K].try_into().unwrap();
+
+    let slice: &[i32] = &mut_arr[..K];
+    let arr_mut_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+
+    let arr_field_struct = ArrFieldStruct { arr: [0; N] };
+    let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+
+    let arr_2d: [[i32; N]; N] = [[0; N]; N];
+    let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+}

--- a/tests/ui/suspicious_slice_copies.stderr
+++ b/tests/ui/suspicious_slice_copies.stderr
@@ -1,0 +1,412 @@
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:18:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut mut_arr[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::suspicious-slice-copies` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::suspicious_slice_copies)]`
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut mut_arr[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = (&mut mut_arr[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut mut_arr[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&mut_arr[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:21:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = (&mut arr_mut_ref[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:25:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = (&mut arr_mut_ref[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:30:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = (&mut arr_mut_ref[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:35:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut (*arr_mut_ref)[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut (*arr_mut_ref)[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = (&mut (*arr_mut_ref)[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut (*arr_mut_ref)[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&(*arr_mut_ref)[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:40:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut mut_vec[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut mut_vec[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = (&mut mut_vec[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut mut_vec[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&mut_vec[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:46:38
+   |
+LL |     let mut_arr_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+LL +     let mut_arr_ref: &mut [i32; K] = slice.try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+LL +     let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(slice).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:49:38
+   |
+LL |     let mut_arr_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+LL +     let mut_arr_ref: &mut [i32; K] = (&mut arr[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+LL +     let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:52:38
+   |
+LL |     let mut_arr_ref: &mut [i32; K] = &mut (arr[..K].try_into().unwrap());
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut (arr[..K].try_into().unwrap());
+LL +     let mut_arr_ref: &mut [i32; K] = (&mut arr[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut (arr[..K].try_into().unwrap());
+LL +     let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:55:14
+   |
+LL |     arr_incr(&mut arr[..K].try_into().expect("never happen"));
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     arr_incr(&mut arr[..K].try_into().expect("never happen"));
+LL +     arr_incr((&mut arr[..K]).try_into().expect("never happen"));
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     arr_incr(&mut arr[..K].try_into().expect("never happen"));
+LL +     arr_incr(&mut <[_; _]>::try_from(&arr[..K]).expect("never happen"));
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:59:40
+   |
+LL |     let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+LL +     let mut_field_arr: &mut [i32; K] = (&mut arr_field_struct.arr[..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+LL +     let mut_field_arr: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_field_struct.arr[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:63:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = (&mut arr_2d[0][..K]).try_into().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_2d[0][..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:69:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut mut_arr[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut mut_arr[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = mut_arr[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut mut_arr[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&mut_arr[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:72:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = arr_mut_ref[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:76:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = arr_mut_ref[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:81:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = arr_mut_ref[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_mut_ref[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_mut_ref[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:86:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut (*arr_mut_ref)[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut (*arr_mut_ref)[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = (*arr_mut_ref)[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut (*arr_mut_ref)[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&(*arr_mut_ref)[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:91:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut mut_vec[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut mut_vec[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = mut_vec[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut mut_vec[..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&mut_vec[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:97:38
+   |
+LL |     let mut_arr_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+LL +     let mut_arr_ref: &mut [i32; K] = slice.as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut slice.try_into().unwrap();
+LL +     let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(slice).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:100:38
+   |
+LL |     let mut_arr_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+LL +     let mut_arr_ref: &mut [i32; K] = arr[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut arr[..K].try_into().unwrap();
+LL +     let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:103:38
+   |
+LL |     let mut_arr_ref: &mut [i32; K] = &mut (arr[..K].try_into().unwrap());
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut (arr[..K].try_into().unwrap());
+LL +     let mut_arr_ref: &mut [i32; K] = arr[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let mut_arr_ref: &mut [i32; K] = &mut (arr[..K].try_into().unwrap());
+LL +     let mut_arr_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:106:14
+   |
+LL |     arr_incr(&mut arr[..K].try_into().expect("never happen"));
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     arr_incr(&mut arr[..K].try_into().expect("never happen"));
+LL +     arr_incr(arr[..K].as_mut_array().expect("never happen"));
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     arr_incr(&mut arr[..K].try_into().expect("never happen"));
+LL +     arr_incr(&mut <[_; _]>::try_from(&arr[..K]).expect("never happen"));
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:110:40
+   |
+LL |     let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+LL +     let mut_field_arr: &mut [i32; K] = arr_field_struct.arr[..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let mut_field_arr: &mut [i32; K] = &mut arr_field_struct.arr[..K].try_into().unwrap();
+LL +     let mut_field_arr: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_field_struct.arr[..K]).unwrap();
+   |
+
+error: using a mutable reference to temporary array
+  --> tests/ui/suspicious_slice_copies.rs:114:40
+   |
+LL |     let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: borrow the slice as an array
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = arr_2d[0][..K].as_mut_array().unwrap();
+   |
+help: explicitly create a new array using `TryFrom`
+   |
+LL -     let slice_mut_ref: &mut [i32; K] = &mut arr_2d[0][..K].try_into().unwrap();
+LL +     let slice_mut_ref: &mut [i32; K] = &mut <[_; _]>::try_from(&arr_2d[0][..K]).unwrap();
+   |
+
+error: aborting due to 24 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16671)*

*implements lint for checking usage of  a `&mut` to a temporary array copied from a slice*

changelog: [`suspicious_slice_copies`]

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Fixes rust-lang/rust-clippy#16507. The lint checks only calls `try_into` by `[T]` or `&mut [T]`. If any other cases should be covered by this lint, please share your feedback.