### PR TITLE
Add `matches_with_unrelated_if` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6957,6 +6957,7 @@ Released 2018-09-13
 [`match_str_case_mismatch`]: https://rust-lang.github.io/rust-clippy/master/index.html#match_str_case_mismatch
 [`match_wild_err_arm`]: https://rust-lang.github.io/rust-clippy/master/index.html#match_wild_err_arm
 [`match_wildcard_for_single_variants`]: https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants
+[`matches_with_unrelated_if`]: https://rust-lang.github.io/rust-clippy/master/index.html#matches_with_unrelated_if
 [`maybe_infinite_iter`]: https://rust-lang.github.io/rust-clippy/master/index.html#maybe_infinite_iter
 [`maybe_misused_cfg`]: https://rust-lang.github.io/rust-clippy/master/index.html#maybe_misused_cfg
 [`mem_discriminant_non_enum`]: https://rust-lang.github.io/rust-clippy/master/index.html#mem_discriminant_non_enum

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -320,7 +320,7 @@ pub(super) fn parens_around(expr: &Expr<'_>) -> Vec<(Span, String)> {
 fn span_extract_keyword(cx: &impl HasSession, span: Span, keyword: &str) -> Option<Span> {
     span.with_source_text(cx, |snippet| {
         tokenize_with_text(snippet)
-            .filter(|(t, s, _)| matches!(t, TokenKind::Ident if *s == keyword))
+            .filter(|(t, s, _)| matches!(t, TokenKind::Ident) && *s == keyword)
             .map(|(_, _, inner)| {
                 span.split_at(u32::try_from(inner.start).unwrap())
                     .1

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -342,6 +342,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::matches::MATCH_STR_CASE_MISMATCH_INFO,
     crate::matches::MATCH_WILD_ERR_ARM_INFO,
     crate::matches::MATCH_WILDCARD_FOR_SINGLE_VARIANTS_INFO,
+    crate::matches::MATCHES_WITH_UNRELATED_IF_INFO,
     crate::matches::NEEDLESS_MATCH_INFO,
     crate::matches::REDUNDANT_GUARDS_INFO,
     crate::matches::REDUNDANT_PATTERN_MATCHING_INFO,

--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -124,8 +124,7 @@ fn check_struct<'tcx>(
     let is_default_without_adjusts = |expr| {
         is_default_equivalent(cx, expr)
             && typeck_results.expr_adjustments(expr).iter().all(|adj| {
-                !matches!(adj.kind, Adjust::Pointer(PointerCoercion::Unsize)
-                    if contains_trait_object(adj.target))
+                !(matches!(adj.kind, Adjust::Pointer(PointerCoercion::Unsize)) && contains_trait_object(adj.target))
             })
     };
 

--- a/clippy_lints/src/matches/matches_with_unrelated_if.rs
+++ b/clippy_lints/src/matches/matches_with_unrelated_if.rs
@@ -1,0 +1,66 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::source::snippet;
+use clippy_utils::{is_direct_expn_of, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{Arm, Expr, PatKind};
+use rustc_lint::LateContext;
+
+use super::MATCHES_WITH_UNRELATED_IF;
+
+/// Checks for `matches!(expr, Pattern if guard)` where `guard` does not use any
+/// variable bound by `Pattern`.
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, ex: &'tcx Expr<'tcx>, arms: &'tcx [Arm<'tcx>]) {
+    // Only fire inside a `matches!` macro call
+    if is_direct_expn_of(expr.span, sym::matches).is_none() {
+        return;
+    }
+
+    // `matches!` expands to exactly 2 arms: the user's arm and a wildcard `_ => false`
+    let [arm, _] = arms else {
+        return;
+    };
+
+    // Only relevant when the arm has a guard
+    let Some(guard) = arm.guard else {
+        return;
+    };
+
+    // Collect all HirIds of bindings introduced by the pattern
+    let mut binding_ids = Vec::new();
+    arm.pat.walk(|pat| {
+        if let PatKind::Binding(_, hir_id, _, _) = pat.kind {
+            binding_ids.push(hir_id);
+        }
+        true
+    });
+
+    // Check whether the guard uses any of the pattern's bindings
+    let guard_uses_binding = binding_ids
+        .iter()
+        .any(|id| clippy_utils::visitors::is_local_used(cx, guard, *id));
+
+    if guard_uses_binding {
+        return;
+    }
+
+    // The guard is unrelated to the pattern — emit the lint
+    let call_site = expr.span.source_callsite();
+    let scrutinee_snip = snippet(cx, ex.span, "..");
+    let pat_snip = snippet(cx, arm.pat.span, "..");
+    let guard_snip = snippet(cx, guard.span, "..");
+
+    span_lint_and_then(
+        cx,
+        MATCHES_WITH_UNRELATED_IF,
+        call_site,
+        "the `if` guard in `matches!` does not use any variable bound by the pattern",
+        |diag| {
+            diag.span_suggestion(
+                call_site,
+                "move the guard outside of `matches!`",
+                format!("matches!({scrutinee_snip}, {pat_snip}) && {guard_snip}"),
+                Applicability::MachineApplicable,
+            );
+        },
+    );
+}

--- a/clippy_lints/src/matches/matches_with_unrelated_if.rs
+++ b/clippy_lints/src/matches/matches_with_unrelated_if.rs
@@ -9,7 +9,12 @@ use super::MATCHES_WITH_UNRELATED_IF;
 
 /// Checks for `matches!(expr, Pattern if guard)` where `guard` does not use any
 /// variable bound by `Pattern`.
-pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, ex: &'tcx Expr<'tcx>, arms: &'tcx [Arm<'tcx>]) {
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    ex: &'tcx Expr<'tcx>,
+    arms: &'tcx [Arm<'tcx>],
+) {
     // Only fire inside a `matches!` macro call
     if is_direct_expn_of(expr.span, sym::matches).is_none() {
         return;

--- a/clippy_lints/src/matches/matches_with_unrelated_if.rs
+++ b/clippy_lints/src/matches/matches_with_unrelated_if.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet;
 use clippy_utils::{is_direct_expn_of, sym};
 use rustc_errors::Applicability;
@@ -54,18 +54,13 @@ pub(super) fn check<'tcx>(
     let pat_snip = snippet(cx, arm.pat.span, "..");
     let guard_snip = snippet(cx, guard.span, "..");
 
-    span_lint_and_then(
+    span_lint_and_sugg(
         cx,
         MATCHES_WITH_UNRELATED_IF,
         call_site,
         "the `if` guard in `matches!` does not use any variable bound by the pattern",
-        |diag| {
-            diag.span_suggestion(
-                call_site,
-                "move the guard outside of `matches!`",
-                format!("matches!({scrutinee_snip}, {pat_snip}) && {guard_snip}"),
-                Applicability::MachineApplicable,
-            );
-        },
+        "move the guard outside of `matches!`",
+        format!("matches!({scrutinee_snip}, {pat_snip}) && {guard_snip}"),
+        Applicability::MachineApplicable,
     );
 }

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -553,44 +553,6 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for `matches!(expr, Pattern if guard)` where `guard` does not use any
-    /// variable bound by `Pattern`.
-    ///
-    /// ### Why is this bad?
-    /// The `if` guard creates an illusory connection between the pattern and the
-    /// condition. The guard is really an independent check and belongs outside the
-    /// `matches!` call. If the intent was to use a binding from the pattern inside
-    /// the guard, this lint also hints at a potential oversight.
-    ///
-    /// ### Example
-    /// ```no_run
-    /// struct Foo;
-    /// impl Foo {
-    ///     fn foo(&self) -> Option<i32> { todo!() }
-    ///     fn is_bar(&self) -> bool { todo!() }
-    /// }
-    ///
-    /// let f = Foo;
-    /// let _ = matches!(f.foo(), Some(_) if f.is_bar());
-    /// ```
-    /// Use instead:
-    /// ```no_run
-    /// # struct Foo;
-    /// # impl Foo {
-    /// #     fn foo(&self) -> Option<i32> { todo!() }
-    /// #     fn is_bar(&self) -> bool { todo!() }
-    /// # }
-    /// # let f = Foo;
-    /// let _ = matches!(f.foo(), Some(_)) && f.is_bar();
-    /// ```
-    #[clippy::version = "1.88.0"]
-    pub MATCHES_WITH_UNRELATED_IF,
-    style,
-    "`if` guard in `matches!` that does not use any variable from the pattern"
-}
-
-declare_clippy_lint! {
-    /// ### What it does
     /// Checks for wildcard enum matches for a single variant.
     ///
     /// ### Why is this bad?
@@ -625,6 +587,44 @@ declare_clippy_lint! {
     pub MATCH_WILDCARD_FOR_SINGLE_VARIANTS,
     pedantic,
     "a wildcard enum match for a single variant"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `matches!(expr, Pattern if guard)` where `guard` does not use any
+    /// variable bound by `Pattern`.
+    ///
+    /// ### Why is this bad?
+    /// The `if` guard creates an illusory connection between the pattern and the
+    /// condition. The guard is really an independent check and belongs outside the
+    /// `matches!` call. If the intent was to use a binding from the pattern inside
+    /// the guard, this lint also hints at a potential oversight.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// struct Foo;
+    /// impl Foo {
+    ///     fn foo(&self) -> Option<i32> { todo!() }
+    ///     fn is_bar(&self) -> bool { todo!() }
+    /// }
+    ///
+    /// let f = Foo;
+    /// let _ = matches!(f.foo(), Some(_) if f.is_bar());
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # struct Foo;
+    /// # impl Foo {
+    /// #     fn foo(&self) -> Option<i32> { todo!() }
+    /// #     fn is_bar(&self) -> bool { todo!() }
+    /// # }
+    /// # let f = Foo;
+    /// let _ = matches!(f.foo(), Some(_)) && f.is_bar();
+    /// ```
+    #[clippy::version = "1.88.0"]
+    pub MATCHES_WITH_UNRELATED_IF,
+    style,
+    "`if` guard in `matches!` that does not use any variable from the pattern"
 }
 
 declare_clippy_lint! {
@@ -1053,6 +1053,7 @@ impl_lint_pass!(Matches => [
     MANUAL_OK_ERR,
     MANUAL_UNWRAP_OR,
     MANUAL_UNWRAP_OR_DEFAULT,
+    MATCHES_WITH_UNRELATED_IF,
     MATCH_AS_REF,
     MATCH_BOOL,
     MATCH_LIKE_MATCHES_MACRO,
@@ -1063,7 +1064,6 @@ impl_lint_pass!(Matches => [
     MATCH_STR_CASE_MISMATCH,
     MATCH_WILDCARD_FOR_SINGLE_VARIANTS,
     MATCH_WILD_ERR_ARM,
-    MATCHES_WITH_UNRELATED_IF,
     NEEDLESS_MATCH,
     REDUNDANT_GUARDS,
     REDUNDANT_PATTERN_MATCHING,

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -14,6 +14,7 @@ mod match_single_binding;
 mod match_str_case_mismatch;
 mod match_wild_enum;
 mod match_wild_err_arm;
+mod matches_with_unrelated_if;
 mod needless_match;
 mod overlapping_arms;
 mod redundant_guards;
@@ -552,6 +553,44 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for `matches!(expr, Pattern if guard)` where `guard` does not use any
+    /// variable bound by `Pattern`.
+    ///
+    /// ### Why is this bad?
+    /// The `if` guard creates an illusory connection between the pattern and the
+    /// condition. The guard is really an independent check and belongs outside the
+    /// `matches!` call. If the intent was to use a binding from the pattern inside
+    /// the guard, this lint also hints at a potential oversight.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// struct Foo;
+    /// impl Foo {
+    ///     fn foo(&self) -> Option<i32> { todo!() }
+    ///     fn is_bar(&self) -> bool { todo!() }
+    /// }
+    ///
+    /// let f = Foo;
+    /// let _ = matches!(f.foo(), Some(_) if f.is_bar());
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # struct Foo;
+    /// # impl Foo {
+    /// #     fn foo(&self) -> Option<i32> { todo!() }
+    /// #     fn is_bar(&self) -> bool { todo!() }
+    /// # }
+    /// # let f = Foo;
+    /// let _ = matches!(f.foo(), Some(_)) && f.is_bar();
+    /// ```
+    #[clippy::version = "1.88.0"]
+    pub MATCHES_WITH_UNRELATED_IF,
+    style,
+    "`if` guard in `matches!` that does not use any variable from the pattern"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for wildcard enum matches for a single variant.
     ///
     /// ### Why is this bad?
@@ -1024,6 +1063,7 @@ impl_lint_pass!(Matches => [
     MATCH_STR_CASE_MISMATCH,
     MATCH_WILDCARD_FOR_SINGLE_VARIANTS,
     MATCH_WILD_ERR_ARM,
+    MATCHES_WITH_UNRELATED_IF,
     NEEDLESS_MATCH,
     REDUNDANT_GUARDS,
     REDUNDANT_PATTERN_MATCHING,
@@ -1064,6 +1104,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
             {
                 redundant_pattern_match::check_match(cx, expr, ex, arms);
                 redundant_pattern_match::check_matches_true(cx, expr, arm, ex);
+                matches_with_unrelated_if::check(cx, expr, ex, arms);
             }
 
             if source == MatchSource::Normal && !is_span_match(cx, expr.span) {

--- a/tests/ui/filter_map_bool_then.fixed
+++ b/tests/ui/filter_map_bool_then.fixed
@@ -2,6 +2,7 @@
 #![allow(
     clippy::clone_on_copy,
     clippy::map_identity,
+    clippy::matches_with_unrelated_if,
     clippy::unnecessary_lazy_evaluations,
     clippy::unnecessary_filter_map,
     unused

--- a/tests/ui/filter_map_bool_then.rs
+++ b/tests/ui/filter_map_bool_then.rs
@@ -2,6 +2,7 @@
 #![allow(
     clippy::clone_on_copy,
     clippy::map_identity,
+    clippy::matches_with_unrelated_if,
     clippy::unnecessary_lazy_evaluations,
     clippy::unnecessary_filter_map,
     unused

--- a/tests/ui/filter_map_bool_then.stderr
+++ b/tests/ui/filter_map_bool_then.stderr
@@ -1,5 +1,5 @@
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:19:22
+  --> tests/ui/filter_map_bool_then.rs:20:22
    |
 LL |     v.clone().iter().filter_map(|i| (i % 2 == 0).then(|| i + 1));
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i % 2 == 0)).map(|i| i + 1)`
@@ -8,61 +8,61 @@ LL |     v.clone().iter().filter_map(|i| (i % 2 == 0).then(|| i + 1));
    = help: to override `-D warnings` add `#[allow(clippy::filter_map_bool_then)]`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:21:27
+  --> tests/ui/filter_map_bool_then.rs:22:27
    |
 LL |     v.clone().into_iter().filter_map(|i| (i % 2 == 0).then(|| i + 1));
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i % 2 == 0)).map(|i| i + 1)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:25:10
+  --> tests/ui/filter_map_bool_then.rs:26:10
    |
 LL |         .filter_map(|i| -> Option<_> { (i % 2 == 0).then(|| i + 1) });
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i % 2 == 0)).map(|i| i + 1)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:30:10
+  --> tests/ui/filter_map_bool_then.rs:31:10
    |
 LL |         .filter_map(|i| (i % 2 == 0).then(|| i + 1));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i % 2 == 0)).map(|i| i + 1)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:35:10
+  --> tests/ui/filter_map_bool_then.rs:36:10
    |
 LL |         .filter_map(|i| (i.clone() % 2 == 0).then(|| i + 1));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i.clone() % 2 == 0)).map(|i| i + 1)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:42:22
+  --> tests/ui/filter_map_bool_then.rs:43:22
    |
 LL |     v.clone().iter().filter_map(|i| (i == &NonCopy).then(|| i));
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i == &NonCopy)).map(|i| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:67:50
+  --> tests/ui/filter_map_bool_then.rs:68:50
    |
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| *b).map(|(i, b)| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:72:50
+  --> tests/ui/filter_map_bool_then.rs:73:50
    |
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| ***b).map(|(i, b)| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:77:50
+  --> tests/ui/filter_map_bool_then.rs:78:50
    |
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| **b).map(|(i, b)| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:89:50
+  --> tests/ui/filter_map_bool_then.rs:90:50
    |
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| ****b).map(|(i, b)| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:110:10
+  --> tests/ui/filter_map_bool_then.rs:111:10
    |
 LL |         .filter_map(|(t, s, i)| matches!(t, MyEnum::A if s.starts_with("bar")).then(|| foo!(x)));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(t, s, i)| matches!(t, MyEnum::A if s.starts_with("bar"))).map(|(t, s, i)| foo!(x))`

--- a/tests/ui/manual_pattern_char_comparison.fixed
+++ b/tests/ui/manual_pattern_char_comparison.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::manual_pattern_char_comparison)]
+#![allow(clippy::matches_with_unrelated_if)]
 
 struct NotStr;
 

--- a/tests/ui/manual_pattern_char_comparison.rs
+++ b/tests/ui/manual_pattern_char_comparison.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::manual_pattern_char_comparison)]
+#![allow(clippy::matches_with_unrelated_if)]
 
 struct NotStr;
 

--- a/tests/ui/manual_pattern_char_comparison.stderr
+++ b/tests/ui/manual_pattern_char_comparison.stderr
@@ -1,5 +1,5 @@
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:11:31
+  --> tests/ui/manual_pattern_char_comparison.rs:12:31
    |
 LL |     sentence.trim_end_matches(|c: char| c == '.' || c == ',' || c == '!' || c == '?');
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['.', ',', '!', '?']`
@@ -8,55 +8,55 @@ LL |     sentence.trim_end_matches(|c: char| c == '.' || c == ',' || c == '!' ||
    = help: to override `-D warnings` add `#[allow(clippy::manual_pattern_char_comparison)]`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:13:20
+  --> tests/ui/manual_pattern_char_comparison.rs:14:20
    |
 LL |     sentence.split(|c: char| c == '\n' || c == 'X');
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['\n', 'X']`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:15:20
+  --> tests/ui/manual_pattern_char_comparison.rs:16:20
    |
 LL |     sentence.split(|c| c == '\n' || c == 'X');
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['\n', 'X']`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:17:24
+  --> tests/ui/manual_pattern_char_comparison.rs:18:24
    |
 LL |     sentence.splitn(3, |c: char| c == 'X');
    |                        ^^^^^^^^^^^^^^^^^^ help: consider using a `char`: `'X'`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:21:24
+  --> tests/ui/manual_pattern_char_comparison.rs:22:24
    |
 LL |     sentence.splitn(3, |c: char| c == char_compare);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a `char`: `char_compare`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:23:20
+  --> tests/ui/manual_pattern_char_comparison.rs:24:20
    |
 LL |     sentence.split(|c: char| matches!(c, '\n' | 'X' | 'Y'));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['\n', 'X', 'Y']`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:25:24
+  --> tests/ui/manual_pattern_char_comparison.rs:26:24
    |
 LL |     sentence.splitn(3, |c: char| matches!(c, 'X'));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a `char`: `'X'`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:27:24
+  --> tests/ui/manual_pattern_char_comparison.rs:28:24
    |
 LL |     sentence.splitn(3, |c: char| matches!(c, 'X' | 'W'));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['X', 'W']`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:29:19
+  --> tests/ui/manual_pattern_char_comparison.rs:30:19
    |
 LL |     sentence.find(|c| c == '🎈');
    |                   ^^^^^^^^^^^^^ help: consider using a `char`: `'🎈'`
 
 error: this manual char comparison can be written more succinctly
-  --> tests/ui/manual_pattern_char_comparison.rs:69:31
+  --> tests/ui/manual_pattern_char_comparison.rs:70:31
    |
 LL |     sentence.trim_end_matches(|c: char| c == '.' || c == ',' || c == '!' || c == '?');
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['.', ',', '!', '?']`

--- a/tests/ui/matches_with_unrelated_if.fixed
+++ b/tests/ui/matches_with_unrelated_if.fixed
@@ -1,0 +1,42 @@
+#![warn(clippy::matches_with_unrelated_if)]
+#![allow(unused, clippy::redundant_pattern_matching)]
+
+struct Foo;
+
+impl Foo {
+    fn foo(&self) -> Option<i32> {
+        todo!()
+    }
+    fn is_bar(&self) -> bool {
+        todo!()
+    }
+}
+
+fn main() {
+    let f = Foo;
+
+    // Should lint: guard uses `f`, not any variable from `Some(_)`
+    let _ = matches!(f.foo(), Some(_)) && f.is_bar();
+    //~^ matches_with_unrelated_if
+
+    // Should lint: guard references `f`, not `x` from `Some(x)`
+    let _ = matches!(f.foo(), Some(x)) && f.is_bar();
+    //~^ matches_with_unrelated_if
+
+    // Should lint: no bindings in pattern at all, guard uses outer var
+    let cond = true;
+    let _ = matches!(f.foo(), None) && cond;
+    //~^ matches_with_unrelated_if
+
+    // Should NOT lint: guard uses `x` which is bound by the pattern
+    let _ = matches!(f.foo(), Some(x) if x > 0);
+
+    // Should NOT lint: guard uses `x` (by-ref binding)
+    let _ = matches!(f.foo(), Some(ref x) if x == &42);
+
+    // Should NOT lint: no guard
+    let _ = matches!(f.foo(), Some(_));
+
+    // Should NOT lint: guard uses both a binding and an outer var
+    let _ = matches!(f.foo(), Some(x) if x > 0 && f.is_bar());
+}

--- a/tests/ui/matches_with_unrelated_if.rs
+++ b/tests/ui/matches_with_unrelated_if.rs
@@ -1,0 +1,42 @@
+#![warn(clippy::matches_with_unrelated_if)]
+#![allow(unused, clippy::redundant_pattern_matching)]
+
+struct Foo;
+
+impl Foo {
+    fn foo(&self) -> Option<i32> {
+        todo!()
+    }
+    fn is_bar(&self) -> bool {
+        todo!()
+    }
+}
+
+fn main() {
+    let f = Foo;
+
+    // Should lint: guard uses `f`, not any variable from `Some(_)`
+    let _ = matches!(f.foo(), Some(_) if f.is_bar());
+    //~^ matches_with_unrelated_if
+
+    // Should lint: guard references `f`, not `x` from `Some(x)`
+    let _ = matches!(f.foo(), Some(x) if f.is_bar());
+    //~^ matches_with_unrelated_if
+
+    // Should lint: no bindings in pattern at all, guard uses outer var
+    let cond = true;
+    let _ = matches!(f.foo(), None if cond);
+    //~^ matches_with_unrelated_if
+
+    // Should NOT lint: guard uses `x` which is bound by the pattern
+    let _ = matches!(f.foo(), Some(x) if x > 0);
+
+    // Should NOT lint: guard uses `x` (by-ref binding)
+    let _ = matches!(f.foo(), Some(ref x) if x == &42);
+
+    // Should NOT lint: no guard
+    let _ = matches!(f.foo(), Some(_));
+
+    // Should NOT lint: guard uses both a binding and an outer var
+    let _ = matches!(f.foo(), Some(x) if x > 0 && f.is_bar());
+}

--- a/tests/ui/matches_with_unrelated_if.stderr
+++ b/tests/ui/matches_with_unrelated_if.stderr
@@ -1,0 +1,23 @@
+error: the `if` guard in `matches!` does not use any variable bound by the pattern
+  --> tests/ui/matches_with_unrelated_if.rs:19:13
+   |
+LL |     let _ = matches!(f.foo(), Some(_) if f.is_bar());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: move the guard outside of `matches!`: `matches!(f.foo(), Some(_)) && f.is_bar()`
+   |
+   = note: `-D clippy::matches-with-unrelated-if` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::matches_with_unrelated_if)]`
+
+error: the `if` guard in `matches!` does not use any variable bound by the pattern
+  --> tests/ui/matches_with_unrelated_if.rs:23:13
+   |
+LL |     let _ = matches!(f.foo(), Some(x) if f.is_bar());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: move the guard outside of `matches!`: `matches!(f.foo(), Some(x)) && f.is_bar()`
+
+error: the `if` guard in `matches!` does not use any variable bound by the pattern
+  --> tests/ui/matches_with_unrelated_if.rs:28:13
+   |
+LL |     let _ = matches!(f.foo(), None if cond);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: move the guard outside of `matches!`: `matches!(f.foo(), None) && cond`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/redundant_guards.fixed
+++ b/tests/ui/redundant_guards.fixed
@@ -1,5 +1,11 @@
 //@aux-build:proc_macros.rs
-#![allow(clippy::no_effect, unused, clippy::single_match, invalid_nan_comparisons, clippy::matches_with_unrelated_if)]
+#![allow(
+    clippy::no_effect,
+    unused,
+    clippy::single_match,
+    invalid_nan_comparisons,
+    clippy::matches_with_unrelated_if
+)]
 #![warn(clippy::redundant_guards)]
 
 #[macro_use]

