### PR TITLE
Fix semicolon-inside-block inside try_blocks

### DIFF
--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -170,7 +170,7 @@ impl LateLintPass<'_> for SemicolonBlock {
             StmtKind::Semi(Expr {
                 kind: ExprKind::Block(block, _),
                 ..
-            }) if !block.span.from_expansion() => {
+            }) if !block.span.from_expansion() && !block.targeted_by_break => {
                 let attrs = cx.tcx.hir_attrs(stmt.hir_id);
                 if !attrs.is_empty() && !cx.tcx.features().stmt_expr_attributes() {
                     return;

--- a/tests/ui/semicolon_inside_block.fixed
+++ b/tests/ui/semicolon_inside_block.fixed
@@ -7,6 +7,7 @@
     clippy::double_parens
 )]
 #![warn(clippy::semicolon_inside_block)]
+#![feature(try_blocks)]
 
 macro_rules! m {
     (()) => {
@@ -105,4 +106,12 @@ fn issue15380() {
 pub fn issue15388() {
     #[rustfmt::skip]
     {0; 0};
+}
+
+fn issue_try_blocks() {
+    // try blocks should NOT trigger semicolon_inside_block:
+    // moving `;` inside changes the return type (e.g. `Option<i32>` -> `Option<()>`)
+    // which in turn changes the type constraints on `?` operators inside the block,
+    // causing type errors.
+    try { Some(1)? };
 }

--- a/tests/ui/semicolon_inside_block.rs
+++ b/tests/ui/semicolon_inside_block.rs
@@ -7,6 +7,7 @@
     clippy::double_parens
 )]
 #![warn(clippy::semicolon_inside_block)]
+#![feature(try_blocks)]
 
 macro_rules! m {
     (()) => {
@@ -105,4 +106,12 @@ fn issue15380() {
 pub fn issue15388() {
     #[rustfmt::skip]
     {0; 0};
+}
+
+fn issue_try_blocks() {
+    // try blocks should NOT trigger semicolon_inside_block:
+    // moving `;` inside changes the return type (e.g. `Option<i32>` -> `Option<()>`)
+    // which in turn changes the type constraints on `?` operators inside the block,
+    // causing type errors.
+    try { Some(1)? };
 }

--- a/tests/ui/semicolon_inside_block.stderr
+++ b/tests/ui/semicolon_inside_block.stderr
@@ -1,5 +1,5 @@
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:39:5
+  --> tests/ui/semicolon_inside_block.rs:40:5
    |
 LL |     { unit_fn_block() };
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     { unit_fn_block(); }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:41:5
+  --> tests/ui/semicolon_inside_block.rs:42:5
    |
 LL |     unsafe { unit_fn_block() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     unsafe { unit_fn_block(); }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:50:5
+  --> tests/ui/semicolon_inside_block.rs:51:5
    |
 LL | /     {
 LL | |
@@ -41,7 +41,7 @@ LL ~     }
    |
 
 error: consider moving the `;` inside the block for consistent formatting
-  --> tests/ui/semicolon_inside_block.rs:64:5
+  --> tests/ui/semicolon_inside_block.rs:65:5
    |
 LL |     { m!(()) };
    |     ^^^^^^^^^^^


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16696

changelog: [`semicolon_inside_block`]: fix false positive in `try` blocks where moving `;` inside changes the block's return type and causes type errors.