### PR TITLE
manual_pop_if: lint more cases, even if we do not provide a suggestion

### DIFF
--- a/clippy_lints/src/manual_pop_if.rs
+++ b/clippy_lints/src/manual_pop_if.rs
@@ -1,18 +1,19 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
 use clippy_utils::source::snippet_with_context;
-use clippy_utils::visitors::is_local_used;
-use clippy_utils::{eq_expr_value, is_else_clause, is_lang_item_or_ctor, peel_blocks_with_stmt, sym};
+use clippy_utils::visitors::{for_each_expr_without_closures, is_local_used};
+use clippy_utils::{eq_expr_value, is_else_clause, is_lang_item_or_ctor, span_contains_non_whitespace, sym};
 use rustc_ast::LitKind;
-use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, LangItem, PatKind, StmtKind};
+use rustc_errors::{Applicability, MultiSpan};
+use rustc_hir::{BlockCheckMode, Expr, ExprKind, LangItem, PatKind, StmtKind, UnsafeSource};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::impl_lint_pass;
-use rustc_span::{Span, Symbol};
+use rustc_span::{BytePos, Span, Symbol};
 use std::fmt;
+use std::ops::ControlFlow;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -22,11 +23,9 @@ declare_clippy_lint! {
     /// Using `pop_if` is more concise and idiomatic.
     ///
     /// ### Known issues
-    /// Currently, the lint does not handle the case where the
-    /// `if` condition is part of an `else if` branch.
-    ///
-    /// The lint also does not handle the case where
-    /// the popped value is assigned and used.
+    /// When the popped value is assigned or used in an expression,
+    /// or when the `if` condition is part of an `else if` branch, the
+    /// lint will trigger but will not provide an automatic suggestion.
     ///
     /// ### Examples
     /// ```no_run
@@ -93,7 +92,7 @@ enum ManualPopIfKind {
 }
 
 impl ManualPopIfKind {
-    fn check_method(self) -> Symbol {
+    fn peek_method(self) -> Symbol {
         match self {
             ManualPopIfKind::Vec => sym::last,
             ManualPopIfKind::VecDequeBack => sym::back,
@@ -153,10 +152,18 @@ struct ManualPopIfPattern<'tcx> {
 
     /// Span of the if expression (including the `if` keyword)
     if_span: Span,
+
+    /// Span of the:
+    /// - check call (`vec.last().is_some_and(|x| *x > 5)`)
+    /// - pop+unwrap call (`vec.pop().unwrap()`)
+    spans: MultiSpan,
+
+    /// Whether we are able to provide a suggestion
+    suggestable: bool,
 }
 
 impl ManualPopIfPattern<'_> {
-    fn emit_lint(&self, cx: &LateContext<'_>) {
+    fn emit_lint(self, cx: &LateContext<'_>) {
         let mut app = Applicability::MachineApplicable;
         let ctxt = self.if_span.ctxt();
         let collection_snippet = snippet_with_context(cx, self.collection_expr.span, ctxt, "..", &mut app).0;
@@ -164,33 +171,20 @@ impl ManualPopIfPattern<'_> {
         let param_name = self.param_name;
         let pop_if_method = self.kind.pop_if_method();
 
-        let suggestion = format!("{collection_snippet}.{pop_if_method}(|{param_name}| {predicate_snippet});");
-
-        span_lint_and_sugg(
+        span_lint_and_then(
             cx,
             MANUAL_POP_IF,
-            self.if_span,
+            self.spans,
             format!("manual implementation of {}", self.kind),
-            "try",
-            suggestion,
-            app,
+            |diag| {
+                let sugg = format!("{collection_snippet}.{pop_if_method}(|{param_name}| {predicate_snippet});");
+                if self.suggestable {
+                    diag.span_suggestion_verbose(self.if_span, "try", sugg, app);
+                } else {
+                    diag.help(format!("try refactoring the code using `{sugg}`"));
+                }
+            },
         );
-    }
-}
-
-fn pop_value_is_used(then_block: &Expr<'_>) -> bool {
-    let ExprKind::Block(block, _) = then_block.kind else {
-        return true;
-    };
-
-    if block.expr.is_some() {
-        return true;
-    }
-
-    match block.stmts {
-        [stmt] => !matches!(stmt.kind, StmtKind::Semi(_) | StmtKind::Item(_)),
-        [.., last] => matches!(last.kind, StmtKind::Expr(_)),
-        [] => false,
     }
 }
 
@@ -207,21 +201,17 @@ fn check_is_some_and_pattern<'tcx>(
     if_expr_span: Span,
     kind: ManualPopIfKind,
 ) -> Option<ManualPopIfPattern<'tcx>> {
-    if pop_value_is_used(then_block) {
-        return None;
-    }
-
-    let check_method = kind.check_method();
+    let peek_method = kind.peek_method();
     let pop_method = kind.pop_method();
 
     if let ExprKind::MethodCall(path, receiver, [closure_arg], _) = cond.kind
         && path.ident.name == sym::is_some_and
         && let ExprKind::MethodCall(check_path, collection_expr, [], _) = receiver.kind
-        && check_path.ident.name == check_method
+        && check_path.ident.name == peek_method
         && kind.is_diag_item(cx, collection_expr)
         && let ExprKind::Closure(closure) = closure_arg.kind
         && let body = cx.tcx.hir_body(closure.body)
-        && let Some((pop_collection, _pop_span)) = check_pop_unwrap(then_block, pop_method)
+        && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
         && eq_expr_value(cx, collection_expr, pop_collection)
         && let Some(param) = body.params.first()
         && let Some(ident) = param.pat.simple_ident()
@@ -232,6 +222,8 @@ fn check_is_some_and_pattern<'tcx>(
             predicate: body.value,
             param_name: ident.name,
             if_span: if_expr_span,
+            spans: MultiSpan::from(vec![if_expr_span.with_hi(cond.span.hi()), pop_span]),
+            suggestable,
         });
     }
 
@@ -253,7 +245,7 @@ fn check_if_let_pattern<'tcx>(
     if_expr_span: Span,
     kind: ManualPopIfKind,
 ) -> Option<ManualPopIfPattern<'tcx>> {
