### PR TITLE
Fixed two macro expansion FPs and added tests

### DIFF
--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -79,7 +79,8 @@ const FORGET_NON_DROP_SUMMARY: &str = "call to `std::mem::forget` with a value t
 
 impl<'tcx> LateLintPass<'tcx> for DropForgetRef {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if let ExprKind::Call(path, [arg]) = expr.kind
+        if  !expr.span.from_expansion()
+            && let ExprKind::Call(path, [arg]) = expr.kind
             && let ExprKind::Path(ref qpath) = path.kind
             && let Some(def_id) = cx.qpath_res(qpath, path.hir_id).opt_def_id()
             && let Some(fn_name) = cx.tcx.get_diagnostic_name(def_id)

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -79,7 +79,7 @@ const FORGET_NON_DROP_SUMMARY: &str = "call to `std::mem::forget` with a value t
 
 impl<'tcx> LateLintPass<'tcx> for DropForgetRef {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if  !expr.span.from_expansion()
+        if !expr.span.from_expansion()
             && let ExprKind::Call(path, [arg]) = expr.kind
             && let ExprKind::Path(ref qpath) = path.kind
             && let Some(def_id) = cx.qpath_res(qpath, path.hir_id).opt_def_id()

--- a/clippy_lints/src/trailing_empty_array.rs
+++ b/clippy_lints/src/trailing_empty_array.rs
@@ -38,7 +38,7 @@ declare_lint_pass!(TrailingEmptyArray => [TRAILING_EMPTY_ARRAY]);
 
 impl<'tcx> LateLintPass<'tcx> for TrailingEmptyArray {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
-        if  !item.span.from_expansion()
+        if !item.span.from_expansion()
             && is_struct_with_trailing_zero_sized_array(cx, item)
             && !has_repr_attr(cx, item.hir_id())
             && !is_in_test(cx.tcx, item.hir_id())

--- a/clippy_lints/src/trailing_empty_array.rs
+++ b/clippy_lints/src/trailing_empty_array.rs
@@ -38,7 +38,8 @@ declare_lint_pass!(TrailingEmptyArray => [TRAILING_EMPTY_ARRAY]);
 
 impl<'tcx> LateLintPass<'tcx> for TrailingEmptyArray {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
-        if is_struct_with_trailing_zero_sized_array(cx, item)
+        if  !item.span.from_expansion()
+            && is_struct_with_trailing_zero_sized_array(cx, item)
             && !has_repr_attr(cx, item.hir_id())
             && !is_in_test(cx.tcx, item.hir_id())
         {

--- a/tests/ui/drop_non_drop.rs
+++ b/tests/ui/drop_non_drop.rs
@@ -21,6 +21,15 @@ fn drop_generic<T>(t: T) {
     drop(t)
 }
 
+macro_rules! drop_macro{
+    () => {
+        {
+            struct T;
+            drop(T)
+        }
+    };
+}
+
 fn main() {
     struct Foo;
     // Lint
@@ -50,4 +59,7 @@ fn main() {
     // Lint
     drop(make_result_uninhabited_err(Foo));
     //~^ drop_non_drop
+
+    //Don't lint
+    drop_macro!();
 }

--- a/tests/ui/drop_non_drop.rs
+++ b/tests/ui/drop_non_drop.rs
@@ -21,13 +21,11 @@ fn drop_generic<T>(t: T) {
     drop(t)
 }
 
-macro_rules! drop_macro{
-    () => {
-        {
-            struct T;
-            drop(T)
-        }
-    };
+macro_rules! drop_macro {
+    () => {{
+        struct T;
+        drop(T)
+    }};
 }
 
 fn main() {

--- a/tests/ui/drop_non_drop.stderr
+++ b/tests/ui/drop_non_drop.stderr
@@ -1,11 +1,11 @@
 error: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
-  --> tests/ui/drop_non_drop.rs:36:5
+  --> tests/ui/drop_non_drop.rs:34:5
    |
 LL |     drop(Foo);
    |     ^^^^^^^^^
    |
 note: argument has type `main::Foo`
-  --> tests/ui/drop_non_drop.rs:36:10
+  --> tests/ui/drop_non_drop.rs:34:10
    |
 LL |     drop(Foo);
    |          ^^^
@@ -13,25 +13,25 @@ LL |     drop(Foo);
    = help: to override `-D warnings` add `#[allow(clippy::drop_non_drop)]`
 
 error: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
-  --> tests/ui/drop_non_drop.rs:53:5
+  --> tests/ui/drop_non_drop.rs:51:5
    |
 LL |     drop(Baz(Foo));
    |     ^^^^^^^^^^^^^^
    |
 note: argument has type `main::Baz<main::Foo>`
-  --> tests/ui/drop_non_drop.rs:53:10
+  --> tests/ui/drop_non_drop.rs:51:10
    |
 LL |     drop(Baz(Foo));
    |          ^^^^^^^^
 
 error: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
-  --> tests/ui/drop_non_drop.rs:60:5
+  --> tests/ui/drop_non_drop.rs:58:5
    |
 LL |     drop(make_result_uninhabited_err(Foo));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: argument has type `std::result::Result<main::Foo, std::convert::Infallible>`
-  --> tests/ui/drop_non_drop.rs:60:10
+  --> tests/ui/drop_non_drop.rs:58:10
    |
 LL |     drop(make_result_uninhabited_err(Foo));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/drop_non_drop.stderr
+++ b/tests/ui/drop_non_drop.stderr
@@ -1,11 +1,11 @@
 error: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
-  --> tests/ui/drop_non_drop.rs:27:5
+  --> tests/ui/drop_non_drop.rs:36:5
    |
 LL |     drop(Foo);
    |     ^^^^^^^^^
    |
 note: argument has type `main::Foo`
-  --> tests/ui/drop_non_drop.rs:27:10
+  --> tests/ui/drop_non_drop.rs:36:10
    |
 LL |     drop(Foo);
    |          ^^^
@@ -13,25 +13,25 @@ LL |     drop(Foo);
    = help: to override `-D warnings` add `#[allow(clippy::drop_non_drop)]`
 
 error: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
-  --> tests/ui/drop_non_drop.rs:44:5
+  --> tests/ui/drop_non_drop.rs:53:5
    |
 LL |     drop(Baz(Foo));
    |     ^^^^^^^^^^^^^^
    |
 note: argument has type `main::Baz<main::Foo>`
-  --> tests/ui/drop_non_drop.rs:44:10
+  --> tests/ui/drop_non_drop.rs:53:10
    |
 LL |     drop(Baz(Foo));
    |          ^^^^^^^^
 
 error: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
-  --> tests/ui/drop_non_drop.rs:51:5
+  --> tests/ui/drop_non_drop.rs:60:5
    |
 LL |     drop(make_result_uninhabited_err(Foo));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: argument has type `std::result::Result<main::Foo, std::convert::Infallible>`
-  --> tests/ui/drop_non_drop.rs:51:10
+  --> tests/ui/drop_non_drop.rs:60:10
    |
 LL |     drop(make_result_uninhabited_err(Foo));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/trailing_empty_array.rs
+++ b/tests/ui/trailing_empty_array.rs
@@ -188,13 +188,11 @@ struct TwoGenericParams<T, const N: usize> {
 }
 
 macro_rules! trailing_zero_macro {
-    () => {
-        {
-            struct MacroTrailingZero{
-                tz: [usize; 0],
-            }
+    () => {{
+        struct MacroTrailingZero {
+            tz: [usize; 0],
         }
-    };
+    }};
 }
 
 type A = ConstParamZeroDefault;
@@ -203,7 +201,6 @@ type C = ConstParamNoDefault<0>;
 type D = ConstParamNonZeroDefault<0>;
 
 fn main() {
-
     //Don't lint
     trailing_zero_macro!();
 }

--- a/tests/ui/trailing_empty_array.rs
+++ b/tests/ui/trailing_empty_array.rs
@@ -187,12 +187,26 @@ struct TwoGenericParams<T, const N: usize> {
     last: [T; N],
 }
 
+macro_rules! trailing_zero_macro {
+    () => {
+        {
+            struct MacroTrailingZero{
+                tz: [usize; 0],
+            }
+        }
+    };
+}
+
 type A = ConstParamZeroDefault;
 type B = ConstParamZeroDefault<0>;
 type C = ConstParamNoDefault<0>;
 type D = ConstParamNonZeroDefault<0>;
 
-fn main() {}
+fn main() {
+
+    //Don't lint
+    trailing_zero_macro!();
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`lint_name`]: your change
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [drop_non_drop]: fixed issue rust-lang/rust-clippy#16753; Added code that checks if lint occurs in macro expansion.
changelog: [drop_non_drop]: Added test in drop_non_drop.rs in ui tests.
changelog: [trailing_empty_array]: fixed issue rust-lang/rust-clippy#16754; Added code that checks if lint occurs in macro expansion. 
changelog: [trailing_empty_array]: Added test in trailing_empty_array.rs in ui tests.
