### PR TITLE
new lint: maybe_uninit_drop_in_place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6961,6 +6961,7 @@ Released 2018-09-13
 [`match_wildcard_for_single_variants`]: https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants
 [`maybe_infinite_iter`]: https://rust-lang.github.io/rust-clippy/master/index.html#maybe_infinite_iter
 [`maybe_misused_cfg`]: https://rust-lang.github.io/rust-clippy/master/index.html#maybe_misused_cfg
+[`maybe_uninit_drop_in_place`]: https://rust-lang.github.io/rust-clippy/master/index.html#maybe_uninit_drop_in_place
 [`mem_discriminant_non_enum`]: https://rust-lang.github.io/rust-clippy/master/index.html#mem_discriminant_non_enum
 [`mem_forget`]: https://rust-lang.github.io/rust-clippy/master/index.html#mem_forget
 [`mem_replace_option_with_none`]: https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_option_with_none

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -435,6 +435,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::MAP_IDENTITY_INFO,
     crate::methods::MAP_UNWRAP_OR_INFO,
     crate::methods::MAP_WITH_UNUSED_ARGUMENT_OVER_RANGES_INFO,
+    crate::methods::MAYBE_UNINIT_DROP_IN_PLACE_INFO,
     crate::methods::MUT_MUTEX_LOCK_INFO,
     crate::methods::NAIVE_BYTECOUNT_INFO,
     crate::methods::NEEDLESS_AS_BYTES_INFO,

--- a/clippy_lints/src/methods/maybe_uninit_drop_in_place.rs
+++ b/clippy_lints/src/methods/maybe_uninit_drop_in_place.rs
@@ -1,0 +1,44 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::res::MaybeDef;
+use rustc_hir::{Expr, ExprKind, LangItem, QPath};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, func: &Expr<'_>, args: &[Expr<'_>]) {
+    if let [arg] = args
+        && let ExprKind::Path(QPath::Resolved(_, path)) = func.kind
+        && let Some(def_id) = path.res.opt_def_id()
+        && cx.tcx.lang_items().drop_in_place_fn() == Some(def_id)
+        && let ty::RawPtr(mut pointee, _) = *cx.typeck_results().expr_ty_adjusted(arg).kind()
+    {
+        // See through `[MaybeUninit<T>]` and `MaybeUninit<[T; N]>`
+        let mut is_slice_or_array = false;
+        while let ty::Array(inner, _) | ty::Slice(inner) = *pointee.kind() {
+            pointee = inner;
+            is_slice_or_array = true;
+        }
+
+        if !pointee.is_lang_item(cx, LangItem::MaybeUninit) {
+            return;
+        }
+
+        // Intentionally no structured suggestion, since we don't know if the `MaybeUninit`
+        // is initialized or not in the user's code.
+        span_lint_and_then(
+            cx,
+            super::MAYBE_UNINIT_DROP_IN_PLACE,
+            expr.span,
+            "calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op",
+            |diag| {
+                diag.note("`MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped");
+                if is_slice_or_array {
+                    diag.help(
+                        "if initialized, drop the inner `T`s by casting the pointer to `*mut T` before forming the slice",
+                    );
+                } else {
+                    diag.help("if initialized, drop the inner `T` with `MaybeUninit::assume_init_drop`");
+                }
+            },
+        );
+    }
+}

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -77,6 +77,7 @@ mod map_identity;
 mod map_unwrap_or;
 mod map_unwrap_or_else;
 mod map_with_unused_argument_over_ranges;
+mod maybe_uninit_drop_in_place;
 mod mut_mutex_lock;
 mod needless_as_bytes;
 mod needless_character_iteration;
