### PR TITLE
doc_markdown: split words on `{` and `}`

### DIFF
--- a/clippy_lints/src/doc/markdown.rs
+++ b/clippy_lints/src/doc/markdown.rs
@@ -18,7 +18,7 @@ pub fn check(
     code_level: isize,
     blockquote_level: isize,
 ) {
-    for orig_word in text.split(|c: char| c.is_whitespace() || c == '\'') {
+    for orig_word in text.split(|c: char| c.is_whitespace() || c == '\'' || c == '{' || c == '}') {
         // Trim punctuation as in `some comment (see foo::bar).`
         //                                                   ^^
         // Or even as in `_foo bar_` which is emphasized. Also preserve `::` as a prefix/suffix.

--- a/tests/ui/doc/doc_markdown-issue_16819.fixed
+++ b/tests/ui/doc/doc_markdown-issue_16819.fixed
@@ -1,0 +1,13 @@
+#![deny(clippy::doc_markdown)]
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/16819
+// Adjacent brace-delimited items separated by `.` should be detected as
+// independent words instead of being merged into a single span.
+
+/// We have {`SymbolA`} and {`symbol_b`}.
+//~^ ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+/// We have {`SymbolA`}.{`symbol_b`}.
+//~^ ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+pub fn issue_16819() {}

--- a/tests/ui/doc/doc_markdown-issue_16819.rs
+++ b/tests/ui/doc/doc_markdown-issue_16819.rs
@@ -1,0 +1,13 @@
+#![deny(clippy::doc_markdown)]
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/16819
+// Adjacent brace-delimited items separated by `.` should be detected as
+// independent words instead of being merged into a single span.
+
+/// We have {SymbolA} and {symbol_b}.
+//~^ ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+/// We have {SymbolA}.{symbol_b}.
+//~^ ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+pub fn issue_16819() {}

--- a/tests/ui/doc/doc_markdown-issue_16819.stderr
+++ b/tests/ui/doc/doc_markdown-issue_16819.stderr
@@ -1,0 +1,55 @@
+error: item in documentation is missing backticks
+  --> tests/ui/doc/doc_markdown-issue_16819.rs:7:14
+   |
+LL | /// We have {SymbolA} and {symbol_b}.
+   |              ^^^^^^^
+   |
+note: the lint level is defined here
+  --> tests/ui/doc/doc_markdown-issue_16819.rs:1:9
+   |
+LL | #![deny(clippy::doc_markdown)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+help: try
+   |
+LL - /// We have {SymbolA} and {symbol_b}.
+LL + /// We have {`SymbolA`} and {symbol_b}.
+   |
+
+error: item in documentation is missing backticks
+  --> tests/ui/doc/doc_markdown-issue_16819.rs:7:28
+   |
+LL | /// We have {SymbolA} and {symbol_b}.
+   |                            ^^^^^^^^
+   |
+help: try
+   |
+LL - /// We have {SymbolA} and {symbol_b}.
+LL + /// We have {SymbolA} and {`symbol_b`}.
+   |
+
+error: item in documentation is missing backticks
+  --> tests/ui/doc/doc_markdown-issue_16819.rs:10:14
+   |
+LL | /// We have {SymbolA}.{symbol_b}.
+   |              ^^^^^^^
+   |
+help: try
+   |
+LL - /// We have {SymbolA}.{symbol_b}.
+LL + /// We have {`SymbolA`}.{symbol_b}.
+   |
+
+error: item in documentation is missing backticks
+  --> tests/ui/doc/doc_markdown-issue_16819.rs:10:24
+   |
+LL | /// We have {SymbolA}.{symbol_b}.
+   |                        ^^^^^^^^
+   |
+help: try
+   |
+LL - /// We have {SymbolA}.{symbol_b}.
+LL + /// We have {SymbolA}.{`symbol_b`}.
+   |
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16819

When two brace-delimited items are separated by `.` (e.g. `{SymbolA}.{symbol_b}`), the word splitter only broke on whitespace and `'`, so the whole sequence was tokenized as a single word. After trimming non-alphanumeric chars from the ends, that left `SymbolA}.{symbol_b`, which `has_underscore` then matched and the lint wrapped the entire span in one pair of backticks.

Treating `{` and `}` as word boundaries makes each braced item get processed independently — same as if there had been whitespace between them.

## Before

```text
38 - /// We have {SymbolA}.{symbol_b}.
38 + /// We have {`SymbolA}.{symbol_b`}.
                          ^^^
```

## After

```text
38 - /// We have {SymbolA}.{symbol_b}.
38 + /// We have {`SymbolA`}.{`symbol_b`}.
```

The case with whitespace between the braces (`{SymbolA} and {symbol_b}`) was already being handled correctly and continues to work — the regression test covers both shapes.

changelog: [`doc_markdown`]: correctly handle adjacent brace-delimited items separated by `.`