### PR TITLE
Add `BinaryHeap::pop_if()` to `manual_pop_if`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -865,7 +865,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(move |tcx| Box::new(duration_suboptimal_units::DurationSuboptimalUnits::new(tcx, conf))),
         Box::new(move |_| Box::new(manual_take::ManualTake::new(conf))),
         Box::new(|_| Box::new(manual_checked_ops::ManualCheckedOps)),
-        Box::new(move |_| Box::new(manual_pop_if::ManualPopIf::new(conf))),
+        Box::new(move |tcx| Box::new(manual_pop_if::ManualPopIf::new(tcx, conf))),
         // add late passes here, used by `cargo dev new_lint`
     ];
     store.late_passes.extend(late_lints);

--- a/clippy_lints/src/manual_pop_if.rs
+++ b/clippy_lints/src/manual_pop_if.rs
@@ -7,8 +7,9 @@ use clippy_utils::visitors::is_local_used;
 use clippy_utils::{eq_expr_value, is_else_clause, is_lang_item_or_ctor, peel_blocks_with_stmt, sym};
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, LangItem, PatKind, RustcVersion, StmtKind};
+use rustc_hir::{Expr, ExprKind, LangItem, PatKind, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TyCtxt;
 use rustc_session::impl_lint_pass;
 use rustc_span::{Span, Symbol};
 use std::fmt;
@@ -61,11 +62,24 @@ impl_lint_pass!(ManualPopIf => [MANUAL_POP_IF]);
 
 pub struct ManualPopIf {
     msrv: Msrv,
+    binary_heap_pop_if_feature_enabled: bool,
 }
 
 impl ManualPopIf {
-    pub fn new(conf: &'static Conf) -> Self {
-        Self { msrv: conf.msrv }
+    pub fn new(tcx: TyCtxt<'_>, conf: &'static Conf) -> Self {
+        Self {
+            msrv: conf.msrv,
+            binary_heap_pop_if_feature_enabled: tcx.features().enabled(sym::binary_heap_pop_if),
+        }
+    }
+
+    fn msrv_compatible(&self, cx: &LateContext<'_>, kind: ManualPopIfKind) -> bool {
+        match kind {
+            ManualPopIfKind::Vec => self.msrv.meets(cx, msrvs::VEC_POP_IF),
+            ManualPopIfKind::VecDequeBack => self.msrv.meets(cx, msrvs::VEC_DEQUE_POP_BACK_IF),
+            ManualPopIfKind::VecDequeFront => self.msrv.meets(cx, msrvs::VEC_DEQUE_POP_FRONT_IF),
+            ManualPopIfKind::BinaryHeap => self.binary_heap_pop_if_feature_enabled,
+        }
     }
 }
 
@@ -75,6 +89,7 @@ enum ManualPopIfKind {
     Vec,
     VecDequeBack,
     VecDequeFront,
+    BinaryHeap,
 }
 
 impl ManualPopIfKind {
@@ -83,12 +98,13 @@ impl ManualPopIfKind {
             ManualPopIfKind::Vec => sym::last,
             ManualPopIfKind::VecDequeBack => sym::back,
             ManualPopIfKind::VecDequeFront => sym::front,
+            ManualPopIfKind::BinaryHeap => sym::peek,
         }
     }
 
     fn pop_method(self) -> Symbol {
         match self {
-            ManualPopIfKind::Vec => sym::pop,
+            ManualPopIfKind::Vec | ManualPopIfKind::BinaryHeap => sym::pop,
             ManualPopIfKind::VecDequeBack => sym::pop_back,
             ManualPopIfKind::VecDequeFront => sym::pop_front,
         }
@@ -96,7 +112,7 @@ impl ManualPopIfKind {
 
     fn pop_if_method(self) -> Symbol {
         match self {
-            ManualPopIfKind::Vec => sym::pop_if,
+            ManualPopIfKind::Vec | ManualPopIfKind::BinaryHeap => sym::pop_if,
             ManualPopIfKind::VecDequeBack => sym::pop_back_if,
             ManualPopIfKind::VecDequeFront => sym::pop_front_if,
         }
@@ -107,14 +123,7 @@ impl ManualPopIfKind {
         match self {
             ManualPopIfKind::Vec => ty.is_diag_item(cx, sym::Vec),
             ManualPopIfKind::VecDequeBack | ManualPopIfKind::VecDequeFront => ty.is_diag_item(cx, sym::VecDeque),
-        }
-    }
-
-    fn msrv(self) -> RustcVersion {
-        match self {
-            ManualPopIfKind::Vec => msrvs::VEC_POP_IF,
-            ManualPopIfKind::VecDequeBack => msrvs::VEC_DEQUE_POP_BACK_IF,
-            ManualPopIfKind::VecDequeFront => msrvs::VEC_DEQUE_POP_FRONT_IF,
+            ManualPopIfKind::BinaryHeap => ty.is_diag_item(cx, sym::BinaryHeap),
         }
     }
 }
@@ -125,6 +134,7 @@ impl fmt::Display for ManualPopIfKind {
             ManualPopIfKind::Vec => write!(f, "`Vec::pop_if`"),
             ManualPopIfKind::VecDequeBack => write!(f, "`VecDeque::pop_back_if`"),
             ManualPopIfKind::VecDequeFront => write!(f, "`VecDeque::pop_front_if`"),
+            ManualPopIfKind::BinaryHeap => write!(f, "`BinaryHeap::pop_if`"),
         }
     }
 }
@@ -419,12 +429,13 @@ impl<'tcx> LateLintPass<'tcx> for ManualPopIf {
             ManualPopIfKind::Vec,
             ManualPopIfKind::VecDequeBack,
             ManualPopIfKind::VecDequeFront,
+            ManualPopIfKind::BinaryHeap,
         ] {
             if let Some(pattern) = check_is_some_and_pattern(cx, cond, then_block, expr.span, kind)
                 .or_else(|| check_if_let_pattern(cx, cond, then_block, expr.span, kind))
                 .or_else(|| check_let_chain_pattern(cx, cond, then_block, expr.span, kind))
                 .or_else(|| check_map_unwrap_or_pattern(cx, cond, then_block, expr.span, kind))
-                && self.msrv.meets(cx, kind.msrv())
+                && self.msrv_compatible(cx, kind)
             {
                 pattern.emit_lint(cx);
                 return;

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -141,6 +141,7 @@ generate! {
     assert_failed,
     author,
     back,
+    binary_heap_pop_if,
     binaryheap_iter,
     bool_then,
     borrow,

--- a/tests/ui/manual_pop_if.fixed
+++ b/tests/ui/manual_pop_if.fixed
@@ -1,7 +1,8 @@
 #![warn(clippy::manual_pop_if)]
 #![allow(clippy::collapsible_if, clippy::redundant_closure)]
+#![feature(binary_heap_pop_if)]
 
-use std::collections::VecDeque;
+use std::collections::{BinaryHeap, VecDeque};
 use std::marker::PhantomData;
 
 // FakeVec has the same methods as Vec but isn't actually a Vec
@@ -17,7 +18,7 @@ impl<T> FakeVec<T> {
     }
 }
 
-fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
+fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
     vec.pop_if(|x| *x > 2);
 
     vec.pop_if(|x| *x > 2);
@@ -25,6 +26,8 @@ fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
     deque.pop_back_if(|x| *x > 2);
 
     deque.pop_front_if(|x| *x > 2);
+
+    heap.pop_if(|x| *x > 2);
 }
 
 fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
@@ -66,7 +69,7 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
     };
 }
 
-fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
+fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
     vec.pop_if(|x| *x > 2);
 
     vec.pop_if(|x| *x > 2);
@@ -74,6 +77,8 @@ fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
     deque.pop_back_if(|x| *x > 2);
 
     deque.pop_front_if(|x| *x > 2);
+
+    heap.pop_if(|x| *x > 2);
 }
 
 fn if_let_pattern_negative(mut vec: Vec<i32>) {
@@ -115,7 +120,7 @@ fn if_let_pattern_negative(mut vec: Vec<i32>) {
     };
 }
 
-fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
+fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
     vec.pop_if(|x| *x > 2);
 
     vec.pop_if(|x| *x > 2);
@@ -123,6 +128,8 @@ fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
     deque.pop_back_if(|x| *x > 2);
 
     deque.pop_front_if(|x| *x > 2);
+
+    heap.pop_if(|x| *x > 2);
 }
 
 fn let_chain_pattern_negative(mut vec: Vec<i32>) {
@@ -165,7 +172,7 @@ fn let_chain_pattern_negative(mut vec: Vec<i32>) {
     };
 }
 
-fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
+fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
     vec.pop_if(|x| *x > 2);
 
     vec.pop_if(|x| *x > 2);
@@ -173,6 +180,8 @@ fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
     deque.pop_back_if(|x| *x > 2);
 
     deque.pop_front_if(|x| *x > 2);
+
+    heap.pop_if(|x| *x > 2);
 }
 
 fn map_unwrap_or_pattern_negative(mut vec: Vec<i32>) {

--- a/tests/ui/manual_pop_if.rs
+++ b/tests/ui/manual_pop_if.rs
@@ -1,7 +1,8 @@
 #![warn(clippy::manual_pop_if)]
 #![allow(clippy::collapsible_if, clippy::redundant_closure)]
+#![feature(binary_heap_pop_if)]
 
-use std::collections::VecDeque;
+use std::collections::{BinaryHeap, VecDeque};
 use std::marker::PhantomData;
 
 // FakeVec has the same methods as Vec but isn't actually a Vec
@@ -17,7 +18,7 @@ impl<T> FakeVec<T> {
     }
 }
 
-fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
+fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
     if vec.last().is_some_and(|x| *x > 2) {
         //~^ manual_pop_if
         vec.pop().unwrap();
@@ -36,6 +37,11 @@ fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
     if deque.front().is_some_and(|x| *x > 2) {
         //~^ manual_pop_if
         deque.pop_front().unwrap();
+    }
+
+    if heap.peek().is_some_and(|x| *x > 2) {
+        //~^ manual_pop_if
+        heap.pop().unwrap();
     }
 }
 
@@ -78,7 +84,7 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
     };
 }
 
-fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
+fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
     if let Some(x) = vec.last() {
         //~^ manual_pop_if
         if *x > 2 {
@@ -104,6 +110,13 @@ fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
         //~^ manual_pop_if
         if *x > 2 {
             deque.pop_front().unwrap();
+        }
+    }
+
+    if let Some(x) = heap.peek() {
+        //~^ manual_pop_if
+        if *x > 2 {
+            heap.pop().unwrap();
         }
     }
 }
@@ -147,7 +160,7 @@ fn if_let_pattern_negative(mut vec: Vec<i32>) {
     };
 }
 
-fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
+fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
     if let Some(x) = vec.last() //~ manual_pop_if
         && *x > 2
     {
@@ -170,6 +183,12 @@ fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
         && *x > 2
     {
         deque.pop_front().unwrap();
+    }
+
+    if let Some(x) = heap.peek() //~ manual_pop_if
+        && *x > 2
+    {
+        heap.pop().unwrap();
     }
 }
 
@@ -213,7 +232,7 @@ fn let_chain_pattern_negative(mut vec: Vec<i32>) {
     };
 }
 
-fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
+fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap: BinaryHeap<i32>) {
     if vec.last().map(|x| *x > 2).unwrap_or(false) {
         //~^ manual_pop_if
         vec.pop().unwrap();
@@ -232,6 +251,11 @@ fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
     if deque.front().map(|x| *x > 2).unwrap_or(false) {
         //~^ manual_pop_if
         deque.pop_front().unwrap();
+    }
+
+    if heap.peek().map(|x| *x > 2).unwrap_or(false) {
+        //~^ manual_pop_if
+        heap.pop().unwrap();
     }
 }
 

--- a/tests/ui/manual_pop_if.stderr
+++ b/tests/ui/manual_pop_if.stderr
@@ -1,5 +1,5 @@
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:21:5
+  --> tests/ui/manual_pop_if.rs:22:5
    |
 LL | /     if vec.last().is_some_and(|x| *x > 2) {
 LL | |
@@ -11,7 +11,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::manual_pop_if)]`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:26:5
+  --> tests/ui/manual_pop_if.rs:27:5
    |
 LL | /     if vec.last().is_some_and(|x| *x > 2) {
 LL | |
@@ -20,7 +20,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:31:5
+  --> tests/ui/manual_pop_if.rs:32:5
    |
 LL | /     if deque.back().is_some_and(|x| *x > 2) {
 LL | |
@@ -29,7 +29,7 @@ LL | |     }
    | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:36:5
+  --> tests/ui/manual_pop_if.rs:37:5
    |
 LL | /     if deque.front().is_some_and(|x| *x > 2) {
 LL | |
@@ -37,8 +37,17 @@ LL | |         deque.pop_front().unwrap();
 LL | |     }
    | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
 
+error: manual implementation of `BinaryHeap::pop_if`
+  --> tests/ui/manual_pop_if.rs:42:5
+   |
+LL | /     if heap.peek().is_some_and(|x| *x > 2) {
+LL | |
+LL | |         heap.pop().unwrap();
+LL | |     }
+   | |_____^ help: try: `heap.pop_if(|x| *x > 2);`
+
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:82:5
+  --> tests/ui/manual_pop_if.rs:88:5
    |
 LL | /     if let Some(x) = vec.last() {
 LL | |
@@ -49,7 +58,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:89:5
+  --> tests/ui/manual_pop_if.rs:95:5
    |
 LL | /     if let Some(x) = vec.last() {
 LL | |
@@ -60,7 +69,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:96:5
+  --> tests/ui/manual_pop_if.rs:102:5
    |
 LL | /     if let Some(x) = deque.back() {
 LL | |
@@ -71,7 +80,7 @@ LL | |     }
    | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:103:5
+  --> tests/ui/manual_pop_if.rs:109:5
    |
 LL | /     if let Some(x) = deque.front() {
 LL | |
@@ -81,8 +90,19 @@ LL | |         }
 LL | |     }
    | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
 
+error: manual implementation of `BinaryHeap::pop_if`
+  --> tests/ui/manual_pop_if.rs:116:5
+   |
+LL | /     if let Some(x) = heap.peek() {
+LL | |
+LL | |         if *x > 2 {
+LL | |             heap.pop().unwrap();
+LL | |         }
+LL | |     }
+   | |_____^ help: try: `heap.pop_if(|x| *x > 2);`
+
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:151:5
+  --> tests/ui/manual_pop_if.rs:164:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -92,7 +112,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:157:5
+  --> tests/ui/manual_pop_if.rs:170:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -102,7 +122,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:163:5
+  --> tests/ui/manual_pop_if.rs:176:5
    |
 LL | /     if let Some(x) = deque.back()
 LL | |         && *x > 2
@@ -112,7 +132,7 @@ LL | |     }
    | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:169:5
+  --> tests/ui/manual_pop_if.rs:182:5
    |
 LL | /     if let Some(x) = deque.front()
 LL | |         && *x > 2
@@ -121,8 +141,18 @@ LL | |         deque.pop_front().unwrap();
 LL | |     }
    | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
 
+error: manual implementation of `BinaryHeap::pop_if`
+  --> tests/ui/manual_pop_if.rs:188:5
+   |
+LL | /     if let Some(x) = heap.peek()
+LL | |         && *x > 2
+LL | |     {
+LL | |         heap.pop().unwrap();
+LL | |     }
+   | |_____^ help: try: `heap.pop_if(|x| *x > 2);`
+
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:217:5
+  --> tests/ui/manual_pop_if.rs:236:5
    |
 LL | /     if vec.last().map(|x| *x > 2).unwrap_or(false) {
 LL | |
@@ -131,7 +161,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:222:5
+  --> tests/ui/manual_pop_if.rs:241:5
    |
 LL | /     if vec.last().map(|x| *x > 2).unwrap_or(false) {
 LL | |
@@ -140,7 +170,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:227:5
+  --> tests/ui/manual_pop_if.rs:246:5
    |
 LL | /     if deque.back().map(|x| *x > 2).unwrap_or(false) {
 LL | |
@@ -149,7 +179,7 @@ LL | |     }
    | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:232:5
+  --> tests/ui/manual_pop_if.rs:251:5
    |
 LL | /     if deque.front().map(|x| *x > 2).unwrap_or(false) {
 LL | |
@@ -157,8 +187,17 @@ LL | |         deque.pop_front().unwrap();
 LL | |     }
    | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
 
+error: manual implementation of `BinaryHeap::pop_if`
+  --> tests/ui/manual_pop_if.rs:256:5
+   |
+LL | /     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
+LL | |
+LL | |         heap.pop().unwrap();
+LL | |     }
+   | |_____^ help: try: `heap.pop_if(|x| *x > 2);`
+
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:276:5
+  --> tests/ui/manual_pop_if.rs:300:5
    |
 LL | /     if vec.last().is_some_and(|e| *e == vec![1]) {
 LL | |
@@ -167,7 +206,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|e| *e == vec![1]);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:302:5
+  --> tests/ui/manual_pop_if.rs:326:5
    |
 LL | /     if vec.last().is_some_and(|x| *x > 2) {
 LL | |
@@ -176,7 +215,7 @@ LL | |     }
    | |_____^ help: try: `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:310:5
+  --> tests/ui/manual_pop_if.rs:334:5
    |
 LL | /     if deque.back().is_some_and(|x| *x > 2) {
 LL | |
@@ -185,7 +224,7 @@ LL | |     }
    | |_____^ help: try: `deque.pop_back_if(|x| *x > 2);`
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:315:5
+  --> tests/ui/manual_pop_if.rs:339:5
    |
 LL | /     if deque.front().is_some_and(|x| *x > 2) {
 LL | |
@@ -193,5 +232,5 @@ LL | |         deque.pop_front().unwrap();
 LL | |     }
    | |_____^ help: try: `deque.pop_front_if(|x| *x > 2);`
 
-error: aborting due to 20 previous errors
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
Detects manual implementations of the newly implemented [`BinaryHeap::pop_if()`](https://github.com/rust-lang/rust/issues/151828) in `manual_pop_if`.

I wasn't sure about how best to handle checking for the nightly feature. Could we let people compiling with nightly know that the feature is available even if they don't have it enabled?

changelog: [`manual_pop_if`]: detect manual implementations of `BinaryHeap::pop_if()`