### PR TITLE
question_mark: drop redundant block in statement-position suggestion

### DIFF
--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -18,8 +18,8 @@ use rustc_errors::Applicability;
 use rustc_hir::LangItem::{self, OptionNone, OptionSome, ResultErr, ResultOk};
 use rustc_hir::def::Res;
 use rustc_hir::{
-    Arm, BindingMode, Block, Body, ByRef, Expr, ExprKind, FnRetTy, HirId, LetStmt, MatchSource, Mutability, Node, Pat,
-    PatKind, PathSegment, QPath, Stmt, StmtKind,
+    Arm, BindingMode, Block, BlockCheckMode, Body, ByRef, Expr, ExprKind, FnRetTy, HirId, LetStmt, MatchSource,
+    Mutability, Node, Pat, PatKind, PathSegment, QPath, Stmt, StmtKind,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
@@ -514,6 +514,28 @@ fn check_if_try_match<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
     }
 }
 
+/// Returns the span covering the statements of a block (no tail expression),
+/// excluding the surrounding braces. Returns `None` if the block is empty,
+/// contains a tail expression, any statement comes from a macro expansion, or
+/// any statement is a `let` binding (dropping the braces would extend those
+/// bindings into the enclosing scope and can change which binding later code
+/// resolves to).
+fn block_stmts_span(block: &Block<'_>) -> Option<Span> {
+    if block.expr.is_some() || block.stmts.is_empty() {
+        return None;
+    }
+    if block
+        .stmts
+        .iter()
+        .any(|s| s.span.from_expansion() || matches!(s.kind, StmtKind::Let(_)))
+    {
+        return None;
+    }
+    let first = block.stmts.first()?.span;
+    let last = block.stmts.last()?.span;
+    Some(first.to(last))
+}
+
 fn check_if_let_some_or_err_and_early_return<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
     if let Some(higher::IfLet {
         let_pat,
@@ -585,9 +607,37 @@ fn check_if_let_some_or_err_and_early_return<'tcx>(cx: &LateContext<'tcx>, expr:
                     return;
                 }
 
-                let mut sugg = snippet_with_applicability(cx, if_then.span, "..", &mut applicability).into_owned();
                 let binding_snippet = snippet_with_applicability(cx, field.span, "..", &mut applicability);
                 let indent = indent_of(cx, expr.span).unwrap_or_default();
+                let parent = cx.tcx.parent_hir_node(expr.hir_id);
+                // When the `if let ... else { return ... }` is itself a statement, the
+                // replacement statements live at the same block level as the original, so
+                // wrapping them in a fresh `{ ... }` only introduces a redundant scope.
+                // In that case emit the body statements directly next to a new `let` binding.
+                if matches!(parent, Node::Stmt(_))
+                    && let ExprKind::Block(body_block, _) = if_then.kind
+                    && !body_block.targeted_by_break
+                    && body_block.rules == BlockCheckMode::DefaultBlock
+                    && let Some(body_inner_span) = block_stmts_span(body_block)
+                {
+                    // The braces of the original `if let` constrain the lifetime of the new
+                    // `let` binding and anything else defined in the body. Dropping them
+                    // extends those lifetimes to the enclosing scope, which can change drop
+                    // order for non-Copy types, so downgrade the suggestion.
+                    applicability = Applicability::MaybeIncorrect;
+                    let body_snippet =
+                        snippet_with_applicability(cx, body_inner_span, "..", &mut applicability).into_owned();
+                    let reindented = reindent_multiline(&body_snippet, true, Some(indent));
+                    let sugg = format!(
+                        "let {binding_snippet} = {receiver_str}?;\n{}{}",
+                        " ".repeat(indent),
+                        reindented,
+                    );
+                    diag.span_suggestion(expr.span, "replace it with", sugg, applicability);
+                    return;
+                }
+
+                let mut sugg = snippet_with_applicability(cx, if_then.span, "..", &mut applicability).into_owned();
                 sugg.insert_str(
                     1,
                     &format!("\n{}let {binding_snippet} = {receiver_str}?;", " ".repeat(indent + 4)),

--- a/tests/ui/question_mark.fixed
+++ b/tests/ui/question_mark.fixed
@@ -564,3 +564,22 @@ fn issue16751(mut v: Option<usize>) -> Option<usize> {
         if n > 10 { Some(42) } else { None }
     }
 }
+
+fn issue_16892(v: Option<i32>) -> Option<()> {
+    let x = v?;
+    std::hint::black_box(x);
+    Some(())
+}
+
+fn issue_16892_shadow(x: Option<u32>) -> Option<u32> {
+    // Body introduces a shadowing `let x`; dropping the outer braces would extend
+    // the shadow into the enclosing scope and change which `x` the trailing
+    // expression resolves to, so the suggestion must keep the braces.
+    {
+        let x = x?;
+        //~^ question_mark
+        let x = x + 1;
+        std::hint::black_box(x);
+    }
+    x
+}

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -710,3 +710,27 @@ fn issue16751(mut v: Option<usize>) -> Option<usize> {
         None => return None,
     }
 }
