### PR TITLE
Update cargo_metadata to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ color-print = "0.3.4"
 anstream = "0.6.18"
 
 [dev-dependencies]
-cargo_metadata = "0.18.1"
+cargo_metadata = "0.23"
 ui_test = "0.30.2"
 regex = "1.5.5"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-cargo_metadata = "0.18"
+cargo_metadata = "0.23"
 clippy_config = { path = "../clippy_config" }
 clippy_utils = { path = "../clippy_utils" }
 declare_clippy_lint = { path = "../declare_clippy_lint" }

--- a/clippy_lints/src/cargo/multiple_crate_versions.rs
+++ b/clippy_lints/src/cargo/multiple_crate_versions.rs
@@ -32,7 +32,7 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata, allowed_duplicate
     {
         for (name, group) in &packages
             .iter()
-            .filter(|p| !allowed_duplicate_crates.contains(&p.name))
+            .filter(|p| !allowed_duplicate_crates.contains(p.name.as_str()))
             .group_by(|p| &p.name)
         {
             let group: Vec<&Package> = group.collect();

--- a/clippy_lints/src/cargo/wildcard_dependencies.rs
+++ b/clippy_lints/src/cargo/wildcard_dependencies.rs
@@ -10,7 +10,7 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
         // VersionReq::any() does not work
         if let Ok(wildcard_ver) = semver::VersionReq::parse("*")
             && let Some(ref source) = dep.source
-            && !source.starts_with("git")
+            && !source.repr.starts_with("git")
             && dep.req == wildcard_ver
         {
             span_lint(

--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 default-run = "lintcheck"
 
 [dependencies]
-cargo_metadata = "0.15.3"
+cargo_metadata = "0.23"
 clap = { version = "4.4", features = ["derive", "env"] }
 crossbeam-channel = "0.5.6"
 diff = "0.1.13"


### PR DESCRIPTION
Updates cargo_metadata to 0.23 and fixes all the resultant issues.

changelog: none
