### PR TITLE
Add `unused_impl` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7261,6 +7261,7 @@ Released 2018-09-13
 [`unused_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_collect
 [`unused_enumerate_index`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_enumerate_index
 [`unused_format_specs`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_format_specs
+[`unused_impl`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_impl
 [`unused_io_amount`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount
 [`unused_label`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_label
 [`unused_peekable`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_peekable

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -777,6 +777,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::unnested_or_patterns::UNNESTED_OR_PATTERNS_INFO,
     crate::unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME_INFO,
     crate::unused_async::UNUSED_ASYNC_INFO,
+    crate::unused_impl::UNUSED_IMPL_INFO,
     crate::unused_io_amount::UNUSED_IO_AMOUNT_INFO,
     crate::unused_peekable::UNUSED_PEEKABLE_INFO,
     crate::unused_result_ok::UNUSED_RESULT_OK_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -380,6 +380,7 @@ mod unneeded_struct_pattern;
 mod unnested_or_patterns;
 mod unsafe_removed_from_name;
 mod unused_async;
+mod unused_impl;
 mod unused_io_amount;
 mod unused_peekable;
 mod unused_result_ok;
@@ -518,6 +519,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(|| Box::new(byte_char_slices::ByteCharSlice)),
         Box::new(|| Box::new(cfg_not_test::CfgNotTest)),
         Box::new(|| Box::new(empty_line_after::EmptyLineAfter::new())),
+        Box::new(|| Box::new(unused_impl::UnusedImpl)),
         // add early passes here, used by `cargo dev new_lint`
     ];
     store.early_passes.extend(early_lints);

--- a/clippy_lints/src/unused_impl.rs
+++ b/clippy_lints/src/unused_impl.rs
@@ -1,0 +1,58 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::sugg::DiagExt;
+use rustc_ast::ast::{Impl, Item, ItemKind};
+use rustc_errors::Applicability;
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::declare_lint_pass;
+use rustc_span::sym;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for implementations with an empty body and without a trait.
+    ///
+    /// ### Why is this bad?
+    /// Adds unnecessary clutter.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// struct Foo;
+    /// impl Foo {}
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// struct Foo;
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub UNUSED_IMPL,
+    style,
+    "empty implementation, which adds unnecessary clutter"
+}
+
+declare_lint_pass!(UnusedImpl => [UNUSED_IMPL]);
+
+impl EarlyLintPass for UnusedImpl {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
+        if item.span.from_expansion() {
+            return;
+        }
+
+        if let ItemKind::Impl(Impl {
+            of_trait: None, items, ..
+        }) = &item.kind
+            && items.is_empty()
+            && item
+                .attrs
+                .iter()
+                .all(|attr| !attr.has_name(sym::cfg) && !attr.is_doc_comment())
+        {
+            span_lint_and_then(cx, UNUSED_IMPL, item.span, "empty impl body", |diag| {
+                diag.suggest_remove_item(
+                    cx,
+                    item.span_with_attributes(),
+                    "remove this",
+                    Applicability::MachineApplicable,
+                );
+            });
+        }
+    }
+}

--- a/tests/ui/empty_line_after/doc_comments.1.fixed
+++ b/tests/ui/empty_line_after/doc_comments.1.fixed
@@ -145,6 +145,8 @@ impl Foo for LineComment {
 //~v empty_line_after_doc_comments
 /// Docs for this item.
 // fn some_item() {}
-impl LineComment {} // or any other nameless item kind
+impl LineComment {
+    fn bar() {}
+} // or any other nameless item kind
 
 fn main() {}

--- a/tests/ui/empty_line_after/doc_comments.2.fixed
+++ b/tests/ui/empty_line_after/doc_comments.2.fixed
@@ -156,6 +156,8 @@ impl Foo for LineComment {
 // /// Docs for this item.
 // fn some_item() {}
 
-impl LineComment {} // or any other nameless item kind
+impl LineComment {
+    fn bar() {}
+} // or any other nameless item kind
 
 fn main() {}

--- a/tests/ui/empty_line_after/doc_comments.rs
+++ b/tests/ui/empty_line_after/doc_comments.rs
@@ -159,6 +159,8 @@ impl Foo for LineComment {
 /// Docs for this item.
 // fn some_item() {}
 
-impl LineComment {} // or any other nameless item kind
+impl LineComment {
+    fn bar() {}
+} // or any other nameless item kind
 
 fn main() {}

--- a/tests/ui/empty_line_after/doc_comments.stderr
+++ b/tests/ui/empty_line_after/doc_comments.stderr
@@ -195,7 +195,7 @@ LL | / /// Docs for this item.
 LL | | // fn some_item() {}
 LL | |
    | |_^
-LL |   impl LineComment {} // or any other nameless item kind
+LL |   impl LineComment {
    |   - the comment documents this implementation
    |
    = help: if the empty line is unintentional, remove it

--- a/tests/ui/impl.rs
+++ b/tests/ui/impl.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code, clippy::extra_unused_lifetimes)]
 #![warn(clippy::multiple_inherent_impl)]
+#![expect(clippy::unused_impl)]
 
 struct MyStruct;
 

--- a/tests/ui/impl.stderr
+++ b/tests/ui/impl.stderr
@@ -1,5 +1,5 @@
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:10:1
+  --> tests/ui/impl.rs:11:1
    |
 LL | / impl MyStruct {
 LL | |
@@ -9,7 +9,7 @@ LL | | }
    | |_^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:6:1
+  --> tests/ui/impl.rs:7:1
    |
 LL | / impl MyStruct {
 LL | |     fn first() {}
@@ -19,7 +19,7 @@ LL | | }
    = help: to override `-D warnings` add `#[allow(clippy::multiple_inherent_impl)]`
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:16:1
+  --> tests/ui/impl.rs:17:1
    |
 LL | / impl<'a> MyStruct {
 LL | |
@@ -28,7 +28,7 @@ LL | | }
    | |_^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:6:1
+  --> tests/ui/impl.rs:7:1
    |
 LL | / impl MyStruct {
 LL | |     fn first() {}
@@ -36,7 +36,7 @@ LL | | }
    | |_^
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:27:5
+  --> tests/ui/impl.rs:28:5
    |
 LL | /     impl super::MyStruct {
 LL | |
@@ -46,7 +46,7 @@ LL | |     }
    | |_____^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:6:1
