### PR TITLE
fix: [manual_slice_fill] detect for in loops over &mut [T; N] slices

### DIFF
--- a/clippy_lints/src/loops/manual_slice_fill.rs
+++ b/clippy_lints/src/loops/manual_slice_fill.rs
@@ -13,6 +13,7 @@ use rustc_hir::QPath::Resolved;
 use rustc_hir::def::Res;
 use rustc_hir::{Expr, ExprKind, Pat};
 use rustc_lint::LateContext;
+use rustc_middle::ty;
 use rustc_span::{Spanned, sym};
 
 use super::MANUAL_SLICE_FILL;
@@ -83,6 +84,24 @@ pub(super) fn check<'tcx>(
         && msrv.meets(cx, msrvs::SLICE_FILL)
     {
         sugg(cx, body, expr, recv_path.span, assignval.span);
+    }
+    // `for slot in s { *slot = value; }` where `s` is already `&mut [T; N]`
+    else if let ExprKind::Assign(assignee, assignval, _) = peel_blocks_with_stmt(body).kind
+        && let ExprKind::Unary(UnOp::Deref, slice_iter) = assignee.kind
+        && let ExprKind::Path(Resolved(_, slice_path)) = slice_iter.kind
+        && let Res::Local(local) = slice_path.res
+        && local == pat.hir_id
+        && !assignval.span.from_expansion()
+        && switch_to_eager_eval(cx, assignval)
+        && !is_local_used(cx, assignval, local)
+        && let arg_ty = cx.typeck_results().expr_ty(arg)
+        && let ty::Ref(_, inner_ty, rustc_ast::Mutability::Mut) = arg_ty.kind()
+        && is_slice_like(cx, *inner_ty)
+        && let Some(clone_trait) = cx.tcx.lang_items().clone_trait()
+        && implements_trait(cx, *inner_ty, clone_trait, &[])
+        && msrv.meets(cx, msrvs::SLICE_FILL)
+    {
+        sugg(cx, body, expr, arg.span, assignval.span);
     }
 }
 

--- a/tests/ui/manual_slice_fill.fixed
+++ b/tests/ui/manual_slice_fill.fixed
@@ -34,6 +34,38 @@ fn should_lint() {
     some_slice.fill(0);
 }
 
+fn should_lint_direct_mutref_array(s: &mut [u8; 1]) {
+    s.fill(0);
+}
+
+fn should_lint_direct_mutref_array_non_zero(s: &mut [u8; 4]) {
+    s.fill(42);
+}
+
+fn should_lint_direct_mutref_array_variable(s: &mut [i32; 3]) {
+    let x = 7;
+    s.fill(x);
+}
+
+fn should_not_lint_direct_mutref_array_fn(s: &mut [usize; 2]) {
+    for slot in s {
+        *slot = num();
+    }
+}
+
+fn should_not_lint_direct_mutref_array_iter_used(s: &mut [u8; 3]) {
+    for slot in s {
+        *slot = !*slot;
+    }
+}
+
+fn should_not_lint_direct_mutref_array_extra_stmt(s: &mut [u8; 2]) {
+    for slot in s {
+        *slot = 0;
+        println!("foo");
+    }
+}
+
 fn should_not_lint() {
     let mut some_slice = [1, 2, 3, 4, 5];
 

--- a/tests/ui/manual_slice_fill.rs
+++ b/tests/ui/manual_slice_fill.rs
@@ -47,6 +47,47 @@ fn should_lint() {
     }
 }
 
+fn should_lint_direct_mutref_array(s: &mut [u8; 1]) {
+    for slot in s {
+        //~^ manual_slice_fill
+        *slot = 0;
+    }
+}
+
+fn should_lint_direct_mutref_array_non_zero(s: &mut [u8; 4]) {
+    for slot in s {
+        //~^ manual_slice_fill
+        *slot = 42;
+    }
+}
+
+fn should_lint_direct_mutref_array_variable(s: &mut [i32; 3]) {
+    let x = 7;
+    for slot in s {
+        //~^ manual_slice_fill
+        *slot = x;
+    }
+}
+
+fn should_not_lint_direct_mutref_array_fn(s: &mut [usize; 2]) {
+    for slot in s {
+        *slot = num();
+    }
+}
+
+fn should_not_lint_direct_mutref_array_iter_used(s: &mut [u8; 3]) {
+    for slot in s {
+        *slot = !*slot;
+    }
+}
+
+fn should_not_lint_direct_mutref_array_extra_stmt(s: &mut [u8; 2]) {
+    for slot in s {
+        *slot = 0;
+        println!("foo");
+    }
+}
+
 fn should_not_lint() {
     let mut some_slice = [1, 2, 3, 4, 5];
 

--- a/tests/ui/manual_slice_fill.stderr
+++ b/tests/ui/manual_slice_fill.stderr
@@ -38,5 +38,32 @@ LL | |         // foo
 LL | |     }
    | |_____^ help: try: `some_slice.fill(0);`
 
-error: aborting due to 4 previous errors
+error: manually filling a slice
+  --> tests/ui/manual_slice_fill.rs:51:5
+   |
+LL | /     for slot in s {
+LL | |
+LL | |         *slot = 0;
+LL | |     }
+   | |_____^ help: try: `s.fill(0);`
+
+error: manually filling a slice
+  --> tests/ui/manual_slice_fill.rs:58:5
+   |
+LL | /     for slot in s {
+LL | |
+LL | |         *slot = 42;
+LL | |     }
+   | |_____^ help: try: `s.fill(42);`
+
+error: manually filling a slice
+  --> tests/ui/manual_slice_fill.rs:66:5
+   |
+LL | /     for slot in s {
+LL | |
+LL | |         *slot = x;
+LL | |     }
+   | |_____^ help: try: `s.fill(x);`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16924

lint should now fire and recommend fill on already &mut [T; n] slices.

changelog: [`manual_slice_fill`]: detect for loops on already `&mut [T; n]` and suggest `.fill()`.
