### PR TITLE
fix: `unused_async` false positive when async fn has arguments

### DIFF
--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -211,7 +211,9 @@ fn async_fn_contains_todo_unimplemented_macro(cx: &LateContext<'_>, body: &Body<
         && let ClosureKind::Coroutine(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) = closure.kind
         && let body = cx.tcx.hir_body(closure.body)
         && let ExprKind::Block(block, _) = body.value.kind
-        && block.stmts.is_empty()
+        // Don't require stmts.is_empty() — rustc desugars async fn arguments
+        // into `let` bindings inside the async block body, so a function like
+        // `async fn f(_arg: i32) { todo!() }` will have non-empty stmts.
         && let Some(expr) = block.expr
         && let ExprKind::DropTemps(inner) = expr.kind
     {

--- a/tests/ui/unused_async.rs
+++ b/tests/ui/unused_async.rs
@@ -134,3 +134,16 @@ mod issue15305 {
         unimplemented!("Implement task");
     }
 }
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/16825
+// `unused_async` should not fire when the body is `todo!()` or `unimplemented!()`,
+// even if the function has arguments (rustc desugars them into let bindings).
+mod issue16825 {
+    async fn todo_with_arg(_arg: i32) {
+        todo!()
+    }
+
+    async fn unimplemented_with_arg(_a: String, _b: bool) {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16825

`unused_async` fires on `async fn test(_arg: i32) { todo!() }` even though the body is just a placeholder stub.

The lint has a check for `todo!()`/`unimplemented!()` stubs to suppress the warning on placeholder functions. But it required `block.stmts.is_empty()` before checking the tail expression. When the async fn has arguments, rustc desugars them into `let` bindings inside the async block body — so `stmts` is non-empty and the todo check never runs.

**Before:**
```rust
async fn test(_arg: i32) {
    todo!()  // triggers unused_async — false positive
}
```

**After:**
```rust
async fn test(_arg: i32) {
    todo!()  // no warning — correctly recognized as a stub
}
```

Removed the `stmts.is_empty()` requirement. The tail expression is now checked for `todo!()`/`unimplemented!()` regardless of argument bindings.

Added test cases with single and multiple arguments.

changelog: [`unused_async`]: don't fire on `todo!()`/`unimplemented!()` stubs when the async fn has arguments