### PR TITLE
Fixes a `collapsible_match` false positive where the suggested if-into-guard collapse produces code that fails the borrow checker (E0502).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ document.
 
 [df995e...master](https://github.com/rust-lang/rust-clippy/compare/df995e...master)
 
+### False Positive Fixes
+
+* [`collapsible_match`]: no longer suggests an if-into-guard collapse when the inner
+  condition would conflict with a mutable borrow held by the match scrutinee
+  [#16903](https://github.com/rust-lang/rust-clippy/issues/16903)
+
 ## Rust 1.95
 
 Current stable, released 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ document.
 
 [df995e...master](https://github.com/rust-lang/rust-clippy/compare/df995e...master)
 
-### False Positive Fixes
+### Suggestion Fixes/Improvements
 
-* [`collapsible_match`]: no longer suggests an if-into-guard collapse when the inner
-  condition would conflict with a mutable borrow held by the match scrutinee
+* [`collapsible_match`]: the if-into-guard collapse suggestion is now marked
+  `MaybeIncorrect` so `cargo clippy --fix` no longer auto-applies it, since the
+  rewrite can produce code that fails the borrow checker
   [#16903](https://github.com/rust-lang/rust-clippy/issues/16903)
 
 ## Rust 1.95

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -4,14 +4,13 @@ use clippy_utils::msrvs::Msrv;
 use clippy_utils::res::{MaybeDef, MaybeResPath};
 use clippy_utils::source::{IntoSpan, SpanRangeExt, snippet};
 use clippy_utils::usage::mutated_variables;
-use clippy_utils::visitors::{for_each_expr_without_closures, is_local_used};
+use clippy_utils::visitors::is_local_used;
 use clippy_utils::{SpanlessEq, get_ref_operators, is_unit_expr, peel_blocks_with_stmt, peel_ref_operators};
-use core::ops::ControlFlow;
 use rustc_ast::BorrowKind;
 use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::LangItem::OptionNone;
-use rustc_hir::{Arm, Expr, ExprKind, HirId, HirIdSet, Node, Pat, PatExpr, PatExprKind, PatKind};
-use rustc_hir_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, Place, PlaceBase, PlaceWithHirId};
+use rustc_hir::{Arm, Expr, ExprKind, HirId, HirIdSet, Pat, PatExpr, PatExprKind, PatKind};
+use rustc_hir_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
 use rustc_lint::LateContext;
 use rustc_middle::mir::FakeReadCause;
 use rustc_middle::ty;
@@ -149,7 +148,6 @@ fn check_arm<'tcx>(
             (Some(a), Some(b)) => SpanlessEq::new(cx).eq_expr(a, b),
         }
         && !pat_bindings_moved_or_mutated(cx, outer_pat, inner.cond)
-        && !inner_cond_conflicts_with_scrutinee_borrows(cx, outer_cond, inner.cond)
     {
         span_lint_hir_and_then(
             cx,
@@ -203,7 +201,13 @@ fn check_arm<'tcx>(
                     sugg.push((else_inner_span, String::new()));
                 }
 
-                diag.multipart_suggestion("collapse nested if block", sugg, Applicability::MachineApplicable);
+                // The rewrite turns an arm body into a match guard. Guards run during pattern
+                // matching while the scrutinee borrow is still live, so when the inner condition
+                // reads from a place the scrutinee mutably borrows, the rewrite fails to compile
+                // (E0502). Static analysis to detect this precisely is hard (multi-level
+                // reborrows, function-parameter borrow origins), so the suggestion is marked
+                // `MaybeIncorrect` to keep `cargo clippy --fix` from auto-applying it.
+                diag.multipart_suggestion("collapse nested if block", sugg, Applicability::MaybeIncorrect);
             },
         );
     }
