### PR TITLE
New lint: `bitwise_not_zero`, rewrite `!0` as `{int}::MAX`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6445,6 +6445,7 @@ Released 2018-09-13
 [`bad_bit_mask`]: https://rust-lang.github.io/rust-clippy/master/index.html#bad_bit_mask
 [`big_endian_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#big_endian_bytes
 [`bind_instead_of_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#bind_instead_of_map
+[`bitwise_not_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#bitwise_not_zero
 [`blacklisted_name`]: https://rust-lang.github.io/rust-clippy/master/index.html#blacklisted_name
 [`blanket_clippy_restriction_lints`]: https://rust-lang.github.io/rust-clippy/master/index.html#blanket_clippy_restriction_lints
 [`block_in_if_condition_expr`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_in_if_condition_expr

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -588,6 +588,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::operators::ARITHMETIC_SIDE_EFFECTS_INFO,
     crate::operators::ASSIGN_OP_PATTERN_INFO,
     crate::operators::BAD_BIT_MASK_INFO,
+    crate::operators::BITWISE_NOT_ZERO_INFO,
     crate::operators::CMP_OWNED_INFO,
     crate::operators::DECIMAL_BITWISE_OPERANDS_INFO,
     crate::operators::DOUBLE_COMPARISONS_INFO,

--- a/clippy_lints/src/methods/manual_saturating_arithmetic.rs
+++ b/clippy_lints/src/methods/manual_saturating_arithmetic.rs
@@ -172,7 +172,7 @@ fn is_min_or_max(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<MinMax> {
         }
         (minval, maxval)
     } else {
-        (0, if bits == 128 { !0 } else { (1 << bits) - 1 })
+        (0, if bits == 128 { u128::MAX } else { (1 << bits) - 1 })
     };
 
     let check_lit = |expr: &Expr<'_>, check_min: bool| {

--- a/clippy_lints/src/operators/bitwise_not_zero.rs
+++ b/clippy_lints/src/operators/bitwise_not_zero.rs
@@ -1,0 +1,35 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use rustc_errors::Applicability;
+use rustc_hir::Expr;
+use rustc_lint::{LateContext, LintContext};
+
+use crate::operators::BITWISE_NOT_ZERO;
+
+/// `arg` is argument to the `!` operator, `expr` is the entire expression
+pub(super) fn check(cx: &LateContext<'_>, expr: Expr<'_>, arg: Expr<'_>) {
+    if !clippy_utils::consts::is_zero_integer_const(cx, &arg, arg.span.ctxt()) {
+        return;
+    }
+
+    // If argument to `!` is from a macro expansion, bail
+    if arg.span.in_external_macro(cx.sess().source_map()) {
+        return;
+    }
+
+    let arg_ty = cx.typeck_results().expr_ty(&arg);
+
+    let integer = match arg_ty.kind() {
+        rustc_middle::ty::Uint(uint_ty) => uint_ty.name_str(),
+        _ => return,
+    };
+
+    span_lint_and_sugg(
+        cx,
+        BITWISE_NOT_ZERO,
+        expr.span,
+        "usage of the bitwise not `!` on zero",
+        "this is clearer written as the maximum value",
+        format!("{integer}::MAX"),
+        Applicability::MaybeIncorrect,
+    );
+}

--- a/clippy_lints/src/operators/identity_op.rs
+++ b/clippy_lints/src/operators/identity_op.rs
@@ -204,7 +204,7 @@ fn is_redundant_op(cx: &LateContext<'_>, e: &Expr<'_>, m: i8, ctxt: SyntaxContex
     if let Some(Constant::Int(v)) = ConstEvalCtxt::new(cx).eval_local(e, ctxt).map(Constant::peel_refs) {
         let check = match *cx.typeck_results().expr_ty(e).peel_refs().kind() {
             ty::Int(ity) => unsext(cx.tcx, -1_i128, ity),
-            ty::Uint(uty) => clip(cx.tcx, !0, uty),
+            ty::Uint(uty) => clip(cx.tcx, u128::MAX, uty),
             _ => return false,
         };
         if match m {

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -1,6 +1,7 @@
 mod absurd_extreme_comparisons;
 mod assign_op_pattern;
 mod bit_mask;
+mod bitwise_not_zero;
 mod cmp_owned;
 mod const_comparisons;
 mod decimal_bitwise_operands;
@@ -174,6 +175,32 @@ declare_clippy_lint! {
     pub BAD_BIT_MASK,
     correctness,
     "expressions of the form `_ & mask == select` that will only ever return `true` or `false`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for `!0`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `!0` performs a bitwise NOT, which is equivalent to `{uint}::MAX`, which is clearer.
+    ///
+    /// ### Example
+    ///
+    /// ```no_run
+    /// !0_u32;
+    /// ```
+    ///
+    /// Can be equivalently written as:
+    ///
+    /// ```no_run
+    /// u32::MAX;
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub BITWISE_NOT_ZERO,
+    complexity,
+    "bitwise not on zero"
 }
 
 declare_clippy_lint! {
@@ -963,6 +990,7 @@ impl_lint_pass!(Operators => [
     ARITHMETIC_SIDE_EFFECTS,
     ASSIGN_OP_PATTERN,
     BAD_BIT_MASK,
+    BITWISE_NOT_ZERO,
     CMP_OWNED,
     DECIMAL_BITWISE_OPERANDS,
     DOUBLE_COMPARISONS,
@@ -1064,11 +1092,11 @@ impl<'tcx> LateLintPass<'tcx> for Operators {
                 assign_op_pattern::check(cx, e, lhs, rhs, self.msrv);
                 self_assignment::check(cx, e, lhs, rhs);
             },
-            ExprKind::Unary(op, arg) =>
-            {
-                #[expect(clippy::collapsible_match)]
+            ExprKind::Unary(op, arg) => {
                 if op == UnOp::Neg {
                     self.arithmetic_context.check_negate(cx, e, arg);
+                } else if op == UnOp::Not {
+                    self.arithmetic_context.check_not(cx, e, arg);
                 }
             },
             _ => (),

--- a/clippy_lints/src/operators/numeric_arithmetic.rs
+++ b/clippy_lints/src/operators/numeric_arithmetic.rs
@@ -50,6 +50,7 @@ impl Context {
         }
     }
 
+    /// Checks for usage of the `-` operator on `arg`.
     pub fn check_negate<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, arg: &'tcx hir::Expr<'_>) {
         if self.skip_expr(expr) {
             return;
@@ -59,6 +60,14 @@ impl Context {
             span_lint(cx, FLOAT_ARITHMETIC, expr.span, "floating-point arithmetic detected");
             self.expr_id = Some(expr.hir_id);
         }
+    }
+
+    /// Checks for usage of the `!` operator on `arg`.
+    pub fn check_not<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, arg: &'tcx hir::Expr<'_>) {
+        if self.skip_expr(expr) {
+            return;
+        }
+        super::bitwise_not_zero::check(cx, *expr, *arg);
     }
 
     pub fn expr_post(&mut self, id: hir::HirId) {

--- a/tests/ui/absurd-extreme-comparisons.rs
+++ b/tests/ui/absurd-extreme-comparisons.rs
@@ -4,6 +4,7 @@
     clippy::eq_op,
     clippy::no_effect,
     clippy::unnecessary_operation,
+    clippy::bitwise_not_zero,
     clippy::needless_pass_by_value
 )]
 

--- a/tests/ui/absurd-extreme-comparisons.stderr
+++ b/tests/ui/absurd-extreme-comparisons.stderr
@@ -1,5 +1,5 @@
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:14:5
+  --> tests/ui/absurd-extreme-comparisons.rs:15:5
    |
 LL |     u <= 0;
    |     ^^^^^^
@@ -9,7 +9,7 @@ LL |     u <= 0;
    = help: to override `-D warnings` add `#[allow(clippy::absurd_extreme_comparisons)]`
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:17:5
+  --> tests/ui/absurd-extreme-comparisons.rs:18:5
    |
 LL |     u <= Z;
    |     ^^^^^^
@@ -17,7 +17,7 @@ LL |     u <= Z;
    = help: because `Z` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `u == Z` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:20:5
+  --> tests/ui/absurd-extreme-comparisons.rs:21:5
    |
 LL |     u < Z;
    |     ^^^^^
@@ -25,7 +25,7 @@ LL |     u < Z;
    = help: because `Z` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:23:5
+  --> tests/ui/absurd-extreme-comparisons.rs:24:5
    |
 LL |     Z >= u;
    |     ^^^^^^
@@ -33,7 +33,7 @@ LL |     Z >= u;
    = help: because `Z` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `Z == u` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:26:5
+  --> tests/ui/absurd-extreme-comparisons.rs:27:5
    |
 LL |     Z > u;
    |     ^^^^^
@@ -41,7 +41,7 @@ LL |     Z > u;
    = help: because `Z` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:29:5
+  --> tests/ui/absurd-extreme-comparisons.rs:30:5
    |
 LL |     u > u32::MAX;
    |     ^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     u > u32::MAX;
    = help: because `u32::MAX` is the maximum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:32:5
+  --> tests/ui/absurd-extreme-comparisons.rs:33:5
    |
 LL |     u >= u32::MAX;
    |     ^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL |     u >= u32::MAX;
    = help: because `u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u == u32::MAX` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:35:5
+  --> tests/ui/absurd-extreme-comparisons.rs:36:5
    |
 LL |     u32::MAX < u;
    |     ^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     u32::MAX < u;
    = help: because `u32::MAX` is the maximum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:38:5
+  --> tests/ui/absurd-extreme-comparisons.rs:39:5
    |
 LL |     u32::MAX <= u;
    |     ^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     u32::MAX <= u;
    = help: because `u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u32::MAX == u` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:41:5
+  --> tests/ui/absurd-extreme-comparisons.rs:42:5
    |
 LL |     1-1 > u;
    |     ^^^^^^^
@@ -81,7 +81,7 @@ LL |     1-1 > u;
    = help: because `1-1` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:44:5
+  --> tests/ui/absurd-extreme-comparisons.rs:45:5
    |
 LL |     u >= !0;
    |     ^^^^^^^
@@ -89,7 +89,7 @@ LL |     u >= !0;
    = help: because `!0` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u == !0` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:47:5
+  --> tests/ui/absurd-extreme-comparisons.rs:48:5
    |
 LL |     u <= 12 - 2*6;
    |     ^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL |     u <= 12 - 2*6;
    = help: because `12 - 2*6` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `u == 12 - 2*6` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:51:5
+  --> tests/ui/absurd-extreme-comparisons.rs:52:5
    |
 LL |     i < -127 - 1;
    |     ^^^^^^^^^^^^
@@ -105,7 +105,7 @@ LL |     i < -127 - 1;
    = help: because `-127 - 1` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:54:5
+  --> tests/ui/absurd-extreme-comparisons.rs:55:5
    |
 LL |     i8::MAX >= i;
    |     ^^^^^^^^^^^^
@@ -113,7 +113,7 @@ LL |     i8::MAX >= i;
    = help: because `i8::MAX` is the maximum value for this type, this comparison is always true
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:57:5
+  --> tests/ui/absurd-extreme-comparisons.rs:58:5
    |
 LL |     3-7 < i32::MIN;
    |     ^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     3-7 < i32::MIN;
    = help: because `i32::MIN` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:61:5
+  --> tests/ui/absurd-extreme-comparisons.rs:62:5
    |
 LL |     b >= true;
    |     ^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     b >= true;
    = help: because `true` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `b == true` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
-  --> tests/ui/absurd-extreme-comparisons.rs:64:5
+  --> tests/ui/absurd-extreme-comparisons.rs:65:5
    |
 LL |     false > b;
    |     ^^^^^^^^^
@@ -137,7 +137,7 @@ LL |     false > b;
    = help: because `false` is the minimum value for this type, this comparison is always false
 
 error: <-comparison of unit values detected. This will always be false
-  --> tests/ui/absurd-extreme-comparisons.rs:69:5
+  --> tests/ui/absurd-extreme-comparisons.rs:70:5
    |
 LL |     () < {};
    |     ^^^^^^^

--- a/tests/ui/bitwise_not_zero.fixed
+++ b/tests/ui/bitwise_not_zero.fixed
@@ -1,0 +1,48 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::bitwise_not_zero)]
+#![allow(clippy::eq_op)]
+
+extern crate proc_macros;
+
+macro_rules! local_macro {
+    ($($tt:tt)*) => {
+        $($tt)*
+    }
+}
+
+fn main() {
+    // OK, !0 == -1, not i32::MAX
+    assert_eq!(!0, i32::MAX);
+
+    // this should be OK:
+    const ZERO: u16 = 0;
+    assert_eq!(!ZERO, u16::MAX);
+
+    // this should be OK:
+    let zero: u8 = 0;
+    assert_eq!(!zero, u8::MAX);
+
+    assert_eq!(u64::MAX, u64::MAX);
+    //~^ bitwise_not_zero
+
+    assert_eq!(u8::MAX, u8::MAX);
+    //~^ bitwise_not_zero
+
+    assert_eq!(usize::MAX, usize::MAX);
+    //~^ bitwise_not_zero
+
+    proc_macros::external!(assert_eq!(!0usize, usize::MAX));
+
+    local_macro!(assert_eq!(usize::MAX, usize::MAX));
+    //~^ bitwise_not_zero
+
+    assert_eq!(proc_macros::external!(!0u16), u16::MAX);
+    assert_eq!(local_macro!(u16::MAX), u16::MAX);
+    //~^ bitwise_not_zero
+
+    assert_eq!(u64::MAX, proc_macros::external!(u64::MAX));
+    //~^ bitwise_not_zero
+
+    assert_eq!(u32::MAX, proc_macros::external!(u32::MAX));
+    //~^ bitwise_not_zero
+}

--- a/tests/ui/bitwise_not_zero.rs
+++ b/tests/ui/bitwise_not_zero.rs
@@ -1,0 +1,48 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::bitwise_not_zero)]
+#![allow(clippy::eq_op)]
+
+extern crate proc_macros;
+
+macro_rules! local_macro {
+    ($($tt:tt)*) => {
+        $($tt)*
+    }
+}
+
+fn main() {
+    // OK, !0 == -1, not i32::MAX
+    assert_eq!(!0, i32::MAX);
+
+    // this should be OK:
+    const ZERO: u16 = 0;
+    assert_eq!(!ZERO, u16::MAX);
+
+    // this should be OK:
+    let zero: u8 = 0;
+    assert_eq!(!zero, u8::MAX);
+
+    assert_eq!(!0u64, u64::MAX);
+    //~^ bitwise_not_zero
+
+    assert_eq!(!0_u8, u8::MAX);
+    //~^ bitwise_not_zero
+
+    assert_eq!(!0usize, usize::MAX);
+    //~^ bitwise_not_zero
+
+    proc_macros::external!(assert_eq!(!0usize, usize::MAX));
+
+    local_macro!(assert_eq!(!0usize, usize::MAX));
+    //~^ bitwise_not_zero
+
+    assert_eq!(proc_macros::external!(!0u16), u16::MAX);
+    assert_eq!(local_macro!(!0u16), u16::MAX);
+    //~^ bitwise_not_zero
+
+    assert_eq!(!0u64, proc_macros::external!(u64::MAX));
+    //~^ bitwise_not_zero
+
+    assert_eq!(!local_macro!(0u32), proc_macros::external!(u32::MAX));
+    //~^ bitwise_not_zero
+}

--- a/tests/ui/bitwise_not_zero.stderr
+++ b/tests/ui/bitwise_not_zero.stderr
@@ -1,0 +1,47 @@
+error: usage of the bitwise not `!` on zero
+  --> tests/ui/bitwise_not_zero.rs:25:16
+   |
+LL |     assert_eq!(!0u64, u64::MAX);
+   |                ^^^^^ help: this is clearer written as the maximum value: `u64::MAX`
+   |
+   = note: `-D clippy::bitwise-not-zero` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::bitwise_not_zero)]`
+
+error: usage of the bitwise not `!` on zero
+  --> tests/ui/bitwise_not_zero.rs:28:16
+   |
+LL |     assert_eq!(!0_u8, u8::MAX);
+   |                ^^^^^ help: this is clearer written as the maximum value: `u8::MAX`
+
+error: usage of the bitwise not `!` on zero
+  --> tests/ui/bitwise_not_zero.rs:31:16
+   |
+LL |     assert_eq!(!0usize, usize::MAX);
+   |                ^^^^^^^ help: this is clearer written as the maximum value: `usize::MAX`
+
+error: usage of the bitwise not `!` on zero
+  --> tests/ui/bitwise_not_zero.rs:36:29
+   |
+LL |     local_macro!(assert_eq!(!0usize, usize::MAX));
+   |                             ^^^^^^^ help: this is clearer written as the maximum value: `usize::MAX`
+
+error: usage of the bitwise not `!` on zero
+  --> tests/ui/bitwise_not_zero.rs:40:29
+   |
+LL |     assert_eq!(local_macro!(!0u16), u16::MAX);
+   |                             ^^^^^ help: this is clearer written as the maximum value: `u16::MAX`
+
+error: usage of the bitwise not `!` on zero
+  --> tests/ui/bitwise_not_zero.rs:43:16
+   |
+LL |     assert_eq!(!0u64, proc_macros::external!(u64::MAX));
+   |                ^^^^^ help: this is clearer written as the maximum value: `u64::MAX`
+
+error: usage of the bitwise not `!` on zero
+  --> tests/ui/bitwise_not_zero.rs:46:16
+   |
+LL |     assert_eq!(!local_macro!(0u32), proc_macros::external!(u32::MAX));
+   |                ^^^^^^^^^^^^^^^^^^^ help: this is clearer written as the maximum value: `u32::MAX`
+
+error: aborting due to 7 previous errors
+

--- a/tests/ui/decimal_bitwise_operands.rs
+++ b/tests/ui/decimal_bitwise_operands.rs
@@ -2,6 +2,7 @@
     clippy::erasing_op,
     clippy::no_effect,
     clippy::unnecessary_operation,
+    clippy::bitwise_not_zero,
     clippy::unnecessary_cast,
     clippy::op_ref
 )]

