### PR TITLE
Do not propose to refactor when no variant constructor is used

### DIFF
--- a/clippy_lints/src/methods/bind_instead_of_map.rs
+++ b/clippy_lints/src/methods/bind_instead_of_map.rs
@@ -128,6 +128,7 @@ impl BindInsteadOfMap {
             }
         });
         let (span, msg) = if can_sugg
+            && !suggs.is_empty()
             && let hir::ExprKind::MethodCall(segment, ..) = expr.kind
             && let Some(msg) = self.lint_msg(cx)
         {

--- a/tests/ui/bind_instead_of_map.fixed
+++ b/tests/ui/bind_instead_of_map.fixed
@@ -26,3 +26,9 @@ pub fn foo() -> Option<String> {
 pub fn example2(x: bool) -> Option<&'static str> {
     Some("a").and_then(|s| Some(if x { s } else { return None }))
 }
+
+fn issue16861(b: bool, res: Result<u32, u32>) {
+    let _: Result<u32, u32> = res.or_else(|_| panic!("should not happen"));
+    let _: Result<u32, u32> = res.map_err(|_| if b { panic!("should not happen") } else { 42 });
+    //~^ bind_instead_of_map
+}

--- a/tests/ui/bind_instead_of_map.rs
+++ b/tests/ui/bind_instead_of_map.rs
@@ -26,3 +26,9 @@ pub fn foo() -> Option<String> {
 pub fn example2(x: bool) -> Option<&'static str> {
     Some("a").and_then(|s| Some(if x { s } else { return None }))
 }
+
+fn issue16861(b: bool, res: Result<u32, u32>) {
+    let _: Result<u32, u32> = res.or_else(|_| panic!("should not happen"));
+    let _: Result<u32, u32> = res.or_else(|_| if b { panic!("should not happen") } else { Err(42) });
+    //~^ bind_instead_of_map
+}

--- a/tests/ui/bind_instead_of_map.stderr
+++ b/tests/ui/bind_instead_of_map.stderr
@@ -22,5 +22,17 @@ error: using `Result.and_then(Ok)`, which is a no-op
 LL |     let _ = x.and_then(Ok);
    |             ^^^^^^^^^^^^^^ help: use the expression directly: `x`
 
-error: aborting due to 3 previous errors
+error: using `Result.or_else(|x| Err(y))`, which is more succinctly expressed as `map_err(|x| y)`
+  --> tests/ui/bind_instead_of_map.rs:32:31
+   |
+LL |     let _: Result<u32, u32> = res.or_else(|_| if b { panic!("should not happen") } else { Err(42) });
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `map_err` instead
+   |
+LL -     let _: Result<u32, u32> = res.or_else(|_| if b { panic!("should not happen") } else { Err(42) });
+LL +     let _: Result<u32, u32> = res.map_err(|_| if b { panic!("should not happen") } else { 42 });
+   |
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
If all the ways to "leave" the closure is through a divergent statement other than `return` (not detected as a potential return value by the visitor), do not trigger the lint.

changelog: [`bind_instead_of_map`]: do not propose to rewrite the expression if the only way to leave the closure is through a divergent statement other than `return`

Fixes rust-lang/rust-clippy#16861 