--- a/tests/ui/redundant_guards.fixed
+++ b/tests/ui/redundant_guards.fixed
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-#![allow(clippy::no_effect, unused, clippy::single_match, invalid_nan_comparisons)]
+#![allow(clippy::no_effect, unused, clippy::single_match, invalid_nan_comparisons, clippy::matches_with_unrelated_if)]
 #![warn(clippy::redundant_guards)]
 
 #[macro_use]

--- a/tests/ui/redundant_guards.rs
+++ b/tests/ui/redundant_guards.rs
@@ -1,5 +1,11 @@
 //@aux-build:proc_macros.rs
-#![allow(clippy::no_effect, unused, clippy::single_match, invalid_nan_comparisons, clippy::matches_with_unrelated_if)]
+#![allow(
+    clippy::no_effect,
+    unused,
+    clippy::single_match,
+    invalid_nan_comparisons,
+    clippy::matches_with_unrelated_if
+)]
 #![warn(clippy::redundant_guards)]
 
 #[macro_use]

--- a/tests/ui/redundant_guards.rs
+++ b/tests/ui/redundant_guards.rs
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-#![allow(clippy::no_effect, unused, clippy::single_match, invalid_nan_comparisons)]
+#![allow(clippy::no_effect, unused, clippy::single_match, invalid_nan_comparisons, clippy::matches_with_unrelated_if)]
 #![warn(clippy::redundant_guards)]
 
 #[macro_use]