-    let check_method = kind.check_method();
+    let peek_method = kind.peek_method();
     let pop_method = kind.pop_method();
 
     if let ExprKind::Let(let_expr) = cond.kind
@@ -265,7 +257,7 @@ fn check_if_let_pattern<'tcx>(
             && is_lang_item_or_ctor(cx, def_id, LangItem::OptionSome)
             && let PatKind::Binding(_, binding_id, binding_name, _) = binding_pat.kind
             && let ExprKind::MethodCall(path, collection_expr, [], _) = let_expr.init.kind
-            && path.ident.name == check_method
+            && path.ident.name == peek_method
             && kind.is_diag_item(cx, collection_expr)
             && let ExprKind::Block(block, _) = then_block.kind
         {
@@ -281,8 +273,7 @@ fn check_if_let_pattern<'tcx>(
 
             if let ExprKind::If(inner_cond, inner_then, None) = inner_if.kind
                 && is_local_used(cx, inner_cond, binding_id)
-                && !pop_value_is_used(inner_then)
-                && let Some((pop_collection, _pop_span)) = check_pop_unwrap(inner_then, pop_method)
+                && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, inner_then, pop_method)
                 && eq_expr_value(cx, collection_expr, pop_collection)
             {
                 return Some(ManualPopIfPattern {
@@ -291,6 +282,12 @@ fn check_if_let_pattern<'tcx>(
                     predicate: inner_cond,
                     param_name: binding_name.name,
                     if_span: if_expr_span,
+                    spans: MultiSpan::from(vec![
+                        if_expr_span.with_hi(cond.span.hi()),
+                        inner_if.span.with_hi(inner_cond.span.hi()),
+                        pop_span,
+                    ]),
+                    suggestable,
                 });
             }
         }
@@ -312,11 +309,7 @@ fn check_let_chain_pattern<'tcx>(
     if_expr_span: Span,
     kind: ManualPopIfKind,
 ) -> Option<ManualPopIfPattern<'tcx>> {
-    if pop_value_is_used(then_block) {
-        return None;
-    }
-
-    let check_method = kind.check_method();
+    let peek_method = kind.peek_method();
     let pop_method = kind.pop_method();
 
     if let ExprKind::Binary(op, left, right) = cond.kind
@@ -330,11 +323,10 @@ fn check_let_chain_pattern<'tcx>(
             && is_lang_item_or_ctor(cx, def_id, LangItem::OptionSome)
             && let PatKind::Binding(_, binding_id, binding_name, _) = binding_pat.kind
             && let ExprKind::MethodCall(path, collection_expr, [], _) = let_expr.init.kind
-            && path.ident.name == check_method
+            && path.ident.name == peek_method
             && kind.is_diag_item(cx, collection_expr)
             && is_local_used(cx, right, binding_id)
-            && !pop_value_is_used(then_block)
-            && let Some((pop_collection, _pop_span)) = check_pop_unwrap(then_block, pop_method)
+            && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
             && eq_expr_value(cx, collection_expr, pop_collection)
         {
             return Some(ManualPopIfPattern {
@@ -343,6 +335,8 @@ fn check_let_chain_pattern<'tcx>(
                 predicate: right,
                 param_name: binding_name.name,
                 if_span: if_expr_span,
+                spans: MultiSpan::from(vec![if_expr_span.with_hi(cond.span.hi()), pop_span]),
+                suggestable,
             });
         }
     }
@@ -363,11 +357,7 @@ fn check_map_unwrap_or_pattern<'tcx>(
     if_expr_span: Span,
     kind: ManualPopIfKind,
 ) -> Option<ManualPopIfPattern<'tcx>> {
-    if pop_value_is_used(then_block) {
-        return None;
-    }
-
-    let check_method = kind.check_method();
+    let peek_method = kind.peek_method();
     let pop_method = kind.pop_method();
 
     if let ExprKind::MethodCall(unwrap_path, receiver, [default_arg], _) = cond.kind
@@ -376,12 +366,12 @@ fn check_map_unwrap_or_pattern<'tcx>(
         && let ExprKind::MethodCall(map_path, map_receiver, [closure_arg], _) = receiver.kind
         && map_path.ident.name == sym::map
         && let ExprKind::MethodCall(check_path, collection_expr, [], _) = map_receiver.kind
-        && check_path.ident.name == check_method
+        && check_path.ident.name == peek_method
         && kind.is_diag_item(cx, collection_expr)
         && let ExprKind::Closure(closure) = closure_arg.kind
         && let body = cx.tcx.hir_body(closure.body)
         && cx.typeck_results().expr_ty(body.value).is_bool()
-        && let Some((pop_collection, _pop_span)) = check_pop_unwrap(then_block, pop_method)
+        && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
         && eq_expr_value(cx, collection_expr, pop_collection)
         && let Some(param) = body.params.first()
         && let Some(ident) = param.pat.simple_ident()
@@ -392,6 +382,8 @@ fn check_map_unwrap_or_pattern<'tcx>(
             predicate: body.value,
             param_name: ident.name,
             if_span: if_expr_span,
+            spans: MultiSpan::from(vec![if_expr_span.with_hi(cond.span.hi()), pop_span]),
+            suggestable,
         });
     }
 
