### PR TITLE
Add Vec<T> into Arc/Rc<[T]> lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7404,6 +7404,7 @@ Released 2018-09-13
 [`vec_box`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_box
 [`vec_init_then_push`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_init_then_push
 [`vec_resize_to_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_resize_to_zero
+[`vec_to_rc_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_to_rc_slice
 [`verbose_bit_mask`]: https://rust-lang.github.io/rust-clippy/master/index.html#verbose_bit_mask
 [`verbose_file_reads`]: https://rust-lang.github.io/rust-clippy/master/index.html#verbose_file_reads
 [`volatile_composites`]: https://rust-lang.github.io/rust-clippy/master/index.html#volatile_composites

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -794,6 +794,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::useless_conversion::USELESS_CONVERSION_INFO,
     crate::useless_vec::USELESS_VEC_INFO,
     crate::vec_init_then_push::VEC_INIT_THEN_PUSH_INFO,
+    crate::vec_to_rc_slice::VEC_TO_RC_SLICE_INFO,
     crate::visibility::NEEDLESS_PUB_SELF_INFO,
     crate::visibility::PUB_WITH_SHORTHAND_INFO,
     crate::visibility::PUB_WITHOUT_SHORTHAND_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -395,6 +395,7 @@ mod useless_concat;
 mod useless_conversion;
 mod useless_vec;
 mod vec_init_then_push;
+mod vec_to_rc_slice;
 mod visibility;
 mod volatile_composites;
 mod wildcard_imports;
@@ -867,6 +868,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(move |tcx| Box::new(manual_pop_if::ManualPopIf::new(tcx, conf))),
         Box::new(move |_| Box::new(manual_noop_waker::ManualNoopWaker::new(conf))),
         Box::new(|_| Box::new(byte_char_slices::ByteCharSlice)),
+        Box::new(|_| Box::new(vec_to_rc_slice::VecToRcSlice)),
         // add late passes here, used by `cargo dev new_lint`
     ];
     store.late_passes.extend(late_lints);

--- a/clippy_lints/src/vec_to_rc_slice.rs
+++ b/clippy_lints/src/vec_to_rc_slice.rs
@@ -141,18 +141,14 @@ fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, vec_expr: &Expr<'_>, wrapper
                 let mut applicability = Applicability::MachineApplicable;
                 let slice_snippet = snippet_with_context(cx, ty_span, ty_span.ctxt(), "_", &mut applicability).0;
                 diag.multipart_suggestion(
-                    format!(
-                        "convert target type to `{wrapper}<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy"
-                    ),
+                    format!("convert target type to `{wrapper}<Box<[T]>>`"),
                     vec![(expr.span, expr_sugg), (ty_span, format!("Box<{slice_snippet}>"))],
                     app,
                 );
             } else {
                 diag.span_suggestion_verbose(
                     expr.span,
-                    format!(
-                        "convert target type to `{wrapper}<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy"
-                    ),
+                    format!("convert target type to `{wrapper}<Box<[T]>>`"),
                     expr_sugg,
                     app,
                 );

--- a/clippy_lints/src/vec_to_rc_slice.rs
+++ b/clippy_lints/src/vec_to_rc_slice.rs
@@ -1,0 +1,119 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
+use clippy_utils::sym;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, Ty};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Detects conversions from `Vec<T>` to `Arc<[T]>` or `Rc<[T]>` via `.into()`,
+    /// `Arc::from()`, `Rc::from()`, or `From::from()`.
+    ///
+    /// ### Why is this bad?
+    /// `Arc<[T]>` and `Rc<[T]>` store the reference count and slice data in a single
+    /// contiguous allocation. Because `Vec<T>` uses a separate heap allocation with a
+    /// different layout, converting `Vec<T>` into `Arc<[T]>` or `Rc<[T]>` must allocate
+    /// a new block and **copy** all elements. For large vectors this copy can be expensive.
+    ///
+    /// Using `Arc<Box<[T]>>` (or `Rc<Box<[T]>>`) avoids the copy:
+    /// `Vec::into_boxed_slice()` can reuse the existing allocation (shrinking if needed),
+    /// and wrapping the resulting `Box<[T]>` in an `Arc`/`Rc` is a cheap pointer-sized
+    /// allocation.
+    ///
+    /// The trade-off is one extra level of indirection when accessing the data.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// let v: Vec<u8> = vec![1, 2, 3];
+    /// let a: Arc<[u8]> = v.into();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// let v: Vec<u8> = vec![1, 2, 3];
+    /// let a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
+    /// ```
+    #[clippy::version = "1.86.0"]
+    pub VEC_TO_RC_SLICE,
+    perf,
+    "converting `Vec<T>` to `Arc<[T]>` or `Rc<[T]>` copies all elements to a new allocation"
+}
+
+declare_lint_pass!(VecToRcSlice => [VEC_TO_RC_SLICE]);
+
+/// Checks if `ty` is `Vec<T>` for some `T`.
+fn is_vec(cx: &LateContext<'_>, ty: Ty<'_>) -> bool {
+    if let ty::Adt(adt, _) = ty.kind() {
+        cx.tcx.is_diagnostic_item(sym::Vec, adt.did())
+    } else {
+        false
+    }
+}
+
+/// If `ty` is `Arc<[T]>` or `Rc<[T]>`, returns the wrapper name (`"Arc"` or `"Rc"`).
+fn rc_slice_wrapper(cx: &LateContext<'_>, ty: Ty<'_>) -> Option<&'static str> {
+    if let ty::Adt(adt, args) = ty.kind()
+        && let Some(inner) = args.types().next()
+        && inner.is_slice()
+    {
+        match cx.tcx.get_diagnostic_name(adt.did()) {
+            Some(sym::Arc) => Some("Arc"),
+            Some(sym::Rc) => Some("Rc"),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for VecToRcSlice {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
+        if e.span.from_expansion() {
+            return;
+        }
+
+        match e.kind {
+            // `vec_expr.into()`
+            ExprKind::MethodCall(name, recv, [], _) => {
+                if name.ident.name == sym::into
+                    && cx.ty_based_def(e).opt_parent(cx).is_diag_item(cx, sym::Into)
+                    && is_vec(cx, cx.typeck_results().expr_ty(recv))
+                    && let Some(wrapper) = rc_slice_wrapper(cx, cx.typeck_results().expr_ty(e))
+                {
+                    emit_lint(cx, e, wrapper);
+                }
+            },
+
+            // `Arc::from(vec)` / `Rc::from(vec)` / `From::from(vec)`
+            ExprKind::Call(path, [arg]) => {
+                if let ExprKind::Path(ref qpath) = path.kind
+                    && let Some(def_id) = cx.qpath_res(qpath, path.hir_id).opt_def_id()
+                    && cx.tcx.get_diagnostic_name(def_id) == Some(sym::from_fn)
+                    && is_vec(cx, cx.typeck_results().expr_ty(arg))
+                    && let Some(wrapper) = rc_slice_wrapper(cx, cx.typeck_results().expr_ty(e))
+                {
+                    emit_lint(cx, e, wrapper);
+                }
+            },
+
+            _ => {},
+        }
+    }
+}
+
+fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, wrapper: &str) {
+    span_lint_and_help(
+        cx,
+        VEC_TO_RC_SLICE,
+        expr.span,
+        format!("converting a `Vec` to `{wrapper}<[T]>` copies all elements to a new allocation"),
+        None,
+        format!(
+            "consider using `{wrapper}::new(vec.into_boxed_slice())` which gives \
+             `{wrapper}<Box<[T]>>` and avoids the copy",
+        ),
+    );
+}

