### PR TITLE
Unneeded wildcard improvement

### DIFF
--- a/clippy_lints/src/misc_early/mod.rs
+++ b/clippy_lints/src/misc_early/mod.rs
@@ -197,7 +197,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for tuple patterns with a wildcard
+    /// Checks for tuple and struct patterns with a wildcard
     /// pattern (`_`) is next to a rest pattern (`..`).
     ///
     /// _NOTE_: While `_, ..` means there is at least one element left, `..`
@@ -231,7 +231,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.40.0"]
     pub UNNEEDED_WILDCARD_PATTERN,
     complexity,
-    "tuple patterns with a wildcard pattern (`_`) is next to a rest pattern (`..`)"
+    "tuple and struct patterns with a wildcard pattern (`_`) is next to a rest pattern (`..`)"
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/misc_early/unneeded_wildcard_pattern.rs
+++ b/clippy_lints/src/misc_early/unneeded_wildcard_pattern.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use rustc_ast::ast::{Pat, PatKind};
+use rustc_ast::ast::{Pat, PatFieldsRest, PatKind};
 use rustc_errors::Applicability;
 use rustc_lint::EarlyContext;
 use rustc_span::Span;
@@ -32,6 +32,19 @@ pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
                 right_index == 0,
             );
         }
+    } else if let PatKind::Struct(_, _, patfields, rest) = &pat.kind
+        && let PatFieldsRest::Rest(rspan) = rest
+        && let Some((right_index, _right_pat)) = patfields
+            .iter()
+            .rev()
+            .take_while(|patfield| matches!(patfield.pat.kind, PatKind::Wild))
+            .enumerate()
+            .last()
+    {
+        // Unlike the tuples above, structs have patfields rathter than patterns, and separate out the
+        // `..` into a separate parameter. Also, the `..` can only be at the end of the pattern.
+        let singlewild = patfields.len() - right_index - 1;
+        span_lint(cx, patfields[singlewild].span.until(*rspan), right_index == 0);
     }
 }
 

--- a/tests/ui/needless_borrowed_ref.fixed
+++ b/tests/ui/needless_borrowed_ref.fixed
@@ -4,7 +4,8 @@
     irrefutable_let_patterns,
     non_shorthand_field_patterns,
     clippy::needless_borrow,
-    clippy::needless_ifs
+    clippy::needless_ifs,
+    clippy::unneeded_wildcard_pattern
 )]
 
 fn main() {}

--- a/tests/ui/needless_borrowed_ref.rs
+++ b/tests/ui/needless_borrowed_ref.rs
@@ -4,7 +4,8 @@
     irrefutable_let_patterns,
     non_shorthand_field_patterns,
     clippy::needless_borrow,
-    clippy::needless_ifs
+    clippy::needless_ifs,
+    clippy::unneeded_wildcard_pattern
 )]
 
 fn main() {}

--- a/tests/ui/needless_borrowed_ref.stderr
+++ b/tests/ui/needless_borrowed_ref.stderr
@@ -1,5 +1,5 @@
 error: this pattern takes a reference on something that is being dereferenced
-  --> tests/ui/needless_borrowed_ref.rs:30:34
+  --> tests/ui/needless_borrowed_ref.rs:31:34
    |
 LL |     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
    |                                  ^^^^^^
@@ -13,7 +13,7 @@ LL +     let _ = v.iter_mut().filter(|a| a.is_empty());
    |
 
 error: this pattern takes a reference on something that is being dereferenced
-  --> tests/ui/needless_borrowed_ref.rs:35:17
+  --> tests/ui/needless_borrowed_ref.rs:36:17
    |
 LL |     if let Some(&ref v) = thingy {}
    |                 ^^^^^^
@@ -25,7 +25,7 @@ LL +     if let Some(v) = thingy {}
    |
 
 error: this pattern takes a reference on something that is being dereferenced
-  --> tests/ui/needless_borrowed_ref.rs:38:14
+  --> tests/ui/needless_borrowed_ref.rs:39:14
    |
 LL |     if let &[&ref a, ref b] = slice_of_refs {}
    |              ^^^^^^
