### PR TITLE
Allow [`absolute_paths`] to be configured based on occurrence

### DIFF
--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -345,6 +345,8 @@ define_Conf! {
     /// Which crates to allow absolute paths from
     #[lints(absolute_paths)]
     absolute_paths_allowed_crates: Vec<String> = Vec::new(),
+    /// The maximum number of times an absolute path can appear in a module before being linted.
+    absolute_paths_max_occurrences: u64 = 0,
     /// The maximum number of segments a path can have before being linted, anything above this will
     /// be linted.
     #[lints(absolute_paths)]

--- a/clippy_lints/src/absolute_paths.rs
+++ b/clippy_lints/src/absolute_paths.rs
@@ -1,14 +1,14 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::is_from_proc_macro;
+use clippy_utils::{fulfill_or_allowed, is_from_proc_macro};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CRATE_DEF_INDEX, DefId};
-use rustc_hir::{HirId, ItemKind, Node, Path};
+use rustc_hir::{HirId, ItemKind, Node, OwnerNode, Path};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
-use rustc_span::Symbol;
 use rustc_span::symbol::kw;
+use rustc_span::{Span, Symbol};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -56,19 +56,23 @@ declare_clippy_lint! {
 impl_lint_pass!(AbsolutePaths => [ABSOLUTE_PATHS]);
 
 pub struct AbsolutePaths {
-    pub absolute_paths_max_segments: u64,
-    pub absolute_paths_allowed_crates: FxHashSet<Symbol>,
+    pub max_segments: u64,
+    pub allowed_crates: FxHashSet<Symbol>,
+    pub max_occurrences: u64,
+    occurrences: Vec<((DefId, DefId), Span)>, // To track count of occurences
 }
 
 impl AbsolutePaths {
     pub fn new(conf: &'static Conf) -> Self {
         Self {
-            absolute_paths_max_segments: conf.absolute_paths_max_segments,
-            absolute_paths_allowed_crates: conf
+            max_segments: conf.absolute_paths_max_segments,
+            allowed_crates: conf
                 .absolute_paths_allowed_crates
                 .iter()
                 .map(|x| Symbol::intern(x))
                 .collect(),
+            max_occurrences: conf.absolute_paths_max_occurrences,
+            occurrences: Vec::new(),
         }
     }
 }
@@ -93,7 +97,7 @@ impl<'tcx> LateLintPass<'tcx> for AbsolutePaths {
             && let has_root = s1.ident.name == kw::PathRoot
             && let first = if has_root { s2 } else { s1 }
             && let len = segments.len() - usize::from(has_root)
-            && len as u64 > self.absolute_paths_max_segments
+            && len as u64 > self.max_segments
             && let crate_name = if let Res::Def(DefKind::Mod, DefId { index, .. }) = first.res
                 && index == CRATE_DEF_INDEX
             {
@@ -108,15 +112,56 @@ impl<'tcx> LateLintPass<'tcx> for AbsolutePaths {
             && !path.span.from_expansion()
             && let node = cx.tcx.hir_node(hir_id)
             && !matches!(node, Node::Item(item) if matches!(item.kind, ItemKind::Use(..)))
-            && !self.absolute_paths_allowed_crates.contains(&crate_name)
+            && !self.allowed_crates.contains(&crate_name)
             && !is_from_proc_macro(cx, path)
         {
-            span_lint(
-                cx,
-                ABSOLUTE_PATHS,
-                path.span,
-                "consider bringing this path into scope with the `use` keyword",
-            );
+            if self.max_occurrences == 0 {
+                // Default behaviour : emit lint directly, no need for occurence tracking
+                span_lint(
+                    cx,
+                    ABSOLUTE_PATHS,
+                    path.span,
+                    "consider bringing this path into scope with the `use` keyword",
+                );
+            } else if let Res::Def(_, def_id) = path.res
+                && !fulfill_or_allowed(cx, ABSOLUTE_PATHS, [hir_id])
+            {
+                // Occurence based behaviour : accumulate spans and emit lint in check_crate_post
+                // if the occurence count is exceeded
+                let module = cx
+                    .tcx
+                    .hir_parent_owner_iter(hir_id)
+                    .find(|(_, node)| {
+                        if let OwnerNode::Item(item) = node {
+                            matches!(item.kind, ItemKind::Mod(..))
+                        } else {
+                            matches!(node, OwnerNode::Crate(..))
+                        }
+                    })
+                    .map(|(id, _)| id);
+                if let Some(module) = module {
+                    self.occurrences.push(((def_id, module.to_def_id()), path.span));
+                }
+            }
+        }
+    }
+
+    fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
+        // Only runs when absolute_paths_max_occurrences > 0.
+        // Emit lints for any path that exceeded the per-file occurrence threshold.
+        self.occurrences
+            .sort_by_key(|((item_did, mod_did), span)| (item_did.index.as_u32(), mod_did.index.as_u32(), span.lo()));
+        for chunk in self.occurrences.chunk_by(|(key1, _), (key2, _)| key1 == key2) {
+            if chunk.len() as u64 > self.max_occurrences {
+                for (_, span) in chunk {
+                    span_lint(
+                        cx,
+                        ABSOLUTE_PATHS,
+                        *span,
+                        "this absolute path is used too many times, consider bringing it into scope with the `use` keyword",
+                    );
+                }
+            }
         }
     }
 }

--- a/tests/ui-toml/absolute_paths/absolute_paths.allow_crates.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.allow_crates.stderr
@@ -1,44 +1,140 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:7:9
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:8:9
    |
 LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:33:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:33:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:48:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:111:17
+   |
+LL |         let _ = std::io::ErrorKind::Other;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:115:17
+   |
+LL |         let _ = std::io::ErrorKind::Other;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:121:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:126:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:131:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:138:17
+   |
+LL |         let _ = std::fs::read_dir(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:142:17
+   |
+LL |         let _ = std::fs::read_dir(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:146:17
+   |
+LL |         let _ = std::fs::metadata(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:150:17
+   |
+LL |         let _ = std::fs::metadata(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:157:17
+   |
+LL |         let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:162:17
+   |
+LL |         let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:171:17
+   |
+LL |         let _ = std::collections::linked_list::LinkedList::from([1]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:176:17
+   |
+LL |         let _ = std::collections::linked_list::LinkedList::from([1]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:208:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:213:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:218:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 22 previous errors
 

--- a/tests/ui-toml/absolute_paths/absolute_paths.allow_long.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.allow_long.stderr
@@ -1,14 +1,38 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:7:9
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:8:9
    |
 LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:157:17
+   |
+LL |         let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:162:17
+   |
+LL |         let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:171:17
+   |
+LL |         let _ = std::collections::linked_list::LinkedList::from([1]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:176:17
+   |
+LL |         let _ = std::collections::linked_list::LinkedList::from([1]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui-toml/absolute_paths/absolute_paths.default.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.default.stderr
@@ -1,80 +1,182 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:7:9
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:8:9
    |
 LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:33:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:33:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:37:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:42:13
    |
 LL |     let _ = ::core::clone::Clone::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:40:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:45:13
    |
 LL |     let _ = <i32 as core::clone::Clone>::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:48:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:17
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:17
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                 ^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:18
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:75:18
    |
 LL |         where T: core::clone::Clone
    |                  ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:32
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:32
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                                ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:116:5
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:111:17
+   |
+LL |         let _ = std::io::ErrorKind::Other;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:115:17
+   |
+LL |         let _ = std::io::ErrorKind::Other;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:121:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:126:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:131:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:138:17
+   |
+LL |         let _ = std::fs::read_dir(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:142:17
+   |
+LL |         let _ = std::fs::read_dir(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:146:17
+   |
+LL |         let _ = std::fs::metadata(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:150:17
+   |
+LL |         let _ = std::fs::metadata(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:157:17
+   |
+LL |         let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:162:17
+   |
+LL |         let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:171:17
+   |
+LL |         let _ = std::collections::linked_list::LinkedList::from([1]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:176:17
+   |
+LL |         let _ = std::collections::linked_list::LinkedList::from([1]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:197:5
    |
 LL |     crate::m1::S
    |     ^^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:208:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:213:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:218:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:224:17
+   |
+LL |         let _ = ::core::clone::Clone::clone(&0i32);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 29 previous errors
 

--- a/tests/ui-toml/absolute_paths/absolute_paths.max_occurrences.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.max_occurrences.stderr
@@ -1,0 +1,44 @@
+error: this absolute path is used too many times, consider bringing it into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:121:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:8:9
+   |
+LL | #![deny(clippy::absolute_paths)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: this absolute path is used too many times, consider bringing it into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:126:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: this absolute path is used too many times, consider bringing it into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:131:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: this absolute path is used too many times, consider bringing it into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:208:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: this absolute path is used too many times, consider bringing it into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:213:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: this absolute path is used too many times, consider bringing it into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:218:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui-toml/absolute_paths/absolute_paths.no_short.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.no_short.stderr
@@ -1,98 +1,200 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:7:9
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:8:9
    |
 LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:33:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:33:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:37:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:42:13
    |
 LL |     let _ = ::core::clone::Clone::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:40:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:45:13
    |
 LL |     let _ = <i32 as core::clone::Clone>::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:48:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:17
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:17
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                 ^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:18
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:75:18
    |
 LL |         where T: core::clone::Clone
    |                  ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:32
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:32
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                                ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:113:10
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:111:17
+   |
+LL |         let _ = std::io::ErrorKind::Other;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:115:17
+   |
+LL |         let _ = std::io::ErrorKind::Other;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:121:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:126:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:131:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:138:17
+   |
+LL |         let _ = std::fs::read_dir(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:142:17
+   |
+LL |         let _ = std::fs::read_dir(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:146:17
+   |
+LL |         let _ = std::fs::metadata(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:150:17
+   |
+LL |         let _ = std::fs::metadata(".");
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:157:17
+   |
+LL |         let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:162:17
+   |
+LL |         let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:171:17
+   |
+LL |         let _ = std::collections::linked_list::LinkedList::from([1]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:176:17
+   |
+LL |         let _ = std::collections::linked_list::LinkedList::from([1]);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:194:10
    |
 LL | const _: crate::S = {
    |          ^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:114:9
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:195:9
    |
 LL |     let crate::S = m1::S;
    |         ^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:116:5
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:197:5
    |
 LL |     crate::m1::S
    |     ^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:122:14
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:203:14
    |
 LL |     let _ = <crate::S as Clone>::clone(&m1::S);
    |              ^^^^^^^^
 
-error: aborting due to 15 previous errors
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:208:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:213:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:218:17
+   |
+LL |         let _ = std::env::current_dir();
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider bringing this path into scope with the `use` keyword
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:224:17
+   |
+LL |         let _ = ::core::clone::Clone::clone(&0i32);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 32 previous errors
 

--- a/tests/ui-toml/absolute_paths/absolute_paths.rs
+++ b/tests/ui-toml/absolute_paths/absolute_paths.rs
@@ -1,9 +1,10 @@
 //@aux-build:../../ui/auxiliary/proc_macros.rs
-//@revisions: default allow_crates allow_long no_short
+//@revisions: default allow_crates allow_long no_short max_occurrences
 //@[default] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/default
 //@[allow_crates] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/allow_crates
 //@[allow_long] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/allow_long
 //@[no_short] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/no_short
+//@[max_occurrences] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/max_occurrences
 #![deny(clippy::absolute_paths)]
 
 extern crate proc_macros;
@@ -22,7 +23,11 @@ fn main() {
     //~[allow_crates]| absolute_paths
     //~[no_short]| absolute_paths
 
-    let _ = std::collections::hash_map::HashMap::<i32, i32>::new(); //~ absolute_paths
+    let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
+    //~[default]^ absolute_paths
+    //~[allow_crates]| absolute_paths
+    //~[allow_long]| absolute_paths
+    //~[no_short]| absolute_paths
 
     // Note `std::path::Path::new` is treated as having three parts
     let _: &std::path::Path = std::path::Path::new("");
@@ -98,6 +103,82 @@ fn main() {
     inline! {
         let _ = std::path::is_separator(' ');
     }
+
+    {
+        // Test with max_occurrences = 2
+
+        // Used exactly twice, should NOT trigger
+        let _ = std::io::ErrorKind::Other;
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        let _ = std::io::ErrorKind::Other;
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+
+        // Used three times, should trigger on ALL occurrences
+        let _ = std::env::current_dir();
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        //~[max_occurrences]| absolute_paths
+        let _ = std::env::current_dir();
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        //~[max_occurrences]| absolute_paths
+        let _ = std::env::current_dir();
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        //~[max_occurrences]| absolute_paths
+
+        // Distinct paths to show it does the path distinction correctly
+        let _ = std::fs::read_dir(".");
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        let _ = std::fs::read_dir(".");
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        let _ = std::fs::metadata(".");
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        let _ = std::fs::metadata(".");
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+
+        #[allow(clippy::absolute_paths)]
+        let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+        let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[allow_long]| absolute_paths
+        //~[no_short]| absolute_paths
+        let _ = std::collections::btree_map::BTreeMap::from([("Mercury", 0.4)]);
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[allow_long]| absolute_paths
+        //~[no_short]| absolute_paths
+
+        // #[expect] works the same way.
+        #[expect(clippy::absolute_paths)]
+        let _ = std::collections::linked_list::LinkedList::from([1]);
+        let _ = std::collections::linked_list::LinkedList::from([1]);
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[allow_long]| absolute_paths
+        //~[no_short]| absolute_paths
+        let _ = std::collections::linked_list::LinkedList::from([1]);
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[allow_long]| absolute_paths
+        //~[no_short]| absolute_paths
+    }
 }
 
 pub use core::cmp::Ordering;
@@ -120,4 +201,28 @@ const _: crate::S = {
 
 pub fn f() {
     let _ = <crate::S as Clone>::clone(&m1::S); //~[no_short] absolute_paths
+}
+
+mod submodule {
+    pub fn f() {
+        let _ = std::env::current_dir();
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        //~[max_occurrences]| absolute_paths
+        let _ = std::env::current_dir();
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        //~[max_occurrences]| absolute_paths
+        let _ = std::env::current_dir();
+        //~[default]^ absolute_paths
+        //~[allow_crates]| absolute_paths
+        //~[no_short]| absolute_paths
+        //~[max_occurrences]| absolute_paths
+
+        let _ = ::core::clone::Clone::clone(&0i32);
+        //~[default]^ absolute_paths
+        //~[no_short]| absolute_paths
+    }
 }

--- a/tests/ui-toml/absolute_paths/max_occurrences/clippy.toml
+++ b/tests/ui-toml/absolute_paths/max_occurrences/clippy.toml
@@ -1,0 +1,1 @@
+absolute-paths-max-occurrences = 2

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -1,5 +1,6 @@
 error: error reading Clippy's configuration file: unknown field `foobar`, expected one of
            absolute-paths-allowed-crates
+           absolute-paths-max-occurrences
            absolute-paths-max-segments
            accept-comment-above-attributes
            accept-comment-above-statement
@@ -101,6 +102,7 @@ LL | foobar = 42
 
 error: error reading Clippy's configuration file: unknown field `barfoo`, expected one of
            absolute-paths-allowed-crates
+           absolute-paths-max-occurrences
            absolute-paths-max-segments
            accept-comment-above-attributes
            accept-comment-above-statement
@@ -202,6 +204,7 @@ LL | barfoo = 53
 
 error: error reading Clippy's configuration file: unknown field `allow_mixed_uninlined_format_args`, expected one of
            absolute-paths-allowed-crates
+           absolute-paths-max-occurrences
            absolute-paths-max-segments
            accept-comment-above-attributes
            accept-comment-above-statement


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16574

Add `absolute-paths-max-occurrences` config option to [`absolute_paths`]

Allow users to only trigger the lint when the same absolute path is used
more than N times in a single file, rather than on every occurrence. The
default value of 0 preserves the existing behavior of linting every
occurrence unconditionally.

Occurrences suppressed by `#[allow]` or `#[expect]` are excluded from
the count entirely, so they do not contribute toward the threshold.

I have two small problems : 
1. I have the following warning, I don't know how to proceed (allow it or better way to handle this ?)
```
warning: using `drain` can result in unstable query results
   --> clippy_lints/src/absolute_paths.rs:139:63
    |
139 |         for ((_def_id, _file), spans_vec) in self.occurrences.drain() {
    |                                                               ^^^^^
    |
    = note: if you believe this case to be fine, allow this lint and add a comment explaining your rationale
note: the lint level is defined here
   --> clippy_lints/src/lib.rs:26:5
    |
 26 |     rustc::internal
    |     ^^^^^^^^^^^^^^^
    = note: `#[warn(rustc::potential_query_instability)]` implied by `#[warn(rustc::internal)]`
```
2. To test the behaviour "lints only if find N times in the **file**", I should probably add tests in `tests/ui-cargo` with a dedicated crate. My question is : should I move the other existing tests there ?

changelog: [`absolute_paths`]: Add `absolute-paths-max-occurrences` config option
