### PR TITLE
fix: `single_match` emits compilable code when matching bool expressions

### DIFF
--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -14,7 +14,7 @@ use rustc_hir::intravisit::{Visitor, walk_pat};
 use rustc_hir::{Arm, Expr, ExprKind, HirId, Node, Pat, PatExpr, PatExprKind, PatKind, QPath, StmtKind};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, AdtDef, TyCtxt, TypeckResults, VariantDef};
-use rustc_span::Span;
+use rustc_span::{Span, SyntaxContext};
 
 use super::{MATCH_BOOL, SINGLE_MATCH, SINGLE_MATCH_ELSE};
 
@@ -82,9 +82,9 @@ pub(crate) fn check<'tcx>(
     }
 }
 
-fn report_single_pattern(
-    cx: &LateContext<'_>,
-    ex: &Expr<'_>,
+fn report_single_pattern<'tcx>(
+    cx: &LateContext<'tcx>,
+    ex: &'tcx Expr<'_>,
     arm: &Arm<'_>,
     expr: &Expr<'_>,
     els: Option<&Expr<'_>>,
@@ -165,21 +165,11 @@ fn report_single_pattern(
 
         let msg = "you seem to be trying to use `match` for an equality check. Consider using `if`";
         let body = expr_block(cx, arm.body, ctxt, "..", Some(expr.span), &mut app);
-        // When matching a `bool` scrutinee against a literal `true`/`false` pattern,
-        // emit `if <scrutinee>` / `if !<scrutinee>` directly instead of the awkward
-        // `if <scrutinee> == true`. The `Sugg::not` impl rewrites `==`/`!=`/etc. into
-        // their inverses (e.g. `i == 1` -> `i != 1`) and adds parentheses where needed.
-        let sugg = if let PatKind::Expr(PatExpr {
-            kind: PatExprKind::Lit { lit, negated: false },
-            ..
-        }) = pat.kind
-            && let LitKind::Bool(pat_is_true) = lit.node
-            && ty.is_bool()
+        let sugg = if ty.is_bool()
             && ref_or_deref_adjust.is_empty()
+            && let Some(sugg) = bool_literal_if_sugg(cx, ex, pat, ctxt, &body, &els_str, &mut app)
         {
-            let scrutinee = Sugg::hir_with_context(cx, ex, ctxt, "..", &mut app);
-            let cond = if pat_is_true { scrutinee } else { !scrutinee };
-            format!("if {cond} {body}{els_str}")
+            sugg
         } else {
             // For non-bool patterns the scrutinee may need parentheses to avoid
             // non-compiling chained comparisons like `i == 1 == 1`.
@@ -212,6 +202,34 @@ fn report_single_pattern(
         diag.span_suggestion(expr.span, "try", sugg, app);
         note(diag);
     });
+}
+
+/// When matching a literal `true`/`false` pattern, returns the suggested
+/// `if <expr>` / `if !<expr>` form. The caller is expected to ensure the
+/// scrutinee is a `bool` with no ref/deref adjustment. `Sugg::not` rewrites
+/// comparison operators into their inverses (e.g. `i == 1` -> `i != 1`) and
+/// adds parentheses where needed.
+fn bool_literal_if_sugg<'tcx>(
+    cx: &LateContext<'tcx>,
+    ex: &'tcx Expr<'_>,
+    pat: &Pat<'_>,
+    ctxt: SyntaxContext,
+    body: &str,
+    els_str: &str,
+    app: &mut Applicability,
+) -> Option<String> {
+    if let PatKind::Expr(PatExpr {
+        kind: PatExprKind::Lit { lit, negated: false },
+        ..
+    }) = pat.kind
+        && let LitKind::Bool(pat_is_true) = lit.node
+    {
+        let scrutinee = Sugg::hir_with_context(cx, ex, ctxt, "..", app);
+        let cond = if pat_is_true { scrutinee } else { !scrutinee };
+        Some(format!("if {cond} {body}{els_str}"))
+    } else {
+        None
+    }
 }
 
 struct PatVisitor<'tcx> {

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -7,6 +7,7 @@ use clippy_utils::ty::{implements_trait, peel_and_count_ty_refs};
 use clippy_utils::{is_lint_allowed, is_unit_expr, peel_blocks, peel_hir_pat_refs, peel_n_hir_expr_refs, sym};
 use core::ops::ControlFlow;
 use rustc_arena::DroplessArena;
