### PR TITLE
Add `split_filter_map_ok` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7240,6 +7240,7 @@ Released 2018-09-13
 [`sliced_string_as_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#sliced_string_as_bytes
 [`slow_vector_initialization`]: https://rust-lang.github.io/rust-clippy/master/index.html#slow_vector_initialization
 [`some_filter`]: https://rust-lang.github.io/rust-clippy/master/index.html#some_filter
+[`split_filter_map_ok`]: https://rust-lang.github.io/rust-clippy/master/index.html#split_filter_map_ok
 [`stable_sort_primitive`]: https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive
 [`std_instead_of_alloc`]: https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_alloc
 [`std_instead_of_core`]: https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_core

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -476,6 +476,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::SKIP_WHILE_NEXT_INFO,
     crate::methods::SLICED_STRING_AS_BYTES_INFO,
     crate::methods::SOME_FILTER_INFO,
+    crate::methods::SPLIT_FILTER_MAP_OK_INFO,
     crate::methods::STABLE_SORT_PRIMITIVE_INFO,
     crate::methods::STR_SPLIT_AT_NEWLINE_INFO,
     crate::methods::STRING_EXTEND_CHARS_INFO,

--- a/clippy_lints/src/methods/lines_filter_map_ok.rs
+++ b/clippy_lints/src/methods/lines_filter_map_ok.rs
@@ -4,20 +4,48 @@ use clippy_utils::res::{MaybeDef, MaybeResPath, MaybeTypeckRes};
 use clippy_utils::sym;
 use rustc_errors::Applicability;
 use rustc_hir::{Body, Closure, Expr, ExprKind};
-use rustc_lint::LateContext;
+use rustc_lint::{LateContext, Lint};
+use rustc_middle::ty::Ty;
 use rustc_span::Span;
 
-use super::LINES_FILTER_MAP_OK;
+use super::{LINES_FILTER_MAP_OK, SPLIT_FILTER_MAP_OK};
+
+#[derive(Clone, Copy)]
+enum Variant {
+    Lines,
+    Split,
+}
+
+impl Variant {
+    fn lint(self) -> &'static Lint {
+        match self {
+            Variant::Lines => LINES_FILTER_MAP_OK,
+            Variant::Split => SPLIT_FILTER_MAP_OK,
+        }
+    }
+
+    fn type_name(self) -> &'static str {
+        match self {
+            Variant::Lines => "std::io::Lines",
+            Variant::Split => "std::io::Split",
+        }
+    }
+}
+
+fn get_variant(cx: &LateContext<'_>, ty: Ty<'_>) -> Option<Variant> {
+    match ty.opt_diag_name(cx) {
+        Some(sym::IoLines) => Some(Variant::Lines),
+        Some(sym::IoSplit) => Some(Variant::Split),
+        _ => None,
+    }
+}
 
 pub(super) fn check_flatten(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, call_span: Span, msrv: Msrv) {
     if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator)
-        && cx
-            .typeck_results()
-            .expr_ty_adjusted(recv)
-            .is_diag_item(cx, sym::IoLines)
+        && let Some(variant) = get_variant(cx, cx.typeck_results().expr_ty_adjusted(recv))
         && msrv.meets(cx, msrvs::MAP_WHILE)
     {
-        emit(cx, recv, "flatten", call_span);
+        emit(cx, recv, "flatten", call_span, variant);
     }
 }
 
@@ -31,10 +59,7 @@ pub(super) fn check_filter_or_flat_map(
     msrv: Msrv,
 ) {
     if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator)
-        && cx
-            .typeck_results()
-            .expr_ty_adjusted(recv)
-            .is_diag_item(cx, sym::IoLines)
+        && let Some(variant) = get_variant(cx, cx.typeck_results().expr_ty_adjusted(recv))
         && match method_arg.kind {
             // Detect `Result::ok`
             ExprKind::Path(ref qpath) => cx
@@ -58,21 +83,24 @@ pub(super) fn check_filter_or_flat_map(
         }
         && msrv.meets(cx, msrvs::MAP_WHILE)
     {
-        emit(cx, recv, method_name, call_span);
+        emit(cx, recv, method_name, call_span, variant);
     }
 }
 
-fn emit(cx: &LateContext<'_>, recv: &Expr<'_>, method_name: &'static str, call_span: Span) {
+fn emit(cx: &LateContext<'_>, recv: &Expr<'_>, method_name: &'static str, call_span: Span, variant: Variant) {
     span_lint_and_then(
         cx,
-        LINES_FILTER_MAP_OK,
+        variant.lint(),
         call_span,
         format!("`{method_name}()` will run forever if the iterator repeatedly produces an `Err`"),
         |diag| {
             diag.span_note(
                 recv.span,
-                "this expression returning a `std::io::Lines` may produce \
+                format!(
+                    "this expression returning a `{0}` may produce \
                         an infinite number of `Err` in case of a read error",
+                    variant.type_name(),
+                ),
             );
             diag.span_suggestion(
                 call_span,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3629,6 +3629,55 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for usage of `split.filter_map(Result::ok)` or `split.flat_map(Result::ok)`
+    /// when `split` has type `std::io::Split`.
+    ///
+    /// ### Why is this bad?
+    /// `Split` instances might produce a never-ending stream of `Err`, in which case
+    /// `filter_map(Result::ok)` will enter an infinite loop while waiting for an
+    /// `Ok` variant. Calling `next()` once is sufficient to enter the infinite loop,
+    /// even in the absence of explicit loops in the user code.
+    ///
+    /// This situation can arise when working with user-provided paths. On some platforms,
+    /// `std::fs::File::open(path)` might return `Ok(fs)` even when `path` is a directory,
+    /// but any later attempt to read from `fs` will return an error.
+    ///
+    /// ### Known problems
+    /// This lint suggests replacing `filter_map()` or `flat_map()` applied to a `Split`
+    /// instance in all cases. There are two cases where the suggestion might not be
+    /// appropriate or necessary:
+    ///
+    /// - If the `Split` instance can never produce any error, or if an error is produced
+    ///   only once just before terminating the iterator, using `map_while()` is not
+    ///   necessary but will not do any harm.
+    /// - If the `Split` instance can produce intermittent errors then recover and produce
+    ///   successful results, using `map_while()` would stop at the first error.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # use std::{fs::File, io::{self, BufRead, BufReader}};
+    /// # let _ = || -> io::Result<()> {
+    /// let mut parts = BufReader::new(File::open("some-path")?).split(0).filter_map(Result::ok);
+    /// // If "some-path" points to a directory, the next statement never terminates:
+    /// let first_part: Option<Vec<_>> = parts.next();
+    /// # Ok(()) };
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # use std::{fs::File, io::{self, BufRead, BufReader}};
+    /// # let _ = || -> io::Result<()> {
+    /// let mut parts = BufReader::new(File::open("some-path")?).split(0).map_while(Result::ok);
+    /// let first_part: Option<Vec<_>> = parts.next();
+    /// # Ok(()) };
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub SPLIT_FILTER_MAP_OK,
+    suspicious,
+    "filtering `std::io::Split` with `filter_map()`, `flat_map()`, or `flatten()` might cause an infinite loop"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// When sorting primitive values (integers, bools, chars, as well
     /// as arrays, slices, and tuples of such items), it is typically better to
     /// use an unstable sort than a stable sort.
@@ -4952,6 +5001,7 @@ impl_lint_pass!(Methods => [
     SKIP_WHILE_NEXT,
     SLICED_STRING_AS_BYTES,
     SOME_FILTER,
+    SPLIT_FILTER_MAP_OK,
     STABLE_SORT_PRIMITIVE,
     STRING_EXTEND_CHARS,
     STRING_LIT_CHARS_ANY,

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -72,6 +72,7 @@ generate! {
     IoLines,
     IoRead,
     IoSeek,
+    IoSplit,
     IoWrite,
     IpAddr,
     Ipv4Addr,

--- a/tests/ui/split_filter_map_ok.fixed
+++ b/tests/ui/split_filter_map_ok.fixed
@@ -1,0 +1,45 @@
+#![allow(clippy::map_identity)]
+#![warn(clippy::split_filter_map_ok)]
+
+use std::io::{self, BufRead, BufReader};
+
+fn main() -> io::Result<()> {
+    // Lint:
+
+    let f = std::fs::File::open("/")?;
+    BufReader::new(f).split(0).map_while(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+    let f = std::fs::File::open("/")?;
+    BufReader::new(f).split(0).map_while(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+    let f = std::fs::File::open("/")?;
+    BufReader::new(f).split(0).map_while(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+
+    io::stdin().lock().split(0).map_while(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+    io::stdin().lock().split(0).map_while(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+    io::stdin().lock().split(0).map_while(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+
+    // Do not lint:
+
+    // not an `std::io::Split` iterator
+    io::stdin()
+        .lock()
+        .split(0)
+        .map(std::convert::identity)
+        .filter_map(|x| x.ok())
+        .for_each(|_| ());
+    // not a `Result::ok()` extractor
+    io::stdin().lock().split(0).filter_map(|x| x.err()).for_each(|_| ());
+    Ok(())
+}
+
+#[clippy::msrv = "1.56"]
+fn msrv_check() {
+    let _lines = BufReader::new(std::fs::File::open("some-path").unwrap())
+        .split(0)
+        .filter_map(Result::ok);
+}

--- a/tests/ui/split_filter_map_ok.rs
+++ b/tests/ui/split_filter_map_ok.rs
@@ -1,0 +1,45 @@
+#![allow(clippy::map_identity)]
+#![warn(clippy::split_filter_map_ok)]
+
+use std::io::{self, BufRead, BufReader};
+
+fn main() -> io::Result<()> {
+    // Lint:
+
+    let f = std::fs::File::open("/")?;
+    BufReader::new(f).split(0).filter_map(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+    let f = std::fs::File::open("/")?;
+    BufReader::new(f).split(0).flat_map(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+    let f = std::fs::File::open("/")?;
+    BufReader::new(f).split(0).flatten().for_each(|_| ());
+    //~^ split_filter_map_ok
+
+    io::stdin().lock().split(0).filter_map(Result::ok).for_each(|_| ());
+    //~^ split_filter_map_ok
+    io::stdin().lock().split(0).filter_map(|x| x.ok()).for_each(|_| ());
+    //~^ split_filter_map_ok
+    io::stdin().lock().split(0).flatten().for_each(|_| ());
+    //~^ split_filter_map_ok
+
+    // Do not lint:
+
+    // not an `std::io::Split` iterator
+    io::stdin()
+        .lock()
+        .split(0)
+        .map(std::convert::identity)
+        .filter_map(|x| x.ok())
+        .for_each(|_| ());
+    // not a `Result::ok()` extractor
+    io::stdin().lock().split(0).filter_map(|x| x.err()).for_each(|_| ());
+    Ok(())
+}
+
+#[clippy::msrv = "1.56"]
+fn msrv_check() {
+    let _lines = BufReader::new(std::fs::File::open("some-path").unwrap())
+        .split(0)
+        .filter_map(Result::ok);
+}

--- a/tests/ui/split_filter_map_ok.stderr
+++ b/tests/ui/split_filter_map_ok.stderr
@@ -1,0 +1,76 @@
+error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
+  --> tests/ui/split_filter_map_ok.rs:10:32
+   |
+LL |     BufReader::new(f).split(0).filter_map(Result::ok).for_each(|_| ());
+   |                                ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+   |
+note: this expression returning a `std::io::Split` may produce an infinite number of `Err` in case of a read error
+  --> tests/ui/split_filter_map_ok.rs:10:5
+   |
+LL |     BufReader::new(f).split(0).filter_map(Result::ok).for_each(|_| ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `-D clippy::split-filter-map-ok` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::split_filter_map_ok)]`
+
+error: `flat_map()` will run forever if the iterator repeatedly produces an `Err`
+  --> tests/ui/split_filter_map_ok.rs:13:32
+   |
+LL |     BufReader::new(f).split(0).flat_map(Result::ok).for_each(|_| ());
+   |                                ^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+   |
+note: this expression returning a `std::io::Split` may produce an infinite number of `Err` in case of a read error
+  --> tests/ui/split_filter_map_ok.rs:13:5
+   |
+LL |     BufReader::new(f).split(0).flat_map(Result::ok).for_each(|_| ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `flatten()` will run forever if the iterator repeatedly produces an `Err`
+  --> tests/ui/split_filter_map_ok.rs:16:32
+   |
+LL |     BufReader::new(f).split(0).flatten().for_each(|_| ());
+   |                                ^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+   |
+note: this expression returning a `std::io::Split` may produce an infinite number of `Err` in case of a read error
+  --> tests/ui/split_filter_map_ok.rs:16:5
+   |
+LL |     BufReader::new(f).split(0).flatten().for_each(|_| ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
+  --> tests/ui/split_filter_map_ok.rs:19:33
+   |
+LL |     io::stdin().lock().split(0).filter_map(Result::ok).for_each(|_| ());
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+   |
+note: this expression returning a `std::io::Split` may produce an infinite number of `Err` in case of a read error
+  --> tests/ui/split_filter_map_ok.rs:19:5
+   |
+LL |     io::stdin().lock().split(0).filter_map(Result::ok).for_each(|_| ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
+  --> tests/ui/split_filter_map_ok.rs:21:33
+   |
+LL |     io::stdin().lock().split(0).filter_map(|x| x.ok()).for_each(|_| ());
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+   |
+note: this expression returning a `std::io::Split` may produce an infinite number of `Err` in case of a read error
+  --> tests/ui/split_filter_map_ok.rs:21:5
+   |
+LL |     io::stdin().lock().split(0).filter_map(|x| x.ok()).for_each(|_| ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `flatten()` will run forever if the iterator repeatedly produces an `Err`
+  --> tests/ui/split_filter_map_ok.rs:23:33
+   |
+LL |     io::stdin().lock().split(0).flatten().for_each(|_| ());
+   |                                 ^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+   |
+note: this expression returning a `std::io::Split` may produce an infinite number of `Err` in case of a read error
+  --> tests/ui/split_filter_map_ok.rs:23:5
+   |
+LL |     io::stdin().lock().split(0).flatten().for_each(|_| ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
Add a new lint identical to `lines_filter_map_ok` except that it checks for `std::io::Split` instead of `std::io::Lines`.

---

changelog: [`split_filter_map_ok`]: add lint