@@ -2420,6 +2421,43 @@ declare_clippy_lint! {
     pub MAP_WITH_UNUSED_ARGUMENT_OVER_RANGES,
     restriction,
     "map of a trivial closure (not dependent on parameter) over a range"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for calls to `std::ptr::drop_in_place` whose argument points to a
+    /// `MaybeUninit<T>` (i.e. has type `*mut MaybeUninit<T>` or
+    /// `&mut MaybeUninit<T>`).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `MaybeUninit<T>` does not implement `Drop`, so the call is a no-op
+    /// rather than dropping the wrapped `T`. This is almost always a bug:
+    /// the author meant to drop the value inside the `MaybeUninit`.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let mut x = MaybeUninit::new(String::from("hi"));
+    /// unsafe {
+    ///     std::ptr::drop_in_place(&mut x); // no-op — does NOT drop the String
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let mut x = MaybeUninit::new(String::from("hi"));
+    /// unsafe {
+    ///     x.assume_init_drop();
+    /// }
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub MAYBE_UNINIT_DROP_IN_PLACE,
+    suspicious,
+    "calling `std::ptr::drop_in_place` on a `MaybeUninit` is a no-op"
 }
 
 declare_clippy_lint! {
@@ -4861,6 +4899,7 @@ impl_lint_pass!(Methods => [
     MAP_IDENTITY,
     MAP_UNWRAP_OR,
     MAP_WITH_UNUSED_ARGUMENT_OVER_RANGES,
+    MAYBE_UNINIT_DROP_IN_PLACE,
     MUT_MUTEX_LOCK,
     NAIVE_BYTECOUNT,
     NEEDLESS_AS_BYTES,
@@ -5018,6 +5057,7 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
                 io_other_error::check(cx, expr, func, args, self.msrv);
                 swap_with_temporary::check(cx, expr, func, args);
                 ip_constant::check(cx, expr, func, args);
+                maybe_uninit_drop_in_place::check(cx, expr, func, args);
                 unwrap_expect_used::check_call(
                     cx,
                     expr,

--- a/tests/ui/maybe_uninit_drop_in_place.rs
+++ b/tests/ui/maybe_uninit_drop_in_place.rs
@@ -1,0 +1,124 @@
+//@no-rustfix: lint emits help, not a suggestion (rewrite to `assume_init_drop` is UB if uninit)
+#![warn(clippy::maybe_uninit_drop_in_place)]
+#![allow(clippy::cast_slice_from_raw_parts)]
+
+use std::mem::{ManuallyDrop, MaybeUninit};
+
+fn pos_basic() {
+    let mut x = std::mem::MaybeUninit::<String>::uninit();
+    unsafe {
+        std::ptr::drop_in_place(&mut x);
+        //~^ maybe_uninit_drop_in_place
+    }
+}
+
+fn pos_reference_inner() {
+    let mut x = MaybeUninit::<&i32>::uninit();
+    unsafe {
+        std::ptr::drop_in_place(&mut x);
+        //~^ maybe_uninit_drop_in_place
+    }
+}
+
+fn pos_fully_qualified() {
+    let mut x = MaybeUninit::<Vec<u8>>::uninit();
+    unsafe {
+        std::ptr::drop_in_place(&mut x);
+        //~^ maybe_uninit_drop_in_place
+    }
+}
+
+fn pos_through_binding() {
+    let mut x = MaybeUninit::<String>::uninit();
+    let p = &mut x;
+    unsafe {
+        std::ptr::drop_in_place(p);
+        //~^ maybe_uninit_drop_in_place
+    }
+}
+
+fn pos_raw_pointer() {
+    let mut x = MaybeUninit::<String>::uninit();
+    let p: *mut MaybeUninit<String> = &raw mut x;
+    unsafe {
+        std::ptr::drop_in_place(p);
+        //~^ maybe_uninit_drop_in_place
+    }
+}
+
+fn pos_generic_inner<T>() {
+    let mut x = MaybeUninit::<T>::uninit();
+    unsafe {
+        std::ptr::drop_in_place(&mut x);
+        //~^ maybe_uninit_drop_in_place
+    }
+}
+
+fn pos_slice_of_maybe_uninit() {
+    let mut buf: [MaybeUninit<String>; 4] = [const { MaybeUninit::uninit() }; 4];
+    let begin = 0usize;
+    let len = 2usize;
+    unsafe {
+        let slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr().add(begin), len);
+        std::ptr::drop_in_place(slice);
+        //~^ maybe_uninit_drop_in_place
+    }
+}
+
+fn pos_array_of_maybe_uninit() {
+    let mut buf: [MaybeUninit<String>; 4] = [const { MaybeUninit::uninit() }; 4];
+    unsafe {
+        std::ptr::drop_in_place(&mut buf);
+        //~^ maybe_uninit_drop_in_place
+    }
+}
+
+fn neg_slice_cast_to_inner() {
+    let mut buf: [MaybeUninit<String>; 4] = [const { MaybeUninit::uninit() }; 4];
+    let begin = 0usize;
+    let length = 2usize;
+    unsafe {
+        let k1_ptr = buf.as_mut_ptr().add(begin) as *mut String;
+        std::ptr::drop_in_place(std::slice::from_raw_parts_mut(k1_ptr, length));
+    }
+}
+
+fn neg_correct_inner_drop() {
+    let mut x = MaybeUninit::new(String::from("hi"));
+    unsafe {
+        std::ptr::drop_in_place(x.as_mut_ptr());
+    }
+}
+
+fn neg_assume_init_drop() {
+    let mut x = MaybeUninit::new(String::from("hi"));
+    unsafe {
+        x.assume_init_drop();
+    }
+}
+
+fn neg_plain_type() {
+    let mut s = ManuallyDrop::new(String::from("hello"));
+    unsafe {
+        std::ptr::drop_in_place(&mut *s);
+    }
+}
+
+// Don't lint code that the user can't fix.
+macro_rules! drop_it {
+    ($e:expr) => {
+        unsafe { std::ptr::drop_in_place(&mut $e) }
+    };
+}
+fn neg_in_macro() {
+    let mut x = MaybeUninit::<String>::uninit();
+    drop_it!(x);
+}
+
+fn neg_fully_generic<T>(x: &mut T) {
+    unsafe {
+        std::ptr::drop_in_place(x);
+    }
+}
+
+fn main() {}

--- a/tests/ui/maybe_uninit_drop_in_place.stderr
+++ b/tests/ui/maybe_uninit_drop_in_place.stderr
@@ -1,0 +1,76 @@
+error: calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op
+  --> tests/ui/maybe_uninit_drop_in_place.rs:10:9
+   |
+LL |         std::ptr::drop_in_place(&mut x);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped
+   = help: if initialized, drop the inner `T` with `MaybeUninit::assume_init_drop`
+   = note: `-D clippy::maybe-uninit-drop-in-place` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::maybe_uninit_drop_in_place)]`
+
+error: calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op
+  --> tests/ui/maybe_uninit_drop_in_place.rs:18:9
+   |
+LL |         std::ptr::drop_in_place(&mut x);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped
+   = help: if initialized, drop the inner `T` with `MaybeUninit::assume_init_drop`
+
+error: calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op
+  --> tests/ui/maybe_uninit_drop_in_place.rs:26:9
+   |
+LL |         std::ptr::drop_in_place(&mut x);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped
+   = help: if initialized, drop the inner `T` with `MaybeUninit::assume_init_drop`
+
+error: calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op
+  --> tests/ui/maybe_uninit_drop_in_place.rs:35:9
+   |
+LL |         std::ptr::drop_in_place(p);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped
+   = help: if initialized, drop the inner `T` with `MaybeUninit::assume_init_drop`
+
+error: calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op
+  --> tests/ui/maybe_uninit_drop_in_place.rs:44:9
+   |
+LL |         std::ptr::drop_in_place(p);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped
+   = help: if initialized, drop the inner `T` with `MaybeUninit::assume_init_drop`
+
+error: calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op
+  --> tests/ui/maybe_uninit_drop_in_place.rs:52:9
+   |
+LL |         std::ptr::drop_in_place(&mut x);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped
+   = help: if initialized, drop the inner `T` with `MaybeUninit::assume_init_drop`
+
+error: calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op
+  --> tests/ui/maybe_uninit_drop_in_place.rs:63:9
+   |
+LL |         std::ptr::drop_in_place(slice);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped
+   = help: if initialized, drop the inner `T`s by casting the pointer to `*mut T` before forming the slice
+
+error: calling `ptr::drop_in_place` on a `MaybeUninit` is a no-op
+  --> tests/ui/maybe_uninit_drop_in_place.rs:71:9
+   |
+LL |         std::ptr::drop_in_place(&mut buf);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MaybeUninit<T>` does not implement `Drop`, so the wrapped `T` is not dropped
+   = help: if initialized, drop the inner `T`s by casting the pointer to `*mut T` before forming the slice
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
Hello! First time contributor to rust-clippy here. This PR adds a new lint, `maybe_uninit_drop_in_place`, which warns against `std::ptr::drop_in_place` on `MaybeUninit<T>` types. We ran into this issue at [turbopuffer](https://turbopuffer.com) where we thought we were dropping T, but in reality, we weren't, causing a memory leak which was extremely difficult to debug. I went back and forth on rustfix here, e.g. there's a world where we auto-fix to assume_init_drop(), but I worried that this could be UB if the MaybeUninit was in fact uninitialized, so I biased towards a suggestion instead, would love to hear input from others on this.

changelog: [`maybe_uninit_drop_in_place`]: A new lint for detecting usage of `std::ptr::drop_in_place` on `MaybeUninit<T>` values, which is almost never correct.

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo dev fmt`