### PR TITLE
Remove myself from rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -93,6 +93,7 @@ users_on_vacation = [
     "Alexendoo",
     "y21",
     "blyxyas",
+    "samueltardieu",
 ]
 
 [assign.owners]


### PR DESCRIPTION
I'll be away for around ten days. Apparently, setting oneself out of rotation using triagebot is not enough.

changelog: none

r? ghost