@@ -37,7 +37,7 @@ LL +     if let &[a, ref b] = slice_of_refs {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:41:9
+  --> tests/ui/needless_borrowed_ref.rs:42:9
    |
 LL |     let &[ref a, ..] = &array;
    |         ^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +     let [a, ..] = &array;
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:43:9
+  --> tests/ui/needless_borrowed_ref.rs:44:9
    |
 LL |     let &[ref a, ref b, ..] = &array;
    |         ^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL +     let [a, b, ..] = &array;
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:46:12
+  --> tests/ui/needless_borrowed_ref.rs:47:12
    |
 LL |     if let &[ref a, ref b] = slice {}
    |            ^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +     if let [a, b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:48:12
+  --> tests/ui/needless_borrowed_ref.rs:49:12
    |
 LL |     if let &[ref a, ref b] = &vec[..] {}
    |            ^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +     if let [a, b] = &vec[..] {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:51:12
+  --> tests/ui/needless_borrowed_ref.rs:52:12
    |
 LL |     if let &[ref a, ref b, ..] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL +     if let [a, b, ..] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:53:12
+  --> tests/ui/needless_borrowed_ref.rs:54:12
    |
 LL |     if let &[ref a, .., ref b] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL +     if let [a, .., b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:55:12
+  --> tests/ui/needless_borrowed_ref.rs:56:12
    |
 LL |     if let &[.., ref a, ref b] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL +     if let [.., a, b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:58:12
+  --> tests/ui/needless_borrowed_ref.rs:59:12
    |
 LL |     if let &[ref a, _] = slice {}
    |            ^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL +     if let [a, _] = slice {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:61:12
+  --> tests/ui/needless_borrowed_ref.rs:62:12
    |
 LL |     if let &(ref a, ref b, ref c) = &tuple {}
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL +     if let (a, b, c) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:63:12
+  --> tests/ui/needless_borrowed_ref.rs:64:12
    |
 LL |     if let &(ref a, _, ref c) = &tuple {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     if let (a, _, c) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:65:12
+  --> tests/ui/needless_borrowed_ref.rs:66:12
    |
 LL |     if let &(ref a, ..) = &tuple {}
    |            ^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL +     if let (a, ..) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:68:12
+  --> tests/ui/needless_borrowed_ref.rs:69:12
    |
 LL |     if let &TupleStruct(ref a, ..) = &tuple_struct {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     if let TupleStruct(a, ..) = &tuple_struct {}
    |
 
 error: dereferencing a struct pattern where every field's pattern takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:71:12
+  --> tests/ui/needless_borrowed_ref.rs:72:12
    |
 LL |       if let &Struct {
    |  ____________^
@@ -202,7 +202,7 @@ LL ~         c: renamed,
    |
 
 error: dereferencing a struct pattern where every field's pattern takes a reference
-  --> tests/ui/needless_borrowed_ref.rs:79:12
+  --> tests/ui/needless_borrowed_ref.rs:80:12
    |
 LL |     if let &Struct { ref a, b: _, .. } = &s {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unneeded_wildcard_pattern.fixed
+++ b/tests/ui/unneeded_wildcard_pattern.fixed
@@ -64,4 +64,30 @@ fn main() {
         let t = (0, 1, 2, 3);
         if let (0, _, ..) = t {};
     }
+
+    struct Struct4 {
+        a: u32,
+        b: u32,
+        c: u32,
+        d: u32,
+    }
+
+    let fourval = Struct4 {
+        a: 5,
+        b: 10,
+        c: 15,
+        d: 20,
+    };
+
+    // unlike the tuple forms, the struct form can only have the `..` at the end of the list
+    let Struct4 { mut a, mut b, .. } = fourval;
+    //~^ unneeded_wildcard_pattern
+    let Struct4 { mut b, .. } = fourval;
+    //~^ unneeded_wildcard_pattern
+    let Struct4 { mut a, b, c, d: _ } = fourval;
+    let Struct4 { mut c, d, .. } = fourval;
+    let Struct4 { .. } = fourval;
+    //~^ unneeded_wildcard_pattern
+    let Struct4 { .. } = fourval;
+    //~^ unneeded_wildcard_pattern
 }

--- a/tests/ui/unneeded_wildcard_pattern.rs
+++ b/tests/ui/unneeded_wildcard_pattern.rs
@@ -64,4 +64,30 @@ fn main() {
         let t = (0, 1, 2, 3);
         if let (0, _, ..) = t {};
     }
+
+    struct Struct4 {
+        a: u32,
+        b: u32,
+        c: u32,
+        d: u32,
+    }
+
+    let fourval = Struct4 {
+        a: 5,
+        b: 10,
+        c: 15,
+        d: 20,
+    };
+
+    // unlike the tuple forms, the struct form can only have the `..` at the end of the list
+    let Struct4 { mut a, mut b, c: _, .. } = fourval;
+    //~^ unneeded_wildcard_pattern
+    let Struct4 { mut b, c: _, d: _, .. } = fourval;
+    //~^ unneeded_wildcard_pattern
+    let Struct4 { mut a, b, c, d: _ } = fourval;
+    let Struct4 { mut c, d, .. } = fourval;
+    let Struct4 { b: _, c: _, .. } = fourval;
+    //~^ unneeded_wildcard_pattern
+    let Struct4 { c: _, .. } = fourval;
+    //~^ unneeded_wildcard_pattern
 }

--- a/tests/ui/unneeded_wildcard_pattern.stderr
+++ b/tests/ui/unneeded_wildcard_pattern.stderr
@@ -88,5 +88,29 @@ error: these patterns are unneeded as the `..` pattern can match those elements
 LL |         if let S(0, .., _, _,) = s {};
    |                       ^^^^^^ help: remove them
 
-error: aborting due to 14 previous errors
+error: this pattern is unneeded as the `..` pattern can match that element
+  --> tests/ui/unneeded_wildcard_pattern.rs:83:33
+   |
+LL |     let Struct4 { mut a, mut b, c: _, .. } = fourval;
+   |                                 ^^^^^^ help: remove it
+
+error: these patterns are unneeded as the `..` pattern can match those elements
+  --> tests/ui/unneeded_wildcard_pattern.rs:85:26
+   |
+LL |     let Struct4 { mut b, c: _, d: _, .. } = fourval;
+   |                          ^^^^^^^^^^^^ help: remove them
+
+error: these patterns are unneeded as the `..` pattern can match those elements
+  --> tests/ui/unneeded_wildcard_pattern.rs:89:19
+   |
+LL |     let Struct4 { b: _, c: _, .. } = fourval;
+   |                   ^^^^^^^^^^^^ help: remove them
+
+error: this pattern is unneeded as the `..` pattern can match that element
+  --> tests/ui/unneeded_wildcard_pattern.rs:91:19
+   |
+LL |     let Struct4 { c: _, .. } = fourval;
+   |                   ^^^^^^ help: remove it
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16733)*


changelog: [`unneeded_wildcard_pattern`]: add support for struct constructs.

Closes [#16638](https://github.com/rust-lang/rust-clippy/issues/16638)

The existing lint only looks at tuples and tuplestructs.  This change adds support for standard structs, looking for cases
where one or more `_` immediately  preceed a `..`.  The preceeding `_` members may be omitted, as they will be collected by the `..` operator.  
