### PR TITLE
Extend `clippy::missing_safety_doc` to unsafe fields

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -6,7 +6,7 @@ use clippy_utils::diagnostics::{span_lint, span_lint_and_help, span_lint_and_the
 use clippy_utils::{is_entrypoint_fn, is_trait_impl_item};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
-use rustc_hir::{Attribute, ImplItemKind, ItemKind, Node, Safety, TraitItemKind};
+use rustc_hir::{Attribute, FieldDef, ImplItemKind, ItemKind, Node, Safety, TraitItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintContext};
 use rustc_resolve::rustdoc::pulldown_cmark::Event::{
     Code, DisplayMath, End, FootnoteReference, HardBreak, Html, InlineHtml, InlineMath, Rule, SoftBreak, Start,
@@ -754,6 +754,23 @@ impl<'tcx> LateLintPass<'tcx> for Documentation {
         };
 
         match cx.tcx.hir_node(cx.last_node_with_lint_attrs) {
+            Node::Field(FieldDef { span, safety, .. }) => match (headers.safety, safety) {
+                (false, Safety::Unsafe) => span_lint(
+                    cx,
+                    MISSING_SAFETY_DOC,
+                    *span,
+                    "docs for unsafe field missing `# Safety` section",
+                ),
+                (true, Safety::Safe) if cx.tcx.features().unsafe_fields() => span_lint_and_help(
+                    cx,
+                    UNNECESSARY_SAFETY_DOC,
+                    *span,
+                    "field with `# Safety` documentation is not marked unsafe",
+                    None,
+                    "if the field has safety invariants, mark it `unsafe`",
+                ),
+                _ => (),
+            },
             Node::Item(item) => {
                 too_long_first_doc_paragraph::check(
                     cx,

--- a/tests/ui/derive.rs
+++ b/tests/ui/derive.rs
@@ -117,6 +117,7 @@ impl<T: Copy> Clone for Packed<T> {
 fn issue14558() {
     pub struct Valid {
         pub unsafe actual: (),
+        //~^ missing_safety_doc
     }
 
     unsafe impl Copy for Valid {}

--- a/tests/ui/derive.stderr
+++ b/tests/ui/derive.stderr
@@ -65,5 +65,14 @@ LL | | }
    |
    = help: consider deriving `Clone` or removing `Copy`
 
-error: aborting due to 5 previous errors
+error: docs for unsafe field missing `# Safety` section
+  --> tests/ui/derive.rs:119:9
+   |
+LL |         pub unsafe actual: (),
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::missing-safety-doc` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_safety_doc)]`
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/doc_unsafe.rs
+++ b/tests/ui/doc_unsafe.rs
@@ -1,6 +1,9 @@
 //@aux-build:proc_macros.rs
 
 #![allow(clippy::let_unit_value, clippy::needless_pass_by_ref_mut)]
+#![deny(clippy::unnecessary_safety_doc)]
+#![expect(incomplete_features)]
+#![feature(unsafe_fields)]
 
 extern crate proc_macros;
 use proc_macros::external;
@@ -37,6 +40,45 @@ mod private_mod {
 }
 
 pub use private_mod::republished;
+
+struct UnsafeStruct {
+    // Unsafe fields are almost always private, so excluding according to
+    // `check-private-items` does not make sense (they are also not items).
+    unsafe field: u8,
+    //~^ missing_safety_doc
+}
+
+enum UnsafeEnum {
+    Variant {
+        unsafe field: u8,
+        //~^ missing_safety_doc
+    },
+}
+
+union UnsafeUnion {
+    unsafe field: u8,
+    //~^ missing_safety_doc
+}
+
+struct SafeStruct {
+    /// # Safety
+    field: u8,
+    //~^ unnecessary_safety_doc
+}
+
+enum SafeEnum {
+    Variant {
+        /// # Safety
+        field: u8,
+        //~^ unnecessary_safety_doc
+    },
+}
+
+union SafeUnion {
+    /// # Safety
+    field: u8,
+    //~^ unnecessary_safety_doc
+}
 
 pub trait SafeTraitUnsafeMethods {
     unsafe fn woefully_underdocumented(self);

--- a/tests/ui/doc_unsafe.stderr
+++ b/tests/ui/doc_unsafe.stderr
@@ -1,5 +1,5 @@
 error: unsafe function's docs are missing a `# Safety` section
-  --> tests/ui/doc_unsafe.rs:9:1
+  --> tests/ui/doc_unsafe.rs:12:1
    |
 LL | pub unsafe fn destroy_the_planet() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,31 +8,78 @@ LL | pub unsafe fn destroy_the_planet() {
    = help: to override `-D warnings` add `#[allow(clippy::missing_safety_doc)]`
 
 error: unsafe function's docs are missing a `# Safety` section
-  --> tests/ui/doc_unsafe.rs:33:5
+  --> tests/ui/doc_unsafe.rs:36:5
    |
 LL |     pub unsafe fn republished() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: docs for unsafe field missing `# Safety` section
+  --> tests/ui/doc_unsafe.rs:47:5
+   |
+LL |     unsafe field: u8,
+   |     ^^^^^^^^^^^^^^^^
+
+error: docs for unsafe field missing `# Safety` section
+  --> tests/ui/doc_unsafe.rs:53:9
+   |
+LL |         unsafe field: u8,
+   |         ^^^^^^^^^^^^^^^^
+
+error: docs for unsafe field missing `# Safety` section
+  --> tests/ui/doc_unsafe.rs:59:5
+   |
+LL |     unsafe field: u8,
+   |     ^^^^^^^^^^^^^^^^
+
+error: field with `# Safety` documentation is not marked unsafe
+  --> tests/ui/doc_unsafe.rs:65:5
+   |
+LL |     field: u8,
+   |     ^^^^^^^^^
+   |
+   = help: if the field has safety invariants, mark it `unsafe`
+note: the lint level is defined here
+  --> tests/ui/doc_unsafe.rs:4:9
+   |
+LL | #![deny(clippy::unnecessary_safety_doc)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: field with `# Safety` documentation is not marked unsafe
+  --> tests/ui/doc_unsafe.rs:72:9
+   |
+LL |         field: u8,
+   |         ^^^^^^^^^
+   |
+   = help: if the field has safety invariants, mark it `unsafe`
+
+error: field with `# Safety` documentation is not marked unsafe
+  --> tests/ui/doc_unsafe.rs:79:5
+   |
+LL |     field: u8,
+   |     ^^^^^^^^^
+   |
+   = help: if the field has safety invariants, mark it `unsafe`
+
 error: unsafe function's docs are missing a `# Safety` section
-  --> tests/ui/doc_unsafe.rs:42:5
+  --> tests/ui/doc_unsafe.rs:84:5
    |
 LL |     unsafe fn woefully_underdocumented(self);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for unsafe trait missing `# Safety` section
-  --> tests/ui/doc_unsafe.rs:49:1
+  --> tests/ui/doc_unsafe.rs:91:1
    |
 LL | pub unsafe trait UnsafeTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe function's docs are missing a `# Safety` section
-  --> tests/ui/doc_unsafe.rs:80:5
+  --> tests/ui/doc_unsafe.rs:122:5
    |
 LL |     pub unsafe fn more_undocumented_unsafe() -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe function's docs are missing a `# Safety` section
-  --> tests/ui/doc_unsafe.rs:97:9
+  --> tests/ui/doc_unsafe.rs:139:9
    |
 LL |         pub unsafe fn whee() {
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -42,5 +89,5 @@ LL | very_unsafe!();
    |
    = note: this error originates in the macro `very_unsafe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
changelog: [`missing_safety_doc`]: lint unsafe fields

Makes progress towards rust-lang/rust#132922

