### PR TITLE
`useless_conversion`: do not lint `(a..b).into_iter()` (for edition migration)

### DIFF
--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -6,7 +6,7 @@ use clippy_utils::ty::{is_copy, same_type_modulo_regions};
 use clippy_utils::{get_parent_expr, is_ty_alias, sym};
 use rustc_errors::Applicability;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{BindingMode, Expr, ExprKind, HirId, MatchSource, Mutability, Node, PatKind};
+use rustc_hir::{BindingMode, Expr, ExprKind, HirId, LangItem, MatchSource, Mutability, Node, PatKind};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::Obligation;
 use rustc_lint::{LateContext, LateLintPass};
@@ -19,7 +19,7 @@ use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` calls
+    /// Checks for `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIterator` calls
     /// which uselessly convert to the same type.
     ///
     /// ### Why is this bad?
@@ -38,7 +38,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.45.0"]
     pub USELESS_CONVERSION,
     complexity,
-    "calls to `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` which perform useless conversions to the same type"
+    "calls to `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIterator` which perform useless conversions to the same type"
 }
 
 impl_lint_pass!(UselessConversion => [USELESS_CONVERSION]);
@@ -322,13 +322,13 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                         return;
                     }
 
-                    let a = cx.typeck_results().expr_ty(e);
-                    let b = cx.typeck_results().expr_ty(recv);
+                    let iter_ty = cx.typeck_results().expr_ty(e);
+                    let into_iter_ty = cx.typeck_results().expr_ty(recv);
 
                     // If the types are identical then .into_iter() can be removed, unless the type
                     // implements Copy, in which case .into_iter() returns a copy of the receiver and
                     // cannot be safely omitted.
-                    if same_type_modulo_regions(a, b) && !is_copy(cx, b) {
+                    if same_type_modulo_regions(iter_ty, into_iter_ty) && !is_copy(cx, into_iter_ty) {
                         // Below we check if the parent method call meets the following conditions:
                         // 1. First parameter is `&mut self` (requires mutable reference)
                         // 2. Second parameter implements the `FnMut` trait (e.g., Iterator::any)
@@ -356,6 +356,28 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                             return;
                         }
 
+                        // In a future edition of Rust (edition 2027, hopefully), or with the unstable
+                        // `feature(new_range)`, the syntax `a..b` will change from producing type `core::ops::Range`,
+                        // which implements `Iterator`, to producing type `core::range::Range`, which implements
+                        // `IntoIterator` only.
+                        //
+                        // Therefore, an `(a..b).into_iter()` call that is technically useless today will be useful for
+                        // edition migration or unstable feature testing; do not remove it.
+                        //
+                        // In the future, after most code has either migrated to the new range types or declined to
+                        // do so, this special case will be much less useful and could be removed.
+                        if let Some(parent) = get_parent_expr(cx, e)
+                            // Is a method call, not, say, a for loop where the conversion *is* useless.
+                            && let ExprKind::MethodCall(_, _, _, _) = parent.kind
+                            // These lang items are the 3 core::ops range types that implement Iterator.
+                            // All other range types do not implement Iterator, so this lint does not apply to them.
+                            && (into_iter_ty.is_lang_item(cx, LangItem::Range)
+                                || into_iter_ty.is_lang_item(cx, LangItem::RangeFrom)
+                                || into_iter_ty.is_lang_item(cx, LangItem::RangeInclusiveStruct))
+                        {
+                            return;
+                        }
+
                         let mut applicability = Applicability::MachineApplicable;
                         let sugg = snippet_with_context(cx, recv.span, e.span.ctxt(), "<expr>", &mut applicability)
                             .0
@@ -364,7 +386,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                             cx,
                             USELESS_CONVERSION,
                             e.span,
-                            format!("useless conversion to the same type: `{b}`"),
+                            format!("useless conversion to the same type: `{into_iter_ty}`"),
                             "consider removing `.into_iter()`",
                             sugg,
                             applicability,

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -72,13 +72,13 @@ fn lint_into_iter_on_expr_implementing_iterator_2() {
 
 #[allow(const_item_mutation)]
 fn lint_into_iter_on_const_implementing_iterator() {
-    const NUMBERS: std::ops::Range<i32> = 0..10;
+    const NUMBERS: std::iter::Empty<i32> = std::iter::empty();
     let _ = NUMBERS.next();
     //~^ useless_conversion
 }
 
 fn lint_into_iter_on_const_implementing_iterator_2() {
-    const NUMBERS: std::ops::Range<i32> = 0..10;
+    const NUMBERS: std::iter::Empty<i32> = std::iter::empty();
     let mut n = NUMBERS;
     //~^ useless_conversion
     n.next();
@@ -423,10 +423,8 @@ mod issue11819 {
     }
 }
 
-fn issue14739() {
-    use std::ops::Range;
-
-    const R: Range<u32> = 2..7;
+fn issue14800() {
+    const R: std::iter::Empty<u32> = std::iter::empty();
 
     R.into_iter().all(|_x| true); // no lint
 
@@ -436,6 +434,33 @@ fn issue14739() {
     //~^ useless_conversion
     let _ = R.map(|_x| 0);
     //~^ useless_conversion
+}
+
+// In a future edition of Rust or with the unstable `feature(new_range)`, the syntax `a..b`
+// will change from producing type `core::ops::Range`, which implements `Iterator`, to
+// producing type `core::range::Range`, which implements `IntoIterator`.
+//
+// Therefore, an `.into_iter()` call that is technically useless today will be useful for
+// edition migration or unstable feature testing; do not remove it.
+//
+// This test case tests that the ranges produced *by range syntax* aren’t linted on, which
+// should be true both before and after the expected 2027 edition migration (but after such
+// migration, this test will not really be testing anything).
+fn do_not_lint_on_ops_range_into_iter_before_method() {
+    #![allow(clippy::never_loop)]
+
+    // No lint on these
+    (0..10).into_iter().for_each(drop);
+    (0..=10).into_iter().for_each(drop);
+    (0..).into_iter().take(10).for_each(drop);
+
+    // But do still lint on for loops
+    for _ in (0..10) {} //~ useless_conversion
+    for _ in (0..=10) {} //~ useless_conversion
+    for _ in (0..) {
+        //~^ useless_conversion
+        break;
+    }
 }
 
 fn issue16165() {

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -72,13 +72,13 @@ fn lint_into_iter_on_expr_implementing_iterator_2() {
 
 #[allow(const_item_mutation)]
 fn lint_into_iter_on_const_implementing_iterator() {
-    const NUMBERS: std::ops::Range<i32> = 0..10;
+    const NUMBERS: std::iter::Empty<i32> = std::iter::empty();
     let _ = NUMBERS.into_iter().next();
     //~^ useless_conversion
 }
 
 fn lint_into_iter_on_const_implementing_iterator_2() {
-    const NUMBERS: std::ops::Range<i32> = 0..10;
+    const NUMBERS: std::iter::Empty<i32> = std::iter::empty();
     let mut n = NUMBERS.into_iter();
     //~^ useless_conversion
     n.next();
@@ -423,10 +423,8 @@ mod issue11819 {
     }
 }
 
-fn issue14739() {
-    use std::ops::Range;
-
-    const R: Range<u32> = 2..7;
+fn issue14800() {
+    const R: std::iter::Empty<u32> = std::iter::empty();
 
     R.into_iter().all(|_x| true); // no lint
 
@@ -436,6 +434,33 @@ fn issue14739() {
     //~^ useless_conversion
     let _ = R.into_iter().map(|_x| 0);
     //~^ useless_conversion
+}
+
+// In a future edition of Rust or with the unstable `feature(new_range)`, the syntax `a..b`
+// will change from producing type `core::ops::Range`, which implements `Iterator`, to
+// producing type `core::range::Range`, which implements `IntoIterator`.
+//
+// Therefore, an `.into_iter()` call that is technically useless today will be useful for
+// edition migration or unstable feature testing; do not remove it.
+//
+// This test case tests that the ranges produced *by range syntax* aren’t linted on, which
+// should be true both before and after the expected 2027 edition migration (but after such
+// migration, this test will not really be testing anything).
+fn do_not_lint_on_ops_range_into_iter_before_method() {
+    #![allow(clippy::never_loop)]
+
+    // No lint on these
+    (0..10).into_iter().for_each(drop);
+    (0..=10).into_iter().for_each(drop);
+    (0..).into_iter().take(10).for_each(drop);
+
+    // But do still lint on for loops
+    for _ in (0..10).into_iter() {} //~ useless_conversion
+    for _ in (0..=10).into_iter() {} //~ useless_conversion
+    for _ in (0..).into_iter() {
+        //~^ useless_conversion
+        break;
+    }
 }
 
 fn issue16165() {

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -40,13 +40,13 @@ error: useless conversion to the same type: `std::str::Lines<'_>`
 LL |     if Some("ok") == text.lines().into_iter().next() {}
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `text.lines()`
 