--- a/tests/ui/redundant_guards.stderr
+++ b/tests/ui/redundant_guards.stderr
@@ -1,5 +1,5 @@
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:21:14
+  --> tests/ui/redundant_guards.rs:27:14
    |
 LL |         x if x == 0.0 => todo!(),
    |              ^^^^^^^^
@@ -13,7 +13,7 @@ LL +         0.0 => todo!(),
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:28:14
+  --> tests/ui/redundant_guards.rs:34:14
    |
 LL |         x if x == FloatWrapper(0.0) => todo!(),
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +         FloatWrapper(0.0) => todo!(),
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:44:20
+  --> tests/ui/redundant_guards.rs:50:20
    |
 LL |         C(x, y) if let 1 = y => ..,
    |                    ^^^^^^^^^
@@ -37,7 +37,7 @@ LL +         C(x, 1) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:51:20
+  --> tests/ui/redundant_guards.rs:57:20
    |
 LL |         Some(x) if matches!(x, Some(1) if true) => ..,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +         Some(Some(1)) if true => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:53:20
+  --> tests/ui/redundant_guards.rs:59:20
    |
 LL |         Some(x) if matches!(x, Some(1)) => {
    |                    ^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL +         Some(Some(1)) => {
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:58:20
+  --> tests/ui/redundant_guards.rs:64:20
    |
 LL |         Some(x) if let Some(1) = x => ..,
    |                    ^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +         Some(Some(1)) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:60:20
+  --> tests/ui/redundant_guards.rs:66:20
    |
 LL |         Some(x) if x == Some(2) => ..,
    |                    ^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +         Some(Some(2)) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:62:20
+  --> tests/ui/redundant_guards.rs:68:20
    |
 LL |         Some(x) if Some(2) == x => ..,
    |                    ^^^^^^^^^^^^
@@ -97,7 +97,7 @@ LL +         Some(Some(2)) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:88:20
+  --> tests/ui/redundant_guards.rs:94:20
    |
 LL |         B { e } if matches!(e, Some(A(2))) => ..,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL +         B { e: Some(A(2)) } => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:126:20
+  --> tests/ui/redundant_guards.rs:132:20
    |
 LL |         E::A(y) if y == "not from an or pattern" => {},
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL +         E::A("not from an or pattern") => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:134:14
+  --> tests/ui/redundant_guards.rs:140:14
    |
 LL |         x if matches!(x, Some(0)) => ..,
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL +         Some(0) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:142:14
+  --> tests/ui/redundant_guards.rs:148:14
    |
 LL |         i if i == -1 => {},
    |              ^^^^^^^
@@ -145,7 +145,7 @@ LL +         -1 => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:144:14
+  --> tests/ui/redundant_guards.rs:150:14
    |
 LL |         i if i == 1 => {},
    |              ^^^^^^
@@ -157,7 +157,7 @@ LL +         1 => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:207:28
+  --> tests/ui/redundant_guards.rs:213:28
    |
 LL |             Some(ref x) if x == &1 => {},
    |                            ^^^^^^^
@@ -169,7 +169,7 @@ LL +             Some(1) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:209:28
+  --> tests/ui/redundant_guards.rs:215:28
    |
 LL |             Some(ref x) if &1 == x => {},
    |                            ^^^^^^^
@@ -181,7 +181,7 @@ LL +             Some(1) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:211:28
+  --> tests/ui/redundant_guards.rs:217:28
    |
 LL |             Some(ref x) if let &2 = x => {},
    |                            ^^^^^^^^^^
@@ -193,7 +193,7 @@ LL +             Some(2) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:213:28
+  --> tests/ui/redundant_guards.rs:219:28
    |
 LL |             Some(ref x) if matches!(x, &3) => {},
    |                            ^^^^^^^^^^^^^^^
@@ -205,7 +205,7 @@ LL +             Some(3) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:234:32
+  --> tests/ui/redundant_guards.rs:240:32
    |
 LL |             B { ref c, .. } if c == &1 => {},
    |                                ^^^^^^^
@@ -217,7 +217,7 @@ LL +             B { c: 1, .. } => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:236:32
+  --> tests/ui/redundant_guards.rs:242:32
    |
 LL |             B { ref c, .. } if &1 == c => {},
    |                                ^^^^^^^
@@ -229,7 +229,7 @@ LL +             B { c: 1, .. } => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:238:32
+  --> tests/ui/redundant_guards.rs:244:32
    |
 LL |             B { ref c, .. } if let &1 = c => {},
    |                                ^^^^^^^^^^
@@ -241,7 +241,7 @@ LL +             B { c: 1, .. } => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:240:32
+  --> tests/ui/redundant_guards.rs:246:32
    |
 LL |             B { ref c, .. } if matches!(c, &1) => {},
    |                                ^^^^^^^^^^^^^^^
@@ -253,7 +253,7 @@ LL +             B { c: 1, .. } => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:251:26
+  --> tests/ui/redundant_guards.rs:257:26
    |
 LL |         Some(Some(x)) if x.is_empty() => {},
    |                          ^^^^^^^^^^^^
@@ -262,18 +262,6 @@ help: try
    |
 LL -         Some(Some(x)) if x.is_empty() => {},
 LL +         Some(Some("")) => {},
-   |
-
-error: redundant guard
-  --> tests/ui/redundant_guards.rs:263:26
-   |
-LL |         Some(Some(x)) if x.is_empty() => {},
-   |                          ^^^^^^^^^^^^
-   |
-help: try
-   |
-LL -         Some(Some(x)) if x.is_empty() => {},
-LL +         Some(Some([])) => {},
    |
 
 error: redundant guard
@@ -289,7 +277,19 @@ LL +         Some(Some([])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:281:26
+  --> tests/ui/redundant_guards.rs:275:26
+   |
+LL |         Some(Some(x)) if x.is_empty() => {},
+   |                          ^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -         Some(Some(x)) if x.is_empty() => {},
+LL +         Some(Some([])) => {},
+   |
+
+error: redundant guard
+  --> tests/ui/redundant_guards.rs:287:26
    |
 LL |         Some(Some(x)) if x.starts_with(&[]) => {},
    |                          ^^^^^^^^^^^^^^^^^^
@@ -301,7 +301,7 @@ LL +         Some(Some([..])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:287:26
+  --> tests/ui/redundant_guards.rs:293:26
    |
 LL |         Some(Some(x)) if x.starts_with(&[1]) => {},
    |                          ^^^^^^^^^^^^^^^^^^^
@@ -313,7 +313,7 @@ LL +         Some(Some([1, ..])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:293:26
+  --> tests/ui/redundant_guards.rs:299:26
    |
 LL |         Some(Some(x)) if x.starts_with(&[1, 2]) => {},
    |                          ^^^^^^^^^^^^^^^^^^^^^^
@@ -325,7 +325,7 @@ LL +         Some(Some([1, 2, ..])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:299:26
+  --> tests/ui/redundant_guards.rs:305:26
    |
 LL |         Some(Some(x)) if x.ends_with(&[1, 2]) => {},
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -337,7 +337,7 @@ LL +         Some(Some([.., 1, 2])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:322:18
+  --> tests/ui/redundant_guards.rs:328:18
    |
 LL |             y if y.is_empty() => {},
    |                  ^^^^^^^^^^^^
@@ -349,7 +349,7 @@ LL +             "" => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:341:22
+  --> tests/ui/redundant_guards.rs:347:22
    |
 LL |                 y if y.is_empty() => {},
    |                      ^^^^^^^^^^^^

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -4,7 +4,8 @@
     clippy::needless_ifs,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
-    clippy::if_same_then_else
+    clippy::if_same_then_else,
+    clippy::matches_with_unrelated_if
 )]
 
 fn issue_11174<T>(boolean: bool, maybe_some: Option<T>) -> bool {

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -4,7 +4,8 @@
     clippy::needless_ifs,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
-    clippy::if_same_then_else
+    clippy::if_same_then_else,
+    clippy::matches_with_unrelated_if
 )]
 
 fn issue_11174<T>(boolean: bool, maybe_some: Option<T>) -> bool {

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:11:5
+  --> tests/ui/redundant_pattern_matching_option.rs:12:5
    |
 LL |     matches!(maybe_some, None if !boolean)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_some.is_none() && (!boolean)`
@@ -8,55 +8,55 @@ LL |     matches!(maybe_some, None if !boolean)
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:16:13
+  --> tests/ui/redundant_pattern_matching_option.rs:17:13
    |
 LL |     let _ = matches!(maybe_some, None if boolean || boolean2); // guard needs parentheses
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_some.is_none() && (boolean || boolean2)`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:32:12
+  --> tests/ui/redundant_pattern_matching_option.rs:33:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:35:12
+  --> tests/ui/redundant_pattern_matching_option.rs:36:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:38:12
+  --> tests/ui/redundant_pattern_matching_option.rs:39:12
    |
 LL |     if let Some(_) = Some(42) {
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:45:15
+  --> tests/ui/redundant_pattern_matching_option.rs:46:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:48:15
+  --> tests/ui/redundant_pattern_matching_option.rs:49:15
    |
 LL |     while let None = Some(42) {}
    |     ----------^^^^----------- help: try: `while Some(42).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:51:15
+  --> tests/ui/redundant_pattern_matching_option.rs:52:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:55:15
+  --> tests/ui/redundant_pattern_matching_option.rs:56:15
    |
 LL |     while let Some(_) = v.pop() {
    |     ----------^^^^^^^---------- help: try: `while v.pop().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:64:5
+  --> tests/ui/redundant_pattern_matching_option.rs:65:5
    |
 LL | /     match Some(42) {
 LL | |
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:70:5
+  --> tests/ui/redundant_pattern_matching_option.rs:71:5
    |
 LL | /     match None::<()> {
 LL | |
@@ -76,7 +76,7 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:76:13
+  --> tests/ui/redundant_pattern_matching_option.rs:77:13
    |
 LL |       let _ = match None::<()> {
    |  _____________^
@@ -87,55 +87,55 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:83:20
+  --> tests/ui/redundant_pattern_matching_option.rs:84:20
    |
 LL |     let _ = if let Some(_) = opt { true } else { false };
    |             -------^^^^^^^------ help: try: `if opt.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:90:20
+  --> tests/ui/redundant_pattern_matching_option.rs:91:20
    |
 LL |     let _ = if let Some(_) = gen_opt() {
    |             -------^^^^^^^------------ help: try: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:93:19
+  --> tests/ui/redundant_pattern_matching_option.rs:94:19
    |
 LL |     } else if let None = gen_opt() {
    |            -------^^^^------------ help: try: `if gen_opt().is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:100:12
+  --> tests/ui/redundant_pattern_matching_option.rs:101:12
    |
 LL |     if let Some(..) = gen_opt() {}
    |     -------^^^^^^^^------------ help: try: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:116:12
+  --> tests/ui/redundant_pattern_matching_option.rs:117:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:119:12
+  --> tests/ui/redundant_pattern_matching_option.rs:120:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:122:15
+  --> tests/ui/redundant_pattern_matching_option.rs:123:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:125:15
+  --> tests/ui/redundant_pattern_matching_option.rs:126:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:128:5
+  --> tests/ui/redundant_pattern_matching_option.rs:129:5
    |
 LL | /     match Some(42) {
 LL | |
@@ -145,7 +145,7 @@ LL | |     };
    | |_____^ help: try: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:134:5
+  --> tests/ui/redundant_pattern_matching_option.rs:135:5
    |
 LL | /     match None::<()> {
 LL | |
@@ -155,19 +155,19 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:143:12
+  --> tests/ui/redundant_pattern_matching_option.rs:144:12
    |
 LL |     if let None = *(&None::<()>) {}
    |     -------^^^^----------------- help: try: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:145:12
+  --> tests/ui/redundant_pattern_matching_option.rs:146:12
    |
 LL |     if let None = *&None::<()> {}
    |     -------^^^^--------------- help: try: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:152:5
+  --> tests/ui/redundant_pattern_matching_option.rs:153:5
    |
 LL | /     match x {
 LL | |
@@ -177,7 +177,7 @@ LL | |     };
    | |_____^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:158:5
+  --> tests/ui/redundant_pattern_matching_option.rs:159:5
    |
 LL | /     match x {
 LL | |
@@ -187,7 +187,7 @@ LL | |     };
    | |_____^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:164:5
+  --> tests/ui/redundant_pattern_matching_option.rs:165:5
    |
 LL | /     match x {
 LL | |
@@ -197,7 +197,7 @@ LL | |     };
    | |_____^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:170:5
+  --> tests/ui/redundant_pattern_matching_option.rs:171:5
    |
 LL | /     match x {
 LL | |
@@ -207,43 +207,43 @@ LL | |     };
    | |_____^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:186:13
+  --> tests/ui/redundant_pattern_matching_option.rs:187:13
    |
 LL |     let _ = matches!(x, Some(_));
    |             ^^^^^^^^^^^^^^^^^^^^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:189:13
+  --> tests/ui/redundant_pattern_matching_option.rs:190:13
    |
 LL |     let _ = matches!(x, None);
    |             ^^^^^^^^^^^^^^^^^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:200:17
+  --> tests/ui/redundant_pattern_matching_option.rs:201:17
    |
 LL |         let _ = matches!(*p, None);
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `(*p).is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:208:16
+  --> tests/ui/redundant_pattern_matching_option.rs:209:16
    |
 LL |         if let Some(_) = x? {
    |         -------^^^^^^^----- help: try: `if x?.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:228:16
+  --> tests/ui/redundant_pattern_matching_option.rs:229:16
    |
 LL |         if let Some(_) = x.await {
    |         -------^^^^^^^---------- help: try: `if x.await.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:241:12
+  --> tests/ui/redundant_pattern_matching_option.rs:242:12
    |
 LL |     if let Some(_) = (x! {}) {};
    |     -------^^^^^^^---------- help: try: `if x! {}.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:243:15
+  --> tests/ui/redundant_pattern_matching_option.rs:244:15
    |
 LL |     while let Some(_) = (x! {}) {}
    |     ----------^^^^^^^---------- help: try: `while x! {}.is_some()`

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -3,6 +3,7 @@
 #![allow(
     clippy::if_same_then_else,
     clippy::match_like_matches_macro,
+    clippy::matches_with_unrelated_if,
     clippy::needless_bool,
     clippy::needless_ifs,
     clippy::uninlined_format_args,

--- a/tests/ui/redundant_pattern_matching_result.rs
+++ b/tests/ui/redundant_pattern_matching_result.rs
@@ -3,6 +3,7 @@
 #![allow(
     clippy::if_same_then_else,
     clippy::match_like_matches_macro,
+    clippy::matches_with_unrelated_if,
     clippy::needless_bool,
     clippy::needless_ifs,
     clippy::uninlined_format_args,

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:14:12
+  --> tests/ui/redundant_pattern_matching_result.rs:15:12
    |
 LL |     if let Ok(_) = &result {}
    |     -------^^^^^---------- help: try: `if result.is_ok()`
@@ -8,31 +8,31 @@ LL |     if let Ok(_) = &result {}
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:17:12
+  --> tests/ui/redundant_pattern_matching_result.rs:18:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:20:12
+  --> tests/ui/redundant_pattern_matching_result.rs:21:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:23:15
+  --> tests/ui/redundant_pattern_matching_result.rs:24:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:26:15
+  --> tests/ui/redundant_pattern_matching_result.rs:27:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:37:5
+  --> tests/ui/redundant_pattern_matching_result.rs:38:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |
@@ -42,7 +42,7 @@ LL | |     };
    | |_____^ help: try: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:43:5
+  --> tests/ui/redundant_pattern_matching_result.rs:44:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |
@@ -52,7 +52,7 @@ LL | |     };
    | |_____^ help: try: `Ok::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:49:5
+  --> tests/ui/redundant_pattern_matching_result.rs:50:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |
@@ -62,7 +62,7 @@ LL | |     };
    | |_____^ help: try: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:55:5
+  --> tests/ui/redundant_pattern_matching_result.rs:56:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |
@@ -72,73 +72,73 @@ LL | |     };
    | |_____^ help: try: `Err::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:61:20
+  --> tests/ui/redundant_pattern_matching_result.rs:62:20
    |
 LL |     let _ = if let Ok(_) = Ok::<usize, ()>(4) { true } else { false };
    |             -------^^^^^--------------------- help: try: `if Ok::<usize, ()>(4).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:70:20
+  --> tests/ui/redundant_pattern_matching_result.rs:71:20
    |
 LL |     let _ = if let Ok(_) = gen_res() {
    |             -------^^^^^------------ help: try: `if gen_res().is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:73:19
+  --> tests/ui/redundant_pattern_matching_result.rs:74:19
    |
 LL |     } else if let Err(_) = gen_res() {
    |            -------^^^^^^------------ help: try: `if gen_res().is_err()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_result.rs:97:19
+  --> tests/ui/redundant_pattern_matching_result.rs:98:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
    |         ----------^^^^^^^----------------------- help: try: `while r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_result.rs:99:16
+  --> tests/ui/redundant_pattern_matching_result.rs:100:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
    |         -------^^^^^^^----------------------- help: try: `if r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_result.rs:106:12
+  --> tests/ui/redundant_pattern_matching_result.rs:107:12
    |
 LL |     if let Some(_) = m!() {}
    |     -------^^^^^^^------- help: try: `if m!().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_result.rs:108:15
+  --> tests/ui/redundant_pattern_matching_result.rs:109:15
    |
 LL |     while let Some(_) = m!() {}
    |     ----------^^^^^^^------- help: try: `while m!().is_some()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:127:12
+  --> tests/ui/redundant_pattern_matching_result.rs:128:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:130:12
+  --> tests/ui/redundant_pattern_matching_result.rs:131:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:133:15
+  --> tests/ui/redundant_pattern_matching_result.rs:134:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:136:15
+  --> tests/ui/redundant_pattern_matching_result.rs:137:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:139:5
+  --> tests/ui/redundant_pattern_matching_result.rs:140:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |
@@ -148,7 +148,7 @@ LL | |     };
    | |_____^ help: try: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:145:5
+  --> tests/ui/redundant_pattern_matching_result.rs:146:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |
@@ -158,7 +158,7 @@ LL | |     };
    | |_____^ help: try: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:156:5
+  --> tests/ui/redundant_pattern_matching_result.rs:157:5
    |
 LL | /     match x {
 LL | |
@@ -168,7 +168,7 @@ LL | |     };
    | |_____^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:162:5
+  --> tests/ui/redundant_pattern_matching_result.rs:163:5
    |
 LL | /     match x {
 LL | |
@@ -178,7 +178,7 @@ LL | |     };
    | |_____^ help: try: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:168:5
+  --> tests/ui/redundant_pattern_matching_result.rs:169:5
    |
 LL | /     match x {
 LL | |
@@ -188,7 +188,7 @@ LL | |     };
    | |_____^ help: try: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:174:5
+  --> tests/ui/redundant_pattern_matching_result.rs:175:5
    |
 LL | /     match x {
 LL | |
@@ -198,19 +198,19 @@ LL | |     };
    | |_____^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:196:13
+  --> tests/ui/redundant_pattern_matching_result.rs:197:13
    |
 LL |     let _ = matches!(x, Ok(_));
    |             ^^^^^^^^^^^^^^^^^^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:199:13
+  --> tests/ui/redundant_pattern_matching_result.rs:200:13
    |
 LL |     let _ = matches!(x, Err(_));
    |             ^^^^^^^^^^^^^^^^^^^ help: try: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:216:13
+  --> tests/ui/redundant_pattern_matching_result.rs:217:13
    |
 LL |       let _ = match test_expr!(42) {
    |  _____________^
@@ -221,7 +221,7 @@ LL | |     };
    | |_____^ help: try: `test_expr!(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:229:13
+  --> tests/ui/redundant_pattern_matching_result.rs:230:13
    |
 LL |     let _ = matches!(x, Ok(_) if test_guard!(42));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.is_ok() && test_guard!(42)`


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16719

### What this PR does

Adds a new `style` lint `matches_with_unrelated_if` that warns when
`matches!(expr, Pattern if guard)` is used and the guard does not
reference any variable introduced by `Pattern`.

### Motivation

The `if` guard inside `matches!` implies a relationship between the
pattern bindings and the condition. When the guard is independent of the
pattern, the grouping is misleading. Moving it out makes the intent clearer:

```rust
// Before (misleading — `f.is_bar()` has nothing to do with `Some(_)`)
let _ = matches!(f.foo(), Some(_) if f.is_bar());

// After (the two checks are clearly independent)
let _ = matches!(f.foo(), Some(_)) && f.is_bar();
```

This also helps catch cases where the user *intended* to use a pattern
binding in the guard but made an oversight (e.g. typed `f.is_bar()`
instead of `x.is_bar()` when the pattern was `Some(x)`).

### Implementation

- New file: `clippy_lints/src/matches/matches_with_unrelated_if.rs`
- Registered in `declared_lints.rs` and `matches/mod.rs`
- Category: `style`, machine-applicable suggestion

### Tests

Added `tests/ui/matches_with_unrelated_if.rs` covering:
- Guard uses an outer variable (should lint)
- Pattern has bindings that are never used in the guard (should lint)
- Pattern has no bindings, guard uses outer variable (should lint)
- Guard correctly uses the pattern binding (no lint)
- No guard at all (no lint)
- Guard uses both a binding and an outer variable (no lint)

changelog: new lint [`matches_with_unrelated_if`]