@@ -399,19 +391,72 @@ fn check_map_unwrap_or_pattern<'tcx>(
 }
 
 /// Checks for `collection.<pop_method>().unwrap()` or `collection.<pop_method>().expect(..)`
-/// and returns the collection and the span of the peeled expr
-fn check_pop_unwrap<'tcx>(expr: &'tcx Expr<'_>, pop_method: Symbol) -> Option<(&'tcx Expr<'tcx>, Span)> {
-    let inner_expr = peel_blocks_with_stmt(expr);
+/// and returns the collection expression and the span of the pop+unwrap call.
+/// If the pop+unwrap is the only statement in the block, the result is marked as
+/// suggestable (we can provide an automatic fix).
+fn check_pop_unwrap<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    pop_method: Symbol,
+) -> Option<(&'tcx Expr<'tcx>, Span, bool)> {
+    let ExprKind::Block(block, _) = expr.kind else {
+        return None;
+    };
 
-    if let ExprKind::MethodCall(unwrap_path, receiver, _, _) = inner_expr.kind
-        && matches!(unwrap_path.ident.name, sym::unwrap | sym::expect)
-        && let ExprKind::MethodCall(pop_path, collection_expr, [], _) = receiver.kind
-        && pop_path.ident.name == pop_method
+    let as_pop_unwrap = |expr: &Expr<'tcx>| -> Option<(&'tcx Expr<'tcx>, Span)> {
+        if let ExprKind::MethodCall(unwrap_path, receiver, _, _) = expr.kind
+            && matches!(
+                unwrap_path.ident.name,
+                sym::unwrap | sym::unwrap_unchecked | sym::expect
+            )
+            && let ExprKind::MethodCall(pop_path, collection_expr, [], _) = receiver.kind
+            && pop_path.ident.name == pop_method
+        {
+            Some((collection_expr, expr.span))
+        } else {
+            None
+        }
+    };
+
+    // Peel through an `unsafe` block for `unwrap_unchecked`.
+    let peel_unsafe = |expr: &'tcx Expr<'tcx>| -> &'tcx Expr<'tcx> {
+        if let ExprKind::Block(block, _) = expr.kind
+            && block.rules == BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided)
+            && block.stmts.is_empty()
+            && let Some(inner) = block.expr
+        {
+            inner
+        } else {
+            expr
+        }
+    };
+
+    // Check for single statement with the pop unwrap (not in a macro or other expression)
+    // and that there are no comments or other text before or after the pop call.
+    if let [stmt] = block.stmts
+        && block.expr.is_none()
+        && let StmtKind::Semi(stmt_expr) | StmtKind::Expr(stmt_expr) = &stmt.kind
+        && !stmt_expr.span.from_expansion()
+        && let Some((collection_expr, span)) = as_pop_unwrap(peel_unsafe(stmt_expr))
     {
-        return Some((collection_expr, inner_expr.span));
+        let span_before = block
+            .span
+            .with_lo(block.span.lo() + BytePos(1))
+            .with_hi(stmt_expr.span.lo());
+        let span_after = stmt.span.shrink_to_hi().with_hi(block.span.hi() - BytePos(1));
+        let suggestable = !span_contains_non_whitespace(cx, span_before, false)
+            && !span_contains_non_whitespace(cx, span_after, false);
+        return Some((collection_expr, span, suggestable));
     }
 