--- a/tests/ui/decimal_bitwise_operands.stderr
+++ b/tests/ui/decimal_bitwise_operands.stderr
@@ -1,5 +1,5 @@
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:21:9
+  --> tests/ui/decimal_bitwise_operands.rs:22:9
    |
 LL |     x & 9_8765_4321;
    |         ^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     x & 9_8765_4321;
    = help: to override `-D warnings` add `#[allow(clippy::decimal_bitwise_operands)]`
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:22:9
+  --> tests/ui/decimal_bitwise_operands.rs:23:9
    |
 LL |     x & 100_i32;
    |         ^^^^^^^
@@ -17,7 +17,7 @@ LL |     x & 100_i32;
    = help: use binary (0b110_0100_i32), hex (0x0064_i32), or octal (0o144_i32) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:23:23
+  --> tests/ui/decimal_bitwise_operands.rs:24:23
    |
 LL |     x | (/* comment */99);
    |                       ^^
@@ -25,7 +25,7 @@ LL |     x | (/* comment */99);
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:24:10
+  --> tests/ui/decimal_bitwise_operands.rs:25:10
    |
 LL |     x ^ (99);
    |          ^^
@@ -33,7 +33,7 @@ LL |     x ^ (99);
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:25:10
+  --> tests/ui/decimal_bitwise_operands.rs:26:10
    |
 LL |     x &= 99;
    |          ^^
