### PR TITLE
perf: disable `nonminimal_bool` by default

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -30,6 +30,8 @@ declare_clippy_lint! {
     /// Ignores short circuiting behavior of `||` and
     /// `&&`. Ignores `|`, `&` and `^`.
     ///
+    /// Creates a big toll on performance, **only enable sporadically**
+    ///
     /// ### Example
     /// ```ignore
     /// if a && true {}
@@ -43,7 +45,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub NONMINIMAL_BOOL,
-    complexity,
+    pedantic,
     "boolean expressions that can be written more concisely"
 }
 
@@ -57,6 +59,7 @@ declare_clippy_lint! {
     ///
     /// ### Known problems
     /// Ignores short circuiting behavior.
+    /// Creates a big toll on performance, **only enable sporadically**
     ///
     /// ### Example
     /// ```rust,ignore
@@ -70,7 +73,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub OVERLY_COMPLEX_BOOL_EXPR,
-    correctness,
+    pedantic,
     "boolean expressions that contain terminals which can be eliminated"
 }
 


### PR DESCRIPTION
After performance concers on the `nonminimal_bool` lint, we [performed a crater run](https://github.com/rust-lang/rust/issues/153883)

This crater run revealed that in 19120 suggestions taken from 1.3 million crates, only about 36% had resulted in multi-terminal suggestions (suggestions that were not only a single boolean).

This suggests that most cases of this lint firing, the expression that triggered was pretty simple. And thus, we should not take such a huge toll for a lint that isn't that useful.

In the future, a rewrite of that `bool_expr` function could be very useful to alleviate the performance toll. Because clearly running the Quine McCluskey algorithm on all those boolean operations is not ideal.

---

## Performance report:

`cargo clippy` -> 5,077,447,157 icount
`cargo check` -> 3,629,576,891 icount

So the Clippy that `rustup` delivers is about 1.4b instructions more than `cargo check`.

`NonminimalBool` lint pass -> 318,169,034

$$\frac{nonminimal\\_bool}{clippy-check}*100 = 21.97496844$$

So, the `NonminimalBool` lint pass is about 22% of all Clippy-exclusive instruction count.

---

After this change, we can now compare the Clippy BUILT FROM MASTER, NOT DELIVERED BY RUSTUP, with the Clippy from this PR.

`master/target/release/cargo-clippy` -> 5,296,838,955 (Slower than Rustup)
`pr/target/release/cargo-clippy` -> 4,977,035,941.

So, $master - PR = 319803014$, which is the exact icount of `Nonminimal_bool` and about 22% of Clippy's whole execution time.

Profiled on `syn-2.0.71`, with Callgrind.

changelog:[`nonminimal_bool`]: Move to `pedantic`.
changelog:[`overly_complex_bool_expr`]: Move to `pedantic`.