### PR TITLE
Lint bit width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6979,6 +6979,7 @@ Released 2018-09-13
 [`manual_assert`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_assert
 [`manual_assert_eq`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_assert_eq
 [`manual_async_fn`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_async_fn
+[`manual_bit_width`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_bit_width
 [`manual_bits`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_bits
 [`manual_c_str_literals`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals
 [`manual_checked_ops`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_checked_ops
@@ -7071,6 +7072,7 @@ Released 2018-09-13
 [`min_ident_chars`]: https://rust-lang.github.io/rust-clippy/master/index.html#min_ident_chars
 [`min_max`]: https://rust-lang.github.io/rust-clippy/master/index.html#min_max
 [`misaligned_transmute`]: https://rust-lang.github.io/rust-clippy/master/index.html#misaligned_transmute
+[`mismatched_bit_width_type`]: https://rust-lang.github.io/rust-clippy/master/index.html#mismatched_bit_width_type
 [`mismatched_target_os`]: https://rust-lang.github.io/rust-clippy/master/index.html#mismatched_target_os
 [`mismatching_type_param_order`]: https://rust-lang.github.io/rust-clippy/master/index.html#mismatching_type_param_order
 [`misnamed_getters`]: https://rust-lang.github.io/rust-clippy/master/index.html#misnamed_getters

--- a/clippy_lints/src/bit_width.rs
+++ b/clippy_lints/src/bit_width.rs
@@ -1,0 +1,191 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::{is_from_proc_macro, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Expr, ExprKind, QPath};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::ty::{self, Ty};
+use rustc_session::impl_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for usage of `T::BITS - x.leading_zeros()` when `x.bit_width()` is available.
+    ///
+    /// ### Why is this bad?
+    ///  Manual reimplementations of `bit_width` increase code complexity for little benefit.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let x: u32 = 5;
+    /// let bit_width = u32::BITS - x.leading_zeros();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let x: u32 = 5;
+    /// let bit_width = x.bit_width();
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub MANUAL_BIT_WIDTH,
+    pedantic,
+    "manually reimplementing `bit_width`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for usage of `T::BITS - x.leading_zeros()` where T and x are of different types.
+    ///
+    /// ### Why is this bad?
+    /// Substracting `leading_zeros` from the number of bits of another type might be
+    /// a buggy implementation of the `bit_width` method.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let x: u64 = 5;
+    /// let bit_width = u32::BITS - x.leading_zeros();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let x: u64 = 5;
+    /// let bit_width = x.bit_width();
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub MISMATCHED_BIT_WIDTH_TYPE,
+    suspicious,
+    "type mismatch in bit width calculation"
+}
+
+impl_lint_pass!(ManualBitWidth => [MANUAL_BIT_WIDTH, MISMATCHED_BIT_WIDTH_TYPE]);
+
+#[derive(Clone, Copy, PartialEq)]
+enum IntKind<'a> {
+    Int(ty::IntTy),
+    Uint(ty::UintTy),
+    // NOTE: in the following two variants, the inner `Ty` stores the entire `NonZero<T>`
+    // and not just `T`. This is so that we can print it in the suggestion.
+    NonZero(Ty<'a>),
+    NonZeroU(Ty<'a>),
+}
+
+impl IntKind<'_> {
+    fn inner_ty(self) -> String {
+        match self {
+            Self::Int(ty) => ty.name_str().to_string(),
+            Self::Uint(ty) => ty.name_str().to_string(),
+            Self::NonZero(ty) | Self::NonZeroU(ty) => ty.to_string(),
+        }
+    }
+
+    fn suggestion(&self) -> &'static str {
+        match self {
+            Self::Int(_) => ".cast_unsigned().bit_width()",
+            Self::Uint(_) => ".bit_width()",
+            Self::NonZero(_) => ".cast_unsigned().bit_width().get()",
+            Self::NonZeroU(_) => ".bit_width().get()",
+        }
+    }
+}
+
+pub struct ManualBitWidth {
+    msrv: Msrv,
+}
+
+impl ManualBitWidth {
+    pub fn new(conf: &Conf) -> Self {
+        Self { msrv: conf.msrv }
+    }
+}
+
+impl LateLintPass<'_> for ManualBitWidth {
+    fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+        if expr.span.in_external_macro(cx.sess().source_map()) {
+            return;
+        }
+
+        match expr.kind {
+            // `T::BITS - n.leading_zeros()`
+            ExprKind::Binary(op, left, right)
+                if op.node == BinOpKind::Sub
+                    && let ExprKind::MethodCall(leading_zeros, recv, [], _) = right.kind
+                    && leading_zeros.ident.name == sym::leading_zeros
+                    && let ExprKind::Path(QPath::TypeRelative(hir_ty, segment)) = left.kind
+                    && segment.ident.name == sym::BITS
+                    && let right_ty = cx.typeck_results().expr_ty(recv)
+                    && let Some(right_int_kind) = get_int_kind(cx, right_ty)
+                    && let left_ty = cx.typeck_results().node_type(hir_ty.hir_id)
+                    && let Some(left_int_kind) = get_int_kind(cx, left_ty)
+                    && self.msrv.meets(cx, msrvs::BIT_WIDTH)
+                    && left.span.eq_ctxt(right.span)
+                    && !is_from_proc_macro(cx, expr) =>
+            {
+                if left_int_kind == right_int_kind {
+                    // manual implementation of bit_width
+                    emit_manual_bit_width(cx, recv, expr, right_int_kind);
+                } else {
+                    // mismatched calling types
+                    emit_type_mismatch(cx, recv, expr, right_int_kind);
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+fn get_int_kind<'a>(cx: &LateContext<'a>, ty: Ty<'a>) -> Option<IntKind<'a>> {
+    match ty.kind() {
+        // int::BITS or uint::BITS
+        ty::Int(int_ty) => Some(IntKind::Int(*int_ty)),
+        ty::Uint(uint_ty) => Some(IntKind::Uint(*uint_ty)),
+        // NonZero::<int/uint>::BITS
+        ty::Adt(adt, args) if cx.tcx.is_diagnostic_item(sym::NonZero, adt.did()) => {
+            let arg = args.type_at(0);
+            match arg.kind() {
+                ty::Int(_) => Some(IntKind::NonZero(ty)),
+                ty::Uint(_) => Some(IntKind::NonZeroU(ty)),
+                _ => None,
+            }
+        },
+        _ => None,
+    }
+}
+
+fn emit_manual_bit_width(cx: &LateContext<'_>, recv: &Expr<'_>, full_expr: &Expr<'_>, ty_kind: IntKind<'_>) {
+    span_lint_and_then(
+        cx,
+        MANUAL_BIT_WIDTH,
+        full_expr.span,
+        "manual implementation of `bit_width`",
+        |diag| {
+            let mut app = Applicability::MachineApplicable;
+            let (recv_snip, _) = snippet_with_context(cx, recv.span, full_expr.span.ctxt(), "_", &mut app);
+            let suggestion = ty_kind.suggestion();
+
+            diag.span_suggestion_verbose(full_expr.span, "try", format!("{recv_snip}{suggestion}"), app);
+        },
+    );
+}
+
+fn emit_type_mismatch(cx: &LateContext<'_>, recv: &Expr<'_>, full_expr: &Expr<'_>, ty_kind: IntKind<'_>) {
+    span_lint_and_then(
+        cx,
+        MISMATCHED_BIT_WIDTH_TYPE,
+        full_expr.span,
+        "possible buggy implementation of `bit_width`",
+        |diag| {
+            diag.note("in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`");
+
+            let mut app = Applicability::MaybeIncorrect;
+            let (recv_snip, _) = snippet_with_context(cx, recv.span, full_expr.span.ctxt(), "_", &mut app);
+            let suggestion = ty_kind.suggestion();
+            let x_ty = ty_kind.inner_ty();
+
+            diag.span_suggestion_verbose(
+                full_expr.span,
+                format!("if you meant to use `{x_ty}::BITS`, use"),
+                format!("{recv_snip}{suggestion}"),
+                app,
+            );
+        },
+    );
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -33,6 +33,8 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::await_holding_invalid::AWAIT_HOLDING_INVALID_TYPE_INFO,
     crate::await_holding_invalid::AWAIT_HOLDING_LOCK_INFO,
     crate::await_holding_invalid::AWAIT_HOLDING_REFCELL_REF_INFO,
+    crate::bit_width::MANUAL_BIT_WIDTH_INFO,
+    crate::bit_width::MISMATCHED_BIT_WIDTH_TYPE_INFO,
     crate::blocks_in_conditions::BLOCKS_IN_CONDITIONS_INFO,
     crate::bool_assert_comparison::BOOL_ASSERT_COMPARISON_INFO,
     crate::bool_comparison::BOOL_COMPARISON_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -75,6 +75,7 @@ mod assigning_clones;
 mod async_yields_async;
 mod attrs;
 mod await_holding_invalid;
+mod bit_width;
 mod blocks_in_conditions;
 mod bool_assert_comparison;
 mod bool_comparison;
@@ -733,6 +734,7 @@ rustc_lint::late_lint_methods!(
         NeedlessLateInit: needless_late_init::NeedlessLateInit<'tcx> = needless_late_init::NeedlessLateInit::new(conf),
         ReturnSelfNotMustUse: return_self_not_must_use::ReturnSelfNotMustUse = return_self_not_must_use::ReturnSelfNotMustUse,
         NumberedFields: init_numbered_fields::NumberedFields = init_numbered_fields::NumberedFields,
+        ManualBitWidth: bit_width::ManualBitWidth = bit_width::ManualBitWidth::new(conf),
         ManualBits: manual_bits::ManualBits = manual_bits::ManualBits::new(conf),
         DefaultUnionRepresentation: default_union_representation::DefaultUnionRepresentation = default_union_representation::DefaultUnionRepresentation,
         OnlyUsedInRecursion: only_used_in_recursion::OnlyUsedInRecursion = <only_used_in_recursion::OnlyUsedInRecursion>::default(),

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -24,7 +24,7 @@ macro_rules! msrv_aliases {
 
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
-    1,97,0 { ISOLATE_LOWEST_ONE }
+    1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }
     1,91,0 { DURATION_FROM_MINUTES_HOURS }
     1,88,0 { LET_CHAINS, AS_CHUNKS }

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -40,6 +40,7 @@ generate! {
     AsyncReadExt,
     AsyncWriteExt,
     BACKSLASH_SINGLE_QUOTE: r"\'",
+    BITS,
     BTreeEntry,
     BTreeSet,
     Binary,

--- a/tests/ui/manual_bit_width.fixed
+++ b/tests/ui/manual_bit_width.fixed
@@ -1,0 +1,59 @@
+#![warn(clippy::manual_bit_width)]
+
+use core::num::{self, NonZero, NonZeroI32, NonZeroU32};
+
+fn main() {
+    // `T::BITS - x.leading_zeros()`
+    // unsigned
+    let w: u8 = 5;
+    let _ = w.bit_width(); //~ manual_bit_width
+    let w: u16 = 5;
+    let _ = w.bit_width(); //~ manual_bit_width
+    let w: u32 = 5;
+    let _ = w.bit_width(); //~ manual_bit_width
+    let w: u64 = 5;
+    let _ = w.bit_width(); //~ manual_bit_width
+    let w: usize = 5;
+    let _ = w.bit_width(); //~ manual_bit_width
+
+    // signed
+    let x: i8 = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ manual_bit_width
+    let x: i16 = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ manual_bit_width
+    let x: i32 = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ manual_bit_width
+    let x: i64 = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ manual_bit_width
+    let x: isize = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ manual_bit_width
+
+    // `NonZero::<T>::BITS - x.leading_zeros()`
+    // unsigned
+    let y = NonZero::<u8>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ manual_bit_width
+    let y = NonZero::<u16>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ manual_bit_width
+    let y = NonZero::<u32>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ manual_bit_width
+    let y = NonZero::<u64>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ manual_bit_width
+    let y = NonZero::<usize>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ manual_bit_width
+
+    // signed
+    let z = NonZero::<i8>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ manual_bit_width
+    let z = NonZero::<i16>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ manual_bit_width
+    let z = NonZero::<i32>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ manual_bit_width
+    let z = NonZero::<i64>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ manual_bit_width
+    let z = NonZero::<isize>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ manual_bit_width
+
+    // negative cases.
+    // left expression is a literal
+    let z: u32 = 1_000_000 - x.leading_zeros();
+}

--- a/tests/ui/manual_bit_width.rs
+++ b/tests/ui/manual_bit_width.rs
@@ -1,0 +1,59 @@
+#![warn(clippy::manual_bit_width)]
+
+use core::num::{self, NonZero, NonZeroI32, NonZeroU32};
+
+fn main() {
+    // `T::BITS - x.leading_zeros()`
+    // unsigned
+    let w: u8 = 5;
+    let _ = u8::BITS - w.leading_zeros(); //~ manual_bit_width
+    let w: u16 = 5;
+    let _ = u16::BITS - w.leading_zeros(); //~ manual_bit_width
+    let w: u32 = 5;
+    let _ = u32::BITS - w.leading_zeros(); //~ manual_bit_width
+    let w: u64 = 5;
+    let _ = u64::BITS - w.leading_zeros(); //~ manual_bit_width
+    let w: usize = 5;
+    let _ = usize::BITS - w.leading_zeros(); //~ manual_bit_width
+
+    // signed
+    let x: i8 = -5;
+    let _ = i8::BITS - x.leading_zeros(); //~ manual_bit_width
+    let x: i16 = -5;
+    let _ = i16::BITS - x.leading_zeros(); //~ manual_bit_width
+    let x: i32 = -5;
+    let _ = i32::BITS - x.leading_zeros(); //~ manual_bit_width
+    let x: i64 = -5;
+    let _ = i64::BITS - x.leading_zeros(); //~ manual_bit_width
+    let x: isize = -5;
+    let _ = isize::BITS - x.leading_zeros(); //~ manual_bit_width
+
+    // `NonZero::<T>::BITS - x.leading_zeros()`
+    // unsigned
+    let y = NonZero::<u8>::new(5).unwrap();
+    let _ = NonZero::<u8>::BITS - y.leading_zeros(); //~ manual_bit_width
+    let y = NonZero::<u16>::new(5).unwrap();
+    let _ = NonZero::<u16>::BITS - y.leading_zeros(); //~ manual_bit_width
+    let y = NonZero::<u32>::new(5).unwrap();
+    let _ = NonZeroU32::BITS - y.leading_zeros(); //~ manual_bit_width
+    let y = NonZero::<u64>::new(5).unwrap();
+    let _ = NonZero::<u64>::BITS - y.leading_zeros(); //~ manual_bit_width
+    let y = NonZero::<usize>::new(5).unwrap();
+    let _ = num::NonZero::<usize>::BITS - y.leading_zeros(); //~ manual_bit_width
+
+    // signed
+    let z = NonZero::<i8>::new(-5).unwrap();
+    let _ = NonZero::<i8>::BITS - z.leading_zeros(); //~ manual_bit_width
+    let z = NonZero::<i16>::new(-5).unwrap();
+    let _ = NonZero::<i16>::BITS - z.leading_zeros(); //~ manual_bit_width
+    let z = NonZero::<i32>::new(-5).unwrap();
+    let _ = NonZeroI32::BITS - z.leading_zeros(); //~ manual_bit_width
+    let z = NonZero::<i64>::new(-5).unwrap();
+    let _ = NonZero::<i64>::BITS - z.leading_zeros(); //~ manual_bit_width
+    let z = NonZero::<isize>::new(-5).unwrap();
+    let _ = num::NonZero::<isize>::BITS - z.leading_zeros(); //~ manual_bit_width
+
+    // negative cases.
+    // left expression is a literal
+    let z: u32 = 1_000_000 - x.leading_zeros();
+}

--- a/tests/ui/manual_bit_width.stderr
+++ b/tests/ui/manual_bit_width.stderr
@@ -1,0 +1,244 @@
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:9:13
+   |
+LL |     let _ = u8::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::manual-bit-width` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_bit_width)]`
+help: try
+   |
+LL -     let _ = u8::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:11:13
+   |
+LL |     let _ = u16::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = u16::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:13:13
+   |
+LL |     let _ = u32::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = u32::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:15:13
+   |
+LL |     let _ = u64::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = u64::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:17:13
+   |
+LL |     let _ = usize::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = usize::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:21:13
+   |
+LL |     let _ = i8::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = i8::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:23:13
+   |
+LL |     let _ = i16::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = i16::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:25:13
+   |
+LL |     let _ = i32::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = i32::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:27:13
+   |
+LL |     let _ = i64::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = i64::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:29:13
+   |
+LL |     let _ = isize::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = isize::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:34:13
+   |
+LL |     let _ = NonZero::<u8>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = NonZero::<u8>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:36:13
+   |
+LL |     let _ = NonZero::<u16>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = NonZero::<u16>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:38:13
+   |
+LL |     let _ = NonZeroU32::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = NonZeroU32::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:40:13
+   |
+LL |     let _ = NonZero::<u64>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = NonZero::<u64>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:42:13
+   |
+LL |     let _ = num::NonZero::<usize>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = num::NonZero::<usize>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:46:13
+   |
+LL |     let _ = NonZero::<i8>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = NonZero::<i8>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:48:13
+   |
+LL |     let _ = NonZero::<i16>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = NonZero::<i16>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:50:13
+   |
+LL |     let _ = NonZeroI32::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = NonZeroI32::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:52:13
+   |
+LL |     let _ = NonZero::<i64>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = NonZero::<i64>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: manual implementation of `bit_width`
+  --> tests/ui/manual_bit_width.rs:54:13
+   |
+LL |     let _ = num::NonZero::<isize>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = num::NonZero::<isize>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: aborting due to 20 previous errors
+

--- a/tests/ui/mismatched_bit_width_type.fixed
+++ b/tests/ui/mismatched_bit_width_type.fixed
@@ -1,0 +1,79 @@
+#![warn(clippy::mismatched_bit_width_type)]
+
+use core::num::{self, NonZero, NonZeroI32, NonZeroU32};
+
+fn main() {
+    // left and right ewpression have different calling types
+    // unsigned
+    let w: u8 = 5;
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let w: u16 = 5;
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let w: u32 = 5;
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let w: u64 = 5;
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let w: usize = 5;
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+    let _ = w.bit_width(); //~ mismatched_bit_width_type
+
+    // signed
+    let x: i8 = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let x: i16 = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let x: i32 = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let x: i64 = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let x: isize = -5;
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+    let _ = x.cast_unsigned().bit_width(); //~ mismatched_bit_width_type
+
+    // `NonZero::<T>::BITS - x.leading_zeros()`
+    // unsigned
+    let y = NonZero::<u8>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let y = NonZero::<u16>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let y = NonZero::<u32>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let y = NonZero::<u64>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let y = NonZero::<usize>::new(5).unwrap();
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+    let _ = y.bit_width().get(); //~ mismatched_bit_width_type
+
+    // signed
+    let z = NonZero::<i8>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let z = NonZero::<i16>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let z = NonZero::<i32>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let z = NonZero::<i64>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let z = NonZero::<isize>::new(-5).unwrap();
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+    let _ = z.cast_unsigned().bit_width().get(); //~ mismatched_bit_width_type
+
+    // negative case.
+    // left expression is a literal
+    let z: u32 = 1_000_000 - x.leading_zeros();
+}

--- a/tests/ui/mismatched_bit_width_type.rs
+++ b/tests/ui/mismatched_bit_width_type.rs
@@ -1,0 +1,79 @@
+#![warn(clippy::mismatched_bit_width_type)]
+
+use core::num::{self, NonZero, NonZeroI32, NonZeroU32};
+
+fn main() {
+    // left and right ewpression have different calling types
+    // unsigned
+    let w: u8 = 5;
+    let _ = i8::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = u32::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let w: u16 = 5;
+    let _ = i16::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = u8::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let w: u32 = 5;
+    let _ = i32::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = isize::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let w: u64 = 5;
+    let _ = i64::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = NonZero::<u64>::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let w: usize = 5;
+    let _ = isize::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = NonZero::<isize>::BITS - w.leading_zeros(); //~ mismatched_bit_width_type
+
+    // signed
+    let x: i8 = -5;
+    let _ = u8::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = i16::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let x: i16 = -5;
+    let _ = u16::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = NonZero::<u32>::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let x: i32 = -5;
+    let _ = u32::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = NonZero::<i32>::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let x: i64 = -5;
+    let _ = u64::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = isize::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let x: isize = -5;
+    let _ = usize::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = u32::BITS - x.leading_zeros(); //~ mismatched_bit_width_type
+
+    // `NonZero::<T>::BITS - x.leading_zeros()`
+    // unsigned
+    let y = NonZero::<u8>::new(5).unwrap();
+    let _ = NonZero::<i8>::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = u8::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let y = NonZero::<u16>::new(5).unwrap();
+    let _ = NonZero::<i16>::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = i16::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let y = NonZero::<u32>::new(5).unwrap();
+    let _ = NonZeroI32::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = NonZero::<u64>::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let y = NonZero::<u64>::new(5).unwrap();
+    let _ = NonZero::<i64>::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = NonZero::<usize>::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let y = NonZero::<usize>::new(5).unwrap();
+    let _ = num::NonZero::<isize>::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = u64::BITS - y.leading_zeros(); //~ mismatched_bit_width_type
+
+    // signed
+    let z = NonZero::<i8>::new(-5).unwrap();
+    let _ = NonZero::<u8>::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = u8::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let z = NonZero::<i16>::new(-5).unwrap();
+    let _ = NonZero::<u16>::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = i16::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let z = NonZero::<i32>::new(-5).unwrap();
+    let _ = NonZeroU32::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = NonZero::<u32>::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let z = NonZero::<i64>::new(-5).unwrap();
+    let _ = NonZero::<u64>::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = NonZero::<i32>::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let z = NonZero::<isize>::new(-5).unwrap();
+    let _ = num::NonZero::<usize>::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+    let _ = num::NonZero::<i64>::BITS - z.leading_zeros(); //~ mismatched_bit_width_type
+
+    // negative case.
+    // left expression is a literal
+    let z: u32 = 1_000_000 - x.leading_zeros();
+}

--- a/tests/ui/mismatched_bit_width_type.stderr
+++ b/tests/ui/mismatched_bit_width_type.stderr
@@ -1,0 +1,524 @@
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:9:13
+   |
+LL |     let _ = i8::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+   = note: `-D clippy::mismatched-bit-width-type` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::mismatched_bit_width_type)]`
+help: if you meant to use `u8::BITS`, use
+   |
+LL -     let _ = i8::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:10:13
+   |
+LL |     let _ = u32::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `u8::BITS`, use
+   |
+LL -     let _ = u32::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:12:13
+   |
+LL |     let _ = i16::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `u16::BITS`, use
+   |
+LL -     let _ = i16::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:13:13
+   |
+LL |     let _ = u8::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `u16::BITS`, use
+   |
+LL -     let _ = u8::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:15:13
+   |
+LL |     let _ = i32::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `u32::BITS`, use
+   |
+LL -     let _ = i32::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:16:13
+   |
+LL |     let _ = isize::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `u32::BITS`, use
+   |
+LL -     let _ = isize::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:18:13
+   |
+LL |     let _ = i64::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `u64::BITS`, use
+   |
+LL -     let _ = i64::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:19:13
+   |
+LL |     let _ = NonZero::<u64>::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `u64::BITS`, use
+   |
+LL -     let _ = NonZero::<u64>::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:21:13
+   |
+LL |     let _ = isize::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `usize::BITS`, use
+   |
+LL -     let _ = isize::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:22:13
+   |
+LL |     let _ = NonZero::<isize>::BITS - w.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `usize::BITS`, use
+   |
+LL -     let _ = NonZero::<isize>::BITS - w.leading_zeros();
+LL +     let _ = w.bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:26:13
+   |
+LL |     let _ = u8::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `i8::BITS`, use
+   |
+LL -     let _ = u8::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:27:13
+   |
+LL |     let _ = i16::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `i8::BITS`, use
+   |
+LL -     let _ = i16::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:29:13
+   |
+LL |     let _ = u16::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `i16::BITS`, use
+   |
+LL -     let _ = u16::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:30:13
+   |
+LL |     let _ = NonZero::<u32>::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `i16::BITS`, use
+   |
+LL -     let _ = NonZero::<u32>::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:32:13
+   |
+LL |     let _ = u32::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `i32::BITS`, use
+   |
+LL -     let _ = u32::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:33:13
+   |
+LL |     let _ = NonZero::<i32>::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `i32::BITS`, use
+   |
+LL -     let _ = NonZero::<i32>::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:35:13
+   |
+LL |     let _ = u64::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `i64::BITS`, use
+   |
+LL -     let _ = u64::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:36:13
+   |
+LL |     let _ = isize::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `i64::BITS`, use
+   |
+LL -     let _ = isize::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:38:13
+   |
+LL |     let _ = usize::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `isize::BITS`, use
+   |
+LL -     let _ = usize::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:39:13
+   |
+LL |     let _ = u32::BITS - x.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `isize::BITS`, use
+   |
+LL -     let _ = u32::BITS - x.leading_zeros();
+LL +     let _ = x.cast_unsigned().bit_width();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:44:13
+   |
+LL |     let _ = NonZero::<i8>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<u8>::BITS`, use
+   |
+LL -     let _ = NonZero::<i8>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:45:13
+   |
+LL |     let _ = u8::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<u8>::BITS`, use
+   |
+LL -     let _ = u8::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:47:13
+   |
+LL |     let _ = NonZero::<i16>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<u16>::BITS`, use
+   |
+LL -     let _ = NonZero::<i16>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:48:13
+   |
+LL |     let _ = i16::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<u16>::BITS`, use
+   |
+LL -     let _ = i16::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:50:13
+   |
+LL |     let _ = NonZeroI32::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<u32>::BITS`, use
+   |
+LL -     let _ = NonZeroI32::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:51:13
+   |
+LL |     let _ = NonZero::<u64>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<u32>::BITS`, use
+   |
+LL -     let _ = NonZero::<u64>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:53:13
+   |
+LL |     let _ = NonZero::<i64>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<u64>::BITS`, use
+   |
+LL -     let _ = NonZero::<i64>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:54:13
+   |
+LL |     let _ = NonZero::<usize>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<u64>::BITS`, use
+   |
+LL -     let _ = NonZero::<usize>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:56:13
+   |
+LL |     let _ = num::NonZero::<isize>::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<usize>::BITS`, use
+   |
+LL -     let _ = num::NonZero::<isize>::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:57:13
+   |
+LL |     let _ = u64::BITS - y.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<usize>::BITS`, use
+   |
+LL -     let _ = u64::BITS - y.leading_zeros();
+LL +     let _ = y.bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:61:13
+   |
+LL |     let _ = NonZero::<u8>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<i8>::BITS`, use
+   |
+LL -     let _ = NonZero::<u8>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:62:13
+   |
+LL |     let _ = u8::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<i8>::BITS`, use
+   |
+LL -     let _ = u8::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:64:13
+   |
+LL |     let _ = NonZero::<u16>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<i16>::BITS`, use
+   |
+LL -     let _ = NonZero::<u16>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:65:13
+   |
+LL |     let _ = i16::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<i16>::BITS`, use
+   |
+LL -     let _ = i16::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:67:13
+   |
+LL |     let _ = NonZeroU32::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<i32>::BITS`, use
+   |
+LL -     let _ = NonZeroU32::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:68:13
+   |
+LL |     let _ = NonZero::<u32>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<i32>::BITS`, use
+   |
+LL -     let _ = NonZero::<u32>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:70:13
+   |
+LL |     let _ = NonZero::<u64>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<i64>::BITS`, use
+   |
+LL -     let _ = NonZero::<u64>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:71:13
+   |
+LL |     let _ = NonZero::<i32>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<i64>::BITS`, use
+   |
+LL -     let _ = NonZero::<i32>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:73:13
+   |
+LL |     let _ = num::NonZero::<usize>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<isize>::BITS`, use
+   |
+LL -     let _ = num::NonZero::<usize>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: possible buggy implementation of `bit_width`
+  --> tests/ui/mismatched_bit_width_type.rs:74:13
+   |
+LL |     let _ = num::NonZero::<i64>::BITS - z.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: in order to calculate the bit width, `T::BITS` should match the type of the value calling `.leading_zeros()`
+help: if you meant to use `std::num::NonZero<isize>::BITS`, use
+   |
+LL -     let _ = num::NonZero::<i64>::BITS - z.leading_zeros();
+LL +     let _ = z.cast_unsigned().bit_width().get();
+   |
+
+error: aborting due to 40 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16902)*


Fixes rust-lang/rust-clippy#16876 

Current state:
- [x] suggests change of `Uint::BITS - x.leading_zeros()` to `x.bit_width()`
- [x] suggests change of `Int::BITS - x.leading_zeros()` to `x.cast_unsigned().bit_width()`
- [x] suggests change of `NonZero::<Uint>::BITS - x.leading_zeros()` to `x.bit_width().get()`
- [x] suggests change of `NonZero::<Int>::BITS - x.leading_zeros()` to `x.cast_unsigned().bit_width().get()`
- [x] when the calling Type of `T::BITS` does not align with value (`x`) calling `leading_zeros()` the lint will raise this mismatch and suggest to replace the whole line with `x.bit_width()`

## Description
 rust 1.97 introduces the method `bit_width()` for uints and NonZero ([docs](https://doc.rust-lang.org/nightly/core/primitive.u32.html?search=bit_width)), this will make the manual computation redundant  and unnecessary.

## Example 1

```rust
let x: u32 = b'101';
let bit_width = u32::BITS - x.leading_zeros();
```

Can be replaced with:
```rust
let x: u32 = b'101';
let bit_width = x.bit_width();
```

## Example 2

```rust
let y = NonZero::<u32>::new(5).unwrap();
let _ = NonZero::<u32>::BITS - y.leading_zeros(); 
```

Can be replaced with:
```rust
let y = NonZero::<u32>::new(5).unwrap();
let bit_width = y.bit_width().get();
```

## Example 3

```rust
let y: i32 = 5;
let _ = i32::BITS - y.leading_zeros(); 
```

Can be replaced with:
```rust
let y: i32 = 5;
let _ = y.cast_unsigned().bit_width();
```

## Example 4

```rust
let y = NonZero::<i32>::new(5).unwrap();
let _ = NonZero::<i32>::BITS - y.leading_zeros(); 
```

Can be replaced with:
```rust
let y = NonZero::<i32>::new(5).unwrap();
let bit_width = y.cast_unsigned().bit_width().get();
```

## Example 5

```rust
let y: u32 = 5;
let _ = NonZero::<u64>::BITS - y.leading_zeros(); 
```

Can be replaced with:
```rust
let y: u32 = 5;
let bit_width = y.bit_width();
```

changelog: [`manual_bit_width`], [`mismatched_bit_width_type`]: Added a lint to detect bit_width implementations.


I have 

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`
