### PR TITLE
Fix `expect_fun_call` suggests wrongly for string slicing

### DIFF
--- a/clippy_lints/src/methods/expect_fun_call.rs
+++ b/clippy_lints/src/methods/expect_fun_call.rs
@@ -75,7 +75,13 @@ fn get_arg_root<'a>(cx: &LateContext<'_>, arg: &'a hir::Expr<'a>) -> &'a hir::Ex
     let mut arg_root = peel_blocks(arg);
     loop {
         arg_root = match &arg_root.kind {
-            hir::ExprKind::AddrOf(hir::BorrowKind::Ref, _, expr) => expr,
+            hir::ExprKind::AddrOf(hir::BorrowKind::Ref, _, expr) => {
+                let expr_ty = cx.typeck_results().expr_ty(expr);
+                if expr_ty.is_str() {
+                    break;
+                }
+                expr
+            },
             hir::ExprKind::MethodCall(method_name, receiver, [], ..) => {
                 if (method_name.ident.name == sym::as_str || method_name.ident.name == sym::as_ref) && {
                     let arg_type = cx.typeck_results().expr_ty(receiver);

--- a/tests/ui/expect_fun_call.fixed
+++ b/tests/ui/expect_fun_call.fixed
@@ -147,3 +147,13 @@ fn main() {
         return;
     });
 }
+
+fn issue16747() {
+    let x = 42;
+    let _c = char::from_u32(x).unwrap_or_else(|| panic!("{}", &format!("Illegal: {x}")[..]));
+    //~^ expect_fun_call
+
+    let s = "hello";
+    let _c = char::from_u32(x).unwrap_or_else(|| panic!("{}", &s.to_lowercase()[..2]));
+    //~^ expect_fun_call
+}

--- a/tests/ui/expect_fun_call.rs
+++ b/tests/ui/expect_fun_call.rs
@@ -147,3 +147,13 @@ fn main() {
         return;
     });
 }
+
+fn issue16747() {
+    let x = 42;
+    let _c = char::from_u32(x).expect(&format!("Illegal: {x}")[..]);
+    //~^ expect_fun_call
+
+    let s = "hello";
+    let _c = char::from_u32(x).expect(&s.to_lowercase()[..2]);
+    //~^ expect_fun_call
+}

--- a/tests/ui/expect_fun_call.stderr
+++ b/tests/ui/expect_fun_call.stderr
@@ -97,5 +97,17 @@ error: function call inside of `expect`
 LL |     format_capture_and_value.expect(&format!("{error_code}, {}", 1));
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{error_code}, {}", 1))`
 
-error: aborting due to 16 previous errors
+error: function call inside of `expect`
+  --> tests/ui/expect_fun_call.rs:153:32
+   |
+LL |     let _c = char::from_u32(x).expect(&format!("Illegal: {x}")[..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{}", &format!("Illegal: {x}")[..]))`
+
+error: function call inside of `expect`
+  --> tests/ui/expect_fun_call.rs:157:32
+   |
+LL |     let _c = char::from_u32(x).expect(&s.to_lowercase()[..2]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{}", &s.to_lowercase()[..2]))`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16747 

changelog: [`expect_fun_call`] fix wrong suggestions for string slicing
