### PR TITLE
fix: suppress `from_over_into` when blanket From impl would conflict

### DIFF
--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -80,6 +80,7 @@ impl<'tcx> LateLintPass<'tcx> for FromOverInto {
             && cx.tcx.is_diagnostic_item(sym::Into, middle_trait_ref.def_id)
             && !matches!(middle_trait_ref.args.type_at(1).kind(), ty::Alias(ty::Opaque, _))
             && self.msrv.meets(cx, msrvs::RE_REBALANCING_COHERENCE)
+            && !has_blanket_from_impl(cx, middle_trait_ref.self_ty())
         {
             span_lint_and_then(
                 cx,
@@ -235,4 +236,33 @@ fn convert_to_from(
     }
 
     Some(suggestions)
+}
+
+/// Checks if a type has a `From` impl with generic type parameters in the source position.
+///
+/// For example, `impl<T> From<T> for Foo where String: From<T>` has a generic `T` in the
+/// source (`From<T>`). When such an impl exists, converting `impl Into<Target> for Foo` to
+/// `impl From<Foo> for Target` could create a coherence conflict with the blanket
+/// `impl<T> From<T> for T` in core.
+fn has_blanket_from_impl<'tcx>(cx: &LateContext<'tcx>, self_ty: ty::Ty<'tcx>) -> bool {
+    let Some(from_def_id) = cx.tcx.get_diagnostic_item(sym::From) else {
+        return false;
+    };
+
+    // Check non-blanket From impls for self_ty. Look for impls where the source type
+    // (the `T` in `From<T>`) is a generic parameter. For example:
+    //   `impl<T> From<T> for Foo where String: From<T>`
+    // When such an impl exists, adding `impl From<Foo> for String` could satisfy the
+    // where clause and create a coherence conflict with `impl<T> From<T> for T` in core.
+    for impl_def_id in cx.tcx.non_blanket_impls_for_ty(from_def_id, self_ty) {
+        let impl_trait_ref = cx.tcx.impl_trait_ref(impl_def_id).instantiate_identity();
+        // The source type is the first generic arg of `From<Source>`
+        let source_ty = impl_trait_ref.args.type_at(1);
+        // If the source type is a type parameter, this is a blanket-like From impl
+        if matches!(source_ty.kind(), ty::Param(_)) {
+            return true;
+        }
+    }
+
+    false
 }

--- a/tests/ui/from_over_into.fixed
+++ b/tests/ui/from_over_into.fixed
@@ -116,4 +116,27 @@ fn issue_112502() {
     }
 }
 
+// Blanket From impl should suppress the lint to avoid coherence conflicts (issue #16823)
+mod issue_16823 {
+    pub struct Foo(pub String);
+
+    impl<T> From<T> for Foo
+    where
+        String: From<T>,
+    {
+        fn from(label: T) -> Self {
+            Self(String::from(label))
+        }
+    }
+
+    // This should NOT trigger from_over_into because converting to
+    // `impl From<Foo> for String` would conflict with the blanket impl above
+    // (via `impl<T> From<T> for T` in core).
+    impl Into<String> for Foo {
+        fn into(self) -> String {
+            self.0
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/from_over_into.rs
+++ b/tests/ui/from_over_into.rs
@@ -116,4 +116,27 @@ fn issue_112502() {
     }
 }
 
+// Blanket From impl should suppress the lint to avoid coherence conflicts (issue #16823)
+mod issue_16823 {
+    pub struct Foo(pub String);
+
+    impl<T> From<T> for Foo
+    where
+        String: From<T>,
+    {
+        fn from(label: T) -> Self {
+            Self(String::from(label))
+        }
+    }
+
+    // This should NOT trigger from_over_into because converting to
+    // `impl From<Foo> for String` would conflict with the blanket impl above
+    // (via `impl<T> From<T> for T` in core).
+    impl Into<String> for Foo {
+        fn into(self) -> String {
+            self.0
+        }
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16823

When a type has a generic `From` impl like:
```rust
impl<T> From<T> for Foo where String: From<T> { ... }
```

The `from_over_into` lint would suggest converting `impl Into<String> for Foo` to `impl From<Foo> for String`. But that causes a coherence conflict (E0119) because it makes the blanket impl's where clause satisfiable, which overlaps with core's `impl<T> From<T> for T`.

**Before:** lint fires, suggestion doesn't compile
```
warning: an implementation of `From` is preferred since it gives you `Into<_>` for free
  --> src/lib.rs:13:1
   |
13 | impl Into<String> for Foo {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: replace the `Into` implementation with `From<Foo>`
```

**After:** lint correctly suppressed, no false positive

The fix checks whether the self type has any `From` impl where the source type is a bare generic parameter (like `impl<T> From<T> for Foo`). If so, the lint is skipped.

Added a test case with the exact reproducer from the issue.

changelog: [`from_over_into`]: don't suggest `From` conversion when a generic `From` impl would cause a coherence conflict