### PR TITLE
`return` can be removed from the last stmt of a block if it has an expr

### DIFF
--- a/clippy_lints/src/returns/needless_return_with_question_mark.rs
+++ b/clippy_lints/src/returns/needless_return_with_question_mark.rs
@@ -27,7 +27,7 @@ pub(super) fn check_stmt<'tcx>(cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
         && let ExprKind::Block(block, _) = peel_async_body(block).kind
         && !is_inside_let_else(cx.tcx, expr)
         && let [.., final_stmt] = block.stmts
-        && final_stmt.hir_id != stmt.hir_id
+        && (block.expr.is_some() || final_stmt.hir_id != stmt.hir_id)
         && !is_from_proc_macro(cx, expr)
         && !stmt_needs_never_type(cx, stmt.hir_id)
     {

--- a/tests/ui/needless_return_with_question_mark.fixed
+++ b/tests/ui/needless_return_with_question_mark.fixed
@@ -154,3 +154,13 @@ async fn async_block_final_stmt() -> Result<(), ()> {
     }
     .await
 }
+
+fn last_stmt() -> Result<(), ()> {
+    return Err(())?;
+}
+
+fn expr_after_stmt() -> Result<(), ()> {
+    Err(())?;
+    //~^ needless_return_with_question_mark
+    Ok(())
+}

--- a/tests/ui/needless_return_with_question_mark.rs
+++ b/tests/ui/needless_return_with_question_mark.rs
@@ -154,3 +154,13 @@ async fn async_block_final_stmt() -> Result<(), ()> {
     }
     .await
 }
+
+fn last_stmt() -> Result<(), ()> {
+    return Err(())?;
+}
+
+fn expr_after_stmt() -> Result<(), ()> {
+    return Err(())?;
+    //~^ needless_return_with_question_mark
+    Ok(())
+}

--- a/tests/ui/needless_return_with_question_mark.stderr
+++ b/tests/ui/needless_return_with_question_mark.stderr
@@ -25,5 +25,11 @@ error: unneeded `return` statement with `?` operator
 LL |             return Err(())?;
    |             ^^^^^^^ help: remove it
 
-error: aborting due to 4 previous errors
+error: unneeded `return` statement with `?` operator
+  --> tests/ui/needless_return_with_question_mark.rs:163:5
+   |
+LL |     return Err(())?;
+   |     ^^^^^^^ help: remove it
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
changelog: [`needless_return_with_question_mark`]: lint more cases when the block in which the `return` is located has a final expression

Fixes rust-lang/rust-clippy#16958 