### PR TITLE
Fix `duration_suboptimal_units` for small literals

### DIFF
--- a/clippy_lints/src/duration_suboptimal_units.rs
+++ b/clippy_lints/src/duration_suboptimal_units.rs
@@ -19,6 +19,9 @@ declare_clippy_lint! {
     /// Checks for instances where a `std::time::Duration` is constructed using a smaller time unit
     /// when the value could be expressed more clearly using a larger unit.
     ///
+    /// For literal values that would convert to 10 or fewer of the larger unit,
+    /// this lint does not apply.
+    ///
     /// ### Why is this bad?
     ///
     /// Using a smaller unit for a duration that is evenly divisible by a larger unit reduces
@@ -29,8 +32,8 @@ declare_clippy_lint! {
     /// ```
     /// use std::time::Duration;
     ///
-    /// let dur = Duration::from_millis(5_000);
-    /// let dur = Duration::from_secs(180);
+    /// let dur = Duration::from_millis(50_000);
+    /// let dur = Duration::from_secs(1800);
     /// let dur = Duration::from_mins(10 * 60);
     /// ```
     ///
@@ -38,8 +41,8 @@ declare_clippy_lint! {
     /// ```
     /// use std::time::Duration;
     ///
-    /// let dur = Duration::from_secs(5);
-    /// let dur = Duration::from_mins(3);
+    /// let dur = Duration::from_secs(50);
+    /// let dur = Duration::from_mins(30);
     /// let dur = Duration::from_hours(10);
     /// ```
     #[clippy::version = "1.95.0"]
@@ -80,13 +83,20 @@ impl LateLintPass<'_> for DurationSuboptimalUnits {
             // We intentionally don't want to evaluate referenced constants, as we don't want to
             // recommend a literal value over using constants:
             //
-            // let dur = Duration::from_secs(SIXTY);
-            //           ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Duration::from_mins(1)`
+            // let dur = Duration::from_millis(TWELVE_THOUSAND);
+            //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Duration::from_secs(12)`
             && let Some(Constant::Int(value)) = ConstEvalCtxt::new(cx).eval_local(arg, expr.span.ctxt())
             && let Ok(value) = u64::try_from(value) // Cannot fail
             // There is no need to promote e.g. 0 seconds to 0 hours
             && value != 0
             && let Some((promoted_constructor, promoted_value)) = self.promote(cx, func_name.ident.name, value)
+            // For plain integer literals, only lint if the promoted value is large enough.
+            // Small promoted values (e.g. `from_millis(1_000)` -> `from_secs(1)`) are not
+            // necessarily more readable, and keeping the smaller unit makes quick adjustments
+            // easier (e.g. changing 1_000 to 1_200 without also changing the function name).
+            // For expressions (e.g. `10 * 60`), always lint since the expression already
+            // signals intent to compute a converted value.
+            && (!matches!(arg.kind, ExprKind::Lit(_)) || promoted_value > 10)
         {
             span_lint_and_then(
                 cx,

--- a/tests/ui/duration_suboptimal_units.fixed
+++ b/tests/ui/duration_suboptimal_units.fixed
@@ -6,8 +6,8 @@ use std::time::Duration;
 const SIXTY: u64 = 60;
 
 macro_rules! mac {
-    (slow_rythm) => {
-        3600
+    (slow_rhythm) => {
+        60 * 60
     };
     (duration) => {
         Duration::from_mins(5)
@@ -23,8 +23,6 @@ fn main() {
     let dur = Duration::from_secs(42);
     let dur = Duration::from_hours(3);
 
-    let dur = Duration::from_mins(1);
-    //~^ duration_suboptimal_units
     let dur = Duration::from_mins(3);
     //~^ duration_suboptimal_units
     let dur = Duration::from_mins(10);
@@ -44,7 +42,15 @@ fn main() {
 
     const {
         let dur = Duration::from_secs(0);
+        let dur = Duration::from_millis(5_000);
         let dur = Duration::from_secs(5);
+        //~^ duration_suboptimal_units
+        let dur = Duration::from_secs(11);
+        //~^ duration_suboptimal_units
+
+        let dur = Duration::from_secs(180);
+        // 39600 secs = 11 hours
+        let dur = Duration::from_hours(11);
         //~^ duration_suboptimal_units
         let dur = Duration::from_mins(3);
         //~^ duration_suboptimal_units
@@ -55,10 +61,11 @@ fn main() {
     }
 
     // Qualified Durations must be kept
-    std::time::Duration::from_mins(1);
+    std::time::Duration::from_mins(12);
     //~^ duration_suboptimal_units
 
     // We lint in normal macros
+    assert_eq!(Duration::from_secs(3_600), Duration::from_mins(6));
     assert_eq!(Duration::from_hours(1), Duration::from_mins(6));
     //~^ duration_suboptimal_units
 
@@ -66,13 +73,13 @@ fn main() {
     let dur = mac!(duration);
 
     // We don't lint in macros if duration comes from outside
-    let dur = mac!(arg => 3600);
+    let dur = mac!(arg => 60 * 60);
 
     // We don't lint in external macros
-    let dur = proc_macros::external! { Duration::from_secs(3_600) };
+    let dur = proc_macros::external! { Duration::from_secs(60 * 60) };
 
     // We don't lint values coming from macros
-    let dur = Duration::from_secs(mac!(slow_rythm));
+    let dur = Duration::from_secs(mac!(slow_rhythm));
 }
 
 mod my_duration {
@@ -103,5 +110,36 @@ fn insufficient_msrv() {
 #[clippy::msrv = "1.91"]
 fn sufficient_msrv() {
     _ = Duration::from_hours(18824455811688);
+    //~^ duration_suboptimal_units
+}
+
+fn issue16532() {
+    // Literals with small promoted values should not lint (issue #16532)
+    let dur = Duration::from_secs(60);
+    let dur = Duration::from_secs(180);
+    let dur = Duration::from_millis(5_000);
+    let dur = Duration::from_millis(1_000);
+    let dur = Duration::from_secs(3_600);
+    let dur = Duration::from_secs(600);
+
+    // Literals with larger promoted values should lint
+    let dur = Duration::from_secs(20);
+    //~^ duration_suboptimal_units
+    let dur = Duration::from_hours(12);
+    //~^ duration_suboptimal_units
+    let dur = Duration::from_mins(11);
+    //~^ duration_suboptimal_units
+
+    // Expressions should always be promoted, as they show intent to use a larger unit
+    // 5 minutes
+    let dur = Duration::from_mins(5);
+    //~^ duration_suboptimal_units
+
+    // 2 Hours
+    let dur = Duration::from_hours(2);
+    //~^ duration_suboptimal_units
+
+    // Daily
+    let dur = Duration::from_hours(24);
     //~^ duration_suboptimal_units
 }

--- a/tests/ui/duration_suboptimal_units.rs
+++ b/tests/ui/duration_suboptimal_units.rs
@@ -6,11 +6,11 @@ use std::time::Duration;
 const SIXTY: u64 = 60;
 
 macro_rules! mac {
-    (slow_rythm) => {
-        3600
+    (slow_rhythm) => {
+        60 * 60
     };
     (duration) => {
-        Duration::from_secs(300)
+        Duration::from_secs(60 * 5)
         //~^ duration_suboptimal_units
     };
     (arg => $e:expr) => {
@@ -23,15 +23,13 @@ fn main() {
     let dur = Duration::from_secs(42);
     let dur = Duration::from_hours(3);
 
-    let dur = Duration::from_secs(60);
-    //~^ duration_suboptimal_units
-    let dur = Duration::from_secs(180);
+    let dur = Duration::from_secs(60 * 3);
     //~^ duration_suboptimal_units
     let dur = Duration::from_secs(10 * 60);
     //~^ duration_suboptimal_units
     let dur = Duration::from_mins(24 * 60);
     //~^ duration_suboptimal_units
-    let dur = Duration::from_millis(5_000);
+    let dur = Duration::from_millis(5 * 1000);
     //~^ duration_suboptimal_units
     let dur = Duration::from_nanos(13 * 60 * 60 * 1_000 * 1_000 * 1_000);
     //~^ duration_suboptimal_units
@@ -45,8 +43,16 @@ fn main() {
     const {
         let dur = Duration::from_secs(0);
         let dur = Duration::from_millis(5_000);
+        let dur = Duration::from_millis(1000 * 5);
         //~^ duration_suboptimal_units
+        let dur = Duration::from_millis(11000);
+        //~^ duration_suboptimal_units
+
         let dur = Duration::from_secs(180);
+        // 39600 secs = 11 hours
+        let dur = Duration::from_secs(39600);
+        //~^ duration_suboptimal_units
+        let dur = Duration::from_secs(3 * 60);
         //~^ duration_suboptimal_units
         let dur = Duration::from_mins(24 * 60);
         //~^ duration_suboptimal_units
@@ -55,24 +61,25 @@ fn main() {
     }
 
     // Qualified Durations must be kept
-    std::time::Duration::from_secs(60);
+    std::time::Duration::from_secs(12 * 60);
     //~^ duration_suboptimal_units
 
     // We lint in normal macros
     assert_eq!(Duration::from_secs(3_600), Duration::from_mins(6));
+    assert_eq!(Duration::from_secs(60 * 60), Duration::from_mins(6));
     //~^ duration_suboptimal_units
 
     // We lint in normal macros (marker is in macro itself)
     let dur = mac!(duration);
 
     // We don't lint in macros if duration comes from outside
-    let dur = mac!(arg => 3600);
+    let dur = mac!(arg => 60 * 60);
 
     // We don't lint in external macros
-    let dur = proc_macros::external! { Duration::from_secs(3_600) };
+    let dur = proc_macros::external! { Duration::from_secs(60 * 60) };
 
     // We don't lint values coming from macros
-    let dur = Duration::from_secs(mac!(slow_rythm));
+    let dur = Duration::from_secs(mac!(slow_rhythm));
 }
 
 mod my_duration {
@@ -103,5 +110,36 @@ fn insufficient_msrv() {
 #[clippy::msrv = "1.91"]
 fn sufficient_msrv() {
     _ = Duration::from_secs(67_768_040_922_076_800);
+    //~^ duration_suboptimal_units
+}
+
+fn issue16532() {
+    // Literals with small promoted values should not lint (issue #16532)
+    let dur = Duration::from_secs(60);
+    let dur = Duration::from_secs(180);
+    let dur = Duration::from_millis(5_000);
+    let dur = Duration::from_millis(1_000);
+    let dur = Duration::from_secs(3_600);
+    let dur = Duration::from_secs(600);
+
+    // Literals with larger promoted values should lint
+    let dur = Duration::from_millis(20_000);
+    //~^ duration_suboptimal_units
+    let dur = Duration::from_mins(720);
+    //~^ duration_suboptimal_units
+    let dur = Duration::from_secs(660);
+    //~^ duration_suboptimal_units
+
+    // Expressions should always be promoted, as they show intent to use a larger unit
+    // 5 minutes
+    let dur = Duration::from_secs(60 * 5);
+    //~^ duration_suboptimal_units
+
+    // 2 Hours
+    let dur = Duration::from_mins(60 * 2);
+    //~^ duration_suboptimal_units
+
+    // Daily
+    let dur = Duration::from_mins(60 * 24);
     //~^ duration_suboptimal_units
 }

--- a/tests/ui/duration_suboptimal_units.stderr
+++ b/tests/ui/duration_suboptimal_units.stderr
@@ -1,31 +1,19 @@
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
   --> tests/ui/duration_suboptimal_units.rs:26:15
    |
-LL |     let dur = Duration::from_secs(60);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_secs(60 * 3);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::duration-suboptimal-units` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::duration_suboptimal_units)]`
 help: try using from_mins
    |
-LL -     let dur = Duration::from_secs(60);
-LL +     let dur = Duration::from_mins(1);
-   |
-
-error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:28:15
-   |
-LL |     let dur = Duration::from_secs(180);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: try using from_mins
-   |
-LL -     let dur = Duration::from_secs(180);
+LL -     let dur = Duration::from_secs(60 * 3);
 LL +     let dur = Duration::from_mins(3);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:30:15
+  --> tests/ui/duration_suboptimal_units.rs:28:15
    |
 LL |     let dur = Duration::from_secs(10 * 60);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +25,7 @@ LL +     let dur = Duration::from_mins(10);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:32:15
+  --> tests/ui/duration_suboptimal_units.rs:30:15
    |
 LL |     let dur = Duration::from_mins(24 * 60);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,19 +37,19 @@ LL +     let dur = Duration::from_hours(24);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:34:15
+  --> tests/ui/duration_suboptimal_units.rs:32:15
    |
-LL |     let dur = Duration::from_millis(5_000);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_millis(5 * 1000);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_secs
    |
-LL -     let dur = Duration::from_millis(5_000);
+LL -     let dur = Duration::from_millis(5 * 1000);
 LL +     let dur = Duration::from_secs(5);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:36:15
+  --> tests/ui/duration_suboptimal_units.rs:34:15
    |
 LL |     let dur = Duration::from_nanos(13 * 60 * 60 * 1_000 * 1_000 * 1_000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,31 +61,55 @@ LL +     let dur = Duration::from_hours(13);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:47:19
+  --> tests/ui/duration_suboptimal_units.rs:46:19
    |
-LL |         let dur = Duration::from_millis(5_000);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let dur = Duration::from_millis(1000 * 5);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_secs
    |
-LL -         let dur = Duration::from_millis(5_000);
+LL -         let dur = Duration::from_millis(1000 * 5);
 LL +         let dur = Duration::from_secs(5);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:49:19
+  --> tests/ui/duration_suboptimal_units.rs:48:19
    |
-LL |         let dur = Duration::from_secs(180);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let dur = Duration::from_millis(11000);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_secs
+   |
+LL -         let dur = Duration::from_millis(11000);
+LL +         let dur = Duration::from_secs(11);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:53:19
+   |
+LL |         let dur = Duration::from_secs(39600);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_hours
+   |
+LL -         let dur = Duration::from_secs(39600);
+LL +         let dur = Duration::from_hours(11);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:55:19
+   |
+LL |         let dur = Duration::from_secs(3 * 60);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_mins
    |
-LL -         let dur = Duration::from_secs(180);
+LL -         let dur = Duration::from_secs(3 * 60);
 LL +         let dur = Duration::from_mins(3);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:51:19
+  --> tests/ui/duration_suboptimal_units.rs:57:19
    |
 LL |         let dur = Duration::from_mins(24 * 60);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,34 +121,34 @@ LL +         let dur = Duration::from_hours(24);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:58:5
+  --> tests/ui/duration_suboptimal_units.rs:64:5
    |
-LL |     std::time::Duration::from_secs(60);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     std::time::Duration::from_secs(12 * 60);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_mins
    |
-LL -     std::time::Duration::from_secs(60);
-LL +     std::time::Duration::from_mins(1);
+LL -     std::time::Duration::from_secs(12 * 60);
+LL +     std::time::Duration::from_mins(12);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:62:16
+  --> tests/ui/duration_suboptimal_units.rs:69:16
    |
-LL |     assert_eq!(Duration::from_secs(3_600), Duration::from_mins(6));
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     assert_eq!(Duration::from_secs(60 * 60), Duration::from_mins(6));
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_hours
    |
-LL -     assert_eq!(Duration::from_secs(3_600), Duration::from_mins(6));
+LL -     assert_eq!(Duration::from_secs(60 * 60), Duration::from_mins(6));
 LL +     assert_eq!(Duration::from_hours(1), Duration::from_mins(6));
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
   --> tests/ui/duration_suboptimal_units.rs:13:9
    |
-LL |         Duration::from_secs(300)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         Duration::from_secs(60 * 5)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     let dur = mac!(duration);
    |               -------------- in this macro invocation
@@ -144,12 +156,12 @@ LL |     let dur = mac!(duration);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: try using from_mins
    |
-LL -         Duration::from_secs(300)
+LL -         Duration::from_secs(60 * 5)
 LL +         Duration::from_mins(5)
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units.rs:105:9
+  --> tests/ui/duration_suboptimal_units.rs:112:9
    |
 LL |     _ = Duration::from_secs(67_768_040_922_076_800);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -160,5 +172,77 @@ LL -     _ = Duration::from_secs(67_768_040_922_076_800);
 LL +     _ = Duration::from_hours(18824455811688);
    |
 
-error: aborting due to 13 previous errors
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:126:15
+   |
+LL |     let dur = Duration::from_millis(20_000);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_secs
+   |
+LL -     let dur = Duration::from_millis(20_000);
+LL +     let dur = Duration::from_secs(20);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:128:15
+   |
+LL |     let dur = Duration::from_mins(720);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_hours
+   |
+LL -     let dur = Duration::from_mins(720);
+LL +     let dur = Duration::from_hours(12);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:130:15
+   |
+LL |     let dur = Duration::from_secs(660);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_mins
+   |
+LL -     let dur = Duration::from_secs(660);
+LL +     let dur = Duration::from_mins(11);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:135:15
+   |
+LL |     let dur = Duration::from_secs(60 * 5);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_mins
+   |
+LL -     let dur = Duration::from_secs(60 * 5);
+LL +     let dur = Duration::from_mins(5);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:139:15
+   |
+LL |     let dur = Duration::from_mins(60 * 2);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_hours
+   |
+LL -     let dur = Duration::from_mins(60 * 2);
+LL +     let dur = Duration::from_hours(2);
+   |
+
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units.rs:143:15
+   |
+LL |     let dur = Duration::from_mins(60 * 24);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_hours
+   |
+LL -     let dur = Duration::from_mins(60 * 24);
+LL +     let dur = Duration::from_hours(24);
+   |
+
+error: aborting due to 20 previous errors
 

--- a/tests/ui/duration_suboptimal_units_days_weeks.fixed
+++ b/tests/ui/duration_suboptimal_units_days_weeks.fixed
@@ -6,12 +6,18 @@
 use std::time::Duration;
 
 fn main() {
-    let dur = Duration::from_mins(1);
+    let dur = Duration::from_secs(60);
+    let dur = Duration::from_mins(100);
     //~^ duration_suboptimal_units
 
-    let dur = Duration::from_days(1);
+    let dur = Duration::from_hours(24);
+    let dur = Duration::from_days(1000);
     //~^ duration_suboptimal_units
 
     let dur = Duration::from_weeks(13);
+    //~^ duration_suboptimal_units
+
+    // Weekly
+    let dur = Duration::from_weeks(1);
     //~^ duration_suboptimal_units
 }

--- a/tests/ui/duration_suboptimal_units_days_weeks.rs
+++ b/tests/ui/duration_suboptimal_units_days_weeks.rs
@@ -7,11 +7,17 @@ use std::time::Duration;
 
 fn main() {
     let dur = Duration::from_secs(60);
+    let dur = Duration::from_secs(6000);
     //~^ duration_suboptimal_units
 
     let dur = Duration::from_hours(24);
+    let dur = Duration::from_hours(24000);
     //~^ duration_suboptimal_units
 
     let dur = Duration::from_nanos(13 * 7 * 24 * 60 * 60 * 1_000 * 1_000 * 1_000);
+    //~^ duration_suboptimal_units
+
+    // Weekly
+    let dur = Duration::from_hours(24 * 7);
     //~^ duration_suboptimal_units
 }

--- a/tests/ui/duration_suboptimal_units_days_weeks.stderr
+++ b/tests/ui/duration_suboptimal_units_days_weeks.stderr
@@ -1,31 +1,31 @@
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units_days_weeks.rs:9:15
+  --> tests/ui/duration_suboptimal_units_days_weeks.rs:10:15
    |
-LL |     let dur = Duration::from_secs(60);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_secs(6000);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::duration-suboptimal-units` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::duration_suboptimal_units)]`
 help: try using from_mins
    |
-LL -     let dur = Duration::from_secs(60);
-LL +     let dur = Duration::from_mins(1);
+LL -     let dur = Duration::from_secs(6000);
+LL +     let dur = Duration::from_mins(100);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units_days_weeks.rs:12:15
+  --> tests/ui/duration_suboptimal_units_days_weeks.rs:14:15
    |
-LL |     let dur = Duration::from_hours(24);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let dur = Duration::from_hours(24000);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try using from_days
    |
-LL -     let dur = Duration::from_hours(24);
-LL +     let dur = Duration::from_days(1);
+LL -     let dur = Duration::from_hours(24000);
+LL +     let dur = Duration::from_days(1000);
    |
 
 error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
-  --> tests/ui/duration_suboptimal_units_days_weeks.rs:15:15
+  --> tests/ui/duration_suboptimal_units_days_weeks.rs:17:15
    |
 LL |     let dur = Duration::from_nanos(13 * 7 * 24 * 60 * 60 * 1_000 * 1_000 * 1_000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,5 +36,17 @@ LL -     let dur = Duration::from_nanos(13 * 7 * 24 * 60 * 60 * 1_000 * 1_000 * 
 LL +     let dur = Duration::from_weeks(13);
    |
 
-error: aborting due to 3 previous errors
+error: constructing a `Duration` using a smaller unit when a larger unit would be more readable
+  --> tests/ui/duration_suboptimal_units_days_weeks.rs:21:15
+   |
+LL |     let dur = Duration::from_hours(24 * 7);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try using from_weeks
+   |
+LL -     let dur = Duration::from_hours(24 * 7);
+LL +     let dur = Duration::from_weeks(1);
+   |
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/16922)*

fixes rust-lang/rust-clippy#16532 

changelog: [`duration_suboptimal_units`]: fix false positive for small integer literals whose promoted value would be at most 10.

Combined rust-lang/rust-clippy#16565 and rust-lang/rust-clippy#16596 