@@ -41,7 +41,7 @@ LL |     x &= 99;
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:26:12
+  --> tests/ui/decimal_bitwise_operands.rs:27:12
    |
 LL |     x |= { 99 };
    |            ^^
@@ -49,7 +49,7 @@ LL |     x |= { 99 };
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:27:14
+  --> tests/ui/decimal_bitwise_operands.rs:28:14
    |
 LL |     x |= { { 99 } };
    |              ^^
@@ -57,7 +57,7 @@ LL |     x |= { { 99 } };
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:30:9
+  --> tests/ui/decimal_bitwise_operands.rs:31:9
    |
 LL |         99
    |         ^^
@@ -65,7 +65,7 @@ LL |         99
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:32:11
+  --> tests/ui/decimal_bitwise_operands.rs:33:11
    |
 LL |     x ^= (99);
    |           ^^
@@ -73,7 +73,7 @@ LL |     x ^= (99);
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:35:14
+  --> tests/ui/decimal_bitwise_operands.rs:36:14
    |
 LL |     0b1010 & 99;
    |              ^^
@@ -81,7 +81,7 @@ LL |     0b1010 & 99;
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:36:15
+  --> tests/ui/decimal_bitwise_operands.rs:37:15
    |
 LL |     0b1010 | (99);
    |               ^^