--- a/clippy_lints/src/vec_to_rc_slice.rs
+++ b/clippy_lints/src/vec_to_rc_slice.rs
@@ -138,8 +138,8 @@ fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, vec_expr: &Expr<'_>, wrapper
             let expr_sugg = format!("{wrapper}::new({vec_snippet}.into_boxed_slice())");
 
             if let Some(ty_span) = inner_slice_span {
-                let mut ty_app = Applicability::MachineApplicable;
-                let slice_snippet = snippet_with_context(cx, ty_span, ty_span.ctxt(), "_", &mut ty_app).0;
+                let mut applicability = Applicability::MachineApplicable;
+                let slice_snippet = snippet_with_context(cx, ty_span, ty_span.ctxt(), "_", &mut applicability).0;
                 diag.multipart_suggestion(
                     "use `into_boxed_slice()` to avoid the copy",
                     vec![(expr.span, expr_sugg), (ty_span, format!("Box<{slice_snippet}>"))],

--- a/clippy_lints/src/vec_to_rc_slice.rs
+++ b/clippy_lints/src/vec_to_rc_slice.rs
@@ -125,34 +125,28 @@ impl<'tcx> LateLintPass<'tcx> for VecToRcSlice {
 }
 
 fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, vec_expr: &Expr<'_>, wrapper: &str) {
-    let mut app = Applicability::MaybeIncorrect;
-    let vec_snippet = snippet_with_context(cx, vec_expr.span, expr.span.ctxt(), "<vec>", &mut app).0;
-    let inner_slice_span = let_ty_inner_slice_span(cx, expr);
-
     span_lint_and_then(
         cx,
         VEC_TO_RC_SLICE,
         expr.span,
         format!("converting a `Vec<T>` to `{wrapper}<[T]>` copies all elements to a new allocation"),
         |diag| {
+            let mut app = Applicability::MaybeIncorrect;
+            let ctxt = expr.span.ctxt();
+            let vec_snippet = snippet_with_context(cx, vec_expr.span, ctxt, "<vec>", &mut app).0;
+            let inner_slice_span = let_ty_inner_slice_span(cx, expr);
+
             let expr_sugg = format!("{wrapper}::new({vec_snippet}.into_boxed_slice())");
 
+            let mut sugg = vec![(expr.span, expr_sugg)];
+            // if `expr` is part of a let stmt with a type ascription,
+            // also fix the latter as part of the suggestion.
             if let Some(ty_span) = inner_slice_span {
-                let mut applicability = Applicability::MachineApplicable;
-                let slice_snippet = snippet_with_context(cx, ty_span, ty_span.ctxt(), "_", &mut applicability).0;
-                diag.multipart_suggestion(
-                    format!("convert target type to `{wrapper}<Box<[T]>>`"),
-                    vec![(expr.span, expr_sugg), (ty_span, format!("Box<{slice_snippet}>"))],
-                    app,
-                );
-            } else {
-                diag.span_suggestion_verbose(
-                    expr.span,
-                    format!("convert target type to `{wrapper}<Box<[T]>>`"),
-                    expr_sugg,
-                    app,
-                );
+                let slice_snippet = snippet_with_context(cx, ty_span, ctxt, "_", &mut app).0;
+                sugg.push((ty_span, format!("Box<{slice_snippet}>")));
             }
+
+            diag.multipart_suggestion(format!("convert target type to `{wrapper}<Box<[T]>>`"), sugg, app);
         },
     );
 }

--- a/clippy_lints/src/vec_to_rc_slice.rs
+++ b/clippy_lints/src/vec_to_rc_slice.rs
@@ -1,12 +1,13 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
+use clippy_utils::res::{MaybeDef, MaybeResPath, MaybeTypeckRes};
 use clippy_utils::source::snippet_with_context;
-use clippy_utils::sym;
+use clippy_utils::{qpath_generic_tys, sym};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, Node, TyKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_session::declare_lint_pass;
+use rustc_span::Span;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -71,6 +72,23 @@ fn rc_slice_wrapper(cx: &LateContext<'_>, ty: Ty<'_>) -> Option<&'static str> {
     }
 }
 