+
+fn issue_16892(v: Option<i32>) -> Option<()> {
+    if let Some(x) = v {
+        //~^ question_mark
+        std::hint::black_box(x);
+    } else {
+        return None;
+    }
+    Some(())
+}
+
+fn issue_16892_shadow(x: Option<u32>) -> Option<u32> {
+    // Body introduces a shadowing `let x`; dropping the outer braces would extend
+    // the shadow into the enclosing scope and change which `x` the trailing
+    // expression resolves to, so the suggestion must keep the braces.
+    if let Some(x) = x {
+        //~^ question_mark
+        let x = x + 1;
+        std::hint::black_box(x);
+    } else {
+        return None;
+    }
+    x
+}

--- a/tests/ui/question_mark.stderr
+++ b/tests/ui/question_mark.stderr
@@ -498,5 +498,44 @@ LL +         if n > 10 { Some(42) } else { None }
 LL +     }
    |
 
-error: aborting due to 46 previous errors
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:715:5
+   |
+LL | /     if let Some(x) = v {
+LL | |
+LL | |         std::hint::black_box(x);
+LL | |     } else {
+LL | |         return None;
+LL | |     }
+   | |_____^
+   |
+help: replace it with
+   |
+LL ~     let x = v?;
+LL +     std::hint::black_box(x);
+   |
+
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:728:5
+   |
+LL | /     if let Some(x) = x {
+LL | |
+LL | |         let x = x + 1;
+LL | |         std::hint::black_box(x);
+LL | |     } else {
+LL | |         return None;
+LL | |     }
+   | |_____^
+   |
+help: replace it with
+   |
+LL ~     {
+LL +         let x = x?;
+LL +
+LL +         let x = x + 1;
+LL +         std::hint::black_box(x);
+LL +     }
+   |
+
+error: aborting due to 48 previous errors
 


### PR DESCRIPTION
The `question_mark` lint currently rewrites

```rust
if let Some(x) = Some(1) {
    black_box(x);
} else {
    return None;
}
Some(())
```

to

```rust
{
    let x = Some(1)?;
    black_box(x);
}
Some(())
```

but the outer `{ ... }` has no purpose at statement level. This PR emits the
rewrite as sibling statements whenever the `if let` is itself a statement and
the body consists only of statements (no tail expression, no macro-expanded
statements):

```rust
let x = Some(1)?;
black_box(x);
Some(())
```

Because removing the braces extends the lifetime of the new `let` binding (and
any other bindings defined in the body) to the enclosing scope, the suggestion
is downgraded from `MachineApplicable` to `MaybeIncorrect` for this case so
that `cargo fix` will not silently change drop order for non-`Copy` types.
When the body has a tail expression or the inner block needs to stay (e.g. an
RHS of `let _ = ...`), the previous braced suggestion is still produced.

fixes rust-lang/rust-clippy#16892

changelog: [`question_mark`]: drop redundant block scope when the rewrite fits at statement level