-    None
+    // Check if the pop unwrap is present at all
+    for_each_expr_without_closures(block, |expr| {
+        if let Some((collection_expr, span)) = as_pop_unwrap(expr) {
+            ControlFlow::Break((collection_expr, span, false))
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
 }
 
 impl<'tcx> LateLintPass<'tcx> for ManualPopIf {
@@ -420,10 +465,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualPopIf {
             return;
         };
 
-        // Do not lint if we are in an else-if branch.
-        if is_else_clause(cx.tcx, expr) {
-            return;
-        }
+        let in_else_clause = is_else_clause(cx.tcx, expr);
 
         for kind in [
             ManualPopIfKind::Vec,
@@ -431,12 +473,16 @@ impl<'tcx> LateLintPass<'tcx> for ManualPopIf {
             ManualPopIfKind::VecDequeFront,
             ManualPopIfKind::BinaryHeap,
         ] {
-            if let Some(pattern) = check_is_some_and_pattern(cx, cond, then_block, expr.span, kind)
+            if let Some(mut pattern) = check_is_some_and_pattern(cx, cond, then_block, expr.span, kind)
                 .or_else(|| check_if_let_pattern(cx, cond, then_block, expr.span, kind))
                 .or_else(|| check_let_chain_pattern(cx, cond, then_block, expr.span, kind))
                 .or_else(|| check_map_unwrap_or_pattern(cx, cond, then_block, expr.span, kind))
                 && self.msrv_compatible(cx, kind)
             {
+                if in_else_clause {
+                    pattern.suggestable = false;
+                }
+
                 pattern.emit_lint(cx);
                 return;
             }

--- a/tests/ui/manual_pop_if.fixed
+++ b/tests/ui/manual_pop_if.fixed
@@ -5,6 +5,8 @@
 use std::collections::{BinaryHeap, VecDeque};
 use std::marker::PhantomData;
 
+fn main() {}
+
 // FakeVec has the same methods as Vec but isn't actually a Vec
 struct FakeVec<T>(PhantomData<T>);
 
@@ -19,14 +21,22 @@ impl<T> FakeVec<T> {
 }
 
 fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
+    //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
 
+    //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
 
+    //~v manual_pop_if
+    vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
     deque.pop_back_if(|x| *x > 2);
 
+    //~v manual_pop_if
     deque.pop_front_if(|x| *x > 2);
 
+    //~v manual_pop_if
     heap.pop_if(|x| *x > 2);
 }
 
@@ -43,24 +53,6 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
         fake_vec.pop().unwrap();
     }
 
-    // Do not lint, else-if branch
-    if false {
-        // something
-    } else if vec.last().is_some_and(|x| *x > 2) {
-        vec.pop().unwrap();
-    }
-
-    // Do not lint, value used in let binding
-    if vec.last().is_some_and(|x| *x > 2) {
-        let _value = vec.pop().unwrap();
-        println!("Popped: {}", _value);
-    }
-
-    // Do not lint, value used in expression
-    if vec.last().is_some_and(|x| *x > 2) {
-        println!("Popped: {}", vec.pop().unwrap());
-    }
-
     // Do not lint, else block
     let _result = if vec.last().is_some_and(|x| *x > 2) {
         vec.pop().unwrap()
@@ -70,14 +62,22 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
 }
 
 fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
+    //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
 
+    //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
 
+    //~v manual_pop_if
+    vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
     deque.pop_back_if(|x| *x > 2);
 
+    //~v manual_pop_if
     deque.pop_front_if(|x| *x > 2);
 
+    //~v manual_pop_if
     heap.pop_if(|x| *x > 2);
 }
 
@@ -105,13 +105,6 @@ fn if_let_pattern_negative(mut vec: Vec<i32>) {
         }
     }
 
-    // Do not lint, value used in let binding
-    if let Some(x) = vec.last() {
-        if *x > 2 {
-            let _val = vec.pop().unwrap();
-        }
-    }
-
     // Do not lint, else block
     let _result = if let Some(x) = vec.last() {
         if *x > 2 { vec.pop().unwrap() } else { 0 }
@@ -121,6 +114,8 @@ fn if_let_pattern_negative(mut vec: Vec<i32>) {
 }
 
 fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
+    vec.pop_if(|x| *x > 2);
+
     vec.pop_if(|x| *x > 2);
 
     vec.pop_if(|x| *x > 2);
@@ -148,20 +143,6 @@ fn let_chain_pattern_negative(mut vec: Vec<i32>) {
         vec.pop().unwrap();
     }
 
-    // Do not lint, value used in let binding
-    if let Some(x) = vec.last()
-        && *x > 2
-    {
-        let _val = vec.pop().unwrap();
-    }
-
-    // Do not lint, value used in expression
-    if let Some(x) = vec.last()
-        && *x > 2
-    {
-        println!("Popped: {}", vec.pop().unwrap());
-    }
-
     // Do not lint, else block
     let _result = if let Some(x) = vec.last()
         && *x > 2
@@ -173,14 +154,22 @@ fn let_chain_pattern_negative(mut vec: Vec<i32>) {
 }
 
 fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
+    //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
 
+    //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
 
+    //~v manual_pop_if
+    vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
     deque.pop_back_if(|x| *x > 2);
 
+    //~v manual_pop_if
     deque.pop_front_if(|x| *x > 2);
 
+    //~v manual_pop_if
     heap.pop_if(|x| *x > 2);
 }
 
@@ -207,11 +196,6 @@ fn map_unwrap_or_pattern_negative(mut vec: Vec<i32>) {
         vec.pop().unwrap();
     }
 
-    // Do not lint, value used in let binding
-    if vec.last().map(|x| *x > 2).unwrap_or(false) {
-        let _val = vec.pop().unwrap();
-    }
-
     // Do not lint, else block
     let _result = if vec.last().map(|x| *x > 2).unwrap_or(false) {
         vec.pop().unwrap()
@@ -222,6 +206,7 @@ fn map_unwrap_or_pattern_negative(mut vec: Vec<i32>) {
 
 // this makes sure we do not expand vec![] in the suggestion
 fn handle_macro_in_closure(mut vec: Vec<Vec<i32>>) {
+    //~v manual_pop_if
     vec.pop_if(|e| *e == vec![1]);
 }
 
@@ -245,12 +230,15 @@ fn msrv_too_low_vecdeque(mut deque: VecDeque<i32>) {
 
 #[clippy::msrv = "1.86.0"]
 fn msrv_high_enough_vec(mut vec: Vec<i32>) {
+    //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
 }
 
 #[clippy::msrv = "1.93.0"]
 fn msrv_high_enough_vecdeque(mut deque: VecDeque<i32>) {
+    //~v manual_pop_if
     deque.pop_back_if(|x| *x > 2);
 
+    //~v manual_pop_if
     deque.pop_front_if(|x| *x > 2);
 }

--- a/tests/ui/manual_pop_if.rs
+++ b/tests/ui/manual_pop_if.rs
@@ -5,6 +5,8 @@
 use std::collections::{BinaryHeap, VecDeque};
 use std::marker::PhantomData;
 
+fn main() {}
+
 // FakeVec has the same methods as Vec but isn't actually a Vec
 struct FakeVec<T>(PhantomData<T>);
 
@@ -19,28 +21,33 @@ impl<T> FakeVec<T> {
 }
 
 fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
+    //~v manual_pop_if
     if vec.last().is_some_and(|x| *x > 2) {
-        //~^ manual_pop_if
         vec.pop().unwrap();
     }
 
+    //~v manual_pop_if
     if vec.last().is_some_and(|x| *x > 2) {
-        //~^ manual_pop_if
+        unsafe { vec.pop().unwrap_unchecked() };
+    }
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
         vec.pop().expect("element");
     }
 
+    //~v manual_pop_if
     if deque.back().is_some_and(|x| *x > 2) {
-        //~^ manual_pop_if
         deque.pop_back().unwrap();
     }
 
+    //~v manual_pop_if
     if deque.front().is_some_and(|x| *x > 2) {
-        //~^ manual_pop_if
         deque.pop_front().unwrap();
     }
 
+    //~v manual_pop_if
     if heap.peek().is_some_and(|x| *x > 2) {
-        //~^ manual_pop_if
         heap.pop().unwrap();
     }
 }
@@ -58,24 +65,6 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
         fake_vec.pop().unwrap();
     }
 
-    // Do not lint, else-if branch
-    if false {
-        // something
-    } else if vec.last().is_some_and(|x| *x > 2) {
-        vec.pop().unwrap();
-    }
-
-    // Do not lint, value used in let binding
-    if vec.last().is_some_and(|x| *x > 2) {
-        let _value = vec.pop().unwrap();
-        println!("Popped: {}", _value);
-    }
-
-    // Do not lint, value used in expression
-    if vec.last().is_some_and(|x| *x > 2) {
-        println!("Popped: {}", vec.pop().unwrap());
-    }
-
     // Do not lint, else block
     let _result = if vec.last().is_some_and(|x| *x > 2) {
         vec.pop().unwrap()
@@ -85,36 +74,43 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
 }
 
 fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
+    //~v manual_pop_if
     if let Some(x) = vec.last() {
-        //~^ manual_pop_if
         if *x > 2 {
             vec.pop().unwrap();
         }
     }
 
+    //~v manual_pop_if
     if let Some(x) = vec.last() {
-        //~^ manual_pop_if
+        if *x > 2 {
+            unsafe { vec.pop().unwrap_unchecked() };
+        }
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last() {
         if *x > 2 {
             vec.pop().expect("element");
         }
     }
 
+    //~v manual_pop_if
     if let Some(x) = deque.back() {
-        //~^ manual_pop_if
         if *x > 2 {
             deque.pop_back().unwrap();
         }
     }
 
+    //~v manual_pop_if
     if let Some(x) = deque.front() {
-        //~^ manual_pop_if
         if *x > 2 {
             deque.pop_front().unwrap();
         }
     }
 
+    //~v manual_pop_if
     if let Some(x) = heap.peek() {
-        //~^ manual_pop_if
         if *x > 2 {
             heap.pop().unwrap();
         }
@@ -145,13 +141,6 @@ fn if_let_pattern_negative(mut vec: Vec<i32>) {
         }
     }
 
-    // Do not lint, value used in let binding
-    if let Some(x) = vec.last() {
-        if *x > 2 {
-            let _val = vec.pop().unwrap();
-        }
-    }
-
     // Do not lint, else block
     let _result = if let Some(x) = vec.last() {
         if *x > 2 { vec.pop().unwrap() } else { 0 }
@@ -165,6 +154,12 @@ fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut h
         && *x > 2
     {
         vec.pop().unwrap();
+    }
+
+    if let Some(x) = vec.last() //~ manual_pop_if
+        && *x > 2
+    {
+        unsafe { vec.pop().unwrap_unchecked() };
     }
 
     if let Some(x) = vec.last() //~ manual_pop_if
@@ -208,20 +203,6 @@ fn let_chain_pattern_negative(mut vec: Vec<i32>) {
         vec.pop().unwrap();
     }
 
-    // Do not lint, value used in let binding
-    if let Some(x) = vec.last()
-        && *x > 2
-    {
-        let _val = vec.pop().unwrap();
-    }
-
-    // Do not lint, value used in expression
-    if let Some(x) = vec.last()
-        && *x > 2
-    {
-        println!("Popped: {}", vec.pop().unwrap());
-    }
-
     // Do not lint, else block
     let _result = if let Some(x) = vec.last()
         && *x > 2
@@ -233,28 +214,33 @@ fn let_chain_pattern_negative(mut vec: Vec<i32>) {
 }
 
 fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
+    //~v manual_pop_if
     if vec.last().map(|x| *x > 2).unwrap_or(false) {
-        //~^ manual_pop_if
         vec.pop().unwrap();
     }
 
+    //~v manual_pop_if
     if vec.last().map(|x| *x > 2).unwrap_or(false) {
-        //~^ manual_pop_if
+        unsafe { vec.pop().unwrap_unchecked() };
+    }
+
+    //~v manual_pop_if
+    if vec.last().map(|x| *x > 2).unwrap_or(false) {
         vec.pop().expect("element");
     }
 
+    //~v manual_pop_if
     if deque.back().map(|x| *x > 2).unwrap_or(false) {
-        //~^ manual_pop_if
         deque.pop_back().unwrap();
     }
 
+    //~v manual_pop_if
     if deque.front().map(|x| *x > 2).unwrap_or(false) {
-        //~^ manual_pop_if
         deque.pop_front().unwrap();
     }
 
+    //~v manual_pop_if
     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
-        //~^ manual_pop_if
         heap.pop().unwrap();
     }
 }
@@ -282,11 +268,6 @@ fn map_unwrap_or_pattern_negative(mut vec: Vec<i32>) {
         vec.pop().unwrap();
     }
 
-    // Do not lint, value used in let binding
-    if vec.last().map(|x| *x > 2).unwrap_or(false) {
-        let _val = vec.pop().unwrap();
-    }
-
     // Do not lint, else block
     let _result = if vec.last().map(|x| *x > 2).unwrap_or(false) {
         vec.pop().unwrap()
@@ -297,8 +278,8 @@ fn map_unwrap_or_pattern_negative(mut vec: Vec<i32>) {
 
 // this makes sure we do not expand vec![] in the suggestion
 fn handle_macro_in_closure(mut vec: Vec<Vec<i32>>) {
+    //~v manual_pop_if
     if vec.last().is_some_and(|e| *e == vec![1]) {
-        //~^ manual_pop_if
         vec.pop().unwrap();
     }
 }
@@ -323,21 +304,21 @@ fn msrv_too_low_vecdeque(mut deque: VecDeque<i32>) {
 
 #[clippy::msrv = "1.86.0"]
 fn msrv_high_enough_vec(mut vec: Vec<i32>) {
+    //~v manual_pop_if
     if vec.last().is_some_and(|x| *x > 2) {
-        //~^ manual_pop_if
         vec.pop().unwrap();
     }
 }
 
 #[clippy::msrv = "1.93.0"]
 fn msrv_high_enough_vecdeque(mut deque: VecDeque<i32>) {
+    //~v manual_pop_if
     if deque.back().is_some_and(|x| *x > 2) {
-        //~^ manual_pop_if
         deque.pop_back().unwrap();
     }
 
+    //~v manual_pop_if
     if deque.front().is_some_and(|x| *x > 2) {
-        //~^ manual_pop_if
         deque.pop_front().unwrap();
     }
 }

--- a/tests/ui/manual_pop_if.stderr
+++ b/tests/ui/manual_pop_if.stderr
@@ -1,236 +1,500 @@
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:22:5
+  --> tests/ui/manual_pop_if.rs:25:5
    |
-LL | /     if vec.last().is_some_and(|x| *x > 2) {
-LL | |
-LL | |         vec.pop().unwrap();
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::manual-pop-if` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_pop_if)]`
+help: try
+   |
+LL -     if vec.last().is_some_and(|x| *x > 2) {
+LL -         vec.pop().unwrap();
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:27:5
+  --> tests/ui/manual_pop_if.rs:30:5
    |
-LL | /     if vec.last().is_some_and(|x| *x > 2) {
-LL | |
-LL | |         vec.pop().expect("element");
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         unsafe { vec.pop().unwrap_unchecked() };
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().is_some_and(|x| *x > 2) {
+LL -         unsafe { vec.pop().unwrap_unchecked() };
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:35:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().expect("element");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().is_some_and(|x| *x > 2) {
+LL -         vec.pop().expect("element");
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:32:5
+  --> tests/ui/manual_pop_if.rs:40:5
    |
-LL | /     if deque.back().is_some_and(|x| *x > 2) {
-LL | |
-LL | |         deque.pop_back().unwrap();
-LL | |     }
-   | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
+LL |     if deque.back().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_back().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.back().is_some_and(|x| *x > 2) {
+LL -         deque.pop_back().unwrap();
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:37:5
+  --> tests/ui/manual_pop_if.rs:45:5
    |
-LL | /     if deque.front().is_some_and(|x| *x > 2) {
-LL | |
-LL | |         deque.pop_front().unwrap();
-LL | |     }
-   | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
+LL |     if deque.front().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_front().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.front().is_some_and(|x| *x > 2) {
+LL -         deque.pop_front().unwrap();
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:42:5
+  --> tests/ui/manual_pop_if.rs:50:5
    |
-LL | /     if heap.peek().is_some_and(|x| *x > 2) {
-LL | |
-LL | |         heap.pop().unwrap();
-LL | |     }
-   | |_____^ help: try: `heap.pop_if(|x| *x > 2);`
+LL |     if heap.peek().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         heap.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if heap.peek().is_some_and(|x| *x > 2) {
+LL -         heap.pop().unwrap();
+LL -     }
+LL +     heap.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:88:5
+  --> tests/ui/manual_pop_if.rs:78:5
    |
-LL | /     if let Some(x) = vec.last() {
-LL | |
-LL | |         if *x > 2 {
-LL | |             vec.pop().unwrap();
-LL | |         }
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             vec.pop().unwrap();
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = vec.last() {
+LL -         if *x > 2 {
+LL -             vec.pop().unwrap();
+LL -         }
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:95:5
+  --> tests/ui/manual_pop_if.rs:85:5
    |
-LL | /     if let Some(x) = vec.last() {
-LL | |
-LL | |         if *x > 2 {
-LL | |             vec.pop().expect("element");
-LL | |         }
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             unsafe { vec.pop().unwrap_unchecked() };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = vec.last() {
+LL -         if *x > 2 {
+LL -             unsafe { vec.pop().unwrap_unchecked() };
+LL -         }
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:92:5
+   |
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             vec.pop().expect("element");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = vec.last() {
+LL -         if *x > 2 {
+LL -             vec.pop().expect("element");
+LL -         }
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:102:5
+  --> tests/ui/manual_pop_if.rs:99:5
    |
-LL | /     if let Some(x) = deque.back() {
-LL | |
-LL | |         if *x > 2 {
-LL | |             deque.pop_back().unwrap();
-LL | |         }
-LL | |     }
-   | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
+LL |     if let Some(x) = deque.back() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             deque.pop_back().unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = deque.back() {
+LL -         if *x > 2 {
+LL -             deque.pop_back().unwrap();
+LL -         }
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:109:5
+  --> tests/ui/manual_pop_if.rs:106:5
    |
-LL | /     if let Some(x) = deque.front() {
-LL | |
-LL | |         if *x > 2 {
-LL | |             deque.pop_front().unwrap();
-LL | |         }
-LL | |     }
-   | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
+LL |     if let Some(x) = deque.front() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             deque.pop_front().unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = deque.front() {
+LL -         if *x > 2 {
+LL -             deque.pop_front().unwrap();
+LL -         }
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:116:5
+  --> tests/ui/manual_pop_if.rs:113:5
    |
-LL | /     if let Some(x) = heap.peek() {
-LL | |
-LL | |         if *x > 2 {
-LL | |             heap.pop().unwrap();
-LL | |         }
-LL | |     }
-   | |_____^ help: try: `heap.pop_if(|x| *x > 2);`
+LL |     if let Some(x) = heap.peek() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             heap.pop().unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = heap.peek() {
+LL -         if *x > 2 {
+LL -             heap.pop().unwrap();
+LL -         }
+LL -     }
+LL +     heap.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:164:5
+  --> tests/ui/manual_pop_if.rs:153:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
-LL | |     {
-LL | |         vec.pop().unwrap();
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+   | |_________________^
+LL |       {
+LL |           vec.pop().unwrap();
+   |           ^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = vec.last()
+LL -         && *x > 2
+LL -     {
+LL -         vec.pop().unwrap();
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:170:5
+  --> tests/ui/manual_pop_if.rs:159:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
-LL | |     {
-LL | |         vec.pop().expect("element");
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+   | |_________________^
+LL |       {
+LL |           unsafe { vec.pop().unwrap_unchecked() };
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = vec.last()
+LL -         && *x > 2
+LL -     {
+LL -         unsafe { vec.pop().unwrap_unchecked() };
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:165:5
+   |
+LL | /     if let Some(x) = vec.last()
+LL | |         && *x > 2
+   | |_________________^
+LL |       {
+LL |           vec.pop().expect("element");
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = vec.last()
+LL -         && *x > 2
+LL -     {
+LL -         vec.pop().expect("element");
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:176:5
+  --> tests/ui/manual_pop_if.rs:171:5
    |
 LL | /     if let Some(x) = deque.back()
 LL | |         && *x > 2
-LL | |     {
-LL | |         deque.pop_back().unwrap();
-LL | |     }
-   | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
+   | |_________________^
+LL |       {
+LL |           deque.pop_back().unwrap();
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = deque.back()
+LL -         && *x > 2
+LL -     {
+LL -         deque.pop_back().unwrap();
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:182:5
+  --> tests/ui/manual_pop_if.rs:177:5
    |
 LL | /     if let Some(x) = deque.front()
 LL | |         && *x > 2
-LL | |     {
-LL | |         deque.pop_front().unwrap();
-LL | |     }
-   | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
+   | |_________________^
+LL |       {
+LL |           deque.pop_front().unwrap();
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = deque.front()
+LL -         && *x > 2
+LL -     {
+LL -         deque.pop_front().unwrap();
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:188:5
+  --> tests/ui/manual_pop_if.rs:183:5
    |
 LL | /     if let Some(x) = heap.peek()
 LL | |         && *x > 2
-LL | |     {
-LL | |         heap.pop().unwrap();
-LL | |     }
-   | |_____^ help: try: `heap.pop_if(|x| *x > 2);`
+   | |_________________^
+LL |       {
+LL |           heap.pop().unwrap();
+   |           ^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = heap.peek()
+LL -         && *x > 2
+LL -     {
+LL -         heap.pop().unwrap();
+LL -     }
+LL +     heap.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:236:5
+  --> tests/ui/manual_pop_if.rs:218:5
    |
-LL | /     if vec.last().map(|x| *x > 2).unwrap_or(false) {
-LL | |
-LL | |         vec.pop().unwrap();
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+LL -         vec.pop().unwrap();
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:241:5
+  --> tests/ui/manual_pop_if.rs:223:5
    |
-LL | /     if vec.last().map(|x| *x > 2).unwrap_or(false) {
-LL | |
-LL | |         vec.pop().expect("element");
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         unsafe { vec.pop().unwrap_unchecked() };
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+LL -         unsafe { vec.pop().unwrap_unchecked() };
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:228:5
+   |
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().expect("element");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+LL -         vec.pop().expect("element");
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:246:5
+  --> tests/ui/manual_pop_if.rs:233:5
    |
-LL | /     if deque.back().map(|x| *x > 2).unwrap_or(false) {
-LL | |
-LL | |         deque.pop_back().unwrap();
-LL | |     }
-   | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
+LL |     if deque.back().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_back().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.back().map(|x| *x > 2).unwrap_or(false) {
+LL -         deque.pop_back().unwrap();
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:251:5
+  --> tests/ui/manual_pop_if.rs:238:5
    |
-LL | /     if deque.front().map(|x| *x > 2).unwrap_or(false) {
-LL | |
-LL | |         deque.pop_front().unwrap();
-LL | |     }
-   | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
+LL |     if deque.front().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_front().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.front().map(|x| *x > 2).unwrap_or(false) {
+LL -         deque.pop_front().unwrap();
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:256:5
+  --> tests/ui/manual_pop_if.rs:243:5
    |
-LL | /     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
-LL | |
-LL | |         heap.pop().unwrap();
-LL | |     }
-   | |_____^ help: try: `heap.pop_if(|x| *x > 2);`
+LL |     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         heap.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
+LL -         heap.pop().unwrap();
+LL -     }
+LL +     heap.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:300:5
+  --> tests/ui/manual_pop_if.rs:282:5
    |
-LL | /     if vec.last().is_some_and(|e| *e == vec![1]) {
-LL | |
-LL | |         vec.pop().unwrap();
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|e| *e == vec![1]);`
+LL |     if vec.last().is_some_and(|e| *e == vec![1]) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().is_some_and(|e| *e == vec![1]) {
+LL -         vec.pop().unwrap();
+LL -     }
+LL +     vec.pop_if(|e| *e == vec![1]);
+   |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:326:5
+  --> tests/ui/manual_pop_if.rs:308:5
    |
-LL | /     if vec.last().is_some_and(|x| *x > 2) {
-LL | |
-LL | |         vec.pop().unwrap();
-LL | |     }
-   | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().is_some_and(|x| *x > 2) {
+LL -         vec.pop().unwrap();
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:334:5
+  --> tests/ui/manual_pop_if.rs:316:5
    |
-LL | /     if deque.back().is_some_and(|x| *x > 2) {
-LL | |
-LL | |         deque.pop_back().unwrap();
-LL | |     }
-   | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
+LL |     if deque.back().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_back().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.back().is_some_and(|x| *x > 2) {
+LL -         deque.pop_back().unwrap();
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:339:5
+  --> tests/ui/manual_pop_if.rs:321:5
    |
-LL | /     if deque.front().is_some_and(|x| *x > 2) {
-LL | |
-LL | |         deque.pop_front().unwrap();
-LL | |     }
-   | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
+LL |     if deque.front().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_front().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.front().is_some_and(|x| *x > 2) {
+LL -         deque.pop_front().unwrap();
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
 
-error: aborting due to 24 previous errors
+error: aborting due to 28 previous errors
 

--- a/tests/ui/manual_pop_if_unfixable.rs
+++ b/tests/ui/manual_pop_if_unfixable.rs
@@ -1,0 +1,128 @@
+#![warn(clippy::manual_pop_if)]
+#![allow(clippy::collapsible_if, clippy::redundant_closure)]
+//@no-rustfix
+
+fn main() {}
+
+fn is_some_and_pattern(mut vec: Vec<i32>) {
+    if false {
+        // something
+    } else if vec.last().is_some_and(|x| *x > 2) {
+        vec.pop().unwrap();
+    }
+    //~^^^ manual_pop_if
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        let val = vec.pop().unwrap();
+        println!("Popped: {}", val);
+    }
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        println!("Popped: {}", vec.pop().unwrap());
+    }
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        // a comment before the pop
+        vec.pop().unwrap();
+    }
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        vec.pop().unwrap();
+        // a comment after the pop
+    }
+}
+
+fn if_let_pattern(mut vec: Vec<i32>) {
+    //~v manual_pop_if
+    if let Some(x) = vec.last() {
+        if *x > 2 {
+            let val = vec.pop().unwrap();
+            println!("Popped: {}", val);
+        }
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last() {
+        if *x > 2 {
+            println!("Popped: {}", vec.pop().unwrap());
+        }
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last() {
+        if *x > 2 {
+            // a comment before the pop
+            vec.pop().unwrap();
+        }
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last() {
+        if *x > 2 {
+            vec.pop().unwrap();
+            // a comment after the pop
+        }
+    }
+}
+
+fn let_chain_pattern(mut vec: Vec<i32>) {
+    //~v manual_pop_if
+    if let Some(x) = vec.last()
+        && *x > 2
+    {
+        let val = vec.pop().unwrap();
+        println!("Popped: {}", val);
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last()
+        && *x > 2
+    {
+        println!("Popped: {}", vec.pop().unwrap());
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last()
+        && *x > 2
+    {
+        // a comment before the pop
+        vec.pop().unwrap();
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last()
+        && *x > 2
+    {
+        vec.pop().unwrap();
+        // a comment after the pop
+    }
+}
+
+fn map_unwrap_or_pattern(mut vec: Vec<i32>) {
+    //~v manual_pop_if
+    if vec.last().map(|x| *x > 2).unwrap_or(false) {
+        let val = vec.pop().unwrap();
+        println!("Popped: {}", val);
+    }
+
+    //~v manual_pop_if
+    if vec.last().map(|x| *x > 2).unwrap_or(false) {
+        println!("Popped: {}", vec.pop().unwrap());
+    }
+
+    //~v manual_pop_if
+    if vec.last().map(|x| *x > 2).unwrap_or(false) {
+        // a comment before the pop
+        vec.pop().unwrap();
+    }
+
+    //~v manual_pop_if
+    if vec.last().map(|x| *x > 2).unwrap_or(false) {
+        vec.pop().unwrap();
+        // a comment after the pop
+    }
+}

--- a/tests/ui/manual_pop_if_unfixable.stderr
+++ b/tests/ui/manual_pop_if_unfixable.stderr
@@ -1,0 +1,193 @@
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:10:12
+   |
+LL |     } else if vec.last().is_some_and(|x| *x > 2) {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+   = note: `-D clippy::manual-pop-if` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_pop_if)]`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:16:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let val = vec.pop().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:22:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         println!("Popped: {}", vec.pop().unwrap());
+   |                                ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:27:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         // a comment before the pop
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:33:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:41:5
+   |
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             let val = vec.pop().unwrap();
+   |                       ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:49:5
+   |
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             println!("Popped: {}", vec.pop().unwrap());
+   |                                    ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:56:5
+   |
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             // a comment before the pop
+LL |             vec.pop().unwrap();
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:64:5
+   |
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             vec.pop().unwrap();
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:74:5
+   |
+LL | /     if let Some(x) = vec.last()
+LL | |         && *x > 2
+   | |_________________^
+LL |       {
+LL |           let val = vec.pop().unwrap();
+   |                     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:82:5
+   |
+LL | /     if let Some(x) = vec.last()
+LL | |         && *x > 2
+   | |_________________^
+LL |       {
+LL |           println!("Popped: {}", vec.pop().unwrap());
+   |                                  ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:89:5
+   |
+LL | /     if let Some(x) = vec.last()
+LL | |         && *x > 2
+   | |_________________^
+...
+LL |           vec.pop().unwrap();
+   |           ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:97:5
+   |
+LL | /     if let Some(x) = vec.last()
+LL | |         && *x > 2
+   | |_________________^
+LL |       {
+LL |           vec.pop().unwrap();
+   |           ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:107:5
+   |
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let val = vec.pop().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:113:5
+   |
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         println!("Popped: {}", vec.pop().unwrap());
+   |                                ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:118:5
+   |
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         // a comment before the pop
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:124:5
+   |
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: aborting due to 17 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16683)*

Extend the lint to detect the case where the popped value is used, but in such cases just emit the lint with no suggestion.

changelog: [`manual_pop_if`]: in case the popped value is used, just emit the lint with no suggestion.
changelog: [`manual_pop_if`]: also cover `.pop().unwrap_unchecked()`