### PR TITLE
Fix unused_unit suggestion for standalone unit expressions

### DIFF
--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::{SpanExt as _, position_before_rarrow};
 use clippy_utils::{is_never_expr, is_unit_expr};
 use rustc_ast::{Block, StmtKind};
@@ -131,21 +131,49 @@ impl EarlyLintPass for UnusedUnit {
             && expr.attrs.is_empty()
         {
             let sp = expr.span;
-            span_lint_and_sugg(
-                cx,
-                UNUSED_UNIT,
-                sp,
-                "unneeded unit expression",
-                "remove the final `()`",
-                String::new(),
-                Applicability::MachineApplicable,
-            );
+            let sugg_span = unit_expr_suggestion_span(cx, sp);
+            span_lint_and_then(cx, UNUSED_UNIT, sp, "unneeded unit expression", |diag| {
+                if sugg_span == sp {
+                    diag.span_suggestion(
+                        sp,
+                        "remove the final `()`",
+                        String::new(),
+                        Applicability::MachineApplicable,
+                    );
+                } else {
+                    diag.span_suggestion_hidden(
+                        sugg_span,
+                        "remove the final `()`",
+                        String::new(),
+                        Applicability::MachineApplicable,
+                    );
+                }
+            });
         }
     }
 }
 
 fn is_unit_ty(ty: &Ty<'_>) -> bool {
     matches!(ty.kind, TyKind::Tup([]))
+}
+
+fn unit_expr_suggestion_span(cx: &EarlyContext<'_>, span: Span) -> Span {
+    span.map_range(cx, |_, src, range| {
+        let before = src.get(..range.start)?;
+        let line_start = before.rfind('\n').map_or(0, |index| index + 1);
+        let after = src.get(range.end..)?;
+        let line_end = after.find('\n').map_or(range.end, |index| range.end + index + 1);
+
+        let before_unit = src.get(line_start..range.start)?.trim().is_empty();
+        let after_unit = src.get(range.end..line_end)?.trim().is_empty();
+
+        if before_unit && after_unit {
+            Some(line_start..line_end)
+        } else {
+            Some(range)
+        }
+    })
+    .map_or(span, |range| span.with_lo(range.start).with_hi(range.end))
 }
 
 // get the def site

--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::{SpanExt as _, position_before_rarrow};
 use clippy_utils::{is_never_expr, is_unit_expr};
 use rustc_ast::{Block, StmtKind};
-use rustc_errors::Applicability;
+use rustc_errors::{Applicability, SuggestionStyle};
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{
@@ -12,7 +12,7 @@ use rustc_hir::{
 use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 use rustc_span::edition::Edition;
-use rustc_span::{BytePos, Pos as _, Span, sym};
+use rustc_span::{BytePos, Pos as _, RelativeBytePos, Span, sym};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -141,11 +141,13 @@ impl EarlyLintPass for UnusedUnit {
                         Applicability::MachineApplicable,
                     );
                 } else {
-                    diag.span_suggestion_hidden(
+                    diag.span_help(sp, "remove the final `()`");
+                    diag.span_suggestion_with_style(
                         sugg_span,
                         "remove the final `()`",
                         String::new(),
                         Applicability::MachineApplicable,
+                        SuggestionStyle::CompletelyHidden,
                     );
                 }
             });
