### PR TITLE
apply useless_borrows_in_formatting fixes

### DIFF
--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -502,7 +502,7 @@ fn setup_mod_file(path: &Path, lint: &LintData<'_>) -> io::Result<&'static str> 
     file_contents.replace_range(arr_start + 1..arr_end, &new_arr_content);
 
     // Just add the mod declaration at the top, it'll be fixed by rustfmt
-    file_contents.insert_str(0, &format!("mod {};\n", &lint.name));
+    file_contents.insert_str(0, &format!("mod {};\n", lint.name));
 
     let mut file = OpenOptions::new()
         .write(true)

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -360,7 +360,7 @@ impl SuggestContext<'_, '_, '_> {
                         if app != Applicability::MachineApplicable {
                             return None;
                         }
-                        let _cannot_fail = write!(&mut self.output, "{}", &(!snip));
+                        let _cannot_fail = write!(&mut self.output, "{}", !snip);
                     }
                 },
                 True | False | Not(_) => {

--- a/clippy_lints/src/methods/wrong_self_convention.rs
+++ b/clippy_lints/src/methods/wrong_self_convention.rs
@@ -121,7 +121,7 @@ pub(super) fn check<'tcx>(
 
                     format!("methods with the following characteristics: ({s})")
                 } else {
-                    format!("methods called {}", &conventions[0])
+                    format!("methods called {}", conventions[0])
                 }
             };
 

--- a/clippy_lints/src/operators/manual_div_ceil.rs
+++ b/clippy_lints/src/operators/manual_div_ceil.rs
@@ -177,11 +177,7 @@ fn build_suggestion(
     // suggestion message, we want to make a suggestion string before `div_ceil` like
     // `(-2048_{type_suffix})`.
     let suggestion_before_div_ceil = if has_enclosing_paren(&dividend_sugg_str) {
-        format!(
-            "{}{})",
-            &dividend_sugg_str[..dividend_sugg_str.len() - 1].to_string(),
-            type_suffix
-        )
+        format!("{}{type_suffix})", &dividend_sugg_str[..dividend_sugg_str.len() - 1])
     } else {
         format!("{dividend_sugg_str}{type_suffix}")
     };

--- a/clippy_lints/src/ref_option_ref.rs
+++ b/clippy_lints/src/ref_option_ref.rs
@@ -58,7 +58,7 @@ impl<'tcx> LateLintPass<'tcx> for RefOptionRef {
                 ty.span,
                 "since `&` implements the `Copy` trait, `&Option<&T>` can be simplified to `Option<&T>`",
                 "try",
-                format!("Option<{}>", &snippet(cx, inner_ty.span, "..")),
+                format!("Option<{}>", snippet(cx, inner_ty.span, "..")),
                 Applicability::MaybeIncorrect,
             );
         }

--- a/clippy_lints/src/unit_types/unit_arg.rs
+++ b/clippy_lints/src/unit_types/unit_arg.rs
@@ -231,9 +231,8 @@ fn fmt_stmts_and_call(
         let block_indent = call_expr_indent + 4;
         stmts_and_call_snippet = reindent_multiline(&stmts_and_call_snippet, true, Some(block_indent));
         stmts_and_call_snippet = format!(
-            "{{\n{}{}\n{}}}",
+            "{{\n{}{stmts_and_call_snippet}\n{}}}",
             " ".repeat(block_indent),
-            &stmts_and_call_snippet,
             " ".repeat(call_expr_indent)
         );
     }

--- a/clippy_lints_internal/src/collapsible_span_lint_calls.rs
+++ b/clippy_lints_internal/src/collapsible_span_lint_calls.rs
@@ -232,8 +232,8 @@ fn suggest_help(
         "this call is collapsible",
         "collapse into",
         format!(
-            "span_lint_and_help({}, {}, {}, {}, {}, {help})",
-            and_then_snippets.cx, and_then_snippets.lint, and_then_snippets.span, and_then_snippets.msg, &option_span,
+            "span_lint_and_help({}, {}, {}, {}, {option_span}, {help})",
+            and_then_snippets.cx, and_then_snippets.lint, and_then_snippets.span, and_then_snippets.msg
         ),
         app,
     );

--- a/lintcheck/src/main.rs
+++ b/lintcheck/src/main.rs
@@ -85,12 +85,12 @@ impl Crate {
         if config.max_jobs == 1 {
             println!(
                 "{index}/{total_crates_to_lint} {perc}% Linting {} {}",
-                &self.name, &self.version
+                self.name, self.version
             );
         } else {
             println!(
                 "{index}/{total_crates_to_lint} {perc}% Linting {} {} in target dir {thread_index:?}",
-                &self.name, &self.version
+                self.name, self.version
             );
         }
 


### PR DESCRIPTION
minor code cleanup getting ready for the `useless_borrows_in_formatting` lint

See rust-lang/rust-clippy#16523

r? @samueltardieu

---

changelog: none
