### PR TITLE
Fix: lint groups priority comma

### DIFF
--- a/clippy_lints/src/cargo/lint_groups_priority.rs
+++ b/clippy_lints/src/cargo/lint_groups_priority.rs
@@ -97,7 +97,7 @@ fn check_table(cx: &LateContext<'_>, table: &DeTable<'_>, known_groups: &FxHashS
                     diag.span_suggestion_verbose(
                         config_span,
                         format!(
-                            "to have lints override the group set `{}` to a lower priority",
+                            "to have lints override the group, set `{}` to a lower priority",
                             group.as_ref()
                         ),
                         format!("{{ level = {:?}, priority = {low_priority} }}", group_config.level),

--- a/tests/ui-cargo/lint_groups_priority/fail/Cargo.stderr
+++ b/tests/ui-cargo/lint_groups_priority/fail/Cargo.stderr
@@ -9,7 +9,7 @@ error: lint group `rust_2018_idioms` has the same priority (0) as a lint
    |
    = note: the order of the lints in the table is ignored by Cargo
    = note: `#[deny(clippy::lint_groups_priority)]` on by default
-help: to have lints override the group set `rust_2018_idioms` to a lower priority
+help: to have lints override the group, set `rust_2018_idioms` to a lower priority
    |
  7 - rust_2018_idioms = "warn"
  7 + rust_2018_idioms = { level = "warn", priority = -1 }
@@ -20,12 +20,12 @@ error: lint group `unused` has the same priority (0) as a lint
    |
 10 | unused = { level = "deny" }
    | ^^^^^^   ------------------ has an implicit priority of 0
-11 | unused_braces = { level = "allow", priority = 1 }
+11 | unused_braces = { level = "allow", p...
 12 | unused_attributes = { level = "allow" }
    | ----------------- has the same priority as this lint
    |
    = note: the order of the lints in the table is ignored by Cargo
-help: to have lints override the group set `unused` to a lower priority
+help: to have lints override the group, set `unused` to a lower priority
    |
 10 | unused = { level = "deny", priority = -1 }
    |                          +++++++++++++++
@@ -35,11 +35,11 @@ error: lint group `pedantic` has the same priority (-1) as a lint
    |
 15 | pedantic = { level = "warn", priority = -1 }
    | ^^^^^^^^
-16 | similar_names = { level = "allow", priority = -1 }
+16 | similar_names = { level = "allow", priority =...
    | ------------- has the same priority as this lint
    |
    = note: the order of the lints in the table is ignored by Cargo
-help: to have lints override the group set `pedantic` to a lower priority
+help: to have lints override the group, set `pedantic` to a lower priority
    |
 15 - pedantic = { level = "warn", priority = -1 }
 15 + pedantic = { level = "warn", priority = -2 }
@@ -54,7 +54,7 @@ error: lint group `rust_2018_idioms` has the same priority (0) as a lint
    | ------------------ has the same priority as this lint
    |
    = note: the order of the lints in the table is ignored by Cargo
-help: to have lints override the group set `rust_2018_idioms` to a lower priority
+help: to have lints override the group, set `rust_2018_idioms` to a lower priority
    |
 19 - rust_2018_idioms = "warn"
 19 + rust_2018_idioms = { level = "warn", priority = -1 }
@@ -69,7 +69,7 @@ error: lint group `pedantic` has the same priority (0) as a lint
    | ------------- has the same priority as this lint
    |
    = note: the order of the lints in the table is ignored by Cargo
-help: to have lints override the group set `pedantic` to a lower priority
+help: to have lints override the group, set `pedantic` to a lower priority
    |
 23 - pedantic = "warn"
 23 + pedantic = { level = "warn", priority = -1 }


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16812

Adding a missing comma to the diagnostic suggestion text of the `lint_groups_priority` lint to fix grammatically phrasing.

changelog: [`lint_groups_priority`]: Fixed missing comma in diagnostic suggestion text.
