### PR TITLE
chore(deps): update rust crate tar to v0.4.45

### DIFF
--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -21,7 +21,7 @@ rayon = "1.5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
 strip-ansi-escapes = "0.2.0"
-tar = "0.4"
+tar = "0.4.45"
 toml = "0.9.7"
 ureq = { version = "2.2", features = ["json"] }
 walkdir = "2.3"


### PR DESCRIPTION
Fix [RUSTSEC-2026-0068](https://rustsec.org/advisories/RUSTSEC-2026-0068.html): tar-rs incorrectly ignores PAX size headers if header size is nonzero
Fix [RUSTSEC-2026-0067](https://rustsec.org/advisories/RUSTSEC-2026-0067.html): `unpack_in` can chmod arbitrary directories by following symlinks

changelog: none