### PR TITLE
`inline_modules`: fix the rust version the lint was introduced in

### DIFF
--- a/clippy_lints/src/module_style.rs
+++ b/clippy_lints/src/module_style.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// // in `src/foo.rs` (or `src/foo/mod.rs`)
     /// /* module contents */
     /// ```
-    #[clippy::version = "1.96.0"]
+    #[clippy::version = "1.97.0"]
     pub INLINE_MODULES,
     restriction,
     "checks that module layout does not use inline modules"


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust-clippy/pull/16732

changelog: none