### PR TITLE
Update itertools to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.122"
 walkdir = "2.3"
 filetime = "0.2.9"
-itertools = "0.12"
+itertools = "0.15"
 pulldown-cmark = { version = "0.11", default-features = false, features = ["html"] }
 askama = { version = "0.16.0", default-features = false, features = ["alloc", "config", "derive"] }
 

--- a/clippy_config/Cargo.toml
+++ b/clippy_config/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clippy_utils = { path = "../clippy_utils" }
-itertools = "0.12"
+itertools = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.7.3"
 

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 clap = { version = "4.4", features = ["derive"] }
 indoc = "1.0"
-itertools = "0.12"
+itertools = "0.15"
 opener = "0.8"
 rustc-literal-escaper = "0.0.7"
 walkdir = "2.3"

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -14,7 +14,7 @@ cargo_metadata = "0.23"
 clippy_config = { path = "../clippy_config" }
 clippy_utils = { path = "../clippy_utils" }
 declare_clippy_lint = { path = "../declare_clippy_lint" }
-itertools = "0.12"
+itertools = "0.15"
 quine-mc_cluskey = "0.2"
 regex-syntax = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/clippy_lints/src/cargo/multiple_crate_versions.rs
+++ b/clippy_lints/src/cargo/multiple_crate_versions.rs
@@ -33,7 +33,7 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata, allowed_duplicate
         for (name, group) in &packages
             .iter()
             .filter(|p| !allowed_duplicate_crates.contains(p.name.as_str()))
-            .group_by(|p| &p.name)
+            .chunk_by(|p| &p.name)
         {
             let group: Vec<&Package> = group.collect();
 

--- a/clippy_lints_internal/Cargo.toml
+++ b/clippy_lints_internal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 clippy_config = { path = "../clippy_config" }
 clippy_utils = { path = "../clippy_utils" }
-itertools = "0.12"
+itertools = "0.15"
 regex = { version = "1.5" }
 rustc-semver = "1.1"
 

--- a/clippy_test_deps/Cargo.toml
+++ b/clippy_test_deps/Cargo.toml
@@ -14,7 +14,7 @@ syn = { version = "2.0", features = ["full"] }
 futures = "0.3"
 parking_lot = "0.12"
 tokio = { version = "1", features = ["io-util"] }
-itertools = "0.12"
+itertools = "0.15"
 
 # Make sure we are not part of the rustc workspace.
 [workspace]

--- a/clippy_utils/Cargo.toml
+++ b/clippy_utils/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["development-tools"]
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-itertools = "0.12"
+itertools = "0.15"
 # FIXME(f16_f128): remove when no longer needed for parsing
 rustc_apfloat = "0.2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4.4", features = ["derive", "env"] }
 crossbeam-channel = "0.5.6"
 diff = "0.1.13"
 flate2 = "1.0"
-itertools = "0.13"
+itertools = "0.15"
 rayon = "1.5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"


### PR DESCRIPTION
Updates itertools to 0.15 and fixes a warning by moving from `group_by()` to `chunk_by()`.

changelog: none