-error: useless conversion to the same type: `std::ops::Range<i32>`
+error: useless conversion to the same type: `std::iter::Empty<i32>`
   --> tests/ui/useless_conversion.rs:76:13
    |
 LL |     let _ = NUMBERS.into_iter().next();
    |             ^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `NUMBERS`
 
-error: useless conversion to the same type: `std::ops::Range<i32>`
+error: useless conversion to the same type: `std::iter::Empty<i32>`
   --> tests/ui/useless_conversion.rs:82:17
    |
 LL |     let mut n = NUMBERS.into_iter();
@@ -421,32 +421,50 @@ LL -             takes_into_iter(self.my_field.into_iter());
 LL +             takes_into_iter(&mut *self.my_field);
    |
 
-error: useless conversion to the same type: `std::ops::Range<u32>`
-  --> tests/ui/useless_conversion.rs:435:5
+error: useless conversion to the same type: `std::iter::Empty<u32>`
+  --> tests/ui/useless_conversion.rs:433:5
    |
 LL |     R.into_iter().for_each(|_x| {});
    |     ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
-error: useless conversion to the same type: `std::ops::Range<u32>`
-  --> tests/ui/useless_conversion.rs:437:13
+error: useless conversion to the same type: `std::iter::Empty<u32>`
+  --> tests/ui/useless_conversion.rs:435:13
    |
 LL |     let _ = R.into_iter().map(|_x| 0);
    |             ^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `R`
 
