### PR TITLE
fix `from_over_into` false positive with conflicting blanket From impl

### DIFF
--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -169,9 +169,9 @@ fn has_blanket_from_impl<'tcx>(cx: &LateContext<'tcx>, self_ty: Ty<'tcx>) -> boo
     let Some(from_def_id) = cx.tcx.get_diagnostic_item(sym::From) else {
         return false;
     };
-    cx.tcx.all_impls(from_def_id).any(|impl_id| {
+    cx.tcx.non_blanket_impls_for_ty(from_def_id, self_ty).any(|impl_id| {
         let impl_trait_ref = cx.tcx.impl_trait_ref(impl_id).instantiate_identity();
-        impl_trait_ref.self_ty() == self_ty && matches!(impl_trait_ref.args.type_at(1).kind(), ty::Param(_))
+        matches!(impl_trait_ref.args.type_at(1).kind(), ty::Param(_))
     })
 }
 

--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -10,11 +10,11 @@ use rustc_errors::Applicability;
 use rustc_hir::intravisit::{Visitor, walk_path};
 use rustc_hir::{
     FnRetTy, GenericArg, GenericArgs, HirId, Impl, ImplItemId, ImplItemKind, Item, ItemKind, PatKind, Path,
-    PathSegment, Ty, TyKind,
+    PathSegment, Ty as HirTy, TyKind,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::hir::nested_filter::OnlyBodies;
-use rustc_middle::ty;
+use rustc_middle::ty::{self, Ty};
 use rustc_session::impl_lint_pass;
 use rustc_span::symbol::{kw, sym};
 use rustc_span::{Span, Symbol};
@@ -165,7 +165,7 @@ impl<'tcx> Visitor<'tcx> for SelfFinder<'_, 'tcx> {
     }
 }
 
-fn has_blanket_from_impl<'tcx>(cx: &LateContext<'tcx>, self_ty: ty::Ty<'tcx>) -> bool {
+fn has_blanket_from_impl<'tcx>(cx: &LateContext<'tcx>, self_ty: Ty<'tcx>) -> bool {
     let Some(from_def_id) = cx.tcx.get_diagnostic_item(sym::From) else {
         return false;
     };
@@ -178,8 +178,8 @@ fn has_blanket_from_impl<'tcx>(cx: &LateContext<'tcx>, self_ty: ty::Ty<'tcx>) ->
 fn convert_to_from(
     cx: &LateContext<'_>,
     into_trait_seg: &PathSegment<'_>,
-    target_ty: &Ty<'_>,
-    self_ty: &Ty<'_>,
+    target_ty: &HirTy<'_>,
+    self_ty: &HirTy<'_>,
     impl_item_ref: ImplItemId,
 ) -> Option<Vec<(Span, String)>> {
     if !target_ty.find_self_aliases().is_empty() {

--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -80,6 +80,8 @@ impl<'tcx> LateLintPass<'tcx> for FromOverInto {
             && cx.tcx.is_diagnostic_item(sym::Into, middle_trait_ref.def_id)
             && !matches!(middle_trait_ref.args.type_at(1).kind(), ty::Alias(ty::Opaque, _))
             && self.msrv.meets(cx, msrvs::RE_REBALANCING_COHERENCE)
+            // skip if there's a blanket From impl, the suggested impl would conflict
+            && !has_blanket_from_impl(cx, middle_trait_ref.self_ty())
         {
             span_lint_and_then(
                 cx,
@@ -161,6 +163,16 @@ impl<'tcx> Visitor<'tcx> for SelfFinder<'_, 'tcx> {
             ControlFlow::Continue(())
         }
     }
+}
+
+fn has_blanket_from_impl<'tcx>(cx: &LateContext<'tcx>, self_ty: ty::Ty<'tcx>) -> bool {
+    let Some(from_def_id) = cx.tcx.get_diagnostic_item(sym::From) else {
+        return false;
+    };
+    cx.tcx.all_impls(from_def_id).any(|impl_id| {
+        let impl_trait_ref = cx.tcx.impl_trait_ref(impl_id).instantiate_identity();
+        impl_trait_ref.self_ty() == self_ty && matches!(impl_trait_ref.args.type_at(1).kind(), ty::Param(_))
+    })
 }
 
 fn convert_to_from(

--- a/tests/ui/from_over_into.fixed
+++ b/tests/ui/from_over_into.fixed
@@ -116,4 +116,24 @@ fn issue_112502() {
     }
 }
 
+fn issue_16823() {
+    pub struct Foo(pub String);
+
+    impl<T> From<T> for Foo
+    where
+        String: From<T>,
+    {
+        fn from(val: T) -> Self {
+            Self(String::from(val))
+        }
+    }
+
+    // no lint, From<Foo> for String would conflict with the blanket impl above
+    impl Into<String> for Foo {
+        fn into(self) -> String {
+            self.0
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/from_over_into.rs
+++ b/tests/ui/from_over_into.rs
@@ -116,4 +116,24 @@ fn issue_112502() {
     }
 }
 
+fn issue_16823() {
+    pub struct Foo(pub String);
+
+    impl<T> From<T> for Foo
+    where
+        String: From<T>,
+    {
+        fn from(val: T) -> Self {
+            Self(String::from(val))
+        }
+    }
+
+    // no lint, From<Foo> for String would conflict with the blanket impl above
+    impl Into<String> for Foo {
+        fn into(self) -> String {
+            self.0
+        }
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16823

This is my first contribution to Clippy,  happy to make changes if the approach isn't quite right

changelog: [`from_over_into`]: don't lint when a blanket `From` impl would cause a coherence conflict