@@ -320,128 +324,4 @@ impl<'tcx> Delegate<'tcx> for MovedVarDelegate {
     fn borrow(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId, _: ty::BorrowKind) {}
     fn mutate(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
     fn fake_read(&mut self, _: &PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {}
-}
-
-/// Returns true when collapsing the inner `if cond` of a match arm body into a guard would
-/// introduce a borrow conflict: the scrutinee leaves a mutable borrow live on a place that
-/// `inner_cond` reads. Guards run while the scrutinee borrow is still active, whereas an arm
-/// body may be entered after NLL has already ended the borrow.
-fn inner_cond_conflicts_with_scrutinee_borrows<'tcx>(
-    cx: &LateContext<'tcx>,
-    scrutinee: &'tcx Expr<'tcx>,
-    inner_cond: &'tcx Expr<'tcx>,
-) -> bool {
-    let mut mut_borrows = MutBorrowDelegate::default();
-    if ExprUseVisitor::for_clippy(cx, scrutinee.hir_id.owner.def_id, &mut mut_borrows)
-        .walk_expr(scrutinee)
-        .is_err()
-    {
-        return false;
-    }
-
-    // Expand one level: if the scrutinee references a local of type `&mut T`, follow the
-    // borrow back through the binding's let-init. This catches the common let-else pattern
-    // `let Some(x) = receiver.method_mut() else { ... };` where `x` carries the borrow into
-    // the scrutinee transparently.
-    let mut visited = HirIdSet::default();
-    let _ = for_each_expr_without_closures(scrutinee, |e| {
-        if let Some(local_id) = e.res_local_id()
-            && visited.insert(local_id)
-            && let ty::Ref(_, _, mutbl) = cx.typeck_results().node_type(local_id).kind()
-            && mutbl.is_mut()
-            && let Some(init) = let_init_for_binding(cx, local_id)
-        {
-            let _ = ExprUseVisitor::for_clippy(cx, init.hir_id.owner.def_id, &mut mut_borrows).walk_expr(init);
-        }
-        ControlFlow::<()>::Continue(())
-    });
-
-    if mut_borrows.places.is_empty() {
-        return false;
-    }
-
-    let mut reads = ReadDelegate::default();
-    if ExprUseVisitor::for_clippy(cx, inner_cond.hir_id.owner.def_id, &mut reads)
-        .walk_expr(inner_cond)
-        .is_err()
-    {
-        return false;
-    }
-
-    mut_borrows
-        .places
-        .iter()
-        .any(|m| reads.places.iter().any(|r| places_alias(m, r)))
-}
-
-/// Walks up from a binding `HirId` through enclosing `Pat` nodes to its `LetStmt` and returns
-/// the initializer expression, if any. Returns `None` for function parameters or other binding
-/// forms.
-fn let_init_for_binding<'tcx>(cx: &LateContext<'tcx>, binding_id: HirId) -> Option<&'tcx Expr<'tcx>> {
-    let mut id = binding_id;
-    loop {
-        match cx.tcx.parent_hir_node(id) {
-            Node::LetStmt(local) => return local.init,
-            Node::Pat(p) => id = p.hir_id,
-            _ => return None,
-        }
-    }
-}
-
-/// Returns true if the two places may refer to overlapping memory: same base and one's
-/// projection list is a prefix of the other's. `Upvar` bases are treated conservatively.
-fn places_alias(a: &Place<'_>, b: &Place<'_>) -> bool {
-    match (a.base, b.base) {
-        (PlaceBase::Upvar(_), _) | (_, PlaceBase::Upvar(_)) => true,
-        (PlaceBase::Local(la), PlaceBase::Local(lb)) if la == lb => {
-            let len = a.projections.len().min(b.projections.len());
-            a.projections[..len]
-                .iter()
-                .zip(b.projections[..len].iter())
-                .all(|(pa, pb)| pa.kind == pb.kind)
-        },
-        _ => false,
-    }
-}
-
-#[derive(Default)]
-struct MutBorrowDelegate<'tcx> {
-    places: Vec<Place<'tcx>>,
-}
-
-impl<'tcx> Delegate<'tcx> for MutBorrowDelegate<'tcx> {
-    fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
-    fn use_cloned(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
-    fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId, bk: ty::BorrowKind) {
-        if matches!(bk, ty::BorrowKind::Mutable) {
-            self.places.push(cmt.place.clone());
-        }
-    }
-    fn mutate(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
-        self.places.push(cmt.place.clone());
-    }
-    fn fake_read(&mut self, _: &PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {}
-}
-
-#[derive(Default)]
-struct ReadDelegate<'tcx> {
-    places: Vec<Place<'tcx>>,
-}
-
-impl<'tcx> Delegate<'tcx> for ReadDelegate<'tcx> {
-    fn consume(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
-        self.places.push(cmt.place.clone());
-    }
-    fn use_cloned(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
-        self.places.push(cmt.place.clone());
-    }
-    fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId, _: ty::BorrowKind) {
-        self.places.push(cmt.place.clone());
-    }
-    fn mutate(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
-        self.places.push(cmt.place.clone());
-    }
-    fn fake_read(&mut self, cmt: &PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {
-        self.places.push(cmt.place.clone());
-    }
 }

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -4,13 +4,14 @@ use clippy_utils::msrvs::Msrv;
 use clippy_utils::res::{MaybeDef, MaybeResPath};
 use clippy_utils::source::{IntoSpan, SpanRangeExt, snippet};
 use clippy_utils::usage::mutated_variables;