@@ -89,7 +89,7 @@ LL |     0b1010 | (99);
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:37:28
+  --> tests/ui/decimal_bitwise_operands.rs:38:28
    |
 LL |     0b1010 ^ (/* comment */99);
    |                            ^^
@@ -97,7 +97,7 @@ LL |     0b1010 ^ (/* comment */99);
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:38:5
+  --> tests/ui/decimal_bitwise_operands.rs:39:5
    |
 LL |     99 & 0b1010;
    |     ^^
@@ -105,7 +105,7 @@ LL |     99 & 0b1010;
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:39:6
+  --> tests/ui/decimal_bitwise_operands.rs:40:6
    |
 LL |     (99) | 0b1010;
    |      ^^
@@ -113,7 +113,7 @@ LL |     (99) | 0b1010;
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:40:19
+  --> tests/ui/decimal_bitwise_operands.rs:41:19
    |
 LL |     (/* comment */99) ^ 0b1010;
    |                   ^^
@@ -121,7 +121,7 @@ LL |     (/* comment */99) ^ 0b1010;
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:41:13
+  --> tests/ui/decimal_bitwise_operands.rs:42:13
    |
 LL |     0xD | { 99 };
    |             ^^
@@ -129,7 +129,7 @@ LL |     0xD | { 99 };
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:42:5
+  --> tests/ui/decimal_bitwise_operands.rs:43:5
    |
 LL |     88 & 99;
    |     ^^