+  --> tests/ui/impl.rs:7:1
    |
 LL | / impl MyStruct {
 LL | |     fn first() {}
@@ -54,7 +54,7 @@ LL | | }
    | |_^
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:49:1
+  --> tests/ui/impl.rs:50:1
    |
 LL | / impl WithArgs<u64> {
 LL | |
@@ -64,7 +64,7 @@ LL | | }
    | |_^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:46:1
+  --> tests/ui/impl.rs:47:1
    |
 LL | / impl WithArgs<u64> {
 LL | |     fn f2() {}
@@ -72,67 +72,67 @@ LL | | }
    | |_^
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:72:1
+  --> tests/ui/impl.rs:73:1
    |
 LL | impl OneAllowedImpl {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:69:1
+  --> tests/ui/impl.rs:70:1
    |
 LL | impl OneAllowedImpl {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:85:1
+  --> tests/ui/impl.rs:86:1
    |
 LL | impl OneExpected {}
    | ^^^^^^^^^^^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:82:1
+  --> tests/ui/impl.rs:83:1
    |
 LL | impl OneExpected {}
    | ^^^^^^^^^^^^^^^^^^^
 
 error: multiple implementations of this structure
+  --> tests/ui/impl.rs:95:1
+   |
+LL | impl Lifetime<'_> {}
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+note: first implementation here
   --> tests/ui/impl.rs:94:1
    |
 LL | impl Lifetime<'_> {}
    | ^^^^^^^^^^^^^^^^^^^^
-   |
-note: first implementation here
-  --> tests/ui/impl.rs:93:1
-   |
-LL | impl Lifetime<'_> {}
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error: multiple implementations of this structure
+  --> tests/ui/impl.rs:99:1
+   |
+LL | impl<'a> Lifetime<'a> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first implementation here
   --> tests/ui/impl.rs:98:1
    |
 LL | impl<'a> Lifetime<'a> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: first implementation here
-  --> tests/ui/impl.rs:97:1
-   |
-LL | impl<'a> Lifetime<'a> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: multiple implementations of this structure
+  --> tests/ui/impl.rs:111:1
+   |
+LL | impl<G> Generic<G> {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first implementation here
   --> tests/ui/impl.rs:110:1
    |
 LL | impl<G> Generic<G> {}
    | ^^^^^^^^^^^^^^^^^^^^^
-   |
-note: first implementation here
-  --> tests/ui/impl.rs:109:1
-   |
-LL | impl<G> Generic<G> {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/impl.rs:124:1
+  --> tests/ui/impl.rs:125:1
    |
 LL | / impl<T: Debug> GenericWithBounds<T> {
 LL | |
@@ -143,7 +143,7 @@ LL | | }
    | |_^
    |
 note: first implementation here
-  --> tests/ui/impl.rs:118:1
+  --> tests/ui/impl.rs:119:1
    |
 LL | / impl<T: Debug> GenericWithBounds<T> {
 LL | |     fn make_one(_one: T) -> Self {

--- a/tests/ui/into_iter_without_iter.rs
+++ b/tests/ui/into_iter_without_iter.rs
@@ -1,6 +1,7 @@
 //@no-rustfix: suggestions reference out of scope lifetimes/types
 //@aux-build:proc_macros.rs
 #![warn(clippy::into_iter_without_iter)]
+#![expect(clippy::unused_impl)]
 extern crate proc_macros;
 
 use std::iter::IntoIterator;

--- a/tests/ui/into_iter_without_iter.stderr
+++ b/tests/ui/into_iter_without_iter.stderr
@@ -1,5 +1,5 @@
 error: `IntoIterator` implemented for a reference type without an `iter` method
-  --> tests/ui/into_iter_without_iter.rs:9:1
+  --> tests/ui/into_iter_without_iter.rs:10:1
    |
 LL | / impl<'a> IntoIterator for &'a S1 {
 LL | |
@@ -22,7 +22,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter_mut` method
-  --> tests/ui/into_iter_without_iter.rs:17:1
+  --> tests/ui/into_iter_without_iter.rs:18:1
    |
 LL | / impl<'a> IntoIterator for &'a mut S1 {
 LL | |
@@ -43,7 +43,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter` method
-  --> tests/ui/into_iter_without_iter.rs:27:1
+  --> tests/ui/into_iter_without_iter.rs:28:1
    |
 LL | / impl<'a, T> IntoIterator for &'a S2<T> {
 LL | |
@@ -64,7 +64,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter_mut` method
-  --> tests/ui/into_iter_without_iter.rs:35:1
+  --> tests/ui/into_iter_without_iter.rs:36:1
    |
 LL | / impl<'a, T> IntoIterator for &'a mut S2<T> {
 LL | |
@@ -85,7 +85,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter_mut` method
-  --> tests/ui/into_iter_without_iter.rs:86:1
+  --> tests/ui/into_iter_without_iter.rs:87:1
    |
 LL | / impl<'a, T> IntoIterator for &mut S4<'a, T> {
 LL | |
@@ -106,7 +106,7 @@ LL + }
    |
 
 error: `IntoIterator` implemented for a reference type without an `iter` method
-  --> tests/ui/into_iter_without_iter.rs:120:9
+  --> tests/ui/into_iter_without_iter.rs:121:9
    |
 LL | /         impl<'a> IntoIterator for &'a Issue12037 {
 LL | |

--- a/tests/ui/mismatching_type_param_order.rs
+++ b/tests/ui/mismatching_type_param_order.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::mismatching_type_param_order)]
 #![allow(clippy::disallowed_names, clippy::needless_lifetimes)]
+#![expect(clippy::unused_impl)]
 
 fn main() {
     struct Foo<A, B> {

--- a/tests/ui/mismatching_type_param_order.stderr
+++ b/tests/ui/mismatching_type_param_order.stderr
@@ -1,5 +1,5 @@
 error: `Foo` has a similarly named generic type parameter `B` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:11:20
+  --> tests/ui/mismatching_type_param_order.rs:12:20
    |
 LL |     impl<B, A> Foo<B, A> {}
    |                    ^
@@ -9,7 +9,7 @@ LL |     impl<B, A> Foo<B, A> {}
    = help: to override `-D warnings` add `#[allow(clippy::mismatching_type_param_order)]`
 
 error: `Foo` has a similarly named generic type parameter `A` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:11:23
+  --> tests/ui/mismatching_type_param_order.rs:12:23
    |
 LL |     impl<B, A> Foo<B, A> {}
    |                       ^
@@ -17,7 +17,7 @@ LL |     impl<B, A> Foo<B, A> {}
    = help: try `B`, or a name that does not conflict with `Foo`'s generic params
 
 error: `Foo` has a similarly named generic type parameter `A` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:16:23
+  --> tests/ui/mismatching_type_param_order.rs:17:23
    |
 LL |     impl<C, A> Foo<C, A> {}
    |                       ^
@@ -25,7 +25,7 @@ LL |     impl<C, A> Foo<C, A> {}
    = help: try `B`, or a name that does not conflict with `Foo`'s generic params
 
 error: `FooLifetime` has a similarly named generic type parameter `B` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:28:44
+  --> tests/ui/mismatching_type_param_order.rs:29:44
    |
 LL |     impl<'m, 'l, B, A> FooLifetime<'m, 'l, B, A> {}
    |                                            ^
@@ -33,7 +33,7 @@ LL |     impl<'m, 'l, B, A> FooLifetime<'m, 'l, B, A> {}
    = help: try `A`, or a name that does not conflict with `FooLifetime`'s generic params
 
 error: `FooLifetime` has a similarly named generic type parameter `A` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:28:47
+  --> tests/ui/mismatching_type_param_order.rs:29:47
    |
 LL |     impl<'m, 'l, B, A> FooLifetime<'m, 'l, B, A> {}
    |                                               ^
@@ -41,7 +41,7 @@ LL |     impl<'m, 'l, B, A> FooLifetime<'m, 'l, B, A> {}
    = help: try `B`, or a name that does not conflict with `FooLifetime`'s generic params
 
 error: `FooEnum` has a similarly named generic type parameter `C` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:46:27
+  --> tests/ui/mismatching_type_param_order.rs:47:27
    |
 LL |     impl<C, A, B> FooEnum<C, A, B> {}
    |                           ^
@@ -49,7 +49,7 @@ LL |     impl<C, A, B> FooEnum<C, A, B> {}
    = help: try `A`, or a name that does not conflict with `FooEnum`'s generic params
 
 error: `FooEnum` has a similarly named generic type parameter `A` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:46:30
+  --> tests/ui/mismatching_type_param_order.rs:47:30
    |
 LL |     impl<C, A, B> FooEnum<C, A, B> {}
    |                              ^
@@ -57,7 +57,7 @@ LL |     impl<C, A, B> FooEnum<C, A, B> {}
    = help: try `B`, or a name that does not conflict with `FooEnum`'s generic params
 
 error: `FooEnum` has a similarly named generic type parameter `B` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:46:33
+  --> tests/ui/mismatching_type_param_order.rs:47:33
    |
 LL |     impl<C, A, B> FooEnum<C, A, B> {}
    |                                 ^
@@ -65,7 +65,7 @@ LL |     impl<C, A, B> FooEnum<C, A, B> {}
    = help: try `C`, or a name that does not conflict with `FooEnum`'s generic params
 
 error: `FooUnion` has a similarly named generic type parameter `B` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:60:31
+  --> tests/ui/mismatching_type_param_order.rs:61:31
    |
 LL |     impl<B: Copy, A> FooUnion<B, A> where A: Copy {}
    |                               ^
@@ -73,7 +73,7 @@ LL |     impl<B: Copy, A> FooUnion<B, A> where A: Copy {}
    = help: try `A`, or a name that does not conflict with `FooUnion`'s generic params
 
 error: `FooUnion` has a similarly named generic type parameter `A` in its declaration, but in a different order
-  --> tests/ui/mismatching_type_param_order.rs:60:34
+  --> tests/ui/mismatching_type_param_order.rs:61:34
    |
 LL |     impl<B: Copy, A> FooUnion<B, A> where A: Copy {}
    |                                  ^

--- a/tests/ui/multiple_inherent_impl_cfg.rs
+++ b/tests/ui/multiple_inherent_impl_cfg.rs
@@ -1,5 +1,6 @@
 //@compile-flags: --cfg test
 #![deny(clippy::multiple_inherent_impl)]
+#![expect(clippy::unused_impl)]
 
 // issue #13040
 

--- a/tests/ui/multiple_inherent_impl_cfg.stderr
+++ b/tests/ui/multiple_inherent_impl_cfg.stderr
@@ -1,11 +1,11 @@
 error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:12:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:13:1
    |
 LL | impl A {}
    | ^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:10:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:11:1
    |
 LL | impl A {}
    | ^^^^^^^^^
@@ -16,49 +16,49 @@ LL | #![deny(clippy::multiple_inherent_impl)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:19:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:20:1
    |
 LL | impl A {}
    | ^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:16:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:17:1
    |
 LL | impl A {}
    | ^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:29:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:30:1
    |
 LL | impl B {}
    | ^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:24:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:25:1
    |
 LL | impl B {}
    | ^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:33:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:34:1
    |
 LL | impl B {}
    | ^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:27:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:28:1
    |
 LL | impl B {}
    | ^^^^^^^^^
 
 error: multiple implementations of this structure
-  --> tests/ui/multiple_inherent_impl_cfg.rs:43:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:44:1
    |
 LL | impl C {}
    | ^^^^^^^^^
    |
 note: first implementation here
-  --> tests/ui/multiple_inherent_impl_cfg.rs:40:1
+  --> tests/ui/multiple_inherent_impl_cfg.rs:41:1
    |
 LL | impl C {}
    | ^^^^^^^^^

--- a/tests/ui/needless_lifetimes.fixed
+++ b/tests/ui/needless_lifetimes.fixed
@@ -12,6 +12,7 @@
     clippy::get_first,
     mismatched_lifetime_syntaxes
 )]
+#![expect(clippy::unused_impl)]
 
 extern crate proc_macros;
 use proc_macros::inline_macros;

--- a/tests/ui/needless_lifetimes.rs
+++ b/tests/ui/needless_lifetimes.rs
@@ -12,6 +12,7 @@
     clippy::get_first,
     mismatched_lifetime_syntaxes
 )]
+#![expect(clippy::unused_impl)]
 
 extern crate proc_macros;
 use proc_macros::inline_macros;

--- a/tests/ui/needless_lifetimes.stderr
+++ b/tests/ui/needless_lifetimes.stderr
@@ -1,5 +1,5 @@
 error: the following explicit lifetimes could be elided: 'a, 'b
-  --> tests/ui/needless_lifetimes.rs:19:23
+  --> tests/ui/needless_lifetimes.rs:20:23
    |
 LL | fn distinct_lifetimes<'a, 'b>(_x: &'a u8, _y: &'b u8, _z: u8) {}
    |                       ^^  ^^       ^^          ^^
@@ -13,7 +13,7 @@ LL + fn distinct_lifetimes(_x: &u8, _y: &u8, _z: u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a, 'b
-  --> tests/ui/needless_lifetimes.rs:22:24
+  --> tests/ui/needless_lifetimes.rs:23:24
    |
 LL | fn distinct_and_static<'a, 'b>(_x: &'a u8, _y: &'b u8, _z: &'static u8) {}
    |                        ^^  ^^       ^^          ^^
@@ -25,7 +25,7 @@ LL + fn distinct_and_static(_x: &u8, _y: &u8, _z: &'static u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:33:15
+  --> tests/ui/needless_lifetimes.rs:34:15
    |
 LL | fn in_and_out<'a>(x: &'a u8, _y: u8) -> &'a u8 {
    |               ^^      ^^                 ^^
@@ -37,7 +37,7 @@ LL + fn in_and_out(x: &u8, _y: u8) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/needless_lifetimes.rs:46:31
+  --> tests/ui/needless_lifetimes.rs:47:31
    |
 LL | fn multiple_in_and_out_2a<'a, 'b>(x: &'a u8, _y: &'b u8) -> &'a u8 {
    |                               ^^                  ^^
@@ -49,7 +49,7 @@ LL + fn multiple_in_and_out_2a<'a>(x: &'a u8, _y: &u8) -> &'a u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:54:27
+  --> tests/ui/needless_lifetimes.rs:55:27
    |
 LL | fn multiple_in_and_out_2b<'a, 'b>(_x: &'a u8, y: &'b u8) -> &'b u8 {
    |                           ^^           ^^
@@ -61,7 +61,7 @@ LL + fn multiple_in_and_out_2b<'b>(_x: &u8, y: &'b u8) -> &'b u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/needless_lifetimes.rs:72:26
+  --> tests/ui/needless_lifetimes.rs:73:26
    |
 LL | fn deep_reference_1a<'a, 'b>(x: &'a u8, _y: &'b u8) -> Result<&'a u8, ()> {
    |                          ^^                  ^^
@@ -73,7 +73,7 @@ LL + fn deep_reference_1a<'a>(x: &'a u8, _y: &u8) -> Result<&'a u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:80:22
+  --> tests/ui/needless_lifetimes.rs:81:22
    |
 LL | fn deep_reference_1b<'a, 'b>(_x: &'a u8, y: &'b u8) -> Result<&'b u8, ()> {
    |                      ^^           ^^
@@ -85,7 +85,7 @@ LL + fn deep_reference_1b<'b>(_x: &u8, y: &'b u8) -> Result<&'b u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:90:21
+  --> tests/ui/needless_lifetimes.rs:91:21
    |
 LL | fn deep_reference_3<'a>(x: &'a u8, _y: u8) -> Result<&'a u8, ()> {
    |                     ^^      ^^                        ^^
@@ -97,7 +97,7 @@ LL + fn deep_reference_3(x: &u8, _y: u8) -> Result<&u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:96:28
+  --> tests/ui/needless_lifetimes.rs:97:28
    |
 LL | fn where_clause_without_lt<'a, T>(x: &'a u8, _y: u8) -> Result<&'a u8, ()>
    |                            ^^         ^^                        ^^
@@ -109,7 +109,7 @@ LL + fn where_clause_without_lt<T>(x: &u8, _y: u8) -> Result<&u8, ()>
    |
 
 error: the following explicit lifetimes could be elided: 's
-  --> tests/ui/needless_lifetimes.rs:127:21
+  --> tests/ui/needless_lifetimes.rs:128:21
    |
 LL |     fn self_and_out<'s>(&'s self) -> &'s u8 {
    |                     ^^   ^^           ^^
