### PR TITLE
New lint: `empty_expect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6577,6 +6577,7 @@ Released 2018-09-13
 [`empty_enum`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_enum
 [`empty_enum_variants_with_brackets`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_enum_variants_with_brackets
 [`empty_enums`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_enums
+[`empty_expect`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_expect
 [`empty_line_after_doc_comments`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
 [`empty_line_after_outer_attr`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_outer_attr
 [`empty_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_loop

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -140,6 +140,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::else_if_without_else::ELSE_IF_WITHOUT_ELSE_INFO,
     crate::empty_drop::EMPTY_DROP_INFO,
     crate::empty_enums::EMPTY_ENUMS_INFO,
+    crate::empty_expect::EMPTY_EXPECT_INFO,
     crate::empty_line_after::EMPTY_LINE_AFTER_DOC_COMMENTS_INFO,
     crate::empty_line_after::EMPTY_LINE_AFTER_OUTER_ATTR_INFO,
     crate::empty_with_brackets::EMPTY_ENUM_VARIANTS_WITH_BRACKETS_INFO,

--- a/clippy_lints/src/empty_expect.rs
+++ b/clippy_lints/src/empty_expect.rs
@@ -1,0 +1,64 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::res::MaybeDef;
+use clippy_utils::sym;
+use rustc_ast::ast::LitKind;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Detects `.expect("")` calls where the expect message is an empty string literal.
+    ///
+    /// ### Why is this bad?
+    /// An empty expect message provides no more context than a plain `.unwrap()` call.
+    /// It is sometimes used to bypass the `unwrap_used` lint without actually providing
+    /// a useful panic message.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let x: Option<i32> = Some(1);
+    /// let _ = x.expect("");
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let x: Option<i32> = Some(1);
+    /// let _ = x.expect("x should always be Some because ...");
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub EMPTY_EXPECT,
+    suspicious,
+    "`.expect(\"\")` with an empty string provides no useful panic message"
+}
+declare_lint_pass!(EmptyExpect => [EMPTY_EXPECT]);
+
+impl<'tcx> LateLintPass<'tcx> for EmptyExpect {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        if let ExprKind::MethodCall(method, recv, [arg], _) = expr.kind
+            && method.ident.name == sym::expect
+            && is_empty_str_lit(arg)
+        {
+            let ty = cx.typeck_results().expr_ty(recv).peel_refs();
+            if matches!(ty.opt_diag_name(cx), Some(sym::Option | sym::Result)) {
+                span_lint_and_help(
+                    cx,
+                    EMPTY_EXPECT,
+                    expr.span,
+                    "`.expect(\"\")` with an empty string provides no useful panic message",
+                    None,
+                    "provide a meaningful expect message or use `.unwrap()` instead",
+                );
+            }
+        }
+    }
+}
+
+fn is_empty_str_lit(expr: &Expr<'_>) -> bool {
+    if let ExprKind::Lit(lit) = expr.kind
+        && let LitKind::Str(sym, _) = lit.node
+    {
+        sym.is_empty()
+    } else {
+        false
+    }
+}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -116,6 +116,7 @@ mod duration_suboptimal_units;
 mod else_if_without_else;
 mod empty_drop;
 mod empty_enums;
+mod empty_expect;
 mod empty_line_after;
 mod empty_with_brackets;
 mod endian_bytes;
@@ -865,6 +866,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(move |_| Box::new(manual_take::ManualTake::new(conf))),
         Box::new(|_| Box::new(manual_checked_ops::ManualCheckedOps)),
         Box::new(move |tcx| Box::new(manual_pop_if::ManualPopIf::new(tcx, conf))),
+        Box::new(|_| Box::new(empty_expect::EmptyExpect)),
         // add late passes here, used by `cargo dev new_lint`
     ];
     store.late_passes.extend(late_lints);

--- a/tests/ui/empty_expect.rs
+++ b/tests/ui/empty_expect.rs
@@ -1,0 +1,14 @@
+#![warn(clippy::empty_expect)]
+#![allow(clippy::unnecessary_literal_unwrap)]
+
+fn main() {
+    let x: Option<i32> = Some(1);
+    let _ = x.expect(""); // should warn
+    //~^ empty_expect
+    let _ = x.expect("valid value"); // should not warn
+
+    let v: Result<i32, &str> = Ok(1);
+    let _ = v.expect(""); // should warn
+    //~^ empty_expect
+    let _ = v.expect("parsing succeeds"); // should not warn
+}

--- a/tests/ui/empty_expect.stderr
+++ b/tests/ui/empty_expect.stderr
@@ -1,0 +1,20 @@
+error: `.expect("")` with an empty string provides no useful panic message
+  --> tests/ui/empty_expect.rs:6:13
+   |
+LL |     let _ = x.expect(""); // should warn
+   |             ^^^^^^^^^^^^
+   |
+   = help: provide a meaningful expect message or use `.unwrap()` instead
+   = note: `-D clippy::empty-expect` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::empty_expect)]`
+
+error: `.expect("")` with an empty string provides no useful panic message
+  --> tests/ui/empty_expect.rs:11:13
+   |
+LL |     let _ = v.expect(""); // should warn
+   |             ^^^^^^^^^^^^
+   |
+   = help: provide a meaningful expect message or use `.unwrap()` instead
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
## Summary
- Adds new `empty_expect` lint (category: `suspicious`)
- Detects `.expect("")` calls with empty string message
- These provide no more context than `.unwrap()` and are sometimes used to bypass `unwrap_used`

## Test plan
- Added UI tests for `Option::expect("")` and `Result::expect("")`
- Verified non-empty `.expect("msg")` does not trigger

Closes rust-lang/rust-clippy#16764

🤖 Generated with [Claude Code](https://claude.com/claude-code)