@@ -137,7 +137,7 @@ LL |     88 & 99;
    = help: use binary (0b101_1000), hex (0x0058), or octal (0o130) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:42:10
+  --> tests/ui/decimal_bitwise_operands.rs:43:10
    |
 LL |     88 & 99;
    |          ^^
@@ -145,7 +145,7 @@ LL |     88 & 99;
    = help: use binary (0b110_0011), hex (0x0063), or octal (0o143) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:45:15
+  --> tests/ui/decimal_bitwise_operands.rs:46:15
    |
 LL |     37 & 38 & 39;
    |               ^^
@@ -153,7 +153,7 @@ LL |     37 & 38 & 39;
    = help: use binary (0b10_0111), hex (0x0027), or octal (0o47) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:45:5
+  --> tests/ui/decimal_bitwise_operands.rs:46:5
    |
 LL |     37 & 38 & 39;
    |     ^^
@@ -161,7 +161,7 @@ LL |     37 & 38 & 39;
    = help: use binary (0b10_0101), hex (0x0025), or octal (0o45) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:45:10
+  --> tests/ui/decimal_bitwise_operands.rs:46:10
    |
 LL |     37 & 38 & 39;
    |          ^^
@@ -169,7 +169,7 @@ LL |     37 & 38 & 39;
    = help: use binary (0b10_0110), hex (0x0026), or octal (0o46) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:80:10
