### PR TITLE
Avoid map_unwrap_or fix when default is adjusted

### DIFF
--- a/clippy_lints/src/methods/map_unwrap_or.rs
+++ b/clippy_lints/src/methods/map_unwrap_or.rs
@@ -35,6 +35,7 @@ pub(super) fn check<'tcx>(
     };
 
     let unwrap_arg_ty = cx.typeck_results().expr_ty(unwrap_arg);
+    let unwrap_arg_ty_adjusted = cx.typeck_results().expr_ty_adjusted(unwrap_arg);
     if !is_copy(cx, unwrap_arg_ty) {
         // Replacing `.map(<f>).unwrap_or(<a>)` with `.map_or(<a>, <f>)` can sometimes lead to
         // borrowck errors, see #10579 for one such instance.
@@ -128,10 +129,10 @@ pub(super) fn check<'tcx>(
                     (SuggestedKind::AndThen, _) => "and_then",
                     (SuggestedKind::IsVariantAnd, sym::Result) => "is_ok_and",
                     (SuggestedKind::IsVariantAnd, sym::Option) => "is_some_and",
-                    (SuggestedKind::Other, _)
-                        if unwrap_arg_ty.peel_refs().is_array()
-                            && cx.typeck_results().expr_ty_adjusted(unwrap_arg).peel_refs().is_slice() =>
-                    {
+                    (SuggestedKind::Other, _) if unwrap_arg_ty != unwrap_arg_ty_adjusted => {
+                        // If the `unwrap_or` argument needs an adjustment, moving it into `map_or`'s
+                        // first argument can make type inference pick the unadjusted type and reject
+                        // the closure return type. Keep the lint, but don't emit a rustfix.
                         return;
                     },
                     _ => "map_or",

--- a/clippy_lints/src/methods/map_unwrap_or.rs
+++ b/clippy_lints/src/methods/map_unwrap_or.rs
@@ -35,7 +35,6 @@ pub(super) fn check<'tcx>(
     };
 
     let unwrap_arg_ty = cx.typeck_results().expr_ty(unwrap_arg);
-    let unwrap_arg_ty_adjusted = cx.typeck_results().expr_ty_adjusted(unwrap_arg);
     if !is_copy(cx, unwrap_arg_ty) {
         // Replacing `.map(<f>).unwrap_or(<a>)` with `.map_or(<a>, <f>)` can sometimes lead to
         // borrowck errors, see #10579 for one such instance.
@@ -129,7 +128,7 @@ pub(super) fn check<'tcx>(
                     (SuggestedKind::AndThen, _) => "and_then",
                     (SuggestedKind::IsVariantAnd, sym::Result) => "is_ok_and",
                     (SuggestedKind::IsVariantAnd, sym::Option) => "is_some_and",
-                    (SuggestedKind::Other, _) if unwrap_arg_ty != unwrap_arg_ty_adjusted => {
+                    (SuggestedKind::Other, _) if unwrap_arg_ty != cx.typeck_results().expr_ty_adjusted(unwrap_arg) => {
                         // If the `unwrap_or` argument needs an adjustment, moving it into `map_or`'s
                         // first argument can make type inference pick the unadjusted type and reject
                         // the closure return type. Keep the lint, but don't emit a rustfix.

--- a/tests/ui/map_unwrap_or.rs
+++ b/tests/ui/map_unwrap_or.rs
@@ -161,3 +161,10 @@ fn issue15752() {
     x.map(|y| y.0).unwrap_or(&[]);
     //~^ map_unwrap_or
 }
+
+fn issue16901() {
+    let raw = String::from("scope:value");
+    let after_scope = raw.split_once(':').map(|(_, v)| v).unwrap_or(&raw);
+    //~^ map_unwrap_or
+    let _: &str = after_scope;
+}

--- a/tests/ui/map_unwrap_or.stderr
+++ b/tests/ui/map_unwrap_or.stderr
@@ -238,5 +238,11 @@ error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
 LL |     x.map(|y| y.0).unwrap_or(&[]);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 16 previous errors
+error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
+  --> tests/ui/map_unwrap_or.rs:167:23
+   |
+LL |     let after_scope = raw.split_once(':').map(|(_, v)| v).unwrap_or(&raw);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16901

Suppress the machine-applicable `map_or` suggestion for `map_unwrap_or` when the `unwrap_or` default expression was type-adjusted by the original call. In those cases, moving the default into `map_or` can make inference use the unadjusted type and reject the closure return type. The lint still fires, but without an autofix.

Added a regression for the reported `split_once(...).map(|(_, v)| v).unwrap_or(&raw)` case.

Verification:
- `TESTNAME=map_unwrap_or cargo uitest`
- `cargo fmt --check`
- `git diff --check`

changelog: [`map_unwrap_or`]: avoid suggesting `map_or` when the `unwrap_or` default requires a type adjustment
