### PR TITLE
fix: lints for UFCS call in [`clone_on_copy`]

### DIFF
--- a/clippy_lints/src/methods/clone_on_copy.rs
+++ b/clippy_lints/src/methods/clone_on_copy.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::peel_hir_expr_refs;
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::ty::is_copy;
 use rustc_errors::Applicability;
@@ -9,6 +10,51 @@ use rustc_middle::ty::adjustment::Adjust;
 use rustc_middle::ty::print::with_forced_trimmed_paths;
 
 use super::CLONE_ON_COPY;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ParentIsSuffixExpr {
+    Yes,
+    No,
+    Return,
+}
+
+fn check_parent_is_suffix_expr(cx: &LateContext<'_>, expr: &Expr<'_>) -> ParentIsSuffixExpr {
+    match cx.tcx.parent_hir_node(expr.hir_id) {
+        Node::Expr(parent) => match parent.kind {
+            // &*x is a nop, &x.clone() is not
+            ExprKind::AddrOf(..) => ParentIsSuffixExpr::Return,
+            // (*x).func() is useless, x.clone().func() can work in case func borrows self
+            ExprKind::MethodCall(_, self_arg, ..)
+                if expr.hir_id == self_arg.hir_id
+                    && cx.typeck_results().expr_ty(expr) != cx.typeck_results().expr_ty_adjusted(expr) =>
+            {
+                ParentIsSuffixExpr::Return
+            },
+            // ? is a Call, makes sure not to rec *x?, but rather (*x)?
+            ExprKind::Call(hir_callee, [_]) => {
+                if matches!(
+                    hir_callee.kind,
+                    ExprKind::Path(qpath)
+                    if cx.tcx.qpath_is_lang_item(qpath, rustc_hir::LangItem::TryTraitBranch)
+                ) {
+                    ParentIsSuffixExpr::Yes
+                } else {
+                    ParentIsSuffixExpr::No
+                }
+            },
+            ExprKind::MethodCall(_, self_arg, ..) if expr.hir_id == self_arg.hir_id => ParentIsSuffixExpr::Yes,
+            ExprKind::Match(_, _, MatchSource::TryDesugar(_) | MatchSource::AwaitDesugar)
+            | ExprKind::Field(..)
+            | ExprKind::Index(..) => ParentIsSuffixExpr::Yes,
+            _ => ParentIsSuffixExpr::No,
+        },
+        // local binding capturing a reference
+        Node::LetStmt(l) if matches!(l.pat.kind, PatKind::Binding(BindingMode(ByRef::Yes(..), _), ..)) => {
+            ParentIsSuffixExpr::Return
+        },
+        _ => ParentIsSuffixExpr::No,
+    }
+}
 
 /// Checks for the `CLONE_ON_COPY` lint.
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>) {
@@ -33,46 +79,81 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>) 
         return; // don't report clone_on_copy
     }
 
