### PR TITLE
Fix `collapsible_if` FP when the inner if contains cfg

### DIFF
--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -2,7 +2,7 @@ use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::msrvs::Msrv;
 use clippy_utils::source::{HasSession, IntoSpan as _, SpanRangeExt, snippet, snippet_block_with_applicability};
-use clippy_utils::{can_use_if_let_chains, span_contains_non_whitespace, sym, tokenize_with_text};
+use clippy_utils::{can_use_if_let_chains, span_contains_cfg, span_contains_non_whitespace, sym, tokenize_with_text};
 use rustc_ast::{BinOpKind, MetaItemInner};
 use rustc_errors::Applicability;
 use rustc_hir::{Block, Expr, ExprKind, StmtKind};
@@ -169,6 +169,11 @@ impl CollapsibleIf {
             && self.eligible_condition(cx, check_inner)
             && expr.span.eq_ctxt(inner.span)
             && self.check_significant_tokens_and_expect_attrs(cx, then, inner, sym::collapsible_if)
+            && let then_closing_bracket = {
+                let end = then.span.shrink_to_hi();
+                end.with_lo(end.lo() - BytePos(1))
+            }
+            && !span_contains_cfg(cx, inner.span.between(then_closing_bracket))
         {
             span_lint_hir_and_then(
                 cx,
@@ -178,12 +183,7 @@ impl CollapsibleIf {
                 "this `if` statement can be collapsed",
                 |diag| {
                     let then_open_bracket = then.span.split_at(1).0.with_leading_whitespace(cx).into_span();
-                    let then_closing_bracket = {
-                        let end = then.span.shrink_to_hi();
-                        end.with_lo(end.lo() - BytePos(1))
-                            .with_leading_whitespace(cx)
-                            .into_span()
-                    };
+                    let then_closing_bracket = then_closing_bracket.with_leading_whitespace(cx).into_span();
                     let (paren_start, inner_if_span, paren_end) = peel_parens(cx, inner.span);
                     let inner_if = inner_if_span.split_at(2).0;
                     let mut sugg = vec![

--- a/tests/ui/collapsible_if_unfixable.rs
+++ b/tests/ui/collapsible_if_unfixable.rs
@@ -18,3 +18,19 @@ fn issue13365() {
     }
     //~^^^^ ERROR: this lint expectation is unfulfilled
 }
+
+#[allow(unexpected_cfgs)]
+fn issue16715(o: Option<i32>) {
+    if let Some(x) = o {
+        if x > 0 {
+            println!("Positive: {}", x);
+        }
+
+        #[cfg(feature = "some_feature")]
+        {
+            if x % 2 == 0 {
+                println!("Even: {}", x);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16715 

changelog: [`collapsible_if`] fix FP when the inner if contains cfg
