### PR TITLE
find_all_ret_expressions: change `bool` to `Result`

### DIFF
--- a/clippy_lints/src/methods/bind_instead_of_map.rs
+++ b/clippy_lints/src/methods/bind_instead_of_map.rs
@@ -114,7 +114,7 @@ impl BindInsteadOfMap {
 
     fn lint_closure(&self, cx: &LateContext<'_>, expr: &hir::Expr<'_>, closure_expr: &hir::Expr<'_>) -> bool {
         let mut suggs = Vec::new();
-        let can_sugg: bool = find_all_ret_expressions(cx, closure_expr, |ret_expr| {
+        let (span, msg) = if let Ok(()) = find_all_ret_expressions(cx, closure_expr, |ret_expr| {
             if !ret_expr.span.from_expansion()
                 && let hir::ExprKind::Call(func_path, [arg]) = ret_expr.kind
                 && let hir::ExprKind::Path(QPath::Resolved(_, path)) = func_path.kind
@@ -122,13 +122,11 @@ impl BindInsteadOfMap {
                 && !contains_return(arg)
             {
                 suggs.push((ret_expr.span, arg.span.source_callsite()));
-                true
+                Ok(())
             } else {
-                false
+                Err(())
             }
-        });
-        let (span, msg) = if can_sugg
-            && let hir::ExprKind::MethodCall(segment, ..) = expr.kind
+        }) && let hir::ExprKind::MethodCall(segment, ..) = expr.kind
             && let Some(msg) = self.lint_msg(cx)
         {
             (segment.ident.span, msg)

--- a/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -513,8 +513,9 @@ fn can_change_type<'a>(cx: &LateContext<'a>, mut expr: &'a Expr<'a>, mut ty: Ty<
                     let mut count = 0;
                     return find_all_ret_expressions(cx, body_expr, |_| {
                         count += 1;
-                        count <= 1
-                    });
+                        if count <= 1 { Ok(()) } else { Err(()) }
+                    })
+                    .is_ok();
                 }
             },
             Node::Expr(parent_expr) => {

--- a/clippy_lints/src/unnecessary_wraps.rs
+++ b/clippy_lints/src/unnecessary_wraps.rs
@@ -135,13 +135,13 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
                         snippet(cx, arg.span.source_callsite(), "..").to_string()
                     },
                 ));
-                true
+                Ok(())
             } else {
-                false
+                Err(())
             }
         });
 
-        if can_sugg && !suggs.is_empty() {
+        if can_sugg.is_ok() && !suggs.is_empty() {
             let (lint_msg, return_type_sugg_msg, return_type_sugg, body_sugg_msg) = if inner_type.is_unit() {
                 (
                     "this function's return value is unnecessary".to_string(),

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -204,13 +204,19 @@ fn contains_try(expr: &Expr<'_>) -> bool {
     .is_some()
 }
 
-pub fn find_all_ret_expressions<'hir, F>(_cx: &LateContext<'_>, expr: &'hir Expr<'hir>, callback: F) -> bool
-where
-    F: FnMut(&'hir Expr<'hir>) -> bool,
-{
+pub enum FindAllRetError {
+    ContainsTry,
+    CallbackFailed,
+}
+
+pub fn find_all_ret_expressions<'hir>(
+    _cx: &LateContext<'_>,
+    expr: &'hir Expr<'hir>,
+    callback: impl FnMut(&'hir Expr<'hir>) -> Result<(), ()>,
+) -> Result<(), FindAllRetError> {
     struct RetFinder<F> {
         in_stmt: bool,
-        failed: bool,
+        status: Result<(), ()>,
         cb: F,
     }
 
@@ -249,22 +255,19 @@ where
         }
     }
 
-    impl<'hir, F: FnMut(&'hir Expr<'hir>) -> bool> Visitor<'hir> for RetFinder<F> {
+    impl<'hir, F: FnMut(&'hir Expr<'hir>) -> Result<(), ()>> Visitor<'hir> for RetFinder<F> {
         fn visit_stmt(&mut self, stmt: &'hir Stmt<'_>) {
             intravisit::walk_stmt(&mut *self.inside_stmt(true), stmt);
         }
 
         fn visit_expr(&mut self, expr: &'hir Expr<'_>) {
-            if self.failed {
-                return;
-            }
-            if self.in_stmt {
-                match expr.kind {
+            match self.status {
+                Err(()) => {},
+                Ok(()) if self.in_stmt => match expr.kind {
                     ExprKind::Ret(Some(expr)) => self.inside_stmt(false).visit_expr(expr),
                     _ => walk_expr(self, expr),
-                }
-            } else {
-                match expr.kind {
+                },
+                Ok(()) => match expr.kind {
                     ExprKind::If(cond, then, else_opt) => {
                         self.inside_stmt(true).visit_expr(cond);
                         self.visit_expr(then);
@@ -280,20 +283,22 @@ where
                     },
                     ExprKind::Block(..) => walk_expr(self, expr),
                     ExprKind::Ret(Some(expr)) => self.visit_expr(expr),
-                    _ => self.failed |= !(self.cb)(expr),
-                }
+                    _ => self.status = (self.cb)(expr),
+                },
             }
         }
     }
 
-    !contains_try(expr) && {
+    if contains_try(expr) {
+        Err(FindAllRetError::ContainsTry)
+    } else {
         let mut ret_finder = RetFinder {
             in_stmt: false,
-            failed: false,
+            status: Ok(()),
             cb: callback,
         };
         ret_finder.visit_expr(expr);
-        !ret_finder.failed
+        ret_finder.status.map_err(|()| FindAllRetError::CallbackFailed)
     }
 }
 


### PR DESCRIPTION
I think the semantics are clearer this way

---

changelog: none
