### PR TITLE
Fix `collapsible_match` suggests wrongly when match body has no braces

### DIFF
--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -156,18 +156,6 @@ fn check_arm<'tcx>(
             inner_expr.span,
             "this `if` can be collapsed into the outer `match`",
             |diag| {
-                let outer_then_open_bracket = outer_then_body
-                    .span
-                    .split_at(1)
-                    .0
-                    .with_leading_whitespace(cx)
-                    .into_span();
-                let outer_then_closing_bracket = {
-                    let end = outer_then_body.span.shrink_to_hi();
-                    end.with_lo(end.lo() - BytePos(1))
-                        .with_leading_whitespace(cx)
-                        .into_span()
-                };
                 let outer_arrow_end = if let Some(outer_guard) = outer_guard {
                     outer_guard.span.shrink_to_hi()
                 } else {
@@ -175,11 +163,25 @@ fn check_arm<'tcx>(
                 };
                 let (paren_start, inner_if_span, paren_end) = peel_parens(cx, inner_expr.span);
                 let inner_if = inner_if_span.split_at(2).0;
-                let mut sugg = vec![
-                    (inner.then.span.shrink_to_lo(), "=> ".to_string()),
-                    (outer_arrow_end.to(outer_then_open_bracket), String::new()),
-                    (outer_then_closing_bracket, String::new()),
-                ];
+                let mut sugg = vec![(inner.then.span.shrink_to_lo(), "=> ".to_string())];
+                if matches!(outer_then_body.kind, ExprKind::Block(..)) {
+                    let outer_then_open_bracket = outer_then_body
+                        .span
+                        .split_at(1)
+                        .0
+                        .with_leading_whitespace(cx)
+                        .into_span();
+                    let outer_then_closing_bracket = {
+                        let end = outer_then_body.span.shrink_to_hi();
+                        end.with_lo(end.lo() - BytePos(1))
+                            .with_leading_whitespace(cx)
+                            .into_span()
+                    };
+                    sugg.push((outer_arrow_end.to(outer_then_open_bracket), String::new()));
+                    sugg.push((outer_then_closing_bracket, String::new()));
+                } else {
+                    sugg.push((outer_arrow_end.until(inner_if), " ".to_string()));
+                }
 
                 if let Some(outer_guard) = outer_guard {
                     sugg.extend(parens_around(outer_guard));

--- a/tests/ui/collapsible_match_fixable.fixed
+++ b/tests/ui/collapsible_match_fixable.fixed
@@ -43,3 +43,35 @@ fn issue16875(a: Option<&str>, b: i32) -> i32 {
     }
     res
 }
+
+#[rustfmt::skip]
+fn issue16716(n: u32) {
+    match n {
+        0 | 1 if false => { println!("hello world"); },
+        //~^ collapsible_match
+        _ => (),
+    }
+
+    let opt = Some(1);
+    let _ = match opt {
+        Some(s) if s == 1 => { s }
+        //~^ collapsible_match
+        _ => 1,
+    };
+}
+
+#[rustfmt::skip]
+fn issue16894() {
+    let a = 5_u8;
+    let b = a;
+    _ = match a {
+        11 => 0,
+        13 if a > b => { 1 }, _ => 0,
+        //~^ collapsible_match
+    };
+
+    _ = match a {
+        11 => 0, 12 if a == b => { 1 }, _ => 0,
+        //~^ collapsible_match
+    };
+}

--- a/tests/ui/collapsible_match_fixable.rs
+++ b/tests/ui/collapsible_match_fixable.rs
@@ -45,3 +45,35 @@ fn issue16875(a: Option<&str>, b: i32) -> i32 {
     }
     res
 }
+
+#[rustfmt::skip]
+fn issue16716(n: u32) {
+    match n {
+        0 | 1 => if false { println!("hello world"); },
+        //~^ collapsible_match
+        _ => (),
+    }
+
+    let opt = Some(1);
+    let _ = match opt {
+        Some(s) => if s == 1 { s } else { 1 }
+        //~^ collapsible_match
+        _ => 1,
+    };
+}
+
+#[rustfmt::skip]
+fn issue16894() {
+    let a = 5_u8;
+    let b = a;
+    _ = match a {
+        11 => 0,
+        13 => if a > b { 1 } else { 0 }, _ => 0,
+        //~^ collapsible_match
+    };
+
+    _ = match a {
+        11 => 0, 12 => if a == b { 1 } else { 0 }, _ => 0,
+        //~^ collapsible_match
+    };
+}

--- a/tests/ui/collapsible_match_fixable.stderr
+++ b/tests/ui/collapsible_match_fixable.stderr
@@ -64,5 +64,53 @@ LL |                 res = 1;
 LL ~             },
    |
 
-error: aborting due to 4 previous errors
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:52:18
+   |
+LL |         0 | 1 => if false { println!("hello world"); },
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: collapse nested if block
+   |
+LL -         0 | 1 => if false { println!("hello world"); },
+LL +         0 | 1 if false => { println!("hello world"); },
+   |
+
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:59:20
+   |
+LL |         Some(s) => if s == 1 { s } else { 1 }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: collapse nested if block
+   |
+LL -         Some(s) => if s == 1 { s } else { 1 }
+LL +         Some(s) if s == 1 => { s }
+   |
+
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:71:15
+   |
+LL |         13 => if a > b { 1 } else { 0 }, _ => 0,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: collapse nested if block
+   |
+LL -         13 => if a > b { 1 } else { 0 }, _ => 0,
+LL +         13 if a > b => { 1 }, _ => 0,
+   |
+
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:76:24
+   |
+LL |         11 => 0, 12 => if a == b { 1 } else { 0 }, _ => 0,
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: collapse nested if block
+   |
+LL -         11 => 0, 12 => if a == b { 1 } else { 0 }, _ => 0,
+LL +         11 => 0, 12 if a == b => { 1 }, _ => 0,
+   |
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16716 
Closes rust-lang/rust-clippy#16894

changelog: [`collapsible_match`] fix wrong suggestions when match body has no braces