+  --> tests/ui/decimal_bitwise_operands.rs:81:10
    |
 LL |     x & !100;
    |          ^^^
@@ -177,7 +177,7 @@ LL |     x & !100;
    = help: use binary (0b110_0100), hex (0x0064), or octal (0o144) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:81:10
+  --> tests/ui/decimal_bitwise_operands.rs:82:10
    |
 LL |     x & -100;
    |          ^^^
@@ -185,7 +185,7 @@ LL |     x & -100;
    = help: use binary (0b110_0100), hex (0x0064), or octal (0o144) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:82:10
+  --> tests/ui/decimal_bitwise_operands.rs:83:10
    |
 LL |     x & (100 as i32);
    |          ^^^
@@ -193,7 +193,7 @@ LL |     x & (100 as i32);
    = help: use binary (0b110_0100), hex (0x0064), or octal (0o144) notation for better readability
 
 error: using decimal literal for bitwise operation
-  --> tests/ui/decimal_bitwise_operands.rs:83:10
+  --> tests/ui/decimal_bitwise_operands.rs:84:10
    |
 LL |     x & &100;
    |          ^^^

--- a/tests/ui/unnecessary_min_or_max.fixed
+++ b/tests/ui/unnecessary_min_or_max.fixed
@@ -1,8 +1,7 @@
 //@aux-build:external_consts.rs
 
