### PR TITLE
Move `coerce_container_to_any` to suspicious

### DIFF
--- a/clippy_lints/src/coerce_container_to_any.rs
+++ b/clippy_lints/src/coerce_container_to_any.rs
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.89.0"]
     pub COERCE_CONTAINER_TO_ANY,
-    nursery,
+    suspicious,
     "coercing to `&dyn Any` when dereferencing could produce a `dyn Any` without coercion is usually not intended"
 }
 


### PR DESCRIPTION
changelog: [`coerce_container_to_any`]: move from nursery to suspicious

Motivated by organic demand [on bsky](https://bsky.app/profile/lukaswirth.dev/post/3mf574efo4s2z).