### PR TITLE
Generalize `extend_with_drain` to `VecDeque` and `BinaryHeap`.

### DIFF
--- a/clippy_lints/src/methods/extend_with_drain.rs
+++ b/clippy_lints/src/methods/extend_with_drain.rs
@@ -10,33 +10,54 @@ use super::EXTEND_WITH_DRAIN;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg: &Expr<'_>) {
     let ty = cx.typeck_results().expr_ty(recv).peel_refs();
-    if ty.is_diag_item(cx, sym::Vec)
-        //check source object
-        && let ExprKind::MethodCall(src_method, drain_vec, [drain_arg], _) = &arg.kind
-        && src_method.ident.name == sym::drain
-        && let src_ty = cx.typeck_results().expr_ty(drain_vec)
-        //check if actual src type is mutable for code suggestion
-        && let immutable = src_ty.is_mutable_ptr()
-        && let src_ty = src_ty.peel_refs()
-        && src_ty.is_diag_item(cx, sym::Vec)
-        //check drain range
-        && let src_ty_range = cx.typeck_results().expr_ty(drain_arg).peel_refs()
-        && src_ty_range.is_lang_item(cx, LangItem::RangeFull)
+
+    // Each of these containers has:
+    // * A method `fn append(&mut self, other: &mut Self)`.
+    // * A method `fn drain(&mut self, /* maybe a range parameter too */)`.
+    for (container_type_sym, expect_drain_range_argument) in
+        [(sym::Vec, true), (sym::VecDeque, true), (sym::BinaryHeap, false)]
     {
-        let mut applicability = Applicability::MachineApplicable;
-        span_lint_and_sugg(
-            cx,
-            EXTEND_WITH_DRAIN,
-            expr.span,
-            "use of `extend` instead of `append` for adding the full range of a second vector",
-            "try",
-            format!(
-                "{}.append({}{})",
-                snippet_with_applicability(cx, recv.span, "..", &mut applicability),
-                if immutable { "" } else { "&mut " },
-                snippet_with_applicability(cx, drain_vec.span, "..", &mut applicability)
-            ),
-            applicability,
-        );
+        if ty.is_diag_item(cx, container_type_sym)
+        // Check that `extend()`'s argument is `drain()`
+        && let ExprKind::MethodCall(src_method, drain_vec, drain_args, _) = &arg.kind
+        && src_method.ident.name == sym::drain
+        // Check that the receiver of `drain()` is a collection of the same type
+        && let src_ty = cx.typeck_results().expr_ty(drain_vec)
+        && src_ty.peel_refs().is_diag_item(cx, container_type_sym)
+        // Check that the drain range (if there is one) is full, not partial
+        && drain_args_are_full_range(cx, drain_args, expect_drain_range_argument)
+        {
+            let mut applicability = Applicability::MachineApplicable;
+            span_lint_and_sugg(
+                cx,
+                EXTEND_WITH_DRAIN,
+                expr.span,
+                format!(
+                    "use of `extend` instead of `append` for moving \
+                    the full contents of a second `{container_type_sym}`"
+                ),
+                "try",
+                format!(
+                    "{}.append({}{})",
+                    snippet_with_applicability(cx, recv.span, "..", &mut applicability),
+                    if src_ty.is_mutable_ptr() { "" } else { "&mut " },
+                    snippet_with_applicability(cx, drain_vec.span, "..", &mut applicability)
+                ),
+                applicability,
+            );
+        }
+    }
+}
+
+/// Check for the correct count of arguments to a `drain()` call, and, if a range is expected,
+/// that the range is the full range `..`.
+fn drain_args_are_full_range(cx: &LateContext<'_>, args: &[Expr<'_>], expect_drain_range_argument: bool) -> bool {
+    match (expect_drain_range_argument, args) {
+        (false, []) => true,
+        (true, [drain_arg]) => {
+            let src_ty_range = cx.typeck_results().expr_ty(drain_arg).peel_refs();
+            src_ty_range.is_lang_item(cx, LangItem::RangeFull)
+        },
+        (_, _) => false,
     }
 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -641,10 +641,12 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for occurrences where one vector gets extended instead of append
+    /// Checks for use of `extend()` and `drain()` methods to transfer items from one `Vec`,
+    /// `VecDeque`, or `BinaryHeap` to another.
     ///
     /// ### Why is this bad?
-    /// Using `append` instead of `extend` is more concise and faster
+    /// Using `append()` instead of `extend()` is more concise, and faster because the
+    /// `append()` method can take advantage of knowledge of the collection’s structure.
     ///
     /// ### Example
     /// ```no_run
@@ -664,7 +666,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.55.0"]
     pub EXTEND_WITH_DRAIN,
     perf,
-    "using vec.append(&mut vec) to move the full range of a vector to another"
+    "use of `extend(other.drain())` to move the contents of a collection is inefficient"
 }
 
 declare_clippy_lint! {

--- a/tests/ui/extend_with_drain.fixed
+++ b/tests/ui/extend_with_drain.fixed
@@ -1,5 +1,24 @@
 #![warn(clippy::extend_with_drain)]
-use std::collections::BinaryHeap;
+
+use std::collections::{BinaryHeap, VecDeque};
+
+struct NotAStdCollection {}
+impl NotAStdCollection {
+    /// The lint should *not* use this method because it doesn't know what it does,
+    /// despite looking similar.
+    fn append(&mut self, _other: &mut Self) {
+        unimplemented!()
+    }
+    fn drain<R: core::ops::RangeBounds<usize>>(&mut self, _range: R) -> impl Iterator<Item = ()> {
+        core::iter::empty()
+    }
+}
+impl Extend<()> for NotAStdCollection {
+    fn extend<T: IntoIterator<Item = ()>>(&mut self, _iter: T) {
+        unimplemented!()
+    }
+}
+
 fn main() {
     //gets linted
     let mut vec1 = vec![0u8; 1024];
@@ -38,17 +57,28 @@ fn main() {
 
     return_vector().append(&mut vec9);
 
-    //won't get linted because it is not a vec
-
-    let mut heap = BinaryHeap::from(vec![1, 3]);
-    let mut heap2 = BinaryHeap::from(vec![]);
-    heap2.extend(heap.drain());
-
     let mut x = vec![0, 1, 2, 3, 5];
     let ref_x = &mut x;
     let mut y = Vec::new();
     y.append(ref_x);
     //~^ extend_with_drain
+
+    // VecDeque works the same as Vec and gets the same lint
+    let mut vec_deque1 = VecDeque::from([0u8; 1024]);
+    let mut vec_deque2 = VecDeque::new();
+    vec_deque2.append(&mut vec_deque1);
+    //~^ extend_with_drain
+
+    // BinaryHeap is the same except for not having a range parameter
+    let mut heap = BinaryHeap::from(vec![1, 3]);
+    let mut heap2 = BinaryHeap::from(vec![]);
+    heap2.append(&mut heap);
+    //~^ extend_with_drain
+
+    // Unknown types should not get the same treatment
+    let mut foreign1 = NotAStdCollection {};
+    let mut foreign2 = NotAStdCollection {};
+    foreign2.extend(foreign1.drain(..));
 }
 
 fn return_vector() -> Vec<u8> {

--- a/tests/ui/extend_with_drain.rs
+++ b/tests/ui/extend_with_drain.rs
@@ -1,5 +1,24 @@
 #![warn(clippy::extend_with_drain)]
-use std::collections::BinaryHeap;
+
+use std::collections::{BinaryHeap, VecDeque};
+
+struct NotAStdCollection {}
+impl NotAStdCollection {
+    /// The lint should *not* use this method because it doesn't know what it does,
+    /// despite looking similar.
+    fn append(&mut self, _other: &mut Self) {
+        unimplemented!()
+    }
+    fn drain<R: core::ops::RangeBounds<usize>>(&mut self, _range: R) -> impl Iterator<Item = ()> {
+        core::iter::empty()
+    }
+}
+impl Extend<()> for NotAStdCollection {
+    fn extend<T: IntoIterator<Item = ()>>(&mut self, _iter: T) {
+        unimplemented!()
+    }
+}
+
 fn main() {
     //gets linted
     let mut vec1 = vec![0u8; 1024];
@@ -38,17 +57,28 @@ fn main() {
 
     return_vector().append(&mut vec9);
 
-    //won't get linted because it is not a vec
-
-    let mut heap = BinaryHeap::from(vec![1, 3]);
-    let mut heap2 = BinaryHeap::from(vec![]);
-    heap2.extend(heap.drain());
-
     let mut x = vec![0, 1, 2, 3, 5];
     let ref_x = &mut x;
     let mut y = Vec::new();
     y.extend(ref_x.drain(..));
     //~^ extend_with_drain
+
+    // VecDeque works the same as Vec and gets the same lint
+    let mut vec_deque1 = VecDeque::from([0u8; 1024]);
+    let mut vec_deque2 = VecDeque::new();
+    vec_deque2.extend(vec_deque1.drain(..));
+    //~^ extend_with_drain
+
+    // BinaryHeap is the same except for not having a range parameter
+    let mut heap = BinaryHeap::from(vec![1, 3]);
+    let mut heap2 = BinaryHeap::from(vec![]);
+    heap2.extend(heap.drain());
+    //~^ extend_with_drain
+
+    // Unknown types should not get the same treatment
+    let mut foreign1 = NotAStdCollection {};
+    let mut foreign2 = NotAStdCollection {};
+    foreign2.extend(foreign1.drain(..));
 }
 
 fn return_vector() -> Vec<u8> {

--- a/tests/ui/extend_with_drain.stderr
+++ b/tests/ui/extend_with_drain.stderr
@@ -1,5 +1,5 @@
-error: use of `extend` instead of `append` for adding the full range of a second vector
-  --> tests/ui/extend_with_drain.rs:7:5
+error: use of `extend` instead of `append` for moving the full contents of a second `Vec`
+  --> tests/ui/extend_with_drain.rs:26:5
    |
 LL |     vec2.extend(vec1.drain(..));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec2.append(&mut vec1)`
@@ -7,23 +7,35 @@ LL |     vec2.extend(vec1.drain(..));
    = note: `-D clippy::extend-with-drain` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::extend_with_drain)]`
 
-error: use of `extend` instead of `append` for adding the full range of a second vector
-  --> tests/ui/extend_with_drain.rs:13:5
+error: use of `extend` instead of `append` for moving the full contents of a second `Vec`
+  --> tests/ui/extend_with_drain.rs:32:5
    |
 LL |     vec4.extend(vec3.drain(..));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec4.append(&mut vec3)`
 
-error: use of `extend` instead of `append` for adding the full range of a second vector
-  --> tests/ui/extend_with_drain.rs:18:5
+error: use of `extend` instead of `append` for moving the full contents of a second `Vec`
+  --> tests/ui/extend_with_drain.rs:37:5
    |
 LL |     vec11.extend(return_vector().drain(..));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec11.append(&mut return_vector())`
 
-error: use of `extend` instead of `append` for adding the full range of a second vector
-  --> tests/ui/extend_with_drain.rs:50:5
+error: use of `extend` instead of `append` for moving the full contents of a second `Vec`
+  --> tests/ui/extend_with_drain.rs:63:5
    |
 LL |     y.extend(ref_x.drain(..));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `y.append(ref_x)`
 
-error: aborting due to 4 previous errors
+error: use of `extend` instead of `append` for moving the full contents of a second `VecDeque`
+  --> tests/ui/extend_with_drain.rs:69:5
+   |
+LL |     vec_deque2.extend(vec_deque1.drain(..));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec_deque2.append(&mut vec_deque1)`
+
+error: use of `extend` instead of `append` for moving the full contents of a second `BinaryHeap`
+  --> tests/ui/extend_with_drain.rs:75:5
+   |
+LL |     heap2.extend(heap.drain());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `heap2.append(&mut heap)`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
I also modified the code a little more than necessary, in order to make it clearer and shorter; in particular, `src_ty` is no longer shadowed and the `immutable` variable is gone.

changelog: [`extend_with_drain`]: now applies to uses of `VecDeque` and `BinaryHeap` as well as `Vec`
