### PR TITLE
fix: add check for image with embedded link

### DIFF
--- a/clippy_lints/src/doc/doc_paragraphs_missing_punctuation.rs
+++ b/clippy_lints/src/doc/doc_paragraphs_missing_punctuation.rs
@@ -54,13 +54,14 @@ fn is_missing_punctuation(doc_string: &str) -> Vec<MissingPunctuation> {
     let mut missing_punctuation = Vec::new();
     let mut current_paragraph = None;
     let mut current_event_is_missing_punctuation = false;
-
+    let mut current_event_is_image = false;
     for (event, offset) in
         Parser::new_ext(doc_string, main_body_opts() - Options::ENABLE_SMART_PUNCTUATION).into_offset_iter()
     {
         let last_event_was_missing_punctuation = current_event_is_missing_punctuation;
         current_event_is_missing_punctuation = false;
-
+        let last_event_was_image = current_event_is_image;
+        current_event_is_image = false;
         match event {
             Event::Start(Tag::FootnoteDefinition(_) | Tag::Heading { .. } | Tag::HtmlBlock | Tag::Table(_)) => {
                 no_report_depth += 1;
@@ -82,7 +83,11 @@ fn is_missing_punctuation(doc_string: &str) -> Vec<MissingPunctuation> {
                 no_report_depth -= 1;
                 current_paragraph = None;
             },
-            Event::InlineHtml(_) | Event::Start(Tag::Image { .. }) | Event::End(TagEnd::Image) => {
+            Event::InlineHtml(_) | Event::Start(Tag::Image { .. }) => {
+                current_paragraph = None;
+            },
+            Event::End(TagEnd::Image) => {
+                current_event_is_image = true;
                 current_paragraph = None;
             },
             Event::End(TagEnd::Paragraph) => {
@@ -94,7 +99,9 @@ fn is_missing_punctuation(doc_string: &str) -> Vec<MissingPunctuation> {
             Event::Code(..) | Event::Start(Tag::Link { .. }) | Event::End(TagEnd::Link)
                 if no_report_depth == 0 && !offset.is_empty() =>
             {
-                if trim_trailing_symbols(&doc_string[..offset.end]).ends_with(TERMINAL_PUNCTUATION_MARKS) {
+                if trim_trailing_symbols(&doc_string[..offset.end]).ends_with(TERMINAL_PUNCTUATION_MARKS)
+                    || last_event_was_image
+                {
                     current_paragraph = None;
                 } else {
                     current_paragraph = Some(MissingPunctuation::Fixable(offset.end));

--- a/tests/ui/doc/doc_paragraphs_missing_punctuation.fixed
+++ b/tests/ui/doc/doc_paragraphs_missing_punctuation.fixed
@@ -181,3 +181,11 @@ struct BlockDocComment;
 #[doc = ""]
 /// ```
 struct DocAttribute;
+
+// Should not trigger when given simply an image which is also a link.
+/// [![git]](https://github.com/rust-lang/rust)
+///
+/// [git]: https://rustfoundation.org/wp-content/uploads/2024/07/cropped-rust-lang-logo-black-270x270.png
+fn rust_is_cool() ->i32{
+    1
+}

--- a/tests/ui/doc/doc_paragraphs_missing_punctuation.rs
+++ b/tests/ui/doc/doc_paragraphs_missing_punctuation.rs
@@ -181,3 +181,11 @@ struct BlockDocComment;
 #[doc = ""]
 /// ```
 struct DocAttribute;
+
+// Should not trigger when given simply an image which is also a link.
+/// [![git]](https://github.com/rust-lang/rust)
+///
+/// [git]: https://rustfoundation.org/wp-content/uploads/2024/07/cropped-rust-lang-logo-black-270x270.png
+fn rust_is_cool() ->i32{
+    1
+}


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16773)*

This fix adds an aditional check, by checking if the previous element was an image, and ignoring the lack of punctuation for a subsequent link. An aditional test was added to account for this case.

Closes rust-lang/rust-clippy#16439

changelog: [`doc_paragraphs_missing_punctuation`]: fixed false positive on images with embedded link and added a test for such a case

