### PR TITLE
`missing_headers`: skip linting test functions, functions in test modules, and functions with #[cfg(test)] to avoid false positives

### DIFF
--- a/clippy_lints/src/doc/missing_headers.rs
+++ b/clippy_lints/src/doc/missing_headers.rs
@@ -5,8 +5,7 @@ use clippy_utils::res::MaybeDef;
 use clippy_utils::ty::implements_trait_with_env;
 use clippy_utils::visitors::for_each_expr;
 use clippy_utils::{
-    fulfill_or_allowed, is_cfg_test, is_doc_hidden, is_in_cfg_test, is_inside_always_const_context,
-    is_test_function, method_chain_args, return_ty,
+    fulfill_or_allowed, is_doc_hidden, is_in_test, is_inside_always_const_context, method_chain_args, return_ty,
 };
 use rustc_hir::{BodyId, FnSig, OwnerId, Safety};
 use rustc_lint::LateContext;
@@ -26,7 +25,7 @@ pub fn check(
         return; // Private functions do not require doc comments
     }
 
-    // do not lint if any parent has `#[doc(hidden)]` attribute (#7347)
+    // Do not lint if any parent has `#[doc(hidden)]` attribute (#7347)
     if !check_private_items
         && cx
             .tcx
@@ -36,9 +35,10 @@ pub fn check(
         return;
     }
 
-    // do not lint test functions, functions inside test modules or with #[cfg(test)]
-    let hir_id = cx.tcx.local_def_id_to_hir_id(owner_id.def_id);
-    if is_test_function(cx.tcx, owner_id.def_id) || is_cfg_test(cx.tcx, hir_id) || is_in_cfg_test(cx.tcx, hir_id) {
+    // Do not lint if any parent has `#[test]` attribute or is in `#[cfg(test)]` (#12265)
+    if let Some(body_id) = body_id
+        && is_in_test(cx.tcx, body_id.hir_id)
+    {
         return;
     }
 

--- a/clippy_lints/src/doc/missing_headers.rs
+++ b/clippy_lints/src/doc/missing_headers.rs
@@ -4,7 +4,10 @@ use clippy_utils::macros::{is_panic, root_macro_call_first_node};
 use clippy_utils::res::MaybeDef;
 use clippy_utils::ty::implements_trait_with_env;
 use clippy_utils::visitors::for_each_expr;
-use clippy_utils::{fulfill_or_allowed, is_doc_hidden, is_inside_always_const_context, method_chain_args, return_ty};
+use clippy_utils::{
+    fulfill_or_allowed, is_cfg_test, is_doc_hidden, is_in_cfg_test, is_inside_always_const_context,
+    is_test_function, method_chain_args, return_ty,
+};
 use rustc_hir::{BodyId, FnSig, OwnerId, Safety};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
@@ -30,6 +33,12 @@ pub fn check(
             .hir_parent_iter(owner_id.into())
             .any(|(id, _node)| is_doc_hidden(cx.tcx.hir_attrs(id)))
     {
+        return;
+    }
+
+    // do not lint test functions, functions inside test modules or with #[cfg(test)]
+    let hir_id = cx.tcx.local_def_id_to_hir_id(owner_id.def_id);
+    if is_test_function(cx.tcx, owner_id.def_id) || is_cfg_test(cx.tcx, hir_id) || is_in_cfg_test(cx.tcx, hir_id) {
         return;
     }
 

--- a/tests/ui-toml/private-doc-errors/doc_lints.rs
+++ b/tests/ui-toml/private-doc-errors/doc_lints.rs
@@ -57,4 +57,10 @@ fn test() -> Result<(), ()> {
     Ok(())
 }
 
+#[test]
+fn test_with_panic() {
+    let result: Result<i32, &str> = Ok(1);
+    result.unwrap();
+}
+
 fn main() {}


### PR DESCRIPTION
## Summary

This PR fixes unnecessary warnings for `missing_headers` on test code.

## Changes

Add logic to skip the `missing_headers` lint for:
- Test functions (functions named `test_*` or decorated with `#[test]`)
- Functions inside test modules (`mod tests { ... }`)
- Functions with `#[cfg(test)]` attribute

This avoids triggering the lint on test code where documentation headers are often unnecessary.

The logic should affect these lints:
- `missing_errors_doc`
- `missing_panics_doc`
- `missing_safety_doc`
- `unnecessary_safety_doc`

fixes rust-lang/rust-clippy#13391 and rust-lang/rust-clippy#12265 

changelog: [`missing_headers`]: skip linting test functions, functions in test modules, and functions with `#[cfg(test)]` to avoid false positives