-    if is_copy(cx, ty) {
-        let parent_is_suffix_expr = match cx.tcx.parent_hir_node(expr.hir_id) {
-            Node::Expr(parent) => match parent.kind {
-                // &*x is a nop, &x.clone() is not
-                ExprKind::AddrOf(..) => return,
-                // (*x).func() is useless, x.clone().func() can work in case func borrows self
-                ExprKind::MethodCall(_, self_arg, ..)
-                    if expr.hir_id == self_arg.hir_id && ty != cx.typeck_results().expr_ty_adjusted(expr) =>
-                {
-                    return;
-                },
-                // ? is a Call, makes sure not to rec *x?, but rather (*x)?
-                ExprKind::Call(hir_callee, [_]) => matches!(
-                    hir_callee.kind,
-                    ExprKind::Path(qpath)
-                    if cx.tcx.qpath_is_lang_item(qpath, rustc_hir::LangItem::TryTraitBranch)
-                ),
-                ExprKind::MethodCall(_, self_arg, ..) if expr.hir_id == self_arg.hir_id => true,
-                ExprKind::Match(_, _, MatchSource::TryDesugar(_) | MatchSource::AwaitDesugar)
-                | ExprKind::Field(..)
-                | ExprKind::Index(..) => true,
-                _ => false,
-            },
-            // local binding capturing a reference
-            Node::LetStmt(l) if matches!(l.pat.kind, PatKind::Binding(BindingMode(ByRef::Yes(..), _), ..)) => {
-                return;
-            },
-            _ => false,
-        };
+    if !is_copy(cx, ty) {
+        return;
+    }
+    let check_res = check_parent_is_suffix_expr(cx, expr);
+    if check_res == ParentIsSuffixExpr::Return {
+        return;
+    }
+
+    let mut app = Applicability::MachineApplicable;
+    let snip = snippet_with_context(cx, receiver.span, expr.span.ctxt(), "_", &mut app).0;
+
+    let deref_count = arg_adjustments
+        .iter()
+        .take_while(|adj| matches!(adj.kind, Adjust::Deref(_)))
+        .count();
+    let (help, sugg) = if deref_count == 0 {
+        ("try removing the `clone` call", snip.into())
+    } else if check_res == ParentIsSuffixExpr::Yes {
+        ("try dereferencing it", format!("({}{snip})", "*".repeat(deref_count)))
+    } else {
+        ("try dereferencing it", format!("{}{snip}", "*".repeat(deref_count)))
+    };
+
+    span_lint_and_sugg(
+        cx,
+        CLONE_ON_COPY,
+        expr.span,
+        with_forced_trimmed_paths!(format!(
+            "using `clone` on type `{ty}` which implements the `Copy` trait"
+        )),
+        help,
+        sugg,
+        app,
+    );
+}
+
+pub(super) fn check_function(cx: &LateContext<'_>, expr: &Expr<'_>) {
+    let ExprKind::Call(func, args) = expr.kind else { return };
+
+    if let ExprKind::Path(qpath) = func.kind
+        && let Some(def_id) = cx.typeck_results().qpath_res(&qpath, func.hir_id).opt_def_id()
+        && cx.tcx.trait_of_assoc(def_id) == cx.tcx.lang_items().clone_trait()
+        && let [arg] = args
+        && let ty = cx.typeck_results().expr_ty(expr)
+    {
+        if !is_copy(cx, ty) {
+            return;
+        }
+
+        let check_res = check_parent_is_suffix_expr(cx, expr);
+        if check_res == ParentIsSuffixExpr::Return {
+            return;
+        }
+
+        // Peel the & operator in the argument.
+        let (peeled_arg, ref_count) = peel_hir_expr_refs(arg);
 
         let mut app = Applicability::MachineApplicable;
-        let snip = snippet_with_context(cx, receiver.span, expr.span.ctxt(), "_", &mut app).0;
+        let snip = snippet_with_context(cx, peeled_arg.span, func.span.ctxt(), "_", &mut app).0;
 
+        let arg_adjustments = cx.typeck_results().expr_adjustments(arg);
         let deref_count = arg_adjustments
             .iter()
             .take_while(|adj| matches!(adj.kind, Adjust::Deref(_)))
-            .count();
+            .count()
+            - ref_count;
+
         let (help, sugg) = if deref_count == 0 {
-            ("try removing the `clone` call", snip.into())
-        } else if parent_is_suffix_expr {
+            if check_res == ParentIsSuffixExpr::Yes && snip.starts_with('*') {
+                ("try dereferencing it", format!("({snip})"))
+            } else {
+                ("try removing the `clone` call", snip.into())
+            }
+        } else if check_res == ParentIsSuffixExpr::Yes {
+            // deref_count comes from the original argument `&x`, so we need to decrement `deref_count`.
             ("try dereferencing it", format!("({}{snip})", "*".repeat(deref_count)))
         } else {
             ("try dereferencing it", format!("{}{snip}", "*".repeat(deref_count)))

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5160,6 +5160,7 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
                 io_other_error::check(cx, expr, func, args, self.msrv);
                 swap_with_temporary::check(cx, expr, func, args);
                 ip_constant::check(cx, expr, func, args);
+                clone_on_copy::check_function(cx, expr);
                 unwrap_expect_used::check_call(
                     cx,
                     expr,

--- a/tests/ui-toml/absolute_paths/absolute_paths.allow_crates.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.allow_crates.stderr
@@ -1,5 +1,5 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,31 +11,31 @@ LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:44:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/absolute_paths/absolute_paths.allow_long.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.allow_long.stderr
@@ -1,5 +1,5 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/absolute_paths/absolute_paths.default.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.default.stderr
@@ -1,5 +1,5 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,67 +11,67 @@ LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:37:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:38:13
    |
 LL |     let _ = ::core::clone::Clone::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:40:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:41:13
    |
 LL |     let _ = <i32 as core::clone::Clone>::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:44:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:17
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:66:17
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                 ^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:18
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:71:18
    |
 LL |         where T: core::clone::Clone
    |                  ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:32
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:66:32
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                                ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:116:5
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:117:5
    |
 LL |     crate::m1::S
    |     ^^^^^^^^^^^^

--- a/tests/ui-toml/absolute_paths/absolute_paths.no_short.stderr
+++ b/tests/ui-toml/absolute_paths/absolute_paths.no_short.stderr
@@ -1,5 +1,5 @@
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:14:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:15:13
    |
 LL |     let _ = std::path::is_separator(' ');
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,85 +11,85 @@ LL | #![deny(clippy::absolute_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:20:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:21:13
    |
 LL |     let _ = ::std::path::MAIN_SEPARATOR;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:25:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:26:13
    |
 LL |     let _ = std::collections::hash_map::HashMap::<i32, i32>::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:31
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:31
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |                               ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:28:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:29:13
    |
 LL |     let _: &std::path::Path = std::path::Path::new("");
    |             ^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:37:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:38:13
    |
 LL |     let _ = ::core::clone::Clone::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:40:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:41:13
    |
 LL |     let _ = <i32 as core::clone::Clone>::clone(&0i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:43:13
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:44:13
    |
 LL |     let _ = std::option::Option::None::<i32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:17
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:66:17
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                 ^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:70:18
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:71:18
    |
 LL |         where T: core::clone::Clone
    |                  ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:65:32
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:66:32
    |
 LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                                ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:113:10
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:114:10
    |
 LL | const _: crate::S = {
    |          ^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:114:9
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:115:9
    |
 LL |     let crate::S = m1::S;
    |         ^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:116:5
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:117:5
    |
 LL |     crate::m1::S
    |     ^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:122:14
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:123:14
    |
 LL |     let _ = <crate::S as Clone>::clone(&m1::S);
    |              ^^^^^^^^

--- a/tests/ui-toml/absolute_paths/absolute_paths.rs
+++ b/tests/ui-toml/absolute_paths/absolute_paths.rs
@@ -5,6 +5,7 @@
 //@[allow_long] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/allow_long
 //@[no_short] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/absolute_paths/no_short
 #![deny(clippy::absolute_paths)]
+#![expect(clippy::clone_on_copy)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros, with_span};

--- a/tests/ui/clone_on_copy.fixed
+++ b/tests/ui/clone_on_copy.fixed
@@ -90,6 +90,12 @@ mod issue3052 {
         let a = A;
         let _: E = *****a;
         //~^ clone_on_copy
+        let _: E = *****a;
+        //~^ clone_on_copy
+        let _: E = *****a;
+        //~^ clone_on_copy
+        let _: E = *****a;
+        //~^ clone_on_copy
 
         let _: E = *****a;
     }
@@ -100,11 +106,21 @@ fn issue4348() {
         ch.is_ascii()
     }
 
-    let mut x = 43;
-    let _ = &x.clone(); // ok, getting a ref
     'a'.clone().make_ascii_uppercase(); // ok, clone and then mutate
     is_ascii('z');
     //~^ clone_on_copy
+}
+
+fn issue16969() {
+    let mut x = 43;
+    let _ = &x.clone();
+
+    let _ = &mut x.clone();
+
+    let mut y = &42;
+    let _ = &y.clone();
+
+    let _ = &mut y.clone();
 }
 
 #[expect(clippy::vec_init_then_push)]
@@ -116,8 +132,152 @@ fn issue5436() {
 
 fn issue9277() -> Option<i32> {
     let opt: &Option<i32> = &None;
-    let value = (*opt)?; // operator precedence needed (*opt)?
-    //
-    //~^^ clone_on_copy
+    // operator precedence needed (*opt)?
+    let value = (*opt)?;
+    //~^ clone_on_copy
     None
+}
+
+mod ufcs_clone_on_copy {
+    use std::cell::RefCell;
+
+    fn is_ascii(ch: char) -> bool {
+        ch.is_ascii()
+    }
+
+    #[derive(Clone, Copy)]
+    struct Foo;
+    impl Foo {
+        fn clone(&self) -> u32 {
+            0
+        }
+    }
+
+    macro_rules! m {
+        ($e:expr) => {{ $e }};
+    }
+
+    #[derive(Clone, Copy)]
+    struct Bar {
+        field: i32,
+    }
+
+    struct Wrap([u32; 2]);
+    impl core::ops::Deref for Wrap {
+        type Target = [u32; 2];
+        fn deref(&self) -> &[u32; 2] {
+            &self.0
+        }
+    }
+
+    fn foo(_x: &i32) {}
+
+    fn main() {
+        let mut x = 42_i32;
+
+        let vec = vec![1];
+        let _ = Vec::clone(&vec); // ok, not a Copy type
+        let _ = Clone::clone(&vec); // ok, not a Copy type
+        let opt_vec = Some(vec![1]);
+        let _ = Option::clone(&opt_vec); // ok, not a Copy type
+        let _ = Clone::clone(&opt_vec); // ok, not a Copy type
+
+        let _ = x;
+        //~^ clone_on_copy
+        let _ = x;
+        //~^ clone_on_copy
+        let _ = x;
+        //~^ clone_on_copy
+
+        let ref_ref = &&42_i32;
+        // Clone::clone(ref_ref) and <&i32 as Clone>::clone(ref_ref) both return &i32, so it should be
+        // linted.
+        let _ = *ref_ref;
+        //~^ clone_on_copy
+        let _ = *ref_ref;
+        //~^ clone_on_copy
+
+        let imm_ref = &mut 43_i32;
+        let _ = *imm_ref;
+        //~^ clone_on_copy
+        let _ = *imm_ref;
+        //~^ clone_on_copy
+        let _ = *imm_ref;
+        //~^ clone_on_copy
+
+        let x_ref = &mut x;
+        let _ = *x_ref;
+        //~^ clone_on_copy
+        let _ = *x_ref;
+        //~^ clone_on_copy
+        let _ = *x_ref;
+        //~^ clone_on_copy
+
+        let _ = x.rotate_left(1);
+        //~^ clone_on_copy
+        let _ = x.rotate_left(1);
+        //~^ clone_on_copy
+        let _ = x.rotate_left(1);
+        //~^ clone_on_copy
+
+        char::clone(&'a').make_ascii_uppercase(); // ok, clone and then mutate
+        Clone::clone(&'a').make_ascii_uppercase(); // ok, clone and then mutate
+        <char as Clone>::clone(&'a').make_ascii_uppercase(); // ok, clone and then mutate
+
+        is_ascii('z');
+        //~^ clone_on_copy
+        is_ascii('z');
+        //~^ clone_on_copy
+        is_ascii('z');
+        //~^ clone_on_copy
+
+        let _ = Foo::clone(&Foo); // ok, this is not the clone trait
+
+        let _ = m!(42);
+        //~^ clone_on_copy
+
+        let rc = RefCell::new(0);
+        let _ = *rc.borrow();
+        //~^ clone_on_copy
+
+        let bar = Bar { field: 0 };
+        let _ = bar.field;
+        //~^ clone_on_copy
+
+        let array = [0, 0];
+        let _ = array[0];
+        //~^ clone_on_copy
+
+        let wrapped = Wrap([0, 0]);
+        let _ = (*wrapped)[0];
+        //~^ clone_on_copy
+
+        let _: &i32 = &i32::clone(&x);
+        let _: &i32 = &Clone::clone(&x);
+        let _: &i32 = &<i32 as Clone>::clone(&x);
+
+        let _: &mut i32 = &mut i32::clone(&x);
+        let _: &mut i32 = &mut Clone::clone(&x);
+        let _: &mut i32 = &mut <i32 as Clone>::clone(&x);
+
+        let ref _y = i32::clone(&x); // ok, binds by reference
+        let ref _y = Clone::clone(&x); // ok, binds by reference
+        let ref mut _y = <i32 as Clone>::clone(&x); // ok, binds by reference
+
+        foo(&i32::clone(&x));
+        foo(&Clone::clone(&x));
+        foo(&<i32 as Clone>::clone(&x));
+    }
+
+    fn option_clone_on_copy() -> Option<i32> {
+        let opt: &Option<i32> = &Some(0);
+
+        let _ = (*opt)?;
+        //~^ clone_on_copy
+        let _ = (*opt)?;
+        //~^ clone_on_copy
+        let _ = (*opt)?;
+        //~^ clone_on_copy
+        None
+    }
 }

--- a/tests/ui/clone_on_copy.rs
+++ b/tests/ui/clone_on_copy.rs
@@ -90,6 +90,12 @@ mod issue3052 {
         let a = A;
         let _: E = a.clone();
         //~^ clone_on_copy
+        let _: E = E::clone(&a);
+        //~^ clone_on_copy
+        let _: E = Clone::clone(&a);
+        //~^ clone_on_copy
+        let _: E = <E as Clone>::clone(&a);
+        //~^ clone_on_copy
 
         let _: E = *****a;
     }
@@ -100,11 +106,21 @@ fn issue4348() {
         ch.is_ascii()
     }
 
-    let mut x = 43;
-    let _ = &x.clone(); // ok, getting a ref
     'a'.clone().make_ascii_uppercase(); // ok, clone and then mutate
     is_ascii('z'.clone());
     //~^ clone_on_copy
+}
+
+fn issue16969() {
+    let mut x = 43;
+    let _ = &x.clone();
+
+    let _ = &mut x.clone();
+
+    let mut y = &42;
+    let _ = &y.clone();
+
+    let _ = &mut y.clone();
 }
 
 #[expect(clippy::vec_init_then_push)]
@@ -116,8 +132,152 @@ fn issue5436() {
 
 fn issue9277() -> Option<i32> {
     let opt: &Option<i32> = &None;
-    let value = opt.clone()?; // operator precedence needed (*opt)?
-    //
-    //~^^ clone_on_copy
+    // operator precedence needed (*opt)?
+    let value = opt.clone()?;
+    //~^ clone_on_copy
     None
+}
+
+mod ufcs_clone_on_copy {
+    use std::cell::RefCell;
+
+    fn is_ascii(ch: char) -> bool {
+        ch.is_ascii()
+    }
+
+    #[derive(Clone, Copy)]
+    struct Foo;
+    impl Foo {
+        fn clone(&self) -> u32 {
+            0
+        }
+    }
+
+    macro_rules! m {
+        ($e:expr) => {{ $e }};
+    }
+
+    #[derive(Clone, Copy)]
+    struct Bar {
+        field: i32,
+    }
+
+    struct Wrap([u32; 2]);
+    impl core::ops::Deref for Wrap {
+        type Target = [u32; 2];
+        fn deref(&self) -> &[u32; 2] {
+            &self.0
+        }
+    }
+
+    fn foo(_x: &i32) {}
+
+    fn main() {
+        let mut x = 42_i32;
+
+        let vec = vec![1];
+        let _ = Vec::clone(&vec); // ok, not a Copy type
+        let _ = Clone::clone(&vec); // ok, not a Copy type
+        let opt_vec = Some(vec![1]);
+        let _ = Option::clone(&opt_vec); // ok, not a Copy type
+        let _ = Clone::clone(&opt_vec); // ok, not a Copy type
+
+        let _ = i32::clone(&x);
+        //~^ clone_on_copy
+        let _ = Clone::clone(&x);
+        //~^ clone_on_copy
+        let _ = <i32 as Clone>::clone(&x);
+        //~^ clone_on_copy
+
+        let ref_ref = &&42_i32;
+        // Clone::clone(ref_ref) and <&i32 as Clone>::clone(ref_ref) both return &i32, so it should be
+        // linted.
+        let _ = Clone::clone(ref_ref);
+        //~^ clone_on_copy
+        let _ = <&i32 as Clone>::clone(ref_ref);
+        //~^ clone_on_copy
+
+        let imm_ref = &mut 43_i32;
+        let _ = i32::clone(&*imm_ref);
+        //~^ clone_on_copy
+        let _ = Clone::clone(&*imm_ref);
+        //~^ clone_on_copy
+        let _ = <i32 as Clone>::clone(&*imm_ref);
+        //~^ clone_on_copy
+
+        let x_ref = &mut x;
+        let _ = i32::clone(&*x_ref);
+        //~^ clone_on_copy
+        let _ = Clone::clone(&*x_ref);
+        //~^ clone_on_copy
+        let _ = <i32 as Clone>::clone(&*x_ref);
+        //~^ clone_on_copy
+
+        let _ = i32::clone(&x).rotate_left(1);
+        //~^ clone_on_copy
+        let _ = Clone::clone(&x).rotate_left(1);
+        //~^ clone_on_copy
+        let _ = <i32 as Clone>::clone(&x).rotate_left(1);
+        //~^ clone_on_copy
+
+        char::clone(&'a').make_ascii_uppercase(); // ok, clone and then mutate
+        Clone::clone(&'a').make_ascii_uppercase(); // ok, clone and then mutate
+        <char as Clone>::clone(&'a').make_ascii_uppercase(); // ok, clone and then mutate
+
+        is_ascii(char::clone(&'z'));
+        //~^ clone_on_copy
+        is_ascii(Clone::clone(&'z'));
+        //~^ clone_on_copy
+        is_ascii(<char as Clone>::clone(&'z'));
+        //~^ clone_on_copy
+
+        let _ = Foo::clone(&Foo); // ok, this is not the clone trait
+
+        let _ = Clone::clone(&m!(42));
+        //~^ clone_on_copy
+
+        let rc = RefCell::new(0);
+        let _ = Clone::clone(&*rc.borrow());
+        //~^ clone_on_copy
+
+        let bar = Bar { field: 0 };
+        let _ = Clone::clone(&bar).field;
+        //~^ clone_on_copy
+
+        let array = [0, 0];
+        let _ = Clone::clone(&array)[0];
+        //~^ clone_on_copy
+
+        let wrapped = Wrap([0, 0]);
+        let _ = Clone::clone(&*wrapped)[0];
+        //~^ clone_on_copy
+
+        let _: &i32 = &i32::clone(&x);
+        let _: &i32 = &Clone::clone(&x);
+        let _: &i32 = &<i32 as Clone>::clone(&x);
+
+        let _: &mut i32 = &mut i32::clone(&x);
+        let _: &mut i32 = &mut Clone::clone(&x);
+        let _: &mut i32 = &mut <i32 as Clone>::clone(&x);
+
+        let ref _y = i32::clone(&x); // ok, binds by reference
+        let ref _y = Clone::clone(&x); // ok, binds by reference
+        let ref mut _y = <i32 as Clone>::clone(&x); // ok, binds by reference
+
+        foo(&i32::clone(&x));
+        foo(&Clone::clone(&x));
+        foo(&<i32 as Clone>::clone(&x));
+    }
+
+    fn option_clone_on_copy() -> Option<i32> {
+        let opt: &Option<i32> = &Some(0);
+
+        let _ = Option::clone(opt)?;
+        //~^ clone_on_copy
+        let _ = Clone::clone(opt)?;
+        //~^ clone_on_copy
+        let _ = <Option<i32> as Clone>::clone(opt)?;
+        //~^ clone_on_copy
+        None
+    }
 }

--- a/tests/ui/clone_on_copy.stderr
+++ b/tests/ui/clone_on_copy.stderr
@@ -43,23 +43,191 @@ error: using `clone` on type `E` which implements the `Copy` trait
 LL |         let _: E = a.clone();
    |                    ^^^^^^^^^ help: try dereferencing it: `*****a`
 
+error: using `clone` on type `E` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:93:20
+   |
+LL |         let _: E = E::clone(&a);
+   |                    ^^^^^^^^^^^^ help: try dereferencing it: `*****a`
+
+error: using `clone` on type `E` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:95:20
+   |
+LL |         let _: E = Clone::clone(&a);
+   |                    ^^^^^^^^^^^^^^^^ help: try dereferencing it: `*****a`
+
+error: using `clone` on type `E` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:97:20
+   |
+LL |         let _: E = <E as Clone>::clone(&a);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `*****a`
+
 error: using `clone` on type `char` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:106:14
+  --> tests/ui/clone_on_copy.rs:110:14
    |
 LL |     is_ascii('z'.clone());
    |              ^^^^^^^^^^^ help: try removing the `clone` call: `'z'`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:113:14
+  --> tests/ui/clone_on_copy.rs:129:14
    |
 LL |     vec.push(42.clone());
    |              ^^^^^^^^^^ help: try removing the `clone` call: `42`
 
 error: using `clone` on type `Option<i32>` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:119:17
+  --> tests/ui/clone_on_copy.rs:136:17
    |
-LL |     let value = opt.clone()?; // operator precedence needed (*opt)?
+LL |     let value = opt.clone()?;
    |                 ^^^^^^^^^^^ help: try dereferencing it: `(*opt)`
 
-error: aborting due to 10 previous errors
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:185:17
+   |
+LL |         let _ = i32::clone(&x);
+   |                 ^^^^^^^^^^^^^^ help: try removing the `clone` call: `x`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:187:17
+   |
+LL |         let _ = Clone::clone(&x);
+   |                 ^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `x`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:189:17
+   |
+LL |         let _ = <i32 as Clone>::clone(&x);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `x`
+
+error: using `clone` on type `&i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:195:17
+   |
+LL |         let _ = Clone::clone(ref_ref);
+   |                 ^^^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `*ref_ref`
+
+error: using `clone` on type `&i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:197:17
+   |
+LL |         let _ = <&i32 as Clone>::clone(ref_ref);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `*ref_ref`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:201:17
+   |
+LL |         let _ = i32::clone(&*imm_ref);
+   |                 ^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `*imm_ref`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:203:17
+   |
+LL |         let _ = Clone::clone(&*imm_ref);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `*imm_ref`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:205:17
+   |
+LL |         let _ = <i32 as Clone>::clone(&*imm_ref);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `*imm_ref`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:209:17
+   |
+LL |         let _ = i32::clone(&*x_ref);
+   |                 ^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `*x_ref`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:211:17
+   |
+LL |         let _ = Clone::clone(&*x_ref);
+   |                 ^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `*x_ref`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:213:17
+   |
+LL |         let _ = <i32 as Clone>::clone(&*x_ref);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `*x_ref`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:216:17
+   |
+LL |         let _ = i32::clone(&x).rotate_left(1);
+   |                 ^^^^^^^^^^^^^^ help: try removing the `clone` call: `x`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:218:17
+   |
+LL |         let _ = Clone::clone(&x).rotate_left(1);
+   |                 ^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `x`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:220:17
+   |
+LL |         let _ = <i32 as Clone>::clone(&x).rotate_left(1);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `x`
+
+error: using `clone` on type `char` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:227:18
+   |
+LL |         is_ascii(char::clone(&'z'));
+   |                  ^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `'z'`
+
+error: using `clone` on type `char` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:229:18
+   |
+LL |         is_ascii(Clone::clone(&'z'));
+   |                  ^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `'z'`
+
+error: using `clone` on type `char` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:231:18
+   |
+LL |         is_ascii(<char as Clone>::clone(&'z'));
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `'z'`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:236:17
+   |
+LL |         let _ = Clone::clone(&m!(42));
+   |                 ^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `m!(42)`
+
+error: using `clone` on type `i32` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:240:17
+   |
+LL |         let _ = Clone::clone(&*rc.borrow());
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `*rc.borrow()`
+
+error: using `clone` on type `Bar` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:244:17
+   |
+LL |         let _ = Clone::clone(&bar).field;
+   |                 ^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `bar`
+
+error: using `clone` on type `[i32; 2]` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:248:17
+   |
+LL |         let _ = Clone::clone(&array)[0];
+   |                 ^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `array`
+
+error: using `clone` on type `[u32; 2]` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:252:17
+   |
+LL |         let _ = Clone::clone(&*wrapped)[0];
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `(*wrapped)`
+
+error: using `clone` on type `Option<i32>` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:275:17
+   |
+LL |         let _ = Option::clone(opt)?;
+   |                 ^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `(*opt)`
+
+error: using `clone` on type `Option<i32>` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:277:17
+   |
+LL |         let _ = Clone::clone(opt)?;
+   |                 ^^^^^^^^^^^^^^^^^ help: try dereferencing it: `(*opt)`
+
+error: using `clone` on type `Option<i32>` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:279:17
+   |
+LL |         let _ = <Option<i32> as Clone>::clone(opt)?;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `(*opt)`
+
+error: aborting due to 38 previous errors
 


### PR DESCRIPTION
changelog: [`clone_on_copy`] lints for UFCS call like `Clone::clone()` and `i32::clone()`

Fixes rust-lang/rust-clippy#16969 
