### PR TITLE
Fix `single_match` suggests wrongly for bool comparisons

### DIFF
--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -1,11 +1,16 @@
+use std::borrow::Cow;
+use std::ops::Not as _;
+
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::{
     SpanRangeExt, expr_block, snippet, snippet_block_with_context, snippet_with_applicability, snippet_with_context,
 };
+use clippy_utils::sugg::{Sugg, make_binop};
 use clippy_utils::ty::{implements_trait, peel_and_count_ty_refs};
 use clippy_utils::{is_lint_allowed, is_unit_expr, peel_blocks, peel_hir_pat_refs, peel_n_hir_expr_refs, sym};
 use core::ops::ControlFlow;
 use rustc_arena::DroplessArena;
+use rustc_ast::{BinOpKind, LitKind};
 use rustc_errors::{Applicability, Diag};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::{Visitor, walk_pat};
@@ -162,12 +167,22 @@ fn report_single_pattern(
         };
 
         let msg = "you seem to be trying to use `match` for an equality check. Consider using `if`";
-        let sugg = format!(
-            "if {} == {}{} {}{els_str}",
-            snippet_with_context(cx, ex.span, ctxt, "..", &mut app).0,
+        let ex_sugg = Sugg::hir_with_context(cx, ex, ctxt, "..", &mut app);
+
+        let cond_sugg = if ty.is_bool()
+            && let PatKind::Expr(lit) = pat.kind
+            && let PatExprKind::Lit { lit, negated: false } = lit.kind
+            && let LitKind::Bool(value) = lit.node
+        {
+            if value { ex_sugg } else { ex_sugg.not() }
+        } else {
+            let pat_snip = snippet_with_applicability(cx, arm.pat.span, "..", &mut app);
             // PartialEq for different reference counts may not exist.
-            ref_or_deref_adjust,
-            snippet_with_applicability(cx, arm.pat.span, "..", &mut app),
+            let pat_sugg = Sugg::NonParen(Cow::Owned(format!("{ref_or_deref_adjust}{pat_snip}")));
+            make_binop(BinOpKind::Eq, &ex_sugg, &pat_sugg)
+        };
+        let sugg = format!(
+            "if {cond_sugg} {}{els_str}",
             expr_block(cx, arm.body, ctxt, "..", Some(expr.span), &mut app),
         );
         (msg, sugg)

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -403,3 +403,21 @@ fn issue14493() {
         _ => println!("neq"),
     }
 }
+
+fn issue16826() {
+    let i = 2;
+    if i == 1 {
+        println!("{i}")
+    }
+    //~^^^^^^ single_match
+
+    if i != 1 {
+        println!("{i}")
+    }
+    //~^^^^^^ single_match
+
+    if i == 1 {
+        println!("{i}")
+    }
+    //~^^^^^^ single_match
+}

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -504,3 +504,30 @@ fn issue14493() {
         _ => println!("neq"),
     }
 }
+
+fn issue16826() {
+    let i = 2;
+    match i == 1 {
+        true => {
+            println!("{i}")
+        },
+        false => (),
+    }
+    //~^^^^^^ single_match
+
+    match i == 1 {
+        false => {
+            println!("{i}")
+        },
+        true => (),
+    }
+    //~^^^^^^ single_match
+
+    match i {
+        1 => {
+            println!("{i}")
+        },
+        _ => (),
+    }
+    //~^^^^^^ single_match
+}

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -339,5 +339,59 @@ LL | |         _ => (),
 LL | |     }
    | |_____^ help: try: `if mac!(str) == "foo" { println!("eq") }`
 
-error: aborting due to 31 previous errors
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match.rs:510:5
+   |
+LL | /     match i == 1 {
+LL | |         true => {
+LL | |             println!("{i}")
+LL | |         },
+LL | |         false => (),
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if i == 1 {
+LL +         println!("{i}")
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match.rs:518:5
+   |
+LL | /     match i == 1 {
+LL | |         false => {
+LL | |             println!("{i}")
+LL | |         },
+LL | |         true => (),
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if i != 1 {
+LL +         println!("{i}")
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match.rs:526:5
+   |
+LL | /     match i {
+LL | |         1 => {
+LL | |             println!("{i}")
+LL | |         },
+LL | |         _ => (),
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if i == 1 {
+LL +         println!("{i}")
+LL +     }
+   |
+
+error: aborting due to 34 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16826 

changelog: [`single_match`] fix wrong suggestions for bool comparisons
