### PR TITLE
Fixed short span (duplicate match arms) in match_same_arms lint

### DIFF
--- a/clippy_lints/src/matches/match_same_arms.rs
+++ b/clippy_lints/src/matches/match_same_arms.rs
@@ -117,10 +117,14 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'_>]) {
             continue;
         }
 
+        // Skip the first (original) arm and only highlight duplicates.
+        // This avoids pointing at the non-redundant arm and keeps the lint clear.
+        let spans = group.iter().skip(1).map(|(_, arm)| arm.span).collect_vec();
+
         span_lint_and_then(
             cx,
             MATCH_SAME_ARMS,
-            group.iter().map(|(_, arm)| arm.span).collect_vec(),
+            spans,
             "these match arms have identical bodies",
             |diag| {
                 diag.help("if this is unintentional make the arms return different values");

--- a/tests/ui/span_in_match_same_arm.fixed
+++ b/tests/ui/span_in_match_same_arm.fixed
@@ -1,0 +1,11 @@
+#![warn(clippy::match_same_arms)]
+
+fn main() {
+    let x = 2;
+
+    match x {
+        2 => println!("different"),
+        1 | 3 => println!("same"),//~ ERROR: these match arms have identical bodies
+        _ => println!("other"),
+    }
+}

--- a/tests/ui/span_in_match_same_arm.fixed
+++ b/tests/ui/span_in_match_same_arm.fixed
@@ -5,7 +5,8 @@ fn main() {
 
     match x {
         2 => println!("different"),
-        1 | 3 => println!("same"),//~ ERROR: these match arms have identical bodies
+        //~ ERROR: these match arms have identical bodies
+        1 | 3 | 4 => println!("same"),
         _ => println!("other"),
     }
 }

--- a/tests/ui/span_in_match_same_arm.fixed
+++ b/tests/ui/span_in_match_same_arm.fixed
@@ -1,12 +1,12 @@
 #![warn(clippy::match_same_arms)]
 
-fn main() {
-    let x = 2;
+fn multiple_duplicate_groups() {
+    let y = 5;
 
-    match x {
-        2 => println!("different"),
+    match y {
         //~ ERROR: these match arms have identical bodies
-        1 | 3 | 4 => println!("same"),
+        3 => println!("different"),
+        1 | 2 | 4 | 5 => println!("same"),
         _ => println!("other"),
     }
 }

--- a/tests/ui/span_in_match_same_arm.rs
+++ b/tests/ui/span_in_match_same_arm.rs
@@ -1,13 +1,14 @@
 #![warn(clippy::match_same_arms)]
 
-fn main() {
-    let x = 2;
+fn multiple_duplicate_groups() {
+    let y = 5;
 
-    match x {
+    match y {
         1 => println!("same"),
-        2 => println!("different"),
-        3 => println!("same"), //~ ERROR: these match arms have identical bodies
+        2 => println!("same"), //~ ERROR: these match arms have identical bodies
+        3 => println!("different"),
         4 => println!("same"),
+        5 => println!("same"),
         _ => println!("other"),
     }
 }

--- a/tests/ui/span_in_match_same_arm.rs
+++ b/tests/ui/span_in_match_same_arm.rs
@@ -6,7 +6,8 @@ fn main() {
     match x {
         1 => println!("same"),
         2 => println!("different"),
-        3 => println!("same"),//~ ERROR: these match arms have identical bodies
+        3 => println!("same"), //~ ERROR: these match arms have identical bodies
+        4 => println!("same"),
         _ => println!("other"),
     }
 }

--- a/tests/ui/span_in_match_same_arm.rs
+++ b/tests/ui/span_in_match_same_arm.rs
@@ -1,0 +1,12 @@
+#![warn(clippy::match_same_arms)]
+
+fn main() {
+    let x = 2;
+
+    match x {
+        1 => println!("same"),
+        2 => println!("different"),
+        3 => println!("same"),//~ ERROR: these match arms have identical bodies
+        _ => println!("other"),
+    }
+}

--- a/tests/ui/span_in_match_same_arm.stderr
+++ b/tests/ui/span_in_match_same_arm.stderr
@@ -3,6 +3,8 @@ error: these match arms have identical bodies
    |
 LL |         3 => println!("same"),
    |         ^^^^^^^^^^^^^^^^^^^^^
+LL |         4 => println!("same"),
+   |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if this is unintentional make the arms return different values
    = note: `-D clippy::match-same-arms` implied by `-D warnings`
@@ -10,7 +12,8 @@ LL |         3 => println!("same"),
 help: otherwise merge the patterns into a single arm
    |
 LL ~         2 => println!("different"),
-LL ~         1 | 3 => println!("same"),
+LL ~
+LL ~         1 | 3 | 4 => println!("same"),
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/span_in_match_same_arm.stderr
+++ b/tests/ui/span_in_match_same_arm.stderr
@@ -1,0 +1,17 @@
+error: these match arms have identical bodies
+  --> tests/ui/span_in_match_same_arm.rs:9:9
+   |
+LL |         3 => println!("same"),
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is unintentional make the arms return different values
+   = note: `-D clippy::match-same-arms` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::match_same_arms)]`
+help: otherwise merge the patterns into a single arm
+   |
+LL ~         2 => println!("different"),
+LL ~         1 | 3 => println!("same"),
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/span_in_match_same_arm.stderr
+++ b/tests/ui/span_in_match_same_arm.stderr
@@ -1,9 +1,12 @@
 error: these match arms have identical bodies
-  --> tests/ui/span_in_match_same_arm.rs:9:9
+  --> tests/ui/span_in_match_same_arm.rs:8:9
    |
-LL |         3 => println!("same"),
+LL |         2 => println!("same"),
    |         ^^^^^^^^^^^^^^^^^^^^^
+LL |         3 => println!("different"),
 LL |         4 => println!("same"),
+   |         ^^^^^^^^^^^^^^^^^^^^^
+LL |         5 => println!("same"),
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if this is unintentional make the arms return different values
@@ -11,9 +14,9 @@ LL |         4 => println!("same"),
    = help: to override `-D warnings` add `#[allow(clippy::match_same_arms)]`
 help: otherwise merge the patterns into a single arm
    |
-LL ~         2 => println!("different"),
 LL ~
-LL ~         1 | 3 | 4 => println!("same"),
+LL |         3 => println!("different"),
+LL ~         1 | 2 | 4 | 5 => println!("same"),
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
changelog: [`match_same_arms`]: highlight only duplicate match arms instead of the original arm

Previously, the lint highlighted the first (original) match arm when identical arms were detected. I added UI tests to verify this behavior.

However, the lint should point to the duplicate arms rather than the original one. This change updates the span to include only duplicate arms by skipping the first element in the group, ensuring that the diagnostic points to the actual redundant code.

All tests pass, and the `.stderr` / `.fixed` outputs are updated accordingly.

This change addresses part of the Outreachy task described in:
https://github.com/rustfoundation/interop-initiative/issues/53
