### PR TITLE
Fix `unused_async` FP for stubs with args

### DIFF
--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -211,7 +211,6 @@ fn async_fn_contains_todo_unimplemented_macro(cx: &LateContext<'_>, body: &Body<
         && let ClosureKind::Coroutine(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) = closure.kind
         && let body = cx.tcx.hir_body(closure.body)
         && let ExprKind::Block(block, _) = body.value.kind
-        && block.stmts.is_empty()
         && let Some(expr) = block.expr
         && let ExprKind::DropTemps(inner) = expr.kind
     {

--- a/tests/ui/unused_async.rs
+++ b/tests/ui/unused_async.rs
@@ -134,3 +134,14 @@ mod issue15305 {
         unimplemented!("Implement task");
     }
 }
+
+mod issue16835 {
+    async fn todo_task(_arg: i32) {
+        todo!()
+    }
+
+    async fn unimplemented_task(_arg: i32) {
+        let a = 1;
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16825 

changelog: [`unused_async`] fix FP for stubs with args