-#![allow(unused)]
 #![warn(clippy::unnecessary_min_or_max)]
-#![allow(clippy::identity_op)]
+#![allow(clippy::bitwise_not_zero, clippy::identity_op)]
 
 extern crate external_consts;
 

--- a/tests/ui/unnecessary_min_or_max.rs
+++ b/tests/ui/unnecessary_min_or_max.rs
@@ -1,8 +1,7 @@
 //@aux-build:external_consts.rs
 
-#![allow(unused)]
 #![warn(clippy::unnecessary_min_or_max)]
-#![allow(clippy::identity_op)]
+#![allow(clippy::bitwise_not_zero, clippy::identity_op)]
 
 extern crate external_consts;
 

--- a/tests/ui/unnecessary_min_or_max.stderr
+++ b/tests/ui/unnecessary_min_or_max.stderr
@@ -1,5 +1,5 @@
 error: `(-6_i32)` is never greater than `9` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:13:13
+  --> tests/ui/unnecessary_min_or_max.rs:12:13
    |
 LL |     let _ = (-6_i32).min(9);
    |             ^^^^^^^^^^^^^^^ help: try: `(-6_i32)`
@@ -8,145 +8,145 @@ LL |     let _ = (-6_i32).min(9);
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_min_or_max)]`
 
 error: `(-6_i32)` is never greater than `9` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:15:13
+  --> tests/ui/unnecessary_min_or_max.rs:14:13
    |
 LL |     let _ = (-6_i32).max(9);
    |             ^^^^^^^^^^^^^^^ help: try: `9`
 
 error: `9_u32` is never smaller than `6` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:17:13
+  --> tests/ui/unnecessary_min_or_max.rs:16:13
    |
 LL |     let _ = 9_u32.min(6);
    |             ^^^^^^^^^^^^ help: try: `6`
 
 error: `9_u32` is never smaller than `6` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:19:13
+  --> tests/ui/unnecessary_min_or_max.rs:18:13
    |
 LL |     let _ = 9_u32.max(6);
    |             ^^^^^^^^^^^^ help: try: `9_u32`
 
 error: `6` is never greater than `7_u8` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:21:13
+  --> tests/ui/unnecessary_min_or_max.rs:20:13
    |
 LL |     let _ = 6.min(7_u8);
    |             ^^^^^^^^^^^ help: try: `6`
 
 error: `6` is never greater than `7_u8` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:23:13
+  --> tests/ui/unnecessary_min_or_max.rs:22:13
    |
 LL |     let _ = 6.max(7_u8);
    |             ^^^^^^^^^^^ help: try: `7_u8`
 
 error: `0` is never greater than `x` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:28:13
+  --> tests/ui/unnecessary_min_or_max.rs:27:13
    |
 LL |     let _ = 0.min(x);
    |             ^^^^^^^^ help: try: `0`
 
 error: `0` is never greater than `x` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:30:13
+  --> tests/ui/unnecessary_min_or_max.rs:29:13
    |
 LL |     let _ = 0.max(x);
    |             ^^^^^^^^ help: try: `x`
 
 error: `x` is never smaller than `0_u32` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:32:13
+  --> tests/ui/unnecessary_min_or_max.rs:31:13
    |
 LL |     let _ = x.min(0_u32);
    |             ^^^^^^^^^^^^ help: try: `0_u32`
 
 error: `x` is never smaller than `0_u32` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:34:13
+  --> tests/ui/unnecessary_min_or_max.rs:33:13
    |
 LL |     let _ = x.max(0_u32);
    |             ^^^^^^^^^^^^ help: try: `x`
 
 error: `i32::MIN` is never greater than `x` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:39:13
+  --> tests/ui/unnecessary_min_or_max.rs:38:13
    |
 LL |     let _ = i32::MIN.min(x);
    |             ^^^^^^^^^^^^^^^ help: try: `i32::MIN`
 
 error: `i32::MIN` is never greater than `x` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:41:13
+  --> tests/ui/unnecessary_min_or_max.rs:40:13
    |
 LL |     let _ = i32::MIN.max(x);
    |             ^^^^^^^^^^^^^^^ help: try: `x`
 
 error: `x` is never smaller than `i32::MIN` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:43:13
+  --> tests/ui/unnecessary_min_or_max.rs:42:13
    |
 LL |     let _ = x.min(i32::MIN);
    |             ^^^^^^^^^^^^^^^ help: try: `i32::MIN`
 
 error: `x` is never smaller than `i32::MIN` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:45:13
+  --> tests/ui/unnecessary_min_or_max.rs:44:13
    |
 LL |     let _ = x.max(i32::MIN);
    |             ^^^^^^^^^^^^^^^ help: try: `x`
 
 error: `x` is never smaller than `i32::MIN - 0` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:48:13
+  --> tests/ui/unnecessary_min_or_max.rs:47:13
    |
 LL |     let _ = x.min(i32::MIN - 0);
    |             ^^^^^^^^^^^^^^^^^^^ help: try: `i32::MIN - 0`
 
 error: `x` is never smaller than `i32::MIN` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:50:13
+  --> tests/ui/unnecessary_min_or_max.rs:49:13
    |
 LL |     let _ = x.max(i32::MIN);
    |             ^^^^^^^^^^^^^^^ help: try: `x`
 
 error: `x` is never smaller than `i32::MIN - 0` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:53:13
+  --> tests/ui/unnecessary_min_or_max.rs:52:13
    |
 LL |     let _ = x.min(i32::MIN - 0);
    |             ^^^^^^^^^^^^^^^^^^^ help: try: `i32::MIN - 0`
 
 error: `n` is never smaller than `0` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:83:13
+  --> tests/ui/unnecessary_min_or_max.rs:82:13
    |
 LL |     let _ = n.min(0);
    |             ^^^^^^^^ help: try: `0`
 
 error: `n` is never smaller than `0usize` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:86:13
+  --> tests/ui/unnecessary_min_or_max.rs:85:13
    |
 LL |     let _ = n.min(0usize);
    |             ^^^^^^^^^^^^^ help: try: `0usize`
 
 error: `(0usize)` is never greater than `n` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:89:13
+  --> tests/ui/unnecessary_min_or_max.rs:88:13
    |
 LL |     let _ = (0usize).min(n);
    |             ^^^^^^^^^^^^^^^ help: try: `(0usize)`
 
 error: `n` is never smaller than `usize::MIN` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:92:13
+  --> tests/ui/unnecessary_min_or_max.rs:91:13
    |
 LL |     let _ = n.min(usize::MIN);
    |             ^^^^^^^^^^^^^^^^^ help: try: `usize::MIN`
 
 error: `n` is never greater than `usize::MAX` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:95:13
+  --> tests/ui/unnecessary_min_or_max.rs:94:13
    |
 LL |     let _ = n.max(usize::MAX);
    |             ^^^^^^^^^^^^^^^^^ help: try: `usize::MAX`
 
 error: `(usize::MAX)` is never smaller than `n` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:98:13
+  --> tests/ui/unnecessary_min_or_max.rs:97:13
    |
 LL |     let _ = (usize::MAX).max(n);
    |             ^^^^^^^^^^^^^^^^^^^ help: try: `(usize::MAX)`
 
 error: `n` is never greater than `!0usize` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:101:13
+  --> tests/ui/unnecessary_min_or_max.rs:100:13
    |
 LL |     let _ = n.max(!0usize);
    |             ^^^^^^^^^^^^^^ help: try: `!0usize`
 
 error: `n` is never smaller than `0` and has therefore no effect
-  --> tests/ui/unnecessary_min_or_max.rs:104:13
+  --> tests/ui/unnecessary_min_or_max.rs:103:13
    |
 LL |     let _ = n.max(0);
    |             ^^^^^^^^ help: try: `n`


### PR DESCRIPTION

This lint suggests to rewrite expressions like:

```rust
bar_length.unwrap_or(!0)
```

As:

```rust
bar_length.unwrap_or(u32::MAX)
```

Because `!0` is confusing, it performs the bitwise NOT operator, equivalent to specifying the `MAX` value.

---

changelog: [`bitwise_new_lint`]: added lint that replaces `!0` with`{int}::MAX`