### PR TITLE
Optimize `nonstandard_macro_braces` by 99.9683% [1.1b -> 351K]

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -456,6 +456,9 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     // Due to the architecture of the compiler, currently `cfg_attr` attributes on crate
     // level (i.e `#![cfg_attr(...)]`) will still be expanded even when using a pre-expansion pass.
     store.register_pre_expansion_lint_pass(Box::new(move || Box::new(attrs::EarlyAttributes::new(conf))));
+    store.register_pre_expansion_lint_pass(Box::new(move || {
+        Box::new(nonstandard_macro_braces::MacroBraces::new(conf))
+    }));
 
     let format_args_storage = FormatArgsStorage::default();
     let attr_storage = AttrStorage::default();

--- a/clippy_lints/src/nonstandard_macro_braces.rs
+++ b/clippy_lints/src/nonstandard_macro_braces.rs
@@ -1,15 +1,17 @@
 use clippy_config::Conf;
 use clippy_config::types::MacroMatcher;
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::source::{SourceText, SpanExt};
 use rustc_ast::ast;
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_ast::token::{Delimiter, Token, TokenKind};
+use rustc_ast::tokenstream::{TokenStream, TokenTree};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::Applicability;
-use rustc_hir::def_id::DefId;
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::impl_lint_pass;
 use rustc_span::Span;
-use rustc_span::hygiene::{ExpnKind, MacroKind};
+
+use crate::rustc_lint::LintContext;
+use clippy_utils::source::snippet_opt;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -29,127 +31,111 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.55.0"]
     pub NONSTANDARD_MACRO_BRACES,
-    nursery,
+    style,
     "check consistent use of braces in macro"
 }
 
 impl_lint_pass!(MacroBraces => [NONSTANDARD_MACRO_BRACES]);
 
