### PR TITLE
`iter_kv_map`: handle identity map for `map` and `flat_map`

### DIFF
--- a/clippy_lints/src/methods/iter_kv_map.rs
+++ b/clippy_lints/src/methods/iter_kv_map.rs
@@ -48,14 +48,20 @@ pub(super) fn check<'tcx>(
         if let ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) = body_expr.kind
             && let [local_ident] = path.segments
             && local_ident.ident.name == bound_ident.name
+            && [sym::map, sym::flat_map].contains(&method_name)
         {
+            let identity_map_equivalent = match method_name {
+                sym::map => "",
+                sym::flat_map => ".flatten()",
+                _ => unreachable!(),
+            };
             span_lint_and_sugg(
                 cx,
                 ITER_KV_MAP,
                 expr.span,
                 format!("iterating on a map's {replacement_kind}s"),
                 "try",
-                format!("{recv_snippet}.{into_prefix}{replacement_kind}s()"),
+                format!("{recv_snippet}.{into_prefix}{replacement_kind}s(){identity_map_equivalent}"),
                 applicability,
             );
         } else {

--- a/tests/ui/iter_kv_map.fixed
+++ b/tests/ui/iter_kv_map.fixed
@@ -231,3 +231,15 @@ fn issue16515() {
     hash_map.into_values().filter_map(|v| (v > 0).then_some(1));
     //~^ iter_kv_map
 }
+
+fn issue16742() {
+    let map: HashMap<u32, Vec<u32>> = HashMap::new();
+    map.values().flat_map(|v| v.iter().map(|i| *i + 1));
+    //~^ iter_kv_map
+    map.values().flatten();
+    //~^ iter_kv_map
+
+    let map: HashMap<u32, Vec<u32>> = HashMap::new();
+    map.into_values().flatten();
+    //~^ iter_kv_map
+}

--- a/tests/ui/iter_kv_map.rs
+++ b/tests/ui/iter_kv_map.rs
@@ -235,3 +235,15 @@ fn issue16515() {
     hash_map.into_iter().filter_map(|(_, v)| (v > 0).then_some(1));
     //~^ iter_kv_map
 }
+
+fn issue16742() {
+    let map: HashMap<u32, Vec<u32>> = HashMap::new();
+    map.iter().flat_map(|(_, v)| v.iter().map(|i| *i + 1));
+    //~^ iter_kv_map
+    map.iter().flat_map(|(_, v)| v);
+    //~^ iter_kv_map
+
+    let map: HashMap<u32, Vec<u32>> = HashMap::new();
+    map.into_iter().flat_map(|(_, v)| v);
+    //~^ iter_kv_map
+}

--- a/tests/ui/iter_kv_map.stderr
+++ b/tests/ui/iter_kv_map.stderr
@@ -323,5 +323,23 @@ error: iterating on a map's values
 LL |     hash_map.into_iter().filter_map(|(_, v)| (v > 0).then_some(1));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_map.into_values().filter_map(|v| (v > 0).then_some(1))`
 
-error: aborting due to 48 previous errors
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:241:5
+   |
+LL |     map.iter().flat_map(|(_, v)| v.iter().map(|i| *i + 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().flat_map(|v| v.iter().map(|i| *i + 1))`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:243:5
+   |
+LL |     map.iter().flat_map(|(_, v)| v);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().flatten()`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:247:5
+   |
+LL |     map.into_iter().flat_map(|(_, v)| v);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.into_values().flatten()`
+
+error: aborting due to 51 previous errors
 


### PR DESCRIPTION
fixes: rust-lang/rust-clippy#16742

properly select post operation for identity map according to map method kind

changelog: [`iter_kv_map`]: handle identity map for `map` and `flat_map`
