### PR TITLE
fix(needless_ifs): handle vertical tab as whitespace to avoid false negative

### DIFF
--- a/clippy_lints/src/needless_ifs.rs
+++ b/clippy_lints/src/needless_ifs.rs
@@ -55,7 +55,7 @@ impl LateLintPass<'_> for NeedlessIfs {
                 // - comments
                 // - #[cfg]'d out code
                 src.bytes()
-                    .all(|ch| matches!(ch, b'{' | b'}') || ch.is_ascii_whitespace())
+                    .all(|ch| matches!(ch, b'{' | b'}') || ch.is_ascii_whitespace() || ch == b'\x0b')
             })
             && let Some(cond_span) = walk_span_to_context(cond.span, expr.span.ctxt())
             && let Some(cond_snippet) = cond_span.get_source_text(cx)

--- a/tests/ui/needless_ifs.fixed
+++ b/tests/ui/needless_ifs.fixed
@@ -13,7 +13,6 @@
     unused
 )]
 #![warn(clippy::needless_ifs)]
-
 extern crate proc_macros;
 use proc_macros::{external, with_span};
 
@@ -112,4 +111,13 @@ fn issue15960() -> i32 {
     //~^ needless_ifs
 
     1 // put something here so that `if` is a statement not an expression
+}
+
+#[rustfmt::skip]
+fn issue_16845() {
+
+    // Vertical tab (U+000B) should be treated as whitespace,
+    
+    //~^ needless_ifs
+    let () = if maybe_side_effect() {};
 }

--- a/tests/ui/needless_ifs.fixed
+++ b/tests/ui/needless_ifs.fixed
@@ -21,7 +21,6 @@ fn maybe_side_effect() -> bool {
 }
 
 fn main() {
-    // Lint
     
     //~^ needless_ifs
     // Do not remove the condition

--- a/tests/ui/needless_ifs.fixed
+++ b/tests/ui/needless_ifs.fixed
@@ -13,7 +13,6 @@
     unused
 )]
 #![warn(clippy::needless_ifs)]
-
 extern crate proc_macros;
 use proc_macros::{external, with_span};
 
@@ -112,4 +111,14 @@ fn issue15960() -> i32 {
     //~^ needless_ifs
 
     1 // put something here so that `if` is a statement not an expression
+}
+
+#[rustfmt::skip]
+fn issue_16845() {
+    // Lint
+
+    // Vertical tab (U+000B) should be treated as whitespace,
+    
+    //~^ needless_ifs
+    let () = if maybe_side_effect() {};
 }

--- a/tests/ui/needless_ifs.rs
+++ b/tests/ui/needless_ifs.rs
@@ -13,7 +13,6 @@
     unused
 )]
 #![warn(clippy::needless_ifs)]
-
 extern crate proc_macros;
 use proc_macros::{external, with_span};
 
@@ -113,4 +112,13 @@ fn issue15960() -> i32 {
     //~^ needless_ifs
 
     1 // put something here so that `if` is a statement not an expression
+}
+
+#[rustfmt::skip]
+fn issue_16845() {
+
+    // Vertical tab (U+000B) should be treated as whitespace,
+    if true {}
+    //~^ needless_ifs
+    let () = if maybe_side_effect() {};
 }

--- a/tests/ui/needless_ifs.rs
+++ b/tests/ui/needless_ifs.rs
@@ -13,7 +13,6 @@
     unused
 )]
 #![warn(clippy::needless_ifs)]
-
 extern crate proc_macros;
 use proc_macros::{external, with_span};
 
@@ -113,4 +112,14 @@ fn issue15960() -> i32 {
     //~^ needless_ifs
 
     1 // put something here so that `if` is a statement not an expression
+}
+
+#[rustfmt::skip]
+fn issue_16845() {
+    // Lint
+
+    // Vertical tab (U+000B) should be treated as whitespace,
+    if true {}
+    //~^ needless_ifs
+    let () = if maybe_side_effect() {};
 }

--- a/tests/ui/needless_ifs.stderr
+++ b/tests/ui/needless_ifs.stderr
@@ -1,5 +1,5 @@
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:26:5
+  --> tests/ui/needless_ifs.rs:25:5
    |
 LL |     if (true) {}
    |     ^^^^^^^^^^^^ help: you can remove it
@@ -8,13 +8,13 @@ LL |     if (true) {}
    = help: to override `-D warnings` add `#[allow(clippy::needless_ifs)]`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:29:5
+  --> tests/ui/needless_ifs.rs:28:5
    |
 LL |     if maybe_side_effect() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `maybe_side_effect();`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:35:5
