### PR TITLE
Fix FP in `default_numeric_fallback` when type is context-constrained

### DIFF
--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -5,8 +5,8 @@ use rustc_ast::ast::{LitFloatType, LitIntType, LitKind};
 use rustc_errors::Applicability;
 use rustc_hir::intravisit::{Visitor, walk_expr, walk_pat, walk_stmt};
 use rustc_hir::{
-    Block, Body, ConstContext, Expr, ExprKind, FnRetTy, HirId, Lit, Pat, PatExpr, PatExprKind, PatKind, Stmt, StmtKind,
-    StructTailExpr,
+    BinOpKind, Block, Body, ConstContext, Expr, ExprKind, FnRetTy, HirId, Lit, Pat, PatExpr, PatExprKind, PatKind,
+    Stmt, StmtKind, StructTailExpr,
 };
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty::{self, FloatTy, IntTy, PolyFnSig, Ty};
@@ -208,6 +208,30 @@ impl<'tcx> Visitor<'tcx> for NumericFallbackVisitor<'_, 'tcx> {
                 }
             },
 
+            ExprKind::Binary(op, lhs, rhs) => {
+                // For binary operators that require both operands to have the same type
+                // (everything except shifts, where each side is independently typed),
+                // a concretely-typed neighbor constrains the other side, so an unsuffixed
+                // literal there cannot fall back. Shifts are skipped because `a << b` and
+                // `a >> b` allow `a` and `b` to have different integer types.
+                if !matches!(op.node, BinOpKind::Shl | BinOpKind::Shr) {
+                    // Inherit any outer bound: if the surrounding context already pins the
+                    // type, that constraint propagates through the binary op to both sides.
+                    let outer = matches!(self.ty_bounds.last(), Some(ExplicitTyBound(true)));
+                    let lhs_bound = ExplicitTyBound(outer || sibling_bound(self.cx, lhs).0);
+                    let rhs_bound = ExplicitTyBound(outer || sibling_bound(self.cx, rhs).0);
+
+                    self.ty_bounds.push(rhs_bound);
+                    self.visit_expr(lhs);
+                    self.ty_bounds.pop();
+
+                    self.ty_bounds.push(lhs_bound);
+                    self.visit_expr(rhs);
+                    self.ty_bounds.pop();
+                    return;
+                }
+            },
+
             ExprKind::Lit(lit) => {
                 let ty = self.cx.typeck_results().expr_ty(expr);
                 self.check_lit(*lit, ty, expr.hir_id);
@@ -245,6 +269,64 @@ impl<'tcx> Visitor<'tcx> for NumericFallbackVisitor<'_, 'tcx> {
         walk_stmt(self, stmt);
         self.ty_bounds.pop();
     }
+}
+
+/// Returns an [`ExplicitTyBound`] derived from `expr` to constrain its sibling in a binary
+/// operation whose operands must share the same type. The bound is "explicit" only when
+/// `expr` itself has a concrete numeric type that did not come from fallback, i.e. it
+/// contains some non-(unsuffixed-literal) source of type information.
+fn sibling_bound<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> ExplicitTyBound {
+    let ty = cx.typeck_results().expr_ty_opt(expr);
+    if !ty.is_some_and(Ty::is_numeric) {
+        return ExplicitTyBound(false);
+    }
+    ExplicitTyBound(has_explicit_type_source(cx, expr))
+}
+
+/// Walks `expr` looking for any sub-expression whose type is concretely numeric and that
+/// did not get its type from fallback. An unsuffixed integer/float literal does not count;
+/// any other numeric expression (typed paths, casts, suffixed literals, calls returning a
+/// concrete numeric type, ...) does.
+fn has_explicit_type_source<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
+    struct Finder<'a, 'tcx> {
+        cx: &'a LateContext<'tcx>,
+        found: bool,
+    }
+    impl<'tcx> Visitor<'tcx> for Finder<'_, 'tcx> {
+        fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
+            if self.found {
+                return;
+            }
+            // An unsuffixed numeric literal carries no inherent type info.
+            if let ExprKind::Lit(lit) = &expr.kind
+                && matches!(
+                    lit.node,
+                    LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed)
+                )
+            {
+                return;
+            }
+            // Recurse into compound expressions; only count leaves that have a concrete
+            // numeric type (e.g. paths to typed locals, suffixed literals, casts).
+            match &expr.kind {
+                ExprKind::Binary(_, lhs, rhs) => {
+                    self.visit_expr(lhs);
+                    self.visit_expr(rhs);
+                },
+                ExprKind::Unary(_, inner) | ExprKind::AddrOf(_, _, inner) => {
+                    self.visit_expr(inner);
+                },
+                _ => {
+                    if self.cx.typeck_results().expr_ty_opt(expr).is_some_and(Ty::is_numeric) {
+                        self.found = true;
+                    }
+                },
+            }
+        }
+    }
+    let mut finder = Finder { cx, found: false };
+    finder.visit_expr(expr);
+    finder.found
 }
 
 fn fn_sig_opt<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Option<PolyFnSig<'tcx>> {

