### PR TITLE
remove dswij from rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -94,6 +94,7 @@ users_on_vacation = [
     "Alexendoo",
     "y21",
     "blyxyas",
+    "dswij",
 ]
 
 [assign.owners]


### PR DESCRIPTION
Will be unavailable until 22nd May.

changelog: none

r? @ghost