### PR TITLE
fix: `zero_repeat_side_effects` generic type needed

### DIFF
--- a/clippy_lints/src/zero_repeat_side_effects.rs
+++ b/clippy_lints/src/zero_repeat_side_effects.rs
@@ -91,22 +91,29 @@ fn inner_check(cx: &LateContext<'_>, expr: &'_ Expr<'_>, inner_expr: &'_ Expr<'_
             {
                 (
                     x.span,
-                    assign_expr_suggestion(cx, x, l.pat.span, &inner_expr, return_type, vec),
+                    assign_expr_suggestion(cx, x, l.pat.span, &inner_expr, inner_expr_ty, return_type, vec),
                 )
             },
-            Node::LetStmt(l) => (l.span, let_stmt_suggestion(cx, l, &inner_expr, return_type, vec)),
+            Node::LetStmt(l) => (
+                l.span,
+                let_stmt_suggestion(cx, l, &inner_expr, inner_expr_ty, return_type, vec),
+            ),
             Node::Expr(x) if let ExprKind::Assign(l, _, _) = x.kind => (
                 x.span,
-                assign_expr_suggestion(cx, x, l.span, &inner_expr, return_type, vec),
+                assign_expr_suggestion(cx, x, l.span, &inner_expr, inner_expr_ty, return_type, vec),
             ),
             // NOTE: don't use the stmt span to avoid touching the trailing semicolon
-            Node::Stmt(_) => (expr.span, format!("{inner_expr};\n{indent}{vec}[] as {return_type}")),
+            Node::Stmt(_) => (
+                // NOTE: No type annotation needed here, the original code would not compile if the type were ambiguous
+                expr.span,
+                format!("{inner_expr};\n{indent}{vec}[] as {return_type}"),
+            ),
             _ => (
                 expr.span,
                 format!(
                     "\
 {{
-{indent}    {inner_expr};
+{indent}    let _: {inner_expr_ty} = {inner_expr};
 {indent}    {vec}[] as {return_type}
 {indent}}}"
                 ),
