### PR TITLE
Fix `map_unwrap_or` suggests wrongly for conflict borrowing

### DIFF
--- a/clippy_lints/src/assigning_clones.rs
+++ b/clippy_lints/src/assigning_clones.rs
@@ -192,7 +192,7 @@ fn clone_source_borrows_from_dest(cx: &LateContext<'_>, lhs: &Expr<'_>, call_spa
         && let mir::StatementKind::Assign(box (borrowed, _)) = &assignment.kind
         && let Some(borrowers) = borrow_map.get(&borrowed.local)
     {
-        borrowers.contains(source.local)
+        borrowers.contains_key(&source.local)
     } else {
         false
     }

--- a/clippy_lints/src/methods/map_unwrap_or_else.rs
+++ b/clippy_lints/src/methods/map_unwrap_or_else.rs
@@ -1,11 +1,12 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::mir::{BorrowedVariables, PossibleBorrowerMap, enclosing_mir};
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef as _;
 use clippy_utils::source::snippet;
 use clippy_utils::sym;
-use clippy_utils::usage::mutated_variables;
+
 use rustc_errors::Applicability;
-use rustc_hir as hir;
+use rustc_hir::{self as hir};
 use rustc_lint::LateContext;
 
 use super::MAP_UNWRAP_OR;
@@ -30,14 +31,17 @@ pub(super) fn check<'tcx>(
 
     // Don't make a suggestion that may fail to compile due to mutably borrowing
     // the same variable twice.
-    let Some(map_mutated_vars) = mutated_variables(recv, cx) else {
-        return false;
-    };
-    let Some(unwrap_mutated_vars) = mutated_variables(unwrap_arg, cx) else {
-        return false;
-    };
-    if map_mutated_vars.intersection(&unwrap_mutated_vars).next().is_some() {
-        return false;
+    if let Some(mir) = enclosing_mir(cx.tcx, expr.hir_id) {
+        let borrower_map = PossibleBorrowerMap::new(cx, mir);
+        let recv_borrowed_vars = BorrowedVariables::new(cx, recv, &borrower_map);
+        let map_borrowed_vars = BorrowedVariables::new(cx, map_arg, &borrower_map);
+        let unwrap_borrowed_vars = BorrowedVariables::new(cx, unwrap_arg, &borrower_map);
+        if recv_borrowed_vars.conflicts_with(&map_borrowed_vars)
+            || recv_borrowed_vars.conflicts_with(&unwrap_borrowed_vars)
+            || map_borrowed_vars.conflicts_with(&unwrap_borrowed_vars)
+        {
+            return false;
+        }
     }
 
     // lint message

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -10,7 +10,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty::TyCtxt;
 
 mod possible_borrower;
-pub use possible_borrower::PossibleBorrowerMap;
+pub use possible_borrower::{BorrowedVariables, PossibleBorrowerMap};
 
 mod possible_origin;
 

--- a/clippy_utils/src/mir/possible_borrower.rs
+++ b/clippy_utils/src/mir/possible_borrower.rs
@@ -1,7 +1,11 @@
+use crate::mir::expr_local;
+use crate::res::MaybeResPath as _;
+use crate::visitors::for_each_expr_without_closures;
+
 use super::possible_origin::PossibleOriginVisitor;
 use super::transitive_relation::TransitiveRelation;
-use crate::ty::is_copy;
 use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::{Expr, ExprKind};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_lint::LateContext;
 use rustc_middle::mir::visit::Visitor as _;
@@ -10,6 +14,7 @@ use rustc_middle::ty::{self, TyCtxt, TypeVisitor};
 use rustc_mir_dataflow::impls::MaybeStorageLive;
 use rustc_mir_dataflow::{Analysis, ResultsCursor};
 use std::borrow::Cow;
+use std::collections::hash_map::Entry;
 use std::ops::ControlFlow;
 
 /// Collects the possible borrowers of each local.
@@ -19,14 +24,14 @@ struct PossibleBorrowerVisitor<'a, 'b, 'tcx> {
     possible_borrower: TransitiveRelation,
     body: &'b mir::Body<'tcx>,
     cx: &'a LateContext<'tcx>,
-    possible_origin: FxHashMap<mir::Local, DenseBitSet<mir::Local>>,
+    possible_origin: FxHashMap<mir::Local, FxHashMap<mir::Local, Mutability>>,
 }
 
 impl<'a, 'b, 'tcx> PossibleBorrowerVisitor<'a, 'b, 'tcx> {
     fn new(
         cx: &'a LateContext<'tcx>,
         body: &'b mir::Body<'tcx>,
-        possible_origin: FxHashMap<mir::Local, DenseBitSet<mir::Local>>,
+        possible_origin: FxHashMap<mir::Local, FxHashMap<mir::Local, Mutability>>,
     ) -> Self {
         Self {
             possible_borrower: TransitiveRelation::default(),
@@ -36,19 +41,11 @@ impl<'a, 'b, 'tcx> PossibleBorrowerVisitor<'a, 'b, 'tcx> {
         }
     }
 
-    fn into_map(
-        self,
-        cx: &'a LateContext<'tcx>,
-        maybe_live: ResultsCursor<'b, 'tcx, MaybeStorageLive<'tcx>>,
-    ) -> PossibleBorrowerMap<'b, 'tcx> {
+    fn into_map(self, maybe_live: ResultsCursor<'b, 'tcx, MaybeStorageLive<'tcx>>) -> PossibleBorrowerMap<'b, 'tcx> {
         let mut map = FxHashMap::default();
         for row in (1..self.body.local_decls.len()).map(mir::Local::from_usize) {
-            if is_copy(cx, self.body.local_decls[row].ty) {
-                continue;
-            }
-
             let mut borrowers = self.possible_borrower.reachable_from(row, self.body.local_decls.len());
-            borrowers.remove(mir::Local::from_usize(0));
+            borrowers.remove(&mir::Local::from_usize(0));
             if !borrowers.is_empty() {
                 map.insert(row, borrowers);
             }
@@ -67,8 +64,18 @@ impl<'tcx> mir::visit::Visitor<'tcx> for PossibleBorrowerVisitor<'_, '_, 'tcx> {
     fn visit_assign(&mut self, place: &mir::Place<'tcx>, rvalue: &mir::Rvalue<'_>, _location: mir::Location) {
         let lhs = place.local;
         match rvalue {
-            mir::Rvalue::Ref(_, _, borrowed) | mir::Rvalue::CopyForDeref(borrowed) => {
-                self.possible_borrower.add(borrowed.local, lhs);
+            mir::Rvalue::Ref(_, kind, borrowed) => {
+                self.possible_borrower.add(
+                    borrowed.local,
+                    lhs,
+                    match kind {
+                        mir::BorrowKind::Mut { .. } => Mutability::Mut,
+                        _ => Mutability::Not,
+                    },
+                );
+            },
+            mir::Rvalue::CopyForDeref(borrowed) => {
+                self.possible_borrower.add(borrowed.local, lhs, Mutability::Not);
             },
             other => {
                 if ContainsRegion
@@ -79,7 +86,7 @@ impl<'tcx> mir::visit::Visitor<'tcx> for PossibleBorrowerVisitor<'_, '_, 'tcx> {
                 }
                 rvalue_locals(other, |rhs| {
                     if lhs != rhs {
-                        self.possible_borrower.add(rhs, lhs);
+                        self.possible_borrower.add(rhs, lhs, Mutability::Not);
                     }
                 });
             },
@@ -114,10 +121,14 @@ impl<'tcx> mir::visit::Visitor<'tcx> for PossibleBorrowerVisitor<'_, '_, 'tcx> {
                 }
             }
 
+            #[expect(
+                rustc::potential_query_instability,
+                reason = "iterating mutable variables is not sensitive to ordering"
+            )]
             let mut mutable_variables: Vec<mir::Local> = mutable_borrowers
                 .iter()
                 .filter_map(|r| self.possible_origin.get(r))
-                .flat_map(DenseBitSet::iter)
+                .flat_map(|v| v.keys().copied())
                 .collect();
 
             if ContainsRegion.visit_ty(self.body.local_decls[*dest].ty).is_break() {
@@ -126,10 +137,10 @@ impl<'tcx> mir::visit::Visitor<'tcx> for PossibleBorrowerVisitor<'_, '_, 'tcx> {
 
             for y in mutable_variables {
                 for x in &immutable_borrowers {
-                    self.possible_borrower.add(*x, y);
+                    self.possible_borrower.add(*x, y, Mutability::Not);
                 }
                 for x in &mutable_borrowers {
-                    self.possible_borrower.add(*x, y);
+                    self.possible_borrower.add(*x, y, Mutability::Mut);
                 }
             }
         }
@@ -168,7 +179,7 @@ fn rvalue_locals(rvalue: &mir::Rvalue<'_>, mut visit: impl FnMut(mir::Local)) {
 /// Result of `PossibleBorrowerVisitor`.
 pub struct PossibleBorrowerMap<'b, 'tcx> {
     /// Mapping `Local -> its possible borrowers`
-    pub map: FxHashMap<mir::Local, DenseBitSet<mir::Local>>,
+    pub map: FxHashMap<mir::Local, FxHashMap<mir::Local, Mutability>>,
     maybe_live: ResultsCursor<'b, 'tcx, MaybeStorageLive<'tcx>>,
     // Caches to avoid allocation of `DenseBitSet` on every query
     pub bitset: (DenseBitSet<mir::Local>, DenseBitSet<mir::Local>),
@@ -187,7 +198,7 @@ impl<'b, 'tcx> PossibleBorrowerMap<'b, 'tcx> {
                 .into_results_cursor(mir);
         let mut vis = PossibleBorrowerVisitor::new(cx, mir, possible_origin);
         vis.visit_body(mir);
-        vis.into_map(cx, maybe_storage_live_result)
+        vis.into_map(maybe_storage_live_result)
     }
 
     /// Returns true if the set of borrowers of `borrowed` living at `at` matches with `borrowers`.
@@ -209,8 +220,12 @@ impl<'b, 'tcx> PossibleBorrowerMap<'b, 'tcx> {
         self.bitset.0.clear();
         let maybe_live = &mut self.maybe_live;
         if let Some(bitset) = self.map.get(&borrowed) {
-            for b in bitset.iter().filter(move |b| maybe_live.get().contains(*b)) {
-                self.bitset.0.insert(b);
+            #[expect(
+                rustc::potential_query_instability,
+                reason = "iterating over possible borrowers is not sensitive to ordering"
+            )]
+            for b in bitset.keys().filter(move |b| maybe_live.get().contains(**b)) {
+                self.bitset.0.insert(*b);
             }
         } else {
             return false;
@@ -235,5 +250,69 @@ impl<'b, 'tcx> PossibleBorrowerMap<'b, 'tcx> {
     pub fn local_is_alive_at(&mut self, local: mir::Local, at: mir::Location) -> bool {
         self.maybe_live.seek_after_primary_effect(at);
         self.maybe_live.get().contains(local)
+    }
+}
+
+pub struct BorrowedVariables(pub FxHashMap<mir::Local, Mutability>);
+
+impl BorrowedVariables {
+    /// Returns a map of variables borrowed by `expr` and their mutability in the borrowing. The
+    /// `expr` and the `borrower_map` should be from the same MIR body.
+    pub fn new(cx: &LateContext<'_>, expr: &Expr<'_>, borrower_map: &PossibleBorrowerMap<'_, '_>) -> Self {
+        let mut used_vars = FxHashMap::default();
+        for_each_expr_without_closures(expr, |expr| {
+            if let Some(hir_id) = expr
+                .res_local_id()
+                // Closures become `Local`s referencing their bodies in the MIR
+                .or_else(|| matches!(expr.kind, ExprKind::Closure(_)).then_some(expr.hir_id))
+                && let entry = used_vars.entry(hir_id)
+                && matches!(entry, Entry::Vacant(_))
+                && let Some(local) = expr_local(cx.tcx, expr)
+            {
+                entry.insert_entry(local);
+            }
+
+            ControlFlow::<()>::Continue(())
+        });
+
+        let mut borrowed_vars = FxHashMap::default();
+        #[expect(
+            rustc::potential_query_instability,
+            reason = "collecting borrowed variables is not sensitive to ordering"
+        )]
+        for local in used_vars.values() {
+            for (borrower, mutability) in borrower_map
+                .map
+                .iter()
+                .filter_map(|(borrower, borrowed)| borrowed.get(local).map(|mutability| (*borrower, *mutability)))
+            {
+                match borrowed_vars.entry(borrower) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(mutability);
+                    },
+                    Entry::Occupied(mut entry) => {
+                        if mutability.is_mut() && entry.get().is_not() {
+                            entry.insert(Mutability::Mut);
+                        }
+                    },
+                }
+            }
+        }
+
+        Self(borrowed_vars)
+    }
+
+    /// Returns true if `self` and `other` have at least one borrower in conflict, i.e., the same
+    /// borrower is mutably borrowed in one and immutably borrowed in the other or is mutably
+    /// borrowed in both.
+    pub fn conflicts_with(&self, other: &Self) -> bool {
+        #[expect(
+            rustc::potential_query_instability,
+            reason = "checking borrowed variables is not sensitive to ordering"
+        )]
+        self.0.iter().any(|(borrower, mutability)| {
+            matches!(other.0.get(borrower), 
+                Some(other_mutability) if mutability.is_mut() || other_mutability.is_mut())
+        })
     }
 }

--- a/clippy_utils/src/mir/possible_origin.rs
+++ b/clippy_utils/src/mir/possible_origin.rs
@@ -1,7 +1,7 @@
 use super::transitive_relation::TransitiveRelation;
 use crate::ty::is_copy;
+use rustc_ast::Mutability;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_index::bit_set::DenseBitSet;
 use rustc_lint::LateContext;
 use rustc_middle::mir;
 
@@ -21,7 +21,7 @@ impl<'a, 'tcx> PossibleOriginVisitor<'a, 'tcx> {
         }
     }
 
