### PR TITLE
fix [`std_instead_of_core`]: false positives for `core::io`/MSRV

### DIFF
--- a/clippy_lints/src/std_instead_of_core.rs
+++ b/clippy_lints/src/std_instead_of_core.rs
@@ -238,20 +238,21 @@ fn get_first_segment<'tcx>(path: &Path<'tcx>) -> Option<&'tcx PathSegment<'tcx>>
 /// Does not catch individually moved items
 fn is_stable(cx: &LateContext<'_>, mut def_id: DefId, msrv: Msrv) -> bool {
     loop {
-        if let Some(stability) = cx.tcx.lookup_stability(def_id)
-            && let StabilityLevel::Stable {
-                since,
-                allowed_through_unstable_modules: None,
-            } = stability.level
-        {
-            let stable = match since {
-                StableSince::Version(v) => msrv.meets(cx, v),
-                StableSince::Current => msrv.current(cx).is_none(),
-                StableSince::Err(_) => false,
-            };
-
-            if !stable {
-                return false;
+        if let Some(stability) = cx.tcx.lookup_stability(def_id) {
+            match stability.level {
+                // Workaround for items from `core::intrinsics` with a stable export in a different module.
+                // Not that we ignore the `since` field as we are already accessing the item in question.
+                StabilityLevel::Stable {
+                    allowed_through_unstable_modules: Some(_),
+                    ..
+                } => return true,
+                StabilityLevel::Stable { since, .. } => match since {
+                    StableSince::Version(v) if !msrv.meets(cx, v) => return false,
+                    StableSince::Current if msrv.current(cx).is_none() => return false,
+                    StableSince::Err(_) => return false,
+                    StableSince::Version(_) | StableSince::Current => {},
+                },
+                StabilityLevel::Unstable { .. } => return false,
             }
         }
 

--- a/tests/ui/std_instead_of_core.fixed
+++ b/tests/ui/std_instead_of_core.fixed
@@ -96,3 +96,23 @@ fn issue15579() {
 
     let layout = alloc::Layout::new::<u8>();
 }
+
+#[warn(clippy::std_instead_of_core)]
+fn issue13158_core_io() {
+    // items moved from std::io into core::io are stable in an unstable module.
+    use std::io::ErrorKind;
+}
+
+#[clippy::msrv = "1.40"]
+fn issue13158_msrv_1_40(_: &dyn std::panic::UnwindSafe) {}
+
+#[clippy::msrv = "1.41"]
+fn issue13158_msrv_1_41(_: &dyn core::panic::UnwindSafe) {}
+//~^ std_instead_of_core
+
+#[clippy::msrv = "1.80"]
+fn issue13158_msrv_1_80(_: &dyn std::error::Error) {}
+
+#[clippy::msrv = "1.81"]
+fn issue13158_msrv_1_81(_: &dyn core::error::Error) {}
+//~^ std_instead_of_core

--- a/tests/ui/std_instead_of_core.rs
+++ b/tests/ui/std_instead_of_core.rs
@@ -96,3 +96,23 @@ fn issue15579() {
 
     let layout = alloc::Layout::new::<u8>();
 }
+
+#[warn(clippy::std_instead_of_core)]
+fn issue13158_core_io() {
+    // items moved from std::io into core::io are stable in an unstable module.
+    use std::io::ErrorKind;
+}
+
+#[clippy::msrv = "1.40"]
+fn issue13158_msrv_1_40(_: &dyn std::panic::UnwindSafe) {}
+
+#[clippy::msrv = "1.41"]
+fn issue13158_msrv_1_41(_: &dyn std::panic::UnwindSafe) {}
+//~^ std_instead_of_core
+
+#[clippy::msrv = "1.80"]
+fn issue13158_msrv_1_80(_: &dyn std::error::Error) {}
+
+#[clippy::msrv = "1.81"]
+fn issue13158_msrv_1_81(_: &dyn std::error::Error) {}
+//~^ std_instead_of_core

--- a/tests/ui/std_instead_of_core.stderr
+++ b/tests/ui/std_instead_of_core.stderr
@@ -97,5 +97,17 @@ error: used import from `std` instead of `core`
 LL | fn msrv_1_77(_: std::net::IpAddr) {}
    |                 ^^^ help: consider importing the item from `core`: `core`
 
-error: aborting due to 15 previous errors
+error: used import from `std` instead of `core`
+  --> tests/ui/std_instead_of_core.rs:110:33
+   |
+LL | fn issue13158_msrv_1_41(_: &dyn std::panic::UnwindSafe) {}
+   |                                 ^^^ help: consider importing the item from `core`: `core`
+
+error: used import from `std` instead of `core`
+  --> tests/ui/std_instead_of_core.rs:117:33
+   |
+LL | fn issue13158_msrv_1_81(_: &dyn std::error::Error) {}
+   |                                 ^^^ help: consider importing the item from `core`: `core`
+
+error: aborting due to 17 previous errors
 

--- a/tests/ui/std_instead_of_core_unfixable.rs
+++ b/tests/ui/std_instead_of_core_unfixable.rs
@@ -14,3 +14,14 @@ fn issue15143() {
     //~^ std_instead_of_core
     //~| std_instead_of_alloc
 }
+
+#[rustfmt::skip]
+fn pr16964() {
+    use std::{
+        borrow::Cow,
+        //~^ std_instead_of_alloc
+        collections::BTreeSet,
+        //~^ std_instead_of_alloc
+        ffi::OsString,
+    };
+}

--- a/tests/ui/std_instead_of_core_unfixable.stderr
+++ b/tests/ui/std_instead_of_core_unfixable.stderr
@@ -26,5 +26,21 @@ LL |     use std::{error::Error, vec::Vec, fs::File};
    = note: `-D clippy::std-instead-of-alloc` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::std_instead_of_alloc)]`
 
-error: aborting due to 3 previous errors
+error: used import from `std` instead of `alloc`
+  --> tests/ui/std_instead_of_core_unfixable.rs:21:17
+   |
+LL |         borrow::Cow,
+   |                 ^^^
+   |
+   = help: consider importing the item from `alloc`
+
+error: used import from `std` instead of `alloc`
+  --> tests/ui/std_instead_of_core_unfixable.rs:23:22
+   |
+LL |         collections::BTreeSet,
+   |                      ^^^^^^^^
+   |
+   = help: consider importing the item from `alloc`
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
# Objective

- Fix false positive identified by @rktaxe in [this comment](https://github.com/rust-lang/rust-clippy/issues/13158#issuecomment-4373196346) on rust-lang/rust-clippy#13158.
- Fix rust-lang/rust-clippy#13158

## Solution

Previously the lint had an exception for all instances of a stable item in an unstable module, primarily to allow certain intrinsics such as `copy` to be accessible. Instead, I check for the presence of `rustc_allowed_through_unstable_modules` to handle those exceptions, and allow the `is_stable` check within the lint to early out as soon as any part of its path is unstable.

I believe this was the last piece required to resolve rust-lang/rust-clippy#13158, and have added tests for all examples listed in the issue. If there are other examples of this lint failing, I'd greatly appreciate seeing them!

---

## Notes

- No AI tooling of any kind was used during the creation of this PR. 
- Originally opened (in error) as rust-lang/rust#156164

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: fix certain false positives for [`std_instead_of_core`] for stable items in an unstable module (e.g., `core::io::ErrorKind`), and other MSRV-unaware issues.