--- a/tests/ui/default_numeric_fallback_f64.fixed
+++ b/tests/ui/default_numeric_fallback_f64.fixed
@@ -201,4 +201,18 @@ mod in_macro {
     }
 }
 
+mod issue16745 {
+    fn test() {
+        // Should NOT lint these literals because their type is constrained by
+        // the typed neighbor in the binary expression.
+        let b = 92f64;
+        let _ = b + 3.0;
+        let _ = b - 3.0;
+        let _ = b * 3.0;
+        let _ = b / 3.0;
+        let _ = 3.0 + b;
+        let _ = 3.0 - b;
+    }
+}
+
 fn main() {}

--- a/tests/ui/default_numeric_fallback_f64.rs
+++ b/tests/ui/default_numeric_fallback_f64.rs
@@ -201,4 +201,18 @@ mod in_macro {
     }
 }
 
+mod issue16745 {
+    fn test() {
+        // Should NOT lint these literals because their type is constrained by
+        // the typed neighbor in the binary expression.
+        let b = 92f64;
+        let _ = b + 3.0;
+        let _ = b - 3.0;
+        let _ = b * 3.0;
+        let _ = b / 3.0;
+        let _ = 3.0 + b;
+        let _ = 3.0 - b;
+    }
+}
+
 fn main() {}

--- a/tests/ui/default_numeric_fallback_i32.fixed
+++ b/tests/ui/default_numeric_fallback_i32.fixed
@@ -208,6 +208,38 @@ fn check_expect_suppression() {
     let x = 21;
 }
 
