### PR TITLE
Fix wrong suggestion for `println_empty_string` with non-parenthesis delimiters

### DIFF
--- a/clippy_lints/src/write/empty_string.rs
+++ b/clippy_lints/src/write/empty_string.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::macros::MacroCall;
-use clippy_utils::source::expand_past_previous_comma;
+use clippy_utils::source::{expand_past_previous_comma, snippet_opt};
 use clippy_utils::{span_extract_comments, sym};
 use rustc_ast::{FormatArgs, FormatArgsPiece};
 use rustc_errors::Applicability;
@@ -23,17 +23,23 @@ pub(super) fn check(cx: &LateContext<'_>, format_args: &FormatArgs, macro_call: 
             format!("empty string literal in `{name}!`"),
             |diag| {
                 if span_extract_comments(cx, macro_call.span).is_empty() {
-                    let closing_paren = cx.sess().source_map().span_extend_to_prev_char_before(
-                        macro_call.span.shrink_to_hi(),
-                        ')',
-                        false,
-                    );
-                    let mut span = format_args.span.with_hi(closing_paren.lo());
-                    if is_writeln {
-                        span = expand_past_previous_comma(cx, span);
-                    }
+                    let closing_delim = snippet_opt(cx, macro_call.span)
+                        .and_then(|snippet| snippet.chars().last())
+                        .filter(|ch| matches!(ch, ')' | ']' | '}'));
 
-                    diag.span_suggestion(span, "remove the empty string", "", Applicability::MachineApplicable);
+                    if let Some(closing_delim) = closing_delim {
+                        let closing_paren = cx.sess().source_map().span_extend_to_prev_char_before(
+                            macro_call.span.shrink_to_hi(),
+                            closing_delim,
+                            false,
+                        );
+                        let mut span = format_args.span.with_hi(closing_paren.lo());
+                        if is_writeln {
+                            span = expand_past_previous_comma(cx, span);
+                        }
+
+                        diag.span_suggestion(span, "remove the empty string", "", Applicability::MachineApplicable);
+                    }
                 } else {
                     // If there is a comment in the span of macro call, we don't provide an auto-fix suggestion.
                     diag.span_note(format_args.span, "remove the empty string");

--- a/tests/ui/println_empty_string.fixed
+++ b/tests/ui/println_empty_string.fixed
@@ -39,3 +39,28 @@ fn issue_16167() {
         //~^ println_empty_string
     }
 }
+
+#[rustfmt::skip]
+fn issue_16843() {
+    println!{};
+    //~^ println_empty_string
+
+    println![];
+    //~^ println_empty_string
+
+    eprintln!{};
+    //~^ println_empty_string
+
+    eprintln![];
+    //~^ println_empty_string
+
+    match "a" {
+        _ => println!{},
+        //~^ println_empty_string
+    }
+
+    match "a" {
+        _ => println![],
+        //~^ println_empty_string
+    }
+}

--- a/tests/ui/println_empty_string.rs
+++ b/tests/ui/println_empty_string.rs
@@ -43,3 +43,28 @@ fn issue_16167() {
         //~^ println_empty_string
     }
 }
+
+#[rustfmt::skip]
+fn issue_16843() {
+    println!{""};
+    //~^ println_empty_string
+
+    println![""];
+    //~^ println_empty_string
+
+    eprintln!{""};
+    //~^ println_empty_string
+
+    eprintln![""];
+    //~^ println_empty_string
+
+    match "a" {
+        _ => println!{""},
+        //~^ println_empty_string
+    }
+
+    match "a" {
+        _ => println![""],
+        //~^ println_empty_string
+    }
+}

--- a/tests/ui/println_empty_string.stderr
+++ b/tests/ui/println_empty_string.stderr
@@ -70,5 +70,53 @@ LL |         _ => eprintln!(""     ,), // tab and space between "" and comma
    |                        |
    |                        help: remove the empty string
 
-error: aborting due to 8 previous errors
+error: empty string literal in `println!`
+  --> tests/ui/println_empty_string.rs:49:5
+   |
+LL |     println!{""};
+   |     ^^^^^^^^^--^
+   |              |
+   |              help: remove the empty string
+
+error: empty string literal in `println!`
+  --> tests/ui/println_empty_string.rs:52:5
+   |
+LL |     println![""];
+   |     ^^^^^^^^^--^
+   |              |
+   |              help: remove the empty string
+
+error: empty string literal in `eprintln!`
+  --> tests/ui/println_empty_string.rs:55:5
+   |
+LL |     eprintln!{""};
+   |     ^^^^^^^^^^--^
+   |               |
+   |               help: remove the empty string
+
+error: empty string literal in `eprintln!`
+  --> tests/ui/println_empty_string.rs:58:5
+   |
+LL |     eprintln![""];
+   |     ^^^^^^^^^^--^
+   |               |
+   |               help: remove the empty string
+
+error: empty string literal in `println!`
+  --> tests/ui/println_empty_string.rs:62:14
+   |
+LL |         _ => println!{""},
+   |              ^^^^^^^^^--^
+   |                       |
+   |                       help: remove the empty string
+
+error: empty string literal in `println!`
+  --> tests/ui/println_empty_string.rs:67:14
+   |
+LL |         _ => println![""],
+   |              ^^^^^^^^^--^
+   |                       |
+   |                       help: remove the empty string
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16843

changelog: [`println_empty_string`]: fix wrong suggestion with non-parenthesis delimiters
