### PR TITLE
Fixes a case where `collapsible_match` suggested a transformation that changes runtime behavior.

### DIFF
--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -23,8 +23,19 @@ use super::{COLLAPSIBLE_MATCH, pat_contains_disallowed_or};
 
 pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>], msrv: Msrv) {
     if let Some(els_arm) = arms.iter().rfind(|arm| arm_is_wild_like(cx, arm)) {
-        for arm in arms {
-            check_arm(cx, true, arm.pat, expr, arm.body, arm.guard, Some(els_arm.body), msrv);
+        for (idx, arm) in arms.iter().enumerate() {
+            let only_wildcards_after = arms[idx + 1..].iter().all(|a| arm_is_wild_like(cx, a));
+            check_arm(
+                cx,
+                true,
+                arm.pat,
+                expr,
+                arm.body,
+                arm.guard,
+                Some(els_arm.body),
+                msrv,
+                only_wildcards_after,
+            );
         }
     }
 }
@@ -37,7 +48,7 @@ pub(super) fn check_if_let<'tcx>(
     let_expr: &'tcx Expr<'_>,
     msrv: Msrv,
 ) {
-    check_arm(cx, false, pat, let_expr, body, None, else_expr, msrv);
+    check_arm(cx, false, pat, let_expr, body, None, else_expr, msrv, false);
 }
 
 #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
@@ -50,6 +61,7 @@ fn check_arm<'tcx>(
     outer_guard: Option<&'tcx Expr<'tcx>>,
     outer_else_body: Option<&'tcx Expr<'tcx>>,
     msrv: Msrv,
+    only_wildcards_after: bool,
 ) {
     let inner_expr = peel_blocks_with_stmt(outer_then_body);
     if let Some(inner) = IfLetOrMatch::parse(cx, inner_expr)
@@ -126,6 +138,7 @@ fn check_arm<'tcx>(
             );
         });
     } else if outer_is_match // Leave if-let to the `collapsible_if` lint
