### PR TITLE
Don't trigger `unwrap_used` or `expect_used` on uninhabited `Err`

### DIFF
--- a/clippy_lints/src/methods/unwrap_expect_used.rs
+++ b/clippy_lints/src/methods/unwrap_expect_used.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::MaybeDef;
-use clippy_utils::ty::is_never_like;
+use clippy_utils::ty::is_visibly_uninhabited;
 use clippy_utils::{is_in_test, is_inside_always_const_context, is_lint_allowed};
 use rustc_hir::Expr;
 use rustc_hir::def::DefKind;
@@ -56,7 +56,7 @@ pub(super) fn check(
             if let ty::Adt(_, substs) = ty.kind()
                 && let Some(t_or_e_ty) = substs[usize::from(!is_err)].as_type() =>
         {
-            if is_never_like(t_or_e_ty) {
+            if is_visibly_uninhabited(cx, t_or_e_ty) {
                 return;
             }
 

--- a/clippy_lints/src/methods/unwrap_expect_used.rs
+++ b/clippy_lints/src/methods/unwrap_expect_used.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::MaybeDef as _;
-use clippy_utils::ty::is_never_like;
+use clippy_utils::ty::is_visibly_uninhabited;
 use clippy_utils::{is_in_test, is_inside_always_const_context, is_lint_allowed};
 use rustc_hir::Expr;
 use rustc_hir::def::DefKind;
@@ -56,7 +56,7 @@ pub(super) fn check(
             if let ty::Adt(_, substs) = ty.kind()
                 && let Some(t_or_e_ty) = substs[usize::from(!is_err)].as_type() =>
         {
-            if is_never_like(t_or_e_ty) {
+            if is_visibly_uninhabited(cx, t_or_e_ty) {
                 return;
             }
 

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -971,9 +971,12 @@ fn assert_generic_args_match<'tcx>(tcx: TyCtxt<'tcx>, did: DefId, args: &[Generi
     }
 }
 
-/// Returns whether `ty` is never-like; i.e., `!` (never) or an enum with zero variants.
-pub fn is_never_like(ty: Ty<'_>) -> bool {
-    ty.is_never() || (ty.is_enum() && ty.ty_adt_def().is_some_and(|def| def.variants().is_empty()))
+/// Returns whether `ty` is known to be uninhabited (`!`, `std::convert::Infallible`, `enum` with no
+/// variants, `struct` with uninhabited fields, …) from the module being currently linted.
+pub fn is_visibly_uninhabited<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    cx.enclosing_body.is_some_and(|body| {
+        !ty.is_inhabited_from(cx.tcx, cx.tcx.parent_module(body.hir_id).to_def_id(), cx.typing_env())
+    })
 }
 
 /// Makes the projection type for the named associated type in the given impl or trait impl.

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -1164,9 +1164,11 @@ fn assert_generic_args_match<'tcx>(tcx: TyCtxt<'tcx>, did: DefId, args: &[Generi
     }
 }
 
-/// Returns whether `ty` is never-like; i.e., `!` (never) or an enum with zero variants.
-pub fn is_never_like(ty: Ty<'_>) -> bool {
-    ty.is_never() || (ty.is_enum() && ty.ty_adt_def().is_some_and(|def| def.variants().is_empty()))
+/// Returns whether `ty` is known to be uninhabited (`!`, `std::convert::Infallible`, `enum` with no
+/// variants, `struct` with uninhabited fields, …) from the module being currently linted.
+pub fn is_visibly_uninhabited<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    cx.enclosing_body
+        .is_some_and(|body| !ty.is_inhabited_from(cx.tcx, cx.tcx.parent_module(body.hir_id), cx.typing_env()))
 }
 
 /// Makes the projection type for the named associated type in the given impl or trait impl.

--- a/tests/ui/unwrap_expect_used.rs
+++ b/tests/ui/unwrap_expect_used.rs
@@ -95,3 +95,36 @@ fn issue16484() {
     Result::unwrap_err(res); //~ unwrap_used
     Result::expect_err(res, "error message"); //~ expect_used
 }
+
+#[derive(Clone, Debug)]
+struct S {
+    x: std::convert::Infallible,
+    y: u32,
+}
+
+pub mod child {
+    mod grandchild {
+        pub type PrivatelyUninhabited = std::convert::Infallible;
+    }
+    #[derive(Clone, Debug)]
+    pub struct T(grandchild::PrivatelyUninhabited);
+}
+
+#[derive(Clone, Debug)]
+struct T {
+    x: child::T,
+    y: u32,
+}
+
+fn f(s: Result<String, S>, t: Result<String, T>) {
+    // Check that the compiler sees the `S` type as uninhabited (because of its `x` field)
+    let Ok(_) = s.clone();
+    // Do not lint: `s` is necessarily `Ok` as shown above
+    _ = s.clone().unwrap();
+    _ = s.clone().expect("uninhabited struct is inhabited");
+    // Here, we cannot see that T is uninhabited
+    _ = t.clone().unwrap();
+    //~^ unwrap_used
+    _ = t.clone().expect("we do not know much about `T`'s `x` field");
+    //~^ expect_used
+}

--- a/tests/ui/unwrap_expect_used.rs
+++ b/tests/ui/unwrap_expect_used.rs
@@ -94,3 +94,36 @@ fn issue16484() {
     Result::unwrap_err(res); //~ unwrap_used
     Result::expect_err(res, "error message"); //~ expect_used
 }
+
+#[derive(Clone, Debug)]
+struct S {
+    x: std::convert::Infallible,
+    y: u32,
+}
+
+pub mod child {
+    mod grandchild {
+        pub type PrivatelyUninhabited = std::convert::Infallible;
+    }
+    #[derive(Clone, Debug)]
+    pub struct T(grandchild::PrivatelyUninhabited);
+}
+
+#[derive(Clone, Debug)]
+struct T {
+    x: child::T,
+    y: u32,
+}
+
+fn f(s: Result<String, S>, t: Result<String, T>) {
+    // Check that the compiler sees the `S` type as uninhabited (because of its `x` field)
+    let Ok(_) = s.clone();
+    // Do not lint: `s` is necessarily `Ok` as shown above
+    _ = s.clone().unwrap();
+    _ = s.clone().expect("uninhabited struct is inhabited");
+    // Here, we cannot see that T is uninhabited
+    _ = t.clone().unwrap();
+    //~^ unwrap_used
+    _ = t.clone().expect("we do not know much about `T`'s `x` field");
+    //~^ expect_used
+}

--- a/tests/ui/unwrap_expect_used.stderr
+++ b/tests/ui/unwrap_expect_used.stderr
@@ -130,5 +130,21 @@ LL |     Result::expect_err(res, "error message");
    |
    = note: if this value is an `Ok`, it will panic
 
-error: aborting due to 16 previous errors
+error: used `unwrap()` on a `Result` value
+  --> tests/ui/unwrap_expect_used.rs:126:9
+   |
+LL |     _ = t.clone().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Err`, it will panic
+
+error: used `expect()` on a `Result` value
+  --> tests/ui/unwrap_expect_used.rs:128:9
+   |
+LL |     _ = t.clone().expect("we do not know much about `T`'s `x` field");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Err`, it will panic
+
+error: aborting due to 18 previous errors
 

--- a/tests/ui/unwrap_expect_used.stderr
+++ b/tests/ui/unwrap_expect_used.stderr
@@ -130,5 +130,21 @@ LL |     Result::expect_err(res, "error message");
    |
    = note: if this value is an `Ok`, it will panic
 
-error: aborting due to 16 previous errors
+error: used `unwrap()` on a `Result` value
+  --> tests/ui/unwrap_expect_used.rs:125:9
+   |
+LL |     _ = t.clone().unwrap();
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Err`, it will panic
+
+error: used `expect()` on a `Result` value
+  --> tests/ui/unwrap_expect_used.rs:127:9
+   |
+LL |     _ = t.clone().expect("we do not know much about `T`'s `x` field");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is an `Err`, it will panic
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
When the `Err` variant is a known uninhabited type, there is no point in complaining when `.unwrap()` or `.expect(…)` are used, as they cannot fail.

One alternative would be to complain and suggest using `let Ok(_) = _;` which wouldn't fail either, but it may not integrate well into the code flow.

changelog: [`unwrap_used`] [`expect_used`]: do not warn on `Result` types whose `Err` variant is visibly uninhabited.