@@ -121,6 +128,7 @@ fn inner_check(cx: &LateContext<'_>, expr: &'_ Expr<'_>, inner_expr: &'_ Expr<'_
             |diag| {
                 if (!inner_expr_ty.is_never() || cx.tcx.features().never_type())
                     && return_type.is_suggestable(cx.tcx, true)
+                    && inner_expr_ty.is_suggestable(cx.tcx, true)
                 {
                     diag.span_suggestion_verbose(
                         span,
@@ -140,12 +148,13 @@ fn let_stmt_suggestion(
     cx: &LateContext<'_>,
     let_stmt: &LetStmt<'_>,
     inner_expr: &str,
+    inner_expr_ty: Ty<'_>,
     return_type: Ty<'_>,
     vec_str: &str,
 ) -> String {
     let indent = snippet_indent(cx, let_stmt.span).unwrap_or_default();
     format!(
-        "{inner_expr};\n{}let {var_name}: {return_type} = {vec_str}[];",
+        "let _: {inner_expr_ty} = {inner_expr};\n{}let {var_name}: {return_type} = {vec_str}[];",
         indent,
         var_name = snippet(cx, let_stmt.pat.span.source_callsite(), "..")
     )
@@ -156,6 +165,7 @@ fn assign_expr_suggestion(
     outer_expr: &Expr<'_>,
     assign_expr_span: Span,
     inner_expr: &str,
+    inner_expr_ty: Ty<'_>,
     return_type: Ty<'_>,
     vec_str: &str,
 ) -> String {
@@ -168,8 +178,10 @@ fn assign_expr_suggestion(
     let indent = snippet_indent(cx, outer_expr.span).unwrap_or_default();
     let var_name = snippet(cx, assign_expr_span.source_callsite(), "..");
     if needs_curly {
-        format!("{{\n    {indent}{inner_expr};\n    {indent}{var_name} = {vec_str}[] as {return_type}\n{indent}}}")
+        format!(
+            "{{\n    {indent}let _: {inner_expr_ty} = {inner_expr};\n    {indent}{var_name} = {vec_str}[] as {return_type}\n{indent}}}"
+        )
     } else {
-        format!("{inner_expr};\n{indent}{var_name} = {vec_str}[] as {return_type}")
+        format!("let _: {inner_expr_ty} = {inner_expr};\n{indent}{var_name} = {vec_str}[] as {return_type}")
     }
 }

--- a/tests/ui/zero_repeat_side_effects.fixed
+++ b/tests/ui/zero_repeat_side_effects.fixed
@@ -19,37 +19,37 @@ fn main() {
     // should trigger
 
     // on arrays
-    f();
+    let _: i32 = f();
     let a: [i32; 0] = [];
     //~^ zero_repeat_side_effects
     let mut b;
-    f();
+    let _: i32 = f();
     b = [] as [i32; 0];
     //~^ zero_repeat_side_effects
 
     // on vecs
     // vecs dont support inferring value of consts
-    f();
+    let _: i32 = f();
     let c: std::vec::Vec<i32> = vec![];
     //~^ zero_repeat_side_effects
     let d;
-    f();
+    let _: i32 = f();
     d = vec![] as std::vec::Vec<i32>;
     //~^ zero_repeat_side_effects
 
     // for macros
-    println!("side effect");
+    let _: () = println!("side effect");
     let e: [(); 0] = [];
     //~^ zero_repeat_side_effects
 
     // for nested calls
-    { f() };
+    let _: i32 = { f() };
     let g: [i32; 0] = [];
     //~^ zero_repeat_side_effects
 
     // as function param
     drop({
-        f();
+        let _: i32 = f();
         vec![] as std::vec::Vec<i32>
     });
     //~^ zero_repeat_side_effects
@@ -114,12 +114,12 @@ fn issue_14681() {
     foo(&[Some(0i64); 0]);
     foo(&[Some(Some(0i64)); 0]);
     foo(&{
-        Some(f());
+        let _: std::option::Option<i32> = Some(f());
         [] as [std::option::Option<i32>; 0]
     });
     //~^ zero_repeat_side_effects
     foo(&{
-        Some(Some(S::new()));
+        let _: std::option::Option<std::option::Option<S>> = Some(Some(S::new()));
         [] as [std::option::Option<std::option::Option<S>>; 0]
     });
     //~^ zero_repeat_side_effects
@@ -130,7 +130,7 @@ fn issue_15824() {
 
     match 0 {
         0 => {
-            f();
+            let _: () = f();
             _ = [] as [(); 0]
         },
         //~^ zero_repeat_side_effects
@@ -140,10 +140,96 @@ fn issue_15824() {
     let mut a = [(); 0];
     match 0 {
         0 => {
-            f();
+            let _: () = f();
             a = [] as [(); 0]
         },
         //~^ zero_repeat_side_effects
         _ => {},
     }
+}
+
+// // Issue 16474
+use std::marker::PhantomData;
+
+#[derive(Default, Clone)]
+pub struct Generic<T> {
+    pub id: usize,
+    pub data: PhantomData<T>,
+}
+
+fn issue_16474() {
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default, Clone)]
+    struct Entry<T> {
+        id: usize,
+        data: Arc<Mutex<T>>,
+    }
+
+    fn test_let_statement() {
+        let _: issue_16474::Entry<usize> = Entry::default();
+        let mut entries: std::vec::Vec<issue_16474::Entry<usize>> = vec![];
+        //~^ zero_repeat_side_effects
+
+        for (i, e) in entries.iter_mut().enumerate() {
+            e.id = i;
+            *e.data.lock().unwrap() = i;
+        }
+
+        let entry_0 = &entries[0];
+
+        assert_eq!(entry_0.id, *entry_0.data.lock().unwrap());
+    }
+
+    fn test_assign_expr_no_curly() {
+        let mut entries: Vec<Entry<usize>> = vec![];
+        let _: issue_16474::Entry<usize> = Entry::default();
+        entries = vec![] as std::vec::Vec<issue_16474::Entry<usize>>;
+        //~^ zero_repeat_side_effects
+
+        for (i, e) in entries.iter_mut().enumerate() {
+            e.id = i;
+            *e.data.lock().unwrap() = i;
+        }
+
+        let entry_0 = &entries[0];
+
+        assert_eq!(entry_0.id, *entry_0.data.lock().unwrap());
+    }
+
+    fn test_assign_expr_curly() {
+        let mut entries: Vec<Entry<usize>> = vec![];
+        match 0 {
+            0 => {
+                let _: issue_16474::Entry<usize> = Entry::default();
+                entries = vec![] as std::vec::Vec<issue_16474::Entry<usize>>
+            }, //~ zero_repeat_side_effects
+            _ => (),
+        }
+
+        for (i, e) in entries.iter_mut().enumerate() {
+            e.id = i;
+            *e.data.lock().unwrap() = i;
+        }
+
+        let entry_0 = &entries[0];
+
+        assert_eq!(entry_0.id, *entry_0.data.lock().unwrap());
+    }
+
+    fn some_fn(a: Vec<Generic<usize>>, b: usize) {
+        for i in a.iter() {
+            println!("i.id = {},b = {b}", i.id);
+        }
+    }
+
+    test_let_statement();
+    test_assign_expr_no_curly();
+    test_assign_expr_curly();
+
+    some_fn({
+        let _: Generic<usize> = Generic::default();
+        vec![] as std::vec::Vec<Generic<usize>>
+    }, 42);
+    //~^ zero_repeat_side_effects
 }

--- a/tests/ui/zero_repeat_side_effects.rs
+++ b/tests/ui/zero_repeat_side_effects.rs
@@ -124,3 +124,81 @@ fn issue_15824() {
         _ => {},
     }
 }
+
+// // Issue 16474
+use std::marker::PhantomData;
+
+#[derive(Default, Clone)]
+pub struct Generic<T> {
+    pub id: usize,
+    pub data: PhantomData<T>,
+}
+
+fn issue_16474() {
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default, Clone)]
+    struct Entry<T> {
+        id: usize,
+        data: Arc<Mutex<T>>,
+    }
+
+    fn test_let_statement() {
+        let mut entries = vec![Entry::default(); 0];
+        //~^ zero_repeat_side_effects
+
+        for (i, e) in entries.iter_mut().enumerate() {
+            e.id = i;
+            *e.data.lock().unwrap() = i;
+        }
+
+        let entry_0 = &entries[0];
+
+        assert_eq!(entry_0.id, *entry_0.data.lock().unwrap());
+    }
+
+    fn test_assign_expr_no_curly() {
+        let mut entries: Vec<Entry<usize>> = vec![];
+        entries = vec![Entry::default(); 0];
+        //~^ zero_repeat_side_effects
+
+        for (i, e) in entries.iter_mut().enumerate() {
+            e.id = i;
+            *e.data.lock().unwrap() = i;
+        }
+
+        let entry_0 = &entries[0];
+
+        assert_eq!(entry_0.id, *entry_0.data.lock().unwrap());
+    }
+
+    fn test_assign_expr_curly() {
+        let mut entries: Vec<Entry<usize>> = vec![];
+        match 0 {
+            0 => entries = vec![Entry::default(); 0], //~ zero_repeat_side_effects
+            _ => (),
+        }
+
+        for (i, e) in entries.iter_mut().enumerate() {
+            e.id = i;
+            *e.data.lock().unwrap() = i;
+        }
+
+        let entry_0 = &entries[0];
+
+        assert_eq!(entry_0.id, *entry_0.data.lock().unwrap());
+    }
+
+    fn some_fn(a: Vec<Generic<usize>>, b: usize) {
+        for i in a.iter() {
+            println!("i.id = {},b = {b}", i.id);
+        }
+    }
+
+    test_let_statement();
+    test_assign_expr_no_curly();
+    test_assign_expr_curly();
+
+    some_fn(vec![Generic::default(); 0], 42);
+    //~^ zero_repeat_side_effects
+}

--- a/tests/ui/zero_repeat_side_effects.stderr
+++ b/tests/ui/zero_repeat_side_effects.stderr
@@ -8,7 +8,7 @@ LL |     let a = [f(); 0];
    = help: to override `-D warnings` add `#[allow(clippy::zero_repeat_side_effects)]`
 help: consider performing the side effect separately
    |
-LL ~     f();
+LL ~     let _: i32 = f();
 LL +     let a: [i32; 0] = [];
    |
 
@@ -20,7 +20,7 @@ LL |     b = [f(); 0];
    |
 help: consider performing the side effect separately
    |
-LL ~     f();
+LL ~     let _: i32 = f();
 LL ~     b = [] as [i32; 0];
    |
 
@@ -32,7 +32,7 @@ LL |     let c = vec![f(); 0];
    |
 help: consider performing the side effect separately
    |
-LL ~     f();
+LL ~     let _: i32 = f();
 LL +     let c: std::vec::Vec<i32> = vec![];
    |
 
@@ -44,7 +44,7 @@ LL |     d = vec![f(); 0];
    |
 help: consider performing the side effect separately
    |
-LL ~     f();
+LL ~     let _: i32 = f();
 LL ~     d = vec![] as std::vec::Vec<i32>;
    |
 
@@ -56,7 +56,7 @@ LL |     let e = [println!("side effect"); 0];
    |
 help: consider performing the side effect separately
    |
-LL ~     println!("side effect");
+LL ~     let _: () = println!("side effect");
 LL +     let e: [(); 0] = [];
    |
 
@@ -68,7 +68,7 @@ LL |     let g = [{ f() }; 0];
    |
 help: consider performing the side effect separately
    |
-LL ~     { f() };
+LL ~     let _: i32 = { f() };
 LL +     let g: [i32; 0] = [];
    |
 
@@ -81,7 +81,7 @@ LL |     drop(vec![f(); 0]);
 help: consider performing the side effect separately
    |
 LL ~     drop({
-LL +         f();
+LL +         let _: i32 = f();
 LL +         vec![] as std::vec::Vec<i32>
 LL ~     });
    |
@@ -119,7 +119,7 @@ LL |     foo(&[Some(f()); 0]);
 help: consider performing the side effect separately
    |
 LL ~     foo(&{
-LL +         Some(f());
+LL +         let _: std::option::Option<i32> = Some(f());
 LL +         [] as [std::option::Option<i32>; 0]
 LL ~     });
    |
@@ -133,7 +133,7 @@ LL |     foo(&[Some(Some(S::new())); 0]);
 help: consider performing the side effect separately
    |
 LL ~     foo(&{
-LL +         Some(Some(S::new()));
+LL +         let _: std::option::Option<std::option::Option<S>> = Some(Some(S::new()));
 LL +         [] as [std::option::Option<std::option::Option<S>>; 0]
 LL ~     });
    |
@@ -147,7 +147,7 @@ LL |         0 => _ = [f(); 0],
 help: consider performing the side effect separately
    |
 LL ~         0 => {
-LL +             f();
+LL +             let _: () = f();
 LL +             _ = [] as [(); 0]
 LL ~         },
    |
@@ -161,10 +161,62 @@ LL |         0 => a = [f(); 0],
 help: consider performing the side effect separately
    |
 LL ~         0 => {
-LL +             f();
+LL +             let _: () = f();
 LL +             a = [] as [(); 0]
 LL ~         },
    |
 
-error: aborting due to 13 previous errors
+error: expression with side effects as the initial value in a zero-sized array initializer
+  --> tests/ui/zero_repeat_side_effects.rs:147:9
+   |
+LL |         let mut entries = vec![Entry::default(); 0];
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider performing the side effect separately
+   |
+LL ~         let _: issue_16474::Entry<usize> = Entry::default();
+LL +         let mut entries: std::vec::Vec<issue_16474::Entry<usize>> = vec![];
+   |
+
+error: expression with side effects as the initial value in a zero-sized array initializer
+  --> tests/ui/zero_repeat_side_effects.rs:162:9
+   |
+LL |         entries = vec![Entry::default(); 0];
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider performing the side effect separately
+   |
+LL ~         let _: issue_16474::Entry<usize> = Entry::default();
+LL ~         entries = vec![] as std::vec::Vec<issue_16474::Entry<usize>>;
+   |
+
+error: expression with side effects as the initial value in a zero-sized array initializer
+  --> tests/ui/zero_repeat_side_effects.rs:178:18
+   |
+LL |             0 => entries = vec![Entry::default(); 0],
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider performing the side effect separately
+   |
+LL ~             0 => {
+LL +                 let _: issue_16474::Entry<usize> = Entry::default();
+LL +                 entries = vec![] as std::vec::Vec<issue_16474::Entry<usize>>
+LL ~             },
+   |
+
+error: expression with side effects as the initial value in a zero-sized array initializer
+  --> tests/ui/zero_repeat_side_effects.rs:202:13
+   |
+LL |     some_fn(vec![Generic::default(); 0], 42);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider performing the side effect separately
+   |
+LL ~     some_fn({
+LL +         let _: Generic<usize> = Generic::default();
+LL +         vec![] as std::vec::Vec<Generic<usize>>
+LL ~     }, 42);
+   |
+
+error: aborting due to 17 previous errors
 

--- a/tests/ui/zero_repeat_side_effects_never_pattern.fixed
+++ b/tests/ui/zero_repeat_side_effects_never_pattern.fixed
@@ -4,7 +4,7 @@
 
 fn issue_14998() {
     // nameable type thanks to `never_type` being enabled, suggest
-    panic!();
+    let _: ! = panic!();
     let _data: [!; 0] = [];
     //~^ zero_repeat_side_effects
 }

--- a/tests/ui/zero_repeat_side_effects_never_pattern.stderr
+++ b/tests/ui/zero_repeat_side_effects_never_pattern.stderr
@@ -8,7 +8,7 @@ LL |     let _data = [panic!(); 0];
    = help: to override `-D warnings` add `#[allow(clippy::zero_repeat_side_effects)]`
 help: consider performing the side effect separately
    |
-LL ~     panic!();
+LL ~     let _: ! = panic!();
 LL +     let _data: [!; 0] = [];
    |
 


### PR DESCRIPTION
## Fix `zero_repeat_side_effects` emitting broken suggestions for generic types

Fixes rust-lang/rust-clippy#16474

### What's wrong

The `zero_repeat_side_effects` lint suggests splitting
```rust
let mut entries = vec![Entry::default(); 0];
```

into:

```rust
Entry::default();
let mut entries: Vec<Entry<usize>> = vec![];
```

This works fine for simple types, but breaks when the element type has generic parameters, causing:

```
error[E0283]: type annotations needed
  --> src/main.rs:10:5
   |
   | Entry::default();
   | ^^^^^ cannot infer type for type parameter `T`
```

### The fix

I was looking to fix this by suggesting `let _: T = expr;` instead of a bare `expr;`. 

This applies to the `let_stmt_suggestion` and `assign_expr_suggestion` code paths (both the curly and non-curly branches).

I think the `Node::Stmt` case (bare expression statement like `vec![f(); 0];`) does **not** need this fix because if `T` were ambiguous there, the original code would already fail to compile.

### Remaining problems

While writting the tests, I realized my implementation introduces a new broken suggestion.

When the element type is defined inside a function (for instance `issue_16474()`, `Ty::to_string` emits a path like `issue_16474::Entry<usize>` which is invalid in the suggestion since `issue_16474` is a function, not a module.

I see two different approaches:
1. Detect that the type is defined in a function and only emit a help message.
2. Or find a way to trim the function name in the suggestion.

In both case, I don't really know the best way to do this, and  I wanted a reviewer's opinion on the right approach before going further.

Thank you !

changelog: [`zero_repeat_side_effects`]: fix suggestion causes error for generic types