@@ -121,7 +121,7 @@ LL +     fn self_and_out(&self) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 't
-  --> tests/ui/needless_lifetimes.rs:135:30
+  --> tests/ui/needless_lifetimes.rs:136:30
    |
 LL |     fn self_and_in_out_1<'s, 't>(&'s self, _x: &'t u8) -> &'s u8 {
    |                              ^^                 ^^
@@ -133,7 +133,7 @@ LL +     fn self_and_in_out_1<'s>(&'s self, _x: &u8) -> &'s u8 {
    |
 
 error: the following explicit lifetimes could be elided: 's
-  --> tests/ui/needless_lifetimes.rs:143:26
+  --> tests/ui/needless_lifetimes.rs:144:26
    |
 LL |     fn self_and_in_out_2<'s, 't>(&'s self, x: &'t u8) -> &'t u8 {
    |                          ^^       ^^
@@ -145,7 +145,7 @@ LL +     fn self_and_in_out_2<'t>(&self, x: &'t u8) -> &'t u8 {
    |
 
 error: the following explicit lifetimes could be elided: 's, 't
-  --> tests/ui/needless_lifetimes.rs:148:29
+  --> tests/ui/needless_lifetimes.rs:149:29
    |
 LL |     fn distinct_self_and_in<'s, 't>(&'s self, _x: &'t u8) {}
    |                             ^^  ^^   ^^            ^^