+  --> tests/ui/needless_ifs.rs:34:5
    |
 LL | /     if {
 LL | |
@@ -31,7 +31,7 @@ LL +     });
    |
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:50:5
+  --> tests/ui/needless_ifs.rs:49:5
    |
 LL | /     if {
 LL | |
@@ -57,34 +57,40 @@ LL +     } && true);
    |
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:95:5
+  --> tests/ui/needless_ifs.rs:94:5
    |
 LL |     if { maybe_side_effect() } {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `({ maybe_side_effect() });`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:98:5
+  --> tests/ui/needless_ifs.rs:97:5
    |
 LL |     if { maybe_side_effect() } && true {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `({ maybe_side_effect() } && true);`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:103:5
+  --> tests/ui/needless_ifs.rs:102:5
    |
 LL |     if true {}
    |     ^^^^^^^^^^ help: you can remove it: `true;`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:110:5
+  --> tests/ui/needless_ifs.rs:109:5
    |
 LL |     if matches!(2, 3) {}
    |     ^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `matches!(2, 3);`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:112:5
+  --> tests/ui/needless_ifs.rs:111:5
    |
 LL |     if matches!(2, 3) == (2 * 2 == 5) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `matches!(2, 3) == (2 * 2 == 5);`
 
-error: aborting due to 9 previous errors
+error: this `if` branch is empty
+  --> tests/ui/needless_ifs.rs:121:5
+   |
+LL |     if true {␋}
+   |     ^^^^^^^^^^^ help: you can remove it
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/needless_ifs.stderr
+++ b/tests/ui/needless_ifs.stderr
@@ -1,5 +1,5 @@
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:26:5
+  --> tests/ui/needless_ifs.rs:25:5
    |
 LL |     if (true) {}
    |     ^^^^^^^^^^^^ help: you can remove it
@@ -8,13 +8,13 @@ LL |     if (true) {}
    = help: to override `-D warnings` add `#[allow(clippy::needless_ifs)]`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:29:5
+  --> tests/ui/needless_ifs.rs:28:5
    |
 LL |     if maybe_side_effect() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `maybe_side_effect();`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:35:5
+  --> tests/ui/needless_ifs.rs:34:5
    |
 LL | /     if {
 LL | |
@@ -31,7 +31,7 @@ LL +     });
    |
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:50:5
+  --> tests/ui/needless_ifs.rs:49:5
    |
 LL | /     if {
 LL | |
@@ -57,34 +57,40 @@ LL +     } && true);
    |
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:95:5
+  --> tests/ui/needless_ifs.rs:94:5
    |
 LL |     if { maybe_side_effect() } {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `({ maybe_side_effect() });`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:98:5
+  --> tests/ui/needless_ifs.rs:97:5
    |
 LL |     if { maybe_side_effect() } && true {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `({ maybe_side_effect() } && true);`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:103:5
+  --> tests/ui/needless_ifs.rs:102:5
    |
 LL |     if true {}
    |     ^^^^^^^^^^ help: you can remove it: `true;`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:110:5
+  --> tests/ui/needless_ifs.rs:109:5
    |
 LL |     if matches!(2, 3) {}
    |     ^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `matches!(2, 3);`
 
 error: this `if` branch is empty
-  --> tests/ui/needless_ifs.rs:112:5
+  --> tests/ui/needless_ifs.rs:111:5
    |
 LL |     if matches!(2, 3) == (2 * 2 == 5) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `matches!(2, 3) == (2 * 2 == 5);`
 
-error: aborting due to 9 previous errors
+error: this `if` branch is empty
+  --> tests/ui/needless_ifs.rs:122:5
+   |
+LL |     if true {␋}
+   |     ^^^^^^^^^^^ help: you can remove it
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16845)*

`needless_ifs` has a false negative because rust lexer considers vertical tab as a whitespace but `is_ascii_whitespace()` method doesn't handle vertical tab which is  a bug. For reference https://doc.rust-lang.org/reference/whitespace.html. Reference Outreachy tracking issue https://github.com/rustfoundation/interop-initiative/issues/53. 

Should we also switch from `is_ascii_whitespace()` to `is_whitespace()` to handle full Unicode `Pattern_White_Space` characters like `U+0085`, `U+200E`, `U+200F`, `U+2028`, `U+2029`?

Fixes:- https://github.com/rustfoundation/interop-initiative/issues/53

changelog: [`needless_ifs`]: Fix false negative in `needless_ifs` when code contains vertical tab (`\x0B`) whitespace 

CC:- @teor2345 