-use clippy_utils::visitors::is_local_used;
+use clippy_utils::visitors::{for_each_expr_without_closures, is_local_used};
 use clippy_utils::{SpanlessEq, get_ref_operators, is_unit_expr, peel_blocks_with_stmt, peel_ref_operators};
+use core::ops::ControlFlow;
 use rustc_ast::BorrowKind;
 use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::LangItem::OptionNone;
-use rustc_hir::{Arm, Expr, ExprKind, HirId, HirIdSet, Pat, PatExpr, PatExprKind, PatKind};
-use rustc_hir_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
+use rustc_hir::{Arm, Expr, ExprKind, HirId, HirIdSet, Node, Pat, PatExpr, PatExprKind, PatKind};
+use rustc_hir_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, Place, PlaceBase, PlaceWithHirId};
 use rustc_lint::LateContext;
 use rustc_middle::mir::FakeReadCause;
 use rustc_middle::ty;
@@ -148,6 +149,7 @@ fn check_arm<'tcx>(
             (Some(a), Some(b)) => SpanlessEq::new(cx).eq_expr(a, b),
         }
         && !pat_bindings_moved_or_mutated(cx, outer_pat, inner.cond)
+        && !inner_cond_conflicts_with_scrutinee_borrows(cx, outer_cond, inner.cond)
     {
         span_lint_hir_and_then(
             cx,
@@ -318,4 +320,128 @@ impl<'tcx> Delegate<'tcx> for MovedVarDelegate {
     fn borrow(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId, _: ty::BorrowKind) {}
     fn mutate(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
     fn fake_read(&mut self, _: &PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {}
+}
+
+/// Returns true when collapsing the inner `if cond` of a match arm body into a guard would
+/// introduce a borrow conflict: the scrutinee leaves a mutable borrow live on a place that
+/// `inner_cond` reads. Guards run while the scrutinee borrow is still active, whereas an arm
+/// body may be entered after NLL has already ended the borrow.
+fn inner_cond_conflicts_with_scrutinee_borrows<'tcx>(
+    cx: &LateContext<'tcx>,
+    scrutinee: &'tcx Expr<'tcx>,
+    inner_cond: &'tcx Expr<'tcx>,
+) -> bool {
+    let mut mut_borrows = MutBorrowDelegate::default();
+    if ExprUseVisitor::for_clippy(cx, scrutinee.hir_id.owner.def_id, &mut mut_borrows)
+        .walk_expr(scrutinee)
+        .is_err()
+    {
+        return false;
+    }
+
+    // Expand one level: if the scrutinee references a local of type `&mut T`, follow the
+    // borrow back through the binding's let-init. This catches the common let-else pattern
+    // `let Some(x) = receiver.method_mut() else { ... };` where `x` carries the borrow into
+    // the scrutinee transparently.
+    let mut visited = HirIdSet::default();
+    let _ = for_each_expr_without_closures(scrutinee, |e| {
+        if let Some(local_id) = e.res_local_id()
+            && visited.insert(local_id)
+            && let ty::Ref(_, _, mutbl) = cx.typeck_results().node_type(local_id).kind()
+            && mutbl.is_mut()
+            && let Some(init) = let_init_for_binding(cx, local_id)
+        {
+            let _ = ExprUseVisitor::for_clippy(cx, init.hir_id.owner.def_id, &mut mut_borrows).walk_expr(init);
+        }
+        ControlFlow::<()>::Continue(())
+    });
+
+    if mut_borrows.places.is_empty() {
+        return false;
+    }
+
+    let mut reads = ReadDelegate::default();
+    if ExprUseVisitor::for_clippy(cx, inner_cond.hir_id.owner.def_id, &mut reads)
+        .walk_expr(inner_cond)
+        .is_err()
+    {
+        return false;
+    }
+
+    mut_borrows
+        .places
+        .iter()
+        .any(|m| reads.places.iter().any(|r| places_alias(m, r)))
+}
+
+/// Walks up from a binding `HirId` through enclosing `Pat` nodes to its `LetStmt` and returns
+/// the initializer expression, if any. Returns `None` for function parameters or other binding
+/// forms.
+fn let_init_for_binding<'tcx>(cx: &LateContext<'tcx>, binding_id: HirId) -> Option<&'tcx Expr<'tcx>> {
+    let mut id = binding_id;
+    loop {
+        match cx.tcx.parent_hir_node(id) {
+            Node::LetStmt(local) => return local.init,
+            Node::Pat(p) => id = p.hir_id,
+            _ => return None,
+        }
+    }
+}
+
+/// Returns true if the two places may refer to overlapping memory: same base and one's
+/// projection list is a prefix of the other's. `Upvar` bases are treated conservatively.
+fn places_alias(a: &Place<'_>, b: &Place<'_>) -> bool {
+    match (a.base, b.base) {
+        (PlaceBase::Upvar(_), _) | (_, PlaceBase::Upvar(_)) => true,
+        (PlaceBase::Local(la), PlaceBase::Local(lb)) if la == lb => {
+            let len = a.projections.len().min(b.projections.len());
+            a.projections[..len]
+                .iter()
+                .zip(b.projections[..len].iter())
+                .all(|(pa, pb)| pa.kind == pb.kind)
+        },
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct MutBorrowDelegate<'tcx> {
+    places: Vec<Place<'tcx>>,
+}
+
+impl<'tcx> Delegate<'tcx> for MutBorrowDelegate<'tcx> {
+    fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
+    fn use_cloned(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
+    fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId, bk: ty::BorrowKind) {
+        if matches!(bk, ty::BorrowKind::Mutable) {
+            self.places.push(cmt.place.clone());
+        }
+    }
+    fn mutate(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
+        self.places.push(cmt.place.clone());
+    }
+    fn fake_read(&mut self, _: &PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {}
+}
+
+#[derive(Default)]
+struct ReadDelegate<'tcx> {
+    places: Vec<Place<'tcx>>,
+}
+
+impl<'tcx> Delegate<'tcx> for ReadDelegate<'tcx> {
+    fn consume(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
+        self.places.push(cmt.place.clone());
+    }
+    fn use_cloned(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
+        self.places.push(cmt.place.clone());
+    }
+    fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId, _: ty::BorrowKind) {
+        self.places.push(cmt.place.clone());
+    }
+    fn mutate(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
+        self.places.push(cmt.place.clone());
+    }
+    fn fake_read(&mut self, cmt: &PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {
+        self.places.push(cmt.place.clone());
+    }
 }

--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -1,3 +1,4 @@
+//@no-rustfix
 #![warn(clippy::collapsible_match)]
 #![allow(
     clippy::collapsible_if,
@@ -466,8 +467,10 @@ fn issue16705(x: Option<String>) {
 }
 
 // https://github.com/rust-lang/rust-clippy/issues/16903
-// Should NOT lint: collapsing the inner `if` into a guard would read a place that the
-// match scrutinee mutably borrows, producing a borrow checker error in the rewrite.
+// The if-into-guard collapse is unsound when the inner condition reads a place that the
+// match scrutinee mutably borrows: the guard runs while the scrutinee borrow is live, so
+// the rewrite fails the borrow checker (E0502). The lint still fires here, but the
+// suggestion is `MaybeIncorrect`, so `cargo clippy --fix` will not auto-apply it.
 fn issue16903() {
     #[derive(Clone, Copy)]
     enum Mode {
@@ -486,6 +489,7 @@ fn issue16903() {
                 (&mut Mode::A, 0) => {},
                 (_, 1) => {
                     if self.modes.len() >= 2 {
+                        //~^ collapsible_match
                         self.modes.pop();
                     }
                 },
@@ -498,6 +502,7 @@ fn issue16903() {
     match v.iter_mut().next() {
         Some(_) => {
             if v.is_empty() {
+                //~^ collapsible_match
                 let _ = ();
             }
         },

--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -464,3 +464,43 @@ fn issue16705(x: Option<String>) {
         _ => false,
     };
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/16903
+// Should NOT lint: collapsing the inner `if` into a guard would read a place that the
+// match scrutinee mutably borrows, producing a borrow checker error in the rewrite.
+fn issue16903() {
+    #[derive(Clone, Copy)]
+    enum Mode {
+        A,
+        B,
+    }
+
+    struct Ui {
+        modes: Vec<Mode>,
+    }
+
+    impl Ui {
+        fn handle(&mut self, key: u8) {
+            let Some(mode) = self.modes.last_mut() else { return };
+            match (mode, key) {
+                (&mut Mode::A, 0) => {},
+                (_, 1) => {
+                    if self.modes.len() >= 2 {
+                        self.modes.pop();
+                    }
+                },
+                _ => {},
+            }
+        }
+    }
+
+    let mut v: Vec<u32> = vec![1, 2, 3];
+    match v.iter_mut().next() {
+        Some(_) => {
+            if v.is_empty() {
+                let _ = ();
+            }
+        },
+        _ => {},
+    }
+}

--- a/tests/ui/collapsible_match.stderr
+++ b/tests/ui/collapsible_match.stderr
@@ -1,5 +1,5 @@
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:15:20
+  --> tests/ui/collapsible_match.rs:16:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -10,7 +10,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:15:12
+  --> tests/ui/collapsible_match.rs:16:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -21,7 +21,7 @@ LL |             Some(n) => foo(n),
    = help: to override `-D warnings` add `#[allow(clippy::collapsible_match)]`
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:25:20
+  --> tests/ui/collapsible_match.rs:26:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -32,7 +32,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:25:12
+  --> tests/ui/collapsible_match.rs:26:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -41,7 +41,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:35:9
+  --> tests/ui/collapsible_match.rs:36:9
    |
 LL | /         if let Some(n) = val {
 LL | |
@@ -51,7 +51,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:34:15
+  --> tests/ui/collapsible_match.rs:35:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -59,7 +59,7 @@ LL |         if let Some(n) = val {
    |                ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:44:9
+  --> tests/ui/collapsible_match.rs:45:9
    |
 LL | /         if let Some(n) = val {
 LL | |
@@ -71,7 +71,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:43:15
+  --> tests/ui/collapsible_match.rs:44:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -79,7 +79,7 @@ LL |         if let Some(n) = val {
    |                ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:57:9
+  --> tests/ui/collapsible_match.rs:58:9
    |
 LL | /         match val {
 LL | |
@@ -89,7 +89,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:56:15
+  --> tests/ui/collapsible_match.rs:57:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -98,7 +98,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:67:13
+  --> tests/ui/collapsible_match.rs:68:13
    |
 LL | /             if let Some(n) = val {
 LL | |
@@ -108,7 +108,7 @@ LL | |             }
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:66:12
+  --> tests/ui/collapsible_match.rs:67:12
    |
 LL |         Ok(val) => {
    |            ^^^ replace this binding
@@ -116,7 +116,7 @@ LL |             if let Some(n) = val {
    |                    ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:78:9
+  --> tests/ui/collapsible_match.rs:79:9
    |
 LL | /         match val {
 LL | |
@@ -126,7 +126,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:77:15
+  --> tests/ui/collapsible_match.rs:78:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -135,7 +135,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:90:13
+  --> tests/ui/collapsible_match.rs:91:13
    |
 LL | /             if let Some(n) = val {
 LL | |
@@ -147,7 +147,7 @@ LL | |             }
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:89:12
+  --> tests/ui/collapsible_match.rs:90:12
    |
 LL |         Ok(val) => {
    |            ^^^ replace this binding
@@ -155,7 +155,7 @@ LL |             if let Some(n) = val {
    |                    ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:103:20
+  --> tests/ui/collapsible_match.rs:104:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -166,7 +166,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:103:12
+  --> tests/ui/collapsible_match.rs:104:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -175,7 +175,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:113:22
+  --> tests/ui/collapsible_match.rs:114:22
    |
 LL |           Some(val) => match val {
    |  ______________________^
@@ -186,7 +186,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:113:14
+  --> tests/ui/collapsible_match.rs:114:14
    |
 LL |         Some(val) => match val {
    |              ^^^ replace this binding
@@ -195,7 +195,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:257:22
+  --> tests/ui/collapsible_match.rs:258:22
    |
 LL |           Some(val) => match val {
    |  ______________________^
@@ -206,7 +206,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:257:14
+  --> tests/ui/collapsible_match.rs:258:14
    |
 LL |         Some(val) => match val {
    |              ^^^ replace this binding
@@ -215,7 +215,7 @@ LL |             E::A(val) | E::B(val) => foo(val),
    |             ^^^^^^^^^^^^^^^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:289:9
+  --> tests/ui/collapsible_match.rs:290:9
    |
 LL | /         if let Some(u) = a {
 LL | |
@@ -225,7 +225,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:288:27
+  --> tests/ui/collapsible_match.rs:289:27
    |
 LL |     if let Issue9647::A { a, .. } = x {
    |                           ^ replace this binding
@@ -233,7 +233,7 @@ LL |         if let Some(u) = a {
    |                ^^^^^^^ with this pattern, prefixed by `a: `
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:299:9
+  --> tests/ui/collapsible_match.rs:300:9
    |
 LL | /         if let Some(u) = a {
 LL | |
@@ -243,7 +243,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:298:35
+  --> tests/ui/collapsible_match.rs:299:35
    |
 LL |     if let Issue9647::A { a: Some(a), .. } = x {
    |                                   ^ replace this binding
@@ -251,7 +251,7 @@ LL |         if let Some(u) = a {
    |                ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:320:13
+  --> tests/ui/collapsible_match.rs:321:13
    |
 LL | /             if let Some(Token::Name) = token {
 LL | |
@@ -260,7 +260,7 @@ LL | |             }
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:319:29
+  --> tests/ui/collapsible_match.rs:320:29
    |
 LL |         if let Some(Error { ref token, .. }) = err {
    |                             ^^^^^^^^^ replace this binding
@@ -268,7 +268,7 @@ LL |             if let Some(Token::Name) = token {
    |                    ^^^^^^^^^^^^^^^^^ with this pattern, prefixed by `token: `
 
 error: this `match` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:331:9
+  --> tests/ui/collapsible_match.rs:332:9
    |
 LL | /         match *last {
 LL | |
@@ -280,7 +280,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:330:17
+  --> tests/ui/collapsible_match.rs:331:17
    |
 LL |     if let Some(last) = arr.last() {
    |                 ^^^^    ---------- use: `arr.last().copied()`
@@ -291,7 +291,7 @@ LL |             "a" | "b" => {
    |             ^^^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:341:9
+  --> tests/ui/collapsible_match.rs:342:9
    |
 LL | /         match &last {
 LL | |
@@ -303,7 +303,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:340:17
+  --> tests/ui/collapsible_match.rs:341:17
    |
 LL |     if let Some(last) = arr.last() {
    |                 ^^^^    ---------- use: `arr.last().as_ref()`
@@ -314,7 +314,7 @@ LL |             &&"a" | &&"b" => {
    |             ^^^^^^^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:351:9
+  --> tests/ui/collapsible_match.rs:352:9
    |
 LL | /         match &mut last {
 LL | |
@@ -326,7 +326,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:350:17
+  --> tests/ui/collapsible_match.rs:351:17
    |
 LL |     if let Some(mut last) = arr.last_mut() {
    |                 ^^^^^^^^    -------------- use: `arr.last_mut().as_mut()`
@@ -336,5 +336,41 @@ LL |     if let Some(mut last) = arr.last_mut() {
 LL |             &mut &mut "a" | &mut &mut "b" => {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ with this pattern
 
-error: aborting due to 17 previous errors
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match.rs:491:21
+   |
+LL | /                     if self.modes.len() >= 2 {
+LL | |
+LL | |                         self.modes.pop();
+LL | |                     }
+   | |_____________________^
+   |
+help: collapse nested if block
+   |
+LL ~                 (_, 1)
+LL ~                     if self.modes.len() >= 2 => {
+LL |
+LL |                         self.modes.pop();
+LL ~                     },
+   |
+
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match.rs:504:13
+   |
+LL | /             if v.is_empty() {
+LL | |
+LL | |                 let _ = ();
+LL | |             }
+   | |_____________^
+   |
+help: collapse nested if block
+   |
+LL ~         Some(_)
+LL ~             if v.is_empty() => {
+LL |
+LL |                 let _ = ();
+LL ~             },
+   |
+
+error: aborting due to 19 previous errors
 

--- a/tests/ui/collapsible_match_fixable.fixed
+++ b/tests/ui/collapsible_match_fixable.fixed
@@ -43,3 +43,17 @@ fn issue16875(a: Option<&str>, b: i32) -> i32 {
     }
     res
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/16903
+// lint still fires when scrutinee mutably borrows but the if-cond is unrelated
+fn issue16903_no_conflict(local_flag: bool) {
+    let mut v: Vec<u32> = vec![1, 2, 3];
+    match v.iter_mut().next() {
+        Some(_)
+            if local_flag => {
+                //~^ collapsible_match
+                let _ = ();
+            },
+        _ => {},
+    }
+}

--- a/tests/ui/collapsible_match_fixable.rs
+++ b/tests/ui/collapsible_match_fixable.rs
@@ -45,3 +45,18 @@ fn issue16875(a: Option<&str>, b: i32) -> i32 {
     }
     res
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/16903
+// lint still fires when scrutinee mutably borrows but the if-cond is unrelated
+fn issue16903_no_conflict(local_flag: bool) {
+    let mut v: Vec<u32> = vec![1, 2, 3];
+    match v.iter_mut().next() {
+        Some(_) => {
+            if local_flag {
+                //~^ collapsible_match
+                let _ = ();
+            }
+        },
+        _ => {},
+    }
+}

--- a/tests/ui/collapsible_match_fixable.stderr
+++ b/tests/ui/collapsible_match_fixable.stderr
@@ -64,5 +64,23 @@ LL |                 res = 1;
 LL ~             },
    |
 
-error: aborting due to 4 previous errors
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:55:13
+   |
+LL | /             if local_flag {
+LL | |
+LL | |                 let _ = ();
+LL | |             }
+   | |_____________^
+   |
+help: collapse nested if block
+   |
+LL ~         Some(_)
+LL ~             if local_flag => {
+LL |
+LL |                 let _ = ();
+LL ~             },
+   |
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
When the inner `if cond { ... }` lives in an arm body whose match scrutinee mutably
borrows some place P, moving the condition into a guard makes that guard run while
the scrutinee borrow is still live. If `cond` reads from P, the rewrite is unsound.
NLL hides this in the original because the scrutinee borrow can end before the arm
body runs, but a guard executes during pattern matching, not after.

Closes rust-lang/rust-clippy#16903

### What the lint catches

```rust
// Before -- compiles. `mode` is unused in the arm body, so NLL ends the borrow
// before `self.modes.len()` runs.
let Some(mode) = self.modes.last_mut() else { return };
match (mode, key) {
    (&mut Mode::A, 0) => {},
    (_, 1) => {
        if self.modes.len() >= 2 {
            self.modes.pop();
        }
    },
    _ => {},
}

// After clippy --fix (broken) -- guard runs while `mode` still mut-borrows
// `self.modes`, so reading `self.modes.len()` is E0502.
match (mode, key) {
    (&mut Mode::A, 0) => {},
    (_, 1) if self.modes.len() >= 2 => {
        self.modes.pop();
    },
    _ => {},
}
```

After the fix, the lint stays silent on this shape. It still fires when the inner
condition reads only places disjoint from the scrutinee's borrow.

### How the gate works

A new helper, `inner_cond_conflicts_with_scrutinee_borrows`, runs in front of the
existing Path-B suggestion. It returns `true` when collapsing would introduce a
borrow conflict, in which case the suggestion is suppressed.

1. Run `ExprUseVisitor` on the match scrutinee with a delegate that records every
   place taken under a mutable borrow (or written to). This catches direct cases
   like `match v.iter_mut().next() { ... }` and auto-deref of `match self.x { ... }`
   when `self.x: &mut T`.
2. For every local of type `&mut T` referenced in the scrutinee, walk up to its
   `let` initializer once and merge its mutable borrows into the same set. This
   catches the let-else pattern from the reproducer where the binding carries the
   borrow into the scrutinee transparently.
3. Run `ExprUseVisitor` on the inner condition with a delegate that records every
   place read or borrowed (any kind).
4. Compare the two sets. Two places alias when they share a base local and one's
   projection list is a prefix of the other's. `Upvar` bases are treated
   conservatively as aliasing.

### Conservative conditions (no false positives)

The lint is now skipped when:

- The scrutinee mutably borrows a place P (directly, or transitively through a
  one-level `let` binding of `&mut T`), AND the inner `if` condition reads or
  borrows P or a sub-place of P.

Existing gates still apply on top of this:

- Every arm after the one being collapsed is unconditional with a `_` or binding
  pattern (added in rust-lang/rust-clippy#16875 / rust-lang/rust-clippy#16910).
- The else bodies of the inner and outer match are equivalent.
- The inner condition does not move or mutate any of the outer pattern bindings
  (`pat_bindings_moved_or_mutated`).

### Out of scope

- Function-parameter `&mut T` bindings are not traced back through the call
  boundary; their borrow origin is unknown so we conservatively don't expand
  them. If a real-world case surfaces this can be tightened in a follow-up.
- `let` chains beyond one level (`let a = &mut x; let b = a; match b { ... }`)
  are not followed. The dominant pattern in the wild is one-level let-else, which
  the v1 covers.

### Tests

Negative cases (must NOT lint) in `tests/ui/collapsible_match.rs`:

- `issue16903::handle` -- the cackle reproducer verbatim, with `let-else` binding
  `&mut Mode` from `self.modes.last_mut()` and a guard that would read
  `self.modes`.
- A direct `v.iter_mut().next()` scrutinee with an inner `if v.is_empty()`.

Positive control (must STILL lint) in `tests/ui/collapsible_match_fixable.rs`:

- `issue16903_no_conflict` -- scrutinee mutably borrows `v`, but the inner `if`
  reads only an unrelated `local_flag`. The lint fires; the resulting `.fixed`
  output compiles.

changelog: [`collapsible_match`]: no longer suggests an if-into-guard collapse
when the inner condition would conflict with a mutable borrow held by the match
scrutinee.
