### PR TITLE
Fix `match_same_arms` FP with associated consts

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -841,7 +841,8 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
                     && ty.span.ctxt() == self.ctxt.get()
                     && ty_name.ident.span.ctxt() == self.ctxt.get()
                     && matches!(ty_path.res, Res::PrimTy(_))
-                    && let Some((DefKind::AssocConst { .. }, did)) = self.typeck.type_dependent_def(id) =>
+                    && let Some((DefKind::AssocConst { .. }, did)) = self.typeck.type_dependent_def(id)
+                    && self.tcx.inherent_impl_of_assoc(did).is_some() =>
             {
                 did
             },

--- a/tests/ui/match_same_arms.fixed
+++ b/tests/ui/match_same_arms.fixed
@@ -156,3 +156,19 @@ fn issue16678() {
         },
     }
 }
+
+fn issue16698() {
+    trait Foo {
+        const X: u8;
+    }
+    impl Foo for u8 {
+        const X: u8 = 2;
+    }
+    impl Foo for i8 {
+        const X: u8 = 2;
+    }
+    match true {
+        false => u8::X,
+        true => i8::X,
+    };
+}

--- a/tests/ui/match_same_arms.rs
+++ b/tests/ui/match_same_arms.rs
@@ -165,3 +165,19 @@ fn issue16678() {
         },
     }
 }
+
+fn issue16698() {
+    trait Foo {
+        const X: u8;
+    }
+    impl Foo for u8 {
+        const X: u8 = 2;
+    }
+    impl Foo for i8 {
+        const X: u8 = 2;
+    }
+    match true {
+        false => u8::X,
+        true => i8::X,
+    };
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16698 

changelog: [`match_same_arms`] fix FP with associated consts