@@ -157,7 +157,7 @@ LL +     fn distinct_self_and_in(&self, _x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:172:21
+  --> tests/ui/needless_lifetimes.rs:173:21
    |
 LL | fn struct_with_lt4b<'a, 'b>(_foo: &'a Foo<'b>) -> &'b str {
    |                     ^^             ^^
@@ -169,7 +169,7 @@ LL + fn struct_with_lt4b<'b>(_foo: &Foo<'b>) -> &'b str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:188:22
+  --> tests/ui/needless_lifetimes.rs:189:22
    |
 LL | fn trait_obj_elided2<'a>(_arg: &'a dyn Drop) -> &'a str {
    |                      ^^         ^^               ^^
@@ -181,7 +181,7 @@ LL + fn trait_obj_elided2(_arg: &dyn Drop) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:199:20
+  --> tests/ui/needless_lifetimes.rs:200:20
    |
 LL | fn alias_with_lt4b<'a, 'b>(_foo: &'a FooAlias<'b>) -> &'b str {
    |                    ^^             ^^
@@ -193,7 +193,7 @@ LL + fn alias_with_lt4b<'b>(_foo: &FooAlias<'b>) -> &'b str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:204:30
+  --> tests/ui/needless_lifetimes.rs:205:30
    |
 LL | fn named_input_elided_output<'a>(_arg: &'a str) -> &str {
    |                              ^^         ^^          ^
@@ -205,7 +205,7 @@ LL + fn named_input_elided_output(_arg: &str) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:213:19
+  --> tests/ui/needless_lifetimes.rs:214:19
    |
 LL | fn trait_bound_ok<'a, T: WithLifetime<'static>>(_: &'a u8, _: T) {
    |                   ^^                                ^^
@@ -217,7 +217,7 @@ LL + fn trait_bound_ok<T: WithLifetime<'static>>(_: &u8, _: T) {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:249:24
+  --> tests/ui/needless_lifetimes.rs:250:24
    |
 LL |         fn needless_lt<'a>(x: &'a u8) {}
    |                        ^^      ^^
@@ -229,7 +229,7 @@ LL +         fn needless_lt(x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:254:24
+  --> tests/ui/needless_lifetimes.rs:255:24
    |
 LL |         fn needless_lt<'a>(_x: &'a u8) {}
    |                        ^^       ^^
@@ -241,7 +241,7 @@ LL +         fn needless_lt(_x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:285:55
+  --> tests/ui/needless_lifetimes.rs:286:55
    |
 LL |     fn impl_trait_elidable_nested_anonymous_lifetimes<'a>(i: &'a i32, f: impl Fn(&i32) -> &i32) -> &'a i32 {
    |                                                       ^^      ^^                                    ^^
@@ -253,7 +253,7 @@ LL +     fn impl_trait_elidable_nested_anonymous_lifetimes(i: &i32, f: impl Fn(&
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:295:26
+  --> tests/ui/needless_lifetimes.rs:296:26
    |
 LL |     fn generics_elidable<'a, T: Fn(&i32) -> &i32>(i: &'a i32, f: T) -> &'a i32 {
    |                          ^^                           ^^                ^^
@@ -265,7 +265,7 @@ LL +     fn generics_elidable<T: Fn(&i32) -> &i32>(i: &i32, f: T) -> &i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:308:30
+  --> tests/ui/needless_lifetimes.rs:309:30
    |
 LL |     fn where_clause_elidable<'a, T>(i: &'a i32, f: T) -> &'a i32
    |                              ^^         ^^                ^^
@@ -277,7 +277,7 @@ LL +     fn where_clause_elidable<T>(i: &i32, f: T) -> &i32
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:324:28
+  --> tests/ui/needless_lifetimes.rs:325:28
    |
 LL |     fn pointer_fn_elidable<'a>(i: &'a i32, f: fn(&i32) -> &i32) -> &'a i32 {
    |                            ^^      ^^                               ^^