+mod issue16745 {
+    fn test() {
+        // Should NOT lint these literals because their type is constrained by
+        // the typed neighbor in the binary expression.
+        let a = 92i32;
+        let _ = a + 3;
+        let _ = a - 3;
+        let _ = a * 3;
+        let _ = 3 + a;
+        let _ = a & 3;
+        let _ = a | 3;
+        let _ = a ^ 3;
+
+        // Shifts should still lint the LHS literal because the RHS type does not
+        // constrain the LHS in `a << b` or `a >> b`.
+        let _ = 3_i32 << a;
+        //~^ default_numeric_fallback
+        let _ = 3_i32 >> a;
+        //~^ default_numeric_fallback
+
+        // Transitive constraint: nested binary ops where one leaf has a typed
+        // source should also not lint.
+        let _ = a + 1 + 2;
+        let _ = (1 + 2) + a;
+
+        // No typed neighbor: still warn (both sides are unsuffixed literals).
+        let _ = 1_i32 + 2_i32;
+        //~^ default_numeric_fallback
+        //~| default_numeric_fallback
+    }
+}
+
 mod type_already_inferred {
     // Should NOT lint if bound to return type
     fn ret_i32() -> i32 {

--- a/tests/ui/default_numeric_fallback_i32.rs
+++ b/tests/ui/default_numeric_fallback_i32.rs
@@ -208,6 +208,38 @@ fn check_expect_suppression() {
     let x = 21;
 }
 
+mod issue16745 {
+    fn test() {
+        // Should NOT lint these literals because their type is constrained by
+        // the typed neighbor in the binary expression.
+        let a = 92i32;
+        let _ = a + 3;
+        let _ = a - 3;
+        let _ = a * 3;
+        let _ = 3 + a;
+        let _ = a & 3;
+        let _ = a | 3;
+        let _ = a ^ 3;
+
+        // Shifts should still lint the LHS literal because the RHS type does not
+        // constrain the LHS in `a << b` or `a >> b`.
+        let _ = 3 << a;
+        //~^ default_numeric_fallback
+        let _ = 3 >> a;
+        //~^ default_numeric_fallback
+
+        // Transitive constraint: nested binary ops where one leaf has a typed
+        // source should also not lint.
+        let _ = a + 1 + 2;
+        let _ = (1 + 2) + a;
+
+        // No typed neighbor: still warn (both sides are unsuffixed literals).
+        let _ = 1 + 2;
+        //~^ default_numeric_fallback
+        //~| default_numeric_fallback
+    }
+}
+
 mod type_already_inferred {
     // Should NOT lint if bound to return type
     fn ret_i32() -> i32 {

--- a/tests/ui/default_numeric_fallback_i32.stderr
+++ b/tests/ui/default_numeric_fallback_i32.stderr
@@ -154,22 +154,46 @@ LL |         inline!(let x = 22;);
    = note: this error originates in the macro `__inline_mac_fn_internal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: default numeric fallback might occur
-  --> tests/ui/default_numeric_fallback_i32.rs:239:29
+  --> tests/ui/default_numeric_fallback_i32.rs:226:17
+   |
+LL |         let _ = 3 << a;
+   |                 ^ help: consider adding suffix: `3_i32`
+
+error: default numeric fallback might occur
+  --> tests/ui/default_numeric_fallback_i32.rs:228:17
+   |
+LL |         let _ = 3 >> a;
+   |                 ^ help: consider adding suffix: `3_i32`
+
+error: default numeric fallback might occur
+  --> tests/ui/default_numeric_fallback_i32.rs:237:17
+   |
+LL |         let _ = 1 + 2;
+   |                 ^ help: consider adding suffix: `1_i32`
+
+error: default numeric fallback might occur
+  --> tests/ui/default_numeric_fallback_i32.rs:237:21
+   |
+LL |         let _ = 1 + 2;
+   |                     ^ help: consider adding suffix: `2_i32`
+
+error: default numeric fallback might occur
+  --> tests/ui/default_numeric_fallback_i32.rs:271:29
    |
 LL |         let data_i32 = vec![1, 2, 3];
    |                             ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
-  --> tests/ui/default_numeric_fallback_i32.rs:239:32
+  --> tests/ui/default_numeric_fallback_i32.rs:271:32
    |
 LL |         let data_i32 = vec![1, 2, 3];
    |                                ^ help: consider adding suffix: `2_i32`
 
 error: default numeric fallback might occur
-  --> tests/ui/default_numeric_fallback_i32.rs:239:35
+  --> tests/ui/default_numeric_fallback_i32.rs:271:35
    |
 LL |         let data_i32 = vec![1, 2, 3];
    |                                   ^ help: consider adding suffix: `3_i32`
 
-error: aborting due to 28 previous errors
+error: aborting due to 32 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16745

`clippy::default_numeric_fallback` was flagging numeric literals whose resolved type happened to be `i32` / `f64`, even when that type was forced by a typed neighbor in a binary expression rather than by fallback.

### Before

```rust
#![warn(clippy::default_numeric_fallback)]
let a = 92i32;
let _ = a + 3;     // warns on `3` even though `a: i32` already pins the type
let b = 92f64;
let _ = b + 3.0;   // warns on `3.0` for the same reason
```

### After

The above no longer warns. The lint now treats a binary operator (other than `<<` / `>>`) whose sibling operand has a concrete numeric type from a non-(unsuffixed-literal) source as supplying an explicit type bound, the same way it already does for fn arguments and struct fields. The check propagates outer bounds downward, so transitively constrained literals such as the inner ones in `a + 1 + 2` and `(1 + 2) + a` are also accepted.

Shifts are intentionally skipped because `<<` and `>>` permit each side to have its own integer type, so a typed RHS does not constrain a literal LHS:

```rust
let a = 92i32;
let _ = 3 << a;   // still warns: type of `3` is not pinned by `a`
```

Cases where neither side carries explicit type information continue to warn (e.g. `let _ = 1 + 2;`).

changelog: [`default_numeric_fallback`]: do not warn on numeric literals whose type is constrained by a typed operand in a binary expression