+        && only_wildcards_after // adding a guard allows fall-through; unsafe if other arms follow
         && let Some(inner) = If::hir(inner_expr)
         && outer_pat.span.eq_ctxt(inner.cond.span)
         && match (outer_else_body, inner.r#else) {

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -23,8 +23,9 @@ use super::{COLLAPSIBLE_MATCH, pat_contains_disallowed_or};
 
 pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>], msrv: Msrv) {
     if let Some(els_arm) = arms.iter().rfind(|arm| arm_is_wild_like(cx, arm)) {
+        let last_non_wildcard = arms.iter().rposition(|arm| !arm_is_wild_like(cx, arm));
         for (idx, arm) in arms.iter().enumerate() {
-            let only_wildcards_after = arms[idx + 1..].iter().all(|a| arm_is_wild_like(cx, a));
+            let only_wildcards_after = last_non_wildcard.is_none_or(|lnw| idx >= lnw);
             check_arm(
                 cx,
                 true,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5221,7 +5221,6 @@ impl Methods {
                             format_collect::check(cx, expr, m_arg, m_ident_span);
                         },
                         Some((sym::take, take_self_arg, [take_arg], _, _)) => {
-                            #[expect(clippy::collapsible_match)]
                             if self.msrv.meets(cx, msrvs::STR_REPEAT) {
                                 manual_str_repeat::check(cx, expr, recv, take_self_arg, take_arg);
                             }
@@ -5546,9 +5545,7 @@ impl Methods {
                 (sym::open, [_]) => {
                     open_options::check(cx, expr, recv);
                 },
-                (sym::or_else, [arg]) =>
-                {
-                    #[expect(clippy::collapsible_match)]
+                (sym::or_else, [arg]) => {
                     if !bind_instead_of_map::check_or_else_err(cx, expr, recv, arg) {
                         unnecessary_lazy_eval::check(cx, expr, recv, arg, "or");
                     }
@@ -5653,9 +5650,7 @@ impl Methods {
                 (sym::try_into, []) if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::TryInto) => {
                     unnecessary_fallible_conversions::check_method(cx, expr);
                 },
-                (sym::to_owned, []) =>
-                {
-                    #[expect(clippy::collapsible_match)]
+                (sym::to_owned, []) => {
                     if !suspicious_to_owned::check(cx, expr, span) {
                         implicit_clone::check(cx, name, expr, recv);
                     }

--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -390,6 +390,26 @@ fn take<T>(t: T) {}
 
 fn main() {}
 
+// https://github.com/rust-lang/rust-clippy/issues/16875
+// Adding a match guard allows fall-through to subsequent arms, which changes semantics
+// when non-wildcard arms follow the arm being collapsed.
+fn issue16875(a: Option<&str>, b: i32) -> i32 {
+    let mut res = 0;
+    // should NOT lint: `_ if b == 1` is not wild-like (has a guard), so collapsing
+    // `Some(_)` into `Some(_) if b == 0` would let `_ if b == 1` match Some values
+    // that previously fell through to the no-op arm body.
+    match a {
+        Some(_) => {
+            if b == 0 {
+                res = 1;
+            }
+        },
+        _ if b == 1 => res = 2,
+        _ => {},
+    }
+    res
+}
+
 fn issue16705(x: Option<String>) {
     fn takes_ownership(s: String) -> bool {
         true

--- a/tests/ui/collapsible_match_fixable.fixed
+++ b/tests/ui/collapsible_match_fixable.fixed
@@ -28,3 +28,18 @@ fn issue16558() {
         _ => 1,
     };
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/16875
+// lint still fires when only wildcard-like arms follow (fall-through is harmless)
+fn issue16875(a: Option<&str>, b: i32) -> i32 {
+    let mut res = 0;
+    match a {
+        Some(_)
+            if b == 0 => {
+                //~^ collapsible_match
+                res = 1;
+            },
+        _ => {},
+    }
+    res
+}

--- a/tests/ui/collapsible_match_fixable.rs
+++ b/tests/ui/collapsible_match_fixable.rs
@@ -29,3 +29,19 @@ fn issue16558() {
         _ => 1,
     };
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/16875
+// lint still fires when only wildcard-like arms follow (fall-through is harmless)
+fn issue16875(a: Option<&str>, b: i32) -> i32 {
+    let mut res = 0;
+    match a {
+        Some(_) => {
+            if b == 0 {
+                //~^ collapsible_match
+                res = 1;
+            }
+        },
+        _ => {},
+    }
+    res
+}

--- a/tests/ui/collapsible_match_fixable.stderr
+++ b/tests/ui/collapsible_match_fixable.stderr
@@ -46,5 +46,23 @@ LL |
 LL ~         ,
    |
 
-error: aborting due to 3 previous errors
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:39:13
+   |
+LL | /             if b == 0 {
+LL | |
+LL | |                 res = 1;
+LL | |             }
+   | |_____________^
+   |
+help: collapse nested if block
+   |
+LL ~         Some(_)
+LL ~             if b == 0 => {
+LL |
+LL |                 res = 1;
+LL ~             },
+   |
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16875

### What was wrong

The lint suggested collapsing `pattern => { if test { body } }` into `pattern if test => { body }`. These are not equivalent. In the original, once `pattern` matches, the match exits regardless of `test`. In the suggestion, a failing guard allows fall-through to subsequent arms, which can match values that previously never reached them.

```rust
// Before (original)
match a {
    Some(_) => {
        if b == 0 { res = 1 }
    }
    _ if b == 1 => res = 2,  // unreachable when a is Some(_)
    _ => {}
}

// After (suggestion — WRONG, changes behavior)
match a {
    Some(_) if b == 0 => res = 1,
    _ if b == 1 => res = 2,  // now reachable when a is Some(_) and b != 0
    _ => {}
}
```

### Fix

The `if`-guard collapsing is only safe when there are no non-wildcard arms between the current arm and the wildcard arm. The fix adds a check that all arms after the current one are "wild-like" (a bare `_`, a binding, or `None`, all without guards) before suggesting the transformation.

As a side effect, three `#[expect(clippy::collapsible_match)]` suppressions in `clippy_lints/src/methods/mod.rs` are removed. They had been added to suppress this exact false positive and are no longer needed.

### Still lints correctly

When only wildcard arms follow, the transformation is safe and the lint still fires:

```rust
// This still lints — only `_ => {}` follows, fall-through is harmless
match a {
    Some(_) => {
        if b == 0 { res = 1 }  // triggers collapsible_match
    }
    _ => {}
}
```

changelog: [`collapsible_match`]: no longer suggests collapsing `pattern => { if test { body } }` into a match guard when non-wildcard arms follow, as this changes the semantics of the match.


<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [Beta-nomination](https://github.com/rust-lang/rust-clippy/pull/16878#pullrequestreview-4134228149) by [samueltardieu](https://github.com/samueltardieu)

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->