### PR TITLE
feat(lint): Add `missing_no_std_attribute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6984,6 +6984,7 @@ Released 2018-09-13
 [`missing_errors_doc`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
 [`missing_fields_in_debug`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_fields_in_debug
 [`missing_inline_in_public_items`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_inline_in_public_items
+[`missing_no_std_attribute`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_no_std_attribute
 [`missing_panics_doc`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc
 [`missing_safety_doc`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc
 [`missing_spin_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_spin_loop

--- a/clippy_lints/src/attrs/missing_no_std_attribute.rs
+++ b/clippy_lints/src/attrs/missing_no_std_attribute.rs
@@ -1,0 +1,45 @@
+use super::{Attribute, MISSING_NO_STD_ATTRIBUTE};
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::sym;
+use rustc_ast::Crate;
+use rustc_errors::Applicability;
+use rustc_hir::AttrStyle;
+use rustc_lint::EarlyContext;
+
+pub fn check(cx: &EarlyContext<'_>, krate: &Crate) {
+    if !krate
+        .attrs
+        .iter()
+        .any(|attr| is_no_std_attribute(attr) || is_cfg_attr_no_std_attribute(attr))
+    {
+        span_lint_and_sugg(
+            cx,
+            MISSING_NO_STD_ATTRIBUTE,
+            krate.spans.inject_use_span,
+            "missing `#![no_std]` attribute",
+            "use",
+            "#![no_std]\nextern crate std;\n".to_string(),
+            Applicability::MaybeIncorrect,
+        );
+    }
+}
+
+/// Checks if `attr` is of the form `#![no_std]`
+fn is_no_std_attribute(attr: &Attribute) -> bool {
+    attr.has_name(sym::no_std) && attr.style == AttrStyle::Inner
+}
+
+/// Checks if `attr` is of the form `#![cfg_attr(_, ..., no_std, ...)]`
+fn is_cfg_attr_no_std_attribute(attr: &Attribute) -> bool {
+    attr.has_any_name(&[sym::cfg_attr, sym::cfg_attr_trace])
+        && attr.style == AttrStyle::Inner
+        && attr
+            .meta_item_list()
+            .as_ref()
+            .map(|items| items.iter())
+            .into_iter()
+            .flatten()
+            .skip(1)
+            .filter_map(|item| item.meta_item())
+            .any(|item| item.has_name(sym::no_std))
+}

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -5,6 +5,7 @@ mod deprecated_cfg_attr;
 mod deprecated_semver;
 mod duplicated_attributes;
 mod inline_always;
+mod missing_no_std_attribute;
 mod mixed_attributes_style;
 mod non_minimal_cfg;
 mod repr_attributes;
@@ -269,6 +270,39 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks if a crate does not have a `#![no_std]` attribute.
+    ///
+    /// ### Why is this bad?
+    /// Adding `#![no_std]` changes the implicit prelude to `core::prelude`, making
+    /// usage of `std` more explicit, and thus easier to migrate to `no_std`-compatible
+    /// alternatives.
+    ///
+    /// ### Known Issues
+    /// If the crate is currently relying on implicit imports exclusive to `std::prelude`
+    ///
+    /// ### Example
+    /// ```rust,ignore
+    /// ///! My awesome library!
+    ///
+    /// pub struct Foo;
+    /// ```
+    /// Use instead:
+    /// ```rust,ignore
+    /// ///! My awesome library!
+    ///
+    /// #![no_std]
+    /// extern crate std;
+    ///
+    /// pub struct Foo;
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub MISSING_NO_STD_ATTRIBUTE,
+    nursery,
+    "missing `#![no_std]` attribute"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for items that have the same kind of attributes with mixed styles (inner/outer).
     ///
     /// ### Why is this bad?
@@ -483,6 +517,7 @@ impl_lint_pass!(Attributes => [INLINE_ALWAYS, REPR_PACKED_WITHOUT_ABI]);
 impl_lint_pass!(EarlyAttributes => [
     DEPRECATED_CFG_ATTR,
     DEPRECATED_CLIPPY_CFG_ATTR,
+    MISSING_NO_STD_ATTRIBUTE,
     NON_MINIMAL_CFG,
     UNNECESSARY_CLIPPY_CFG,
 ]);
