### PR TITLE
perf: manual_is_ascii_check, remove 822 million instructions

### DIFF
--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -91,6 +91,13 @@ enum CharRange {
 
 impl<'tcx> LateLintPass<'tcx> for ManualIsAsciiCheck {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        if !matches!(
+            expr.kind,
+            ExprKind::Match(_, [_, ..], _) | ExprKind::MethodCall(_, _, [_], _)
+        ) {
+            return;
+        }
+
         if !self.msrv.meets(cx, msrvs::IS_ASCII_DIGIT) {
             return;
         }
@@ -99,8 +106,8 @@ impl<'tcx> LateLintPass<'tcx> for ManualIsAsciiCheck {
             return;
         }
 
-        let (arg, span, range) = if let Some(macro_call) = matching_root_macro_call(cx, expr.span, sym::matches_macro)
-            && let ExprKind::Match(recv, [arm, ..], _) = expr.kind
+        let (arg, span, range) = if let ExprKind::Match(recv, [arm, ..], _) = expr.kind
+            && let Some(macro_call) = matching_root_macro_call(cx, expr.span, sym::matches_macro)
         {
             let recv = peel_ref_operators(cx, recv);
             let range = check_pat(&arm.pat.kind);


### PR DESCRIPTION
Turns out that `manual_is_ascii_check` was taking up 820 million instructions of `wasmi`'s 23 billion. Now... it doesn't. It now takes 23 million, still too much, but not as noticeable.

Profiled in `wasmi`. 23,821,891,527 icount -> 23,010,885,185 icount, 3.3% performance improvement.

changelog:[`manual_is_ascii_check`]: Optimize by 97.125%