### PR TITLE
Fixes a `collapsible_match` false positive where the suggested fix turned an exhaustive `match` into a non-exhaustive one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ document.
 
 [df995e...master](https://github.com/rust-lang/rust-clippy/compare/df995e...master)
 
+### False Positive Fixes
+
+* [`collapsible_match`]: no longer suggests collapsing into a guarded arm when the
+  fall-through arm is wild-LIKE (e.g. `None`) but not a true catch-all; the
+  resulting suggestion would have produced a non-exhaustive match.
+
 ## Rust 1.95
 
 Current stable, released 2026-04-16

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -23,9 +23,18 @@ use super::{COLLAPSIBLE_MATCH, pat_contains_disallowed_or};
 
 pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>], msrv: Msrv) {
     if let Some(els_arm) = arms.iter().rfind(|arm| arm_is_wild_like(cx, arm)) {
-        let last_non_wildcard = arms.iter().rposition(|arm| !arm_is_wild_like(cx, arm));
         for (idx, arm) in arms.iter().enumerate() {
-            let only_wildcards_after = last_non_wildcard.is_none_or(|lnw| idx >= lnw);
+            // For the path-B if-guard collapse to be sound, when the new guard fails the
+            // value must reliably fall through to a truly wild catch-all arm. That requires
+            // every arm after the current one to be unconditional with a `_` or binding
+            // pattern, and there must be at least one such arm. A `None` arm is wild-LIKE
+            // but only matches `None`, so it cannot catch a `Some(_)` value falling
+            // through (issue #16910). A guarded `_ if cond` arm could intercept some
+            // values and change semantics (issue #16875).
+            let has_truly_wild_arm_after = !arms[idx + 1..].is_empty()
+                && arms[idx + 1..]
+                    .iter()
+                    .all(|a| a.guard.is_none() && matches!(a.pat.kind, PatKind::Wild | PatKind::Binding(..)));
             check_arm(
                 cx,
                 true,
@@ -35,7 +44,7 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, ar
                 arm.guard,
                 Some(els_arm.body),
                 msrv,
-                only_wildcards_after,
+                has_truly_wild_arm_after,
             );
         }
     }
@@ -62,7 +71,7 @@ fn check_arm<'tcx>(
     outer_guard: Option<&'tcx Expr<'tcx>>,
     outer_else_body: Option<&'tcx Expr<'tcx>>,
     msrv: Msrv,
-    only_wildcards_after: bool,
+    has_truly_wild_arm_after: bool,
 ) {
     let inner_expr = peel_blocks_with_stmt(outer_then_body);
     if let Some(inner) = IfLetOrMatch::parse(cx, inner_expr)
@@ -139,7 +148,7 @@ fn check_arm<'tcx>(
             );
         });
     } else if outer_is_match // Leave if-let to the `collapsible_if` lint
-        && only_wildcards_after // adding a guard allows fall-through; unsafe if other arms follow
+        && has_truly_wild_arm_after // guard failure must fall through to a real catch-all
         && let Some(inner) = If::hir(inner_expr)
         && outer_pat.span.eq_ctxt(inner.cond.span)
         && match (outer_else_body, inner.r#else) {

--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -410,6 +410,35 @@ fn issue16875(a: Option<&str>, b: i32) -> i32 {
     res
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/16910
+// The outer `None` arm is wild-LIKE but only matches `None`. Collapsing the inner
+// `if`/`else` into a guarded `Some(t)` arm would drop the `else` body and leave the
+// resulting match non-exhaustive for `Some(_)` when the guard fails.
+fn issue16910(opt: Option<u32>, dest_exists: bool) {
+    match opt {
+        None => {},
+        Some(t) => {
+            if dest_exists {
+                let _ = t;
+            } else {
+                // body equal to the `None` arm body but still unsound to drop
+            }
+        },
+    }
+
+    // Same shape with non-unit equal else bodies on both sides.
+    let _ = match opt {
+        None => 0,
+        Some(t) => {
+            if t == 1 {
+                t
+            } else {
+                0
+            }
+        },
+    };
+}
+
 fn issue16705(x: Option<String>) {
     fn takes_ownership(s: String) -> bool {
         true


### PR DESCRIPTION
When the inner `if cond { A } else { B }` was collapsed into a guarded outer arm and the
outer "wild-like" sibling arm was `None` (a constructor pattern, not a true catch-all),
the suggestion dropped the inner `else` body and produced a `match` that no longer
covered `Some(_)` when the guard failed.

Closes rust-lang/rust-clippy#16910

### What changed

`arm_is_wild_like` accepts `Wild`, `Binding`, **and** `OptionNone`. The first two are
true catch-alls; `OptionNone` is wild-LIKE but only matches `None`, so it cannot catch
a `Some(_)` value falling through from a guarded `Some(_)` arm above.

Path B (inner plain `if`) was already gated on `only_wildcards_after` (added in rust-lang/rust-clippy#16875
to handle a similar case where a `_ if cond` arm intercepts the fall-through). That gate
has been tightened: every arm after the one being collapsed must be **unconditional with
a `_` or binding pattern**, and at least one such arm must exist. This catches both the
prior `_ if cond` case and the new `None` case.

### Reproducer (from the issue, simplified)

Before the fix the lint suggested:

```rust
// original (compiles)
match self.temp {
    None => { fs::rename(self.source, dest)?; }
    Some(temp) => {
        if dest.exists() { /* ... uses temp */ }
        else { fs::rename(self.source, dest)?; }
    }
};

// suggested (does NOT compile - `Some(temp) if !dest.exists()` is unhandled)
match self.temp {
    None => { fs::rename(self.source, dest)?; }
    Some(temp) if dest.exists() => { /* ... */ }
};
```

After the fix the lint stays silent on this shape.

### Conditions for the if-guard collapse to fire

* the outer is a `match`
* every arm after the one being collapsed is unconditional and has a `_` or binding
  pattern, and there is at least one such arm
* (existing conditions: else bodies are equivalent, no binding moved/mutated in the new
  guard, etc.)

changelog: [`collapsible_match`]: no longer suggests a fix that drops an `else` branch when the fall-through arm is wild-LIKE (e.g. `None`) but not a true catch-all
