### PR TITLE
Link to fixed tag for source links

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -441,6 +441,7 @@ fn ui_cargo_toml_metadata() {
 struct Renderer<'a> {
     count: usize,
     lints: &'a Vec<LintMetadata>,
+    git_ref: String,
 }
 
 impl Renderer<'_> {
@@ -522,6 +523,7 @@ impl DiagnosticCollector {
                 Renderer {
                     count: LINTS.len(),
                     lints: &metadata,
+                    git_ref: env::var("TAG_NAME").unwrap_or("master".to_string()),
                 }
                 .render()
                 .unwrap(),

--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -207,7 +207,7 @@ Otherwise, have a great day =^.^=
 
                         {# Jump to source #}
                         {% if let Some(id_location) = lint.id_location %}
-                            <a href="https://github.com/rust-lang/rust-clippy/blob/master/{{id_location}}">View Source</a>
+                            <a href="https://github.com/rust-lang/rust-clippy/blob/{{git_ref}}/{{id_location}}">View Source</a>
                         {% endif %}
                     </div> {# #}
                 </div> {# #}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16882.

Make the "View Source" links point to a fixed tag version when `TAG_NAME` env var is set (which is the case in the [release workflow](https://github.com/rust-lang/rust-clippy/blob/5800532ce08a453bb0eb60c4d6661500fc8c7b33/.github/workflows/deploy.yml#L44-L46)) instead of always linking to `master`.

## Test plan

Tested locally with both:

```bash
TAG_NAME=rust-1.95.0 cargo collect-metadata
cargo collect-metadata
```

Links point to `https://github.com/rust-lang/rust-clippy/blob/rust-1.95.0/...` in the first case, and `https://github.com/rust-lang/rust-clippy/blob/master/...` in the second one.

changelog: none