@@ -158,11 +160,11 @@ fn is_unit_ty(ty: &Ty<'_>) -> bool {
 }
 
 fn unit_expr_suggestion_span(cx: &EarlyContext<'_>, span: Span) -> Span {
-    span.map_range(cx, |_, src, range| {
-        let before = src.get(..range.start)?;
-        let line_start = before.rfind('\n').map_or(0, |index| index + 1);
-        let after = src.get(range.end..)?;
-        let line_end = after.find('\n').map_or(range.end, |index| range.end + index + 1);
+    span.map_range(cx, |sf, src, range| {
+        let lines = sf.lines();
+        let line = sf.lookup_line(RelativeBytePos(range.start as u32)).unwrap_or(0);
+        let line_start = lines[line].0 as usize;
+        let line_end = lines.get(line + 1).map_or(sf.end_position().0, |x| x.0) as usize;
 
         let before_unit = src.get(line_start..range.start)?.trim().is_empty();
         let after_unit = src.get(range.end..line_end)?.trim().is_empty();

--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -162,7 +162,10 @@ fn is_unit_ty(ty: &Ty<'_>) -> bool {
 fn unit_expr_suggestion_span(cx: &EarlyContext<'_>, span: Span) -> Span {
     span.map_range(cx, |sf, src, range| {
         let lines = sf.lines();
-        let line = sf.lookup_line(RelativeBytePos(range.start as u32)).unwrap_or(0);
+        let Ok(range_start) = u32::try_from(range.start) else {
+            return Some(range);
+        };
+        let line = sf.lookup_line(RelativeBytePos(range_start)).unwrap_or(0);
         let line_start = lines[line].0 as usize;
         let line_end = lines.get(line + 1).map_or(sf.end_position().0, |x| x.0) as usize;
 

--- a/tests/ui/unused_unit.edition2021.fixed
+++ b/tests/ui/unused_unit.edition2021.fixed
@@ -33,7 +33,6 @@ impl Into<()> for Unitter {
     #[rustfmt::skip]
     fn into(self) {
     //~^ unused_unit
-        
         //~^ unused_unit
     }
 }
@@ -163,5 +162,13 @@ mod issue15035 {
         let result: Result<bool, u64> = Err(42);
         // the `-> ()` is required for the inference of `handle`'s return type
         result.map_err(|err| -> () { handle(err) }).ok()
+    }
+}
+
+mod issue16918 {
+    pub fn foo(x: usize) {
+        //~^ unused_unit
+        let _ = x;
+        //~^ unused_unit
     }
 }

--- a/tests/ui/unused_unit.edition2021.stderr
+++ b/tests/ui/unused_unit.edition2021.stderr
@@ -2,7 +2,7 @@ error: unneeded unit expression
   --> tests/ui/unused_unit.rs:36:9
    |
 LL |         ()
-   |         ^^ help: remove the final `()`
+   |         ^^
    |
    = note: `-D clippy::unused-unit` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unused_unit)]`
@@ -12,6 +12,14 @@ error: unneeded unit expression
    |
 LL | fn return_unit() -> () { () }
    |                          ^^ help: remove the final `()`
+
+error: unneeded unit expression
+  --> tests/ui/unused_unit.rs:175:9
+   |
+LL |         ()
+   |         ^^
+   |
+   = help: remove the final `()`
 
 error: unneeded unit return type
   --> tests/ui/unused_unit.rs:21:28
@@ -121,5 +129,11 @@ error: unneeded unit return type
 LL |     fn bar() -> () {
    |             ^^^^^^ help: remove the `-> ()`
 
-error: aborting due to 20 previous errors
+error: unneeded unit return type
+  --> tests/ui/unused_unit.rs:172:25
+   |
+LL |     pub fn foo(x: usize) -> () {
+   |                         ^^^^^^ help: remove the `-> ()`
+
+error: aborting due to 22 previous errors
 

--- a/tests/ui/unused_unit.edition2021.stderr
+++ b/tests/ui/unused_unit.edition2021.stderr
@@ -4,6 +4,11 @@ error: unneeded unit expression
 LL |         ()
    |         ^^
    |
+help: remove the final `()`
+  --> tests/ui/unused_unit.rs:36:9
+   |
+LL |         ()
+   |         ^^
    = note: `-D clippy::unused-unit` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unused_unit)]`
 
@@ -19,7 +24,11 @@ error: unneeded unit expression
 LL |         ()
    |         ^^
    |
-   = help: remove the final `()`
+help: remove the final `()`
+  --> tests/ui/unused_unit.rs:175:9
+   |
+LL |         ()
+   |         ^^
 
 error: unneeded unit return type
   --> tests/ui/unused_unit.rs:21:28

--- a/tests/ui/unused_unit.edition2021.stderr
+++ b/tests/ui/unused_unit.edition2021.stderr
@@ -19,13 +19,13 @@ LL | fn return_unit() -> () { () }
    |                          ^^ help: remove the final `()`
 
 error: unneeded unit expression
-  --> tests/ui/unused_unit.rs:175:9
+  --> tests/ui/unused_unit.rs:173:9
    |
 LL |         ()
    |         ^^
    |
 help: remove the final `()`
-  --> tests/ui/unused_unit.rs:175:9
+  --> tests/ui/unused_unit.rs:173:9
    |
 LL |         ()
    |         ^^
@@ -139,7 +139,7 @@ LL |     fn bar() -> () {
    |             ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:172:25
+  --> tests/ui/unused_unit.rs:170:25
    |
 LL |     pub fn foo(x: usize) -> () {
    |                         ^^^^^^ help: remove the `-> ()`

--- a/tests/ui/unused_unit.edition2024.fixed
+++ b/tests/ui/unused_unit.edition2024.fixed
@@ -33,7 +33,6 @@ impl Into<()> for Unitter {
     #[rustfmt::skip]
     fn into(self) {
     //~^ unused_unit
-        
         //~^ unused_unit
     }
 }
@@ -163,5 +162,13 @@ mod issue15035 {
         let result: Result<bool, u64> = Err(42);
         // the `-> ()` is required for the inference of `handle`'s return type
         result.map_err(|err| -> () { handle(err) }).ok()
+    }
+}
+
+mod issue16918 {
+    pub fn foo(x: usize) {
+        //~^ unused_unit
+        let _ = x;
+        //~^ unused_unit
     }
 }

--- a/tests/ui/unused_unit.edition2024.stderr
+++ b/tests/ui/unused_unit.edition2024.stderr
@@ -2,7 +2,7 @@ error: unneeded unit expression
   --> tests/ui/unused_unit.rs:36:9
    |
 LL |         ()
-   |         ^^ help: remove the final `()`
+   |         ^^
    |
    = note: `-D clippy::unused-unit` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unused_unit)]`
@@ -12,6 +12,14 @@ error: unneeded unit expression
    |
 LL | fn return_unit() -> () { () }
    |                          ^^ help: remove the final `()`
+
+error: unneeded unit expression
+  --> tests/ui/unused_unit.rs:175:9
+   |
+LL |         ()
+   |         ^^
+   |
+   = help: remove the final `()`
 
 error: unneeded unit return type
   --> tests/ui/unused_unit.rs:21:28
@@ -115,5 +123,11 @@ error: unneeded unit return type
 LL | fn test3()-> (){}
    |           ^^^^^ help: remove the `-> ()`
 
-error: aborting due to 19 previous errors
+error: unneeded unit return type
+  --> tests/ui/unused_unit.rs:172:25
+   |
+LL |     pub fn foo(x: usize) -> () {
+   |                         ^^^^^^ help: remove the `-> ()`
+
+error: aborting due to 21 previous errors
 

--- a/tests/ui/unused_unit.edition2024.stderr
+++ b/tests/ui/unused_unit.edition2024.stderr
@@ -4,6 +4,11 @@ error: unneeded unit expression
 LL |         ()
    |         ^^
    |
+help: remove the final `()`
+  --> tests/ui/unused_unit.rs:36:9
+   |
+LL |         ()
+   |         ^^
    = note: `-D clippy::unused-unit` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unused_unit)]`
 
@@ -19,7 +24,11 @@ error: unneeded unit expression
 LL |         ()
    |         ^^
    |
-   = help: remove the final `()`
+help: remove the final `()`
+  --> tests/ui/unused_unit.rs:175:9
+   |
+LL |         ()
+   |         ^^
 
 error: unneeded unit return type
   --> tests/ui/unused_unit.rs:21:28

--- a/tests/ui/unused_unit.edition2024.stderr
+++ b/tests/ui/unused_unit.edition2024.stderr
@@ -19,13 +19,13 @@ LL | fn return_unit() -> () { () }
    |                          ^^ help: remove the final `()`
 
 error: unneeded unit expression
-  --> tests/ui/unused_unit.rs:175:9
+  --> tests/ui/unused_unit.rs:173:9
    |
 LL |         ()
    |         ^^
    |
 help: remove the final `()`
-  --> tests/ui/unused_unit.rs:175:9
+  --> tests/ui/unused_unit.rs:173:9
    |
 LL |         ()
    |         ^^
@@ -133,7 +133,7 @@ LL | fn test3()-> (){}
    |           ^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:172:25
+  --> tests/ui/unused_unit.rs:170:25
    |
 LL |     pub fn foo(x: usize) -> () {
    |                         ^^^^^^ help: remove the `-> ()`

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -165,3 +165,12 @@ mod issue15035 {
         result.map_err(|err| -> () { handle(err) }).ok()
     }
 }
+
+mod issue16918 {
+    pub fn foo(x: usize) -> () {
+        //~^ unused_unit
+        let _ = x;
+        ()
+        //~^ unused_unit
+    }
+}


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16920)*

Fixes rust-lang/rust-clippy#16918.

This updates `unused_unit` to use a separate machine-applicable suggestion span for final unit expressions that are alone on their source line. The diagnostic still points at the `()`, but rustfix now deletes the whole standalone line so it does not leave a whitespace-only blank line behind.

Inline final `()` expressions keep the existing visible suggestion behavior.

changelog: [`unused_unit`]: avoid leaving blank lines when removing standalone final `()` expressions

Tests:
- `cargo fmt -- clippy_lints/src/unused_unit.rs`
- `TESTNAME=unused_unit cargo uibless`
- `TESTNAME=unused_unit cargo uitest`