-    pub fn into_map(self, cx: &LateContext<'tcx>) -> FxHashMap<mir::Local, DenseBitSet<mir::Local>> {
+    pub fn into_map(self, cx: &LateContext<'tcx>) -> FxHashMap<mir::Local, FxHashMap<mir::Local, Mutability>> {
         let mut map = FxHashMap::default();
         for row in (1..self.body.local_decls.len()).map(mir::Local::from_usize) {
             if is_copy(cx, self.body.local_decls[row].ty) {
@@ -29,7 +29,7 @@ impl<'a, 'tcx> PossibleOriginVisitor<'a, 'tcx> {
             }
 
             let mut borrowers = self.possible_origin.reachable_from(row, self.body.local_decls.len());
-            borrowers.remove(mir::Local::from_usize(0));
+            borrowers.remove(&mir::Local::from_usize(0));
             if !borrowers.is_empty() {
                 map.insert(row, borrowers);
             }
@@ -50,7 +50,7 @@ impl<'tcx> mir::visit::Visitor<'tcx> for PossibleOriginVisitor<'_, 'tcx> {
             // _3 = move _2 as &mut _;
             mir::Rvalue::Cast(_, mir::Operand::Move(borrowed), _)
                 => {
-                self.possible_origin.add(lhs, borrowed.local);
+                self.possible_origin.add(lhs, borrowed.local, Mutability::Mut);
             },
             _ => {},
         }

--- a/clippy_utils/src/mir/transitive_relation.rs
+++ b/clippy_utils/src/mir/transitive_relation.rs
@@ -1,25 +1,27 @@
+use rustc_ast::Mutability;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(super) struct TransitiveRelation {
-    relations: FxHashMap<mir::Local, Vec<mir::Local>>,
+    relations: FxHashMap<mir::Local, Vec<(mir::Local, Mutability)>>,
 }
 
 impl TransitiveRelation {
-    pub fn add(&mut self, a: mir::Local, b: mir::Local) {
-        self.relations.entry(a).or_default().push(b);
+    pub fn add(&mut self, a: mir::Local, b: mir::Local, mutability: Mutability) {
+        self.relations.entry(a).or_default().push((b, mutability));
     }
 
-    pub fn reachable_from(&self, a: mir::Local, domain_size: usize) -> DenseBitSet<mir::Local> {
-        let mut seen = DenseBitSet::new_empty(domain_size);
-        let mut stack = vec![a];
-        while let Some(u) = stack.pop() {
+    pub fn reachable_from(&self, a: mir::Local, domain_size: usize) -> FxHashMap<mir::Local, Mutability> {
+        let mut seen = FxHashMap::default();
+        seen.reserve(domain_size);
+        let mut stack = vec![(a, Mutability::Not)];
+        while let Some((u, u_mut)) = stack.pop() {
             if let Some(edges) = self.relations.get(&u) {
-                for &v in edges {
-                    if seen.insert(v) {
-                        stack.push(v);
+                for &(v, v_mut) in edges {
+                    let new_mut = Mutability::max(u_mut, v_mut);
+                    if seen.insert(v, new_mut).is_none() {
+                        stack.push((v, new_mut));
                     }
                 }
             }

--- a/tests/ui/map_unwrap_or.rs
+++ b/tests/ui/map_unwrap_or.rs
@@ -168,3 +168,29 @@ fn issue16901() {
     //~^ map_unwrap_or
     let _: &str = after_scope;
 }
+
+fn issue11244() {
+    let mut v = [1, 2, 3];
+    let w: Vec<_> = v.iter_mut().collect();
+    let _ = w
+        .into_iter()
+        .next()
+        .map(|x| *x)
+        .unwrap_or_else(|| *v.iter().max().unwrap());
+
+    fn borrow_mut(_: &mut i32) -> i32 {
+        0
+    }
+
+    let mut v = [1, 2, 3];
+    let w: Vec<_> = v.iter_mut().collect();
+    let mut c = 0;
+    let _ = w
+        .into_iter()
+        .next()
+        .map(|x| {
+            borrow_mut(&mut c);
+            *x
+        })
+        .unwrap_or_else(|| borrow_mut(&mut c));
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#11244 

Rewrite the borrowing check part in MIR

changelog: [`map_unwrap_or`] fix wrong suggestions for conflict borrowing
