### PR TITLE
Fix `unnecessary_sort_by` reverse suggestion using wrong closure parameter name

### DIFF
--- a/clippy_lints/src/methods/unnecessary_sort_by.rs
+++ b/clippy_lints/src/methods/unnecessary_sort_by.rs
@@ -257,7 +257,15 @@ fn detect_lint(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>) -> Option<
             if mirrored_exprs(left_expr, right_expr, &binding_map, BindingSource::Left) {
                 (left_expr, l_pat.span, false)
             } else if mirrored_exprs(left_expr, right_expr, &binding_map, BindingSource::Right) {
-                (left_expr, r_pat.span, true)
+                // Use the right-hand expr (the `a` side) as the key body, peeling any `&`
+                // introduced by the `.cmp(&rhs)` call so the suggestion doesn't contain a
+                // spurious borrow.
+                let right_body = if let ExprKind::AddrOf(_, _, inner) = right_expr.kind {
+                    inner
+                } else {
+                    right_expr
+                };
+                (right_body, l_pat.span, true)
             } else {
                 return None;
             };

--- a/tests/ui/unnecessary_sort_by.fixed
+++ b/tests/ui/unnecessary_sort_by.fixed
@@ -19,9 +19,9 @@ fn unnecessary_sort_by() {
     //~^ unnecessary_sort_by
     // Reverse examples
     vec.sort_by(|a, b| b.cmp(a)); // not linted to avoid suggesting `Reverse(b)` which would borrow
-    vec.sort_by_key(|b| std::cmp::Reverse((b + 5).abs()));
+    vec.sort_by_key(|a| std::cmp::Reverse((a + 5).abs()));
     //~^ unnecessary_sort_by
-    vec.sort_unstable_by_key(|b| std::cmp::Reverse(id(-b)));
+    vec.sort_unstable_by_key(|a| std::cmp::Reverse(id(-a)));
     //~^ unnecessary_sort_by
     // Negative examples (shouldn't be changed)
     let c = &7;
@@ -99,9 +99,9 @@ mod issue_6001 {
         args.sort_unstable_by_key(|a| a.name());
         //~^ unnecessary_sort_by
         // Reverse
-        args.sort_by_key(|b| std::cmp::Reverse(b.name()));
+        args.sort_by_key(|a| std::cmp::Reverse(a.name()));
         //~^ unnecessary_sort_by
-        args.sort_unstable_by_key(|b| std::cmp::Reverse(b.name()));
+        args.sort_unstable_by_key(|a| std::cmp::Reverse(a.name()));
         //~^ unnecessary_sort_by
     }
 }

--- a/tests/ui/unnecessary_sort_by.stderr
+++ b/tests/ui/unnecessary_sort_by.stderr
@@ -57,7 +57,7 @@ LL |     vec.sort_by(|a, b| (b + 5).abs().cmp(&(a + 5).abs()));
 help: try
    |
 LL -     vec.sort_by(|a, b| (b + 5).abs().cmp(&(a + 5).abs()));
-LL +     vec.sort_by_key(|b| std::cmp::Reverse((b + 5).abs()));
+LL +     vec.sort_by_key(|a| std::cmp::Reverse((a + 5).abs()));
    |
 
 error: consider using `sort_unstable_by_key`
@@ -69,7 +69,7 @@ LL |     vec.sort_unstable_by(|a, b| id(-b).cmp(&id(-a)));
 help: try
    |
 LL -     vec.sort_unstable_by(|a, b| id(-b).cmp(&id(-a)));
-LL +     vec.sort_unstable_by_key(|b| std::cmp::Reverse(id(-b)));
+LL +     vec.sort_unstable_by_key(|a| std::cmp::Reverse(id(-a)));
    |
 
 error: consider using `sort_by_key`
@@ -129,7 +129,7 @@ LL |         args.sort_by(|a, b| b.name().cmp(&a.name()));
 help: try
    |
 LL -         args.sort_by(|a, b| b.name().cmp(&a.name()));
-LL +         args.sort_by_key(|b| std::cmp::Reverse(b.name()));
+LL +         args.sort_by_key(|a| std::cmp::Reverse(a.name()));
    |
 
 error: consider using `sort_unstable_by_key`
@@ -141,7 +141,7 @@ LL |         args.sort_unstable_by(|a, b| b.name().cmp(&a.name()));
 help: try
    |
 LL -         args.sort_unstable_by(|a, b| b.name().cmp(&a.name()));
-LL +         args.sort_unstable_by_key(|b| std::cmp::Reverse(b.name()));
+LL +         args.sort_unstable_by_key(|a| std::cmp::Reverse(a.name()));
    |
 
 error: consider using `sort_by_key`

--- a/tests/ui/unnecessary_sort_by_no_std.fixed
+++ b/tests/ui/unnecessary_sort_by_no_std.fixed
@@ -15,8 +15,8 @@ fn issue_11524() -> Vec<i32> {
 fn issue_11524_2() -> Vec<i32> {
     let mut vec = vec![1, 2, 3];
 
-    // Should lint and suggest `vec.sort_by_key(|b| core::cmp::Reverse(b + 1));`
-    vec.sort_by_key(|b| core::cmp::Reverse(b + 1));
+    // Should lint and suggest `vec.sort_by_key(|a| core::cmp::Reverse(a + 1));`
+    vec.sort_by_key(|a| core::cmp::Reverse(a + 1));
     //~^ unnecessary_sort_by
     vec
 }

--- a/tests/ui/unnecessary_sort_by_no_std.rs
+++ b/tests/ui/unnecessary_sort_by_no_std.rs
@@ -15,7 +15,7 @@ fn issue_11524() -> Vec<i32> {
 fn issue_11524_2() -> Vec<i32> {
     let mut vec = vec![1, 2, 3];
 
-    // Should lint and suggest `vec.sort_by_key(|b| core::cmp::Reverse(b + 1));`
+    // Should lint and suggest `vec.sort_by_key(|a| core::cmp::Reverse(a + 1));`
     vec.sort_by(|a, b| (b + 1).cmp(&(a + 1)));
     //~^ unnecessary_sort_by
     vec

--- a/tests/ui/unnecessary_sort_by_no_std.stderr
+++ b/tests/ui/unnecessary_sort_by_no_std.stderr
@@ -21,7 +21,7 @@ LL |     vec.sort_by(|a, b| (b + 1).cmp(&(a + 1)));
 help: try
    |
 LL -     vec.sort_by(|a, b| (b + 1).cmp(&(a + 1)));
-LL +     vec.sort_by_key(|b| core::cmp::Reverse(b + 1));
+LL +     vec.sort_by_key(|a| core::cmp::Reverse(a + 1));
    |
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
When suggesting `sort_by_key` for a reversed comparator like `|a, b| b.foo.cmp(&a.foo)`, the lint was picking `left_expr` (the receiver of `.cmp()`, which references `b`) and `r_pat` as the closure arg, producing `|b| Reverse(b.foo)`. Both sides consistently named `b`, but `b` is the second parameter — confusing and inconsistent with the forward-sort suggestion style.

Fixed by using `right_expr` (the `.cmp()` argument, which references `a`) as the key body and `l_pat` as the closure parameter, peeling the single `&` that `.cmp(&rhs)` introduces so the suggestion doesn't contain a spurious borrow.

---

changelog: [`unnecessary_sort_by`]: fix reverse-sort suggestion using second closure parameter name (`b`) instead of first (`a`)