### PR TITLE
perf: reduce `matching_root_macro_call` usage (23b -> 22.24b)

### DIFF
--- a/clippy_lints/src/methods/filter_map.rs
+++ b/clippy_lints/src/methods/filter_map.rs
@@ -247,11 +247,11 @@ impl<'tcx> OffendingFilterExpr<'tcx> {
                 }),
                 _ => None,
             }
-        } else if matching_root_macro_call(cx, expr.span, sym::matches_macro).is_some()
+        } else if let ExprKind::Match(scrutinee, [arm, _], _) = expr.kind
             // we know for a fact that the wildcard pattern is the second arm
-            && let ExprKind::Match(scrutinee, [arm, _], _) = expr.kind
             && scrutinee.res_local_id() == Some(filter_param_id)
             && let PatKind::TupleStruct(QPath::Resolved(_, path), ..) = arm.pat.kind
+            && matching_root_macro_call(cx, expr.span, sym::matches_macro).is_some()
             && let Some(variant_def_id) = path.res.opt_def_id()
         {
             Some(OffendingFilterExpr::Matches { variant_def_id })

--- a/clippy_lints/src/repeat_vec_with_capacity.rs
+++ b/clippy_lints/src/repeat_vec_with_capacity.rs
@@ -77,8 +77,8 @@ fn emit_lint(cx: &LateContext<'_>, span: Span, kind: &str, note: &'static str, s
 
 /// Checks `vec![Vec::with_capacity(x); n]`
 fn check_vec_macro(cx: &LateContext<'_>, expr: &Expr<'_>) {
-    if matching_root_macro_call(cx, expr.span, sym::vec_macro).is_some()
-        && let Some(VecArgs::Repeat(repeat_expr, len_expr)) = VecArgs::hir(cx, expr)
+    if let Some(VecArgs::Repeat(repeat_expr, len_expr)) = VecArgs::hir(cx, expr)
+        && matching_root_macro_call(cx, expr.span, sym::vec_macro).is_some()
         && fn_def_id(cx, repeat_expr).is_some_and(|did| cx.tcx.is_diagnostic_item(sym::vec_with_capacity, did))
         && !len_expr.span.from_expansion()
         && let Some(Constant::Int(2..)) = ConstEvalCtxt::new(cx).eval(expr_or_init(cx, len_expr))

--- a/clippy_lints/src/string_patterns.rs
+++ b/clippy_lints/src/string_patterns.rs
@@ -166,9 +166,9 @@ fn check_manual_pattern_char_comparison(cx: &LateContext<'_>, method_arg: &Expr<
                 },
                 ExprKind::Binary(op, _, _) if op.node == BinOpKind::Or => ControlFlow::Continue(Descend::Yes),
                 ExprKind::Match(match_value, [arm, _], _) => {
-                    if matching_root_macro_call(cx, sub_expr.span, sym::matches_macro).is_none()
-                        || arm.guard.is_some()
+                    if arm.guard.is_some()
                         || match_value.res_local_id() != Some(binding)
+                        || matching_root_macro_call(cx, sub_expr.span, sym::matches_macro).is_none()
                     {
                         return ControlFlow::Break(());
                     }


### PR DESCRIPTION
`matching_root_macro_call` was taking up lots of instructions. This PR reduces its usage and thus, the number of instructions.

Profiled in `wasmi`. 23,010,846,019 icount -> 22,245,910,522 icount **-3.324%** performance improvement!

3 Lints were affected:
    - `repeat_vec_with_capacity`: 783,874,512 -> 24,488,225
    - `string_patterns`: Not measured in benchmark.
    - `filter_map`: Weirdly went from 22,000,078 to 22,017,509. But this doesn't make sense so it's completely anecdotal. (In no world would changing a function call with a boolean check make *anything* more expensive.

changelog:[`repeat_vec_with_capacity`]: Optimize by 96.876%