+/// If the expression is the init of a `let` statement with a type annotation like
+/// `Arc<[T]>` or `Rc<[T]>`, returns the span of the inner slice type (e.g. `[T]`).
+fn let_ty_inner_slice_span(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<Span> {
+    if let Node::LetStmt(let_stmt) = cx.tcx.parent_hir_node(expr.hir_id)
+        && let Some(hir_ty) = let_stmt.ty
+        && let TyKind::Path(ref qpath) = hir_ty.kind
+        && let Some(def_id) = hir_ty.basic_res().opt_def_id()
+        && matches!(cx.tcx.get_diagnostic_name(def_id), Some(sym::Arc | sym::Rc))
+        && let Some(inner_ty) = qpath_generic_tys(qpath).next()
+        && matches!(inner_ty.kind, TyKind::Slice(_))
+    {
+        Some(inner_ty.span)
+    } else {
+        None
+    }
+}
+
 impl<'tcx> LateLintPass<'tcx> for VecToRcSlice {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
         if e.span.from_expansion() {
@@ -109,19 +127,28 @@ impl<'tcx> LateLintPass<'tcx> for VecToRcSlice {
 fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, vec_expr: &Expr<'_>, wrapper: &str) {
     let mut app = Applicability::MaybeIncorrect;
     let vec_snippet = snippet_with_context(cx, vec_expr.span, expr.span.ctxt(), "<vec>", &mut app).0;
+    let inner_slice_span = let_ty_inner_slice_span(cx, expr);
+
     span_lint_and_then(
         cx,
         VEC_TO_RC_SLICE,
         expr.span,
         format!("converting a `Vec<T>` to `{wrapper}<[T]>` copies all elements to a new allocation"),
         |diag| {
-            diag.span_suggestion(
-                expr.span,
-                "use `into_boxed_slice()` to avoid the copy",
-                format!("{wrapper}::new({vec_snippet}.into_boxed_slice())"),
-                app,
-            );
-            diag.note(format!("this gives `{wrapper}<Box<[T]>>` and avoids the copy"));
+            let expr_sugg = format!("{wrapper}::new({vec_snippet}.into_boxed_slice())");
+
+            if let Some(ty_span) = inner_slice_span {
+                let mut ty_app = Applicability::MachineApplicable;
+                let slice_snippet = snippet_with_context(cx, ty_span, ty_span.ctxt(), "_", &mut ty_app).0;
+                diag.multipart_suggestion(
+                    "use `into_boxed_slice()` to avoid the copy",
+                    vec![(expr.span, expr_sugg), (ty_span, format!("Box<{slice_snippet}>"))],
+                    app,
+                );
+            } else {
+                diag.span_suggestion(expr.span, "use `into_boxed_slice()` to avoid the copy", expr_sugg, app);
+                diag.note(format!("this gives `{wrapper}<Box<[T]>>` and avoids the copy"));
+            }
         },
     );
 }

--- a/clippy_lints/src/vec_to_rc_slice.rs
+++ b/clippy_lints/src/vec_to_rc_slice.rs
@@ -1,6 +1,8 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
+use clippy_utils::source::snippet_with_context;
 use clippy_utils::sym;
+use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
@@ -83,7 +85,7 @@ impl<'tcx> LateLintPass<'tcx> for VecToRcSlice {
                     && is_vec(cx, cx.typeck_results().expr_ty(recv))
                     && let Some(wrapper) = rc_slice_wrapper(cx, cx.typeck_results().expr_ty(e))
                 {
-                    emit_lint(cx, e, wrapper);
+                    emit_lint(cx, e, recv, wrapper);
                 }
             },
 
@@ -95,7 +97,7 @@ impl<'tcx> LateLintPass<'tcx> for VecToRcSlice {
                     && is_vec(cx, cx.typeck_results().expr_ty(arg))
                     && let Some(wrapper) = rc_slice_wrapper(cx, cx.typeck_results().expr_ty(e))
                 {
-                    emit_lint(cx, e, wrapper);
+                    emit_lint(cx, e, arg, wrapper);
                 }
             },
 
@@ -104,16 +106,22 @@ impl<'tcx> LateLintPass<'tcx> for VecToRcSlice {
     }
 }
 
-fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, wrapper: &str) {
-    span_lint_and_help(
+fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, vec_expr: &Expr<'_>, wrapper: &str) {
+    let mut app = Applicability::MaybeIncorrect;
+    let vec_snippet = snippet_with_context(cx, vec_expr.span, expr.span.ctxt(), "<vec>", &mut app).0;
+    span_lint_and_then(
         cx,
         VEC_TO_RC_SLICE,
         expr.span,
-        format!("converting a `Vec` to `{wrapper}<[T]>` copies all elements to a new allocation"),
-        None,
-        format!(
-            "consider using `{wrapper}::new(vec.into_boxed_slice())` which gives \
-             `{wrapper}<Box<[T]>>` and avoids the copy",
-        ),
+        format!("converting a `Vec<T>` to `{wrapper}<[T]>` copies all elements to a new allocation"),
+        |diag| {
+            diag.span_suggestion(
+                expr.span,
+                "use `into_boxed_slice()` to avoid the copy",
+                format!("{wrapper}::new({vec_snippet}.into_boxed_slice())"),
+                app,
+            );
+            diag.note(format!("this gives `{wrapper}<Box<[T]>>` and avoids the copy"));
+        },
     );
 }

--- a/clippy_lints/src/vec_to_rc_slice.rs
+++ b/clippy_lints/src/vec_to_rc_slice.rs
@@ -133,14 +133,19 @@ fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, vec_expr: &Expr<'_>, wrapper
         |diag| {
             let mut app = Applicability::MaybeIncorrect;
             let ctxt = expr.span.ctxt();
+
+            // Common case: we have a `Vec` that we can call `into_boxed_slice()` on. Generate the snippet
+            // which does so with the appropriate span to identify the Vec and constructs the target (wrapper)
+            // type from it too.
+            //
+            // e.g. `Rc::from(vec)` -> `Rc::new(vec.into_boxed_slice())`
             let vec_snippet = snippet_with_context(cx, vec_expr.span, ctxt, "<vec>", &mut app).0;
-            let inner_slice_span = let_ty_inner_slice_span(cx, expr);
-
             let expr_sugg = format!("{wrapper}::new({vec_snippet}.into_boxed_slice())");
-
             let mut sugg = vec![(expr.span, expr_sugg)];
-            // if `expr` is part of a let stmt with a type ascription,
-            // also fix the latter as part of the suggestion.
+
+            // if `expr` is part of a let stmt with a type ascription, also fix the latter as part of the
+            // suggestion.
+            let inner_slice_span = let_ty_inner_slice_span(cx, expr);
             if let Some(ty_span) = inner_slice_span {
                 let slice_snippet = snippet_with_context(cx, ty_span, ctxt, "_", &mut app).0;
                 sugg.push((ty_span, format!("Box<{slice_snippet}>")));

--- a/clippy_lints/src/vec_to_rc_slice.rs
+++ b/clippy_lints/src/vec_to_rc_slice.rs
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// let v: Vec<u8> = vec![1, 2, 3];
     /// let a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
     /// ```
-    #[clippy::version = "1.86.0"]
+    #[clippy::version = "1.97.0"]
     pub VEC_TO_RC_SLICE,
     perf,
     "converting `Vec<T>` to `Arc<[T]>` or `Rc<[T]>` copies all elements to a new allocation"
@@ -111,7 +111,7 @@ impl<'tcx> LateLintPass<'tcx> for VecToRcSlice {
             ExprKind::Call(path, [arg]) => {
                 if let ExprKind::Path(ref qpath) = path.kind
                     && let Some(def_id) = cx.qpath_res(qpath, path.hir_id).opt_def_id()
-                    && cx.tcx.get_diagnostic_name(def_id) == Some(sym::from_fn)
+                    && cx.tcx.is_diagnostic_item(sym::from_fn, def_id)
                     && is_vec(cx, cx.typeck_results().expr_ty(arg))
                     && let Some(wrapper) = rc_slice_wrapper(cx, cx.typeck_results().expr_ty(e))
                 {
@@ -141,13 +141,21 @@ fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, vec_expr: &Expr<'_>, wrapper
                 let mut applicability = Applicability::MachineApplicable;
                 let slice_snippet = snippet_with_context(cx, ty_span, ty_span.ctxt(), "_", &mut applicability).0;
                 diag.multipart_suggestion(
-                    "use `into_boxed_slice()` to avoid the copy",
+                    format!(
+                        "convert target type to `{wrapper}<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy"
+                    ),
                     vec![(expr.span, expr_sugg), (ty_span, format!("Box<{slice_snippet}>"))],
                     app,
                 );
             } else {
-                diag.span_suggestion(expr.span, "use `into_boxed_slice()` to avoid the copy", expr_sugg, app);
-                diag.note(format!("this gives `{wrapper}<Box<[T]>>` and avoids the copy"));
+                diag.span_suggestion_verbose(
+                    expr.span,
+                    format!(
+                        "convert target type to `{wrapper}<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy"
+                    ),
+                    expr_sugg,
+                    app,
+                );
             }
         },
     );

--- a/tests/ui/vec_to_rc_slice.fixed
+++ b/tests/ui/vec_to_rc_slice.fixed
@@ -6,12 +6,12 @@ use std::sync::Arc;
 fn main() {
     // Should lint: fully qualified Arc from
     let v: Vec<u8> = vec![1, 2, 3];
-    let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
+    let _a = Arc::new(v.into_boxed_slice());
     //~^ vec_to_rc_slice
 
     // Should lint: fully qualified Rc from
     let v: Vec<u8> = vec![1, 2, 3];
-    let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
+    let _a = Rc::new(v.into_boxed_slice());
     //~^ vec_to_rc_slice
 
     // Should NOT lint: Vec<T>.into() -> something else

--- a/tests/ui/vec_to_rc_slice.fixed
+++ b/tests/ui/vec_to_rc_slice.fixed
@@ -4,9 +4,39 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 fn main() {
+    // Should lint: Vec<T>.into() -> Arc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
+    //~^ vec_to_rc_slice
+
+    // Should lint: Arc::from(vec)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
+    //~^ vec_to_rc_slice
+
+    // Should lint: From::from(vec) when target is Arc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
+    //~^ vec_to_rc_slice
+
     // Should lint: fully qualified Arc from
     let v: Vec<u8> = vec![1, 2, 3];
     let _a = Arc::new(v.into_boxed_slice());
+    //~^ vec_to_rc_slice
+
+    // Should lint: Vec<T>.into() -> Rc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
+    //~^ vec_to_rc_slice
+
+    // Should lint: Rc::from(vec)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
+    //~^ vec_to_rc_slice
+
+    // Should lint: From::from(vec) when target is Rc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
     //~^ vec_to_rc_slice
 
     // Should lint: fully qualified Rc from

--- a/tests/ui/vec_to_rc_slice.rs
+++ b/tests/ui/vec_to_rc_slice.rs
@@ -1,7 +1,11 @@
+//@no-rustfix
 #![warn(clippy::vec_to_rc_slice)]
 
 use std::rc::Rc;
 use std::sync::Arc;
+
+fn accept_arc_slice(_: Arc<[u8]>) {}
+fn accept_rc_slice(_: Rc<[u8]>) {}
 
 fn main() {
     // Should lint: Vec<T>.into() -> Arc<[T]>
@@ -42,6 +46,16 @@ fn main() {
     // Should lint: <Rc<[u8]> as From<Vec<u8>>>::from(vec)
     let v: Vec<u8> = vec![1, 2, 3];
     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: result passed to a function expecting Arc<[T]> (fix requires downstream changes)
+    let v: Vec<u8> = vec![1, 2, 3];
+    accept_arc_slice(v.into());
+    //~^ vec_to_rc_slice
+
+    // Should lint: result passed to a function expecting Rc<[T]> (fix requires downstream changes)
+    let v: Vec<u8> = vec![1, 2, 3];
+    accept_rc_slice(Rc::from(v));
     //~^ vec_to_rc_slice
 
     // Should NOT lint: Vec<T>.into() -> something else

--- a/tests/ui/vec_to_rc_slice.rs
+++ b/tests/ui/vec_to_rc_slice.rs
@@ -1,0 +1,65 @@
+#![warn(clippy::vec_to_rc_slice)]
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+fn main() {
+    // Should lint: Vec<T>.into() -> Arc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = v.into();
+    //~^ vec_to_rc_slice
+
+    // Should lint: Arc::from(vec)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = Arc::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: From::from(vec) when target is Arc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = From::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: <Arc<[u8]> as From<Vec<u8>>>::from(vec)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: Vec<T>.into() -> Rc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = v.into();
+    //~^ vec_to_rc_slice
+
+    // Should lint: Rc::from(vec)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = Rc::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: From::from(vec) when target is Rc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = From::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: <Rc<[u8]> as From<Vec<u8>>>::from(vec)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should NOT lint: Vec<T>.into() -> something else
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _b: Box<[u8]> = v.into();
+
+    // Should NOT lint: non-Vec into Arc<[T]>
+    let _c: Arc<[u8]> = Arc::from([1u8, 2, 3].as_slice());
+
+    // Should NOT lint: Vec into Arc (not Arc<[T]>)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _d: Arc<Vec<u8>> = Arc::new(v);
+
+    // Should NOT lint: the recommended pattern
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _e: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
+
+    // Should NOT lint: Rc recommended pattern
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _f: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
+}

--- a/tests/ui/vec_to_rc_slice.rs
+++ b/tests/ui/vec_to_rc_slice.rs
@@ -4,9 +4,39 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 fn main() {
+    // Should lint: Vec<T>.into() -> Arc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = v.into();
+    //~^ vec_to_rc_slice
+
+    // Should lint: Arc::from(vec)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = Arc::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: From::from(vec) when target is Arc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = From::from(v);
+    //~^ vec_to_rc_slice
+
     // Should lint: fully qualified Arc from
     let v: Vec<u8> = vec![1, 2, 3];
     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: Vec<T>.into() -> Rc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = v.into();
+    //~^ vec_to_rc_slice
+
+    // Should lint: Rc::from(vec)
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = Rc::from(v);
+    //~^ vec_to_rc_slice
+
+    // Should lint: From::from(vec) when target is Rc<[T]>
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = From::from(v);
     //~^ vec_to_rc_slice
 
     // Should lint: fully qualified Rc from

--- a/tests/ui/vec_to_rc_slice.stderr
+++ b/tests/ui/vec_to_rc_slice.stderr
@@ -1,0 +1,68 @@
+error: converting a `Vec` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:9:25
+   |
+LL |     let _a: Arc<[u8]> = v.into();
+   |                         ^^^^^^^^
+   |
+   = help: consider using `Arc::new(vec.into_boxed_slice())` which gives `Arc<Box<[T]>>` and avoids the copy
+   = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
+
+error: converting a `Vec` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:14:25
+   |
+LL |     let _a: Arc<[u8]> = Arc::from(v);
+   |                         ^^^^^^^^^^^^
+   |
+   = help: consider using `Arc::new(vec.into_boxed_slice())` which gives `Arc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:19:25
+   |
+LL |     let _a: Arc<[u8]> = From::from(v);
+   |                         ^^^^^^^^^^^^^
+   |
+   = help: consider using `Arc::new(vec.into_boxed_slice())` which gives `Arc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:24:14
+   |
+LL |     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `Arc::new(vec.into_boxed_slice())` which gives `Arc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:29:24
+   |
+LL |     let _a: Rc<[u8]> = v.into();
+   |                        ^^^^^^^^
+   |
+   = help: consider using `Rc::new(vec.into_boxed_slice())` which gives `Rc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:34:24
+   |
+LL |     let _a: Rc<[u8]> = Rc::from(v);
+   |                        ^^^^^^^^^^^
+   |
+   = help: consider using `Rc::new(vec.into_boxed_slice())` which gives `Rc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:39:24
+   |
+LL |     let _a: Rc<[u8]> = From::from(v);
+   |                        ^^^^^^^^^^^^^
+   |
+   = help: consider using `Rc::new(vec.into_boxed_slice())` which gives `Rc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:44:14
+   |
+LL |     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `Rc::new(vec.into_boxed_slice())` which gives `Rc<Box<[T]>>` and avoids the copy
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/vec_to_rc_slice.stderr
+++ b/tests/ui/vec_to_rc_slice.stderr
@@ -6,7 +6,7 @@ LL |     let _a: Arc<[u8]> = v.into();
    |
    = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
-help: use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
    |
 LL -     let _a: Arc<[u8]> = v.into();
 LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
@@ -18,7 +18,7 @@ error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocati
 LL |     let _a: Arc<[u8]> = Arc::from(v);
    |                         ^^^^^^^^^^^^
    |
-help: use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
    |
 LL -     let _a: Arc<[u8]> = Arc::from(v);
 LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
@@ -30,7 +30,7 @@ error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocati
 LL |     let _a: Arc<[u8]> = From::from(v);
    |                         ^^^^^^^^^^^^^
    |
-help: use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
    |
 LL -     let _a: Arc<[u8]> = From::from(v);
 LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
@@ -40,9 +40,13 @@ error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocati
   --> tests/ui/vec_to_rc_slice.rs:24:14
    |
 LL |     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
+help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+   |
+LL -     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
+LL +     let _a = Arc::new(v.into_boxed_slice());
+   |
 
 error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
   --> tests/ui/vec_to_rc_slice.rs:29:24
@@ -50,7 +54,7 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
 LL |     let _a: Rc<[u8]> = v.into();
    |                        ^^^^^^^^
    |
-help: use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
    |
 LL -     let _a: Rc<[u8]> = v.into();
 LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
@@ -62,7 +66,7 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
 LL |     let _a: Rc<[u8]> = Rc::from(v);
    |                        ^^^^^^^^^^^
    |
-help: use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
    |
 LL -     let _a: Rc<[u8]> = Rc::from(v);
 LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
@@ -74,7 +78,7 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
 LL |     let _a: Rc<[u8]> = From::from(v);
    |                        ^^^^^^^^^^^^^
    |
-help: use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
    |
 LL -     let _a: Rc<[u8]> = From::from(v);
 LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
@@ -84,9 +88,13 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
   --> tests/ui/vec_to_rc_slice.rs:44:14
    |
 LL |     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
+help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+   |
+LL -     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
+LL +     let _a = Rc::new(v.into_boxed_slice());
+   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/vec_to_rc_slice.stderr
+++ b/tests/ui/vec_to_rc_slice.stderr
@@ -1,68 +1,84 @@
-error: converting a `Vec` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:9:25
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:13:25
    |
 LL |     let _a: Arc<[u8]> = v.into();
-   |                         ^^^^^^^^
+   |                         ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
    |
-   = help: consider using `Arc::new(vec.into_boxed_slice())` which gives `Arc<Box<[T]>>` and avoids the copy
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
    = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
 
-error: converting a `Vec` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:14:25
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:18:25
    |
 LL |     let _a: Arc<[u8]> = Arc::from(v);
-   |                         ^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
    |
-   = help: consider using `Arc::new(vec.into_boxed_slice())` which gives `Arc<Box<[T]>>` and avoids the copy
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
 
-error: converting a `Vec` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:19:25
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:23:25
    |
 LL |     let _a: Arc<[u8]> = From::from(v);
-   |                         ^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
    |
-   = help: consider using `Arc::new(vec.into_boxed_slice())` which gives `Arc<Box<[T]>>` and avoids the copy
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
 
-error: converting a `Vec` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:24:14
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:28:14
    |
 LL |     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
    |
-   = help: consider using `Arc::new(vec.into_boxed_slice())` which gives `Arc<Box<[T]>>` and avoids the copy
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
 
-error: converting a `Vec` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:29:24
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:33:24
    |
 LL |     let _a: Rc<[u8]> = v.into();
-   |                        ^^^^^^^^
+   |                        ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
    |
-   = help: consider using `Rc::new(vec.into_boxed_slice())` which gives `Rc<Box<[T]>>` and avoids the copy
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
 
-error: converting a `Vec` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:34:24
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:38:24
    |
 LL |     let _a: Rc<[u8]> = Rc::from(v);
-   |                        ^^^^^^^^^^^
+   |                        ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
    |
-   = help: consider using `Rc::new(vec.into_boxed_slice())` which gives `Rc<Box<[T]>>` and avoids the copy
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
 
-error: converting a `Vec` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:39:24
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:43:24
    |
 LL |     let _a: Rc<[u8]> = From::from(v);
-   |                        ^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
    |
-   = help: consider using `Rc::new(vec.into_boxed_slice())` which gives `Rc<Box<[T]>>` and avoids the copy
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
 
-error: converting a `Vec` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:44:14
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:48:14
    |
 LL |     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
    |
-   = help: consider using `Rc::new(vec.into_boxed_slice())` which gives `Rc<Box<[T]>>` and avoids the copy
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
 
-error: aborting due to 8 previous errors
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:53:22
+   |
+LL |     accept_arc_slice(v.into());
+   |                      ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:58:21
+   |
+LL |     accept_rc_slice(Rc::from(v));
+   |                     ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/vec_to_rc_slice.stderr
+++ b/tests/ui/vec_to_rc_slice.stderr
@@ -6,7 +6,7 @@ LL |     let _a: Arc<[u8]> = v.into();
    |
    = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
-help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Arc<Box<[T]>>`
    |
 LL -     let _a: Arc<[u8]> = v.into();
 LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
@@ -18,7 +18,7 @@ error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocati
 LL |     let _a: Arc<[u8]> = Arc::from(v);
    |                         ^^^^^^^^^^^^
    |
-help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Arc<Box<[T]>>`
    |
 LL -     let _a: Arc<[u8]> = Arc::from(v);
 LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
@@ -30,7 +30,7 @@ error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocati
 LL |     let _a: Arc<[u8]> = From::from(v);
    |                         ^^^^^^^^^^^^^
    |
-help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Arc<Box<[T]>>`
    |
 LL -     let _a: Arc<[u8]> = From::from(v);
 LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
@@ -42,7 +42,7 @@ error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocati
 LL |     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Arc<Box<[T]>>`
    |
 LL -     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
 LL +     let _a = Arc::new(v.into_boxed_slice());
@@ -54,7 +54,7 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
 LL |     let _a: Rc<[u8]> = v.into();
    |                        ^^^^^^^^
    |
-help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Rc<Box<[T]>>`
    |
 LL -     let _a: Rc<[u8]> = v.into();
 LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
@@ -66,7 +66,7 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
 LL |     let _a: Rc<[u8]> = Rc::from(v);
    |                        ^^^^^^^^^^^
    |
-help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Rc<Box<[T]>>`
    |
 LL -     let _a: Rc<[u8]> = Rc::from(v);
 LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
@@ -78,7 +78,7 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
 LL |     let _a: Rc<[u8]> = From::from(v);
    |                        ^^^^^^^^^^^^^
    |
-help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Rc<Box<[T]>>`
    |
 LL -     let _a: Rc<[u8]> = From::from(v);
 LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
@@ -90,7 +90,7 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
 LL |     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Rc<Box<[T]>>`
    |
 LL -     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
 LL +     let _a = Rc::new(v.into_boxed_slice());

--- a/tests/ui/vec_to_rc_slice.stderr
+++ b/tests/ui/vec_to_rc_slice.stderr
@@ -1,20 +1,92 @@
 error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:9:14
+  --> tests/ui/vec_to_rc_slice.rs:9:25
+   |
+LL |     let _a: Arc<[u8]> = v.into();
+   |                         ^^^^^^^^
+   |
+   = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
+help: use `into_boxed_slice()` to avoid the copy
+   |
+LL -     let _a: Arc<[u8]> = v.into();
+LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
+   |
+
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:14:25
+   |
+LL |     let _a: Arc<[u8]> = Arc::from(v);
+   |                         ^^^^^^^^^^^^
+   |
+help: use `into_boxed_slice()` to avoid the copy
+   |
+LL -     let _a: Arc<[u8]> = Arc::from(v);
+LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
+   |
+
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:19:25
+   |
+LL |     let _a: Arc<[u8]> = From::from(v);
+   |                         ^^^^^^^^^^^^^
+   |
+help: use `into_boxed_slice()` to avoid the copy
+   |
+LL -     let _a: Arc<[u8]> = From::from(v);
+LL +     let _a: Arc<Box<[u8]>> = Arc::new(v.into_boxed_slice());
+   |
+
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:24:14
    |
 LL |     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
    |
    = note: this gives `Arc<Box<[T]>>` and avoids the copy
-   = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
 
 error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:14:14
+  --> tests/ui/vec_to_rc_slice.rs:29:24
+   |
+LL |     let _a: Rc<[u8]> = v.into();
+   |                        ^^^^^^^^
+   |
+help: use `into_boxed_slice()` to avoid the copy
+   |
+LL -     let _a: Rc<[u8]> = v.into();
+LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
+   |
+
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:34:24
+   |
+LL |     let _a: Rc<[u8]> = Rc::from(v);
+   |                        ^^^^^^^^^^^
+   |
+help: use `into_boxed_slice()` to avoid the copy
+   |
+LL -     let _a: Rc<[u8]> = Rc::from(v);
+LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
+   |
+
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:39:24
+   |
+LL |     let _a: Rc<[u8]> = From::from(v);
+   |                        ^^^^^^^^^^^^^
+   |
+help: use `into_boxed_slice()` to avoid the copy
+   |
+LL -     let _a: Rc<[u8]> = From::from(v);
+LL +     let _a: Rc<Box<[u8]>> = Rc::new(v.into_boxed_slice());
+   |
+
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice.rs:44:14
    |
 LL |     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
    |
    = note: this gives `Rc<Box<[T]>>` and avoids the copy
 
-error: aborting due to 2 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/vec_to_rc_slice.stderr
+++ b/tests/ui/vec_to_rc_slice.stderr
@@ -1,84 +1,20 @@
 error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:13:25
-   |
-LL |     let _a: Arc<[u8]> = v.into();
-   |                         ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
-   = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
-
-error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:18:25
-   |
-LL |     let _a: Arc<[u8]> = Arc::from(v);
-   |                         ^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:23:25
-   |
-LL |     let _a: Arc<[u8]> = From::from(v);
-   |                         ^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:28:14
+  --> tests/ui/vec_to_rc_slice.rs:9:14
    |
 LL |     let _a = <Arc<[u8]> as From<Vec<u8>>>::from(v);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
    |
    = note: this gives `Arc<Box<[T]>>` and avoids the copy
+   = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
 
 error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:33:24
-   |
-LL |     let _a: Rc<[u8]> = v.into();
-   |                        ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:38:24
-   |
-LL |     let _a: Rc<[u8]> = Rc::from(v);
-   |                        ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:43:24
-   |
-LL |     let _a: Rc<[u8]> = From::from(v);
-   |                        ^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:48:14
+  --> tests/ui/vec_to_rc_slice.rs:14:14
    |
 LL |     let _a = <Rc<[u8]> as From<Vec<u8>>>::from(v);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
    |
    = note: this gives `Rc<Box<[T]>>` and avoids the copy
 
-error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:53:22
-   |
-LL |     accept_arc_slice(v.into());
-   |                      ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice.rs:58:21
-   |
-LL |     accept_rc_slice(Rc::from(v));
-   |                     ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
-
-error: aborting due to 10 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/vec_to_rc_slice_unfixable.rs
+++ b/tests/ui/vec_to_rc_slice_unfixable.rs
@@ -8,36 +8,12 @@ fn accept_arc_slice(_: Arc<[u8]>) {}
 fn accept_rc_slice(_: Rc<[u8]>) {}
 
 fn main() {
-    // Type annotation constrains the result type; fix changes it
-    let v: Vec<u8> = vec![1, 2, 3];
-    let _a: Arc<[u8]> = v.into();
-    //~^ vec_to_rc_slice
-
-    let v: Vec<u8> = vec![1, 2, 3];
-    let _a: Arc<[u8]> = Arc::from(v);
-    //~^ vec_to_rc_slice
-
-    let v: Vec<u8> = vec![1, 2, 3];
-    let _a: Arc<[u8]> = From::from(v);
-    //~^ vec_to_rc_slice
-
-    let v: Vec<u8> = vec![1, 2, 3];
-    let _a: Rc<[u8]> = v.into();
-    //~^ vec_to_rc_slice
-
-    let v: Vec<u8> = vec![1, 2, 3];
-    let _a: Rc<[u8]> = Rc::from(v);
-    //~^ vec_to_rc_slice
-
-    let v: Vec<u8> = vec![1, 2, 3];
-    let _a: Rc<[u8]> = From::from(v);
-    //~^ vec_to_rc_slice
-
-    // Function signature constrains the result type; fix requires downstream changes
+    // Should lint: result passed to a function expecting Arc<[T]> (fix requires downstream changes)
     let v: Vec<u8> = vec![1, 2, 3];
     accept_arc_slice(v.into());
     //~^ vec_to_rc_slice
 
+    // Should lint: result passed to a function expecting Rc<[T]> (fix requires downstream changes)
     let v: Vec<u8> = vec![1, 2, 3];
     accept_rc_slice(Rc::from(v));
     //~^ vec_to_rc_slice

--- a/tests/ui/vec_to_rc_slice_unfixable.rs
+++ b/tests/ui/vec_to_rc_slice_unfixable.rs
@@ -1,0 +1,44 @@
+//@no-rustfix
+#![warn(clippy::vec_to_rc_slice)]
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+fn accept_arc_slice(_: Arc<[u8]>) {}
+fn accept_rc_slice(_: Rc<[u8]>) {}
+
+fn main() {
+    // Type annotation constrains the result type; fix changes it
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = v.into();
+    //~^ vec_to_rc_slice
+
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = Arc::from(v);
+    //~^ vec_to_rc_slice
+
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Arc<[u8]> = From::from(v);
+    //~^ vec_to_rc_slice
+
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = v.into();
+    //~^ vec_to_rc_slice
+
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = Rc::from(v);
+    //~^ vec_to_rc_slice
+
+    let v: Vec<u8> = vec![1, 2, 3];
+    let _a: Rc<[u8]> = From::from(v);
+    //~^ vec_to_rc_slice
+
+    // Function signature constrains the result type; fix requires downstream changes
+    let v: Vec<u8> = vec![1, 2, 3];
+    accept_arc_slice(v.into());
+    //~^ vec_to_rc_slice
+
+    let v: Vec<u8> = vec![1, 2, 3];
+    accept_rc_slice(Rc::from(v));
+    //~^ vec_to_rc_slice
+}

--- a/tests/ui/vec_to_rc_slice_unfixable.stderr
+++ b/tests/ui/vec_to_rc_slice_unfixable.stderr
@@ -1,68 +1,20 @@
 error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice_unfixable.rs:13:25
-   |
-LL |     let _a: Arc<[u8]> = v.into();
-   |                         ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
-   = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
-
-error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice_unfixable.rs:17:25
-   |
-LL |     let _a: Arc<[u8]> = Arc::from(v);
-   |                         ^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice_unfixable.rs:21:25
-   |
-LL |     let _a: Arc<[u8]> = From::from(v);
-   |                         ^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice_unfixable.rs:25:24
-   |
-LL |     let _a: Rc<[u8]> = v.into();
-   |                        ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice_unfixable.rs:29:24
-   |
-LL |     let _a: Rc<[u8]> = Rc::from(v);
-   |                        ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice_unfixable.rs:33:24
-   |
-LL |     let _a: Rc<[u8]> = From::from(v);
-   |                        ^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
-   |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
-
-error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice_unfixable.rs:38:22
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:13:22
    |
 LL |     accept_arc_slice(v.into());
    |                      ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
    |
    = note: this gives `Arc<Box<[T]>>` and avoids the copy
+   = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
 
 error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
-  --> tests/ui/vec_to_rc_slice_unfixable.rs:42:21
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:18:21
    |
 LL |     accept_rc_slice(Rc::from(v));
    |                     ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
    |
    = note: this gives `Rc<Box<[T]>>` and avoids the copy
 
-error: aborting due to 8 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/vec_to_rc_slice_unfixable.stderr
+++ b/tests/ui/vec_to_rc_slice_unfixable.stderr
@@ -2,19 +2,27 @@ error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocati
   --> tests/ui/vec_to_rc_slice_unfixable.rs:13:22
    |
 LL |     accept_arc_slice(v.into());
-   |                      ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
+   |                      ^^^^^^^^
    |
-   = note: this gives `Arc<Box<[T]>>` and avoids the copy
    = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
+help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+   |
+LL -     accept_arc_slice(v.into());
+LL +     accept_arc_slice(Arc::new(v.into_boxed_slice()));
+   |
 
 error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
   --> tests/ui/vec_to_rc_slice_unfixable.rs:18:21
    |
 LL |     accept_rc_slice(Rc::from(v));
-   |                     ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
+   |                     ^^^^^^^^^^^
    |
-   = note: this gives `Rc<Box<[T]>>` and avoids the copy
+help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+   |
+LL -     accept_rc_slice(Rc::from(v));
+LL +     accept_rc_slice(Rc::new(v.into_boxed_slice()));
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/vec_to_rc_slice_unfixable.stderr
+++ b/tests/ui/vec_to_rc_slice_unfixable.stderr
@@ -1,0 +1,68 @@
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:13:25
+   |
+LL |     let _a: Arc<[u8]> = v.into();
+   |                         ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
+   = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
+
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:17:25
+   |
+LL |     let _a: Arc<[u8]> = Arc::from(v);
+   |                         ^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:21:25
+   |
+LL |     let _a: Arc<[u8]> = From::from(v);
+   |                         ^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:25:24
+   |
+LL |     let _a: Rc<[u8]> = v.into();
+   |                        ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:29:24
+   |
+LL |     let _a: Rc<[u8]> = Rc::from(v);
+   |                        ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:33:24
+   |
+LL |     let _a: Rc<[u8]> = From::from(v);
+   |                        ^^^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec<T>` to `Arc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:38:22
+   |
+LL |     accept_arc_slice(v.into());
+   |                      ^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Arc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Arc<Box<[T]>>` and avoids the copy
+
+error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocation
+  --> tests/ui/vec_to_rc_slice_unfixable.rs:42:21
+   |
+LL |     accept_rc_slice(Rc::from(v));
+   |                     ^^^^^^^^^^^ help: use `into_boxed_slice()` to avoid the copy: `Rc::new(v.into_boxed_slice())`
+   |
+   = note: this gives `Rc<Box<[T]>>` and avoids the copy
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/vec_to_rc_slice_unfixable.stderr
+++ b/tests/ui/vec_to_rc_slice_unfixable.stderr
@@ -6,7 +6,7 @@ LL |     accept_arc_slice(v.into());
    |
    = note: `-D clippy::vec-to-rc-slice` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::vec_to_rc_slice)]`
-help: convert target type to `Arc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Arc<Box<[T]>>`
    |
 LL -     accept_arc_slice(v.into());
 LL +     accept_arc_slice(Arc::new(v.into_boxed_slice()));
@@ -18,7 +18,7 @@ error: converting a `Vec<T>` to `Rc<[T]>` copies all elements to a new allocatio
 LL |     accept_rc_slice(Rc::from(v));
    |                     ^^^^^^^^^^^
    |
-help: convert target type to `Rc<Box<[T]>>` and use `into_boxed_slice()` to avoid the copy
+help: convert target type to `Rc<Box<[T]>>`
    |
 LL -     accept_rc_slice(Rc::from(v));
 LL +     accept_rc_slice(Rc::new(v.into_boxed_slice()));


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16790)*

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

---

Adds a lint detecting conversions from `Vec<T>` into `Arc<[T]>` and `Rc<[T]>`. When doing this conversion, the source `Vec<T>` allocation cannot be re-used because of incompatible layout with `Arc<[T]>` and `Rc<[T]>`, which may be a fairly expensive reallocation depending on the source vector's size.

In most cases, it's probably better to convert to an `Arc<Box<[T]>>` instead.

See discussion here for rationale: https://users.rust-lang.org/t/could-arc-t-from-vec-t-be-optimized-to-remove-the-copy/137532


changelog: [`vec_to_rc_slice`]: add perf lint for converting from `Vec<[T]>` to `Arc<[T]>`/`Rc<[T]>`
