### PR TITLE
Fix ICE when using the `min_generic_const_args` incomplete feature

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -845,8 +845,13 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
             {
                 did
             },
-            _ if let Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, did) =
-                self.typeck.qpath_res(qpath, id) =>
+            // TODO: revisit when feature `min_generic_const_args` is stabilized. In the meantime,
+            // `TyCtxt::const_eval_resolve()` will trigger an ICE when evaluating the body of the
+            // `type const` definition.
+            _ if let Res::Def(
+                DefKind::Const { is_type_const: false } | DefKind::AssocConst { is_type_const: false },
+                did,
+            ) = self.typeck.qpath_res(qpath, id) =>
             {
                 self.source.set(ConstantSource::NonLocal);
                 did

--- a/tests/ui/crashes/mgca-16691.rs
+++ b/tests/ui/crashes/mgca-16691.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+#![allow(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+trait Trait {
+    type const N: usize;
+    fn process();
+}
+
+impl Trait for () {
+    type const N: usize = 3;
+    fn process() {
+        const N: usize = <()>::N;
+        _ = 0..Self::N;
+    }
+}


### PR DESCRIPTION
changelog: fix ICE when using the `min_generic_const_args` incomplete feature

Fixes rust-lang/rust-clippy#16691