### PR TITLE
New lint: `disallowed_trait_usage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6864,6 +6864,7 @@ Released 2018-09-13
 [`disallowed_methods`]: https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_methods
 [`disallowed_names`]: https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_names
 [`disallowed_script_idents`]: https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_script_idents
+[`disallowed_trait_usage`]: https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_trait_usage
 [`disallowed_type`]: https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_type
 [`disallowed_types`]: https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_types
 [`diverging_sub_expression`]: https://rust-lang.github.io/rust-clippy/main/index.html#diverging_sub_expression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7705,6 +7705,7 @@ Released 2018-09-13
 [`disallowed-macros`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-macros
 [`disallowed-methods`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-methods
 [`disallowed-names`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-names
+[`disallowed-trait-usage`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-trait-usage
 [`disallowed-types`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-types
 [`doc-valid-idents`]: https://doc.rust-lang.org/clippy/lint_configuration.html#doc-valid-idents
 [`enable-raw-pointer-heuristic-for-send`]: https://doc.rust-lang.org/clippy/lint_configuration.html#enable-raw-pointer-heuristic-for-send

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6864,6 +6864,7 @@ Released 2018-09-13
 [`disallowed_methods`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods
 [`disallowed_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_names
 [`disallowed_script_idents`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_script_idents
+[`disallowed_trait_usage`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_trait_usage
 [`disallowed_type`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_type
 [`disallowed_types`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_types
 [`diverging_sub_expression`]: https://rust-lang.github.io/rust-clippy/master/index.html#diverging_sub_expression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7706,6 +7706,7 @@ Released 2018-09-13
 [`disallowed-macros`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-macros
 [`disallowed-methods`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-methods
 [`disallowed-names`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-names
+[`disallowed-trait-usage`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-trait-usage
 [`disallowed-types`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-types
 [`doc-valid-idents`]: https://doc.rust-lang.org/clippy/lint_configuration.html#doc-valid-idents
 [`enable-raw-pointer-heuristic-for-send`]: https://doc.rust-lang.org/clippy/lint_configuration.html#enable-raw-pointer-heuristic-for-send

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -616,6 +616,29 @@ default configuration of Clippy. By default, any configuration will replace the 
 * [`disallowed_names`](https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_names)
 
 
+## `disallowed-trait-usage`
+The list of disallowed trait usages. Each entry forbids using a specific type via a specific
+trait interface.
+
+**Fields:**
+- `type` (required): the fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`)
+- `trait` (required): the fully qualified path to the trait (e.g. `"std::fmt::Debug"`)
+- `reason` (optional): explanation why this trait usage is disallowed
+
+### Example
+```toml
+disallowed-trait-usage = [
+    { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+]
+```
+
+**Default Value:** `[]`
+
+---
+**Affected lints:**
+* [`disallowed_trait_usage`](https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_trait_usage)
+
+
 ## `disallowed-types`
 The list of disallowed types, written as fully qualified paths.
 

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -624,18 +624,20 @@ be used on.
 - `trait` (required): the fully qualified path to the disallowed trait (e.g. `"std::fmt::Debug"`)
 - `types` (optional): concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`)
 - `implements` (optional): traits whose implementors the trait is disallowed for
-- `all-types` (optional): disallows the trait for every type, with the given string as the reason
+- `reason` (optional): explanation why this trait usage is disallowed
 
 The entries of `types` and `implements` are either a plain path or a table with the same
-fields as [`disallowed-types`](#disallowed-types), minus `replacement`.
+fields as [`disallowed-types`](#disallowed-types), minus `replacement`. They can carry a
+`reason` of their own, in addition to the one of the entry.
 
-At least one of `types`, `implements` or `all-types` must be specified. `all-types` covers
-everything the other two can, so combining it with them warns.
+An entry with neither `types` nor `implements` disallows the trait for every type, and can
+be written as a plain path.
 
 ### Example
 ```toml
 [[disallowed-trait-usage]]
 trait = "std::fmt::Debug"
+reason = "Debug output is not meant for end users"
 # Forbid `Debug` formatting of specific types:
 types = [
     { path = "std::path::PathBuf", reason = "Use path.display() instead" },
@@ -646,10 +648,13 @@ implements = [
     { path = "std::error::Error", reason = "Use Display for errors" },
 ]
 
-# Forbid a trait outright:
+# Forbid a trait for every type:
 [[disallowed-trait-usage]]
 trait = "std::fmt::Pointer"
-all-types = "Do not print addresses"
+reason = "Do not print addresses"
+
+# …or, without a reason:
+disallowed-trait-usage = ["std::fmt::Pointer"]
 ```
 
 **Default Value:** `[]`

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -617,23 +617,39 @@ default configuration of Clippy. By default, any configuration will replace the 
 
 
 ## `disallowed-trait-usage`
-The list of disallowed trait usages. Each entry forbids using a type via a specific
-trait interface.
+The list of disallowed trait usages. Each entry names one trait and the types it may not
+be used on.
 
 **Fields:**
-- `type` (optional): the fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`)
-- `implements` (optional): the fully qualified path to a trait; matches any type implementing it
 - `trait` (required): the fully qualified path to the disallowed trait (e.g. `"std::fmt::Debug"`)
-- `reason` (optional): explanation why this trait usage is disallowed
+- `types` (optional): concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`)
+- `implements` (optional): traits whose implementors the trait is disallowed for
+- `all-types` (optional): disallows the trait for every type, with the given string as the reason
 
-Exactly one of `type` or `implements` must be specified.
+The entries of `types` and `implements` are either a plain path or a table with the same
+fields as [`disallowed-types`](#disallowed-types), minus `replacement`.
+
+At least one of `types`, `implements` or `all-types` must be specified. `all-types` covers
+everything the other two can, so combining it with them warns.
 
 ### Example
 ```toml
-disallowed-trait-usage = [
-    { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
-    { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display instead" },
+[[disallowed-trait-usage]]
+trait = "std::fmt::Debug"
+# Forbid `Debug` formatting of specific types:
+types = [
+    { path = "std::path::PathBuf", reason = "Use path.display() instead" },
+    "std::path::Path",
 ]
+# Forbid `Debug` formatting of every type implementing these traits:
+implements = [
+    { path = "std::error::Error", reason = "Use Display for errors" },
+]
+
+# Forbid a trait outright:
+[[disallowed-trait-usage]]
+trait = "std::fmt::Pointer"
+all-types = "Do not print addresses"
 ```
 
 **Default Value:** `[]`

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -616,6 +616,29 @@ default configuration of Clippy. By default, any configuration will replace the 
 * [`disallowed_names`](https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_names)
 
 
+## `disallowed-trait-usage`
+The list of disallowed trait usages. Each entry forbids using a specific type via a specific
+trait interface.
+
+**Fields:**
+- `type` (required): the fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`)
+- `trait` (required): the fully qualified path to the trait (e.g. `"std::fmt::Debug"`)
+- `reason` (optional): explanation why this trait usage is disallowed
+
+### Example
+```toml
+disallowed-trait-usage = [
+    { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+]
+```
+
+**Default Value:** `[]`
+
+---
+**Affected lints:**
+* [`disallowed_trait_usage`](https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_trait_usage)
+
+
 ## `disallowed-types`
 The list of disallowed types, written as fully qualified paths.
 

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -617,18 +617,22 @@ default configuration of Clippy. By default, any configuration will replace the 
 
 
 ## `disallowed-trait-usage`
-The list of disallowed trait usages. Each entry forbids using a specific type via a specific
+The list of disallowed trait usages. Each entry forbids using a type via a specific
 trait interface.
 
 **Fields:**
-- `type` (required): the fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`)
-- `trait` (required): the fully qualified path to the trait (e.g. `"std::fmt::Debug"`)
+- `type` (optional): the fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`)
+- `implements` (optional): the fully qualified path to a trait; matches any type implementing it
+- `trait` (required): the fully qualified path to the disallowed trait (e.g. `"std::fmt::Debug"`)
 - `reason` (optional): explanation why this trait usage is disallowed
+
+Exactly one of `type` or `implements` must be specified.
 
 ### Example
 ```toml
 disallowed-trait-usage = [
     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display instead" },
 ]
 ```
 

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -656,7 +656,7 @@ all-types = "Do not print addresses"
 
 ---
 **Affected lints:**
-* [`disallowed_trait_usage`](https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_trait_usage)
+* [`disallowed_trait_usage`](https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_trait_usage)
 
 
 ## `disallowed-types`

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -653,18 +653,22 @@ define_Conf! {
     /// default configuration of Clippy. By default, any configuration will replace the default value.
     #[lints(disallowed_names)]
     disallowed_names: Vec<String> = DEFAULT_DISALLOWED_NAMES.iter().map(ToString::to_string).collect(),
-    /// The list of disallowed trait usages. Each entry forbids using a specific type via a specific
+    /// The list of disallowed trait usages. Each entry forbids using a type via a specific
     /// trait interface.
     ///
     /// **Fields:**
-    /// - `type` (required): the fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`)
-    /// - `trait` (required): the fully qualified path to the trait (e.g. `"std::fmt::Debug"`)
+    /// - `type` (optional): the fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`)
+    /// - `implements` (optional): the fully qualified path to a trait; matches any type implementing it
+    /// - `trait` (required): the fully qualified path to the disallowed trait (e.g. `"std::fmt::Debug"`)
     /// - `reason` (optional): explanation why this trait usage is disallowed
+    ///
+    /// Exactly one of `type` or `implements` must be specified.
     ///
     /// ### Example
     /// ```toml
     /// disallowed-trait-usage = [
     ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    ///     { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display instead" },
     /// ]
     /// ```
     #[lints(disallowed_trait_usage)]

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -517,23 +517,39 @@ define_Conf! {
     /// default configuration of Clippy. By default, any configuration will replace the default value.
     #[lints(disallowed_names)]
     disallowed_names("disallowed-names"): Vec<String> = DEFAULT_DISALLOWED_NAMES,
-    /// The list of disallowed trait usages. Each entry forbids using a type via a specific
-    /// trait interface.
+    /// The list of disallowed trait usages. Each entry names one trait and the types it may not
+    /// be used on.
     ///
     /// **Fields:**
-    /// - `type` (optional): the fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`)
-    /// - `implements` (optional): the fully qualified path to a trait; matches any type implementing it
     /// - `trait` (required): the fully qualified path to the disallowed trait (e.g. `"std::fmt::Debug"`)
-    /// - `reason` (optional): explanation why this trait usage is disallowed
+    /// - `types` (optional): concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`)
+    /// - `implements` (optional): traits whose implementors the trait is disallowed for
+    /// - `all-types` (optional): disallows the trait for every type, with the given string as the reason
     ///
-    /// Exactly one of `type` or `implements` must be specified.
+    /// The entries of `types` and `implements` are either a plain path or a table with the same
+    /// fields as [`disallowed-types`](#disallowed-types), minus `replacement`.
+    ///
+    /// At least one of `types`, `implements` or `all-types` must be specified. `all-types` covers
+    /// everything the other two can, so combining it with them warns.
     ///
     /// ### Example
     /// ```toml
-    /// disallowed-trait-usage = [
-    ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
-    ///     { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display instead" },
+    /// [[disallowed-trait-usage]]
+    /// trait = "std::fmt::Debug"
+    /// # Forbid `Debug` formatting of specific types:
+    /// types = [
+    ///     { path = "std::path::PathBuf", reason = "Use path.display() instead" },
+    ///     "std::path::Path",
     /// ]
+    /// # Forbid `Debug` formatting of every type implementing these traits:
+    /// implements = [
+    ///     { path = "std::error::Error", reason = "Use Display for errors" },
+    /// ]
+    ///
+    /// # Forbid a trait outright:
+    /// [[disallowed-trait-usage]]
+    /// trait = "std::fmt::Pointer"
+    /// all-types = "Do not print addresses"
     /// ```
     #[lints(disallowed_trait_usage)]
     disallowed_trait_usage("disallowed-trait-usage"): Vec<crate::types::DisallowedTraitUsage>,

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -517,6 +517,22 @@ define_Conf! {
     /// default configuration of Clippy. By default, any configuration will replace the default value.
     #[lints(disallowed_names)]
     disallowed_names("disallowed-names"): Vec<String> = DEFAULT_DISALLOWED_NAMES,
+    /// The list of disallowed trait usages. Each entry forbids using a specific type via a specific
+    /// trait interface.
+    ///
+    /// **Fields:**
+    /// - `type` (required): the fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`)
+    /// - `trait` (required): the fully qualified path to the trait (e.g. `"std::fmt::Debug"`)
+    /// - `reason` (optional): explanation why this trait usage is disallowed
+    ///
+    /// ### Example
+    /// ```toml
+    /// disallowed-trait-usage = [
+    ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    /// ]
+    /// ```
+    #[lints(disallowed_trait_usage)]
+    disallowed_trait_usage("disallowed-trait-usage"): Vec<crate::types::DisallowedTraitUsage>,
     /// The list of disallowed types, written as fully qualified paths.
     ///
     /// **Fields:**

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -653,6 +653,22 @@ define_Conf! {
     /// default configuration of Clippy. By default, any configuration will replace the default value.
     #[lints(disallowed_names)]
     disallowed_names: Vec<String> = DEFAULT_DISALLOWED_NAMES.iter().map(ToString::to_string).collect(),
+    /// The list of disallowed trait usages. Each entry forbids using a specific type via a specific
+    /// trait interface.
+    ///
+    /// **Fields:**
+    /// - `type` (required): the fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`)
+    /// - `trait` (required): the fully qualified path to the trait (e.g. `"std::fmt::Debug"`)
+    /// - `reason` (optional): explanation why this trait usage is disallowed
+    ///
+    /// ### Example
+    /// ```toml
+    /// disallowed-trait-usage = [
+    ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    /// ]
+    /// ```
+    #[lints(disallowed_trait_usage)]
+    disallowed_trait_usage: Vec<crate::types::DisallowedTraitUsage> = Vec::new(),
     /// The list of disallowed types, written as fully qualified paths.
     ///
     /// **Fields:**

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -524,18 +524,20 @@ define_Conf! {
     /// - `trait` (required): the fully qualified path to the disallowed trait (e.g. `"std::fmt::Debug"`)
     /// - `types` (optional): concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`)
     /// - `implements` (optional): traits whose implementors the trait is disallowed for
-    /// - `all-types` (optional): disallows the trait for every type, with the given string as the reason
+    /// - `reason` (optional): explanation why this trait usage is disallowed
     ///
     /// The entries of `types` and `implements` are either a plain path or a table with the same
-    /// fields as [`disallowed-types`](#disallowed-types), minus `replacement`.
+    /// fields as [`disallowed-types`](#disallowed-types), minus `replacement`. They can carry a
+    /// `reason` of their own, in addition to the one of the entry.
     ///
-    /// At least one of `types`, `implements` or `all-types` must be specified. `all-types` covers
-    /// everything the other two can, so combining it with them warns.
+    /// An entry with neither `types` nor `implements` disallows the trait for every type, and can
+    /// be written as a plain path.
     ///
     /// ### Example
     /// ```toml
     /// [[disallowed-trait-usage]]
     /// trait = "std::fmt::Debug"
+    /// reason = "Debug output is not meant for end users"
     /// # Forbid `Debug` formatting of specific types:
     /// types = [
     ///     { path = "std::path::PathBuf", reason = "Use path.display() instead" },
@@ -546,10 +548,13 @@ define_Conf! {
     ///     { path = "std::error::Error", reason = "Use Display for errors" },
     /// ]
     ///
-    /// # Forbid a trait outright:
+    /// # Forbid a trait for every type:
     /// [[disallowed-trait-usage]]
     /// trait = "std::fmt::Pointer"
-    /// all-types = "Do not print addresses"
+    /// reason = "Do not print addresses"
+    ///
+    /// # …or, without a reason:
+    /// disallowed-trait-usage = ["std::fmt::Pointer"]
     /// ```
     #[lints(disallowed_trait_usage)]
     disallowed_trait_usage("disallowed-trait-usage"): Vec<crate::types::DisallowedTraitUsage>,

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -220,6 +220,36 @@ macro_rules! deserialize {
         }
         (disallowed_paths, disallowed_paths_span)
     }};
+
+    // Like the arm above, but for a list of `$entry_ty` entries that each contain `DisallowedPath`s
+    // of their own. Those nested paths get the span of the entry they belong to.
+    ($map:expr, $ty:ty, $errors:expr, $file:expr, @nested $entry_ty:ty) => {{
+        let array = $map.next_value::<Vec<toml::Spanned<toml::Value>>>()?;
+        let mut entries_span = Range {
+            start: usize::MAX,
+            end: usize::MIN,
+        };
+        let mut entries = Vec::new();
+        for raw_value in array {
+            let value_span = raw_value.span();
+            let mut entry = match <$entry_ty>::deserialize(raw_value.into_inner()) {
+                Err(e) => {
+                    $errors.push(ConfError::spanned(
+                        $file,
+                        e.to_string().replace('\n', " ").trim(),
+                        None,
+                        value_span,
+                    ));
+                    continue;
+                },
+                Ok(entry) => entry,
+            };
+            entries_span = union(&entries_span, &value_span);
+            entry.set_span(span_from_toml_range($file, value_span));
+            entries.push(entry);
+        }
+        (entries, entries_span)
+    }};
 }
 
 macro_rules! define_Conf {
@@ -228,6 +258,7 @@ macro_rules! define_Conf {
         $(#[conf_deprecated($dep:literal, $new_conf:ident)])?
         $(#[default_text = $default_text:expr])?
         $(#[disallowed_paths_allow_replacements = $replacements_allowed:expr])?
+        $(#[nested_disallowed_paths = $entry_ty:ty])?
         $(#[lints($($for_lints:ident),* $(,)?)])?
         $name:ident: $ty:ty = $default:expr,
     )*) => {
@@ -285,7 +316,11 @@ macro_rules! define_Conf {
                             // Is this a deprecated field, i.e., is `$dep` set? If so, push a warning.
                             $(warnings.push(ConfError::spanned(self.0, format!("deprecated field `{}`. {}", name.get_ref(), $dep), None, name.span()));)?
                             let (value, value_span) =
-                                deserialize!(map, $ty, errors, self.0 $(, $replacements_allowed)?);
+                                deserialize!(
+                                    map, $ty, errors, self.0
+                                    $(, $replacements_allowed)?
+                                    $(, @nested $entry_ty)?
+                                );
                             // Was this field set previously?
                             if $name.is_some() {
                                 errors.push(ConfError::spanned(self.0, format!("duplicate field `{}`", name.get_ref()), None, name.span()));
@@ -653,24 +688,41 @@ define_Conf! {
     /// default configuration of Clippy. By default, any configuration will replace the default value.
     #[lints(disallowed_names)]
     disallowed_names: Vec<String> = DEFAULT_DISALLOWED_NAMES.iter().map(ToString::to_string).collect(),
-    /// The list of disallowed trait usages. Each entry forbids using a type via a specific
-    /// trait interface.
+    /// The list of disallowed trait usages. Each entry names one trait and the types it may not
+    /// be used on.
     ///
     /// **Fields:**
-    /// - `type` (optional): the fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`)
-    /// - `implements` (optional): the fully qualified path to a trait; matches any type implementing it
     /// - `trait` (required): the fully qualified path to the disallowed trait (e.g. `"std::fmt::Debug"`)
-    /// - `reason` (optional): explanation why this trait usage is disallowed
+    /// - `types` (optional): concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`)
+    /// - `implements` (optional): traits whose implementors the trait is disallowed for
+    /// - `all-types` (optional): disallows the trait for every type, with the given string as the reason
     ///
-    /// Exactly one of `type` or `implements` must be specified.
+    /// The entries of `types` and `implements` are either a plain path or a table with the same
+    /// fields as [`disallowed-types`](#disallowed-types), minus `replacement`.
+    ///
+    /// At least one of `types`, `implements` or `all-types` must be specified. `all-types` covers
+    /// everything the other two can, so combining it with them warns.
     ///
     /// ### Example
     /// ```toml
-    /// disallowed-trait-usage = [
-    ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
-    ///     { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display instead" },
+    /// [[disallowed-trait-usage]]
+    /// trait = "std::fmt::Debug"
+    /// # Forbid `Debug` formatting of specific types:
+    /// types = [
+    ///     { path = "std::path::PathBuf", reason = "Use path.display() instead" },
+    ///     "std::path::Path",
     /// ]
+    /// # Forbid `Debug` formatting of every type implementing these traits:
+    /// implements = [
+    ///     { path = "std::error::Error", reason = "Use Display for errors" },
+    /// ]
+    ///
+    /// # Forbid a trait outright:
+    /// [[disallowed-trait-usage]]
+    /// trait = "std::fmt::Pointer"
+    /// all-types = "Do not print addresses"
     /// ```
+    #[nested_disallowed_paths = crate::types::DisallowedTraitUsage]
     #[lints(disallowed_trait_usage)]
     disallowed_trait_usage: Vec<crate::types::DisallowedTraitUsage> = Vec::new(),
     /// The list of disallowed types, written as fully qualified paths.

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -517,18 +517,22 @@ define_Conf! {
     /// default configuration of Clippy. By default, any configuration will replace the default value.
     #[lints(disallowed_names)]
     disallowed_names("disallowed-names"): Vec<String> = DEFAULT_DISALLOWED_NAMES,
-    /// The list of disallowed trait usages. Each entry forbids using a specific type via a specific
+    /// The list of disallowed trait usages. Each entry forbids using a type via a specific
     /// trait interface.
     ///
     /// **Fields:**
-    /// - `type` (required): the fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`)
-    /// - `trait` (required): the fully qualified path to the trait (e.g. `"std::fmt::Debug"`)
+    /// - `type` (optional): the fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`)
+    /// - `implements` (optional): the fully qualified path to a trait; matches any type implementing it
+    /// - `trait` (required): the fully qualified path to the disallowed trait (e.g. `"std::fmt::Debug"`)
     /// - `reason` (optional): explanation why this trait usage is disallowed
+    ///
+    /// Exactly one of `type` or `implements` must be specified.
     ///
     /// ### Example
     /// ```toml
     /// disallowed-trait-usage = [
     ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    ///     { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display instead" },
     /// ]
     /// ```
     #[lints(disallowed_trait_usage)]

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -671,6 +671,22 @@ impl Serialize for SourceItemOrderingWithinModuleItemGroupings {
     }
 }
 
+/// An entry in the `disallowed-trait-usage` configuration.
+///
+/// Forbids using a specific type via a specific trait interface.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DisallowedTraitUsage {
+    /// The fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`).
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// The fully qualified path to the trait (e.g. `"std::fmt::Debug"`).
+    #[serde(rename = "trait")]
+    pub trait_path: String,
+    /// Optional reason explaining why this usage is disallowed.
+    pub reason: Option<String>,
+}
+
 // these impls are never actually called but are used by the various config options that default to
 // empty lists
 macro_rules! unimplemented_serialize {
@@ -689,6 +705,7 @@ macro_rules! unimplemented_serialize {
 }
 
 unimplemented_serialize! {
+    DisallowedTraitUsage,
     Rename,
     MacroMatcher,
 }

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -673,14 +673,20 @@ impl Serialize for SourceItemOrderingWithinModuleItemGroupings {
 
 /// An entry in the `disallowed-trait-usage` configuration.
 ///
-/// Forbids using a specific type via a specific trait interface.
+/// Forbids using a type via a specific trait interface. The type can be specified
+/// either as a concrete type (`type`) or as a trait bound (`implements`), but not both.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DisallowedTraitUsage {
-    /// The fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`).
+    /// The fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`).
+    /// Mutually exclusive with `implements`.
     #[serde(rename = "type")]
-    pub type_path: String,
-    /// The fully qualified path to the trait (e.g. `"std::fmt::Debug"`).
+    pub type_path: Option<String>,
+    /// The fully qualified path to a trait (e.g. `"std::error::Error"`).
+    /// When set, the rule applies to any type that implements this trait.
+    /// Mutually exclusive with `type`.
+    pub implements: Option<String>,
+    /// The fully qualified path to the trait being disallowed (e.g. `"std::fmt::Debug"`).
     #[serde(rename = "trait")]
     pub trait_path: String,
     /// Optional reason explaining why this usage is disallowed.

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -96,8 +96,8 @@ macro_rules! conf_enum {
 }
 /// An entry in the `disallowed-trait-usage` configuration.
 ///
-/// Forbids using the trait named by `trait` on the types selected by `types`, `implements`
-/// and `all-types`.
+/// Forbids using the trait named by `trait` on the types selected by `types` and `implements`,
+/// or on every type when neither is given.
 pub struct DisallowedTraitUsage {
     /// The fully qualified path to the trait being disallowed (e.g. `"std::fmt::Debug"`).
     pub trait_path: String,
@@ -108,10 +108,10 @@ pub struct DisallowedTraitUsage {
     /// Traits whose implementors the trait is disallowed for (e.g. `"std::error::Error"`).
     pub implements: Vec<DisallowedPathWithoutReplacement>,
 
-    /// Disallows the trait for every type, with the given reason.
+    /// Why this trait usage is disallowed.
     ///
-    /// Mutually exclusive with `types` and `implements`.
-    pub all_types: Option<String>,
+    /// Applies to the whole entry; the entries of `types` and `implements` can give their own.
+    pub reason: Option<String>,
 
     /// The span of this entry.
     ///
@@ -121,12 +121,20 @@ pub struct DisallowedTraitUsage {
 
 impl Deserialize for DisallowedTraitUsage {
     fn deserialize(dcx: &DiagCtxt<'_>, value: &TomlValue<'_>) -> Option<Self> {
-        if let Some(table) = value.as_ref().as_table() {
+        if let Some(s) = value.as_ref().as_str() {
+            Some(DisallowedTraitUsage {
+                trait_path: s.into(),
+                types: Vec::new(),
+                implements: Vec::new(),
+                reason: None,
+                span: dcx.make_sp(value.span()),
+            })
+        } else if let Some(table) = value.as_ref().as_table() {
             deserialize_table!(dcx, table,
                 trait_path("trait"): String,
                 types("types"): Vec<DisallowedPathWithoutReplacement>,
                 implements("implements"): Vec<DisallowedPathWithoutReplacement>,
-                all_types("all-types"): String,
+                reason("reason"): String,
             );
             let Some(trait_path) = trait_path else {
                 dcx.span_err(value.span(), "missing required field `trait`");
@@ -136,11 +144,11 @@ impl Deserialize for DisallowedTraitUsage {
                 trait_path,
                 types: types.unwrap_or_default(),
                 implements: implements.unwrap_or_default(),
-                all_types,
+                reason,
                 span: dcx.make_sp(value.span()),
             })
         } else {
-            dcx.span_err(value.span(), "expected a table");
+            dcx.span_err(value.span(), "expected either a string or an inline table");
             None
         }
     }

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -101,14 +101,18 @@ macro_rules! conf_enum {
 pub struct DisallowedTraitUsage {
     /// The fully qualified path to the trait being disallowed (e.g. `"std::fmt::Debug"`).
     pub trait_path: String,
+
     /// The concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`).
     pub types: Vec<DisallowedPathWithoutReplacement>,
+
     /// Traits whose implementors the trait is disallowed for (e.g. `"std::error::Error"`).
     pub implements: Vec<DisallowedPathWithoutReplacement>,
+
     /// Disallows the trait for every type, with the given reason.
     ///
     /// Mutually exclusive with `types` and `implements`.
     pub all_types: Option<String>,
+
     /// The span of this entry.
     ///
     /// Used for diagnostics.

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -681,17 +681,21 @@ pub struct DisallowedTraitUsage {
     /// The fully qualified path to the trait being disallowed (e.g. `"std::fmt::Debug"`).
     #[serde(rename = "trait")]
     pub trait_path: String,
+
     /// The concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`).
     #[serde(default)]
     pub types: Vec<DisallowedPathWithoutReplacement>,
+
     /// Traits whose implementors the trait is disallowed for (e.g. `"std::error::Error"`).
     #[serde(default)]
     pub implements: Vec<DisallowedPathWithoutReplacement>,
+
     /// Disallows the trait for every type, with the given reason.
     ///
     /// Mutually exclusive with `types` and `implements`.
     #[serde(rename = "all-types")]
     pub all_types: Option<String>,
+
     /// The span of this entry.
     ///
     /// Used for diagnostics.

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -94,6 +94,46 @@ macro_rules! conf_enum {
         }
     };
 }
+/// An entry in the `disallowed-trait-usage` configuration.
+///
+/// Forbids using a specific type via a specific trait interface.
+pub struct DisallowedTraitUsage {
+    /// The fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`).
+    pub type_path: String,
+    /// The fully qualified path to the trait (e.g. `"std::fmt::Debug"`).
+    pub trait_path: String,
+    /// Optional reason explaining why this usage is disallowed.
+    pub reason: Option<String>,
+}
+
+impl Deserialize for DisallowedTraitUsage {
+    fn deserialize(dcx: &DiagCtxt<'_>, value: &TomlValue<'_>) -> Option<Self> {
+        if let Some(table) = value.as_ref().as_table() {
+            deserialize_table!(dcx, table,
+                type_path("type"): String,
+                trait_path("trait"): String,
+                reason("reason"): String,
+            );
+            let Some(type_path) = type_path else {
+                dcx.span_err(value.span(), "missing required field `type`");
+                return None;
+            };
+            let Some(trait_path) = trait_path else {
+                dcx.span_err(value.span(), "missing required field `trait`");
+                return None;
+            };
+            Some(DisallowedTraitUsage {
+                type_path,
+                trait_path,
+                reason,
+            })
+        } else {
+            dcx.span_err(value.span(), "expected a table");
+            None
+        }
+    }
+}
+
 pub struct Rename {
     pub path: String,
     pub rename: String,

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -96,11 +96,17 @@ macro_rules! conf_enum {
 }
 /// An entry in the `disallowed-trait-usage` configuration.
 ///
-/// Forbids using a specific type via a specific trait interface.
+/// Forbids using a type via a specific trait interface. The type can be specified
+/// either as a concrete type (`type`) or as a trait bound (`implements`), but not both.
 pub struct DisallowedTraitUsage {
-    /// The fully qualified path to the type (e.g. `"i32"`, `"std::path::PathBuf"`).
-    pub type_path: String,
-    /// The fully qualified path to the trait (e.g. `"std::fmt::Debug"`).
+    /// The fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`).
+    /// Mutually exclusive with `implements`.
+    pub type_path: Option<String>,
+    /// The fully qualified path to a trait (e.g. `"std::error::Error"`).
+    /// When set, the rule applies to any type that implements this trait.
+    /// Mutually exclusive with `type`.
+    pub implements: Option<String>,
+    /// The fully qualified path to the trait being disallowed (e.g. `"std::fmt::Debug"`).
     pub trait_path: String,
     /// Optional reason explaining why this usage is disallowed.
     pub reason: Option<String>,
@@ -111,19 +117,17 @@ impl Deserialize for DisallowedTraitUsage {
         if let Some(table) = value.as_ref().as_table() {
             deserialize_table!(dcx, table,
                 type_path("type"): String,
+                implements("implements"): String,
                 trait_path("trait"): String,
                 reason("reason"): String,
             );
-            let Some(type_path) = type_path else {
-                dcx.span_err(value.span(), "missing required field `type`");
-                return None;
-            };
             let Some(trait_path) = trait_path else {
                 dcx.span_err(value.span(), "missing required field `trait`");
                 return None;
             };
             Some(DisallowedTraitUsage {
                 type_path,
+                implements,
                 trait_path,
                 reason,
             })

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -96,40 +96,44 @@ macro_rules! conf_enum {
 }
 /// An entry in the `disallowed-trait-usage` configuration.
 ///
-/// Forbids using a type via a specific trait interface. The type can be specified
-/// either as a concrete type (`type`) or as a trait bound (`implements`), but not both.
+/// Forbids using the trait named by `trait` on the types selected by `types`, `implements`
+/// and `all-types`.
 pub struct DisallowedTraitUsage {
-    /// The fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`).
-    /// Mutually exclusive with `implements`.
-    pub type_path: Option<String>,
-    /// The fully qualified path to a trait (e.g. `"std::error::Error"`).
-    /// When set, the rule applies to any type that implements this trait.
-    /// Mutually exclusive with `type`.
-    pub implements: Option<String>,
     /// The fully qualified path to the trait being disallowed (e.g. `"std::fmt::Debug"`).
     pub trait_path: String,
-    /// Optional reason explaining why this usage is disallowed.
-    pub reason: Option<String>,
+    /// The concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`).
+    pub types: Vec<DisallowedPathWithoutReplacement>,
+    /// Traits whose implementors the trait is disallowed for (e.g. `"std::error::Error"`).
+    pub implements: Vec<DisallowedPathWithoutReplacement>,
+    /// Disallows the trait for every type, with the given reason.
+    ///
+    /// Mutually exclusive with `types` and `implements`.
+    pub all_types: Option<String>,
+    /// The span of this entry.
+    ///
+    /// Used for diagnostics.
+    pub span: Span,
 }
 
 impl Deserialize for DisallowedTraitUsage {
     fn deserialize(dcx: &DiagCtxt<'_>, value: &TomlValue<'_>) -> Option<Self> {
         if let Some(table) = value.as_ref().as_table() {
             deserialize_table!(dcx, table,
-                type_path("type"): String,
-                implements("implements"): String,
                 trait_path("trait"): String,
-                reason("reason"): String,
+                types("types"): Vec<DisallowedPathWithoutReplacement>,
+                implements("implements"): Vec<DisallowedPathWithoutReplacement>,
+                all_types("all-types"): String,
             );
             let Some(trait_path) = trait_path else {
                 dcx.span_err(value.span(), "missing required field `trait`");
                 return None;
             };
             Some(DisallowedTraitUsage {
-                type_path,
-                implements,
                 trait_path,
-                reason,
+                types: types.unwrap_or_default(),
+                implements: implements.unwrap_or_default(),
+                all_types,
+                span: dcx.make_sp(value.span()),
             })
         } else {
             dcx.span_err(value.span(), "expected a table");

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -673,24 +673,40 @@ impl Serialize for SourceItemOrderingWithinModuleItemGroupings {
 
 /// An entry in the `disallowed-trait-usage` configuration.
 ///
-/// Forbids using a type via a specific trait interface. The type can be specified
-/// either as a concrete type (`type`) or as a trait bound (`implements`), but not both.
+/// Forbids using the trait named by `trait` on the types selected by `types`, `implements`
+/// and `all-types`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DisallowedTraitUsage {
-    /// The fully qualified path to a concrete type (e.g. `"i32"`, `"std::path::PathBuf"`).
-    /// Mutually exclusive with `implements`.
-    #[serde(rename = "type")]
-    pub type_path: Option<String>,
-    /// The fully qualified path to a trait (e.g. `"std::error::Error"`).
-    /// When set, the rule applies to any type that implements this trait.
-    /// Mutually exclusive with `type`.
-    pub implements: Option<String>,
     /// The fully qualified path to the trait being disallowed (e.g. `"std::fmt::Debug"`).
     #[serde(rename = "trait")]
     pub trait_path: String,
-    /// Optional reason explaining why this usage is disallowed.
-    pub reason: Option<String>,
+    /// The concrete types the trait is disallowed for (e.g. `"i32"`, `"std::path::PathBuf"`).
+    #[serde(default)]
+    pub types: Vec<DisallowedPathWithoutReplacement>,
+    /// Traits whose implementors the trait is disallowed for (e.g. `"std::error::Error"`).
+    #[serde(default)]
+    pub implements: Vec<DisallowedPathWithoutReplacement>,
+    /// Disallows the trait for every type, with the given reason.
+    ///
+    /// Mutually exclusive with `types` and `implements`.
+    #[serde(rename = "all-types")]
+    pub all_types: Option<String>,
+    /// The span of this entry.
+    ///
+    /// Used for diagnostics.
+    #[serde(skip)]
+    pub span: Span,
+}
+
+impl DisallowedTraitUsage {
+    /// Sets the span of this entry, and of every path it contains.
+    pub fn set_span(&mut self, span: Span) {
+        self.span = span;
+        for disallowed_path in self.types.iter_mut().chain(&mut self.implements) {
+            disallowed_path.set_span(span);
+        }
+    }
 }
 
 // these impls are never actually called but are used by the various config options that default to

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -115,6 +115,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::disallowed_methods::DISALLOWED_METHODS_INFO,
     crate::disallowed_names::DISALLOWED_NAMES_INFO,
     crate::disallowed_script_idents::DISALLOWED_SCRIPT_IDENTS_INFO,
+    crate::disallowed_trait_usage::DISALLOWED_TRAIT_USAGE_INFO,
     crate::disallowed_types::DISALLOWED_TYPES_INFO,
     crate::doc::DOC_BROKEN_LINK_INFO,
     crate::doc::DOC_COMMENT_DOUBLE_SPACE_LINEBREAKS_INFO,

--- a/clippy_lints/src/disallowed_trait_usage.rs
+++ b/clippy_lints/src/disallowed_trait_usage.rs
@@ -3,6 +3,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::macros::{FormatArgsStorage, find_format_arg_expr, is_format_macro, root_macro_call_first_node};
 use clippy_utils::paths::{PathNS, find_crates, lookup_path};
 use clippy_utils::sym;
+use clippy_utils::ty::implements_trait;
 use rustc_ast::{FormatArgsPiece, FormatTrait};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
@@ -29,7 +30,10 @@ declare_clippy_lint! {
     /// ```toml
     /// # clippy.toml
     /// disallowed-trait-usage = [
+    ///     # Forbid Debug formatting of a specific type:
     ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    ///     # Forbid Debug formatting of any type implementing a trait:
+    ///     { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display instead" },
     /// ]
     /// ```
     ///
@@ -52,9 +56,9 @@ declare_clippy_lint! {
 
 impl_lint_pass!(DisallowedTraitUsage => [DISALLOWED_TRAIT_USAGE]);
 
-/// Identifies a type that may be either an ADT or a primitive.
+/// Identifies a type: either a concrete type (ADT/primitive) or "any type implementing a trait".
 #[derive(Clone, Copy)]
-enum TypeId {
+enum TypeMatcher {
     Def(DefId),
     Bool,
     Char,
@@ -62,13 +66,17 @@ enum TypeId {
     Int(ty::IntTy),
     Uint(ty::UintTy),
     Float(ty::FloatTy),
+    /// Matches any type that implements the given trait.
+    ImplementsTrait(DefId),
 }
 
 /// A resolved disallowed (type, trait) pair.
 struct ResolvedEntry {
-    type_id: TypeId,
+    type_matcher: TypeMatcher,
     trait_def_id: DefId,
-    type_path: &'static str,
+    /// Description of the type constraint, used in diagnostics
+    /// (e.g. `"std::path::PathBuf"` or `"implementors of `std::error::Error`"`).
+    type_description: &'static str,
     trait_path: &'static str,
     reason: Option<&'static str>,
 }
@@ -100,16 +108,16 @@ fn emit_invalid_path_warning(tcx: TyCtxt<'_>, sym_path: &[Symbol], path: &str, e
     tcx.sess.dcx().warn(message);
 }
 
-fn resolve_type_id(tcx: TyCtxt<'_>, path: &str) -> Option<TypeId> {
+fn resolve_type_matcher(tcx: TyCtxt<'_>, path: &str) -> Option<TypeMatcher> {
     let sym_name = Symbol::intern(path);
     if let Some(prim) = rustc_hir::PrimTy::from_name(sym_name) {
         return Some(match prim {
-            rustc_hir::PrimTy::Int(i) => TypeId::Int(i),
-            rustc_hir::PrimTy::Uint(u) => TypeId::Uint(u),
-            rustc_hir::PrimTy::Float(f) => TypeId::Float(f),
-            rustc_hir::PrimTy::Str => TypeId::Str,
-            rustc_hir::PrimTy::Bool => TypeId::Bool,
-            rustc_hir::PrimTy::Char => TypeId::Char,
+            rustc_hir::PrimTy::Int(i) => TypeMatcher::Int(i),
+            rustc_hir::PrimTy::Uint(u) => TypeMatcher::Uint(u),
+            rustc_hir::PrimTy::Float(f) => TypeMatcher::Float(f),
+            rustc_hir::PrimTy::Str => TypeMatcher::Str,
+            rustc_hir::PrimTy::Bool => TypeMatcher::Bool,
+            rustc_hir::PrimTy::Char => TypeMatcher::Char,
         });
     }
 
@@ -123,7 +131,7 @@ fn resolve_type_id(tcx: TyCtxt<'_>, path: &str) -> Option<TypeId> {
     });
 
     if let Some(&def_id) = result {
-        Some(TypeId::Def(def_id))
+        Some(TypeMatcher::Def(def_id))
     } else {
         emit_invalid_path_warning(tcx, &sym_path, path, "type");
         None
@@ -149,13 +157,35 @@ impl DisallowedTraitUsage {
             .disallowed_trait_usage
             .iter()
             .filter_map(|entry| {
-                let type_id = resolve_type_id(tcx, &entry.type_path);
                 let trait_def_id = resolve_trait_def_id(tcx, &entry.trait_path);
 
+                let (type_matcher, type_description) = match (&entry.type_path, &entry.implements) {
+                    (Some(type_path), None) => {
+                        let matcher = resolve_type_matcher(tcx, type_path);
+                        (matcher, type_path.as_str())
+                    },
+                    (None, Some(impl_path)) => {
+                        let impl_trait_id = resolve_trait_def_id(tcx, impl_path);
+                        (impl_trait_id.map(TypeMatcher::ImplementsTrait), impl_path.as_str())
+                    },
+                    (Some(_), Some(_)) => {
+                        tcx.sess
+                            .dcx()
+                            .warn("`type` and `implements` are mutually exclusive (in `disallowed-trait-usage`)");
+                        return None;
+                    },
+                    (None, None) => {
+                        tcx.sess
+                            .dcx()
+                            .warn("either `type` or `implements` must be specified (in `disallowed-trait-usage`)");
+                        return None;
+                    },
+                };
+
                 Some(ResolvedEntry {
-                    type_id: type_id?,
+                    type_matcher: type_matcher?,
                     trait_def_id: trait_def_id?,
-                    type_path: &entry.type_path,
+                    type_description,
                     trait_path: &entry.trait_path,
                     reason: entry.reason.as_deref(),
                 })
@@ -179,34 +209,37 @@ impl DisallowedTraitUsage {
                 continue;
             }
 
-            let matches = match entry.type_id {
-                TypeId::Def(def_id) => match ty.kind() {
+            let type_matches = match entry.type_matcher {
+                TypeMatcher::Def(def_id) => match ty.kind() {
                     ty::Adt(adt_def, _) => adt_def.did() == def_id,
                     _ => false,
                 },
-                TypeId::Bool => ty.is_bool(),
-                TypeId::Char => ty.is_char(),
-                TypeId::Str => ty.is_str(),
-                TypeId::Int(int_ty) => matches!(ty.kind(), ty::Int(i) if *i == int_ty),
-                TypeId::Uint(uint_ty) => matches!(ty.kind(), ty::Uint(u) if *u == uint_ty),
-                TypeId::Float(float_ty) => matches!(ty.kind(), ty::Float(f) if *f == float_ty),
+                TypeMatcher::Bool => ty.is_bool(),
+                TypeMatcher::Char => ty.is_char(),
+                TypeMatcher::Str => ty.is_str(),
+                TypeMatcher::Int(int_ty) => matches!(ty.kind(), ty::Int(i) if *i == int_ty),
+                TypeMatcher::Uint(uint_ty) => matches!(ty.kind(), ty::Uint(u) if *u == uint_ty),
+                TypeMatcher::Float(float_ty) => matches!(ty.kind(), ty::Float(f) if *f == float_ty),
+                TypeMatcher::ImplementsTrait(impl_trait_id) => implements_trait(cx, ty, impl_trait_id, &[]),
             };
 
-            if matches {
-                span_lint_and_then(
-                    cx,
-                    DISALLOWED_TRAIT_USAGE,
-                    report_span,
-                    format!(
-                        "use of `{}` via trait `{}` is disallowed",
-                        entry.type_path, entry.trait_path,
+            if type_matches {
+                let message = match entry.type_matcher {
+                    TypeMatcher::ImplementsTrait(_) => format!(
+                        "use of implementor of `{}` via trait `{}` is disallowed",
+                        entry.type_description, entry.trait_path,
                     ),
-                    |diag| {
-                        if let Some(reason) = entry.reason {
-                            diag.note(reason.to_owned());
-                        }
-                    },
-                );
+                    _ => format!(
+                        "use of `{}` via trait `{}` is disallowed",
+                        entry.type_description, entry.trait_path,
+                    ),
+                };
+
+                span_lint_and_then(cx, DISALLOWED_TRAIT_USAGE, report_span, message, |diag| {
+                    if let Some(reason) = entry.reason {
+                        diag.note(reason.to_owned());
+                    }
+                });
             }
         }
     }

--- a/clippy_lints/src/disallowed_trait_usage.rs
+++ b/clippy_lints/src/disallowed_trait_usage.rs
@@ -1,0 +1,268 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::macros::{FormatArgsStorage, find_format_arg_expr, is_format_macro, root_macro_call_first_node};
+use clippy_utils::paths::{PathNS, find_crates, lookup_path};
+use clippy_utils::sym;
+use rustc_ast::{FormatArgsPiece, FormatTrait};
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_session::impl_lint_pass;
+use rustc_span::Symbol;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Denies using a configured type via a configured trait interface.
+    ///
+    /// Note: Even though this lint is warn-by-default, it will only trigger if
+    /// entries are defined in the clippy.toml file.
+    ///
+    /// ### Why is this bad?
+    /// Some trait implementations on certain types produce undesirable results.
+    /// For example, `Debug` formatting of path types includes escaping and quoting
+    /// that is usually not wanted in user-facing output.
+    ///
+    /// ### Example
+    /// An example clippy.toml configuration:
+    /// ```toml
+    /// # clippy.toml
+    /// disallowed-trait-usage = [
+    ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    /// ]
+    /// ```
+    ///
+    /// ```rust,ignore
+    /// use std::path::PathBuf;
+    /// let path = PathBuf::from("/tmp");
+    /// println!("{path:?}"); // Triggers the lint
+    /// ```
+    /// Use instead:
+    /// ```rust,ignore
+    /// use std::path::PathBuf;
+    /// let path = PathBuf::from("/tmp");
+    /// println!("{}", path.display()); // OK
+    /// ```
+    #[clippy::version = "1.96.0"]
+    pub DISALLOWED_TRAIT_USAGE,
+    style,
+    "use of a type via a disallowed trait interface"
+}
+
+impl_lint_pass!(DisallowedTraitUsage => [DISALLOWED_TRAIT_USAGE]);
+
+/// Identifies a type that may be either an ADT or a primitive.
+#[derive(Clone, Copy)]
+enum TypeId {
+    Def(DefId),
+    Bool,
+    Char,
+    Str,
+    Int(ty::IntTy),
+    Uint(ty::UintTy),
+    Float(ty::FloatTy),
+}
+
+/// A resolved disallowed (type, trait) pair.
+struct ResolvedEntry {
+    type_id: TypeId,
+    trait_def_id: DefId,
+    type_path: &'static str,
+    trait_path: &'static str,
+    reason: Option<&'static str>,
+}
+
+pub struct DisallowedTraitUsage {
+    format_args: FormatArgsStorage,
+    entries: Vec<ResolvedEntry>,
+}
+
+/// Returns true if path's root crate is loaded (or the path is a single segment).
+fn is_crate_loaded(tcx: TyCtxt<'_>, sym_path: &[Symbol]) -> bool {
+    sym_path.len() < 2 || !find_crates(tcx, sym_path[0]).is_empty()
+}
+
+fn emit_invalid_path_warning(tcx: TyCtxt<'_>, sym_path: &[Symbol], path: &str, expected: &str) {
+    if !is_crate_loaded(tcx, sym_path) {
+        return;
+    }
+
+    // Re-lookup in arbitrary namespace to produce a good "expected X, found Y" message
+    let found = lookup_path(tcx, PathNS::Arbitrary, sym_path);
+    let message = if let Some(&def_id) = found.first() {
+        let (article, description) = tcx.article_and_description(def_id);
+        format!("expected a {expected}, found {article} {description}: `{path}` (in `disallowed-trait-usage`)")
+    } else {
+        format!("`{path}` does not refer to a reachable {expected} (in `disallowed-trait-usage`)")
+    };
+
+    tcx.sess.dcx().warn(message);
+}
+
+fn resolve_type_id(tcx: TyCtxt<'_>, path: &str) -> Option<TypeId> {
+    let sym_name = Symbol::intern(path);
+    if let Some(prim) = rustc_hir::PrimTy::from_name(sym_name) {
+        return Some(match prim {
+            rustc_hir::PrimTy::Int(i) => TypeId::Int(i),
+            rustc_hir::PrimTy::Uint(u) => TypeId::Uint(u),
+            rustc_hir::PrimTy::Float(f) => TypeId::Float(f),
+            rustc_hir::PrimTy::Str => TypeId::Str,
+            rustc_hir::PrimTy::Bool => TypeId::Bool,
+            rustc_hir::PrimTy::Char => TypeId::Char,
+        });
+    }
+
+    let sym_path: Vec<Symbol> = path.split("::").map(Symbol::intern).collect();
+    let def_ids = lookup_path(tcx, PathNS::Type, &sym_path);
+    let result = def_ids.iter().find(|&&did| {
+        matches!(
+            tcx.def_kind(did),
+            DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::TyAlias | DefKind::ForeignTy
+        )
+    });
+
+    if let Some(&def_id) = result {
+        Some(TypeId::Def(def_id))
+    } else {
+        emit_invalid_path_warning(tcx, &sym_path, path, "type");
+        None
+    }
+}
+
+fn resolve_trait_def_id(tcx: TyCtxt<'_>, path: &str) -> Option<DefId> {
+    let sym_path: Vec<Symbol> = path.split("::").map(Symbol::intern).collect();
+    let def_ids = lookup_path(tcx, PathNS::Type, &sym_path);
+    let result = def_ids.iter().find(|&&did| matches!(tcx.def_kind(did), DefKind::Trait));
+
+    if let Some(&def_id) = result {
+        Some(def_id)
+    } else {
+        emit_invalid_path_warning(tcx, &sym_path, path, "trait");
+        None
+    }
+}
+
+impl DisallowedTraitUsage {
+    pub fn new(tcx: TyCtxt<'_>, conf: &'static Conf, format_args: FormatArgsStorage) -> Self {
+        let entries = conf
+            .disallowed_trait_usage
+            .iter()
+            .filter_map(|entry| {
+                let type_id = resolve_type_id(tcx, &entry.type_path);
+                let trait_def_id = resolve_trait_def_id(tcx, &entry.trait_path);
+
+                Some(ResolvedEntry {
+                    type_id: type_id?,
+                    trait_def_id: trait_def_id?,
+                    type_path: &entry.type_path,
+                    trait_path: &entry.trait_path,
+                    reason: entry.reason.as_deref(),
+                })
+            })
+            .collect();
+
+        Self { format_args, entries }
+    }
+
+    fn check_type_trait<'tcx>(
+        &self,
+        cx: &LateContext<'tcx>,
+        ty: Ty<'tcx>,
+        trait_def_id: DefId,
+        report_span: rustc_span::Span,
+    ) {
+        let ty = ty.peel_refs();
+
+        for entry in &self.entries {
+            if entry.trait_def_id != trait_def_id {
+                continue;
+            }
+
+            let matches = match entry.type_id {
+                TypeId::Def(def_id) => match ty.kind() {
+                    ty::Adt(adt_def, _) => adt_def.did() == def_id,
+                    _ => false,
+                },
+                TypeId::Bool => ty.is_bool(),
+                TypeId::Char => ty.is_char(),
+                TypeId::Str => ty.is_str(),
+                TypeId::Int(int_ty) => matches!(ty.kind(), ty::Int(i) if *i == int_ty),
+                TypeId::Uint(uint_ty) => matches!(ty.kind(), ty::Uint(u) if *u == uint_ty),
+                TypeId::Float(float_ty) => matches!(ty.kind(), ty::Float(f) if *f == float_ty),
+            };
+
+            if matches {
+                span_lint_and_then(
+                    cx,
+                    DISALLOWED_TRAIT_USAGE,
+                    report_span,
+                    format!(
+                        "use of `{}` via trait `{}` is disallowed",
+                        entry.type_path, entry.trait_path,
+                    ),
+                    |diag| {
+                        if let Some(reason) = entry.reason {
+                            diag.note(reason.to_owned());
+                        }
+                    },
+                );
+            }
+        }
+    }
+}
+
+fn format_trait_to_diagnostic_sym(format_trait: FormatTrait) -> Symbol {
+    match format_trait {
+        FormatTrait::Display => rustc_span::sym::Display,
+        FormatTrait::Debug => rustc_span::sym::Debug,
+        FormatTrait::LowerExp => sym::LowerExp,
+        FormatTrait::UpperExp => sym::UpperExp,
+        FormatTrait::Octal => sym::Octal,
+        FormatTrait::Pointer => rustc_span::sym::Pointer,
+        FormatTrait::Binary => sym::Binary,
+        FormatTrait::LowerHex => sym::LowerHex,
+        FormatTrait::UpperHex => sym::UpperHex,
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for DisallowedTraitUsage {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if self.entries.is_empty() {
+            return;
+        }
+
+        // Check format macro arguments
+        if let Some(macro_call) = root_macro_call_first_node(cx, expr)
+            && is_format_macro(cx, macro_call.def_id)
+            && let Some(format_args) = self.format_args.get(cx, expr, macro_call.expn)
+        {
+            for piece in &format_args.template {
+                if let FormatArgsPiece::Placeholder(placeholder) = piece
+                    && let Ok(index) = placeholder.argument.index
+                    && let Some(arg) = format_args.arguments.all_args().get(index)
+                    && let Some(arg_expr) = find_format_arg_expr(expr, arg)
+                {
+                    let diag_sym = format_trait_to_diagnostic_sym(placeholder.format_trait);
+                    if let Some(trait_def_id) = cx.tcx.get_diagnostic_item(diag_sym) {
+                        let ty = cx.typeck_results().expr_ty(arg_expr);
+                        let report_span = placeholder.span.unwrap_or(arg_expr.span);
+                        self.check_type_trait(cx, ty, trait_def_id, report_span);
+                    }
+                }
+            }
+            return;
+        }
+
+        // Check method calls where the method comes from a trait
+        if let ExprKind::MethodCall(name, receiver, _, _) = &expr.kind
+            && let Some(method_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
+        {
+            let method_parent = cx.tcx.parent(method_def_id);
+            if matches!(cx.tcx.def_kind(method_parent), DefKind::Trait) {
+                let ty = cx.typeck_results().expr_ty(receiver);
+                self.check_type_trait(cx, ty, method_parent, name.ident.span);
+            }
+        }
+    }
+}

--- a/clippy_lints/src/disallowed_trait_usage.rs
+++ b/clippy_lints/src/disallowed_trait_usage.rs
@@ -71,8 +71,7 @@ enum TypeMatcher {
 struct ResolvedEntry {
     type_matcher: TypeMatcher,
     trait_def_id: DefId,
-    /// Description of the type constraint, used in diagnostics
-    /// (e.g. `"std::path::PathBuf"` or `"implementors of `std::error::Error`"`).
+    /// Description of the type constraint, used in diagnostics.
     type_description: &'static str,
     trait_path: &'static str,
     reason: Option<&'static str>,

--- a/clippy_lints/src/disallowed_trait_usage.rs
+++ b/clippy_lints/src/disallowed_trait_usage.rs
@@ -59,13 +59,10 @@ impl_lint_pass!(DisallowedTraitUsage => [DISALLOWED_TRAIT_USAGE]);
 /// Identifies a type: either a concrete type (ADT/primitive) or "any type implementing a trait".
 #[derive(Clone, Copy)]
 enum TypeMatcher {
+    /// Matches a specific ADT (struct, enum, union, etc.) by DefId.
     Def(DefId),
-    Bool,
-    Char,
-    Str,
-    Int(ty::IntTy),
-    Uint(ty::UintTy),
-    Float(ty::FloatTy),
+    /// Matches a primitive type.
+    Prim(rustc_hir::PrimTy),
     /// Matches any type that implements the given trait.
     ImplementsTrait(DefId),
 }
@@ -111,14 +108,7 @@ fn emit_invalid_path_warning(tcx: TyCtxt<'_>, sym_path: &[Symbol], path: &str, e
 fn resolve_type_matcher(tcx: TyCtxt<'_>, path: &str) -> Option<TypeMatcher> {
     let sym_name = Symbol::intern(path);
     if let Some(prim) = rustc_hir::PrimTy::from_name(sym_name) {
-        return Some(match prim {
-            rustc_hir::PrimTy::Int(i) => TypeMatcher::Int(i),
-            rustc_hir::PrimTy::Uint(u) => TypeMatcher::Uint(u),
-            rustc_hir::PrimTy::Float(f) => TypeMatcher::Float(f),
-            rustc_hir::PrimTy::Str => TypeMatcher::Str,
-            rustc_hir::PrimTy::Bool => TypeMatcher::Bool,
-            rustc_hir::PrimTy::Char => TypeMatcher::Char,
-        });
+        return Some(TypeMatcher::Prim(prim));
     }
 
     let sym_path: Vec<Symbol> = path.split("::").map(Symbol::intern).collect();
@@ -210,16 +200,8 @@ impl DisallowedTraitUsage {
             }
 
             let type_matches = match entry.type_matcher {
-                TypeMatcher::Def(def_id) => match ty.kind() {
-                    ty::Adt(adt_def, _) => adt_def.did() == def_id,
-                    _ => false,
-                },
-                TypeMatcher::Bool => ty.is_bool(),
-                TypeMatcher::Char => ty.is_char(),
-                TypeMatcher::Str => ty.is_str(),
-                TypeMatcher::Int(int_ty) => matches!(ty.kind(), ty::Int(i) if *i == int_ty),
-                TypeMatcher::Uint(uint_ty) => matches!(ty.kind(), ty::Uint(u) if *u == uint_ty),
-                TypeMatcher::Float(float_ty) => matches!(ty.kind(), ty::Float(f) if *f == float_ty),
+                TypeMatcher::Def(def_id) => matches!(ty.kind(), ty::Adt(adt_def, _) if adt_def.did() == def_id),
+                TypeMatcher::Prim(prim) => ty_matches_prim(ty, prim),
                 TypeMatcher::ImplementsTrait(impl_trait_id) => implements_trait(cx, ty, impl_trait_id, &[]),
             };
 
@@ -242,6 +224,17 @@ impl DisallowedTraitUsage {
                 });
             }
         }
+    }
+}
+
+fn ty_matches_prim(ty: Ty<'_>, prim: rustc_hir::PrimTy) -> bool {
+    match prim {
+        rustc_hir::PrimTy::Bool => ty.is_bool(),
+        rustc_hir::PrimTy::Char => ty.is_char(),
+        rustc_hir::PrimTy::Str => ty.is_str(),
+        rustc_hir::PrimTy::Int(i) => matches!(ty.kind(), ty::Int(ti) if *ti == i),
+        rustc_hir::PrimTy::Uint(u) => matches!(ty.kind(), ty::Uint(tu) if *tu == u),
+        rustc_hir::PrimTy::Float(f) => matches!(ty.kind(), ty::Float(tf) if *tf == f),
     }
 }
 

--- a/clippy_lints/src/disallowed_trait_usage.rs
+++ b/clippy_lints/src/disallowed_trait_usage.rs
@@ -59,7 +59,7 @@ impl_lint_pass!(DisallowedTraitUsage => [DISALLOWED_TRAIT_USAGE]);
 /// Identifies a type: either a concrete type (ADT/primitive) or "any type implementing a trait".
 #[derive(Clone, Copy)]
 enum TypeMatcher {
-    /// Matches a specific ADT (struct, enum, union, etc.) by DefId.
+    /// Matches a specific ADT (struct, enum, union, etc.) by `DefId`.
     Def(DefId),
     /// Matches a primitive type.
     Prim(rustc_hir::PrimTy),

--- a/clippy_lints/src/disallowed_trait_usage.rs
+++ b/clippy_lints/src/disallowed_trait_usage.rs
@@ -1,17 +1,19 @@
 use clippy_config::Conf;
+use clippy_config::types::{DisallowedPathWithoutReplacement, create_disallowed_map};
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::macros::{FormatArgsStorage, find_format_arg_expr, is_format_macro, root_macro_call_first_node};
 use clippy_utils::paths::{PathNS, find_crates, lookup_path};
 use clippy_utils::sym;
 use clippy_utils::ty::implements_trait;
 use rustc_ast::{FormatArgsPiece, FormatTrait};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::def_id::{DefId, DefIdMap};
+use rustc_hir::{Expr, ExprKind, PrimTy};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_session::impl_lint_pass;
-use rustc_span::Symbol;
+use rustc_span::{Span, Symbol};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -29,12 +31,22 @@ declare_clippy_lint! {
     /// An example clippy.toml configuration:
     /// ```toml
     /// # clippy.toml
-    /// disallowed-trait-usage = [
-    ///     # Forbid Debug formatting of a specific type:
-    ///     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
-    ///     # Forbid Debug formatting of any type implementing a trait:
-    ///     { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display instead" },
+    /// [[disallowed-trait-usage]]
+    /// trait = "std::fmt::Debug"
+    /// # Forbid `Debug` formatting of specific types:
+    /// types = [
+    ///     { path = "std::path::PathBuf", reason = "Use path.display() instead" },
+    ///     "std::path::Path",
     /// ]
+    /// # Forbid `Debug` formatting of every type implementing these traits:
+    /// implements = [
+    ///     { path = "std::error::Error", reason = "Use Display for errors" },
+    /// ]
+    ///
+    /// # Forbid a trait outright:
+    /// [[disallowed-trait-usage]]
+    /// trait = "std::fmt::Pointer"
+    /// all-types = "Do not print addresses"
     /// ```
     ///
     /// ```rust,ignore
@@ -56,25 +68,57 @@ declare_clippy_lint! {
 
 impl_lint_pass!(DisallowedTraitUsage => [DISALLOWED_TRAIT_USAGE]);
 
-/// Identifies a type: either a concrete type (ADT/primitive) or "any type implementing a trait".
+/// A configured path, together with the entry it was written as.
 #[derive(Clone, Copy)]
-enum TypeMatcher {
-    /// Matches a specific ADT (struct, enum, union, etc.) by `DefId`.
-    Def(DefId),
-    /// Matches a primitive type.
-    Prim(rustc_hir::PrimTy),
-    /// Matches any type that implements the given trait.
-    ImplementsTrait(DefId),
+struct DisallowedPathEntry {
+    /// The path as written in the configuration.
+    path: &'static str,
+
+    /// The configuration entry the path came from, carrying its `reason`.
+    disallowed_path: &'static DisallowedPathWithoutReplacement,
 }
 
-/// A resolved disallowed (type, trait) pair.
+impl From<(&'static str, &'static DisallowedPathWithoutReplacement)> for DisallowedPathEntry {
+    fn from((path, disallowed_path): (&'static str, &'static DisallowedPathWithoutReplacement)) -> Self {
+        Self { path, disallowed_path }
+    }
+}
+
+/// The concrete types of a `types` list.
+struct DisallowedTypes {
+    def_ids: DefIdMap<DisallowedPathEntry>,
+    prim_tys: FxHashMap<PrimTy, DisallowedPathEntry>,
+}
+
+impl DisallowedTypes {
+    fn get(&self, ty: Ty<'_>) -> Option<DisallowedPathEntry> {
+        match ty.kind() {
+            ty::Adt(adt_def, _) => self.def_ids.get(&adt_def.did()).copied(),
+            _ => ty_as_prim(ty).and_then(|prim| self.prim_tys.get(&prim).copied()),
+        }
+    }
+}
+
+/// Which types a trait is forbidden for.
+enum Forbidden {
+    /// Every type, from `all-types`.
+    All { reason: &'static str },
+
+    /// Only the configured types, from `types` and `implements`.
+    Specific {
+        /// Concrete types, from `types`.
+        types: DisallowedTypes,
+
+        /// Traits whose implementors are disallowed, from `implements`.
+        implements: Vec<(DefId, DisallowedPathEntry)>,
+    },
+}
+
+/// One resolved `disallowed-trait-usage` entry: a trait plus the types it may not be used on.
 struct ResolvedEntry {
-    type_matcher: TypeMatcher,
     trait_def_id: DefId,
-    /// Description of the type constraint, used in diagnostics.
-    type_description: &'static str,
     trait_path: &'static str,
-    reason: Option<&'static str>,
+    forbidden: Forbidden,
 }
 
 pub struct DisallowedTraitUsage {
@@ -87,7 +131,7 @@ fn is_crate_loaded(tcx: TyCtxt<'_>, sym_path: &[Symbol]) -> bool {
     sym_path.len() < 2 || !find_crates(tcx, sym_path[0]).is_empty()
 }
 
-fn emit_invalid_path_warning(tcx: TyCtxt<'_>, sym_path: &[Symbol], path: &str, expected: &str) {
+fn emit_invalid_path_warning(tcx: TyCtxt<'_>, sym_path: &[Symbol], path: &str, expected: &str, span: Span) {
     if !is_crate_loaded(tcx, sym_path) {
         return;
     }
@@ -96,38 +140,59 @@ fn emit_invalid_path_warning(tcx: TyCtxt<'_>, sym_path: &[Symbol], path: &str, e
     let found = lookup_path(tcx, PathNS::Arbitrary, sym_path);
     let message = if let Some(&def_id) = found.first() {
         let (article, description) = tcx.article_and_description(def_id);
-        format!("expected a {expected}, found {article} {description}: `{path}` (in `disallowed-trait-usage`)")
+        format!("expected a {expected}, found {article} {description}")
     } else {
-        format!("`{path}` does not refer to a reachable {expected} (in `disallowed-trait-usage`)")
+        format!("`{path}` does not refer to a reachable {expected}")
     };
 
-    tcx.sess.dcx().warn(message);
+    tcx.sess.dcx().span_warn(span, message);
 }
 
-fn resolve_type_matcher(tcx: TyCtxt<'_>, path: &str) -> Option<TypeMatcher> {
-    let sym_name = Symbol::intern(path);
-    if let Some(prim) = rustc_hir::PrimTy::from_name(sym_name) {
-        return Some(TypeMatcher::Prim(prim));
-    }
+fn type_def_kind_predicate(def_kind: DefKind) -> bool {
+    matches!(
+        def_kind,
+        DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::TyAlias | DefKind::ForeignTy
+    )
+}
 
-    let sym_path: Vec<Symbol> = path.split("::").map(Symbol::intern).collect();
-    let def_ids = lookup_path(tcx, PathNS::Type, &sym_path);
-    let result = def_ids.iter().find(|&&did| {
-        matches!(
-            tcx.def_kind(did),
-            DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::TyAlias | DefKind::ForeignTy
-        )
-    });
+fn trait_def_kind_predicate(def_kind: DefKind) -> bool {
+    matches!(def_kind, DefKind::Trait)
+}
 
-    if let Some(&def_id) = result {
-        Some(TypeMatcher::Def(def_id))
-    } else {
-        emit_invalid_path_warning(tcx, &sym_path, path, "type");
-        None
+/// Resolves the `types` of a `disallowed-trait-usage` entry.
+#[expect(rustc::potential_query_instability, reason = "collected into another unordered map")]
+fn resolve_types(tcx: TyCtxt<'_>, types: &'static [DisallowedPathWithoutReplacement]) -> DisallowedTypes {
+    let (def_ids, prim_tys) = create_disallowed_map(tcx, types, PathNS::Type, type_def_kind_predicate, "type", true);
+
+    DisallowedTypes {
+        def_ids: def_ids
+            .into_items()
+            .map(|(def_id, entry)| (def_id, entry.into()))
+            .into(),
+        prim_tys: prim_tys
+            .into_iter()
+            .map(|(prim_ty, entry)| (prim_ty, entry.into()))
+            .collect(),
     }
 }
 
-fn resolve_trait_def_id(tcx: TyCtxt<'_>, path: &str) -> Option<DefId> {
+/// Resolves the `implements` of a `disallowed-trait-usage` entry.
+fn resolve_implements(
+    tcx: TyCtxt<'_>,
+    implements: &'static [DisallowedPathWithoutReplacement],
+) -> Vec<(DefId, DisallowedPathEntry)> {
+    let (def_ids, _) = create_disallowed_map(tcx, implements, PathNS::Type, trait_def_kind_predicate, "trait", false);
+
+    // Sorted so that diagnostics are emitted in a deterministic order.
+    def_ids
+        .into_items()
+        .into_sorted_stable_ord_by_key(|(_, (path, _))| path)
+        .into_iter()
+        .map(|(def_id, entry)| (def_id, entry.into()))
+        .collect()
+}
+
+fn resolve_trait_def_id(tcx: TyCtxt<'_>, path: &str, span: Span) -> Option<DefId> {
     let sym_path: Vec<Symbol> = path.split("::").map(Symbol::intern).collect();
     let def_ids = lookup_path(tcx, PathNS::Type, &sym_path);
     let result = def_ids.iter().find(|&&did| matches!(tcx.def_kind(did), DefKind::Trait));
@@ -135,7 +200,7 @@ fn resolve_trait_def_id(tcx: TyCtxt<'_>, path: &str) -> Option<DefId> {
     if let Some(&def_id) = result {
         Some(def_id)
     } else {
-        emit_invalid_path_warning(tcx, &sym_path, path, "trait");
+        emit_invalid_path_warning(tcx, &sym_path, path, "trait", span);
         None
     }
 }
@@ -146,37 +211,33 @@ impl DisallowedTraitUsage {
             .disallowed_trait_usage
             .iter()
             .filter_map(|entry| {
-                let trait_def_id = resolve_trait_def_id(tcx, &entry.trait_path);
+                let trait_def_id = resolve_trait_def_id(tcx, &entry.trait_path, entry.span);
 
-                let (type_matcher, type_description) = match (&entry.type_path, &entry.implements) {
-                    (Some(type_path), None) => {
-                        let matcher = resolve_type_matcher(tcx, type_path);
-                        (matcher, type_path.as_str())
-                    },
-                    (None, Some(impl_path)) => {
-                        let impl_trait_id = resolve_trait_def_id(tcx, impl_path);
-                        (impl_trait_id.map(TypeMatcher::ImplementsTrait), impl_path.as_str())
-                    },
-                    (Some(_), Some(_)) => {
-                        tcx.sess
-                            .dcx()
-                            .warn("`type` and `implements` are mutually exclusive (in `disallowed-trait-usage`)");
-                        return None;
-                    },
-                    (None, None) => {
-                        tcx.sess
-                            .dcx()
-                            .warn("either `type` or `implements` must be specified (in `disallowed-trait-usage`)");
-                        return None;
-                    },
+                let forbidden = if let Some(reason) = entry.all_types.as_deref() {
+                    if !entry.types.is_empty() || !entry.implements.is_empty() {
+                        tcx.sess.dcx().span_warn(
+                            entry.span,
+                            "`all-types` already covers `types` and `implements`, which are ignored",
+                        );
+                    }
+                    Forbidden::All { reason }
+                } else if entry.types.is_empty() && entry.implements.is_empty() {
+                    tcx.sess.dcx().span_warn(
+                        entry.span,
+                        "at least one of `types`, `implements` or `all-types` must be specified",
+                    );
+                    return None;
+                } else {
+                    Forbidden::Specific {
+                        types: resolve_types(tcx, &entry.types),
+                        implements: resolve_implements(tcx, &entry.implements),
+                    }
                 };
 
                 Some(ResolvedEntry {
-                    type_matcher: type_matcher?,
                     trait_def_id: trait_def_id?,
-                    type_description,
                     trait_path: &entry.trait_path,
-                    reason: entry.reason.as_deref(),
+                    forbidden,
                 })
             })
             .collect();
@@ -184,56 +245,69 @@ impl DisallowedTraitUsage {
         Self { format_args, entries }
     }
 
-    fn check_type_trait<'tcx>(
-        &self,
-        cx: &LateContext<'tcx>,
-        ty: Ty<'tcx>,
-        trait_def_id: DefId,
-        report_span: rustc_span::Span,
-    ) {
+    fn check_type_trait<'tcx>(&self, cx: &LateContext<'tcx>, ty: Ty<'tcx>, trait_def_id: DefId, span: Span) {
         let ty = ty.peel_refs();
 
         for entry in &self.entries {
-            if entry.trait_def_id != trait_def_id {
+            let ResolvedEntry {
+                trait_def_id: entry_trait_def_id,
+                trait_path,
+                forbidden,
+            } = entry;
+
+            if *entry_trait_def_id != trait_def_id {
                 continue;
             }
 
-            let type_matches = match entry.type_matcher {
-                TypeMatcher::Def(def_id) => matches!(ty.kind(), ty::Adt(adt_def, _) if adt_def.did() == def_id),
-                TypeMatcher::Prim(prim) => ty_matches_prim(ty, prim),
-                TypeMatcher::ImplementsTrait(impl_trait_id) => implements_trait(cx, ty, impl_trait_id, &[]),
-            };
-
-            if type_matches {
-                let message = match entry.type_matcher {
-                    TypeMatcher::ImplementsTrait(_) => format!(
-                        "use of implementor of `{}` via trait `{}` is disallowed",
-                        entry.type_description, entry.trait_path,
-                    ),
-                    _ => format!(
-                        "use of `{}` via trait `{}` is disallowed",
-                        entry.type_description, entry.trait_path,
-                    ),
-                };
-
-                span_lint_and_then(cx, DISALLOWED_TRAIT_USAGE, report_span, message, |diag| {
-                    if let Some(reason) = entry.reason {
-                        diag.note(reason.to_owned());
+            match forbidden {
+                Forbidden::All { reason } => span_lint_and_then(
+                    cx,
+                    DISALLOWED_TRAIT_USAGE,
+                    span,
+                    format!("use of trait `{trait_path}` is disallowed"),
+                    |diag| {
+                        if !reason.is_empty() {
+                            diag.note((*reason).to_owned());
+                        }
+                    },
+                ),
+                Forbidden::Specific { types, implements } => {
+                    if let Some(DisallowedPathEntry { path, disallowed_path }) = types.get(ty) {
+                        span_lint_and_then(
+                            cx,
+                            DISALLOWED_TRAIT_USAGE,
+                            span,
+                            format!("use of `{path}` via trait `{trait_path}` is disallowed"),
+                            disallowed_path.diag_amendment(span),
+                        );
                     }
-                });
+
+                    for &(impl_trait_id, DisallowedPathEntry { path, disallowed_path }) in implements {
+                        if implements_trait(cx, ty, impl_trait_id, &[]) {
+                            span_lint_and_then(
+                                cx,
+                                DISALLOWED_TRAIT_USAGE,
+                                span,
+                                format!("use of implementor of `{path}` via trait `{trait_path}` is disallowed"),
+                                disallowed_path.diag_amendment(span),
+                            );
+                        }
+                    }
+                },
             }
         }
     }
 }
 
-fn ty_matches_prim(ty: Ty<'_>, prim: rustc_hir::PrimTy) -> bool {
-    match prim {
-        rustc_hir::PrimTy::Bool => ty.is_bool(),
-        rustc_hir::PrimTy::Char => ty.is_char(),
-        rustc_hir::PrimTy::Str => ty.is_str(),
-        rustc_hir::PrimTy::Int(i) => matches!(ty.kind(), ty::Int(ti) if *ti == i),
-        rustc_hir::PrimTy::Uint(u) => matches!(ty.kind(), ty::Uint(tu) if *tu == u),
-        rustc_hir::PrimTy::Float(f) => matches!(ty.kind(), ty::Float(tf) if *tf == f),
+fn ty_as_prim(ty: Ty<'_>) -> Option<PrimTy> {
+    match *ty.kind() {
+        ty::Bool => Some(PrimTy::Bool),
+        ty::Char => Some(PrimTy::Char),
+        ty::Str => Some(PrimTy::Str),
+        ty::Int(int_ty) => Some(PrimTy::Int(int_ty)),
+        ty::Uint(uint_ty) => Some(PrimTy::Uint(uint_ty)),
+        ty::Float(float_ty) => Some(PrimTy::Float(float_ty)),
+        _ => None,
     }
 }
 

--- a/clippy_lints/src/disallowed_trait_usage.rs
+++ b/clippy_lints/src/disallowed_trait_usage.rs
@@ -60,7 +60,7 @@ declare_clippy_lint! {
     /// let path = PathBuf::from("/tmp");
     /// println!("{}", path.display()); // OK
     /// ```
-    #[clippy::version = "1.96.0"]
+    #[clippy::version = "1.99.0"]
     pub DISALLOWED_TRAIT_USAGE,
     style,
     "use of a type via a disallowed trait interface"

--- a/clippy_lints/src/disallowed_trait_usage.rs
+++ b/clippy_lints/src/disallowed_trait_usage.rs
@@ -7,6 +7,7 @@ use clippy_utils::sym;
 use clippy_utils::ty::implements_trait;
 use rustc_ast::{FormatArgsPiece, FormatTrait};
 use rustc_data_structures::fx::FxHashMap;
+use rustc_errors::Diag;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, DefIdMap};
 use rustc_hir::{Expr, ExprKind, PrimTy};
@@ -33,6 +34,7 @@ declare_clippy_lint! {
     /// # clippy.toml
     /// [[disallowed-trait-usage]]
     /// trait = "std::fmt::Debug"
+    /// reason = "Debug output is not meant for end users"
     /// # Forbid `Debug` formatting of specific types:
     /// types = [
     ///     { path = "std::path::PathBuf", reason = "Use path.display() instead" },
@@ -43,10 +45,13 @@ declare_clippy_lint! {
     ///     { path = "std::error::Error", reason = "Use Display for errors" },
     /// ]
     ///
-    /// # Forbid a trait outright:
+    /// # Forbid a trait for every type:
     /// [[disallowed-trait-usage]]
     /// trait = "std::fmt::Pointer"
-    /// all-types = "Do not print addresses"
+    /// reason = "Do not print addresses"
+    ///
+    /// # …or, without a reason:
+    /// disallowed-trait-usage = ["std::fmt::Pointer"]
     /// ```
     ///
     /// ```rust,ignore
@@ -101,8 +106,8 @@ impl DisallowedTypes {
 
 /// Which types a trait is forbidden for.
 enum Forbidden {
-    /// Every type, from `all-types`.
-    All { reason: &'static str },
+    /// Every type, for an entry with neither `types` nor `implements`.
+    AllTypes,
 
     /// Only the configured types, from `types` and `implements`.
     Specific {
@@ -119,6 +124,9 @@ struct ResolvedEntry {
     trait_def_id: DefId,
     trait_path: &'static str,
     forbidden: Forbidden,
+
+    /// The `reason` of the entry, applying to everything it forbids.
+    reason: Option<&'static str>,
 }
 
 pub struct DisallowedTraitUsage {
@@ -213,20 +221,8 @@ impl DisallowedTraitUsage {
             .filter_map(|entry| {
                 let trait_def_id = resolve_trait_def_id(tcx, &entry.trait_path, entry.span);
 
-                let forbidden = if let Some(reason) = entry.all_types.as_deref() {
-                    if !entry.types.is_empty() || !entry.implements.is_empty() {
-                        tcx.sess.dcx().span_warn(
-                            entry.span,
-                            "`all-types` already covers `types` and `implements`, which are ignored",
-                        );
-                    }
-                    Forbidden::All { reason }
-                } else if entry.types.is_empty() && entry.implements.is_empty() {
-                    tcx.sess.dcx().span_warn(
-                        entry.span,
-                        "at least one of `types`, `implements` or `all-types` must be specified",
-                    );
-                    return None;
+                let forbidden = if entry.types.is_empty() && entry.implements.is_empty() {
+                    Forbidden::AllTypes
                 } else {
                     Forbidden::Specific {
                         types: resolve_types(tcx, &entry.types),
@@ -238,6 +234,7 @@ impl DisallowedTraitUsage {
                     trait_def_id: trait_def_id?,
                     trait_path: &entry.trait_path,
                     forbidden,
+                    reason: entry.reason.as_deref(),
                 })
             })
             .collect();
@@ -253,23 +250,26 @@ impl DisallowedTraitUsage {
                 trait_def_id: entry_trait_def_id,
                 trait_path,
                 forbidden,
+                reason,
             } = entry;
 
             if *entry_trait_def_id != trait_def_id {
                 continue;
             }
 
+            let note_reason = |diag: &mut Diag<'_, ()>| {
+                if let Some(reason) = reason {
+                    diag.note((*reason).to_owned());
+                }
+            };
+
             match forbidden {
-                Forbidden::All { reason } => span_lint_and_then(
+                Forbidden::AllTypes => span_lint_and_then(
                     cx,
                     DISALLOWED_TRAIT_USAGE,
                     span,
                     format!("use of trait `{trait_path}` is disallowed"),
-                    |diag| {
-                        if !reason.is_empty() {
-                            diag.note((*reason).to_owned());
-                        }
-                    },
+                    note_reason,
                 ),
                 Forbidden::Specific { types, implements } => {
                     if let Some(DisallowedPathEntry { path, disallowed_path }) = types.get(ty) {
@@ -278,7 +278,10 @@ impl DisallowedTraitUsage {
                             DISALLOWED_TRAIT_USAGE,
                             span,
                             format!("use of `{path}` via trait `{trait_path}` is disallowed"),
-                            disallowed_path.diag_amendment(span),
+                            |diag| {
+                                disallowed_path.diag_amendment(span)(diag);
+                                note_reason(diag);
+                            },
                         );
                     }
 
@@ -289,7 +292,10 @@ impl DisallowedTraitUsage {
                                 DISALLOWED_TRAIT_USAGE,
                                 span,
                                 format!("use of implementor of `{path}` via trait `{trait_path}` is disallowed"),
-                                disallowed_path.diag_amendment(span),
+                                |diag| {
+                                    disallowed_path.diag_amendment(span)(diag);
+                                    note_reason(diag);
+                                },
                             );
                         }
                     }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -111,6 +111,7 @@ mod disallowed_macros;
 mod disallowed_methods;
 mod disallowed_names;
 mod disallowed_script_idents;
+mod disallowed_trait_usage;
 mod disallowed_types;
 mod doc;
 mod double_parens;
@@ -724,6 +725,7 @@ rustc_lint::late_lint_methods!(
         BoolAssertComparison: bool_assert_comparison::BoolAssertComparison = bool_assert_comparison::BoolAssertComparison,
         UnusedAsync: unused_async::UnusedAsync = <unused_async::UnusedAsync>::default(),
         DisallowedTypes: disallowed_types::DisallowedTypes = disallowed_types::DisallowedTypes::new(tcx, conf),
+        DisallowedTraitUsage: disallowed_trait_usage::DisallowedTraitUsage = disallowed_trait_usage::DisallowedTraitUsage::new(tcx, conf, format_args.clone()),
         ImportRename: missing_enforced_import_rename::ImportRename = missing_enforced_import_rename::ImportRename::new(tcx, conf),
         StrlenOnCStrings: strlen_on_c_strings::StrlenOnCStrings = strlen_on_c_strings::StrlenOnCStrings::new(conf),
         SelfNamedConstructors: self_named_constructors::SelfNamedConstructors = self_named_constructors::SelfNamedConstructors,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -114,6 +114,7 @@ mod disallowed_macros;
 mod disallowed_methods;
 mod disallowed_names;
 mod disallowed_script_idents;
+mod disallowed_trait_usage;
 mod disallowed_types;
 mod doc;
 mod double_parens;
@@ -727,6 +728,7 @@ rustc_lint::late_lint_methods!(
         BoolAssertComparison: bool_assert_comparison::BoolAssertComparison = bool_assert_comparison::BoolAssertComparison,
         UnusedAsync: unused_async::UnusedAsync = <unused_async::UnusedAsync>::default(),
         DisallowedTypes: disallowed_types::DisallowedTypes = disallowed_types::DisallowedTypes::new(tcx, conf),
+        DisallowedTraitUsage: disallowed_trait_usage::DisallowedTraitUsage = disallowed_trait_usage::DisallowedTraitUsage::new(tcx, conf, format_args.clone()),
         ImportRename: missing_enforced_import_rename::ImportRename = missing_enforced_import_rename::ImportRename::new(tcx, conf),
         StrlenOnCStrings: strlen_on_c_strings::StrlenOnCStrings = strlen_on_c_strings::StrlenOnCStrings::new(conf),
         SelfNamedConstructors: self_named_constructors::SelfNamedConstructors = self_named_constructors::SelfNamedConstructors,

--- a/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
@@ -4,4 +4,6 @@ disallowed-trait-usage = [
     { type = "std::path::Path", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
     { type = "disallowed_trait_usage::MyStruct", trait = "disallowed_trait_usage::MyTrait", reason = "Use a different approach" },
     { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display for errors" },
+    # implements with a custom local trait, no reason
+    { implements = "disallowed_trait_usage::MyTrait", trait = "std::fmt::Debug" },
 ]

--- a/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
@@ -3,4 +3,5 @@ disallowed-trait-usage = [
     { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
     { type = "std::path::Path", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
     { type = "disallowed_trait_usage::MyStruct", trait = "disallowed_trait_usage::MyTrait", reason = "Use a different approach" },
+    { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display for errors" },
 ]

--- a/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
@@ -1,0 +1,6 @@
+disallowed-trait-usage = [
+    { type = "i32", trait = "std::fmt::Debug", reason = "Use Display formatting instead" },
+    { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    { type = "std::path::Path", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
+    { type = "disallowed_trait_usage::MyStruct", trait = "disallowed_trait_usage::MyTrait", reason = "Use a different approach" },
+]

--- a/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
@@ -1,27 +1,26 @@
-[[disallowed-trait-usage]]
-trait = "std::fmt::Debug"
-types = [
-    { path = "i32", reason = "Use Display formatting instead" },
-    { path = "std::path::PathBuf", reason = "Use path.display() instead" },
-    # Plain-string form, without a reason:
-    "std::path::Path",
+disallowed-trait-usage = [
+    {
+        trait = "std::fmt::Debug",
+        types = [
+            { path = "i32", reason = "Use Display formatting instead" },
+            { path = "std::path::PathBuf", reason = "Use path.display() instead" },
+            # Plain-string form, without a reason:
+            "std::path::Path",
+        ],
+        implements = [
+            { path = "std::error::Error", reason = "Use Display for errors" },
+            # A custom local trait, without a reason:
+            "disallowed_trait_usage::MyTrait",
+        ],
+    },
+    # An entry-wide `reason`, on top of the per-type one:
+    {
+        trait = "disallowed_trait_usage::MyTrait",
+        reason = "MyTrait is on its way out",
+        types = [{ path = "disallowed_trait_usage::MyStruct", reason = "Use a different approach" }],
+    },
+    # Disallowed for every type:
+    { trait = "std::fmt::Pointer", reason = "Addresses are not reproducible" },
+    # …and the plain-string form, without a reason:
+    "disallowed_trait_usage::MyOtherTrait",
 ]
-implements = [
-    { path = "std::error::Error", reason = "Use Display for errors" },
-    # A custom local trait, without a reason:
-    "disallowed_trait_usage::MyTrait",
-]
-
-[[disallowed-trait-usage]]
-trait = "disallowed_trait_usage::MyTrait"
-types = [{ path = "disallowed_trait_usage::MyStruct", reason = "Use a different approach" }]
-
-# Disallowed for every type:
-[[disallowed-trait-usage]]
-trait = "std::fmt::Pointer"
-all-types = "Addresses are not reproducible"
-
-# …and without a reason:
-[[disallowed-trait-usage]]
-trait = "disallowed_trait_usage::MyOtherTrait"
-all-types = ""

--- a/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage/clippy.toml
@@ -1,9 +1,27 @@
-disallowed-trait-usage = [
-    { type = "i32", trait = "std::fmt::Debug", reason = "Use Display formatting instead" },
-    { type = "std::path::PathBuf", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
-    { type = "std::path::Path", trait = "std::fmt::Debug", reason = "Use path.display() instead" },
-    { type = "disallowed_trait_usage::MyStruct", trait = "disallowed_trait_usage::MyTrait", reason = "Use a different approach" },
-    { implements = "std::error::Error", trait = "std::fmt::Debug", reason = "Use Display for errors" },
-    # implements with a custom local trait, no reason
-    { implements = "disallowed_trait_usage::MyTrait", trait = "std::fmt::Debug" },
+[[disallowed-trait-usage]]
+trait = "std::fmt::Debug"
+types = [
+    { path = "i32", reason = "Use Display formatting instead" },
+    { path = "std::path::PathBuf", reason = "Use path.display() instead" },
+    # Plain-string form, without a reason:
+    "std::path::Path",
 ]
+implements = [
+    { path = "std::error::Error", reason = "Use Display for errors" },
+    # A custom local trait, without a reason:
+    "disallowed_trait_usage::MyTrait",
+]
+
+[[disallowed-trait-usage]]
+trait = "disallowed_trait_usage::MyTrait"
+types = [{ path = "disallowed_trait_usage::MyStruct", reason = "Use a different approach" }]
+
+# Disallowed for every type:
+[[disallowed-trait-usage]]
+trait = "std::fmt::Pointer"
+all-types = "Addresses are not reproducible"
+
+# …and without a reason:
+[[disallowed-trait-usage]]
+trait = "disallowed_trait_usage::MyOtherTrait"
+all-types = ""

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::disallowed_trait_usage)]
+#![allow(clippy::io_other_error)]
 
 use std::path::{Path, PathBuf};
 
@@ -67,4 +68,19 @@ fn main() {
     // Should NOT trigger: same custom trait on a different type
     let other = OtherStruct;
     other.do_thing();
+
+    // Should trigger: Debug formatting of any type implementing std::error::Error
+    let err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+    println!("{err:?}");
+    //~^ disallowed_trait_usage
+
+    // Should trigger: Debug formatting of Error via format!
+    let _ = format!("{:?}", std::io::Error::new(std::io::ErrorKind::Other, "oops"));
+    //~^ disallowed_trait_usage
+
+    // Should NOT trigger: Display formatting of Error (only Debug is disallowed)
+    println!("{err}");
+
+    // Should NOT trigger: Debug formatting of String (doesn't implement Error)
+    println!("{s:?}");
 }

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
@@ -15,6 +15,12 @@ impl MyTrait for MyStruct {
     }
 }
 
+impl std::fmt::Debug for MyStruct {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("MyStruct")
+    }
+}
+
 struct OtherStruct;
 
 impl MyTrait for OtherStruct {
@@ -24,6 +30,8 @@ impl MyTrait for OtherStruct {
 }
 
 fn main() {
+    // === Concrete `type` matching ===
+
     // Should trigger: Debug formatting of i32
     println!("{:?}", 42_i32);
     //~^ disallowed_trait_usage
@@ -33,17 +41,10 @@ fn main() {
     println!("{path:?}");
     //~^ disallowed_trait_usage
 
-    // Should trigger: Debug formatting of &Path
+    // Should trigger: Debug formatting of &Path (references are peeled)
     let path_ref: &Path = path.as_path();
     println!("{path_ref:?}");
     //~^ disallowed_trait_usage
-
-    // Should NOT trigger: Display formatting of i32
-    println!("{}", 42_i32);
-
-    // Should NOT trigger: Debug formatting of String (not in config)
-    let s = String::from("hello");
-    println!("{s:?}");
 
     // Should trigger: Debug formatting of i32 via format!
     let _ = format!("{:?}", 0_i32);
@@ -65,11 +66,20 @@ fn main() {
     my_ref.do_thing();
     //~^ disallowed_trait_usage
 
-    // Should NOT trigger: same custom trait on a different type
+    // Should NOT trigger: Display formatting of i32 (only Debug is disallowed)
+    println!("{}", 42_i32);
+
+    // Should NOT trigger: Debug formatting of String (not in config)
+    let s = String::from("hello");
+    println!("{s:?}");
+
+    // Should NOT trigger: same custom trait on a different type (OtherStruct not in config)
     let other = OtherStruct;
     other.do_thing();
 
-    // Should trigger: Debug formatting of any type implementing std::error::Error
+    // === `implements` matching ===
+
+    // Should trigger: Debug formatting of std::io::Error (implements std::error::Error)
     let err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
     println!("{err:?}");
     //~^ disallowed_trait_usage
@@ -83,4 +93,20 @@ fn main() {
 
     // Should NOT trigger: Debug formatting of String (doesn't implement Error)
     println!("{s:?}");
+
+    // Should trigger: Debug formatting of MyStruct (implements MyTrait, which is in `implements` config)
+    println!("{my:?}");
+    //~^ disallowed_trait_usage
+
+    // Should NOT trigger: OtherStruct implements MyTrait but doesn't impl Debug,
+    // so Debug formatting can't even be used on it (won't compile without this guard).
+    // Instead, test that Display of MyStruct doesn't trigger (only Debug is disallowed via `implements`).
+    // (MyStruct has no Display impl, so we test via the method call path instead.)
+
+    // Should trigger: method call on a type matching `implements` —
+    // OtherStruct implements MyTrait, and MyTrait::do_thing is disallowed on MyStruct (via concrete `type`),
+    // but OtherStruct is NOT matched by the concrete `type` entry. However, it IS matched by the
+    // `implements = MyTrait` + `trait = Debug` entry — but that only covers Debug, not MyTrait methods.
+    // So this should NOT trigger.
+    other.do_thing();
 }

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
@@ -94,19 +94,20 @@ fn main() {
     // Should NOT trigger: Debug formatting of String (doesn't implement Error)
     println!("{s:?}");
 
-    // Should trigger: Debug formatting of MyStruct (implements MyTrait, which is in `implements` config)
+    // Should trigger: Debug formatting of MyStruct (implements MyTrait, which is in `implements`
+    // config)
     println!("{my:?}");
     //~^ disallowed_trait_usage
 
     // Should NOT trigger: OtherStruct implements MyTrait but doesn't impl Debug,
     // so Debug formatting can't even be used on it (won't compile without this guard).
-    // Instead, test that Display of MyStruct doesn't trigger (only Debug is disallowed via `implements`).
-    // (MyStruct has no Display impl, so we test via the method call path instead.)
+    // Instead, test that Display of MyStruct doesn't trigger (only Debug is disallowed via
+    // `implements`). (MyStruct has no Display impl, so we test via the method call path instead.)
 
     // Should trigger: method call on a type matching `implements` —
-    // OtherStruct implements MyTrait, and MyTrait::do_thing is disallowed on MyStruct (via concrete `type`),
-    // but OtherStruct is NOT matched by the concrete `type` entry. However, it IS matched by the
-    // `implements = MyTrait` + `trait = Debug` entry — but that only covers Debug, not MyTrait methods.
-    // So this should NOT trigger.
+    // OtherStruct implements MyTrait, and MyTrait::do_thing is disallowed on MyStruct (via concrete
+    // `type`), but OtherStruct is NOT matched by the concrete `type` entry. However, it IS matched
+    // by the `implements = MyTrait` + `trait = Debug` entry — but that only covers Debug, not
+    // MyTrait methods. So this should NOT trigger.
     other.do_thing();
 }

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
@@ -1,0 +1,70 @@
+#![warn(clippy::disallowed_trait_usage)]
+
+use std::path::{Path, PathBuf};
+
+trait MyTrait {
+    fn do_thing(&self) -> i32;
+}
+
+struct MyStruct;
+
+impl MyTrait for MyStruct {
+    fn do_thing(&self) -> i32 {
+        42
+    }
+}
+
+struct OtherStruct;
+
+impl MyTrait for OtherStruct {
+    fn do_thing(&self) -> i32 {
+        99
+    }
+}
+
+fn main() {
+    // Should trigger: Debug formatting of i32
+    println!("{:?}", 42_i32);
+    //~^ disallowed_trait_usage
+
+    // Should trigger: Debug formatting of PathBuf
+    let path = PathBuf::from("/tmp");
+    println!("{path:?}");
+    //~^ disallowed_trait_usage
+
+    // Should trigger: Debug formatting of &Path
+    let path_ref: &Path = path.as_path();
+    println!("{path_ref:?}");
+    //~^ disallowed_trait_usage
+
+    // Should NOT trigger: Display formatting of i32
+    println!("{}", 42_i32);
+
+    // Should NOT trigger: Debug formatting of String (not in config)
+    let s = String::from("hello");
+    println!("{s:?}");
+
+    // Should trigger: Debug formatting of i32 via format!
+    let _ = format!("{:?}", 0_i32);
+    //~^ disallowed_trait_usage
+
+    // Should trigger: Debug formatting of PathBuf via write!
+    use std::fmt::Write;
+    let mut buf = String::new();
+    write!(buf, "{path:?}").ok();
+    //~^ disallowed_trait_usage
+
+    // Should trigger: custom trait method call on custom type
+    let my = MyStruct;
+    my.do_thing();
+    //~^ disallowed_trait_usage
+
+    // Should trigger: custom trait method call via reference
+    let my_ref = &MyStruct;
+    my_ref.do_thing();
+    //~^ disallowed_trait_usage
+
+    // Should NOT trigger: same custom trait on a different type
+    let other = OtherStruct;
+    other.do_thing();
+}

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
@@ -7,12 +7,20 @@ trait MyTrait {
     fn do_thing(&self) -> i32;
 }
 
+trait MyOtherTrait {
+    fn other_thing(&self);
+}
+
 struct MyStruct;
 
 impl MyTrait for MyStruct {
     fn do_thing(&self) -> i32 {
         42
     }
+}
+
+impl MyOtherTrait for MyStruct {
+    fn other_thing(&self) {}
 }
 
 impl std::fmt::Debug for MyStruct {
@@ -104,10 +112,18 @@ fn main() {
     // Instead, test that Display of MyStruct doesn't trigger (only Debug is disallowed via
     // `implements`). (MyStruct has no Display impl, so we test via the method call path instead.)
 
-    // Should trigger: method call on a type matching `implements` —
-    // OtherStruct implements MyTrait, and MyTrait::do_thing is disallowed on MyStruct (via concrete
-    // `type`), but OtherStruct is NOT matched by the concrete `type` entry. However, it IS matched
-    // by the `implements = MyTrait` + `trait = Debug` entry — but that only covers Debug, not
-    // MyTrait methods. So this should NOT trigger.
+    // Should NOT trigger: OtherStruct implements MyTrait, and MyTrait::do_thing is disallowed on
+    // MyStruct (via `types`), but OtherStruct is not listed there. It IS matched by the
+    // `implements = MyTrait` entry, but that entry only covers Debug, not MyTrait methods.
     other.do_thing();
+
+    // === `all-types` matching ===
+
+    // Should trigger: Pointer formatting is disallowed for every type
+    println!("{:p}", &42_i32);
+    //~^ disallowed_trait_usage
+
+    // Should trigger: MyOtherTrait is disallowed for every type, with no reason given
+    my.other_thing();
+    //~^ disallowed_trait_usage
 }

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs
@@ -117,7 +117,7 @@ fn main() {
     // `implements = MyTrait` entry, but that entry only covers Debug, not MyTrait methods.
     other.do_thing();
 
-    // === `all-types` matching ===
+    // === Unscoped entries: every type ===
 
     // Should trigger: Pointer formatting is disallowed for every type
     println!("{:p}", &42_i32);

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
@@ -1,5 +1,5 @@
 error: use of `i32` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:27:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:28:15
    |
 LL |     println!("{:?}", 42_i32);
    |               ^^^^
@@ -9,7 +9,7 @@ LL |     println!("{:?}", 42_i32);
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_trait_usage)]`
 
 error: use of `std::path::PathBuf` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:32:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:33:15
    |
 LL |     println!("{path:?}");
    |               ^^^^^^^^
@@ -17,7 +17,7 @@ LL |     println!("{path:?}");
    = note: Use path.display() instead
 
 error: use of `std::path::Path` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:37:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:38:15
    |
 LL |     println!("{path_ref:?}");
    |               ^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     println!("{path_ref:?}");
    = note: Use path.display() instead
 
 error: use of `i32` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:48:22
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:49:22
    |
 LL |     let _ = format!("{:?}", 0_i32);
    |                      ^^^^
@@ -33,7 +33,7 @@ LL |     let _ = format!("{:?}", 0_i32);
    = note: Use Display formatting instead
 
 error: use of `std::path::PathBuf` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:54:18
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:55:18
    |
 LL |     write!(buf, "{path:?}").ok();
    |                  ^^^^^^^^
@@ -41,7 +41,7 @@ LL |     write!(buf, "{path:?}").ok();
    = note: Use path.display() instead
 
 error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:59:8
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:60:8
    |
 LL |     my.do_thing();
    |        ^^^^^^^^
@@ -49,12 +49,28 @@ LL |     my.do_thing();
    = note: Use a different approach
 
 error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:64:12
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:65:12
    |
 LL |     my_ref.do_thing();
    |            ^^^^^^^^
    |
    = note: Use a different approach
 
-error: aborting due to 7 previous errors
+error: use of implementor of `std::error::Error` via trait `std::fmt::Debug` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:74:15
+   |
+LL |     println!("{err:?}");
+   |               ^^^^^^^
+   |
+   = note: Use Display for errors
+
+error: use of implementor of `std::error::Error` via trait `std::fmt::Debug` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:78:22
+   |
+LL |     let _ = format!("{:?}", std::io::Error::new(std::io::ErrorKind::Other, "oops"));
+   |                      ^^^^
+   |
+   = note: Use Display for errors
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
@@ -1,5 +1,5 @@
 error: use of `i32` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:28:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:36:15
    |
 LL |     println!("{:?}", 42_i32);
    |               ^^^^
@@ -9,7 +9,7 @@ LL |     println!("{:?}", 42_i32);
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_trait_usage)]`
 
 error: use of `std::path::PathBuf` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:33:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:41:15
    |
 LL |     println!("{path:?}");
    |               ^^^^^^^^
@@ -17,7 +17,7 @@ LL |     println!("{path:?}");
    = note: Use path.display() instead
 
 error: use of `std::path::Path` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:38:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:46:15
    |
 LL |     println!("{path_ref:?}");
    |               ^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     println!("{path_ref:?}");
    = note: Use path.display() instead
 
 error: use of `i32` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:49:22
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:50:22
    |
 LL |     let _ = format!("{:?}", 0_i32);
    |                      ^^^^
@@ -33,7 +33,7 @@ LL |     let _ = format!("{:?}", 0_i32);
    = note: Use Display formatting instead
 
 error: use of `std::path::PathBuf` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:55:18
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:56:18
    |
 LL |     write!(buf, "{path:?}").ok();
    |                  ^^^^^^^^
@@ -41,7 +41,7 @@ LL |     write!(buf, "{path:?}").ok();
    = note: Use path.display() instead
 
 error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:60:8
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:61:8
    |
 LL |     my.do_thing();
    |        ^^^^^^^^
@@ -49,7 +49,7 @@ LL |     my.do_thing();
    = note: Use a different approach
 
 error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:65:12
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:66:12
    |
 LL |     my_ref.do_thing();
    |            ^^^^^^^^
@@ -57,7 +57,7 @@ LL |     my_ref.do_thing();
    = note: Use a different approach
 
 error: use of implementor of `std::error::Error` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:74:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:84:15
    |
 LL |     println!("{err:?}");
    |               ^^^^^^^
@@ -65,12 +65,18 @@ LL |     println!("{err:?}");
    = note: Use Display for errors
 
 error: use of implementor of `std::error::Error` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:78:22
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:88:22
    |
 LL |     let _ = format!("{:?}", std::io::Error::new(std::io::ErrorKind::Other, "oops"));
    |                      ^^^^
    |
    = note: Use Display for errors
 
-error: aborting due to 9 previous errors
+error: use of implementor of `disallowed_trait_usage::MyTrait` via trait `std::fmt::Debug` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:98:15
+   |
+LL |     println!("{my:?}");
+   |               ^^^^^^
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
@@ -73,7 +73,7 @@ LL |     let _ = format!("{:?}", std::io::Error::new(std::io::ErrorKind::Other, 
    = note: Use Display for errors
 
 error: use of implementor of `disallowed_trait_usage::MyTrait` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:98:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:99:15
    |
 LL |     println!("{my:?}");
    |               ^^^^^^

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
@@ -1,0 +1,60 @@
+error: use of `i32` via trait `std::fmt::Debug` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:27:15
+   |
+LL |     println!("{:?}", 42_i32);
+   |               ^^^^
+   |
+   = note: Use Display formatting instead
+   = note: `-D clippy::disallowed-trait-usage` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::disallowed_trait_usage)]`
+
+error: use of `std::path::PathBuf` via trait `std::fmt::Debug` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:32:15
+   |
+LL |     println!("{path:?}");
+   |               ^^^^^^^^
+   |
+   = note: Use path.display() instead
+
+error: use of `std::path::Path` via trait `std::fmt::Debug` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:37:15
+   |
+LL |     println!("{path_ref:?}");
+   |               ^^^^^^^^^^^^
+   |
+   = note: Use path.display() instead
+
+error: use of `i32` via trait `std::fmt::Debug` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:48:22
+   |
+LL |     let _ = format!("{:?}", 0_i32);
+   |                      ^^^^
+   |
+   = note: Use Display formatting instead
+
+error: use of `std::path::PathBuf` via trait `std::fmt::Debug` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:54:18
+   |
+LL |     write!(buf, "{path:?}").ok();
+   |                  ^^^^^^^^
+   |
+   = note: Use path.display() instead
+
+error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:59:8
+   |
+LL |     my.do_thing();
+   |        ^^^^^^^^
+   |
+   = note: Use a different approach
+
+error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:64:12
+   |
+LL |     my_ref.do_thing();
+   |            ^^^^^^^^
+   |
+   = note: Use a different approach
+
+error: aborting due to 7 previous errors
+

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
@@ -1,5 +1,5 @@
 error: use of `i32` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:36:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:44:15
    |
 LL |     println!("{:?}", 42_i32);
    |               ^^^^
@@ -9,7 +9,7 @@ LL |     println!("{:?}", 42_i32);
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_trait_usage)]`
 
 error: use of `std::path::PathBuf` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:41:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:49:15
    |
 LL |     println!("{path:?}");
    |               ^^^^^^^^
@@ -17,15 +17,13 @@ LL |     println!("{path:?}");
    = note: Use path.display() instead
 
 error: use of `std::path::Path` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:46:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:54:15
    |
 LL |     println!("{path_ref:?}");
    |               ^^^^^^^^^^^^
-   |
-   = note: Use path.display() instead
 
 error: use of `i32` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:50:22
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:58:22
    |
 LL |     let _ = format!("{:?}", 0_i32);
    |                      ^^^^
@@ -33,7 +31,7 @@ LL |     let _ = format!("{:?}", 0_i32);
    = note: Use Display formatting instead
 
 error: use of `std::path::PathBuf` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:56:18
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:64:18
    |
 LL |     write!(buf, "{path:?}").ok();
    |                  ^^^^^^^^
@@ -41,7 +39,7 @@ LL |     write!(buf, "{path:?}").ok();
    = note: Use path.display() instead
 
 error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:61:8
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:69:8
    |
 LL |     my.do_thing();
    |        ^^^^^^^^
@@ -49,7 +47,7 @@ LL |     my.do_thing();
    = note: Use a different approach
 
 error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:66:12
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:74:12
    |
 LL |     my_ref.do_thing();
    |            ^^^^^^^^
@@ -57,7 +55,7 @@ LL |     my_ref.do_thing();
    = note: Use a different approach
 
 error: use of implementor of `std::error::Error` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:84:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:92:15
    |
 LL |     println!("{err:?}");
    |               ^^^^^^^
@@ -65,7 +63,7 @@ LL |     println!("{err:?}");
    = note: Use Display for errors
 
 error: use of implementor of `std::error::Error` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:88:22
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:96:22
    |
 LL |     let _ = format!("{:?}", std::io::Error::new(std::io::ErrorKind::Other, "oops"));
    |                      ^^^^
@@ -73,10 +71,24 @@ LL |     let _ = format!("{:?}", std::io::Error::new(std::io::ErrorKind::Other, 
    = note: Use Display for errors
 
 error: use of implementor of `disallowed_trait_usage::MyTrait` via trait `std::fmt::Debug` is disallowed
-  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:99:15
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:107:15
    |
 LL |     println!("{my:?}");
    |               ^^^^^^
 
-error: aborting due to 10 previous errors
+error: use of trait `std::fmt::Pointer` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:123:15
+   |
+LL |     println!("{:p}", &42_i32);
+   |               ^^^^
+   |
+   = note: Addresses are not reproducible
+
+error: use of trait `disallowed_trait_usage::MyOtherTrait` is disallowed
+  --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:127:8
+   |
+LL |     my.other_thing();
+   |        ^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
 

--- a/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.stderr
@@ -45,6 +45,7 @@ LL |     my.do_thing();
    |        ^^^^^^^^
    |
    = note: Use a different approach
+   = note: MyTrait is on its way out
 
 error: use of `disallowed_trait_usage::MyStruct` via trait `disallowed_trait_usage::MyTrait` is disallowed
   --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:74:12
@@ -53,6 +54,7 @@ LL |     my_ref.do_thing();
    |            ^^^^^^^^
    |
    = note: Use a different approach
+   = note: MyTrait is on its way out
 
 error: use of implementor of `std::error::Error` via trait `std::fmt::Debug` is disallowed
   --> tests/ui-toml/toml_disallowed_trait_usage/disallowed_trait_usage.rs:92:15

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml
@@ -1,0 +1,10 @@
+disallowed-trait-usage = [
+    # Non-existent type
+    { type = "std::nonexistent::FakeType", trait = "std::fmt::Debug", reason = "testing" },
+    # Non-existent trait
+    { type = "i32", trait = "std::nonexistent::FakeTrait", reason = "testing" },
+    # Path exists but is a function, not a type
+    { type = "std::mem::swap", trait = "std::fmt::Debug", reason = "testing" },
+    # Path exists but is a struct, not a trait
+    { type = "i32", trait = "std::string::String", reason = "testing" },
+]

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml
@@ -7,4 +7,8 @@ disallowed-trait-usage = [
     { type = "std::mem::swap", trait = "std::fmt::Debug", reason = "testing" },
     # Path exists but is a struct, not a trait
     { type = "i32", trait = "std::string::String", reason = "testing" },
+    # Both type and implements specified (mutually exclusive)
+    { type = "i32", implements = "std::error::Error", trait = "std::fmt::Debug", reason = "testing" },
+    # Neither type nor implements specified
+    { trait = "std::fmt::Debug", reason = "testing" },
 ]

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml
@@ -1,14 +1,18 @@
 disallowed-trait-usage = [
     # Non-existent type
-    { type = "std::nonexistent::FakeType", trait = "std::fmt::Debug", reason = "testing" },
+    { trait = "std::fmt::Debug", types = ["std::nonexistent::FakeType"] },
     # Non-existent trait
-    { type = "i32", trait = "std::nonexistent::FakeTrait", reason = "testing" },
+    { trait = "std::nonexistent::FakeTrait", types = ["i32"] },
     # Path exists but is a function, not a type
-    { type = "std::mem::swap", trait = "std::fmt::Debug", reason = "testing" },
+    { trait = "std::fmt::Debug", types = ["std::mem::swap"] },
     # Path exists but is a struct, not a trait
-    { type = "i32", trait = "std::string::String", reason = "testing" },
-    # Both type and implements specified (mutually exclusive)
-    { type = "i32", implements = "std::error::Error", trait = "std::fmt::Debug", reason = "testing" },
-    # Neither type nor implements specified
-    { trait = "std::fmt::Debug", reason = "testing" },
+    { trait = "std::string::String", types = ["i32"] },
+    # `implements` entry exists but is a struct, not a trait
+    { trait = "std::fmt::Debug", implements = ["std::string::String"] },
+    # `all-types` is redundant when combined with `types` / `implements`
+    { trait = "std::fmt::Pointer", all-types = "testing", types = ["i32"] },
+    # None of `types`, `implements` or `all-types` specified
+    { trait = "std::fmt::Debug" },
+    # Invalid path, silenced by `allow-invalid`
+    { trait = "std::fmt::Debug", types = [{ path = "std::nonexistent::Silenced", allow-invalid = true }] },
 ]

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml
@@ -9,10 +9,6 @@ disallowed-trait-usage = [
     { trait = "std::string::String", types = ["i32"] },
     # `implements` entry exists but is a struct, not a trait
     { trait = "std::fmt::Debug", implements = ["std::string::String"] },
-    # `all-types` is redundant when combined with `types` / `implements`
-    { trait = "std::fmt::Pointer", all-types = "testing", types = ["i32"] },
-    # None of `types`, `implements` or `all-types` specified
-    { trait = "std::fmt::Debug" },
     # Invalid path, silenced by `allow-invalid`
     { trait = "std::fmt::Debug", types = [{ path = "std::nonexistent::Silenced", allow-invalid = true }] },
 ]

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.rs
@@ -1,0 +1,11 @@
+//@error-in-other-file: `std::nonexistent::FakeType` does not refer to a reachable type
+//@error-in-other-file: `std::nonexistent::FakeTrait` does not refer to a reachable trait
+//@error-in-other-file: expected a type, found a function: `std::mem::swap`
+//@error-in-other-file: expected a trait, found a struct: `std::string::String`
+
+#![warn(clippy::disallowed_trait_usage)]
+
+fn main() {
+    // None of these should trigger since all config entries are invalid
+    println!("{:?}", 42_i32);
+}

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.rs
@@ -2,6 +2,8 @@
 //@error-in-other-file: `std::nonexistent::FakeTrait` does not refer to a reachable trait
 //@error-in-other-file: expected a type, found a function: `std::mem::swap`
 //@error-in-other-file: expected a trait, found a struct: `std::string::String`
+//@error-in-other-file: `type` and `implements` are mutually exclusive
+//@error-in-other-file: either `type` or `implements` must be specified
 
 #![warn(clippy::disallowed_trait_usage)]
 

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.rs
@@ -1,9 +1,10 @@
 //@error-in-other-file: `std::nonexistent::FakeType` does not refer to a reachable type
 //@error-in-other-file: `std::nonexistent::FakeTrait` does not refer to a reachable trait
-//@error-in-other-file: expected a type, found a function: `std::mem::swap`
-//@error-in-other-file: expected a trait, found a struct: `std::string::String`
-//@error-in-other-file: `type` and `implements` are mutually exclusive
-//@error-in-other-file: either `type` or `implements` must be specified
+//@error-in-other-file: expected a type, found a function
+//@error-in-other-file: expected a trait, found a struct
+//@error-in-other-file: expected a trait, found a struct
+//@error-in-other-file: `all-types` already covers `types` and `implements`, which are ignored
+//@error-in-other-file: at least one of `types`, `implements` or `all-types` must be specified
 
 #![warn(clippy::disallowed_trait_usage)]
 

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.rs
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.rs
@@ -3,8 +3,6 @@
 //@error-in-other-file: expected a type, found a function
 //@error-in-other-file: expected a trait, found a struct
 //@error-in-other-file: expected a trait, found a struct
-//@error-in-other-file: `all-types` already covers `types` and `implements`, which are ignored
-//@error-in-other-file: at least one of `types`, `implements` or `all-types` must be specified
 
 #![warn(clippy::disallowed_trait_usage)]
 

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
@@ -1,0 +1,10 @@
+warning: `std::nonexistent::FakeType` does not refer to a reachable type (in `disallowed-trait-usage`)
+
+warning: `std::nonexistent::FakeTrait` does not refer to a reachable trait (in `disallowed-trait-usage`)
+
+warning: expected a type, found a function: `std::mem::swap` (in `disallowed-trait-usage`)
+
+warning: expected a trait, found a struct: `std::string::String` (in `disallowed-trait-usage`)
+
+warning: 4 warnings emitted
+

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
@@ -6,5 +6,9 @@ warning: expected a type, found a function: `std::mem::swap` (in `disallowed-tra
 
 warning: expected a trait, found a struct: `std::string::String` (in `disallowed-trait-usage`)
 
-warning: 4 warnings emitted
+warning: `type` and `implements` are mutually exclusive (in `disallowed-trait-usage`)
+
+warning: either `type` or `implements` must be specified (in `disallowed-trait-usage`)
+
+warning: 6 warnings emitted
 

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
@@ -1,14 +1,50 @@
-warning: `std::nonexistent::FakeType` does not refer to a reachable type (in `disallowed-trait-usage`)
+warning: `std::nonexistent::FakeType` does not refer to a reachable type
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:3:5
+   |
+LL |     { trait = "std::fmt::Debug", types = ["std::nonexistent::FakeType"] },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `allow-invalid = true` to the entry to suppress this warning
 
-warning: `std::nonexistent::FakeTrait` does not refer to a reachable trait (in `disallowed-trait-usage`)
+warning: `std::nonexistent::FakeTrait` does not refer to a reachable trait
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:5:5
+   |
+LL |     { trait = "std::nonexistent::FakeTrait", types = ["i32"] },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: expected a type, found a function: `std::mem::swap` (in `disallowed-trait-usage`)
+warning: expected a type, found a function
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:7:5
+   |
+LL |     { trait = "std::fmt::Debug", types = ["std::mem::swap"] },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `allow-invalid = true` to the entry to suppress this warning
 
-warning: expected a trait, found a struct: `std::string::String` (in `disallowed-trait-usage`)
+warning: expected a trait, found a struct
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:9:5
+   |
+LL |     { trait = "std::string::String", types = ["i32"] },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: `type` and `implements` are mutually exclusive (in `disallowed-trait-usage`)
+warning: expected a trait, found a struct
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:11:5
+   |
+LL |     { trait = "std::fmt::Debug", implements = ["std::string::String"] },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `allow-invalid = true` to the entry to suppress this warning
 
-warning: either `type` or `implements` must be specified (in `disallowed-trait-usage`)
+warning: `all-types` already covers `types` and `implements`, which are ignored
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:13:5
+   |
+LL |     { trait = "std::fmt::Pointer", all-types = "testing", types = ["i32"] },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 6 warnings emitted
+warning: at least one of `types`, `implements` or `all-types` must be specified
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:15:5
+   |
+LL |     { trait = "std::fmt::Debug" },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 7 warnings emitted
 

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
@@ -34,17 +34,5 @@ LL |     { trait = "std::fmt::Debug", implements = ["std::string::String"] },
    |
    = help: add `allow-invalid = true` to the entry to suppress this warning
 
-warning: `all-types` already covers `types` and `implements`, which are ignored
-  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:13:5
-   |
-LL |     { trait = "std::fmt::Pointer", all-types = "testing", types = ["i32"] },
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: at least one of `types`, `implements` or `all-types` must be specified
-  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:15:5
-   |
-LL |     { trait = "std::fmt::Debug" },
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: 7 warnings emitted
+warning: 5 warnings emitted
 

--- a/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
+++ b/tests/ui-toml/toml_disallowed_trait_usage_invalid/disallowed_trait_usage_invalid.stderr
@@ -1,8 +1,8 @@
 warning: `std::nonexistent::FakeType` does not refer to a reachable type
-  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:3:5
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:3:43
    |
 LL |     { trait = "std::fmt::Debug", types = ["std::nonexistent::FakeType"] },
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `allow-invalid = true` to the entry to suppress this warning
 
@@ -13,10 +13,10 @@ LL |     { trait = "std::nonexistent::FakeTrait", types = ["i32"] },
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: expected a type, found a function
-  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:7:5
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:7:43
    |
 LL |     { trait = "std::fmt::Debug", types = ["std::mem::swap"] },
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                           ^^^^^^^^^^^^^^^^
    |
    = help: add `allow-invalid = true` to the entry to suppress this warning
 
@@ -27,10 +27,10 @@ LL |     { trait = "std::string::String", types = ["i32"] },
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: expected a trait, found a struct
-  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:11:5
+  --> $DIR/tests/ui-toml/toml_disallowed_trait_usage_invalid/clippy.toml:11:48
    |
 LL |     { trait = "std::fmt::Debug", implements = ["std::string::String"] },
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `allow-invalid = true` to the entry to suppress this warning
 

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -43,6 +43,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            disallowed-macros
            disallowed-methods
            disallowed-names
+           disallowed-trait-usage
            disallowed-types
            doc-valid-idents
            enable-raw-pointer-heuristic-for-send
@@ -147,6 +148,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            disallowed-macros
            disallowed-methods
            disallowed-names
+           disallowed-trait-usage
            disallowed-types
            doc-valid-idents
            enable-raw-pointer-heuristic-for-send
@@ -251,6 +253,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            disallowed-macros
            disallowed-methods
            disallowed-names
+           disallowed-trait-usage
            disallowed-types
            doc-valid-idents
            enable-raw-pointer-heuristic-for-send

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -49,6 +49,7 @@ LL | foobar = 42
            disallowed-macros
            disallowed-methods
            disallowed-names
+           disallowed-trait-usage
            disallowed-types
            doc-valid-idents
            enable-raw-pointer-heuristic-for-send


### PR DESCRIPTION
New lint: `disallowed_trait_usage`

* fixes https://github.com/rust-lang/rust-clippy/issues/15765
* different from, but related to, https://github.com/rust-lang/rust-clippy/pull/8581

---

This adds a new configurable lint [`disallowed_trait_usage`] that lets users forbid using a type via a specific trait interface.

### Motivation

A common mistake is using `Debug` formatting (`{:?}`) where `Display` formatting (`{}`) would be more appropriate, especially for user-facing output like error messages, logs, and GUIs. For example:

```rust
// Bad: Debug formatting of errors is ugly and implementation-specific
let err: std::io::Error = std::fs::read("missing.txt").unwrap_err();
log::warn!("Failed to read file: {err:?}");
// prints: Failed to read file: Os { code: 2, kind: NotFound, message: "No such file or directory" }

// Good: Display formatting is human-readable
log::warn!("Failed to read file: {err}");
// prints: Failed to read file: No such file or directory (os error 2)
```

This applies broadly — paths, errors, and many other types have `Debug` output that is noisy and not meant for end users. There's no way to systematically catch these with existing lints. The `unnecessary_debug_formatting` lint only covers `OsStr` and `Path`, and can't be extended to arbitrary types or project-specific conventions.

### Configuration

Each entry names one trait, plus the types it may not be used on:

* `trait` (required): the disallowed trait
* `types` (optional): concrete types it is disallowed for
* `implements` (optional): traits whose implementors it is disallowed for
* `reason` (optional): why, for the whole entry

An entry with neither `types` nor `implements` disallows the trait for **every** type, and can then be written as a plain path. The entries of `types` and `implements` are a plain path, or a table with the same fields as [`disallowed-types`](https://doc.rust-lang.org/nightly/clippy/lint_configuration.html#disallowed-types) minus `replacement`, so they take a `reason` and `allow-invalid` of their own.

```toml
# clippy.toml:

# Forbid the whole trait:
disallowed-trait-usage = ["std::fmt::Pointer"]

# Optionally include a reason:
[[disallowed-trait-usage]]
trait = "std::fmt::Pointer"
reason = "Do not print addresses"

# Only ban using the trait for some types:
[[disallowed-trait-usage]]
trait = "std::fmt::Debug"
reason = "Debug output is not meant for end users"
# Forbid `Debug` formatting of specific types:
types = [
    { path = "std::path::PathBuf", reason = "Use path.display() instead" },
    "std::path::Path",
    "i32",
]
# Forbid `Debug` formatting of every type implementing these traits:
implements = [
    { path = "std::error::Error", reason = "Use Display for errors" },
]
```

### What it detects

- **Format macro arguments**: `println!("{:?}", my_path)`, `format!("{path:?}")`, `write!(buf, "{:?}", x)`
- **Direct trait method calls**: `my_struct.trait_method()`

Works with:
- Standard library types and traits (e.g. `std::path::PathBuf` + `std::fmt::Debug`)
- Primitive types (`i32`, `bool`, `str`, etc.)
- Custom user-defined types and traits
- All format traits (`Debug`, `Display`, `Binary`, `Octal`, `LowerHex`, `UpperHex`, `LowerExp`, `UpperExp`, `Pointer`)
- References (automatically peeled)
- Trait-bound matching via `implements` (any type implementing the given trait)

### Path validation

Invalid paths produce clear warnings pointing into `clippy.toml`, following the same pattern as `disallowed_types`/`disallowed_methods`:

```
warning: expected a trait, found a struct
  --> clippy.toml:9:5
   |
LL |     { trait = "std::string::String", types = ["i32"] },
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: `std::nonexistent::FakeType` does not refer to a reachable type
  --> clippy.toml:3:43
   |
LL |     { trait = "std::fmt::Debug", types = ["std::nonexistent::FakeType"] },
   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: add `allow-invalid = true` to the entry to suppress this warning
```

changelog: [`disallowed_trait_usage`]: new lint that forbids using a configured type (or implementors of a trait) via a configured trait interface

---

Implemented with a lot of help from Claude Code