@@ -553,6 +588,10 @@ impl EarlyLintPass for EarlyAttributes {
     }
 
     extract_msrv_attr!();
+
+    fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &ast::Crate) {
+        missing_no_std_attribute::check(cx, krate);
+    }
 }
 
 pub struct PostExpansionEarlyAttributes {

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -24,6 +24,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::attrs::DUPLICATED_ATTRIBUTES_INFO,
     crate::attrs::IGNORE_WITHOUT_REASON_INFO,
     crate::attrs::INLINE_ALWAYS_INFO,
+    crate::attrs::MISSING_NO_STD_ATTRIBUTE_INFO,
     crate::attrs::MIXED_ATTRIBUTES_STYLE_INFO,
     crate::attrs::NON_MINIMAL_CFG_INFO,
     crate::attrs::REPR_PACKED_WITHOUT_ABI_INFO,

--- a/tests/ui/missing_no_std_attribute.fixed
+++ b/tests/ui/missing_no_std_attribute.fixed
@@ -1,0 +1,17 @@
+#![warn(clippy::missing_no_std_attribute)]
+
+#![no_std]
+extern crate std;
+pub const FOO: Foo = Foo; //~missing_no_std_attribute
+
+mod foo {
+    pub struct Foo;
+}
+
+pub use foo::Foo;
+
+use core::fmt::Debug as _;
+
+fn main() {
+    // test code goes here
+}

--- a/tests/ui/missing_no_std_attribute.rs
+++ b/tests/ui/missing_no_std_attribute.rs
@@ -1,0 +1,15 @@
+#![warn(clippy::missing_no_std_attribute)]
+
+pub const FOO: Foo = Foo; //~missing_no_std_attribute
+
+mod foo {
+    pub struct Foo;
+}
+
+pub use foo::Foo;
+
+use core::fmt::Debug as _;
+
+fn main() {
+    // test code goes here
+}

--- a/tests/ui/missing_no_std_attribute.stderr
+++ b/tests/ui/missing_no_std_attribute.stderr
@@ -1,0 +1,16 @@
+error: missing `#![no_std]` attribute
+  --> tests/ui/missing_no_std_attribute.rs:3:1
+   |
+LL | pub const FOO: Foo = Foo;
+   | ^
+   |
+   = note: `-D clippy::missing-no-std-attribute` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_no_std_attribute)]`
+help: use
+   |
+LL + #![no_std]
+LL + extern crate std;
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/missing_no_std_attribute_cfg_attr.rs
+++ b/tests/ui/missing_no_std_attribute_cfg_attr.rs
@@ -1,0 +1,17 @@
+//@check-pass
+#![warn(clippy::missing_no_std_attribute)]
+#![cfg_attr(false, no_std)]
+
+pub const FOO: Foo = Foo;
+
+mod foo {
+    pub struct Foo;
+}
+
+pub use foo::Foo;
+
+use core::fmt::Debug as _;
+
+fn main() {
+    // test code goes here
+}

--- a/tests/ui/missing_no_std_attribute_no_std.rs
+++ b/tests/ui/missing_no_std_attribute_no_std.rs
@@ -1,0 +1,19 @@
+//@check-pass
+#![warn(clippy::missing_no_std_attribute)]
+#![no_std]
+
+extern crate std;
+
+pub const FOO: Foo = Foo;
+
+mod foo {
+    pub struct Foo;
+}
+
+pub use foo::Foo;
+
+use core::fmt::Debug as _;
+
+fn main() {
+    // test code goes here
+}


### PR DESCRIPTION
# Objective

- Contributes to rust-lang/rust-clippy#1569

## Details

This lint checks if a crate does not contain the `#![no_std]` attribute (either bare or through `cfg_attr`) and suggests adding both it and `extern crate std;`.

```diff
+ #![no_std]
+ extern crate std;
```

This suggestion is inserted at the [`ModSpans::inject_use_span`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/ast/struct.ModSpans.html#structfield.inject_use_span) point.

## Notes

- No AI tooling of any kind was used during the creation of this PR.
- This suggestion can fail if the crate currently relies on items through and exclusive to the `std::prelude`. I have marked it as `Applicability::MaybeIncorrect` to reflect this.

---

changelog: [`missing_no_std_attribute`]: add new lint for lack of `#![no_std]` attribute
