### PR TITLE
Lint unnecessary `vec.extend(slice.to_vec())`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5342,6 +5342,7 @@ impl Methods {
                 (sym::extend, [arg]) => {
                     string_extend_chars::check(cx, expr, recv, arg);
                     extend_with_drain::check(cx, expr, recv, arg);
+                    unnecessary_to_owned::extend_with_to_owned::check(cx, expr, recv, arg);
                 },
                 (sym::filter, [arg]) => {
                     if let Some((sym::cloned, recv2, [], _span2, _)) = method_call(recv) {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5476,6 +5476,7 @@ impl Methods {
                 (sym::extend, [arg]) => {
                     string_extend_chars::check(cx, expr, recv, arg);
                     extend_with_drain::check(cx, expr, recv, arg);
+                    unnecessary_to_owned::extend_with_to_owned::check(cx, expr, recv, arg);
                 },
                 (sym::filter, [arg]) => {
                     if let Some((sym::cloned, recv2, [], _span2, _)) = method_call(recv) {

--- a/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -3,10 +3,10 @@ use super::unnecessary_iter_cloned::{self, is_into_iter};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
-use clippy_utils::source::{SpanRangeExt, snippet, snippet_with_context};
+use clippy_utils::source::{SpanRangeExt, snippet, snippet_with_applicability, snippet_with_context};
 use clippy_utils::ty::{get_iterator_item_ty, implements_trait, is_copy, peel_and_count_ty_refs};
 use clippy_utils::visitors::find_all_ret_expressions;
-use clippy_utils::{fn_def_id, get_parent_expr, is_expr_temporary_value, return_ty, sym};
+use clippy_utils::{eq_expr_value, fn_def_id, get_parent_expr, is_expr_temporary_value, return_ty, sym};
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
@@ -758,5 +758,45 @@ fn check_borrow_predicate<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
         && !key_ty.is_ref()
     {
         check_if_applicable_to_argument(cx, &arg);
+    }
+}
+
+pub(super) mod extend_with_to_owned {
+    use super::{
+        Applicability, Expr, ExprKind, LateContext, MaybeDef, UNNECESSARY_TO_OWNED, eq_expr_value,
+        snippet_with_applicability, span_lint_and_sugg, sym, ty,
+    };
+
+    pub fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg: &Expr<'_>) {
+        let recv_ty = cx.typeck_results().expr_ty(recv).peel_refs();
+        if !recv_ty.is_diag_item(cx, sym::Vec) {
+            return;
+        }
+
+        if let ExprKind::MethodCall(method, src_recv, [], _) = &arg.kind
+            && matches!(method.ident.name, sym::to_vec | sym::to_owned | sym::clone)
+        {
+            let src_ty = cx.typeck_results().expr_ty(src_recv);
+            let src_ty_peeled = src_ty.peel_refs();
+
+            // Check src_typ is a slice type (either &[T] or &Vec<T> which derefs to &[T])
+            let is_slice = matches!(src_ty_peeled.kind(), ty::Slice(..)) || src_ty_peeled.is_diag_item(cx, sym::Vec);
+
+            // Skip self-extend: vec.extend(vec.to_vec())
+            if is_slice && !eq_expr_value(cx, expr.span.ctxt(), recv, src_recv) {
+                let mut applicability = Applicability::MachineApplicable;
+                let recv_snip = snippet_with_applicability(cx, recv.span, "..", &mut applicability);
+                let src_snip = snippet_with_applicability(cx, src_recv.span, "..", &mut applicability);
+                span_lint_and_sugg(
+                    cx,
+                    UNNECESSARY_TO_OWNED,
+                    expr.span,
+                    "unnecessary allocation in argument to `extend`",
+                    "try",
+                    format!("{recv_snip}.extend_from_slice({src_snip})"),
+                    applicability,
+                );
+            }
+        }
     }
 }

--- a/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -2,11 +2,11 @@ use super::implicit_clone::is_clone_like;
 use super::unnecessary_iter_cloned::{self, is_into_iter};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::res::MaybeDef as _;
-use clippy_utils::source::{SpanExt as _, snippet, snippet_with_context};
+use clippy_utils::res::MaybeDef;
+use clippy_utils::source::{SpanExt as _, snippet, snippet_with_applicability, snippet_with_context};
 use clippy_utils::ty::{get_iterator_item_ty, implements_trait, is_copy, peel_and_count_ty_refs};
 use clippy_utils::visitors::find_all_ret_expressions;
-use clippy_utils::{fn_def_id, get_parent_expr, is_expr_temporary_value, return_ty, sym};
+use clippy_utils::{eq_expr_value, fn_def_id, get_parent_expr, is_expr_temporary_value, return_ty, sym};
 use rustc_errors::Applicability;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def::{DefKind, Res};
@@ -753,5 +753,45 @@ fn check_borrow_predicate<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
         && !key_ty.is_ref()
     {
         check_if_applicable_to_argument(cx, &arg);
+    }
+}
+
+pub(super) mod extend_with_to_owned {
+    use super::{
+        Applicability, Expr, ExprKind, LateContext, MaybeDef as _, UNNECESSARY_TO_OWNED, eq_expr_value,
+        snippet_with_applicability, span_lint_and_sugg, sym, ty,
+    };
+
+    pub fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg: &Expr<'_>) {
+        let recv_ty = cx.typeck_results().expr_ty(recv).peel_refs();
+        if !recv_ty.is_diag_item(cx, sym::Vec) {
+            return;
+        }
+
+        if let ExprKind::MethodCall(method, src_recv, [], _) = &arg.kind
+            && matches!(method.ident.name, sym::to_vec | sym::to_owned | sym::clone)
+        {
+            let src_ty = cx.typeck_results().expr_ty(src_recv);
+            let src_ty_peeled = src_ty.peel_refs();
+
+            // Check src_typ is a slice type (either &[T] or &Vec<T> which derefs to &[T])
+            let is_slice = matches!(src_ty_peeled.kind(), ty::Slice(..)) || src_ty_peeled.is_diag_item(cx, sym::Vec);
+
+            // Skip self-extend: vec.extend(vec.to_vec())
+            if is_slice && !eq_expr_value(cx, expr.span.ctxt(), recv, src_recv) {
+                let mut applicability = Applicability::MachineApplicable;
+                let recv_snip = snippet_with_applicability(cx, recv.span, "..", &mut applicability);
+                let src_snip = snippet_with_applicability(cx, src_recv.span, "..", &mut applicability);
+                span_lint_and_sugg(
+                    cx,
+                    UNNECESSARY_TO_OWNED,
+                    expr.span,
+                    "unnecessary allocation in argument to `extend`",
+                    "try",
+                    format!("{recv_snip}.extend_from_slice({src_snip})"),
+                    applicability,
+                );
+            }
+        }
     }
 }

--- a/tests/ui/extend_with_to_owned.fixed
+++ b/tests/ui/extend_with_to_owned.fixed
@@ -1,0 +1,24 @@
+#![warn(clippy::unnecessary_to_owned)]
+
+fn main() {
+    let slice: &[u8] = &[1, 2, 3];
+    let mut vec = vec![0u8];
+
+    // Should lint
+    vec.extend_from_slice(slice);
+    //~^ unnecessary_to_owned
+    vec.extend_from_slice(slice);
+    //~^ unnecessary_to_owned
+
+    let other_vec = vec![4, 5, 6];
+    let vec_ref: &Vec<u8> = &other_vec;
+    vec.extend_from_slice(vec_ref);
+    //~^ unnecessary_to_owned
+
+    // Should not lint
+    vec.extend(slice.iter());
+    vec.extend(other_vec);
+
+    // Should not lint: self-extend would cause borrow conflict
+    vec.extend(vec.to_vec());
+}

--- a/tests/ui/extend_with_to_owned.rs
+++ b/tests/ui/extend_with_to_owned.rs
@@ -1,0 +1,24 @@
+#![warn(clippy::unnecessary_to_owned)]
+
+fn main() {
+    let slice: &[u8] = &[1, 2, 3];
+    let mut vec = vec![0u8];
+
+    // Should lint
+    vec.extend(slice.to_vec());
+    //~^ unnecessary_to_owned
+    vec.extend(slice.to_owned());
+    //~^ unnecessary_to_owned
+
+    let other_vec = vec![4, 5, 6];
+    let vec_ref: &Vec<u8> = &other_vec;
+    vec.extend(vec_ref.clone());
+    //~^ unnecessary_to_owned
+
+    // Should not lint
+    vec.extend(slice.iter());
+    vec.extend(other_vec);
+
+    // Should not lint: self-extend would cause borrow conflict
+    vec.extend(vec.to_vec());
+}

--- a/tests/ui/extend_with_to_owned.stderr
+++ b/tests/ui/extend_with_to_owned.stderr
@@ -1,0 +1,23 @@
+error: unnecessary allocation in argument to `extend`
+  --> tests/ui/extend_with_to_owned.rs:8:5
+   |
+LL |     vec.extend(slice.to_vec());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.extend_from_slice(slice)`
+   |
+   = note: `-D clippy::unnecessary-to-owned` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_to_owned)]`
+
+error: unnecessary allocation in argument to `extend`
+  --> tests/ui/extend_with_to_owned.rs:10:5
+   |
+LL |     vec.extend(slice.to_owned());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.extend_from_slice(slice)`
+
+error: unnecessary allocation in argument to `extend`
+  --> tests/ui/extend_with_to_owned.rs:15:5
+   |
+LL |     vec.extend(vec_ref.clone());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.extend_from_slice(vec_ref)`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
  Adds a check under `unnecessary_to_owned` that catches `vec.extend(slice.to_vec())`,
  `vec.extend(slice.to_owned())`, and `vec.extend(vec_ref.clone())` where the argument is a
  needless heap allocation and suggests `vec.extend_from_slice(...)` instead...closes rust-lang/rust-clippy#16725

changelog: [`unnecessary_to_owned`]: lint unnecessary `vec.extend(slice.to_vec())`