@@ -289,7 +289,7 @@ LL +     fn pointer_fn_elidable(i: &i32, f: fn(&i32) -> &i32) -> &i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:338:28
+  --> tests/ui/needless_lifetimes.rs:339:28
    |
 LL |     fn nested_fn_pointer_3<'a>(_: &'a i32) -> fn(fn(&i32) -> &i32) -> i32 {
    |                            ^^      ^^
@@ -301,7 +301,7 @@ LL +     fn nested_fn_pointer_3(_: &i32) -> fn(fn(&i32) -> &i32) -> i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:342:28
+  --> tests/ui/needless_lifetimes.rs:343:28
    |
 LL |     fn nested_fn_pointer_4<'a>(_: &'a i32) -> impl Fn(fn(&i32)) {
    |                            ^^      ^^
@@ -313,7 +313,7 @@ LL +     fn nested_fn_pointer_4(_: &i32) -> impl Fn(fn(&i32)) {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:365:21
+  --> tests/ui/needless_lifetimes.rs:366:21
    |
 LL |         fn implicit<'a>(&'a self) -> &'a () {
    |                     ^^   ^^           ^^
@@ -325,7 +325,7 @@ LL +         fn implicit(&self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:369:25
+  --> tests/ui/needless_lifetimes.rs:370:25
    |
 LL |         fn implicit_mut<'a>(&'a mut self) -> &'a () {
    |                         ^^   ^^               ^^
@@ -337,7 +337,7 @@ LL +         fn implicit_mut(&mut self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:374:21
+  --> tests/ui/needless_lifetimes.rs:375:21
    |
 LL |         fn explicit<'a>(self: &'a Arc<Self>) -> &'a () {
    |                     ^^         ^^                ^^
@@ -349,7 +349,7 @@ LL +         fn explicit(self: &Arc<Self>) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:379:25
+  --> tests/ui/needless_lifetimes.rs:380:25
    |
 LL |         fn explicit_mut<'a>(self: &'a mut Rc<Self>) -> &'a () {
    |                         ^^         ^^                   ^^
@@ -361,7 +361,7 @@ LL +         fn explicit_mut(self: &mut Rc<Self>) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:392:31
+  --> tests/ui/needless_lifetimes.rs:393:31
    |
 LL |         fn lifetime_elsewhere<'a>(self: Box<Self>, here: &'a ()) -> &'a () {
    |                               ^^                          ^^         ^^
@@ -373,7 +373,7 @@ LL +         fn lifetime_elsewhere(self: Box<Self>, here: &()) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:399:21
+  --> tests/ui/needless_lifetimes.rs:400:21
    |
 LL |         fn implicit<'a>(&'a self) -> &'a ();
    |                     ^^   ^^           ^^
@@ -385,7 +385,7 @@ LL +         fn implicit(&self) -> &();
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:401:30
+  --> tests/ui/needless_lifetimes.rs:402:30
    |
 LL |         fn implicit_provided<'a>(&'a self) -> &'a () {
    |                              ^^   ^^           ^^
@@ -397,7 +397,7 @@ LL +         fn implicit_provided(&self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:407:21
+  --> tests/ui/needless_lifetimes.rs:408:21
    |
 LL |         fn explicit<'a>(self: &'a Arc<Self>) -> &'a ();
    |                     ^^         ^^                ^^