+error: useless conversion to the same type: `std::ops::Range<i32>`
+  --> tests/ui/useless_conversion.rs:458:14
+   |
+LL |     for _ in (0..10).into_iter() {}
+   |              ^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `(0..10)`
+
+error: useless conversion to the same type: `std::ops::RangeInclusive<i32>`
+  --> tests/ui/useless_conversion.rs:459:14
+   |
+LL |     for _ in (0..=10).into_iter() {}
+   |              ^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `(0..=10)`
+
+error: useless conversion to the same type: `std::ops::RangeFrom<i32>`
+  --> tests/ui/useless_conversion.rs:460:14
+   |
+LL |     for _ in (0..).into_iter() {
+   |              ^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `(0..)`
+
 error: useless conversion to the same type: `std::slice::Iter<'_, i32>`
-  --> tests/ui/useless_conversion.rs:448:14
+  --> tests/ui/useless_conversion.rs:473:14
    |
 LL |     for _ in mac!(iter [1, 2]).into_iter() {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `mac!(iter [1, 2])`
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:461:27
+  --> tests/ui/useless_conversion.rs:486:27
    |
 LL |     takes_into_iter_usize(b.into_iter());
    |                           ^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:452:34
+  --> tests/ui/useless_conversion.rs:477:34
    |
 LL | fn takes_into_iter_usize(_: impl IntoIterator<Item = usize>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -457,13 +475,13 @@ LL +     takes_into_iter_usize(b);
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:470:31
+  --> tests/ui/useless_conversion.rs:495:31
    |
 LL |         takes_into_iter_usize(b.clone().into_iter());
    |                               ^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:452:34
+  --> tests/ui/useless_conversion.rs:477:34
    |
 LL | fn takes_into_iter_usize(_: impl IntoIterator<Item = usize>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -474,13 +492,13 @@ LL +         takes_into_iter_usize(b.clone());
    |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
-  --> tests/ui/useless_conversion.rs:478:34
+  --> tests/ui/useless_conversion.rs:503:34
    |
 LL |     takes_into_iter_usize_result(b.clone().into_iter())?;
    |                                  ^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
-  --> tests/ui/useless_conversion.rs:453:41
+  --> tests/ui/useless_conversion.rs:478:41
    |
 LL | fn takes_into_iter_usize_result(_: impl IntoIterator<Item = usize>) -> Result<(), ()> {
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -490,5 +508,5 @@ LL -     takes_into_iter_usize_result(b.clone().into_iter())?;
 LL +     takes_into_iter_usize_result(b.clone())?;
    |
 
-error: aborting due to 48 previous errors
+error: aborting due to 51 previous errors
 


### PR DESCRIPTION
In a future edition of Rust or with the unstable `feature(new_range)`, the syntax `a..b` will change from producing type `core::ops::Range`, which implements `Iterator`, to producing type `core::range::Range`, which implements `IntoIterator`.

Therefore, an `.into_iter()` call that is technically useless today will be useful for edition migration or unstable feature testing; do not remove it.

Also:

* Fix issue number for existing tests
* Fix docs reference to `IntoIter` (not the name of the trait)
* Rename some variables to be clearer

changelog: [`useless_conversion`]: do not lint on `(a..b).into_iter()`, to allow compatibility with future range syntax changes
