### PR TITLE
Reduce clippy lints HTML size by removing a CSS class

### DIFF
--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -174,13 +174,13 @@ Otherwise, have a great day =^.^=
                     <h2 class="lint-title"> {# #}
                         <div class="panel-title-name" id="lint-{{lint.id}}"> {# #}
                             {{lint.id ~}}
-                            <a href="#{{lint.id}}" class="anchor label label-default">&para;</a> {#+ #}
-                            <a href="" class="copy-to-clipboard anchor label label-default"> {# #}
+                            <a href="#{{lint.id}}" class="anchor label">&para;</a> {#+ #}
+                            <a href="" class="copy-to-clipboard anchor label"> {# #}
                                 &#128203; {# #}
                             </a> {# #}
                         </div> {# #}
 
-                        <span class="label label-default lint-group group-{{lint.group}}">{{lint.group}}</span> {#+ #}
+                        <span class="label lint-group group-{{lint.group}}">{{lint.group}}</span> {#+ #}
 
                         <span class="label lint-level level-{{lint.level}}">{{lint.level}}</span> {#+ #}
 

--- a/util/gh-pages/style.css
+++ b/util/gh-pages/style.css
@@ -1,5 +1,6 @@
 body {
     --icon-filter: initial;
+    --label-background: #777;
 }
 
 body.ayu {
@@ -230,7 +231,10 @@ button .caret {
 
 .panel-title-name { flex: 1; min-width: 400px;}
 
-.panel-title-name .anchor { display: none; }
+.panel-title-name .anchor {
+    display: none;
+    background-color: var(--label-background);
+}
 article:hover .panel-title-name .anchor { display: inline;}
 
 .search-control {
@@ -397,10 +401,6 @@ article:hover .panel-title-name .anchor { display: inline;}
     text-decoration: none;
 }
 
-.label-default {
-    background-color: #777;
-}
-
 .lint-level {
     min-width: 4em;
 }
@@ -420,6 +420,7 @@ article:hover .panel-title-name .anchor { display: inline;}
 
 .lint-group {
     min-width: 8em;
+    background-color: var(--label-background);
 }
 .group-deprecated {
     opacity: 0.5;


### PR DESCRIPTION
Reduces the size of the clippy lints page from 1.643.619 to 1.609.095 (-2.1%). No UI changes.

r? @samueltardieu 

changelog: none