+use rustc_ast::LitKind;
 use rustc_errors::{Applicability, Diag};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::{Visitor, walk_pat};
@@ -163,25 +164,38 @@ fn report_single_pattern(
         };
 
         let msg = "you seem to be trying to use `match` for an equality check. Consider using `if`";
-        // Use `Sugg` to wrap the scrutinee so that operator precedence is
-        // handled automatically (e.g. `i == 1` becomes `(i == 1) == true`
-        // instead of the non-compiling `i == 1 == true`).
-        let scrutinee = Sugg::hir_with_context(cx, ex, ctxt, "..", &mut app);
-        // Parenthesize binary operator scrutinees to avoid non-compiling
-        // chained comparisons like `i == 1 == true`.
-        let scrutinee = if matches!(scrutinee, Sugg::BinOp(..)) {
-            scrutinee.maybe_paren()
+        let body = expr_block(cx, arm.body, ctxt, "..", Some(expr.span), &mut app);
+        // When matching a `bool` scrutinee against a literal `true`/`false` pattern,
+        // emit `if <scrutinee>` / `if !<scrutinee>` directly instead of the awkward
+        // `if <scrutinee> == true`. The `Sugg::not` impl rewrites `==`/`!=`/etc. into
+        // their inverses (e.g. `i == 1` -> `i != 1`) and adds parentheses where needed.
+        let sugg = if let PatKind::Expr(PatExpr {
+            kind: PatExprKind::Lit { lit, negated: false },
+            ..
+        }) = pat.kind
+            && let LitKind::Bool(pat_is_true) = lit.node
+            && ty.is_bool()
+            && ref_or_deref_adjust.is_empty()
+        {
+            let scrutinee = Sugg::hir_with_context(cx, ex, ctxt, "..", &mut app);
+            let cond = if pat_is_true { scrutinee } else { !scrutinee };
+            format!("if {cond} {body}{els_str}")
         } else {
-            scrutinee
+            // For non-bool patterns the scrutinee may need parentheses to avoid
+            // non-compiling chained comparisons like `i == 1 == 1`.
+            let scrutinee = Sugg::hir_with_context(cx, ex, ctxt, "..", &mut app);
+            let scrutinee = if matches!(scrutinee, Sugg::BinOp(..)) {
+                scrutinee.maybe_paren()
+            } else {
+                scrutinee
+            };
+            format!(
+                "if {scrutinee} == {}{} {body}{els_str}",
+                // PartialEq for different reference counts may not exist.
+                ref_or_deref_adjust,
+                snippet_with_applicability(cx, arm.pat.span, "..", &mut app),
+            )
         };
-        let sugg = format!(
-            "if {} == {}{} {}{els_str}",
-            scrutinee,
-            // PartialEq for different reference counts may not exist.
-            ref_or_deref_adjust,
-            snippet_with_applicability(cx, arm.pat.span, "..", &mut app),
-            expr_block(cx, arm.body, ctxt, "..", Some(expr.span), &mut app),
-        );
         (msg, sugg)
     } else {
         let msg = "you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`";

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -2,6 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::{
     SpanRangeExt, expr_block, snippet, snippet_block_with_context, snippet_with_applicability, snippet_with_context,
 };
+use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::{implements_trait, peel_and_count_ty_refs};
 use clippy_utils::{is_lint_allowed, is_unit_expr, peel_blocks, peel_hir_pat_refs, peel_n_hir_expr_refs, sym};
 use core::ops::ControlFlow;
@@ -129,7 +130,7 @@ fn report_single_pattern(
     }
 
     let (pat, pat_ref_count) = peel_hir_pat_refs(arm.pat);
-    let (msg, sugg) = if let PatKind::Expr(pat_expr) = pat.kind
+    let (msg, sugg) = if let PatKind::Expr(_) = pat.kind
         && let (ty, ty_ref_count, _) = peel_and_count_ty_refs(cx.typeck_results().expr_ty(ex))
         && let Some(spe_trait_id) = cx.tcx.lang_items().structural_peq_trait()
         && let Some(pe_trait_id) = cx.tcx.lang_items().eq_trait()
@@ -138,34 +139,6 @@ fn report_single_pattern(
             || ty.is_str()
             || (implements_trait(cx, ty, spe_trait_id, &[]) && implements_trait(cx, ty, pe_trait_id, &[ty.into()])))
     {
-        // When matching on `true` or `false` from an expression result,
-        // emit `if <expr>` or `if !(<expr>)` instead of `if <expr> == true`
-        // to avoid chained comparisons like `if i == 1 == true`.
-        if ty.is_bool()
-            && let PatExprKind::Lit { lit, negated: false } = pat_expr.kind
-            && let rustc_ast::LitKind::Bool(pat_bool) = lit.node
-        {
-            let cond = snippet_with_context(cx, ex.span, ctxt, "..", &mut app).0;
-            let msg = "you seem to be trying to use `match` for an equality check. Consider using `if`";
-            let sugg = if pat_bool {
-                format!(
-                    "if {} {}{els_str}",
-                    cond,
-                    expr_block(cx, arm.body, ctxt, "..", Some(expr.span), &mut app),
-                )
-            } else {
-                format!(
-                    "if !({}) {}{els_str}",
-                    cond,
-                    expr_block(cx, arm.body, ctxt, "..", Some(expr.span), &mut app),
-                )
-            };
-            return span_lint_and_then(cx, lint, expr.span, msg, |diag| {
-                diag.span_suggestion(expr.span, "try", sugg, app);
-                note(diag);
-            });
-        }
-
         // scrutinee derives PartialEq and the pattern is a constant.
         let pat_ref_count = match pat.kind {
             // string literals are already a reference.
@@ -190,9 +163,20 @@ fn report_single_pattern(
         };
 
         let msg = "you seem to be trying to use `match` for an equality check. Consider using `if`";
+        // Use `Sugg` to wrap the scrutinee so that operator precedence is
+        // handled automatically (e.g. `i == 1` becomes `(i == 1) == true`
+        // instead of the non-compiling `i == 1 == true`).
+        let scrutinee = Sugg::hir_with_context(cx, ex, ctxt, "..", &mut app);
+        // Parenthesize binary operator scrutinees to avoid non-compiling
+        // chained comparisons like `i == 1 == true`.
+        let scrutinee = if matches!(scrutinee, Sugg::BinOp(..)) {
+            scrutinee.maybe_paren()
+        } else {
+            scrutinee
+        };
         let sugg = format!(
             "if {} == {}{} {}{els_str}",
-            snippet_with_context(cx, ex.span, ctxt, "..", &mut app).0,
+            scrutinee,
             // PartialEq for different reference counts may not exist.
             ref_or_deref_adjust,
             snippet_with_applicability(cx, arm.pat.span, "..", &mut app),

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -129,7 +129,7 @@ fn report_single_pattern(
     }
 
     let (pat, pat_ref_count) = peel_hir_pat_refs(arm.pat);
-    let (msg, sugg) = if let PatKind::Expr(_) = pat.kind
+    let (msg, sugg) = if let PatKind::Expr(pat_expr) = pat.kind
         && let (ty, ty_ref_count, _) = peel_and_count_ty_refs(cx.typeck_results().expr_ty(ex))
         && let Some(spe_trait_id) = cx.tcx.lang_items().structural_peq_trait()
         && let Some(pe_trait_id) = cx.tcx.lang_items().eq_trait()
@@ -138,6 +138,34 @@ fn report_single_pattern(
             || ty.is_str()
             || (implements_trait(cx, ty, spe_trait_id, &[]) && implements_trait(cx, ty, pe_trait_id, &[ty.into()])))
     {
+        // When matching on `true` or `false` from an expression result,
+        // emit `if <expr>` or `if !(<expr>)` instead of `if <expr> == true`
+        // to avoid chained comparisons like `if i == 1 == true`.
+        if ty.is_bool()
+            && let PatExprKind::Lit { lit, negated: false } = pat_expr.kind
+            && let rustc_ast::LitKind::Bool(pat_bool) = lit.node
+        {
+            let cond = snippet_with_context(cx, ex.span, ctxt, "..", &mut app).0;
+            let msg = "you seem to be trying to use `match` for an equality check. Consider using `if`";
+            let sugg = if pat_bool {
+                format!(
+                    "if {} {}{els_str}",
+                    cond,
+                    expr_block(cx, arm.body, ctxt, "..", Some(expr.span), &mut app),
+                )
+            } else {
+                format!(
+                    "if !({}) {}{els_str}",
+                    cond,
+                    expr_block(cx, arm.body, ctxt, "..", Some(expr.span), &mut app),
+                )
+            };
+            return span_lint_and_then(cx, lint, expr.span, msg, |diag| {
+                diag.span_suggestion(expr.span, "try", sugg, app);
+                note(diag);
+            });
+        }
+
         // scrutinee derives PartialEq and the pattern is a constant.
         let pat_ref_count = match pat.kind {
             // string literals are already a reference.

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -403,3 +403,15 @@ fn issue14493() {
         _ => println!("neq"),
     }
 }
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/16826
+// Matching on `true`/`false` from a comparison should emit `if <expr>`, not `if <expr> == true`.
+fn issue_16826() {
+    let i = 2;
+    if i == 1 {
+        println!("{i}");
+    }
+    if !(i == 1) {
+        println!("{i}");
+    }
+}

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -6,7 +6,8 @@
     clippy::needless_ifs,
     clippy::redundant_guards,
     clippy::redundant_pattern_matching,
-    clippy::manual_unwrap_or_default
+    clippy::manual_unwrap_or_default,
+    clippy::bool_comparison
 )]
 fn dummy() {}
 
@@ -405,13 +406,13 @@ fn issue14493() {
 }
 
 // Regression test for https://github.com/rust-lang/rust-clippy/issues/16826
-// Matching on `true`/`false` from a comparison should emit `if <expr>`, not `if <expr> == true`.
+// Matching on `true`/`false` from a comparison should emit compilable code.
 fn issue_16826() {
     let i = 2;
-    if i == 1 {
+    if (i == 1) == true {
         println!("{i}");
     }
-    if !(i == 1) {
+    if (i == 1) == false {
         println!("{i}");
     }
 }

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -6,8 +6,7 @@
     clippy::needless_ifs,
     clippy::redundant_guards,
     clippy::redundant_pattern_matching,
-    clippy::manual_unwrap_or_default,
-    clippy::bool_comparison
+    clippy::manual_unwrap_or_default
 )]
 fn dummy() {}
 
@@ -409,10 +408,10 @@ fn issue14493() {
 // Matching on `true`/`false` from a comparison should emit compilable code.
 fn issue_16826() {
     let i = 2;
-    if (i == 1) == true {
+    if i == 1 {
         println!("{i}");
     }
-    if (i == 1) == false {
+    if i != 1 {
         println!("{i}");
     }
 }

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -6,8 +6,7 @@
     clippy::needless_ifs,
     clippy::redundant_guards,
     clippy::redundant_pattern_matching,
-    clippy::manual_unwrap_or_default,
-    clippy::bool_comparison
+    clippy::manual_unwrap_or_default
 )]
 fn dummy() {}
 

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -6,7 +6,8 @@
     clippy::needless_ifs,
     clippy::redundant_guards,
     clippy::redundant_pattern_matching,
-    clippy::manual_unwrap_or_default
+    clippy::manual_unwrap_or_default,
+    clippy::bool_comparison
 )]
 fn dummy() {}
 
@@ -506,7 +507,7 @@ fn issue14493() {
 }
 
 // Regression test for https://github.com/rust-lang/rust-clippy/issues/16826
-// Matching on `true`/`false` from a comparison should emit `if <expr>`, not `if <expr> == true`.
+// Matching on `true`/`false` from a comparison should emit compilable code.
 fn issue_16826() {
     let i = 2;
     match i == 1 {

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -504,3 +504,23 @@ fn issue14493() {
         _ => println!("neq"),
     }
 }
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/16826
+// Matching on `true`/`false` from a comparison should emit `if <expr>`, not `if <expr> == true`.
+fn issue_16826() {
+    let i = 2;
+    match i == 1 {
+        //~^ single_match
+        true => {
+            println!("{i}");
+        },
+        false => (),
+    }
+    match i == 1 {
+        //~^ single_match
+        false => {
+            println!("{i}");
+        },
+        true => (),
+    }
+}

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -339,5 +339,45 @@ LL | |         _ => (),
 LL | |     }
    | |_____^ help: try: `if mac!(str) == "foo" { println!("eq") }`
 
-error: aborting due to 31 previous errors
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match.rs:512:5
+   |
+LL | /     match i == 1 {
+LL | |
+LL | |         true => {
+LL | |             println!("{i}");
+LL | |         },
+LL | |         false => (),
+LL | |     }
+   | |_____^
+   |
+   = note: you might want to preserve the comments from inside the `match`
+help: try
+   |
+LL ~     if i == 1 {
+LL +         println!("{i}");
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match.rs:519:5
+   |
+LL | /     match i == 1 {
+LL | |
+LL | |         false => {
+LL | |             println!("{i}");
+LL | |         },
+LL | |         true => (),
+LL | |     }
+   | |_____^
+   |
+   = note: you might want to preserve the comments from inside the `match`
+help: try
+   |
+LL ~     if !(i == 1) {
+LL +         println!("{i}");
+LL +     }
+   |
+
+error: aborting due to 33 previous errors
 

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:17:5
+  --> tests/ui/single_match.rs:16:5
    |
 LL | /     match x {
 LL | |         Some(y) => {
@@ -19,7 +19,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:26:5
+  --> tests/ui/single_match.rs:25:5
    |
 LL | /     match x {
 ...  |
@@ -30,7 +30,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:37:5
+  --> tests/ui/single_match.rs:36:5
    |
 LL | /     match z {
 LL | |         (2..=3, 7..=9) => dummy(),
@@ -39,7 +39,7 @@ LL | |     };
    | |_____^ help: try: `if let (2..=3, 7..=9) = z { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:67:5
+  --> tests/ui/single_match.rs:66:5
    |
 LL | /     match x {
 LL | |         Some(y) => dummy(),
@@ -48,7 +48,7 @@ LL | |     };
    | |_____^ help: try: `if let Some(y) = x { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:73:5
+  --> tests/ui/single_match.rs:72:5
    |
 LL | /     match y {
 LL | |         Ok(y) => dummy(),
@@ -57,7 +57,7 @@ LL | |     };
    | |_____^ help: try: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:81:5
+  --> tests/ui/single_match.rs:80:5
    |
 LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:103:5
+  --> tests/ui/single_match.rs:102:5
    |
 LL | /     match x {
 LL | |         "test" => println!(),
@@ -75,7 +75,7 @@ LL | |     }
    | |_____^ help: try: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:117:5
+  --> tests/ui/single_match.rs:116:5
    |
 LL | /     match x {
 LL | |         Foo::A => println!(),
@@ -84,7 +84,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:124:5
+  --> tests/ui/single_match.rs:123:5
    |
 LL | /     match x {
 LL | |         FOO_C => println!(),
@@ -93,7 +93,7 @@ LL | |     }
    | |_____^ help: try: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:130:5
+  --> tests/ui/single_match.rs:129:5
    |
 LL | /     match &&x {
 LL | |         Foo::A => println!(),
@@ -102,7 +102,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:137:5
+  --> tests/ui/single_match.rs:136:5
    |
 LL | /     match &x {
 LL | |         Foo::A => println!(),
@@ -111,7 +111,7 @@ LL | |     }
    | |_____^ help: try: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:155:5
+  --> tests/ui/single_match.rs:154:5
    |
 LL | /     match x {
 LL | |         Bar::A => println!(),
@@ -120,7 +120,7 @@ LL | |     }
    | |_____^ help: try: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:164:5
+  --> tests/ui/single_match.rs:163:5
    |
 LL | /     match x {
 LL | |         None => println!(),
@@ -129,7 +129,7 @@ LL | |     };
    | |_____^ help: try: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:187:5
+  --> tests/ui/single_match.rs:186:5
    |
 LL | /     match x {
 LL | |         (Some(_), _) => {},
@@ -138,7 +138,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:194:5
+  --> tests/ui/single_match.rs:193:5
    |
 LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
@@ -147,7 +147,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:201:5
+  --> tests/ui/single_match.rs:200:5
    |
 LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},
@@ -156,7 +156,7 @@ LL | |     }
    | |_____^ help: try: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:274:5
+  --> tests/ui/single_match.rs:273:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -176,7 +176,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:283:5
+  --> tests/ui/single_match.rs:282:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]
@@ -198,7 +198,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:364:5
+  --> tests/ui/single_match.rs:363:5
    |
 LL | /     match Ok::<_, u32>(Some(A)) {
 LL | |         Ok(Some(A)) => println!(),
@@ -207,7 +207,7 @@ LL | |     }
    | |_____^ help: try: `if let Ok(Some(A)) = Ok::<_, u32>(Some(A)) { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:380:5
+  --> tests/ui/single_match.rs:379:5
    |
 LL | /     match &Some(A) {
 LL | |         Some(A | B) => println!(),
@@ -216,7 +216,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(A | B) = &Some(A) { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:388:5
+  --> tests/ui/single_match.rs:387:5
    |
 LL | /     match &s[0..3] {
 LL | |         b"foo" => println!(),
@@ -225,7 +225,7 @@ LL | |     }
    | |_____^ help: try: `if &s[0..3] == b"foo" { println!() }`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:403:5
+  --> tests/ui/single_match.rs:402:5
    |
 LL | /     match DATA {
 LL | |         DATA => println!(),
@@ -234,7 +234,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:409:5
+  --> tests/ui/single_match.rs:408:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -243,7 +243,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:416:5
+  --> tests/ui/single_match.rs:415:5
    |
 LL | /     match i {
 LL | |         i => {
@@ -263,7 +263,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:425:5
+  --> tests/ui/single_match.rs:424:5
    |
 LL | /     match i {
 LL | |         i => {},
@@ -272,7 +272,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:431:5
+  --> tests/ui/single_match.rs:430:5
    |
 LL | /     match i {
 LL | |         i => (),
@@ -281,7 +281,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:437:5
+  --> tests/ui/single_match.rs:436:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -290,7 +290,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:445:5
+  --> tests/ui/single_match.rs:444:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -302,7 +302,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:454:5
+  --> tests/ui/single_match.rs:453:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -322,7 +322,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:480:5
+  --> tests/ui/single_match.rs:479:5
    |
 LL | /     match mac!(some) {
 LL | |         Some(u) => println!("{u}"),
@@ -331,7 +331,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(u) = mac!(some) { println!("{u}") }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:488:5
+  --> tests/ui/single_match.rs:487:5
    |
 LL | /     match mac!(str) {
 LL | |         "foo" => println!("eq"),
@@ -340,7 +340,7 @@ LL | |     }
    | |_____^ help: try: `if mac!(str) == "foo" { println!("eq") }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:513:5
+  --> tests/ui/single_match.rs:512:5
    |
 LL | /     match i == 1 {
 LL | |
@@ -354,13 +354,13 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 help: try
    |
-LL ~     if (i == 1) == true {
+LL ~     if i == 1 {
 LL +         println!("{i}");
 LL +     }
    |
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:520:5
+  --> tests/ui/single_match.rs:519:5
    |
 LL | /     match i == 1 {
 LL | |
@@ -374,7 +374,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 help: try
    |
-LL ~     if (i == 1) == false {
+LL ~     if i != 1 {
 LL +         println!("{i}");
 LL +     }
    |

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:16:5
+  --> tests/ui/single_match.rs:17:5
    |
 LL | /     match x {
 LL | |         Some(y) => {
@@ -19,7 +19,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:25:5
+  --> tests/ui/single_match.rs:26:5
    |
 LL | /     match x {
 ...  |
@@ -30,7 +30,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:36:5
+  --> tests/ui/single_match.rs:37:5
    |
 LL | /     match z {
 LL | |         (2..=3, 7..=9) => dummy(),
@@ -39,7 +39,7 @@ LL | |     };
    | |_____^ help: try: `if let (2..=3, 7..=9) = z { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:66:5
+  --> tests/ui/single_match.rs:67:5
    |
 LL | /     match x {
 LL | |         Some(y) => dummy(),
@@ -48,7 +48,7 @@ LL | |     };
    | |_____^ help: try: `if let Some(y) = x { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:72:5
+  --> tests/ui/single_match.rs:73:5
    |
 LL | /     match y {
 LL | |         Ok(y) => dummy(),
@@ -57,7 +57,7 @@ LL | |     };
    | |_____^ help: try: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:80:5
+  --> tests/ui/single_match.rs:81:5
    |
 LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:102:5
+  --> tests/ui/single_match.rs:103:5
    |
 LL | /     match x {
 LL | |         "test" => println!(),
@@ -75,7 +75,7 @@ LL | |     }
    | |_____^ help: try: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:116:5
+  --> tests/ui/single_match.rs:117:5
    |
 LL | /     match x {
 LL | |         Foo::A => println!(),
@@ -84,7 +84,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:123:5
+  --> tests/ui/single_match.rs:124:5
    |
 LL | /     match x {
 LL | |         FOO_C => println!(),
@@ -93,7 +93,7 @@ LL | |     }
    | |_____^ help: try: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:129:5
+  --> tests/ui/single_match.rs:130:5
    |
 LL | /     match &&x {
 LL | |         Foo::A => println!(),
@@ -102,7 +102,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:136:5
+  --> tests/ui/single_match.rs:137:5
    |
 LL | /     match &x {
 LL | |         Foo::A => println!(),
@@ -111,7 +111,7 @@ LL | |     }
    | |_____^ help: try: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:154:5
+  --> tests/ui/single_match.rs:155:5
    |
 LL | /     match x {
 LL | |         Bar::A => println!(),
@@ -120,7 +120,7 @@ LL | |     }
    | |_____^ help: try: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:163:5
+  --> tests/ui/single_match.rs:164:5
    |
 LL | /     match x {
 LL | |         None => println!(),
@@ -129,7 +129,7 @@ LL | |     };
    | |_____^ help: try: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:186:5
+  --> tests/ui/single_match.rs:187:5
    |
 LL | /     match x {
 LL | |         (Some(_), _) => {},
@@ -138,7 +138,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:193:5
+  --> tests/ui/single_match.rs:194:5
    |
 LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
@@ -147,7 +147,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:200:5
+  --> tests/ui/single_match.rs:201:5
    |
 LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},
@@ -156,7 +156,7 @@ LL | |     }
    | |_____^ help: try: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:273:5
+  --> tests/ui/single_match.rs:274:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -176,7 +176,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:282:5
+  --> tests/ui/single_match.rs:283:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]
@@ -198,7 +198,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:363:5
+  --> tests/ui/single_match.rs:364:5
    |
 LL | /     match Ok::<_, u32>(Some(A)) {
 LL | |         Ok(Some(A)) => println!(),
@@ -207,7 +207,7 @@ LL | |     }
    | |_____^ help: try: `if let Ok(Some(A)) = Ok::<_, u32>(Some(A)) { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:379:5
+  --> tests/ui/single_match.rs:380:5
    |
 LL | /     match &Some(A) {
 LL | |         Some(A | B) => println!(),
@@ -216,7 +216,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(A | B) = &Some(A) { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:387:5
+  --> tests/ui/single_match.rs:388:5
    |
 LL | /     match &s[0..3] {
 LL | |         b"foo" => println!(),
@@ -225,7 +225,7 @@ LL | |     }
    | |_____^ help: try: `if &s[0..3] == b"foo" { println!() }`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:402:5
+  --> tests/ui/single_match.rs:403:5
    |
 LL | /     match DATA {
 LL | |         DATA => println!(),
@@ -234,7 +234,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:408:5
+  --> tests/ui/single_match.rs:409:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -243,7 +243,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:415:5
+  --> tests/ui/single_match.rs:416:5
    |
 LL | /     match i {
 LL | |         i => {
@@ -263,7 +263,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:424:5
+  --> tests/ui/single_match.rs:425:5
    |
 LL | /     match i {
 LL | |         i => {},
@@ -272,7 +272,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:430:5
+  --> tests/ui/single_match.rs:431:5
    |
 LL | /     match i {
 LL | |         i => (),
@@ -281,7 +281,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:436:5
+  --> tests/ui/single_match.rs:437:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -290,7 +290,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:444:5
+  --> tests/ui/single_match.rs:445:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -302,7 +302,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:453:5
+  --> tests/ui/single_match.rs:454:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -322,7 +322,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:479:5
+  --> tests/ui/single_match.rs:480:5
    |
 LL | /     match mac!(some) {
 LL | |         Some(u) => println!("{u}"),
@@ -331,7 +331,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(u) = mac!(some) { println!("{u}") }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:487:5
+  --> tests/ui/single_match.rs:488:5
    |
 LL | /     match mac!(str) {
 LL | |         "foo" => println!("eq"),
@@ -340,7 +340,7 @@ LL | |     }
    | |_____^ help: try: `if mac!(str) == "foo" { println!("eq") }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:512:5
+  --> tests/ui/single_match.rs:513:5
    |
 LL | /     match i == 1 {
 LL | |
@@ -354,13 +354,13 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 help: try
    |
-LL ~     if i == 1 {
+LL ~     if (i == 1) == true {
 LL +         println!("{i}");
 LL +     }
    |
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:519:5
+  --> tests/ui/single_match.rs:520:5
    |
 LL | /     match i == 1 {
 LL | |
@@ -374,7 +374,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 help: try
    |
-LL ~     if !(i == 1) {
+LL ~     if (i == 1) == false {
 LL +         println!("{i}");
 LL +     }
    |


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16826

When matching on `true`/`false` from a comparison expression like:
```rust
match i == 1 {
    true => println!("{i}"),
    false => (),
}
```
the lint suggested `if i == 1 == true { ... }` which doesn't compile — comparison operators can't be chained.

**Before:**
```
try: if i == 1 == true { println!("{i}") }
     // error: comparison operators cannot be chained
```

**After:**
```
try: if i == 1 { println!("{i}") }       // matching true
try: if !(i == 1) { println!("{i}") }    // matching false
```

When the scrutinee is a bool and the pattern is a literal `true` or `false`, the fix emits `if <expr>` or `if !(<expr>)` directly instead of `if <expr> == true/false`.

Added test cases for both `true` and `false` matching with a comparison expression.

changelog: [`single_match`]: emit `if <expr>` instead of `if <expr> == true` when matching bool expression results