### PR TITLE
Extend `zst_offset` lint to detect NonNull<T> offset calculations

### DIFF
--- a/clippy_lints/src/methods/zst_offset.rs
+++ b/clippy_lints/src/methods/zst_offset.rs
@@ -1,13 +1,20 @@
 use clippy_utils::diagnostics::span_lint;
+use clippy_utils::res::MaybeDef;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
 use rustc_middle::ty;
+use rustc_span::sym;
 
 use super::ZST_OFFSET;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, recv: &hir::Expr<'_>) {
-    if let ty::RawPtr(ty, _) = cx.typeck_results().expr_ty(recv).kind()
-        && let Ok(layout) = cx.tcx.layout_of(cx.typing_env().as_query_input(*ty))
+    let recv_ty = cx.typeck_results().expr_ty(recv);
+    let pointee_ty = match recv_ty.kind() {
+        ty::RawPtr(ty, _) => *ty,
+        ty::Adt(_, args) if recv_ty.is_diag_item(cx, sym::NonNull) => args.type_at(0),
+        _ => return,
+    };
+    if let Ok(layout) = cx.tcx.layout_of(cx.typing_env().as_query_input(pointee_ty))
         && layout.is_zst()
     {
         span_lint(cx, ZST_OFFSET, expr.span, "offset calculation on zero-sized value");

--- a/tests/ui/zero_offset.rs
+++ b/tests/ui/zero_offset.rs
@@ -29,5 +29,18 @@ fn main() {
 
         let sized = &1 as *const i32;
         sized.offset(0);
+
+        let nn = core::ptr::NonNull::<()>::dangling();
+        nn.add(0);
+        //~^ zst_offset
+
+        nn.offset(0);
+        //~^ zst_offset
+
+        nn.sub(0);
+        //~^ zst_offset
+
+        let nn_sized = core::ptr::NonNull::<i32>::dangling();
+        nn_sized.add(0);
     }
 }

--- a/tests/ui/zero_offset.stderr
+++ b/tests/ui/zero_offset.stderr
@@ -48,5 +48,23 @@ error: offset calculation on zero-sized value
 LL |         c.wrapping_sub(0);
    |         ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: offset calculation on zero-sized value
+  --> tests/ui/zero_offset.rs:34:9
+   |
+LL |         nn.add(0);
+   |         ^^^^^^^^^
+
+error: offset calculation on zero-sized value
+  --> tests/ui/zero_offset.rs:37:9
+   |
+LL |         nn.offset(0);
+   |         ^^^^^^^^^^^^
+
+error: offset calculation on zero-sized value
+  --> tests/ui/zero_offset.rs:40:9
+   |
+LL |         nn.sub(0);
+   |         ^^^^^^^^^
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16887

The `zst_offset` lint previously only checked raw pointers (`*mut T` / `*const T`) for offset calculations on zero-sized types. `NonNull<T>` also provides `add`, `sub`, and `offset` methods that are equally no-ops on ZSTs, but were not flagged.

The PR extends the lint to also check `NonNull<T>` receivers.

changelog: [`zst_offset`]: detect zero-sized `NonNull<T>` offset calculations.