### PR TITLE
[`unsafe_removed_from_name`]: skip linting when renaming to '_'

### DIFF
--- a/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/clippy_lints/src/unsafe_removed_from_name.rs
@@ -40,6 +40,9 @@ impl EarlyLintPass for UnsafeNameRemoval {
 fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext<'_>, span: Span) {
     match use_tree.kind {
         UseTreeKind::Simple(Some(new_name)) => {
+            if new_name.as_str() == "_" {
+                return;
+            }
             let old_name = use_tree
                 .prefix
                 .segments

--- a/tests/ui/unsafe_removed_from_name.rs
+++ b/tests/ui/unsafe_removed_from_name.rs
@@ -22,6 +22,7 @@ use std::cell::UnsafeCell as Bombsawayunsafe;
 mod mod_with_some_unsafe_things {
     pub struct Safe;
     pub struct Unsafe;
+    pub trait UnsafeTrait {}
 }
 
 use mod_with_some_unsafe_things::Unsafe as LieAboutModSafety;
@@ -39,5 +40,11 @@ use mod_with_some_unsafe_things::Unsafe as SuperUnsafeModThing;
 
 #[allow(clippy::unsafe_removed_from_name)]
 use mod_with_some_unsafe_things::Unsafe as SuperSafeThing;
+
+// issue #16768, don't lint when "renaming" to '_'
+use mod_with_some_unsafe_things::UnsafeTrait as _;
+
+use mod_with_some_unsafe_things::UnsafeTrait as FakeSafeTrait;
+//~^ unsafe_removed_from_name
 
 fn main() {}

--- a/tests/ui/unsafe_removed_from_name.stderr
+++ b/tests/ui/unsafe_removed_from_name.stderr
@@ -14,22 +14,28 @@ LL | use std::cell::UnsafeCell as TotallySafeCellAgain;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: removed `unsafe` from the name of `Unsafe` in use as `LieAboutModSafety`
-  --> tests/ui/unsafe_removed_from_name.rs:27:1
+  --> tests/ui/unsafe_removed_from_name.rs:28:1
    |
 LL | use mod_with_some_unsafe_things::Unsafe as LieAboutModSafety;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: removed `unsafe` from the name of `Unsafe` in use as `A`
-  --> tests/ui/unsafe_removed_from_name.rs:31:1
+  --> tests/ui/unsafe_removed_from_name.rs:32:1
    |
 LL | use mod_with_some_unsafe_things::{Unsafe as A, Unsafe as B};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: removed `unsafe` from the name of `Unsafe` in use as `B`
-  --> tests/ui/unsafe_removed_from_name.rs:31:1
+  --> tests/ui/unsafe_removed_from_name.rs:32:1
    |
 LL | use mod_with_some_unsafe_things::{Unsafe as A, Unsafe as B};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: removed `unsafe` from the name of `UnsafeTrait` in use as `FakeSafeTrait`
+  --> tests/ui/unsafe_removed_from_name.rs:47:1
+   |
+LL | use mod_with_some_unsafe_things::UnsafeTrait as FakeSafeTrait;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
closes: rust-lang/rust-clippy#16768 

I agree with the:
> importing it just to get the side effects of the trait being in scope (anonymously, via as _) is not renaming it...

even without changing the name, we still not able to see it's original name when calling a trait method, so I think this should be fine.

---

changelog: [`unsafe_removed_from_name`]: skip linting when renaming to '_'