-struct MacroInfo {
-    callsite_span: Span,
-    callsite_snippet: SourceText,
-    old_open_brace: char,
-    braces: (char, char),
-}
-
 pub struct MacroBraces {
-    macro_braces: FxHashMap<String, (char, char)>,
-    done: FxHashSet<Span>,
+    macro_braces: (FxHashMap<String, (char, char)>, usize),
+    /// Spans for statement macro calls, they have special behaviour with semicolons
+    mac_stmt_spans: Vec<Span>,
 }
 
 impl MacroBraces {
     pub fn new(conf: &'static Conf) -> Self {
         Self {
             macro_braces: macro_braces(&conf.standard_macro_braces),
-            done: FxHashSet::default(),
+            mac_stmt_spans: Vec::new(),
         }
     }
 }
 
 impl EarlyLintPass for MacroBraces {
-    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
-        if let Some(MacroInfo {
-            callsite_span,
-            callsite_snippet,
-            braces,
-            ..
-        }) = is_offending_macro(cx, item.span, self)
+    fn check_mac(&mut self, cx: &EarlyContext<'_>, mac: &ast::MacCall) {
+        if let Some(last_segment) = mac.path.segments.last()
+            && let name = last_segment.ident.as_str()
+            && let Some(&braces) = self.macro_braces.0.get(name)
+            && let Some(snip) = snippet_opt(cx.sess(), mac.span().with_lo(last_segment.span().lo()))
+            && let Some(macro_args_str) = &snip.strip_prefix(name).and_then(|snip| snip.strip_prefix('!'))
+            && let Some(old_open_brace @ ('{' | '(' | '[')) = macro_args_str.trim_start().chars().next()
+            && old_open_brace != braces.0
         {
-            emit_help(cx, &callsite_snippet, braces, callsite_span, false);
-            self.done.insert(callsite_span);
-        }
-    }
-
-    fn check_stmt(&mut self, cx: &EarlyContext<'_>, stmt: &ast::Stmt) {
-        if let Some(MacroInfo {
-            callsite_span,
-            callsite_snippet,
-            braces,
-            old_open_brace,
-        }) = is_offending_macro(cx, stmt.span, self)
-        {
-            // if we turn `macro!{}` into `macro!()`/`macro![]`, we'll no longer get the implicit
-            // trailing semicolon, see #9913
-            // NOTE: `stmt.kind != StmtKind::MacCall` because `EarlyLintPass` happens after macro expansion
-            let add_semi = matches!(stmt.kind, ast::StmtKind::Expr(..)) && old_open_brace == '{';
-            emit_help(cx, &callsite_snippet, braces, callsite_span, add_semi);
-            self.done.insert(callsite_span);
-        }
-    }
-
-    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr) {
-        if let Some(MacroInfo {
-            callsite_span,
-            callsite_snippet,
-            braces,
-            ..
-        }) = is_offending_macro(cx, expr.span, self)
-        {
-            emit_help(cx, &callsite_snippet, braces, callsite_span, false);
-            self.done.insert(callsite_span);
-        }
-    }
-
-    fn check_ty(&mut self, cx: &EarlyContext<'_>, ty: &ast::Ty) {
-        if let Some(MacroInfo {
-            callsite_span,
-            braces,
-            callsite_snippet,
-            ..
-        }) = is_offending_macro(cx, ty.span, self)
-        {
-            emit_help(cx, &callsite_snippet, braces, callsite_span, false);
-            self.done.insert(callsite_span);
-        }
-    }
-}
-
-fn is_offending_macro(cx: &EarlyContext<'_>, span: Span, mac_braces: &MacroBraces) -> Option<MacroInfo> {
-    let unnested_or_local = |span: Span| {
-        !span.from_expansion()
-            || span
-                .macro_backtrace()
-                .last()
-                .is_some_and(|e| e.macro_def_id.is_some_and(DefId::is_local))
-    };
-
-    let mut ctxt = span.ctxt();
-    while !ctxt.is_root() {
-        let expn_data = ctxt.outer_expn_data();
-        if let ExpnKind::Macro(MacroKind::Bang, mac_name) = expn_data.kind
-        && let name = mac_name.as_str()
-        && let Some(&braces) = mac_braces.macro_braces.get(name)
-        && let Some(snip) = expn_data.call_site.get_text(cx)
-        // we must check only invocation sites
-        // https://github.com/rust-lang/rust-clippy/issues/7422
-        && let Some(macro_args_str) = snip.strip_prefix(name).and_then(|snip| snip.strip_prefix('!'))
-        && let Some(old_open_brace @ ('{' | '(' | '[')) = macro_args_str.trim_start().chars().next()
-        && old_open_brace != braces.0
-        && unnested_or_local(expn_data.call_site)
-        && !mac_braces.done.contains(&expn_data.call_site)
-        {
-            return Some(MacroInfo {
-                callsite_span: expn_data.call_site,
-                callsite_snippet: snip,
-                old_open_brace,
+            // Semicolons added for statements that previously ended in braces, see issue #9913
+            let add_semi = self.mac_stmt_spans.iter().any(|s| *s == mac.span());
+            emit_help(
+                cx,
+                &snippet_opt(cx.sess(), mac.span()).unwrap(),
                 braces,
-            });
+                mac.span(),
+                add_semi,
+            );
         }
-
-        ctxt = expn_data.call_site.ctxt();
     }
 
-    None
+    // See issue #9913
+    fn check_stmt(&mut self, _: &EarlyContext<'_>, stmt: &ast::Stmt) {
+        if let ast::StmtKind::MacCall(mac_callstmt) = &stmt.kind
+            && let ast::MacCallStmt {
+                style: ast::MacStmtStyle::Braces,
+                ..
+            } = **mac_callstmt
+        {
+            self.mac_stmt_spans.push(mac_callstmt.mac.span());
+        }
+    }
+
+    fn check_mac_def(&mut self, cx: &EarlyContext<'_>, mac: &ast::MacroDef) {
+        fn check_ts(cx: &EarlyContext<'_>, ts: &TokenStream, macro_braces: &FxHashMap<String, (char, char)>) {
+            for (i, current_token) in ts.iter().enumerate() {
+                if let TokenTree::Delimited(_, _, _, token_stream) = current_token {
+                    // Peel extra braces and parenthesis in macros!
+                    check_ts(cx, token_stream, macro_braces);
+                } else
+                //        |-TokenKind::Bang
+                //        v
+                // println! { "Hi" }
+                // ^^^^^^^
+                //    |     ^^^^^^^^ Brackets always come 1 token after TokenKind::Bang
+                // ident_token
+                if let TokenTree::Token(
+                    Token {
+                        kind: TokenKind::Ident(ident_token, _),
+                        span: ident_span,
+                    },
+                    _,
+                ) = current_token
+                    && let Some(bang_token) = ts.get(i + 1)
+                    && let Some(macro_args_token) = ts.get(i + 2)
+                    && let TokenTree::Token(
+                        Token {
+                            kind: TokenKind::Bang, ..
+                        },
+                        _,
+                    ) = *bang_token
+                    && let TokenTree::Delimited(delim_span, _, delim, _) = macro_args_token
+                    // Span from ident_token to brackets (so, the full macro call)
+                    && let snip_span = ident_span.with_hi(delim_span.close.hi())
+                    && let Some(snip) = snippet_opt(cx, snip_span)
+                    && let Some(&braces) = macro_braces.get(ident_token.as_str())
+                    && let Some(old_open_brace) = match delim {
+                        Delimiter::Brace => Some('{'),
+                        Delimiter::Parenthesis => Some('('),
+                        Delimiter::Bracket => Some('['),
+                        Delimiter::Invisible(_) => None,
+                    }
+                    && old_open_brace != braces.0
+                {
+                    emit_help(cx, &snip, braces, snip_span, false);
+                }
+            }
+        }
+
+        if mac.macro_rules {
+            check_ts(cx, &mac.body.tokens, &self.macro_braces.0);
+        }
+    }
 }
 
 fn emit_help(cx: &EarlyContext<'_>, snip: &str, (open, close): (char, char), span: Span, add_semi: bool) {
@@ -171,17 +157,21 @@ fn emit_help(cx: &EarlyContext<'_>, snip: &str, (open, close): (char, char), spa
     }
 }
 
