### PR TITLE
fix: const disagree between `rustc` and lint `missing_const_for_fn`

### DIFF
--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -141,9 +141,16 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
             let parent = cx.tcx.hir_get_parent_item(hir_id).def_id;
             if parent != CRATE_DEF_ID
                 && let hir::Node::Item(item) = cx.tcx.hir_node_by_def_id(parent)
-                && let hir::ItemKind::Trait { .. } = &item.kind
             {
-                return;
+                match item.kind {
+                    hir::ItemKind::Impl(impl_item) => {
+                        if impl_item.constness == Constness::Const {
+                            return;
+                        }
+                    },
+                    hir::ItemKind::Trait { .. } => return,
+                    _ => {},
+                }
             }
         }
 

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -8,6 +8,7 @@
 
 #![warn(clippy::missing_const_for_fn)]
 #![feature(type_alias_impl_trait)]
+#![feature(const_trait_impl)]
 
 extern crate helper;
 extern crate proc_macros;
@@ -304,5 +305,34 @@ mod issue14091 {
 
     fn smart_destructure(v: &mut Wrap<(i32, i32)>) {
         let (ref mut _head, ref mut _tail) = **v;
+    }
+}
+
+// Do not lint functions inside inherent `impl const` blocks
+mod const_inherent_impl {
+    struct Bobs;
+
+    const impl Bobs {
+        fn bobs() -> usize {
+            1234
+        }
+
+        fn bats() -> usize {
+            0
+        }
+    }
+}
+
+mod const_inherent_impl_generic {
+    const trait Bits {
+        fn bits() -> usize;
+    }
+
+    struct Bobs<T>(T);
+
+    const impl<T: [const] Bits> Bobs<T> {
+        fn bobs() -> usize {
+            1234
+        }
     }
 }


### PR DESCRIPTION
changelog: [`missing_const_for_fn`]: const disagreement with `rustc`.

Fixes rust-lang/rust-clippy#16946 
