### PR TITLE
Enhance `needless_late_init` to cover grouped assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7574,6 +7574,7 @@ Released 2018-09-13
 [`avoid-breaking-exported-api`]: https://doc.rust-lang.org/clippy/lint_configuration.html#avoid-breaking-exported-api
 [`await-holding-invalid-types`]: https://doc.rust-lang.org/clippy/lint_configuration.html#await-holding-invalid-types
 [`cargo-ignore-publish`]: https://doc.rust-lang.org/clippy/lint_configuration.html#cargo-ignore-publish
+[`check-grouped-late-init`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-grouped-late-init
 [`check-incompatible-msrv-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-incompatible-msrv-in-tests
 [`check-inconsistent-struct-field-initializers`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-inconsistent-struct-field-initializers
 [`check-private-items`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-private-items

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -452,6 +452,37 @@ For internal testing only, ignores the current `publish` settings in the Cargo m
 * [`cargo_common_metadata`](https://rust-lang.github.io/rust-clippy/master/index.html#cargo_common_metadata)
 
 
+## `check-grouped-late-init`
+Whether to check for grouped late initializations from multiple `let` statements.
+
+#### Example
+```rust
+let a;
+let b;
+if true {
+    a = 1;
+    b = 2;
+} else {
+    a = 3;
+    b = 4;
+}
+```
+Use instead:
+```rust
+let (a, b) = if true {
+    (1, 2)
+} else {
+    (3, 4)
+};
+```
+
+**Default Value:** `true`
+
+---
+**Affected lints:**
+* [`needless_late_init`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init)
+
+
 ## `check-incompatible-msrv-in-tests`
 Whether to check MSRV compatibility in `#[test]` and `#[cfg(test)]` code.
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -554,6 +554,30 @@ define_Conf! {
     /// For internal testing only, ignores the current `publish` settings in the Cargo manifest.
     #[lints(cargo_common_metadata)]
     cargo_ignore_publish: bool = false,
+    /// Whether to check for grouped late initializations from multiple `let` statements.
+    ///
+    /// #### Example
+    /// ```rust
+    /// let a;
+    /// let b;
+    /// if true {
+    ///     a = 1;
+    ///     b = 2;
+    /// } else {
+    ///     a = 3;
+    ///     b = 4;
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// let (a, b) = if true {
+    ///     (1, 2)
+    /// } else {
+    ///     (3, 4)
+    /// };
+    /// ```
+    #[lints(needless_late_init)]
+    check_grouped_late_init: bool = true,
     /// Whether to check MSRV compatibility in `#[test]` and `#[cfg(test)]` code.
     #[lints(incompatible_msrv)]
     check_incompatible_msrv_in_tests: bool = false,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -731,7 +731,7 @@ rustc_lint::late_lint_methods!(
         UndocumentedUnsafeBlocks: undocumented_unsafe_blocks::UndocumentedUnsafeBlocks = undocumented_unsafe_blocks::UndocumentedUnsafeBlocks::new(conf),
         FormatArgs: format_args::FormatArgs<'tcx> = format_args::FormatArgs::new(tcx, conf, format_args.clone()),
         TrailingEmptyArray: trailing_empty_array::TrailingEmptyArray = trailing_empty_array::TrailingEmptyArray,
-        NeedlessLateInit: needless_late_init::NeedlessLateInit = needless_late_init::NeedlessLateInit,
+        NeedlessLateInit: needless_late_init::NeedlessLateInit<'tcx> = needless_late_init::NeedlessLateInit::new(conf),
         ReturnSelfNotMustUse: return_self_not_must_use::ReturnSelfNotMustUse = return_self_not_must_use::ReturnSelfNotMustUse,
         NumberedFields: init_numbered_fields::NumberedFields = init_numbered_fields::NumberedFields,
         ManualBits: manual_bits::ManualBits = manual_bits::ManualBits::new(conf),

--- a/clippy_lints/src/needless_late_init.rs
+++ b/clippy_lints/src/needless_late_init.rs
@@ -204,7 +204,7 @@ fn assignment_suggestions<'tcx>(
 }
 
 struct Usage<'tcx> {
-    stmt: &'tcx Stmt<'tcx>,
+    span: Span,
     expr: &'tcx Expr<'tcx>,
     needs_semi: bool,
 }
@@ -226,16 +226,26 @@ fn first_usage<'tcx>(
         .find(|&stmt| is_local_used(cx, stmt, binding_id))
         .and_then(|stmt| match stmt.kind {
             StmtKind::Expr(expr) => Some(Usage {
-                stmt,
+                span: stmt.span,
                 expr,
                 needs_semi: true,
             }),
             StmtKind::Semi(expr) => Some(Usage {
-                stmt,
+                span: stmt.span,
                 expr,
                 needs_semi: false,
             }),
             _ => None,
+        })
+        .or_else(|| {
+            block
+                .expr
+                .filter(|expr| is_local_used(cx, *expr, binding_id))
+                .map(|expr| Usage {
+                    span: expr.span,
+                    expr,
+                    needs_semi: true,
+                })
         })
 }
 
@@ -300,10 +310,10 @@ fn check<'tcx>(
                 "unneeded late initialization",
                 |diag| {
                     suggestions.push((local_stmt.span, String::new()));
-                    suggestions.push((usage.stmt.span.shrink_to_lo(), format!("{let_snippet} = ")));
+                    suggestions.push((usage.span.shrink_to_lo(), format!("{let_snippet} = ")));
 
                     if usage.needs_semi {
-                        suggestions.push((usage.stmt.span.shrink_to_hi(), ";".to_owned()));
+                        suggestions.push((usage.span.shrink_to_hi(), ";".to_owned()));
                     }
 
                     diag.multipart_suggestion(
@@ -327,10 +337,10 @@ fn check<'tcx>(
                 "unneeded late initialization",
                 |diag| {
                     suggestions.push((local_stmt.span, String::new()));
-                    suggestions.push((usage.stmt.span.shrink_to_lo(), format!("{let_snippet} = ")));
+                    suggestions.push((usage.span.shrink_to_lo(), format!("{let_snippet} = ")));
 
                     if usage.needs_semi {
-                        suggestions.push((usage.stmt.span.shrink_to_hi(), ";".to_owned()));
+                        suggestions.push((usage.span.shrink_to_hi(), ";".to_owned()));
                     }
 
                     diag.multipart_suggestion(

--- a/clippy_lints/src/needless_late_init.rs
+++ b/clippy_lints/src/needless_late_init.rs
@@ -1,16 +1,19 @@
+use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::MaybeResPath;
-use clippy_utils::source::{SourceText, SpanExt, snippet};
+use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::needs_ordered_drop;
 use clippy_utils::visitors::{for_each_expr, for_each_expr_without_closures, is_local_used};
 use core::ops::ControlFlow;
 use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::{
-    BindingMode, Block, Expr, ExprKind, HirId, LetStmt, LocalSource, MatchSource, Node, Pat, PatKind, Stmt, StmtKind,
+    BindingMode, Block, Expr, ExprKind, HirId, HirIdMap, HirIdSet, LetStmt, LocalSource, MatchSource, Node, Pat,
+    PatKind, Stmt, StmtKind,
 };
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_session::declare_lint_pass;
+use rustc_session::impl_lint_pass;
 use rustc_span::Span;
+use std::borrow::Cow;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -61,17 +64,126 @@ declare_clippy_lint! {
     "late initializations that can be replaced by a `let` statement with an initializer"
 }
 
-declare_lint_pass!(NeedlessLateInit => [NEEDLESS_LATE_INIT]);
+impl_lint_pass!(NeedlessLateInit<'_> => [NEEDLESS_LATE_INIT]);
 
-fn contains_assign_expr<'tcx>(cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'tcx>) -> bool {
-    for_each_expr(cx.tcx, stmt, |e| {
-        if matches!(e.kind, ExprKind::Assign(..)) {
-            ControlFlow::Break(())
-        } else {
-            ControlFlow::Continue(())
+pub struct NeedlessLateInit<'tcx> {
+    check_grouped_late_init: bool,
+    grouped_late_inits: Vec<(HirId, HirIdMap<GroupedLateInit<'tcx>>)>,
+}
+
+impl<'tcx> NeedlessLateInit<'tcx> {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self {
+            check_grouped_late_init: conf.check_grouped_late_init,
+            grouped_late_inits: Vec::default(),
         }
-    })
-    .is_some()
+    }
+
+    fn check_if_or_match(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        local_stmt: &'tcx LetStmt<'tcx>,
+        block: &'tcx Block<'tcx>,
+        binding_id: HirId,
+        usage: Usage<'tcx>,
+        exprs: impl IntoIterator<Item = &'tcx Expr<'tcx>>,
+    ) {
+        let mut assigns: Vec<LocalAssignGroup<'tcx>> = Vec::new();
+        for expr in exprs {
+            let ty = cx.typeck_results().expr_ty(expr);
+            if ty.is_never() {
+                continue;
+            }
+            if !ty.is_unit() {
+                return;
+            }
+
+            let Some(assign_group) = LocalAssignGroup::new(cx, expr) else {
+                return;
+            };
+
+            if let Some(last_group) = assigns.last()
+                && !assign_group.is_parallel(last_group)
+            {
+                return;
+            }
+
+            assigns.push(assign_group);
+        }
+
+        let Some(first_group) = assigns.first() else {
+            return;
+        };
+        // If there are multiple assignments grouped together, lazyly check them after processing the block.
+        if first_group.0.len() > 1 {
+            if self.check_grouped_late_init {
+                let late_inits = if let Some((hir_id, late_inits)) = self.grouped_late_inits.last_mut()
+                    && *hir_id == block.hir_id
+                {
+                    late_inits
+                } else {
+                    &mut self.grouped_late_inits.push_mut((block.hir_id, HirIdMap::default())).1
+                };
+
+                let mut decls = HirIdMap::default();
+                decls.insert(binding_id, local_stmt);
+                late_inits.insert(usage.expr.hir_id, GroupedLateInit { usage, assigns, decls });
+            }
+
+            return;
+        }
+
+        if first_group.0[0].lhs_id == binding_id {
+            span_lint_and_then(
+                cx,
+                NEEDLESS_LATE_INIT,
+                local_stmt.span,
+                "unneeded late initialization",
+                |diag| {
+                    let mut suggestions = vec![];
+                    for group in assigns {
+                        suggestions.extend(
+                            group
+                                .0
+                                .iter()
+                                .flat_map(|assign| {
+                                    let rhs_span = assign.rhs.span.source_callsite();
+                                    let mut spans = vec![assign.span.until(rhs_span)];
+
+                                    if rhs_span.hi() != assign.span.hi() {
+                                        spans.push(rhs_span.shrink_to_hi().with_hi(assign.span.hi()));
+                                    }
+
+                                    spans
+                                })
+                                .map(|span| (span, String::new())),
+                        );
+                    }
+
+                    suggestions.push((local_stmt.span, String::new()));
+                    let mut applicability = Applicability::MachineApplicable;
+                    let let_snippet = local_snippet_without_semicolon(cx, local_stmt, &mut applicability);
+                    suggestions.push((usage.span.shrink_to_lo(), format!("{let_snippet} = ")));
+                    if usage.needs_semi {
+                        suggestions.push((usage.span.shrink_to_hi(), ";".to_owned()));
+                    }
+                    let binding_name = cx.tcx.hir_name(binding_id);
+                    let descriptor = if matches!(usage.expr.kind, ExprKind::If(..)) {
+                        "branches"
+                    } else {
+                        "`match` arms"
+                    };
+                    diag.multipart_suggestion(
+                    format!(
+                        "move the declaration `{binding_name}` here and remove the assignments from the {descriptor}",
+                    ),
+                    suggestions,
+                    applicability,
+                );
+                },
+            );
+        }
+    }
 }
 
 fn contains_let(cond: &Expr<'_>) -> bool {
@@ -99,110 +211,33 @@ fn stmt_needs_ordered_drop(cx: &LateContext<'_>, stmt: &Stmt<'_>) -> bool {
 }
 
 #[derive(Debug)]
-struct LocalAssign {
+struct LocalAssign<'tcx> {
     lhs_id: HirId,
-    rhs_span: Span,
+    rhs: &'tcx Expr<'tcx>,
     span: Span,
 }
 
-impl LocalAssign {
-    fn from_expr(expr: &Expr<'_>, span: Span) -> Option<Self> {
+impl<'tcx> LocalAssign<'tcx> {
+    fn new(expr: &'tcx Expr<'tcx>, span: Span) -> Option<Self> {
         if expr.span.from_expansion() {
             return None;
         }
 
-        if let ExprKind::Assign(lhs, rhs, _) = expr.kind {
-            if lhs.span.from_expansion() {
-                return None;
-            }
-
-            Some(Self {
+        if let ExprKind::Assign(lhs, rhs, _) = expr.kind
+            && !lhs.span.from_expansion()
+        {
+            return Some(Self {
                 lhs_id: lhs.res_local_id()?,
-                rhs_span: rhs.span.source_callsite(),
+                rhs,
                 span,
-            })
-        } else {
-            None
+            });
         }
-    }
 
-    fn new<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, binding_id: HirId) -> Option<LocalAssign> {
-        let assign = match expr.kind {
-            ExprKind::Block(Block { expr: Some(expr), .. }, _) => Self::from_expr(expr, expr.span),
-            ExprKind::Block(block, _) => {
-                if let Some((last, other_stmts)) = block.stmts.split_last()
-                    && let StmtKind::Expr(expr) | StmtKind::Semi(expr) = last.kind
-
-                    && let assign = Self::from_expr(expr, last.span)?
-
-                    // avoid visiting if not needed
-                    && assign.lhs_id == binding_id
-                    && other_stmts.iter().all(|stmt| !contains_assign_expr(cx, stmt))
-                {
-                    Some(assign)
-                } else {
-                    None
-                }
-            },
-            ExprKind::Assign(..) => Self::from_expr(expr, expr.span),
-            _ => None,
-        }?;
-
-        if assign.lhs_id == binding_id {
-            Some(assign)
-        } else {
-            None
-        }
+        None
     }
 }
 
-fn assignment_suggestions<'tcx>(
-    cx: &LateContext<'tcx>,
-    binding_id: HirId,
-    exprs: impl IntoIterator<Item = &'tcx Expr<'tcx>>,
-) -> Option<(Applicability, Vec<(Span, String)>)> {
-    let mut assignments = Vec::new();
-
-    for expr in exprs {
-        let ty = cx.typeck_results().expr_ty(expr);
-
-        if ty.is_never() {
-            continue;
-        }
-        if !ty.is_unit() {
-            return None;
-        }
-
-        let assign = LocalAssign::new(cx, expr, binding_id)?;
-
-        assignments.push(assign);
-    }
-
-    let suggestions = assignments
-        .iter()
-        .flat_map(|assignment| {
-            let mut spans = vec![assignment.span.until(assignment.rhs_span)];
-
-            if assignment.rhs_span.hi() != assignment.span.hi() {
-                spans.push(assignment.rhs_span.shrink_to_hi().with_hi(assignment.span.hi()));
-            }
-
-            spans
-        })
-        .map(|span| (span, String::new()))
-        .collect::<Vec<(Span, String)>>();
-
-    match suggestions.len() {
-        // All of `exprs` are never types
-        // https://github.com/rust-lang/rust-clippy/issues/8911
-        0 => None,
-        1 => Some((Applicability::MachineApplicable, suggestions)),
-        // multiple suggestions don't work with rustfix in multipart_suggest
-        // https://github.com/rust-lang/rustfix/issues/141
-        _ => Some((Applicability::Unspecified, suggestions)),
-    }
-}
-
+#[derive(Debug)]
 struct Usage<'tcx> {
     span: Span,
     expr: &'tcx Expr<'tcx>,
@@ -249,7 +284,11 @@ fn first_usage<'tcx>(
         })
 }
 
-fn local_snippet_without_semicolon(cx: &LateContext<'_>, local: &LetStmt<'_>) -> Option<SourceText> {
+fn local_snippet_without_semicolon<'a>(
+    cx: &LateContext<'_>,
+    local: &LetStmt<'_>,
+    applicability: &mut Applicability,
+) -> Cow<'a, str> {
     let span = local.span.with_hi(match local.ty {
         // let <pat>: <ty>;
         // ~~~~~~~~~~~~~~~
@@ -259,105 +298,70 @@ fn local_snippet_without_semicolon(cx: &LateContext<'_>, local: &LetStmt<'_>) ->
         None => local.pat.span.hi(),
     });
 
-    span.get_text(cx)
+    snippet_with_applicability(cx, span, "..", applicability)
 }
 
-fn check<'tcx>(
-    cx: &LateContext<'tcx>,
-    local: &'tcx LetStmt<'tcx>,
-    local_stmt: &'tcx Stmt<'tcx>,
-    block: &'tcx Block<'tcx>,
-    binding_id: HirId,
-) -> Option<()> {
-    let usage = first_usage(cx, binding_id, local_stmt.hir_id, block)?;
-    let binding_name = cx.tcx.hir_opt_name(binding_id)?;
-    let let_snippet = local_snippet_without_semicolon(cx, local)?;
+#[derive(Debug)]
+struct LocalAssignGroup<'tcx>(Vec<LocalAssign<'tcx>>);
 
-    match usage.expr.kind {
-        ExprKind::Assign(..) => {
-            let assign = LocalAssign::new(cx, usage.expr, binding_id)?;
-            let mut msg_span = MultiSpan::from_spans(vec![local_stmt.span, assign.span]);
-            msg_span.push_span_label(local_stmt.span, "created here");
-            msg_span.push_span_label(assign.span, "initialised here");
-
-            span_lint_and_then(
-                cx,
-                NEEDLESS_LATE_INIT,
-                msg_span,
-                "unneeded late initialization",
-                |diag| {
-                    diag.multipart_suggestion(
-                        format!("move the declaration `{binding_name}` here"),
-                        vec![
-                            (local_stmt.span, String::new()),
-                            (
-                                assign.span,
-                                let_snippet.to_owned() + " = " + &snippet(cx, assign.rhs_span, ".."),
-                            ),
-                        ],
-                        Applicability::MachineApplicable,
-                    );
-                },
-            );
-        },
-        ExprKind::If(cond, then_expr, Some(else_expr)) if !contains_let(cond) => {
-            let (applicability, mut suggestions) = assignment_suggestions(cx, binding_id, [then_expr, else_expr])?;
-
-            span_lint_and_then(
-                cx,
-                NEEDLESS_LATE_INIT,
-                local_stmt.span,
-                "unneeded late initialization",
-                |diag| {
-                    suggestions.push((local_stmt.span, String::new()));
-                    suggestions.push((usage.span.shrink_to_lo(), format!("{let_snippet} = ")));
-
-                    if usage.needs_semi {
-                        suggestions.push((usage.span.shrink_to_hi(), ";".to_owned()));
+impl<'tcx> LocalAssignGroup<'tcx> {
+    fn new(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> Option<Self> {
+        match expr.kind {
+            ExprKind::Block(Block { expr: Some(expr), .. }, _)
+                if let Some(assign) = LocalAssign::new(expr, expr.span) =>
+            {
+                Some(LocalAssignGroup(vec![assign]))
+            },
+            ExprKind::Block(Block { expr: None, stmts, .. }, _) => {
+                let mut assign_group = Vec::new();
+                // Avoid cases when the assignee is used or reassigned in the subsequent assignments
+                let mut used_locals = HirIdSet::default();
+                for stmt in stmts.iter().rev() {
+                    if let StmtKind::Semi(expr) | StmtKind::Expr(expr) = stmt.kind
+                        && let Some(assign) = LocalAssign::new(expr, stmt.span)
+                        && !used_locals.contains(&assign.lhs_id)
+                    {
+                        used_locals.insert(assign.lhs_id);
+                        for_each_expr(cx.tcx, assign.rhs, |e| {
+                            if let Some(id) = e.res_local_id() {
+                                used_locals.insert(id);
+                            }
+                            ControlFlow::<()>::Continue(())
+                        });
+                        assign_group.push(assign);
+                        continue;
                     }
 
-                    diag.multipart_suggestion(
-                        format!(
-                            "move the declaration `{binding_name}` here and remove the assignments from the branches"
-                        ),
-                        suggestions,
-                        applicability,
-                    );
-                },
-            );
-        },
-        ExprKind::Match(_, arms, MatchSource::Normal) => {
-            let (applicability, mut suggestions) =
-                assignment_suggestions(cx, binding_id, arms.iter().map(|arm| arm.body))?;
-
-            span_lint_and_then(
-                cx,
-                NEEDLESS_LATE_INIT,
-                local_stmt.span,
-                "unneeded late initialization",
-                |diag| {
-                    suggestions.push((local_stmt.span, String::new()));
-                    suggestions.push((usage.span.shrink_to_lo(), format!("{let_snippet} = ")));
-
-                    if usage.needs_semi {
-                        suggestions.push((usage.span.shrink_to_hi(), ";".to_owned()));
-                    }
-
-                    diag.multipart_suggestion(
-                        format!("move the declaration `{binding_name}` here and remove the assignments from the `match` arms"),
-                        suggestions,
-                        applicability,
-                    );
-                },
-            );
-        },
-        _ => {},
+                    break;
+                }
+                if assign_group.is_empty() {
+                    None
+                } else {
+                    Some(LocalAssignGroup(assign_group))
+                }
+            },
+            ExprKind::Assign(..) if let Some(assign) = LocalAssign::new(expr, expr.span) => {
+                Some(LocalAssignGroup(vec![assign]))
+            },
+            _ => None,
+        }
     }
 
-    Some(())
+    /// Checks if the assignments in `self` and `other` are parallel, i.e. they have the same number
+    /// of assignments and the same assignees in the same order.
+    fn is_parallel(&self, other: &Self) -> bool {
+        self.0.len() == other.0.len() && self.0.iter().zip(other.0.iter()).all(|(a, b)| a.lhs_id == b.lhs_id)
+    }
 }
 
-impl<'tcx> LateLintPass<'tcx> for NeedlessLateInit {
+#[derive(Debug)]
+struct GroupedLateInit<'tcx> {
+    usage: Usage<'tcx>,
+    assigns: Vec<LocalAssignGroup<'tcx>>,
+    decls: HirIdMap<&'tcx LetStmt<'tcx>>,
+}
+
+impl<'tcx> LateLintPass<'tcx> for NeedlessLateInit<'tcx> {
     fn check_local(&mut self, cx: &LateContext<'tcx>, local: &'tcx LetStmt<'tcx>) {
         let mut parents = cx.tcx.hir_parent_iter(local.hir_id);
         if let LetStmt {
@@ -372,8 +376,147 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessLateInit {
         } = local
             && let Some((_, Node::Stmt(local_stmt))) = parents.next()
             && let Some((_, Node::Block(block))) = parents.next()
+            && let Some(usage) = first_usage(cx, *binding_id, local_stmt.hir_id, block)
         {
-            check(cx, local, local_stmt, block, *binding_id);
+            if self.check_grouped_late_init
+                && let Some((hir_id, late_inits)) = self.grouped_late_inits.last_mut()
+                && *hir_id == block.hir_id
+                && let Some(late_init) = late_inits.get_mut(&usage.expr.hir_id)
+            {
+                late_init.decls.insert(*binding_id, local);
+                return;
+            }
+
+            match usage.expr.kind {
+                ExprKind::Assign(..)
+                    if let Some(assign) = LocalAssign::new(usage.expr, usage.expr.span)
+                        && assign.lhs_id == *binding_id =>
+                {
+                    let mut applicability = Applicability::MachineApplicable;
+                    let let_snippet = local_snippet_without_semicolon(cx, local, &mut applicability);
+                    let binding_name = cx.tcx.hir_name(*binding_id);
+                    let mut msg_span = MultiSpan::from_spans(vec![local_stmt.span, assign.span]);
+                    msg_span.push_span_label(local_stmt.span, "created here");
+                    msg_span.push_span_label(assign.span, "initialised here");
+
+                    span_lint_and_then(
+                        cx,
+                        NEEDLESS_LATE_INIT,
+                        msg_span,
+                        "unneeded late initialization",
+                        |diag| {
+                            let mut applicability = Applicability::MachineApplicable;
+                            let rhs_snippet = snippet_with_applicability(
+                                cx,
+                                assign.rhs.span.source_callsite(),
+                                "..",
+                                &mut applicability,
+                            );
+                            diag.multipart_suggestion(
+                                format!("move the declaration `{binding_name}` here"),
+                                vec![
+                                    (local_stmt.span, String::new()),
+                                    (assign.span, format!("{let_snippet} = {rhs_snippet}")),
+                                ],
+                                applicability,
+                            );
+                        },
+                    );
+                },
+                ExprKind::If(cond, then_expr, Some(mut else_expr)) if !contains_let(cond) => {
+                    // Flatten multiple if branches
+                    let mut exprs = vec![then_expr];
+                    while let ExprKind::If(cond, then, Some(else_)) = else_expr.kind {
+                        if contains_let(cond) {
+                            return;
+                        }
+                        exprs.push(then);
+                        else_expr = else_;
+                    }
+                    exprs.push(else_expr);
+                    self.check_if_or_match(cx, local, block, *binding_id, usage, exprs);
+                },
+                ExprKind::Match(_, arms, MatchSource::Normal) => {
+                    self.check_if_or_match(cx, local, block, *binding_id, usage, arms.iter().map(|arm| arm.body));
+                },
+                _ => {},
+            }
+        }
+    }
+
+    fn check_block_post(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        if self.check_grouped_late_init
+            && let Some((_, late_inits)) = self.grouped_late_inits.pop_if(|(hir_id, _)| *hir_id == block.hir_id)
+        {
+            'outer: for (_, late_init) in late_inits {
+                if late_init.decls.len() < late_init.assigns[0].0.len() {
+                    continue;
+                }
+
+                let mut suggestions = vec![];
+                for assign in &late_init.assigns[0].0 {
+                    if let Some(local) = late_init.decls.get(&assign.lhs_id)
+                    // If the local has a type annotation, skip it since removing the annotation might cause type
+                    // inference issues while annotating the tuple makes the suggestion harder to read.
+                    && local.ty.is_none()
+                    {
+                        suggestions.push((local.span, String::new()));
+                    } else {
+                        continue 'outer;
+                    }
+                }
+
+                span_lint_and_then(
+                    cx,
+                    NEEDLESS_LATE_INIT,
+                    late_init.usage.span,
+                    "unneeded late initialization",
+                    |diag| {
+                        let mut applicability = Applicability::MachineApplicable;
+                        for group in &late_init.assigns {
+                            let rhs_snippet = group
+                                .0
+                                .iter()
+                                .rev()
+                                .map(|assign| {
+                                    snippet_with_applicability(
+                                        cx,
+                                        assign.rhs.span.source_callsite(),
+                                        "..",
+                                        &mut applicability,
+                                    )
+                                })
+                                .intersperse(", ".into())
+                                .collect::<String>();
+                            suggestions.push((
+                                group.0.last().unwrap().span.to(group.0[0].span),
+                                format!("({rhs_snippet})"),
+                            ));
+                        }
+                        let let_snippet = late_init.assigns[0]
+                            .0
+                            .iter()
+                            .rev()
+                            .map(|assign| cx.tcx.hir_name(assign.lhs_id).to_string())
+                            .intersperse(", ".to_owned())
+                            .collect::<String>();
+                        suggestions.push((late_init.usage.span.shrink_to_lo(), format!("let ({let_snippet}) = ")));
+                        if late_init.usage.needs_semi {
+                            suggestions.push((late_init.usage.span.shrink_to_hi(), ";".to_owned()));
+                        }
+                        let descriptor = if matches!(late_init.usage.expr.kind, ExprKind::If(..)) {
+                            "branches"
+                        } else {
+                            "`match` arms"
+                        };
+                        diag.multipart_suggestion(
+                            format!("move the declarations here and remove the assignments from the {descriptor}"),
+                            suggestions,
+                            applicability,
+                        );
+                    },
+                );
+            }
         }
     }
 }

--- a/tests/ui-toml/needless_late_init/clippy.toml
+++ b/tests/ui-toml/needless_late_init/clippy.toml
@@ -1,0 +1,1 @@
+check-grouped-late-init = false

--- a/tests/ui-toml/needless_late_init/needless_late_init.rs
+++ b/tests/ui-toml/needless_late_init/needless_late_init.rs
@@ -1,0 +1,64 @@
+//@check-pass
+
+fn main() {}
+
+fn issue16330() {
+    let a;
+    let b;
+    if true {
+        a = 1;
+        b = 2;
+    } else {
+        a = 3;
+        b = 4;
+    }
+
+    let a;
+    let mut b = 1;
+    let c;
+    if true {
+        b = 1;
+        a = 2;
+        c = 3;
+    } else {
+        b = 6;
+        a = 4;
+        c = 5;
+    }
+
+    let b;
+    {
+        let a;
+        let c;
+        if true {
+            b = 1;
+            a = 2;
+            c = 3;
+        } else {
+            b = 6;
+            a = 4;
+            c = 5;
+        }
+    }
+
+    let a;
+    let b;
+    let c;
+    match 1 {
+        1 => {
+            a = 1;
+            b = 2;
+            c = 3;
+        },
+        _ if false => {
+            a = 4;
+            b = 5;
+            c = 6;
+        },
+        _ => {
+            a = 7;
+            b = 8;
+            c = 9;
+        },
+    }
+}

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -33,6 +33,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            avoid-breaking-exported-api
            await-holding-invalid-types
            cargo-ignore-publish
+           check-grouped-late-init
            check-incompatible-msrv-in-tests
            check-inconsistent-struct-field-initializers
            check-private-items
@@ -134,6 +135,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            avoid-breaking-exported-api
            await-holding-invalid-types
            cargo-ignore-publish
+           check-grouped-late-init
            check-incompatible-msrv-in-tests
            check-inconsistent-struct-field-initializers
            check-private-items
@@ -235,6 +237,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            avoid-breaking-exported-api
            await-holding-invalid-types
            cargo-ignore-publish
+           check-grouped-late-init
            check-incompatible-msrv-in-tests
            check-inconsistent-struct-field-initializers
            check-private-items

--- a/tests/ui/manual_abs_diff.fixed
+++ b/tests/ui/manual_abs_diff.fixed
@@ -51,6 +51,7 @@ fn main() {
 }
 
 // FIXME: bunch of patterns that should be linted
+#[expect(clippy::needless_late_init)]
 fn fixme() {
     let a: usize = 5;
     let b: usize = 3;

--- a/tests/ui/manual_abs_diff.rs
+++ b/tests/ui/manual_abs_diff.rs
@@ -61,6 +61,7 @@ fn main() {
 }
 
 // FIXME: bunch of patterns that should be linted
+#[expect(clippy::needless_late_init)]
 fn fixme() {
     let a: usize = 5;
     let b: usize = 3;

--- a/tests/ui/manual_abs_diff.stderr
+++ b/tests/ui/manual_abs_diff.stderr
@@ -80,7 +80,7 @@ LL |     let _ = if a > b { (a - b) as u32 } else { (b - a) as u32 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with `abs_diff`: `a.abs_diff(b)`
 
 error: manual absolute difference pattern without using `abs_diff`
-  --> tests/ui/manual_abs_diff.rs:119:5
+  --> tests/ui/manual_abs_diff.rs:120:5
    |
 LL | /     if a < b {
 LL | |

--- a/tests/ui/needless_late_init.fixed
+++ b/tests/ui/needless_late_init.fixed
@@ -299,3 +299,13 @@ fn issue9895() {
     //~^ needless_late_init
     let r = 5;
 }
+
+fn if_or_match_in_block_expr() {
+    
+    //~^ needless_late_init
+    let z = if true {
+        1
+    } else {
+        2
+    };
+}

--- a/tests/ui/needless_late_init.fixed
+++ b/tests/ui/needless_late_init.fixed
@@ -185,25 +185,24 @@ fn does_not_lint() {
     };
 
     // using tuples would be possible, but not always preferable
-    let x;
-    let y;
-    if true {
-        x = 1;
-        y = 2;
+    
+    
+    let (x, y) = if true {
+        //~^ needless_late_init
+        (1, 2)
     } else {
-        x = 3;
-        y = 4;
-    }
+        (3, 4)
+    };
 
-    // could match with a smarter heuristic to avoid multiple assignments
-    let x;
-    if true {
+    
+    //~^ needless_late_init
+    let x = if true {
         let mut y = 5;
         y = 6;
-        x = y;
+        y
     } else {
-        x = 2;
-    }
+        2
+    };
 
     let (x, y);
     if true {
@@ -307,5 +306,159 @@ fn if_or_match_in_block_expr() {
         1
     } else {
         2
+    };
+}
+
+fn issue16330() {
+    // Late init in both if branches, should lint
+    
+    
+    let (a, b) = if true {
+        //~^ needless_late_init
+        (1, 2)
+    } else {
+        (3, 4)
+    };
+
+    // One of the variables is not late init, should not lint
+    let a;
+    let mut b = 1;
+    let c;
+    if true {
+        b = 1;
+        a = 2;
+        c = 3;
+    } else {
+        b = 6;
+        a = 4;
+        c = 5;
+    }
+
+    // One of the variables is defined outside the block, should not lint
+    let b;
+    {
+        let a;
+        let c;
+        if true {
+            b = 1;
+            a = 2;
+            c = 3;
+        } else {
+            b = 6;
+            a = 4;
+            c = 5;
+        }
+    }
+
+    // Late init in all match arms, should lint
+    
+    
+    
+    let (a, b, c) = match 1 {
+        //~^ needless_late_init
+        1 => {
+            (1, 2, 3)
+        },
+        _ if false => {
+            (4, 5, 6)
+        },
+        _ => {
+            (7, 8, 9)
+        },
+    };
+
+    // Late init in all if branches, should lint
+    
+    
+    
+    let (a, b, c) = if true {
+        //~^ needless_late_init
+        (1, 2, 3)
+    } else if false {
+        (4, 5, 6)
+    } else {
+        (7, 8, 9)
+    };
+
+    // One of the variables is not assigned in all branches, should not lint
+    let a;
+    let b;
+    let c;
+    if true {
+        a = 1;
+        b = 2;
+        c = 3;
+    } else if false {
+        a = 4;
+        c = 6;
+    } else {
+        a = 7;
+        b = 8;
+        c = 9;
+    }
+
+    // One of the variables is assigned multiple times, should not lint
+    let mut a;
+    let b;
+    if true {
+        a = 1;
+        b = 2;
+        a = 3;
+    } else {
+        a = 4;
+        b = 5;
+    }
+
+    // One of the variables is assigned in a nested block, should not lint
+    let a;
+    let b;
+    if true {
+        a = 1;
+        b = 2;
+    } else {
+        a = 4;
+        {
+            b = 5;
+        }
+    }
+
+    // The order of the variables is different in different branches, should not lint
+    let a;
+    let b;
+    if true {
+        a = 1;
+        b = 2;
+    } else {
+        b = 5;
+        a = 4;
+    }
+
+    // Later assignments depend on the earlier ones, should only lint the last ones
+    let a;
+    let b;
+    
+    //~^ needless_late_init
+    let c = if true {
+        a = 1;
+        b = a + 1;
+        b + 1
+    } else {
+        a = 4;
+        b = a + 2;
+        b + 2
+    };
+    let a;
+    let b;
+    
+    
+    let (c, d) = if true {
+        //~^ needless_late_init
+        a = 1;
+        b = a + 1;
+        (b + 1, 1)
+    } else {
+        a = 4;
+        b = a + 2;
+        (b + 2, 2)
     };
 }

--- a/tests/ui/needless_late_init.rs
+++ b/tests/ui/needless_late_init.rs
@@ -299,3 +299,13 @@ fn issue9895() {
     //~^ needless_late_init
     (r = 5);
 }
+
+fn if_or_match_in_block_expr() {
+    let z;
+    //~^ needless_late_init
+    if true {
+        z = 1;
+    } else {
+        z = 2;
+    }
+}

--- a/tests/ui/needless_late_init.rs
+++ b/tests/ui/needless_late_init.rs
@@ -188,6 +188,7 @@ fn does_not_lint() {
     let x;
     let y;
     if true {
+        //~^ needless_late_init
         x = 1;
         y = 2;
     } else {
@@ -195,8 +196,8 @@ fn does_not_lint() {
         y = 4;
     }
 
-    // could match with a smarter heuristic to avoid multiple assignments
     let x;
+    //~^ needless_late_init
     if true {
         let mut y = 5;
         y = 6;
@@ -307,5 +308,175 @@ fn if_or_match_in_block_expr() {
         z = 1;
     } else {
         z = 2;
+    }
+}
+
+fn issue16330() {
+    // Late init in both if branches, should lint
+    let a;
+    let b;
+    if true {
+        //~^ needless_late_init
+        a = 1;
+        b = 2;
+    } else {
+        a = 3;
+        b = 4;
+    }
+
+    // One of the variables is not late init, should not lint
+    let a;
+    let mut b = 1;
+    let c;
+    if true {
+        b = 1;
+        a = 2;
+        c = 3;
+    } else {
+        b = 6;
+        a = 4;
+        c = 5;
+    }
+
+    // One of the variables is defined outside the block, should not lint
+    let b;
+    {
+        let a;
+        let c;
+        if true {
+            b = 1;
+            a = 2;
+            c = 3;
+        } else {
+            b = 6;
+            a = 4;
+            c = 5;
+        }
+    }
+
+    // Late init in all match arms, should lint
+    let a;
+    let b;
+    let c;
+    match 1 {
+        //~^ needless_late_init
+        1 => {
+            a = 1;
+            b = 2;
+            c = 3;
+        },
+        _ if false => {
+            a = 4;
+            b = 5;
+            c = 6;
+        },
+        _ => {
+            a = 7;
+            b = 8;
+            c = 9;
+        },
+    }
+
+    // Late init in all if branches, should lint
+    let a;
+    let b;
+    let c;
+    if true {
+        //~^ needless_late_init
+        a = 1;
+        b = 2;
+        c = 3;
+    } else if false {
+        a = 4;
+        b = 5;
+        c = 6;
+    } else {
+        a = 7;
+        b = 8;
+        c = 9;
+    }
+
+    // One of the variables is not assigned in all branches, should not lint
+    let a;
+    let b;
+    let c;
+    if true {
+        a = 1;
+        b = 2;
+        c = 3;
+    } else if false {
+        a = 4;
+        c = 6;
+    } else {
+        a = 7;
+        b = 8;
+        c = 9;
+    }
+
+    // One of the variables is assigned multiple times, should not lint
+    let mut a;
+    let b;
+    if true {
+        a = 1;
+        b = 2;
+        a = 3;
+    } else {
+        a = 4;
+        b = 5;
+    }
+
+    // One of the variables is assigned in a nested block, should not lint
+    let a;
+    let b;
+    if true {
+        a = 1;
+        b = 2;
+    } else {
+        a = 4;
+        {
+            b = 5;
+        }
+    }
+
+    // The order of the variables is different in different branches, should not lint
+    let a;
+    let b;
+    if true {
+        a = 1;
+        b = 2;
+    } else {
+        b = 5;
+        a = 4;
+    }
+
+    // Later assignments depend on the earlier ones, should only lint the last ones
+    let a;
+    let b;
+    let c;
+    //~^ needless_late_init
+    if true {
+        a = 1;
+        b = a + 1;
+        c = b + 1;
+    } else {
+        a = 4;
+        b = a + 2;
+        c = b + 2;
+    }
+    let a;
+    let b;
+    let c;
+    let d;
+    if true {
+        //~^ needless_late_init
+        a = 1;
+        b = a + 1;
+        c = b + 1;
+        d = 1;
+    } else {
+        a = 4;
+        b = a + 2;
+        c = b + 2;
+        d = 2;
     }
 }

--- a/tests/ui/needless_late_init.stderr
+++ b/tests/ui/needless_late_init.stderr
@@ -291,5 +291,22 @@ LL |
 LL ~     let r = 5;
    |
 
-error: aborting due to 17 previous errors
+error: unneeded late initialization
+  --> tests/ui/needless_late_init.rs:304:5
+   |
+LL |     let z;
+   |     ^^^^^^
+   |
+help: move the declaration `z` here and remove the assignments from the branches
+   |
+LL ~     
+LL |
+LL ~     let z = if true {
+LL ~         1
+LL |     } else {
+LL ~         2
+LL ~     };
+   |
+
+error: aborting due to 18 previous errors
 

--- a/tests/ui/needless_late_init.stderr
+++ b/tests/ui/needless_late_init.stderr
@@ -276,7 +276,50 @@ LL ~     };
    |
 
 error: unneeded late initialization
-  --> tests/ui/needless_late_init.rs:298:5
+  --> tests/ui/needless_late_init.rs:199:5
+   |
+LL |     let x;
+   |     ^^^^^^
+   |
+help: move the declaration `x` here and remove the assignments from the branches
+   |
+LL ~     
+LL |
+LL ~     let x = if true {
+LL |         let mut y = 5;
+LL |         y = 6;
+LL ~         y
+LL |     } else {
+LL ~         2
+LL ~     };
+   |
+
+error: unneeded late initialization
+  --> tests/ui/needless_late_init.rs:190:5
+   |
+LL | /     if true {
+LL | |
+LL | |         x = 1;
+LL | |         y = 2;
+...  |
+LL | |         y = 4;
+LL | |     }
+   | |_____^
+   |
+help: move the declarations here and remove the assignments from the branches
+   |
+LL ~     
+LL ~     
+LL ~     let (x, y) = if true {
+LL |
+LL ~         (1, 2)
+LL |     } else {
+LL ~         (3, 4)
+LL ~     };
+   |
+
+error: unneeded late initialization
+  --> tests/ui/needless_late_init.rs:299:5
    |
 LL |     let r;
    |     ^^^^^^ created here
@@ -292,7 +335,7 @@ LL ~     let r = 5;
    |
 
 error: unneeded late initialization
-  --> tests/ui/needless_late_init.rs:304:5
+  --> tests/ui/needless_late_init.rs:305:5
    |
 LL |     let z;
    |     ^^^^^^
@@ -308,5 +351,136 @@ LL ~         2
 LL ~     };
    |
 
-error: aborting due to 18 previous errors
+error: unneeded late initialization
+  --> tests/ui/needless_late_init.rs:455:5
+   |
+LL |     let c;
+   |     ^^^^^^
+   |
+help: move the declaration `c` here and remove the assignments from the branches
+   |
+LL ~     
+LL |
+LL ~     let c = if true {
+LL |         a = 1;
+LL |         b = a + 1;
+LL ~         b + 1
+LL |     } else {
+LL |         a = 4;
+LL |         b = a + 2;
+LL ~         b + 2
+LL ~     };
+   |
+
+error: unneeded late initialization
+  --> tests/ui/needless_late_init.rs:318:5
+   |
+LL | /     if true {
+LL | |
+LL | |         a = 1;
+LL | |         b = 2;
+...  |
+LL | |         b = 4;
+LL | |     }
+   | |_____^
+   |
+help: move the declarations here and remove the assignments from the branches
+   |
+LL ~     
+LL ~     
+LL ~     let (a, b) = if true {
+LL |
+LL ~         (1, 2)
+LL |     } else {
+LL ~         (3, 4)
+LL ~     };
+   |
+
+error: unneeded late initialization
+  --> tests/ui/needless_late_init.rs:361:5
+   |
+LL | /     match 1 {
+LL | |
+LL | |         1 => {
+LL | |             a = 1;
+...  |
+LL | |         },
+LL | |     }
+   | |_____^
+   |
+help: move the declarations here and remove the assignments from the `match` arms
+   |
+LL ~     
+LL ~     
+LL ~     
+LL ~     let (a, b, c) = match 1 {
+LL |
+LL |         1 => {
+LL ~             (1, 2, 3)
+LL |         },
+LL |         _ if false => {
+LL ~             (4, 5, 6)
+LL |         },
+LL |         _ => {
+LL ~             (7, 8, 9)
+LL |         },
+LL ~     };
+   |
+
+error: unneeded late initialization
+  --> tests/ui/needless_late_init.rs:384:5
+   |
+LL | /     if true {
+LL | |
+LL | |         a = 1;
+LL | |         b = 2;
+...  |
+LL | |         c = 9;
+LL | |     }
+   | |_____^
+   |
+help: move the declarations here and remove the assignments from the branches
+   |
+LL ~     
+LL ~     
+LL ~     
+LL ~     let (a, b, c) = if true {
+LL |
+LL ~         (1, 2, 3)
+LL |     } else if false {
+LL ~         (4, 5, 6)
+LL |     } else {
+LL ~         (7, 8, 9)
+LL ~     };
+   |
+
+error: unneeded late initialization
+  --> tests/ui/needless_late_init.rs:470:5
+   |
+LL | /     if true {
+LL | |
+LL | |         a = 1;
+LL | |         b = a + 1;
+...  |
+LL | |         d = 2;
+LL | |     }
+   | |_____^
+   |
+help: move the declarations here and remove the assignments from the branches
+   |
+LL ~     
+LL ~     
+LL ~     let (c, d) = if true {
+LL |
+LL |         a = 1;
+LL |         b = a + 1;
+LL ~         (b + 1, 1)
+LL |     } else {
+LL |         a = 4;
+LL |         b = a + 2;
+LL ~         (b + 2, 2)
+LL ~     };
+   |
+
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16746)*

Closes rust-lang/rust-clippy#16330 

Implemented as an enhancement to `needless_late_init`. Also fixes a FN when if/match is in block expr.

changelog: [`needless_late_init`] fix FN for if/match in block expr
changelog: [`needless_late_init`] extend to cover grouped assignments