@@ -409,7 +409,7 @@ LL +         fn explicit(self: &Arc<Self>) -> &();
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:410:30
+  --> tests/ui/needless_lifetimes.rs:411:30
    |
 LL |         fn explicit_provided<'a>(self: &'a Arc<Self>) -> &'a () {
    |                              ^^         ^^                ^^
@@ -421,7 +421,7 @@ LL +         fn explicit_provided(self: &Arc<Self>) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:421:31
+  --> tests/ui/needless_lifetimes.rs:422:31
    |
 LL |         fn lifetime_elsewhere<'a>(self: Box<Self>, here: &'a ()) -> &'a ();
    |                               ^^                          ^^         ^^
@@ -433,7 +433,7 @@ LL +         fn lifetime_elsewhere(self: Box<Self>, here: &()) -> &();
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:423:40
+  --> tests/ui/needless_lifetimes.rs:424:40
    |
 LL |         fn lifetime_elsewhere_provided<'a>(self: Box<Self>, here: &'a ()) -> &'a () {
    |                                        ^^                          ^^         ^^
@@ -445,7 +445,7 @@ LL +         fn lifetime_elsewhere_provided(self: Box<Self>, here: &()) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:433:12
+  --> tests/ui/needless_lifetimes.rs:434:12
    |
 LL |     fn foo<'a>(x: &'a u8, y: &'_ u8) {}
    |            ^^      ^^
@@ -457,7 +457,7 @@ LL +     fn foo(x: &u8, y: &'_ u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:436:12
+  --> tests/ui/needless_lifetimes.rs:437:12
    |
 LL |     fn bar<'a>(x: &'a u8, y: &'_ u8, z: &'_ u8) {}
    |            ^^      ^^
@@ -469,7 +469,7 @@ LL +     fn bar(x: &u8, y: &'_ u8, z: &'_ u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:444:18
+  --> tests/ui/needless_lifetimes.rs:445:18
    |
 LL |     fn one_input<'a>(x: &'a u8) -> &'a u8 {
    |                  ^^      ^^         ^^
