### PR TITLE
Add `block_scrutinee` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6449,6 +6449,7 @@ Released 2018-09-13
 [`blanket_clippy_restriction_lints`]: https://rust-lang.github.io/rust-clippy/master/index.html#blanket_clippy_restriction_lints
 [`block_in_if_condition_expr`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_in_if_condition_expr
 [`block_in_if_condition_stmt`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_in_if_condition_stmt
+[`block_scrutinee`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_scrutinee
 [`blocks_in_conditions`]: https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions
 [`blocks_in_if_conditions`]: https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_if_conditions
 [`bool_assert_comparison`]: https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6763,6 +6763,7 @@ Released 2018-09-13
 [`blanket_clippy_restriction_lints`]: https://rust-lang.github.io/rust-clippy/master/index.html#blanket_clippy_restriction_lints
 [`block_in_if_condition_expr`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_in_if_condition_expr
 [`block_in_if_condition_stmt`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_in_if_condition_stmt
+[`block_scrutinee`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_scrutinee
 [`blocks_in_conditions`]: https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions
 [`blocks_in_if_conditions`]: https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_if_conditions
 [`bool_assert_comparison`]: https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison

--- a/clippy_lints/src/block_scrutinee.rs
+++ b/clippy_lints/src/block_scrutinee.rs
@@ -1,0 +1,58 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+use rustc_span::edition::Edition;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Warns when a match, if let, or while let scrutinee is wrapped in a block.
+    ///
+    /// ### Why is this bad?
+    /// Prior to the 2024 edition, wrapping the scrutinee in a block did not drop
+    /// temporaries before the body executes.
+    ///
+    /// ### Example
+    /// ```rust,ignore
+    /// if let Some(x) = { my_function() } { .. }
+    /// ```
+    #[clippy::version = "1.80.0"]
+    pub BLOCK_SCRUTINEE,
+    correctness,
+    "warns when the scrutinee is wrapped in a block in older editions"
+}
+
+declare_lint_pass!(BlockScrutinee => [BLOCK_SCRUTINEE]);
+
+impl<'tcx> LateLintPass<'tcx> for BlockScrutinee {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if cx.tcx.sess.edition() >= Edition::Edition2024 {
+            return;
+        }
+
+        let scrutinee = match expr.kind {
+            ExprKind::Match(scrutinee, _, _) => scrutinee,
+            ExprKind::Let(let_expr) => let_expr.init,
+            _ => return,
+        };
+
+        if let ExprKind::Block(block, _) = scrutinee.kind
+            && block.stmts.is_empty()
+            && let Some(inner_expr) = block.expr
+        {
+            let inner_snippet = snippet(cx, inner_expr.span, "..");
+
+            span_lint_and_sugg(
+                cx,
+                BLOCK_SCRUTINEE,
+                scrutinee.span,
+                "scrutinee is wrapped in a block which will not drop temporaries until the end of the statement in this edition",
+                "remove the block",
+                inner_snippet.to_string(),
+                Applicability::MachineApplicable,
+            );
+        }
+    }
+}

--- a/clippy_lints/src/block_scrutinee.rs
+++ b/clippy_lints/src/block_scrutinee.rs
@@ -1,0 +1,111 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::source::{indent_of, snippet};
+use rustc_errors::Applicability;
+use rustc_hir::{BlockCheckMode, Expr, ExprKind, LoopSource};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+use rustc_span::edition::Edition;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Warns when a match, if let, or while let scrutinee is wrapped in a block.
+    /// This lint only triggers on the 2021 edition and older.
+    ///
+    /// ### Why is this bad?
+    /// It is unusual to write `{ expr }` when you could just have written
+    /// `expr`, and it is unlikely that anyone would write that for any reason
+    /// other than wanting temporaries in `expr` to be dropped before executing
+    /// the body of the `match`/`if let`/`while` statement. However, prior to
+    /// the 2024 edition, wrapping the scrutinee in a block did not drop
+    /// temporaries before the body executes.
+    ///
+    /// ### Example
+    /// ```rust,ignore
+    /// if let Some(x) = { my_function() } { .. }
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub BLOCK_SCRUTINEE,
+    suspicious,
+    "warns when the scrutinee is wrapped in a block in older editions"
+}
+
+declare_lint_pass!(BlockScrutinee => [BLOCK_SCRUTINEE]);
+
+impl<'tcx> LateLintPass<'tcx> for BlockScrutinee {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if cx.tcx.sess.edition() >= Edition::Edition2024 {
+            return;
+        }
+
+        let (scrutinee, keyword_fallback) = match expr.kind {
+            ExprKind::Match(scrutinee, _, _) => (scrutinee, "`match`"),
+            ExprKind::Let(let_expr) => (let_expr.init, "`if let` / `while let`"),
+            _ => return,
+        };
+
+        if scrutinee.span.from_expansion() || expr.span.from_expansion() {
+            return;
+        }
+
+        if let ExprKind::Block(block, _) = scrutinee.kind
+            && matches!(block.rules, BlockCheckMode::DefaultBlock)
+            && block.stmts.is_empty()
+            && let Some(inner_expr) = block.expr
+        {
+            let inner_snippet = snippet(cx, inner_expr.span, "..");
+
+            let main_msg = "this scrutinee is wrapped in a block";
+
+            span_lint_and_then(cx, BLOCK_SCRUTINEE, scrutinee.span, main_msg, |diag| {
+                let mut keyword = keyword_fallback;
+                let mut outer_span = expr.span;
+
+                if let ExprKind::Let(_) = expr.kind {
+                    keyword = "`if let`";
+                    for (_, node) in cx.tcx.hir_parent_iter(expr.hir_id) {
+                        if let rustc_hir::Node::Expr(e) = node {
+                            if let ExprKind::If(..) = e.kind {
+                                if keyword == "`if let`" {
+                                    outer_span = e.span;
+                                }
+                            } else if let ExprKind::Loop(_, _, LoopSource::While, _) = e.kind {
+                                keyword = "`while let`";
+                                outer_span = e.span;
+                                break;
+                            }
+                        } else if matches!(node, rustc_hir::Node::Item(..) | rustc_hir::Node::ImplItem(..)) {
+                            break;
+                        }
+                    }
+                }
+
+                diag.note(format!(
+                    "temporary values in this block-wrapped scrutinee will be dropped after the body of the {keyword} statement"
+                ));
+
+                diag.note("starting with the 2024 edition, temporaries within a block's final expression are dropped immediately at the end of the block");
+
+                let suggestion_msg = format!("to drop temporaries after the surrounding {keyword}, remove the block");
+
+                diag.span_suggestion(
+                    scrutinee.span,
+                    suggestion_msg,
+                    inner_snippet.to_string(),
+                    Applicability::MaybeIncorrect,
+                );
+
+                let indent = indent_of(cx, outer_span).unwrap_or(0);
+                let pad = " ".repeat(indent);
+
+                diag.multipart_suggestion(
+                    "to drop temporaries early, move them to a separate local binding (or update your `Cargo.toml` to the 2024 edition)",
+                    vec![
+                        (outer_span.shrink_to_lo(), format!("let res = {inner_snippet};\n{pad}")),
+                        (scrutinee.span, "res".to_string()),
+                    ],
+                    Applicability::MaybeIncorrect,
+                );
+            });
+        }
+    }
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -33,6 +33,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::await_holding_invalid::AWAIT_HOLDING_INVALID_TYPE_INFO,
     crate::await_holding_invalid::AWAIT_HOLDING_LOCK_INFO,
     crate::await_holding_invalid::AWAIT_HOLDING_REFCELL_REF_INFO,
+    crate::block_scrutinee::BLOCK_SCRUTINEE_INFO,
     crate::blocks_in_conditions::BLOCKS_IN_CONDITIONS_INFO,
     crate::bool_assert_comparison::BOOL_ASSERT_COMPARISON_INFO,
     crate::bool_comparison::BOOL_COMPARISON_INFO,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -35,6 +35,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::await_holding_invalid::AWAIT_HOLDING_REFCELL_REF_INFO,
     crate::bit_width::MANUAL_BIT_WIDTH_INFO,
     crate::bit_width::MISMATCHED_BIT_WIDTH_TYPE_INFO,
+    crate::block_scrutinee::BLOCK_SCRUTINEE_INFO,
     crate::blocks_in_conditions::BLOCKS_IN_CONDITIONS_INFO,
     crate::bool_assert_comparison::BOOL_ASSERT_COMPARISON_INFO,
     crate::bool_comparison::BOOL_COMPARISON_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -72,6 +72,7 @@ mod assigning_clones;
 mod async_yields_async;
 mod attrs;
 mod await_holding_invalid;
+mod block_scrutinee;
 mod blocks_in_conditions;
 mod bool_assert_comparison;
 mod bool_comparison;
@@ -867,6 +868,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(move |tcx| Box::new(manual_pop_if::ManualPopIf::new(tcx, conf))),
         Box::new(move |_| Box::new(manual_noop_waker::ManualNoopWaker::new(conf))),
         Box::new(|_| Box::new(byte_char_slices::ByteCharSlice)),
+        Box::new(|_| Box::new(block_scrutinee::BlockScrutinee)),
         // add late passes here, used by `cargo dev new_lint`
     ];
     store.late_passes.extend(late_lints);

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -76,6 +76,7 @@ mod async_yields_async;
 mod attrs;
 mod await_holding_invalid;
 mod bit_width;
+mod block_scrutinee;
 mod blocks_in_conditions;
 mod bool_assert_comparison;
 mod bool_comparison;
@@ -866,6 +867,7 @@ rustc_lint::late_lint_methods!(
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
         RedundantElse: redundant_else::RedundantElse = redundant_else::RedundantElse,
         RestWhenDestructuringStruct: rest_when_destructuring_struct::RestWhenDestructuringStruct = rest_when_destructuring_struct::RestWhenDestructuringStruct,
+        BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/tests/ui/block_scrutinee.1.fixed
+++ b/tests/ui/block_scrutinee.1.fixed
@@ -1,0 +1,60 @@
+//@ edition: 2021
+#![warn(clippy::block_scrutinee)]
+#![allow(clippy::blocks_in_conditions)]
+#![allow(clippy::let_and_return)]
+
+fn my_function() -> Option<i32> {
+    Some(1)
+}
+
+fn main() {
+    if let Some(x) = my_function() {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    match my_function() {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        Some(1) => println!("one"),
+        Some(_) => println!("other"),
+        None => println!("none"),
+    }
+
+    let mut v = vec![1, 2, 3];
+    while let Some(x) = v.pop() {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    if let Some(x) = my_function() {
+        let _ = x;
+    }
+
+    if let Some(x) = {
+        let _y = 2;
+        my_function()
+    } {
+        let _ = x;
+    }
+
+    //~v ERROR: this scrutinee is wrapped in a block
+    if let Some(x) = v.pop() {
+        let _ = x;
+    }
+
+    macro_rules! get_val {
+        () => {{ my_function() }};
+    }
+    if let Some(x) = get_val!() {
+        let _ = x;
+    }
+
+    // Test that `unsafe` blocks are ignored
+    unsafe fn my_unsafe_fn() -> Option<i32> {
+        Some(1)
+    }
+
+    if let Some(x) = unsafe { my_unsafe_fn() } {
+        let _ = x;
+    }
+}

--- a/tests/ui/block_scrutinee.2.fixed
+++ b/tests/ui/block_scrutinee.2.fixed
@@ -1,0 +1,64 @@
+//@ edition: 2021
+#![warn(clippy::block_scrutinee)]
+#![allow(clippy::blocks_in_conditions)]
+#![allow(clippy::let_and_return)]
+
+fn my_function() -> Option<i32> {
+    Some(1)
+}
+
+fn main() {
+    let res = my_function();
+    if let Some(x) = res {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    let res = my_function();
+    match res {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        Some(1) => println!("one"),
+        Some(_) => println!("other"),
+        None => println!("none"),
+    }
+
+    let mut v = vec![1, 2, 3];
+    let res = v.pop();
+    while let Some(x) = res {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    if let Some(x) = my_function() {
+        let _ = x;
+    }
+
+    if let Some(x) = {
+        let _y = 2;
+        my_function()
+    } {
+        let _ = x;
+    }
+
+    //~v ERROR: this scrutinee is wrapped in a block
+    let res = v.pop();
+    if let Some(x) = res {
+        let _ = x;
+    }
+
+    macro_rules! get_val {
+        () => {{ my_function() }};
+    }
+    if let Some(x) = get_val!() {
+        let _ = x;
+    }
+
+    // Test that `unsafe` blocks are ignored
+    unsafe fn my_unsafe_fn() -> Option<i32> {
+        Some(1)
+    }
+
+    if let Some(x) = unsafe { my_unsafe_fn() } {
+        let _ = x;
+    }
+}

--- a/tests/ui/block_scrutinee.fixed
+++ b/tests/ui/block_scrutinee.fixed
@@ -1,0 +1,38 @@
+//@ edition: 2021
+#![warn(clippy::block_scrutinee)]
+#![allow(clippy::blocks_in_conditions)]
+
+fn my_function() -> Option<i32> {
+    Some(1)
+}
+
+fn main() {
+    if let Some(x) = my_function() {
+        //~^ ERROR: scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    match my_function() {
+        //~^ ERROR: scrutinee is wrapped in a block
+        Some(1) => println!("one"),
+        Some(_) => println!("other"),
+        None => println!("none"),
+    }
+
+    let mut v = vec![1, 2, 3];
+    while let Some(x) = v.pop() {
+        //~^ ERROR: scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    if let Some(x) = my_function() {
+        let _ = x;
+    }
+
+    if let Some(x) = {
+        let _y = 2;
+        my_function()
+    } {
+        let _ = x;
+    }
+}

--- a/tests/ui/block_scrutinee.rs
+++ b/tests/ui/block_scrutinee.rs
@@ -1,0 +1,38 @@
+//@ edition: 2021
+#![warn(clippy::block_scrutinee)]
+#![allow(clippy::blocks_in_conditions)]
+
+fn my_function() -> Option<i32> {
+    Some(1)
+}
+
+fn main() {
+    if let Some(x) = { my_function() } {
+        //~^ ERROR: scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    match { my_function() } {
+        //~^ ERROR: scrutinee is wrapped in a block
+        Some(1) => println!("one"),
+        Some(_) => println!("other"),
+        None => println!("none"),
+    }
+
+    let mut v = vec![1, 2, 3];
+    while let Some(x) = { v.pop() } {
+        //~^ ERROR: scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    if let Some(x) = my_function() {
+        let _ = x;
+    }
+
+    if let Some(x) = {
+        let _y = 2;
+        my_function()
+    } {
+        let _ = x;
+    }
+}

--- a/tests/ui/block_scrutinee.rs
+++ b/tests/ui/block_scrutinee.rs
@@ -1,0 +1,63 @@
+//@ edition: 2021
+#![warn(clippy::block_scrutinee)]
+#![allow(clippy::blocks_in_conditions)]
+#![allow(clippy::let_and_return)]
+
+fn my_function() -> Option<i32> {
+    Some(1)
+}
+
+fn main() {
+    if let Some(x) = { my_function() } {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    match { my_function() } {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        Some(1) => println!("one"),
+        Some(_) => println!("other"),
+        None => println!("none"),
+    }
+
+    let mut v = vec![1, 2, 3];
+    while let Some(x) = { v.pop() } {
+        //~^ ERROR: this scrutinee is wrapped in a block
+        let _ = x;
+    }
+
+    if let Some(x) = my_function() {
+        let _ = x;
+    }
+
+    if let Some(x) = {
+        let _y = 2;
+        my_function()
+    } {
+        let _ = x;
+    }
+
+    //~v ERROR: this scrutinee is wrapped in a block
+    if let Some(x) = {
+        // We are popping a value
+        v.pop()
+    } {
+        let _ = x;
+    }
+
+    macro_rules! get_val {
+        () => {{ my_function() }};
+    }
+    if let Some(x) = get_val!() {
+        let _ = x;
+    }
+
+    // Test that `unsafe` blocks are ignored
+    unsafe fn my_unsafe_fn() -> Option<i32> {
+        Some(1)
+    }
+
+    if let Some(x) = unsafe { my_unsafe_fn() } {
+        let _ = x;
+    }
+}

--- a/tests/ui/block_scrutinee.stderr
+++ b/tests/ui/block_scrutinee.stderr
@@ -1,0 +1,23 @@
+error: scrutinee is wrapped in a block which will not drop temporaries until the end of the statement in this edition
+  --> tests/ui/block_scrutinee.rs:10:22
+   |
+LL |     if let Some(x) = { my_function() } {
+   |                      ^^^^^^^^^^^^^^^^^ help: remove the block: `my_function()`
+   |
+   = note: `-D clippy::block-scrutinee` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::block_scrutinee)]`
+
+error: scrutinee is wrapped in a block which will not drop temporaries until the end of the statement in this edition
+  --> tests/ui/block_scrutinee.rs:15:11
+   |
+LL |     match { my_function() } {
+   |           ^^^^^^^^^^^^^^^^^ help: remove the block: `my_function()`
+
+error: scrutinee is wrapped in a block which will not drop temporaries until the end of the statement in this edition
+  --> tests/ui/block_scrutinee.rs:23:25
+   |
+LL |     while let Some(x) = { v.pop() } {
+   |                         ^^^^^^^^^^^ help: remove the block: `v.pop()`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/block_scrutinee.stderr
+++ b/tests/ui/block_scrutinee.stderr
@@ -1,0 +1,87 @@
+error: this scrutinee is wrapped in a block
+  --> tests/ui/block_scrutinee.rs:11:22
+   |
+LL |     if let Some(x) = { my_function() } {
+   |                      ^^^^^^^^^^^^^^^^^
+   |
+   = note: temporary values in this block-wrapped scrutinee will be dropped after the body of the `if let` statement
+   = note: starting with the 2024 edition, temporaries within a block's final expression are dropped immediately at the end of the block
+   = note: `-D clippy::block-scrutinee` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::block_scrutinee)]`
+help: to drop temporaries after the surrounding `if let`, remove the block
+   |
+LL -     if let Some(x) = { my_function() } {
+LL +     if let Some(x) = my_function() {
+   |
+help: to drop temporaries early, move them to a separate local binding (or update your `Cargo.toml` to the 2024 edition)
+   |
+LL ~     let res = my_function();
+LL ~     if let Some(x) = res {
+   |
+
+error: this scrutinee is wrapped in a block
+  --> tests/ui/block_scrutinee.rs:16:11
+   |
+LL |     match { my_function() } {
+   |           ^^^^^^^^^^^^^^^^^
+   |
+   = note: temporary values in this block-wrapped scrutinee will be dropped after the body of the `match` statement
+   = note: starting with the 2024 edition, temporaries within a block's final expression are dropped immediately at the end of the block
+help: to drop temporaries after the surrounding `match`, remove the block
+   |
+LL -     match { my_function() } {
+LL +     match my_function() {
+   |
+help: to drop temporaries early, move them to a separate local binding (or update your `Cargo.toml` to the 2024 edition)
+   |
+LL ~     let res = my_function();
+LL ~     match res {
+   |
+
+error: this scrutinee is wrapped in a block
+  --> tests/ui/block_scrutinee.rs:24:25
+   |
+LL |     while let Some(x) = { v.pop() } {
+   |                         ^^^^^^^^^^^
+   |
+   = note: temporary values in this block-wrapped scrutinee will be dropped after the body of the `while let` statement
+   = note: starting with the 2024 edition, temporaries within a block's final expression are dropped immediately at the end of the block
+help: to drop temporaries after the surrounding `while let`, remove the block
+   |
+LL -     while let Some(x) = { v.pop() } {
+LL +     while let Some(x) = v.pop() {
+   |
+help: to drop temporaries early, move them to a separate local binding (or update your `Cargo.toml` to the 2024 edition)
+   |
+LL ~     let res = v.pop();
+LL ~     while let Some(x) = res {
+   |
+
+error: this scrutinee is wrapped in a block
+  --> tests/ui/block_scrutinee.rs:41:22
+   |
+LL |       if let Some(x) = {
+   |  ______________________^
+LL | |         // We are popping a value
+LL | |         v.pop()
+LL | |     } {
+   | |_____^
+   |
+   = note: temporary values in this block-wrapped scrutinee will be dropped after the body of the `if let` statement
+   = note: starting with the 2024 edition, temporaries within a block's final expression are dropped immediately at the end of the block
+help: to drop temporaries after the surrounding `if let`, remove the block
+   |
+LL -     if let Some(x) = {
+LL -         // We are popping a value
+LL -         v.pop()
+LL -     } {
+LL +     if let Some(x) = v.pop() {
+   |
+help: to drop temporaries early, move them to a separate local binding (or update your `Cargo.toml` to the 2024 edition)
+   |
+LL ~     let res = v.pop();
+LL ~     if let Some(x) = res {
+   |
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/block_scrutinee_2024.rs
+++ b/tests/ui/block_scrutinee_2024.rs
@@ -1,0 +1,28 @@
+//@ edition: 2024
+//@ check-pass
+#![warn(clippy::block_scrutinee)]
+#![allow(clippy::blocks_in_conditions)]
+
+fn my_function() -> Option<i32> {
+    Some(1)
+}
+
+fn main() {
+    // This should NOT trigger the lint on the 2024 edition
+    if let Some(x) = { my_function() } {
+        let _ = x;
+    }
+
+    // This should NOT trigger the lint on the 2024 edition
+    match { my_function() } {
+        Some(1) => println!("one"),
+        Some(_) => println!("other"),
+        None => println!("none"),
+    }
+
+    // This should NOT trigger the lint on the 2024 edition
+    let mut v = vec![1, 2, 3];
+    while let Some(x) = { v.pop() } {
+        let _ = x;
+    }
+}


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16855)*


This PR introduces a new late pass lint to catch scrutinees unnecessarily wrapped in blocks on older editions, preventing unintended behavior regarding temporary lifetimes.

Fixes rust-lang/rust-clippy#16827

changelog: new lint: [`block_scrutinee`] to warn on scrutinees wrapped in blocks in older editions
