### PR TITLE
Fix `bad_bit_mask` ICE for overloaded bit ops

### DIFF
--- a/clippy_lints/src/operators/bit_mask.rs
+++ b/clippy_lints/src/operators/bit_mask.rs
@@ -43,7 +43,8 @@ fn check_compare<'a>(cx: &LateContext<'a>, bit_op: &Expr<'a>, cmp_op: BinOpKind,
         }
         if let Some(mask) = fetch_int_literal(cx, right).or_else(|| fetch_int_literal(cx, left)) {
             let ty = cx.typeck_results().expr_ty(bit_op);
-            if !ty.is_ptr_sized_integral()
+            if ty.is_primitive()
+                && !ty.is_ptr_sized_integral()
                 && let bits = ty.primitive_size(cx.tcx)
             {
                 // Strip high bits that don't fit into the result type as they won't be used in the comparison

--- a/tests/ui/bit_masks.rs
+++ b/tests/ui/bit_masks.rs
@@ -99,3 +99,25 @@ mod issue16781 {
         x & 0x70 == 0x11 << 4
     }
 }
+
+mod issue16935 {
+    struct Wrapper(usize);
+
+    impl std::ops::BitAnd<usize> for Wrapper {
+        type Output = Self;
+
+        fn bitand(self, rhs: usize) -> Self::Output {
+            Self(self.0 & rhs)
+        }
+    }
+
+    impl PartialEq<usize> for Wrapper {
+        fn eq(&self, other: &usize) -> bool {
+            self.0.eq(other)
+        }
+    }
+
+    fn check(value: Wrapper) -> bool {
+        value & 0x1 != 0
+    }
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16935 

changelog: [`bad_bit_mask`] fix ICE for overloaded bit ops