@@ -481,7 +481,7 @@ LL +     fn one_input(x: &u8) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:450:42
+  --> tests/ui/needless_lifetimes.rs:451:42
    |
 LL |     fn multiple_inputs_output_not_elided<'a, 'b>(x: &'a u8, y: &'b u8, z: &'b u8) -> &'b u8 {
    |                                          ^^          ^^
@@ -493,7 +493,7 @@ LL +     fn multiple_inputs_output_not_elided<'b>(x: &u8, y: &'b u8, z: &'b u8) 
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:467:22
+  --> tests/ui/needless_lifetimes.rs:468:22
    |
 LL |         fn one_input<'a>(x: &'a u8) -> &'a u8 {
    |                      ^^      ^^         ^^

--- a/tests/ui/needless_maybe_sized.fixed
+++ b/tests/ui/needless_maybe_sized.fixed
@@ -2,6 +2,7 @@
 
 #![allow(unused, clippy::multiple_bound_locations)]
 #![warn(clippy::needless_maybe_sized)]
+#![expect(clippy::unused_impl)]
 
 extern crate proc_macros;
 use proc_macros::external;

--- a/tests/ui/needless_maybe_sized.rs
+++ b/tests/ui/needless_maybe_sized.rs
@@ -2,6 +2,7 @@
 
 #![allow(unused, clippy::multiple_bound_locations)]
 #![warn(clippy::needless_maybe_sized)]
+#![expect(clippy::unused_impl)]
 
 extern crate proc_macros;
 use proc_macros::external;

--- a/tests/ui/needless_maybe_sized.stderr
+++ b/tests/ui/needless_maybe_sized.stderr
@@ -1,11 +1,11 @@
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:9:24
+  --> tests/ui/needless_maybe_sized.rs:10:24
    |
 LL | fn directly<T: Sized + ?Sized>(t: &T) {}
    |                        ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:9:16
+  --> tests/ui/needless_maybe_sized.rs:10:16
    |
 LL | fn directly<T: Sized + ?Sized>(t: &T) {}
    |                ^^^^^
@@ -18,13 +18,13 @@ LL + fn directly<T: Sized>(t: &T) {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:15:19
+  --> tests/ui/needless_maybe_sized.rs:16:19
    |
 LL | fn depth_1<T: A + ?Sized>(t: &T) {}
    |                   ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:15:15
+  --> tests/ui/needless_maybe_sized.rs:16:15
    |
 LL | fn depth_1<T: A + ?Sized>(t: &T) {}
    |               ^
@@ -36,13 +36,13 @@ LL + fn depth_1<T: A>(t: &T) {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:17:19
+  --> tests/ui/needless_maybe_sized.rs:18:19
    |
 LL | fn depth_2<T: B + ?Sized>(t: &T) {}
    |                   ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:17:15
+  --> tests/ui/needless_maybe_sized.rs:18:15
    |
 LL | fn depth_2<T: B + ?Sized>(t: &T) {}
    |               ^
@@ -55,13 +55,13 @@ LL + fn depth_2<T: B>(t: &T) {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:21:30
+  --> tests/ui/needless_maybe_sized.rs:22:30
    |
 LL | fn multiple_paths<T: A + B + ?Sized>(t: &T) {}
    |                              ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:21:22
+  --> tests/ui/needless_maybe_sized.rs:22:22
    |
 LL | fn multiple_paths<T: A + B + ?Sized>(t: &T) {}
    |                      ^
@@ -73,13 +73,13 @@ LL + fn multiple_paths<T: A + B>(t: &T) {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:26:16
+  --> tests/ui/needless_maybe_sized.rs:27:16
    |
 LL |     T: Sized + ?Sized,
    |                ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:26:8
+  --> tests/ui/needless_maybe_sized.rs:27:8
    |
 LL |     T: Sized + ?Sized,
    |        ^^^^^
@@ -90,13 +90,13 @@ LL +     T: Sized,
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:33:8
+  --> tests/ui/needless_maybe_sized.rs:34:8
    |
 LL |     T: ?Sized,
    |        ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:31:15
+  --> tests/ui/needless_maybe_sized.rs:32:15
    |
 LL | fn mixed_1<T: Sized>(t: &T)
    |               ^^^^^
@@ -107,13 +107,13 @@ LL -     T: ?Sized,
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:38:15
+  --> tests/ui/needless_maybe_sized.rs:39:15
    |
 LL | fn mixed_2<T: ?Sized>(t: &T)
    |               ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:41:8
+  --> tests/ui/needless_maybe_sized.rs:42:8
    |
 LL |     T: Sized,
    |        ^^^^^
@@ -124,13 +124,13 @@ LL + fn mixed_2<T>(t: &T)
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:48:8
+  --> tests/ui/needless_maybe_sized.rs:49:8
    |
 LL |     T: ?Sized,
    |        ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:47:8
+  --> tests/ui/needless_maybe_sized.rs:48:8
    |
 LL |     T: Sized,
    |        ^^^^^
@@ -142,13 +142,13 @@ LL +     T: Sized,
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:53:26
+  --> tests/ui/needless_maybe_sized.rs:54:26
    |
 LL | struct Struct<T: Sized + ?Sized>(T);
    |                          ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:53:18
+  --> tests/ui/needless_maybe_sized.rs:54:18
    |
 LL | struct Struct<T: Sized + ?Sized>(T);
    |                  ^^^^^
@@ -159,13 +159,13 @@ LL + struct Struct<T: Sized>(T);
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:56:17
+  --> tests/ui/needless_maybe_sized.rs:57:17
    |
 LL | impl<T: Sized + ?Sized> Struct<T> {
    |                 ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:56:9
+  --> tests/ui/needless_maybe_sized.rs:57:9
    |
 LL | impl<T: Sized + ?Sized> Struct<T> {
    |         ^^^^^
@@ -176,13 +176,13 @@ LL + impl<T: Sized> Struct<T> {
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:58:26
+  --> tests/ui/needless_maybe_sized.rs:59:26
    |
 LL |     fn method<U: Sized + ?Sized>(&self) {}
    |                          ^^^^^^
    |
 note: `U` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:58:18
+  --> tests/ui/needless_maybe_sized.rs:59:18
    |
 LL |     fn method<U: Sized + ?Sized>(&self) {}
    |                  ^^^^^
@@ -193,13 +193,13 @@ LL +     fn method<U: Sized>(&self) {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:62:22
+  --> tests/ui/needless_maybe_sized.rs:63:22
    |
 LL | enum Enum<T: Sized + ?Sized + 'static> {
    |                      ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:62:14
+  --> tests/ui/needless_maybe_sized.rs:63:14
    |
 LL | enum Enum<T: Sized + ?Sized + 'static> {
    |              ^^^^^
@@ -210,13 +210,13 @@ LL + enum Enum<T: Sized + 'static> {
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:67:28
+  --> tests/ui/needless_maybe_sized.rs:68:28
    |
 LL | union Union<'a, T: Sized + ?Sized> {
    |                            ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:67:20
+  --> tests/ui/needless_maybe_sized.rs:68:20
    |
 LL | union Union<'a, T: Sized + ?Sized> {
    |                    ^^^^^
@@ -227,13 +227,13 @@ LL + union Union<'a, T: Sized> {
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:72:24
+  --> tests/ui/needless_maybe_sized.rs:73:24
    |
 LL | trait Trait<T: Sized + ?Sized> {
    |                        ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:72:16
+  --> tests/ui/needless_maybe_sized.rs:73:16
    |
 LL | trait Trait<T: Sized + ?Sized> {
    |                ^^^^^
@@ -244,13 +244,13 @@ LL + trait Trait<T: Sized> {
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:74:32
+  --> tests/ui/needless_maybe_sized.rs:75:32
    |
 LL |     fn trait_method<U: Sized + ?Sized>() {}
    |                                ^^^^^^
    |
 note: `U` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:74:24
+  --> tests/ui/needless_maybe_sized.rs:75:24
    |
 LL |     fn trait_method<U: Sized + ?Sized>() {}
    |                        ^^^^^
@@ -261,13 +261,13 @@ LL +     fn trait_method<U: Sized>() {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:77:25
+  --> tests/ui/needless_maybe_sized.rs:78:25
    |
 LL |     type GAT<U: Sized + ?Sized>;
    |                         ^^^^^^
    |
 note: `U` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:77:17
+  --> tests/ui/needless_maybe_sized.rs:78:17
    |
 LL |     type GAT<U: Sized + ?Sized>;
    |                 ^^^^^
@@ -278,13 +278,13 @@ LL +     type GAT<U: Sized>;
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:84:23
+  --> tests/ui/needless_maybe_sized.rs:85:23
    |
 LL | fn second_in_trait<T: ?Sized + SecondInTrait>() {}
    |                       ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:84:32
+  --> tests/ui/needless_maybe_sized.rs:85:32
    |
 LL | fn second_in_trait<T: ?Sized + SecondInTrait>() {}
    |                                ^^^^^^^^^^^^^
@@ -296,13 +296,13 @@ LL + fn second_in_trait<T: SecondInTrait>() {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:87:33
+  --> tests/ui/needless_maybe_sized.rs:88:33
    |
 LL | fn impl_trait(_: &(impl Sized + ?Sized)) {}
    |                                 ^^^^^^
    |
 note: `impl Sized + ?Sized` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:87:25
+  --> tests/ui/needless_maybe_sized.rs:88:25
    |
 LL | fn impl_trait(_: &(impl Sized + ?Sized)) {}
    |                         ^^^^^
@@ -313,13 +313,13 @@ LL + fn impl_trait(_: &(impl Sized)) {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:91:42
+  --> tests/ui/needless_maybe_sized.rs:92:42
    |
 LL | fn in_generic_trait<T: GenericTrait<U> + ?Sized, U>() {}
    |                                          ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:91:24
+  --> tests/ui/needless_maybe_sized.rs:92:24
    |
 LL | fn in_generic_trait<T: GenericTrait<U> + ?Sized, U>() {}
    |                        ^^^^^^^^^^^^^^^
@@ -331,13 +331,13 @@ LL + fn in_generic_trait<T: GenericTrait<U>, U>() {}
    |
 
 error: `?Sized` bound is ignored because of a `Sized` requirement
-  --> tests/ui/needless_maybe_sized.rs:107:29
+  --> tests/ui/needless_maybe_sized.rs:108:29
    |
 LL |     fn larger_graph<T: A1 + ?Sized>() {}
    |                             ^^^^^^
    |
 note: `T` cannot be unsized because of the bound
-  --> tests/ui/needless_maybe_sized.rs:107:24
+  --> tests/ui/needless_maybe_sized.rs:108:24
    |
 LL |     fn larger_graph<T: A1 + ?Sized>() {}
    |                        ^^

--- a/tests/ui/unknown_clippy_lints.fixed
+++ b/tests/ui/unknown_clippy_lints.fixed
@@ -16,7 +16,7 @@
 #[warn(dead_code)]
 //~^ ERROR: unknown lint
 // Shouldn't suggest removed/deprecated clippy lint name(`unused_collect`)
-#[warn(clippy::unused_self)]
+#[warn(clippy::unused_impl)]
 //~^ ERROR: unknown lint
 // Shouldn't suggest renamed clippy lint name(`const_static_lifetime`)
 #[warn(clippy::redundant_static_lifetimes)]

--- a/tests/ui/unknown_clippy_lints.stderr
+++ b/tests/ui/unknown_clippy_lints.stderr
@@ -47,7 +47,7 @@ error: unknown lint: `clippy::unused_colle`
   --> tests/ui/unknown_clippy_lints.rs:19:8
    |
 LL | #[warn(clippy::unused_colle)]
-   |        ^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::unused_self`
+   |        ^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::unused_impl`
 
 error: unknown lint: `clippy::const_static_lifetim`
   --> tests/ui/unknown_clippy_lints.rs:22:8

--- a/tests/ui/unused_impl.fixed
+++ b/tests/ui/unused_impl.fixed
@@ -1,0 +1,62 @@
+#![warn(clippy::unused_impl)]
+
+trait MyTrait {}
+
+// Should work inside modules
+mod bar {
+    use crate::MyTrait;
+
+    struct Foo1;
+    //~^ unused_impl
+
+    struct Foo2<'a>(&'a str);
+    // Lifetimes should have no effect
+    //~^ unused_impl
+}
+
+// Implementations with `#[cfg]` and/or doc comments shouldn't lint
+
+// Doc comment only should lint
+struct Bar1;
+/// Hello world
+impl Bar1 {}
+
+// #[cfg] only should lint
+struct Bar2;
+#[cfg(test)]
+impl Bar2 {}
+
+// Both doc comment and attribute should lint
+struct Bar3;
+/// Hello world
+#[cfg(test)]
+impl Bar3 {}
+
+// Different attributes should lint
+struct Bar4;
+//~^ unused_impl
+
+// Just to make sure, lint check attributes should still work
+struct Bar5;
+#[expect(clippy::unused_impl)]
+impl Bar5 {}
+
+struct Baz;
+// Non-empty shouldn't lint
+impl Baz {
+    fn baz() {}
+}
+// Trait implementation shouldn't lint
+impl MyTrait for Baz {}
+
+macro_rules! generate_impl {
+    ($struct:ident) => {
+        impl $struct {}
+    };
+}
+
+struct Qux;
+// Macro expansions shouldn't lint
+generate_impl!(Qux);
+
+fn main() {}

--- a/tests/ui/unused_impl.rs
+++ b/tests/ui/unused_impl.rs
@@ -1,0 +1,66 @@
+#![warn(clippy::unused_impl)]
+
+trait MyTrait {}
+
+// Should work inside modules
+mod bar {
+    use crate::MyTrait;
+
+    struct Foo1;
+    impl Foo1 {}
+    //~^ unused_impl
+
+    struct Foo2<'a>(&'a str);
+    // Lifetimes should have no effect
+    impl<'a> Foo2<'a> {}
+    //~^ unused_impl
+}
+
+// Implementations with `#[cfg]` and/or doc comments shouldn't lint
+
+// Doc comment only should lint
+struct Bar1;
+/// Hello world
+impl Bar1 {}
+
+// #[cfg] only should lint
+struct Bar2;
+#[cfg(test)]
+impl Bar2 {}
+
+// Both doc comment and attribute should lint
+struct Bar3;
+/// Hello world
+#[cfg(test)]
+impl Bar3 {}
+
+// Different attributes should lint
+struct Bar4;
+#[doc(hidden)]
+impl Bar4 {}
+//~^ unused_impl
+
+// Just to make sure, lint check attributes should still work
+struct Bar5;
+#[expect(clippy::unused_impl)]
+impl Bar5 {}
+
+struct Baz;
+// Non-empty shouldn't lint
+impl Baz {
+    fn baz() {}
+}
+// Trait implementation shouldn't lint
+impl MyTrait for Baz {}
+
+macro_rules! generate_impl {
+    ($struct:ident) => {
+        impl $struct {}
+    };
+}
+
+struct Qux;
+// Macro expansions shouldn't lint
+generate_impl!(Qux);
+
+fn main() {}

--- a/tests/ui/unused_impl.stderr
+++ b/tests/ui/unused_impl.stderr
@@ -1,0 +1,30 @@
+error: empty impl body
+  --> tests/ui/unused_impl.rs:10:5
+   |
+LL |       impl Foo1 {}
+   |  _____-^^^^^^^^^^^
+LL | |
+   | |____- help: remove this
+   |
+   = note: `-D clippy::unused-impl` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_impl)]`
+
+error: empty impl body
+  --> tests/ui/unused_impl.rs:15:5
+   |
+LL |       impl<'a> Foo2<'a> {}
+   |  _____-^^^^^^^^^^^^^^^^^^^
+LL | |
+   | |____- help: remove this
+
+error: empty impl body
+  --> tests/ui/unused_impl.rs:40:1
+   |
+LL | / #[doc(hidden)]
+LL | | impl Bar4 {}
+   | | ^^^^^^^^^^^^
+LL | |
+   | |_- help: remove this
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This lint checks for `impl` blocks with no body. Trait implementations are exempted.

Added exceptions to the following lints:
- `impl`
- `into_iter_without_iter`
- `mismatching_type_param_order`
- `multiple_inherent_impl_cfg`
- `needless_lifetimes`
- `needless_maybe_sized`
- `doc_comments`
    - Simple `#![expect]` did not work, so I had to just add a dummy body to the `impl` block.
- `unknown_clippy_lints`
    - Suggestion changed to `clippy::unused_impl` from `clippy::unused_self`

fixes rust-lang/rust-clippy#16758
changelog: new lint: [`unused_impl`]