-fn macro_braces(conf: &[MacroMatcher]) -> FxHashMap<String, (char, char)> {
+fn macro_braces(conf: &[MacroMatcher]) -> (FxHashMap<String, (char, char)>, usize) {
+    // TODO: Use `Symbol`s here, instead of strings.
     let mut braces = FxHashMap::from_iter(
         [
-            ("print", ('(', ')')),
-            ("println", ('(', ')')),
-            ("eprint", ('(', ')')),
-            ("eprintln", ('(', ')')),
-            ("write", ('(', ')')),
-            ("writeln", ('(', ')')),
+            ("assert_matches", ('(', ')')),
+            ("cfg_select", ('{', '}')),
+            ("debug_assert_matches", ('(', ')')),
             ("format", ('(', ')')),
             ("format_args", ('(', ')')),
+            ("eprint", ('(', ')')),
+            ("eprintln", ('(', ')')),
+            ("print", ('(', ')')),
+            ("println", ('(', ')')),
+            ("write", ('(', ')')),
+            ("writeln", ('(', ')')),
             ("vec", ('[', ']')),
             ("matches", ('(', ')')),
         ]
@@ -191,5 +181,17 @@ fn macro_braces(conf: &[MacroMatcher]) -> FxHashMap<String, (char, char)> {
     for it in conf {
         braces.insert(it.name.clone(), it.braces);
     }
-    braces
+
+    #[expect(
+        rustc::potential_query_instability,
+        reason = "iteration order does not matter for `.max()`"
+    )]
+    #[expect(clippy::redundant_closure_for_method_calls, reason = "Clarity")]
+    let max_len = braces
+        .keys()
+        .map(|macro_name| macro_name.len())
+        .max()
+        .expect("`braces` is non-empty");
+
+    (braces, max_len)
 }

--- a/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.fixed
+++ b/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.fixed
@@ -15,10 +15,11 @@ proc_macro_derive::foo_bar!();
 
 #[rustfmt::skip]
 macro_rules! test {
-    () => {
+    () => {{
+        //~v nonstandard_macro_braces
         vec![0, 0, 0]
         //~^ nonstandard_macro_braces
-    };
+    }};
 }
 
 #[rustfmt::skip]

--- a/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs
+++ b/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs
@@ -15,10 +15,11 @@ proc_macro_derive::foo_bar!();
 
 #[rustfmt::skip]
 macro_rules! test {
-    () => {
+    () => {{
+        //~v nonstandard_macro_braces
         vec!{0, 0, 0}
         //~^ nonstandard_macro_braces
-    };
+    }};
 }
 
 #[rustfmt::skip]

--- a/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.stderr
+++ b/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.stderr
@@ -1,88 +1,91 @@
 error: use of irregular braces for `vec!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:45:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:20:9
    |
-LL |     let _ = vec! {1, 2, 3};
-   |             ^^^^^^^^^^^^^^ help: consider writing: `vec![1, 2, 3]`
+LL |         vec!{0, 0, 0}
+   |         ^^^^^^^^^^^^^ help: consider writing: `vec![0, 0, 0]`
    |
    = note: `-D clippy::nonstandard-macro-braces` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::nonstandard_macro_braces)]`
 
+error: use of irregular braces for `vec!` macro
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:46:13
+   |
+LL |     let _ = vec! {1, 2, 3};
+   |             ^^^^^^^^^^^^^^ help: consider writing: `vec![1, 2, 3]`
+
 error: use of irregular braces for `format!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:47:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:48:13
    |
 LL |     let _ = format!["ugh {} stop being such a good compiler", "hello"];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `format!("ugh {} stop being such a good compiler", "hello")`
 
 error: use of irregular braces for `matches!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:49:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:50:13
    |
 LL |     let _ = matches!{{}, ()};
    |             ^^^^^^^^^^^^^^^^ help: consider writing: `matches!({}, ())`
 
 error: use of irregular braces for `quote!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:51:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:52:13
    |
 LL |     let _ = quote!(let x = 1;);
    |             ^^^^^^^^^^^^^^^^^^ help: consider writing: `quote!{let x = 1;}`
 
 error: use of irregular braces for `quote::quote!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:53:13
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:54:13
    |
 LL |     let _ = quote::quote!(match match match);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `quote::quote!{match match match}`
 
-error: use of irregular braces for `vec!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:19:9
-   |
-LL |         vec!{0, 0, 0}
-   |         ^^^^^^^^^^^^^ help: consider writing: `vec![0, 0, 0]`
-...
-LL |     let _ = test!(); // trigger when macro def is inside our own crate
-   |             ------- in this macro invocation
-   |
-   = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: use of irregular braces for `type_pos!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:63:12
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:64:12
    |
 LL |     let _: type_pos!(usize) = vec![];
    |            ^^^^^^^^^^^^^^^^ help: consider writing: `type_pos![usize]`
 
 error: use of irregular braces for `eprint!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:66:5
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:67:5
    |
 LL |     eprint!("test if user config overrides defaults");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `eprint!["test if user config overrides defaults"]`
 
 error: use of irregular braces for `println!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:75:5
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:76:5
    |
 LL |     println! {"hello world"}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `println!("hello world");`
 
 error: use of irregular braces for `println!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:83:5
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:84:5
    |
 LL |     println![];
    |     ^^^^^^^^^^ help: consider writing: `println!()`
 
 error: use of irregular braces for `println!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:85:5
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:86:5
    |
 LL |     println![""];
    |     ^^^^^^^^^^^^ help: consider writing: `println!("")`
 
 error: use of irregular braces for `println!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:87:5
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:88:5
    |
 LL |     println! {};
    |     ^^^^^^^^^^^ help: consider writing: `println!()`
 
 error: use of irregular braces for `println!` macro
-  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:89:5
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:90:5
    |
 LL |     println! {""};
    |     ^^^^^^^^^^^^^ help: consider writing: `println!("")`
 
-error: aborting due to 13 previous errors
+error: use of irregular braces for `vec!` macro
+  --> tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs:20:9
+   |
+LL |         vec!{0, 0, 0}
+   |         ^^^^^^^^^^^^^ help: consider writing: `vec![0, 0, 0]`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/println_empty_string.fixed
+++ b/tests/ui/println_empty_string.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::println_empty_string)]
-#![expect(clippy::match_single_binding)]
+#![expect(clippy::match_single_binding, clippy::nonstandard_macro_braces)]
 
 fn main() {
     println!();

--- a/tests/ui/println_empty_string.rs
+++ b/tests/ui/println_empty_string.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::println_empty_string)]
-#![expect(clippy::match_single_binding)]
+#![expect(clippy::match_single_binding, clippy::nonstandard_macro_braces)]
 
 fn main() {
     println!();

--- a/tests/ui/unnecessary_trailing_comma.fixed
+++ b/tests/ui/unnecessary_trailing_comma.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::unnecessary_trailing_comma)]
+#![allow(clippy::nonstandard_macro_braces)]
 
 fn main() {}
 

--- a/tests/ui/unnecessary_trailing_comma.rs
+++ b/tests/ui/unnecessary_trailing_comma.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::unnecessary_trailing_comma)]
+#![allow(clippy::nonstandard_macro_braces)]
 
 fn main() {}
 

--- a/tests/ui/unnecessary_trailing_comma.stderr
+++ b/tests/ui/unnecessary_trailing_comma.stderr
@@ -1,5 +1,5 @@
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:10:19
+  --> tests/ui/unnecessary_trailing_comma.rs:11:19
    |
 LL |     println!("Foo" , );
    |                   ^^^ help: remove the trailing comma
@@ -8,115 +8,115 @@ LL |     println!("Foo" , );
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_trailing_comma)]`
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:11:19
+  --> tests/ui/unnecessary_trailing_comma.rs:12:19
    |
 LL |     println!{"Foo" , };
    |                   ^^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:12:19
+  --> tests/ui/unnecessary_trailing_comma.rs:13:19
    |
 LL |     println!["Foo" , ];
    |                   ^^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:13:27
+  --> tests/ui/unnecessary_trailing_comma.rs:14:27
    |
 LL |     println!("Foo={}",   1  ,  );
    |                           ^^^^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:14:36
+  --> tests/ui/unnecessary_trailing_comma.rs:15:36
    |
 LL |     println!(concat!("b", "o", "o")  , );
    |                                    ^^^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:15:22
+  --> tests/ui/unnecessary_trailing_comma.rs:16:22
    |
 LL |     println!("Foo(,)",);
    |                      ^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:16:22
+  --> tests/ui/unnecessary_trailing_comma.rs:17:22
    |
 LL |     println!("Foo[,]" , );
    |                      ^^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:17:22
+  --> tests/ui/unnecessary_trailing_comma.rs:18:22
    |
 LL |     println!["Foo(,)", ];
    |                      ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:18:22
+  --> tests/ui/unnecessary_trailing_comma.rs:19:22
    |
 LL |     println!["Foo[,]", ];
    |                      ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:19:24
+  --> tests/ui/unnecessary_trailing_comma.rs:20:24
    |
 LL |     println!["Foo{{,}}", ];
    |                        ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:20:24
+  --> tests/ui/unnecessary_trailing_comma.rs:21:24
    |
 LL |     println!{"Foo{{,}}", };
    |                        ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:21:22
+  --> tests/ui/unnecessary_trailing_comma.rs:22:22
    |
 LL |     println!{"Foo(,)", };
    |                      ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:22:22
+  --> tests/ui/unnecessary_trailing_comma.rs:23:22
    |
 LL |     println!{"Foo[,]", };
    |                      ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:23:21
+  --> tests/ui/unnecessary_trailing_comma.rs:24:21
    |
 LL |     println!["Foo(,", ];
    |                     ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:24:21
+  --> tests/ui/unnecessary_trailing_comma.rs:25:21
    |
 LL |     println!["Foo[,", ];
    |                     ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:25:24
+  --> tests/ui/unnecessary_trailing_comma.rs:26:24
    |
 LL |     println!["Foo{{,}}", ];
    |                        ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:26:24
+  --> tests/ui/unnecessary_trailing_comma.rs:27:24
    |
 LL |     println!{"Foo{{,}}", };
    |                        ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:27:21
+  --> tests/ui/unnecessary_trailing_comma.rs:28:21
    |
 LL |     println!{"Foo(,", };
    |                     ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:28:21
+  --> tests/ui/unnecessary_trailing_comma.rs:29:21
    |
 LL |     println!{"Foo[,", };
    |                     ^^ help: remove the trailing comma
 
 error: unnecessary trailing comma
-  --> tests/ui/unnecessary_trailing_comma.rs:29:42
+  --> tests/ui/unnecessary_trailing_comma.rs:30:42
    |
 LL |     println!(concat!("Foo", "=", "{}"), 1,);
    |                                          ^ help: remove the trailing comma


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16808)*

I know that we shouldn't move lints to pre-expansion, but `nonstandard_macro_braces` was taking up almost a 25% of the Clippy-exclusive runtime in `wasmi-0.35.0`, and moving it to pre-expansion lets us not bother as much with expansion data.

---

Previously, we had to get expansion data via `outer_expn_data`, which does atomic operations, `SessionGlobals` operations (so, locking threads), and was generally a very bumpy way of doing things. For example in `wasmi` we were calling `scoped_tls::ScopedKey<rustc_span::SessionGlobals>::with<<rustc_span::hygiene::HygieneData>::with<rustc_span::hygiene::ExpnData, <rustc_span::hygiene::SyntaxContext>::outer_expn_data::{closure#0}>::{closure#0}, rustc_span::hygiene::ExpnData>` 5,879,804 times. Thus locking the thread 11,759,608 times.

---

So personally I think that moving this lint to pre-expansion is worth.

changelog:[`nonstandard_macro_braces`]: Optimize by 99.97%
