### PR TITLE
absolute_paths.rs: change item in "What it does" example

### DIFF
--- a/clippy_lints/src/absolute_paths.rs
+++ b/clippy_lints/src/absolute_paths.rs
@@ -12,7 +12,7 @@ use rustc_span::symbol::kw;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for usage of items through absolute paths, like `std::env::current_dir`.
+    /// Checks for usage of items through absolute paths, like `std::f64::consts::PI`.
     ///
     /// ### Why restrict this?
     /// Many codebases have their own style when it comes to importing, but one that is seldom used


### PR DESCRIPTION
The choice of `std::env::current_dir` made me originally think this was about file and directory paths - use an item where "path" couldn't mean something else. `std::f64::consts::PI` was chosen to match the example.

changelog: [`absolute_path`]: improve example in documentation
