### PR TITLE
Don't suggest `collapsible_match` guard when condition mutates pattern binding

### DIFF
--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -275,9 +275,10 @@ fn pat_bindings_moved_or_mutated<'tcx>(cx: &LateContext<'tcx>, pat: &Pat<'tcx>, 
     }
 
     let mut candidates = delegate.moved;
-    if let Some(mutated) = mutated_variables(expr, cx) {
-        candidates.extend(mutated);
-    }
+    let Some(mutated) = mutated_variables(expr, cx) else {
+        return true;
+    };
+    candidates.extend(mutated);
 
     !pat.walk_short(|pat| {
         if let PatKind::Binding(_, hir_id, ..) = pat.kind

--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -444,3 +444,28 @@ fn issue16705(x: Option<String>) {
         _ => false,
     };
 }
+
+// issue #16864: don't suggest guard when condition mutates pattern binding
+fn issue16864() -> Option<u32> {
+    struct Foo(u32);
+
+    impl Foo {
+        fn mutates(&mut self) -> bool {
+            self.0 += 1;
+            self.0.is_multiple_of(2)
+        }
+    }
+
+    let mut value: Option<Foo> = Some(Foo(42));
+    // Should NOT lint: inner.mutates() requires &mut self,
+    // but variables are immutable in match guards.
+    match &mut value {
+        Some(inner) => {
+            if inner.mutates() {
+                return Some(inner.0);
+            }
+        },
+        _ => {},
+    }
+    None
+}


### PR DESCRIPTION
When `mutated_variables` returns `None` (cannot determine mutations), `pat_bindings_moved_or_mutated` silently ignored the result instead of conservatively bailing out. This caused the lint to suggest match guards for expressions that require mutable access to pattern bindings, which is forbidden in guards — variables are immutable in pattern guards.

The fix changes the `if let Some(mutated)` to `let Some(mutated) ... else { return true }`, matching the existing conservative bail-out for `ExprUseVisitor` errors a few lines above.

Fixes rust-lang/rust-clippy#16864

changelog: Fix [`collapsible_match`] suggesting a match guard when the condition mutates a pattern binding

---

Drafted with AI assistance. Reviewed, tested, and verified by me.