### PR TITLE
Fix is_cfg_test to handle all(test, ...) cfg attributes

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2423,13 +2423,24 @@ pub fn is_test_function(tcx: TyCtxt<'_>, fn_def_id: LocalDefId) -> bool {
 /// use [`is_in_cfg_test`]
 pub fn is_cfg_test(tcx: TyCtxt<'_>, id: HirId) -> bool {
     if let Some(cfgs) = find_attr!(tcx.hir_attrs(id), CfgTrace(cfgs) => cfgs)
-        && cfgs
-            .iter()
-            .any(|(cfg, _)| matches!(cfg, CfgEntry::NameValue { name: sym::test, .. }))
+        && cfgs.iter().any(|(cfg, _)| cfg_entry_requires_test(cfg))
     {
         true
     } else {
         false
+    }
+}
+
+/// Checks whether a `CfgEntry` requires `test` to be true.
+///
+/// Returns `true` for `test`, `all(test, ...)`, and nested combinations
+/// where `test` must hold. Returns `false` for `any(test, ...)` (since
+/// the condition can be satisfied without `test`) and `not(test)`.
+fn cfg_entry_requires_test(cfg: &CfgEntry) -> bool {
+    match cfg {
+        CfgEntry::NameValue { name, .. } => *name == sym::test,
+        CfgEntry::All(entries, _) => entries.iter().any(cfg_entry_requires_test),
+        _ => false,
     }
 }
 

--- a/tests/ui/tests_outside_test_module.rs
+++ b/tests/ui/tests_outside_test_module.rs
@@ -18,3 +18,18 @@ mod tests {
     #[test]
     fn my_test() {}
 }
+
+#[allow(clippy::non_minimal_cfg)]
+#[cfg(all(test))]
+mod tests_all {
+    // Should not lint: `all(test)` implies `test`
+    #[test]
+    fn my_test() {}
+}
+
+#[cfg(all(test, not(target_pointer_width = "16")))]
+mod tests_all_compound {
+    // Should not lint: `all(test, ...)` implies `test`
+    #[test]
+    fn my_test() {}
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16476

`is_cfg_test` only matched top-level `CfgEntry::NameValue { name: test }`, so `#[cfg(all(test))]` and `#[cfg(all(test, not(...)))]` were not recognized as test configurations. This adds a recursive check into `CfgEntry::All` variants.

changelog: [`tests_outside_test_module`]: fix false positive when using `#[cfg(all(test, ...))]`

## Test plan
- Added UI test cases for `#[cfg(all(test))]` and `#[cfg(all(test, not(target_pointer_width = "16")))]`
- Verified existing tests still pass