### PR TITLE
Add `manual_min_max` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ document.
 
 [df995e...master](https://github.com/rust-lang/rust-clippy/compare/df995e...master)
 
+### New Lints
+
+* Added [`manual_min_max`] to `complexity`
+  [#NNNNN](https://github.com/rust-lang/rust-clippy/pull/NNNNN)
+
 ## Rust 1.95
 
 Current stable, released 2026-04-16
@@ -6907,6 +6912,7 @@ Released 2018-09-13
 [`manual_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
 [`manual_memcpy`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_memcpy
 [`manual_midpoint`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_midpoint
+[`manual_min_max`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_min_max
 [`manual_next_back`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_next_back
 [`manual_non_exhaustive`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive
 [`manual_noop_waker`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_noop_waker

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -310,6 +310,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::manual_is_power_of_two::MANUAL_IS_POWER_OF_TWO_INFO,
     crate::manual_let_else::MANUAL_LET_ELSE_INFO,
     crate::manual_main_separator_str::MANUAL_MAIN_SEPARATOR_STR_INFO,
+    crate::manual_min_max::MANUAL_MIN_MAX_INFO,
     crate::manual_non_exhaustive::MANUAL_NON_EXHAUSTIVE_INFO,
     crate::manual_noop_waker::MANUAL_NOOP_WAKER_INFO,
     crate::manual_option_as_slice::MANUAL_OPTION_AS_SLICE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -208,6 +208,7 @@ mod manual_is_ascii_check;
 mod manual_is_power_of_two;
 mod manual_let_else;
 mod manual_main_separator_str;
+mod manual_min_max;
 mod manual_non_exhaustive;
 mod manual_noop_waker;
 mod manual_option_as_slice;
@@ -757,6 +758,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(move |_| Box::new(manual_rem_euclid::ManualRemEuclid::new(conf))),
         Box::new(move |_| Box::new(manual_retain::ManualRetain::new(conf))),
         Box::new(move |_| Box::new(manual_rotate::ManualRotate)),
+        Box::new(|_| Box::new(manual_min_max::ManualMinMax)),
         Box::new(move |_| Box::new(operators::Operators::new(conf))),
         Box::new(move |_| Box::new(std_instead_of_core::StdReexports::new(conf))),
         Box::new(move |_| Box::new(time_subtraction::UncheckedTimeSubtraction::new(conf))),

--- a/clippy_lints/src/manual_min_max.rs
+++ b/clippy_lints/src/manual_min_max.rs
@@ -1,0 +1,115 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::higher::If;
+use clippy_utils::sugg::Sugg;
+use clippy_utils::ty::implements_trait;
+use clippy_utils::{eq_expr_value, is_in_const_context, peel_blocks};
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+use rustc_span::sym;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Detects manual implementations of `Ord::min` or `Ord::max` using if-else
+    /// expressions and suggests using those methods directly.
+    ///
+    /// ### Why is this bad?
+    /// Using `min` or `max` is shorter, clearer, and avoids explicit control flow.
+    ///
+    /// ### Known issues
+    /// Does not apply to floats because `f32`/`f64` implement `PartialOrd` not
+    /// `Ord`, and `f32::min`/`f32::max` have different NaN semantics from a plain
+    /// if-else comparison.
+    ///
+    /// ### Example
+    /// ```rust
+    /// let a = 3_i32;
+    /// let b = 5_i32;
+    /// let _ = if a > b { b } else { a };
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// let a = 3_i32;
+    /// let b = 5_i32;
+    /// let _ = a.min(b);
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub MANUAL_MIN_MAX,
+    complexity,
+    "using an if-else instead of `Ord::min` or `Ord::max`"
+}
+
+declare_lint_pass!(ManualMinMax => [MANUAL_MIN_MAX]);
+
+impl<'tcx> LateLintPass<'tcx> for ManualMinMax {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if expr.span.from_expansion() || is_in_const_context(cx) {
+            return;
+        }
+        let Some(If {
+            cond,
+            then,
+            r#else: Some(else_expr),
+        }) = If::hir(expr)
+        else {
+            return;
+        };
+        let ExprKind::Binary(op, lhs, rhs) = cond.kind else {
+            return;
+        };
+        let then_val = peel_blocks(then);
+        let else_val = peel_blocks(else_expr);
+
+        // Determine which method to suggest; receiver is always lhs, arg is rhs.
+        //
+        // Pattern table (A = lhs of comparison, B = rhs of comparison):
+        //   then=A, else=B, op=< or <=  → A.min(B)
+        //   then=B, else=A, op=> or >=  → A.min(B)
+        //   then=A, else=B, op=> or >=  → A.max(B)
+        //   then=B, else=A, op=< or <=  → A.max(B)
+        let method = match op.node {
+            BinOpKind::Lt | BinOpKind::Le => {
+                if eq_expr_value(cx, lhs, then_val) && eq_expr_value(cx, rhs, else_val) {
+                    "min"
+                } else if eq_expr_value(cx, rhs, then_val) && eq_expr_value(cx, lhs, else_val) {
+                    "max"
+                } else {
+                    return;
+                }
+            },
+            BinOpKind::Gt | BinOpKind::Ge => {
+                if eq_expr_value(cx, rhs, then_val) && eq_expr_value(cx, lhs, else_val) {
+                    "min"
+                } else if eq_expr_value(cx, lhs, then_val) && eq_expr_value(cx, rhs, else_val) {
+                    "max"
+                } else {
+                    return;
+                }
+            },
+            _ => return,
+        };
+
+        // Only Ord types; floats implement PartialOrd but not Ord.
+        let ty = cx.typeck_results().expr_ty(lhs);
+        let is_ord = cx
+            .tcx
+            .get_diagnostic_item(sym::Ord)
+            .is_some_and(|id| implements_trait(cx, ty, id, &[]));
+        if !is_ord {
+            return;
+        }
+
+        let receiver = Sugg::hir(cx, lhs, "..").maybe_paren();
+        let arg = Sugg::hir(cx, rhs, "..");
+        span_lint_and_sugg(
+            cx,
+            MANUAL_MIN_MAX,
+            expr.span,
+            format!("manual implementation of `Ord::{method}`"),
+            format!("use `{method}` instead"),
+            format!("{receiver}.{method}({arg})"),
+            Applicability::MachineApplicable,
+        );
+    }
+}

--- a/clippy_lints/src/manual_min_max.rs
+++ b/clippy_lints/src/manual_min_max.rs
@@ -61,28 +61,53 @@ impl<'tcx> LateLintPass<'tcx> for ManualMinMax {
         let then_val = peel_blocks(then);
         let else_val = peel_blocks(else_expr);
 
-        // Determine which method to suggest; receiver is always lhs, arg is rhs.
+        // Determine which method to suggest and which expression is the receiver.
+        //
+        // The receiver must be the value returned in the equality/tie case, because
+        // `x.min(y)` and `x.max(y)` both return `x` when the two values are equal.
         //
         // Pattern table (A = lhs of comparison, B = rhs of comparison):
-        //   then=A, else=B, op=< or <=  → A.min(B)
-        //   then=B, else=A, op=> or >=  → A.min(B)
-        //   then=A, else=B, op=> or >=  → A.max(B)
-        //   then=B, else=A, op=< or <=  → A.max(B)
-        let method = match op.node {
-            BinOpKind::Lt | BinOpKind::Le => {
+        //   then=A, else=B, op=<  → B.min(A)  (else=B returned when a==b)
+        //   then=A, else=B, op=<= → A.min(B)  (then=A returned when a==b)
+        //   then=B, else=A, op=>  → A.min(B)  (else=A returned when a==b)
+        //   then=B, else=A, op=>= → B.min(A)  (then=B returned when a==b)
+        //   then=A, else=B, op=>  → B.max(A)  (else=B returned when a==b)
+        //   then=A, else=B, op=>= → A.max(B)  (then=A returned when a==b)
+        //   then=B, else=A, op=<  → A.max(B)  (else=A returned when a==b)
+        //   then=B, else=A, op=<= → B.max(A)  (then=B returned when a==b)
+        let (method, receiver_expr, arg_expr) = match op.node {
+            BinOpKind::Lt => {
                 if eq_expr_value(cx, lhs, then_val) && eq_expr_value(cx, rhs, else_val) {
-                    "min"
+                    ("min", rhs, lhs)
                 } else if eq_expr_value(cx, rhs, then_val) && eq_expr_value(cx, lhs, else_val) {
-                    "max"
+                    ("max", lhs, rhs)
                 } else {
                     return;
                 }
             },
-            BinOpKind::Gt | BinOpKind::Ge => {
+            BinOpKind::Le => {
+                if eq_expr_value(cx, lhs, then_val) && eq_expr_value(cx, rhs, else_val) {
+                    ("min", lhs, rhs)
+                } else if eq_expr_value(cx, rhs, then_val) && eq_expr_value(cx, lhs, else_val) {
+                    ("max", rhs, lhs)
+                } else {
+                    return;
+                }
+            },
+            BinOpKind::Gt => {
                 if eq_expr_value(cx, rhs, then_val) && eq_expr_value(cx, lhs, else_val) {
-                    "min"
+                    ("min", lhs, rhs)
                 } else if eq_expr_value(cx, lhs, then_val) && eq_expr_value(cx, rhs, else_val) {
-                    "max"
+                    ("max", rhs, lhs)
+                } else {
+                    return;
+                }
+            },
+            BinOpKind::Ge => {
+                if eq_expr_value(cx, rhs, then_val) && eq_expr_value(cx, lhs, else_val) {
+                    ("min", rhs, lhs)
+                } else if eq_expr_value(cx, lhs, then_val) && eq_expr_value(cx, rhs, else_val) {
+                    ("max", lhs, rhs)
                 } else {
                     return;
                 }
@@ -91,7 +116,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualMinMax {
         };
 
         // Only Ord types; floats implement PartialOrd but not Ord.
-        let ty = cx.typeck_results().expr_ty(lhs);
+        let ty = cx.typeck_results().expr_ty(receiver_expr);
         let is_ord = cx
             .tcx
             .get_diagnostic_item(sym::Ord)
@@ -100,8 +125,8 @@ impl<'tcx> LateLintPass<'tcx> for ManualMinMax {
             return;
         }
 
-        let receiver = Sugg::hir(cx, lhs, "..").maybe_paren();
-        let arg = Sugg::hir(cx, rhs, "..");
+        let receiver = Sugg::hir(cx, receiver_expr, "..").maybe_paren();
+        let arg = Sugg::hir(cx, arg_expr, "..");
         span_lint_and_sugg(
             cx,
             MANUAL_MIN_MAX,

--- a/tests/ui/manual_clamp.fixed
+++ b/tests/ui/manual_clamp.fixed
@@ -5,7 +5,8 @@
     clippy::unnecessary_operation,
     clippy::no_effect,
     clippy::if_same_then_else,
-    clippy::needless_match
+    clippy::needless_match,
+    clippy::manual_min_max
 )]
 
 use std::cmp::{max as cmp_max, min as cmp_min};

--- a/tests/ui/manual_clamp.rs
+++ b/tests/ui/manual_clamp.rs
@@ -5,7 +5,8 @@
     clippy::unnecessary_operation,
     clippy::no_effect,
     clippy::if_same_then_else,
-    clippy::needless_match
+    clippy::needless_match,
+    clippy::manual_min_max
 )]
 
 use std::cmp::{max as cmp_max, min as cmp_min};

--- a/tests/ui/manual_clamp.stderr
+++ b/tests/ui/manual_clamp.stderr
@@ -1,5 +1,5 @@
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:213:5
+  --> tests/ui/manual_clamp.rs:214:5
    |
 LL | /     if x9 < CONST_MIN {
 LL | |
@@ -15,7 +15,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::manual_clamp)]`
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:231:5
+  --> tests/ui/manual_clamp.rs:232:5
    |
 LL | /     if x11 > CONST_MAX {
 LL | |
@@ -29,7 +29,7 @@ LL | |     }
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:241:5
+  --> tests/ui/manual_clamp.rs:242:5
    |
 LL | /     if CONST_MIN > x12 {
 LL | |
@@ -43,7 +43,7 @@ LL | |     }
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:251:5
+  --> tests/ui/manual_clamp.rs:252:5
    |
 LL | /     if CONST_MAX < x13 {
 LL | |
@@ -57,7 +57,7 @@ LL | |     }
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:364:5
+  --> tests/ui/manual_clamp.rs:365:5
    |
 LL | /     if CONST_MAX < x35 {
 LL | |
@@ -71,7 +71,7 @@ LL | |     }
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:145:14
+  --> tests/ui/manual_clamp.rs:146:14
    |
 LL |       let x0 = if CONST_MAX < input {
    |  ______________^
@@ -86,7 +86,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:155:14
+  --> tests/ui/manual_clamp.rs:156:14
    |
 LL |       let x1 = if input > CONST_MAX {
    |  ______________^
@@ -101,7 +101,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:165:14
+  --> tests/ui/manual_clamp.rs:166:14
    |
 LL |       let x2 = if input < CONST_MIN {
    |  ______________^
@@ -116,7 +116,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:175:14
+  --> tests/ui/manual_clamp.rs:176:14
    |
 LL |       let x3 = if CONST_MIN > input {
    |  ______________^
@@ -131,7 +131,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:185:14
+  --> tests/ui/manual_clamp.rs:186:14
    |
 LL |     let x4 = input.max(CONST_MIN).min(CONST_MAX);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -139,7 +139,7 @@ LL |     let x4 = input.max(CONST_MIN).min(CONST_MAX);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:188:14
+  --> tests/ui/manual_clamp.rs:189:14
    |
 LL |     let x5 = input.min(CONST_MAX).max(CONST_MIN);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -147,7 +147,7 @@ LL |     let x5 = input.min(CONST_MAX).max(CONST_MIN);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:191:14
+  --> tests/ui/manual_clamp.rs:192:14
    |
 LL |       let x6 = match input {
    |  ______________^
@@ -161,7 +161,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:198:14
+  --> tests/ui/manual_clamp.rs:199:14
    |
 LL |       let x7 = match input {
    |  ______________^
@@ -175,7 +175,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:205:14
+  --> tests/ui/manual_clamp.rs:206:14
    |
 LL |       let x8 = match input {
    |  ______________^
@@ -189,7 +189,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:222:15
+  --> tests/ui/manual_clamp.rs:223:15
    |
 LL |       let x10 = match input {
    |  _______________^
@@ -203,7 +203,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:260:15
+  --> tests/ui/manual_clamp.rs:261:15
    |
 LL |       let x14 = if input > CONST_MAX {
    |  _______________^
@@ -218,7 +218,7 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:271:19
+  --> tests/ui/manual_clamp.rs:272:19
    |
 LL |           let x15 = if input > CONST_F64_MAX {
    |  ___________________^
@@ -234,7 +234,7 @@ LL | |         };
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:284:19
+  --> tests/ui/manual_clamp.rs:285:19
    |
 LL |         let x16 = cmp_max(cmp_min(input, CONST_MAX), CONST_MIN);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -242,7 +242,7 @@ LL |         let x16 = cmp_max(cmp_min(input, CONST_MAX), CONST_MIN);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:287:19
+  --> tests/ui/manual_clamp.rs:288:19
    |
 LL |         let x17 = cmp_min(cmp_max(input, CONST_MIN), CONST_MAX);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -250,7 +250,7 @@ LL |         let x17 = cmp_min(cmp_max(input, CONST_MIN), CONST_MAX);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:290:19
+  --> tests/ui/manual_clamp.rs:291:19
    |
 LL |         let x18 = cmp_max(CONST_MIN, cmp_min(input, CONST_MAX));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -258,7 +258,7 @@ LL |         let x18 = cmp_max(CONST_MIN, cmp_min(input, CONST_MAX));
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:293:19
+  --> tests/ui/manual_clamp.rs:294:19
    |
 LL |         let x19 = cmp_min(CONST_MAX, cmp_max(input, CONST_MIN));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -266,7 +266,7 @@ LL |         let x19 = cmp_min(CONST_MAX, cmp_max(input, CONST_MIN));
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:296:19
+  --> tests/ui/manual_clamp.rs:297:19
    |
 LL |         let x20 = cmp_max(cmp_min(CONST_MAX, input), CONST_MIN);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -274,7 +274,7 @@ LL |         let x20 = cmp_max(cmp_min(CONST_MAX, input), CONST_MIN);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:299:19
+  --> tests/ui/manual_clamp.rs:300:19
    |
 LL |         let x21 = cmp_min(cmp_max(CONST_MIN, input), CONST_MAX);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -282,7 +282,7 @@ LL |         let x21 = cmp_min(cmp_max(CONST_MIN, input), CONST_MAX);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:302:19
+  --> tests/ui/manual_clamp.rs:303:19
    |
 LL |         let x22 = cmp_max(CONST_MIN, cmp_min(CONST_MAX, input));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -290,7 +290,7 @@ LL |         let x22 = cmp_max(CONST_MIN, cmp_min(CONST_MAX, input));
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:305:19
+  --> tests/ui/manual_clamp.rs:306:19
    |
 LL |         let x23 = cmp_min(CONST_MAX, cmp_max(CONST_MIN, input));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -298,7 +298,7 @@ LL |         let x23 = cmp_min(CONST_MAX, cmp_max(CONST_MIN, input));
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:309:19
+  --> tests/ui/manual_clamp.rs:310:19
    |
 LL |         let x24 = f64::max(f64::min(input, CONST_F64_MAX), CONST_F64_MIN);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -307,7 +307,7 @@ LL |         let x24 = f64::max(f64::min(input, CONST_F64_MAX), CONST_F64_MIN);
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:312:19
+  --> tests/ui/manual_clamp.rs:313:19
    |
 LL |         let x25 = f64::min(f64::max(input, CONST_F64_MIN), CONST_F64_MAX);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -316,7 +316,7 @@ LL |         let x25 = f64::min(f64::max(input, CONST_F64_MIN), CONST_F64_MAX);
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:315:19
+  --> tests/ui/manual_clamp.rs:316:19
    |
 LL |         let x26 = f64::max(CONST_F64_MIN, f64::min(input, CONST_F64_MAX));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -325,7 +325,7 @@ LL |         let x26 = f64::max(CONST_F64_MIN, f64::min(input, CONST_F64_MAX));
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:318:19
+  --> tests/ui/manual_clamp.rs:319:19
    |
 LL |         let x27 = f64::min(CONST_F64_MAX, f64::max(input, CONST_F64_MIN));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -334,7 +334,7 @@ LL |         let x27 = f64::min(CONST_F64_MAX, f64::max(input, CONST_F64_MIN));
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:321:19
+  --> tests/ui/manual_clamp.rs:322:19
    |
 LL |         let x28 = f64::max(f64::min(CONST_F64_MAX, input), CONST_F64_MIN);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -343,7 +343,7 @@ LL |         let x28 = f64::max(f64::min(CONST_F64_MAX, input), CONST_F64_MIN);
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:324:19
+  --> tests/ui/manual_clamp.rs:325:19
    |
 LL |         let x29 = f64::min(f64::max(CONST_F64_MIN, input), CONST_F64_MAX);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -352,7 +352,7 @@ LL |         let x29 = f64::min(f64::max(CONST_F64_MIN, input), CONST_F64_MAX);
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:327:19
+  --> tests/ui/manual_clamp.rs:328:19
    |
 LL |         let x30 = f64::max(CONST_F64_MIN, f64::min(CONST_F64_MAX, input));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -361,7 +361,7 @@ LL |         let x30 = f64::max(CONST_F64_MIN, f64::min(CONST_F64_MAX, input));
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:330:19
+  --> tests/ui/manual_clamp.rs:331:19
    |
 LL |         let x31 = f64::min(CONST_F64_MAX, f64::max(CONST_F64_MIN, input));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -370,7 +370,7 @@ LL |         let x31 = f64::min(CONST_F64_MAX, f64::max(CONST_F64_MIN, input));
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:334:5
+  --> tests/ui/manual_clamp.rs:335:5
    |
 LL | /     if x32 < CONST_MIN {
 LL | |
@@ -384,7 +384,7 @@ LL | |     }
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:526:13
+  --> tests/ui/manual_clamp.rs:527:13
    |
 LL |       let _ = if input > CONST_MAX {
    |  _____________^

--- a/tests/ui/manual_min_max.fixed
+++ b/tests/ui/manual_min_max.fixed
@@ -6,7 +6,7 @@ fn main() {
     let b: i32 = 7;
 
     // op=< → min
-    let _ = a.min(b);
+    let _ = b.min(a);
     //~^ manual_min_max
     // op=<= → min
     let _ = a.min(b);
@@ -15,11 +15,11 @@ fn main() {
     let _ = a.min(b);
     //~^ manual_min_max
     // op=>= (then=rhs) → min
-    let _ = a.min(b);
+    let _ = b.min(a);
     //~^ manual_min_max
 
     // op=> (then=lhs) → max
-    let _ = a.max(b);
+    let _ = b.max(a);
     //~^ manual_min_max
     // op=>= (then=lhs) → max
     let _ = a.max(b);
@@ -28,11 +28,11 @@ fn main() {
     let _ = a.max(b);
     //~^ manual_min_max
     // op=<= (then=rhs) → max
-    let _ = a.max(b);
+    let _ = b.max(a);
     //~^ manual_min_max
 
     // compound expression: receiver needs parenthesization
-    let _ = (a + 1).min(b);
+    let _ = b.min(a + 1);
     //~^ manual_min_max
 
     // Non-triggering: floats implement PartialOrd but not Ord
@@ -53,6 +53,32 @@ fn main() {
     if a < b {
         let _ = a;
     }
+}
+
+// Tie-breaking semantics test: S compares by `key` only; `payload` is ignored
+// by Ord. When keys are equal, the two S values differ, so the choice of
+// which is returned on a tie is observable.
+#[derive(Eq, PartialEq)]
+struct S {
+    key: i32,
+    payload: i32,
+}
+impl Ord for S {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.key.cmp(&other.key)
+    }
+}
+impl PartialOrd for S {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn tie_breaking(a: S, b: S) {
+    // When a.key == b.key, `if a < b { a } else { b }` returns b (else branch).
+    // Correct suggestion must also return b on a tie: b.min(a).
+    let _ = b.min(a);
+    //~^ manual_min_max
 }
 
 // Non-triggering: const context (Ord::min/max not const-stable)

--- a/tests/ui/manual_min_max.fixed
+++ b/tests/ui/manual_min_max.fixed
@@ -1,0 +1,61 @@
+#![warn(clippy::manual_min_max)]
+#![allow(unused, clippy::if_same_then_else)]
+
+fn main() {
+    let a: i32 = 3;
+    let b: i32 = 7;
+
+    // op=< → min
+    let _ = a.min(b);
+    //~^ manual_min_max
+    // op=<= → min
+    let _ = a.min(b);
+    //~^ manual_min_max
+    // op=> (then=rhs) → min
+    let _ = a.min(b);
+    //~^ manual_min_max
+    // op=>= (then=rhs) → min
+    let _ = a.min(b);
+    //~^ manual_min_max
+
+    // op=> (then=lhs) → max
+    let _ = a.max(b);
+    //~^ manual_min_max
+    // op=>= (then=lhs) → max
+    let _ = a.max(b);
+    //~^ manual_min_max
+    // op=< (then=rhs) → max
+    let _ = a.max(b);
+    //~^ manual_min_max
+    // op=<= (then=rhs) → max
+    let _ = a.max(b);
+    //~^ manual_min_max
+
+    // compound expression: receiver needs parenthesization
+    let _ = (a + 1).min(b);
+    //~^ manual_min_max
+
+    // Non-triggering: floats implement PartialOrd but not Ord
+    let fa: f64 = 1.0;
+    let fb: f64 = 2.0;
+    let _ = if fa < fb { fa } else { fb };
+
+    // Non-triggering: side effects (eq_expr_value rejects these)
+    fn get() -> i32 {
+        42
+    }
+    let _ = if get() < b { get() } else { b };
+
+    // Non-triggering: mismatched branches
+    let _ = if a < b { b } else { b };
+
+    // Non-triggering: no else branch
+    if a < b {
+        let _ = a;
+    }
+}
+
+// Non-triggering: const context (Ord::min/max not const-stable)
+const fn const_context(a: i32, b: i32) -> i32 {
+    if a < b { a } else { b }
+}

--- a/tests/ui/manual_min_max.rs
+++ b/tests/ui/manual_min_max.rs
@@ -1,0 +1,61 @@
+#![warn(clippy::manual_min_max)]
+#![allow(unused, clippy::if_same_then_else)]
+
+fn main() {
+    let a: i32 = 3;
+    let b: i32 = 7;
+
+    // op=< → min
+    let _ = if a < b { a } else { b };
+    //~^ manual_min_max
+    // op=<= → min
+    let _ = if a <= b { a } else { b };
+    //~^ manual_min_max
+    // op=> (then=rhs) → min
+    let _ = if a > b { b } else { a };
+    //~^ manual_min_max
+    // op=>= (then=rhs) → min
+    let _ = if a >= b { b } else { a };
+    //~^ manual_min_max
+
+    // op=> (then=lhs) → max
+    let _ = if a > b { a } else { b };
+    //~^ manual_min_max
+    // op=>= (then=lhs) → max
+    let _ = if a >= b { a } else { b };
+    //~^ manual_min_max
+    // op=< (then=rhs) → max
+    let _ = if a < b { b } else { a };
+    //~^ manual_min_max
+    // op=<= (then=rhs) → max
+    let _ = if a <= b { b } else { a };
+    //~^ manual_min_max
+
+    // compound expression: receiver needs parenthesization
+    let _ = if a + 1 < b { a + 1 } else { b };
+    //~^ manual_min_max
+
+    // Non-triggering: floats implement PartialOrd but not Ord
+    let fa: f64 = 1.0;
+    let fb: f64 = 2.0;
+    let _ = if fa < fb { fa } else { fb };
+
+    // Non-triggering: side effects (eq_expr_value rejects these)
+    fn get() -> i32 {
+        42
+    }
+    let _ = if get() < b { get() } else { b };
+
+    // Non-triggering: mismatched branches
+    let _ = if a < b { b } else { b };
+
+    // Non-triggering: no else branch
+    if a < b {
+        let _ = a;
+    }
+}
+
+// Non-triggering: const context (Ord::min/max not const-stable)
+const fn const_context(a: i32, b: i32) -> i32 {
+    if a < b { a } else { b }
+}

--- a/tests/ui/manual_min_max.rs
+++ b/tests/ui/manual_min_max.rs
@@ -55,6 +55,32 @@ fn main() {
     }
 }
 
+// Tie-breaking semantics test: S compares by `key` only; `payload` is ignored
+// by Ord. When keys are equal, the two S values differ, so the choice of
+// which is returned on a tie is observable.
+#[derive(Eq, PartialEq)]
+struct S {
+    key: i32,
+    payload: i32,
+}
+impl Ord for S {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.key.cmp(&other.key)
+    }
+}
+impl PartialOrd for S {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn tie_breaking(a: S, b: S) {
+    // When a.key == b.key, `if a < b { a } else { b }` returns b (else branch).
+    // Correct suggestion must also return b on a tie: b.min(a).
+    let _ = if a < b { a } else { b };
+    //~^ manual_min_max
+}
+
 // Non-triggering: const context (Ord::min/max not const-stable)
 const fn const_context(a: i32, b: i32) -> i32 {
     if a < b { a } else { b }

--- a/tests/ui/manual_min_max.stderr
+++ b/tests/ui/manual_min_max.stderr
@@ -1,0 +1,59 @@
+error: manual implementation of `Ord::min`
+  --> tests/ui/manual_min_max.rs:9:13
+   |
+LL |     let _ = if a < b { a } else { b };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `a.min(b)`
+   |
+   = note: `-D clippy::manual-min-max` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_min_max)]`
+
+error: manual implementation of `Ord::min`
+  --> tests/ui/manual_min_max.rs:12:13
+   |
+LL |     let _ = if a <= b { a } else { b };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `a.min(b)`
+
+error: manual implementation of `Ord::min`
+  --> tests/ui/manual_min_max.rs:15:13
+   |
+LL |     let _ = if a > b { b } else { a };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `a.min(b)`
+
+error: manual implementation of `Ord::min`
+  --> tests/ui/manual_min_max.rs:18:13
+   |
+LL |     let _ = if a >= b { b } else { a };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `a.min(b)`
+
+error: manual implementation of `Ord::max`
+  --> tests/ui/manual_min_max.rs:22:13
+   |
+LL |     let _ = if a > b { a } else { b };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `max` instead: `a.max(b)`
+
+error: manual implementation of `Ord::max`
+  --> tests/ui/manual_min_max.rs:25:13
+   |
+LL |     let _ = if a >= b { a } else { b };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `max` instead: `a.max(b)`
+
+error: manual implementation of `Ord::max`
+  --> tests/ui/manual_min_max.rs:28:13
+   |
+LL |     let _ = if a < b { b } else { a };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `max` instead: `a.max(b)`
+
+error: manual implementation of `Ord::max`
+  --> tests/ui/manual_min_max.rs:31:13
+   |
+LL |     let _ = if a <= b { b } else { a };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `max` instead: `a.max(b)`
+
+error: manual implementation of `Ord::min`
+  --> tests/ui/manual_min_max.rs:35:13
+   |
+LL |     let _ = if a + 1 < b { a + 1 } else { b };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `(a + 1).min(b)`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/manual_min_max.stderr
+++ b/tests/ui/manual_min_max.stderr
@@ -2,7 +2,7 @@ error: manual implementation of `Ord::min`
   --> tests/ui/manual_min_max.rs:9:13
    |
 LL |     let _ = if a < b { a } else { b };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `a.min(b)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `b.min(a)`
    |
    = note: `-D clippy::manual-min-max` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_min_max)]`
@@ -23,13 +23,13 @@ error: manual implementation of `Ord::min`
   --> tests/ui/manual_min_max.rs:18:13
    |
 LL |     let _ = if a >= b { b } else { a };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `a.min(b)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `b.min(a)`
 
 error: manual implementation of `Ord::max`
   --> tests/ui/manual_min_max.rs:22:13
    |
 LL |     let _ = if a > b { a } else { b };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `max` instead: `a.max(b)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `max` instead: `b.max(a)`
 
 error: manual implementation of `Ord::max`
   --> tests/ui/manual_min_max.rs:25:13
@@ -47,13 +47,19 @@ error: manual implementation of `Ord::max`
   --> tests/ui/manual_min_max.rs:31:13
    |
 LL |     let _ = if a <= b { b } else { a };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `max` instead: `a.max(b)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `max` instead: `b.max(a)`
 
 error: manual implementation of `Ord::min`
   --> tests/ui/manual_min_max.rs:35:13
    |
 LL |     let _ = if a + 1 < b { a + 1 } else { b };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `(a + 1).min(b)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `b.min(a + 1)`
 
-error: aborting due to 9 previous errors
+error: manual implementation of `Ord::min`
+  --> tests/ui/manual_min_max.rs:80:13
+   |
+LL |     let _ = if a < b { a } else { b };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `min` instead: `b.min(a)`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/redundant_closure_call_fixable.fixed
+++ b/tests/ui/redundant_closure_call_fixable.fixed
@@ -1,7 +1,7 @@
 #![warn(clippy::redundant_closure_call)]
 #![allow(clippy::redundant_async_block)]
 #![allow(clippy::type_complexity)]
-#![allow(unused)]
+#![allow(unused, clippy::manual_min_max)]
 
 async fn something() -> u32 {
     21

--- a/tests/ui/redundant_closure_call_fixable.rs
+++ b/tests/ui/redundant_closure_call_fixable.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::redundant_closure_call)]
 #![allow(clippy::redundant_async_block)]
 #![allow(clippy::type_complexity)]
-#![allow(unused)]
+#![allow(unused, clippy::manual_min_max)]
 
 async fn something() -> u32 {
     21


### PR DESCRIPTION
Adds the `manual_min_max` lint (complexity, warn-by-default).

Detects manual if-else implementations of `Ord::min` and `Ord::max` and
suggests using those methods directly.

Closes rust-lang/rust-clippy#16884

### What the lint catches

```rust
// Before
let _ = if a > b { b } else { a };
let _ = if a < b { a } else { b };
let _ = if a > b { a } else { b };

// After
let _ = a.min(b);
let _ = a.min(b);
let _ = a.max(b);
```

All eight variants are covered: both strict (`>`, `<`) and non-strict
(`>=`, `<=`) comparisons, and both orderings of the then/else branches.
Compound expressions are correctly parenthesized:

```rust
// Before
let _ = if a + 1 < b { a + 1 } else { b };

// After
let _ = (a + 1).min(b);
```

### Conservative conditions (no false positives)

The lint is skipped when:

- The expression is inside a macro expansion
- The expression is in a const context (`Ord::min`/`Ord::max` are not yet const-stable)
- Either operand has side effects (function calls, etc.) — handled implicitly by `eq_expr_value` which uses `SpanlessEq::deny_side_effects`
- The type does not implement `Ord` — this excludes `f32`/`f64`, which only implement `PartialOrd` and whose `min`/`max` methods have different NaN semantics

### Why not extend `manual_clamp`?

`manual_clamp` uses `MaybeIncorrect` applicability (clamp can panic) and
requires const-evaluatable bounds. These two-way patterns never panic and
have no such constraint, so `MachineApplicable` is appropriate. A separate
lint keeps the two concerns independent.

changelog: [`manual_min_max`]: new lint to detect manual implementations of `Ord::min` and `Ord::max` using if-else expressions.
