### PR TITLE
feat: `min_ident_chars` lint short idents even if follows trait naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7720,6 +7720,7 @@ Released 2018-09-13
 [`max-struct-bools`]: https://doc.rust-lang.org/clippy/lint_configuration.html#max-struct-bools
 [`max-suggested-slice-pattern-length`]: https://doc.rust-lang.org/clippy/lint_configuration.html#max-suggested-slice-pattern-length
 [`max-trait-bounds`]: https://doc.rust-lang.org/clippy/lint_configuration.html#max-trait-bounds
+[`min-ident-chars-lint-trait-impl`]: https://doc.rust-lang.org/clippy/lint_configuration.html#min-ident-chars-lint-trait-impl
 [`min-ident-chars-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#min-ident-chars-threshold
 [`missing-docs-allow-unused`]: https://doc.rust-lang.org/clippy/lint_configuration.html#missing-docs-allow-unused
 [`missing-docs-in-crate-items`]: https://doc.rust-lang.org/clippy/lint_configuration.html#missing-docs-in-crate-items

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -863,6 +863,16 @@ The maximum number of bounds a trait can have to be linted
 * [`type_repetition_in_bounds`](https://rust-lang.github.io/rust-clippy/master/index.html#type_repetition_in_bounds)
 
 
+## `min-ident-chars-lint-trait-impl`
+Whether to lint idents that have too few chars even when following trait declaration.
+
+**Default Value:** `false`
+
+---
+**Affected lints:**
+* [`min_ident_chars`](https://rust-lang.github.io/rust-clippy/master/index.html#min_ident_chars)
+
+
 ## `min-ident-chars-threshold`
 Minimum chars an ident can have, anything below or equal to this will be linted.
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -756,6 +756,9 @@ define_Conf! {
     /// The maximum number of bounds a trait can have to be linted
     #[lints(type_repetition_in_bounds)]
     max_trait_bounds: u64 = 3,
+    /// Whether to lint idents that have too few chars even when following trait declaration.
+    #[lints(min_ident_chars)]
+    min_ident_chars_lint_trait_impl: bool = false,
     /// Minimum chars an ident can have, anything below or equal to this will be linted.
     #[lints(min_ident_chars)]
     min_ident_chars_threshold: u64 = 1,

--- a/clippy_lints/src/min_ident_chars.rs
+++ b/clippy_lints/src/min_ident_chars.rs
@@ -57,6 +57,8 @@ pub struct MinIdentChars {
     /// Impl trait functions have special rules are handled in `check_impl_item` since
     /// they have special rules. This is used to signal to `check_pat` the number of parameter
     current_fn_params_remaining: u32,
+    /// Whether to lint idents that have too few chars even when following trait declaration.
+    lint_trait_impl: bool,
 }
 
 impl MinIdentChars {
@@ -65,6 +67,7 @@ impl MinIdentChars {
             allowed_idents_below_min_chars: conf.allowed_idents_below_min_chars.iter().cloned().collect(),
             min_chars_threshold: conf.min_ident_chars_threshold,
             current_fn_params_remaining: 0,
+            lint_trait_impl: conf.min_ident_chars_lint_trait_impl,
         }
     }
 
@@ -175,30 +178,32 @@ impl LateLintPass<'_> for MinIdentChars {
         if self.min_chars_threshold == 0 {
             return;
         }
+        // For trait impls only lint if the parameter names are different from the trait's or if the
+        // `min_ident_chars_lint_trait_impl` config item is active.
         if let ImplItemImplKind::Trait {
             trait_item_def_id: Ok(trait_item),
             ..
         } = i.impl_kind
+            && let ImplItemKind::Fn(_, body) = i.kind
         {
-            // For trait impls only lint if the parameter names are different from the trait's.
-            if let ImplItemKind::Fn(_, body) = i.kind {
-                let mut named_params_count = 0;
-                for (trait_ident, param) in iter::zip(cx.tcx.fn_arg_idents(trait_item), cx.tcx.hir_body(body).params) {
-                    if let PatKind::Binding(_, _, ident, _) = param.pat.kind {
-                        named_params_count += 1;
-                        if trait_ident.is_none_or(|trait_ident| ident.name != trait_ident.name)
-                            && let Some(missing) = self.check_sym(ident.name)
-                        {
-                            self.emit_hir(cx, param.pat.hir_id, ident, missing);
-                        }
+            let mut named_params_count = 0;
+            for (trait_ident, param) in iter::zip(cx.tcx.fn_arg_idents(trait_item), cx.tcx.hir_body(body).params) {
+                if let PatKind::Binding(_, _, ident, _) = param.pat.kind {
+                    named_params_count += 1;
+                    if trait_ident.is_none_or(|trait_ident| ident.name != trait_ident.name || self.lint_trait_impl)
+                        && let Some(missing) = self.check_sym(ident.name)
+                    {
+                        self.emit_hir(cx, param.pat.hir_id, ident, missing);
                     }
                 }
-                // Signal the number of parameters to skip to `check_pat`.
-                // This needs to be added since impl items can technically appear inside
-                // both the function signature and generic predicates.
-                self.current_fn_params_remaining += named_params_count;
             }
-        } else if let Some(missing) = self.check_sym(i.ident.name)
+            // Signal the number of parameters to skip to `check_pat`.
+            // This needs to be added since impl items can technically appear inside
+            // both the function signature and generic predicates.
+            self.current_fn_params_remaining += named_params_count;
+        }
+        if (!matches!(i.impl_kind, ImplItemImplKind::Trait { .. }) || self.lint_trait_impl)
+            && let Some(missing) = self.check_sym(i.ident.name)
             && !(matches!(i.kind, ImplItemKind::Fn(..))
                 && cx.tcx.codegen_fn_attrs(i.owner_id.def_id).contains_extern_indicator())
         {

--- a/tests/ui-toml/min_ident_chars_trait_impl/clippy.toml
+++ b/tests/ui-toml/min_ident_chars_trait_impl/clippy.toml
@@ -1,0 +1,1 @@
+min-ident-chars-lint-trait-impl = true

--- a/tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.rs
+++ b/tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.rs
@@ -1,0 +1,24 @@
+#![warn(clippy::min_ident_chars)]
+
+trait ShortParams {
+    fn f(g: i32);
+    //~^ min_ident_chars
+    //~| min_ident_chars
+}
+
+struct MyStruct;
+
+impl ShortParams for MyStruct {
+    fn f(g: i32) {}
+    //~^ min_ident_chars
+    //~| min_ident_chars
+}
+
+impl core::fmt::Display for MyStruct {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        //~^ min_ident_chars
+        write!(f, "MyStruct")
+    }
+}
+
+fn main() {}

--- a/tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.stderr
+++ b/tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.stderr
@@ -1,0 +1,37 @@
+error: this identifier consists of only a single character
+  --> tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.rs:4:10
+   |
+LL |     fn f(g: i32);
+   |          ^
+   |
+   = note: `-D clippy::min-ident-chars` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::min_ident_chars)]`
+
+error: this identifier consists of only a single character
+  --> tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.rs:4:8
+   |
+LL |     fn f(g: i32);
+   |        ^
+
+error: this identifier consists of only a single character
+  --> tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.rs:12:10
+   |
+LL |     fn f(g: i32) {}
+   |          ^
+   |
+   = note: the configured threshold is 1
+
+error: this identifier consists of only a single character
+  --> tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.rs:12:8
+   |
+LL |     fn f(g: i32) {}
+   |        ^
+
+error: this identifier consists of only a single character
+  --> tests/ui-toml/min_ident_chars_trait_impl/min_ident_chars.rs:18:19
+   |
+LL |     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+   |                   ^
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -64,6 +64,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            max-struct-bools
            max-suggested-slice-pattern-length
            max-trait-bounds
+           min-ident-chars-lint-trait-impl
            min-ident-chars-threshold
            missing-docs-allow-unused
            missing-docs-in-crate-items
@@ -167,6 +168,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            max-struct-bools
            max-suggested-slice-pattern-length
            max-trait-bounds
+           min-ident-chars-lint-trait-impl
            min-ident-chars-threshold
            missing-docs-allow-unused
            missing-docs-in-crate-items
@@ -270,6 +272,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            max-struct-bools
            max-suggested-slice-pattern-length
            max-trait-bounds
+           min-ident-chars-lint-trait-impl
            min-ident-chars-threshold
            missing-docs-allow-unused
            missing-docs-in-crate-items


### PR DESCRIPTION
When implementing a trait like `core::fmt::Display`, the name of the parameter is `f` in the trait definition and thus, the `min_ident_chars` (cf. rust-lang/rust-clippy#15275). The goal of this PR is to add a new configuration item to disable this behaviour, to force the lint to fire on short identifiers even in that case.

changelog: [`min_ident_chars`]: add option to enforce lint even when following the naming from the trait

fixes rust-lang/rust-clippy#15365
