### PR TITLE
`cast_possible_truncation`: don't lint when usize is masked to fit target type

### DIFF
--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -23,7 +23,19 @@ fn constant_int(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<u128> {
 }
 
 fn get_constant_bits(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<u64> {
-    constant_int(cx, expr).map(|c| u64::from(128 - c.leading_zeros()))
+    // `ConstEvalCtxt` does not evaluate `ExprKind::Cast`, so peel through cast
+    // expressions to reach the underlying constant (e.g. `u32::MAX as usize`).
+    let mut cur = expr;
+    loop {
+        if let Some(c) = constant_int(cx, cur) {
+            return Some(u64::from(128 - c.leading_zeros()));
+        }
+        if let ExprKind::Cast(inner, _) = cur.kind {
+            cur = inner;
+        } else {
+            return None;
+        }
+    }
 }
 
 fn apply_reductions(cx: &LateContext<'_>, nbits: u64, expr: &Expr<'_>, signed: bool) -> u64 {
@@ -103,7 +115,7 @@ pub(super) fn check(
             let (should_lint, suffix) = match (is_isize_or_usize(cast_from), is_isize_or_usize(cast_to)) {
                 (true, true) | (false, false) => (to_nbits < from_nbits, ""),
                 (true, false) => (
-                    to_nbits <= 32,
+                    to_nbits <= 32 && from_nbits > to_nbits,
                     if to_nbits == 32 {
                         " on targets with 64-bit wide pointers"
                     } else {

--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -183,7 +183,7 @@ pub(super) fn check(
         // TODO: Remove the condition for const contexts when `try_from` and other commonly used methods
         // become const fn.
         if !is_in_const_context(cx) && !cast_from.is_floating_point() {
-            offer_suggestion(cx, expr, cast_expr, cast_to_span, diag);
+            offer_suggestion(cx, expr, cast_expr, cast_from, cast_to, cast_to_span, diag);
         }
     });
 }
@@ -192,11 +192,13 @@ fn offer_suggestion(
     cx: &LateContext<'_>,
     expr: &Expr<'_>,
     cast_expr: &Expr<'_>,
+    cast_from: Ty<'_>,
+    cast_to: Ty<'_>,
     cast_to_span: Span,
     diag: &mut Diag<'_, ()>,
 ) {
     let cast_to_snip = snippet(cx, cast_to_span, "..");
-    let suggestion = if cast_to_snip == "_" {
+    let try_from_suggestion = if cast_to_snip == "_" {
         format!("{}.try_into()", Sugg::hir(cx, cast_expr, "..").maybe_paren())
     } else {
         format!("{cast_to_snip}::try_from({})", Sugg::hir(cx, cast_expr, ".."))
@@ -205,7 +207,20 @@ fn offer_suggestion(
     diag.span_suggestion_verbose(
         expr.span,
         "... or use `try_from` and handle the error accordingly",
-        suggestion,
+        try_from_suggestion,
         Applicability::Unspecified,
     );
+
+    if matches!(cast_from.kind(), ty::Uint(_)) && matches!(cast_to.kind(), ty::Uint(_)) && cast_to_snip != "_" {
+        let mask_suggestion = format!(
+            "({} & {cast_to_snip}::MAX as {cast_from}) as {cast_to_snip}",
+            Sugg::hir(cx, cast_expr, ".."),
+        );
+        diag.span_suggestion_verbose(
+            expr.span,
+            "... or explicitly mask the bits if truncation is intended",
+            mask_suggestion,
+            Applicability::Unspecified,
+        );
+    }
 }

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -251,6 +251,15 @@ fn main() {
     999999u64.clamp(0, 256) as u8;
     //~^ cast_possible_truncation
 
+    // usize masked to u32 range should not lint (issue #16854)
+    let y: usize = 100_000;
+    let _ = (y & u32::MAX as usize) as u32;
+    let _ = (y & 0xFFFF_FFFF_usize) as u32;
+    let _ = (y.saturating_sub(1) & u32::MAX as usize) as u32;
+    // unmasked usize should still lint
+    let _ = y as u32;
+    //~^ cast_possible_truncation
+
     #[derive(Clone, Copy)]
     enum E1 {
         A,

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -385,8 +385,21 @@ LL -     999999u64.clamp(0, 256) as u8;
 LL +     u8::try_from(999999u64.clamp(0, 256));
    |
 
+error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
+  --> tests/ui/cast.rs:260:13
+   |
+LL |     let _ = y as u32;
+   |             ^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL -     let _ = y as u32;
+LL +     let _ = u32::try_from(y);
+   |
+
 error: casting `main::E2` to `u8` may truncate the value
-  --> tests/ui/cast.rs:274:21
+  --> tests/ui/cast.rs:283:21
    |
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
@@ -399,7 +412,7 @@ LL +             let _ = u8::try_from(self);
    |
 
 error: casting `main::E2::B` to `u8` will truncate the value
-  --> tests/ui/cast.rs:277:21
+  --> tests/ui/cast.rs:286:21
    |
 LL |             let _ = Self::B as u8;
    |                     ^^^^^^^^^^^^^
@@ -408,7 +421,7 @@ LL |             let _ = Self::B as u8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_enum_truncation)]`
 
 error: casting `main::E5` to `i8` may truncate the value
-  --> tests/ui/cast.rs:319:21
+  --> tests/ui/cast.rs:328:21
    |
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
@@ -421,13 +434,13 @@ LL +             let _ = i8::try_from(self);
    |
 
 error: casting `main::E5::A` to `i8` will truncate the value
-  --> tests/ui/cast.rs:322:21
+  --> tests/ui/cast.rs:331:21
    |
 LL |             let _ = Self::A as i8;
    |                     ^^^^^^^^^^^^^
 
 error: casting `main::E6` to `i16` may truncate the value
-  --> tests/ui/cast.rs:340:21
+  --> tests/ui/cast.rs:349:21
    |
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
@@ -440,7 +453,7 @@ LL +             let _ = i16::try_from(self);
    |
 
 error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:360:21
+  --> tests/ui/cast.rs:369:21
    |
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
@@ -453,7 +466,7 @@ LL +             let _ = usize::try_from(self);
    |
 
 error: casting `main::E10` to `u16` may truncate the value
-  --> tests/ui/cast.rs:408:21
+  --> tests/ui/cast.rs:417:21
    |
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
@@ -466,7 +479,7 @@ LL +             let _ = u16::try_from(self);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:420:13
+  --> tests/ui/cast.rs:429:13
    |
 LL |     let c = (q >> 16) as u8;
    |             ^^^^^^^^^^^^^^^
@@ -479,7 +492,7 @@ LL +     let c = u8::try_from(q >> 16);
    |
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:425:13
+  --> tests/ui/cast.rs:434:13
    |
 LL |     let c = (q / 1000) as u8;
    |             ^^^^^^^^^^^^^^^^
@@ -492,85 +505,85 @@ LL +     let c = u8::try_from(q / 1000);
    |
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:438:9
+  --> tests/ui/cast.rs:447:9
    |
 LL |         (x * x) as u32;
    |         ^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(x * x).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:444:32
+  --> tests/ui/cast.rs:453:32
    |
 LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
    |                                ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(x * x * x * x).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:447:5
+  --> tests/ui/cast.rs:456:5
    |
 LL |     (2_i32).checked_pow(3).unwrap() as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(2_i32).checked_pow(3).unwrap().cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:449:5
+  --> tests/ui/cast.rs:458:5
    |
 LL |     (-2_i32).pow(3) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(-2_i32).pow(3).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:454:5
+  --> tests/ui/cast.rs:463:5
    |
 LL |     (-5_i32 % 2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(-5_i32 % 2).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:457:5
+  --> tests/ui/cast.rs:466:5
    |
 LL |     (-5_i32 % -2) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(-5_i32 % -2).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:461:5
+  --> tests/ui/cast.rs:470:5
    |
 LL |     (-2_i32 >> 1) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(-2_i32 >> 1).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:465:5
+  --> tests/ui/cast.rs:474:5
    |
 LL |     (x * x) as u32;
    |     ^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(x * x).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:467:5
+  --> tests/ui/cast.rs:476:5
    |
 LL |     (x * x * x) as u32;
    |     ^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(x * x * x).cast_unsigned()`
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:471:5
+  --> tests/ui/cast.rs:480:5
    |
 LL |     (y * y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(y * y * y * y * -2).cast_unsigned()`
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:474:5
+  --> tests/ui/cast.rs:483:5
    |
 LL |     (y * y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(y * y * y / y * 2).cast_unsigned()`
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:476:5
+  --> tests/ui/cast.rs:485:5
    |
 LL |     (y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(y * y / y * 2).cast_unsigned()`
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:479:5
+  --> tests/ui/cast.rs:488:5
    |
 LL |     (y / y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(y / y * y * -2).cast_unsigned()`
 
 error: equal expressions as operands to `/`
-  --> tests/ui/cast.rs:479:6
+  --> tests/ui/cast.rs:488:6
    |
 LL |     (y / y * y * -2) as u16;
    |      ^^^^^
@@ -578,97 +591,97 @@ LL |     (y / y * y * -2) as u16;
    = note: `#[deny(clippy::eq_op)]` on by default
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:483:5
+  --> tests/ui/cast.rs:492:5
    |
 LL |     (y + y + y + -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(y + y + y + -2).cast_unsigned()`
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:486:5
+  --> tests/ui/cast.rs:495:5
    |
 LL |     (y + y + y + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(y + y + y + 2).cast_unsigned()`
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:490:5
+  --> tests/ui/cast.rs:499:5
    |
 LL |     (z + -2) as u16;
    |     ^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(z + -2).cast_unsigned()`
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:493:5
+  --> tests/ui/cast.rs:502:5
    |
 LL |     (z + z + 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(z + z + 2).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:497:9
+  --> tests/ui/cast.rs:506:9
    |
 LL |         (a * a * b * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a * a * b * b * c * c).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:499:9
+  --> tests/ui/cast.rs:508:9
    |
 LL |         (a * b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a * b * c).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:502:9
+  --> tests/ui/cast.rs:511:9
    |
 LL |         (a * -b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a * -b * c).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:505:9
+  --> tests/ui/cast.rs:514:9
    |
 LL |         (a * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a * b * c * c).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:507:9
+  --> tests/ui/cast.rs:516:9
    |
 LL |         (a * -2) as u32;
    |         ^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a * -2).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:510:9
+  --> tests/ui/cast.rs:519:9
    |
 LL |         (a * b * c * -2) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a * b * c * -2).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:513:9
+  --> tests/ui/cast.rs:522:9
    |
 LL |         (a / b) as u32;
    |         ^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a / b).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:515:9
+  --> tests/ui/cast.rs:524:9
    |
 LL |         (a / b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a / b * c).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:518:9
+  --> tests/ui/cast.rs:527:9
    |
 LL |         (a / b + b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a / b + b * c).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:521:9
+  --> tests/ui/cast.rs:530:9
    |
 LL |         a.saturating_pow(3) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `a.saturating_pow(3).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:524:9
+  --> tests/ui/cast.rs:533:9
    |
 LL |         (a.abs() * b.pow(2) / c.abs()) as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `(a.abs() * b.pow(2) / c.abs()).cast_unsigned()`
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:532:21
+  --> tests/ui/cast.rs:541:21
    |
 LL |             let _ = i32::MIN as u32; // cast_sign_loss
    |                     ^^^^^^^^^^^^^^^ help: if this is intentional, use `cast_unsigned()` instead: `i32::MIN.cast_unsigned()`
@@ -679,7 +692,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:535:21
+  --> tests/ui/cast.rs:544:21
    |
 LL |             let _ = u32::MAX as u8; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^
@@ -696,7 +709,7 @@ LL +             let _ = u8::try_from(u32::MAX); // cast_possible_truncation
    |
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:538:21
+  --> tests/ui/cast.rs:547:21
    |
 LL |             let _ = std::f64::consts::PI as f32; // cast_possible_truncation
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -708,7 +721,7 @@ LL |     m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: casting `i64` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:549:5
+  --> tests/ui/cast.rs:558:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -721,13 +734,13 @@ LL +     usize::try_from(bar.unwrap().unwrap())
    |
 
 error: casting `i64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:549:5
+  --> tests/ui/cast.rs:558:5
    |
 LL |     bar.unwrap().unwrap() as usize
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:566:5
+  --> tests/ui/cast.rs:575:5
    |
 LL |     (256 & 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -740,7 +753,7 @@ LL +     u8::try_from(256 & 999999u64);
    |
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:569:5
+  --> tests/ui/cast.rs:578:5
    |
 LL |     (255 % 999999u64) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -753,22 +766,22 @@ LL +     u8::try_from(255 % 999999u64);
    |
 
 error: casting `u8` to `i8` may wrap around the value
-  --> tests/ui/cast.rs:576:13
+  --> tests/ui/cast.rs:585:13
    |
 LL |         _ = 1u8 as i8;
    |             ^^^^^^^^^ help: if this is intentional, use `cast_signed()` instead: `1u8.cast_signed()`
 
 error: casting `u8` to `i8` may wrap around the value
-  --> tests/ui/cast.rs:581:13
+  --> tests/ui/cast.rs:590:13
    |
 LL |         _ = 1u8 as i8;
    |             ^^^^^^^^^
 
 error: casting `u8` to `i8` may wrap around the value
-  --> tests/ui/cast.rs:589:13
+  --> tests/ui/cast.rs:598:13
    |
 LL |         _ = val? as i8;
    |             ^^^^^^^^^^ help: if this is intentional, use `cast_signed()` instead: `val?.cast_signed()`
 
-error: aborting due to 95 previous errors
+error: aborting due to 96 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -132,6 +132,11 @@ help: ... or use `try_from` and handle the error accordingly
 LL -     1f32 as u32 as u16;
 LL +     u16::try_from(1f32 as u32);
    |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL -     1f32 as u32 as u16;
+LL +     (1f32 as u32 & u16::MAX as u32) as u16;
+   |
 
 error: casting `f32` to `u32` may truncate the value
   --> tests/ui/cast.rs:68:5
@@ -384,6 +389,11 @@ help: ... or use `try_from` and handle the error accordingly
 LL -     999999u64.clamp(0, 256) as u8;
 LL +     u8::try_from(999999u64.clamp(0, 256));
    |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL -     999999u64.clamp(0, 256) as u8;
+LL +     (999999u64.clamp(0, 256) & u8::MAX as u64) as u8;
+   |
 
 error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
   --> tests/ui/cast.rs:260:13
@@ -396,6 +406,11 @@ help: ... or use `try_from` and handle the error accordingly
    |
 LL -     let _ = y as u32;
 LL +     let _ = u32::try_from(y);
+   |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL -     let _ = y as u32;
+LL +     let _ = (y & u32::MAX as usize) as u32;
    |
 
 error: casting `main::E2` to `u8` may truncate the value
@@ -490,6 +505,10 @@ help: ... or use `try_from` and handle the error accordingly
 LL -     let c = (q >> 16) as u8;
 LL +     let c = u8::try_from(q >> 16);
    |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL |     let c = (q >> 16 & u8::MAX as u32) as u8;
+   |                      ++++++++++++++++
 
 error: casting `u32` to `u8` may truncate the value
   --> tests/ui/cast.rs:434:13
@@ -503,6 +522,10 @@ help: ... or use `try_from` and handle the error accordingly
 LL -     let c = (q / 1000) as u8;
 LL +     let c = u8::try_from(q / 1000);
    |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL |     let c = (q / 1000 & u8::MAX as u32) as u8;
+   |                       ++++++++++++++++
 
 error: casting `i32` to `u32` may lose the sign of the value
   --> tests/ui/cast.rs:447:9
@@ -707,6 +730,11 @@ help: ... or use `try_from` and handle the error accordingly
 LL -             let _ = u32::MAX as u8; // cast_possible_truncation
 LL +             let _ = u8::try_from(u32::MAX); // cast_possible_truncation
    |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL -             let _ = u32::MAX as u8; // cast_possible_truncation
+LL +             let _ = (u32::MAX & u8::MAX as u32) as u8; // cast_possible_truncation
+   |
 
 error: casting `f64` to `f32` may truncate the value
   --> tests/ui/cast.rs:547:21
@@ -751,6 +779,10 @@ help: ... or use `try_from` and handle the error accordingly
 LL -     (256 & 999999u64) as u8;
 LL +     u8::try_from(256 & 999999u64);
    |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL |     (256 & 999999u64 & u8::MAX as u64) as u8;
+   |                      ++++++++++++++++
 
 error: casting `u64` to `u8` may truncate the value
   --> tests/ui/cast.rs:578:5
@@ -764,6 +796,10 @@ help: ... or use `try_from` and handle the error accordingly
 LL -     (255 % 999999u64) as u8;
 LL +     u8::try_from(255 % 999999u64);
    |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL |     (255 % 999999u64 & u8::MAX as u64) as u8;
+   |                      ++++++++++++++++
 
 error: casting `u8` to `i8` may wrap around the value
   --> tests/ui/cast.rs:585:13

--- a/tests/ui/cast_size.r64bit.stderr
+++ b/tests/ui/cast_size.r64bit.stderr
@@ -78,6 +78,11 @@ help: ... or use `try_from` and handle the error accordingly
 LL -     1usize as u32;
 LL +     u32::try_from(1usize);
    |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL -     1usize as u32;
+LL +     (1usize & u32::MAX as usize) as u32;
+   |
 
 error: casting `usize` to `i32` may truncate the value on targets with 64-bit wide pointers
   --> tests/ui/cast_size.rs:41:5
@@ -157,6 +162,11 @@ help: ... or use `try_from` and handle the error accordingly
    |
 LL -     1u64 as usize;
 LL +     usize::try_from(1u64);
+   |
+help: ... or explicitly mask the bits if truncation is intended
+   |
+LL -     1u64 as usize;
+LL +     (1u64 & usize::MAX as u64) as usize;
    |
 
 error: casting `u32` to `isize` may wrap around the value on targets with 32-bit wide pointers


### PR DESCRIPTION
Fixes the false positive in `cast_possible_truncation` where masking a `usize` value to fit within a `u32` (or smaller) before casting still triggered a warning.

Closes rust-lang/rust-clippy#16854

### What was wrong

```rust
// Before (incorrectly warned):
let remaining = (levels.len().saturating_sub(n) & u32::MAX as usize) as u32;
let remaining = (levels.len().saturating_sub(n) & 0xFFFF_FFFF_usize) as u32;
```

```rust
// After (no warning — value is provably within u32 range):
let remaining = (levels.len().saturating_sub(n) & u32::MAX as usize) as u32;
let remaining = (levels.len().saturating_sub(n) & 0xFFFF_FFFF_usize) as u32;

// Unmasked cast still warns correctly:
let remaining = levels.len() as u32;
//              ^^^^^^^^^^^^^^^^^ cast_possible_truncation
```

### Root cause (two bugs)

1. **`get_constant_bits` couldn't evaluate `u32::MAX as usize`** — `ConstEvalCtxt` has no `ExprKind::Cast` handler, so it returned `None` for cast expressions even when the inner value is a known constant. Fixed by peeling through cast layers to reach the underlying constant.

2. **`apply_reductions` result was ignored for `usize → fixed-size int` casts** — the `(true, false)` match arm checked `to_nbits <= 32` unconditionally, never consulting the reduced `from_nbits`. Fixed by adding `&& from_nbits > to_nbits`.

changelog: [`cast_possible_truncation`]: no longer lints when a `usize` value is masked to fit the target integer type before casting
