### PR TITLE
fix: `missing_docs_in_private_items` unfulfilling `#[expect]` in test mode

### DIFF
--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -1,6 +1,6 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::{is_doc_hidden, is_from_proc_macro, is_in_test};
+use clippy_utils::{is_cfg_test, is_doc_hidden, is_from_proc_macro, is_in_test, is_test_function};
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{
@@ -71,7 +71,7 @@ impl MissingDoc {
 
     fn is_missing_docs(&self, cx: &LateContext<'_>, def_id: LocalDefId, hir_id: HirId) -> bool {
         // Ignore every item in a test module or a #[test] annotated function
-        if is_in_test(cx.tcx, hir_id) {
+        if is_in_test(cx.tcx, hir_id) || is_cfg_test(cx.tcx, hir_id) || is_test_function(cx.tcx, def_id) {
             return false;
         }
 

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -1,6 +1,6 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::{is_doc_hidden, is_from_proc_macro};
+use clippy_utils::{is_doc_hidden, is_from_proc_macro, is_in_test};
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{
@@ -70,7 +70,8 @@ impl MissingDoc {
     }
 
     fn is_missing_docs(&self, cx: &LateContext<'_>, def_id: LocalDefId, hir_id: HirId) -> bool {
-        if cx.tcx.sess.opts.test {
+        // Ignore every item in a test module or a #[test] annotated function
+        if is_in_test(cx.tcx, hir_id) {
             return false;
         }
 

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -1,6 +1,6 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::{is_doc_hidden, is_from_proc_macro};
+use clippy_utils::{is_cfg_test, is_doc_hidden, is_from_proc_macro, is_in_test, is_test_function};
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{
@@ -70,7 +70,12 @@ impl MissingDoc {
     }
 
     fn is_missing_docs(&self, cx: &LateContext<'_>, def_id: LocalDefId, hir_id: HirId) -> bool {
-        if cx.tcx.sess.opts.test {
+        // Ignore every item in a test module or a #[test] annotated function
+        if cx.tcx.sess.opts.test
+            || is_in_test(cx.tcx, hir_id)
+            || is_cfg_test(cx.tcx, hir_id)
+            || is_test_function(cx.tcx, def_id)
+        {
             return false;
         }
 

--- a/tests/ui/missing_docs_in_private_items.rs
+++ b/tests/ui/missing_docs_in_private_items.rs
@@ -1,0 +1,34 @@
+#![warn(clippy::missing_docs_in_private_items)]
+#![allow(dead_code)]
+
+pub fn public() {
+    private();
+}
+
+#[expect(clippy::missing_docs_in_private_items)]
+fn private() {}
+
+// Don't lint for items in test modules
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_in_mod() {
+        fn inner_private() {}
+    }
+
+    fn private_in_mod() {}
+
+    struct PrivateStructInMod;
+}
+
+// Don't lint for items in test functions
+#[test]
+fn test_function() {
+    fn inner_private() {}
+}
+
+fn not_in_test_mod() {}
+//~^ missing_docs_in_private_items
+
+struct NotInTestModStruct;
+//~^ missing_docs_in_private_items

--- a/tests/ui/missing_docs_in_private_items.stderr
+++ b/tests/ui/missing_docs_in_private_items.stderr
@@ -1,0 +1,17 @@
+error: missing documentation for a function
+  --> tests/ui/missing_docs_in_private_items.rs:30:4
+   |
+LL | fn not_in_test_mod() {}
+   |    ^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::missing-docs-in-private-items` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_docs_in_private_items)]`
+
+error: missing documentation for a struct
+  --> tests/ui/missing_docs_in_private_items.rs:33:8
+   |
+LL | struct NotInTestModStruct;
+   |        ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
changelog: fix [`missing_docs_in_private_items`]: unfulfilling `#[expect]` in test mode

Fixes rust-lang/rust-clippy#16934 
