### PR TITLE
Fix `manual_option_zip` FP when the outer param is used in closure

### DIFF
--- a/clippy_lints/src/methods/manual_option_zip.rs
+++ b/clippy_lints/src/methods/manual_option_zip.rs
@@ -3,12 +3,11 @@ use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::peel_blocks;
 use clippy_utils::res::{MaybeDef, MaybeResPath};
 use clippy_utils::source::snippet_with_applicability;
-use clippy_utils::visitors::for_each_expr_without_closures;
+use clippy_utils::usage::local_used_in;
 use rustc_errors::Applicability;
 use rustc_hir::{self as hir, Expr, ExprKind, HirId, PatKind};
 use rustc_lint::LateContext;
 use rustc_span::symbol::sym;
-use std::ops::ControlFlow;
 
 use super::MANUAL_OPTION_ZIP;
 
@@ -31,13 +30,7 @@ pub(super) fn check<'tcx>(
         && method_path.ident.name == sym::map
         && cx.typeck_results().expr_ty(map_recv).is_diag_item(cx, sym::Option)
         // `b` does not reference the outer closure parameter `a`.
-        && for_each_expr_without_closures(map_recv, |e| {
-            if e.res_local_id() == Some(outer_param_id) {
-                ControlFlow::Break(())
-            } else {
-                ControlFlow::Continue(())
-            }
-        }).is_none()
+        && !local_used_in(cx, outer_param_id, map_recv)
         // `|b| (a, b)`
         && let ExprKind::Closure(&hir::Closure { body: inner_body_id, .. }) = map_arg.kind
         && let hir::Body { params: [inner_param], value: inner_value, .. } = cx.tcx.hir_body(inner_body_id)

--- a/tests/ui/manual_option_zip.fixed
+++ b/tests/ui/manual_option_zip.fixed
@@ -116,3 +116,10 @@ impl NotOption {
         self.0.and_then(f)
     }
 }
+
+fn issue16968() {
+    let a = Some(1);
+
+    let opts = [1, 2];
+    let _ = a.and_then(|a| opts.into_iter().find(|b| *b == a).map(|b| (a, b)));
+}

--- a/tests/ui/manual_option_zip.rs
+++ b/tests/ui/manual_option_zip.rs
@@ -116,3 +116,10 @@ impl NotOption {
         self.0.and_then(f)
     }
 }
+
+fn issue16968() {
+    let a = Some(1);
+
+    let opts = [1, 2];
+    let _ = a.and_then(|a| opts.into_iter().find(|b| *b == a).map(|b| (a, b)));
+}


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16968 

changelog: [`manual_option_zip`] fix FP when the outer param is used in closure
