### PR TITLE
Avoid ICE when evaluating constants containing unsized type args

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -885,12 +885,17 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
             _ => return None,
         };
 
+        let args = self.typeck.node_args(id);
+        // We must use the const's own TypingEnv here.
+        // If we rely on the caller, a 'where Self: Sized' bound
+        // could trick us into thinking an unsized type is safe, triggering ICE later.
+        let const_typing_env = ty::TypingEnv::post_analysis(self.tcx, did);
+        if args.types().any(|ty| !ty.is_sized(self.tcx, const_typing_env)) {
+            return None;
+        }
+
         self.tcx
-            .const_eval_resolve(
-                self.typing_env,
-                mir::UnevaluatedConst::new(did, self.typeck.node_args(id)),
-                qpath.span(),
-            )
+            .const_eval_resolve(self.typing_env, mir::UnevaluatedConst::new(did, args), qpath.span())
             .ok()
     }
 

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -885,17 +885,22 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
             _ => return None,
         };
 
-        let args = self.typeck.node_args(id);
-        // We must use the const's own TypingEnv here.
-        // If we rely on the caller, a 'where Self: Sized' bound
-        // could trick us into thinking an unsized type is safe, triggering ICE later.
-        let const_typing_env = ty::TypingEnv::post_analysis(self.tcx, did);
-        if args.types().any(|ty| !ty.is_sized(self.tcx, const_typing_env)) {
+        let owner_def_id = self.typeck.hir_owner.def_id.to_def_id();
+        let identity_args = ty::GenericArgs::identity_for_item(self.tcx, owner_def_id);
+        // Don't try to fully evaluate consts inside code whose bounds can't be satisfied.
+        if self
+            .tcx
+            .instantiate_and_check_impossible_predicates((owner_def_id, identity_args))
+        {
             return None;
         }
 
         self.tcx
-            .const_eval_resolve(self.typing_env, mir::UnevaluatedConst::new(did, args), qpath.span())
+            .const_eval_resolve(
+                self.typing_env,
+                mir::UnevaluatedConst::new(did, self.typeck.node_args(id)),
+                qpath.span(),
+            )
             .ok()
     }
 

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -885,22 +885,22 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
             _ => return None,
         };
 
-        let owner_def_id = self.typeck.hir_owner.def_id.to_def_id();
-        let identity_args = ty::GenericArgs::identity_for_item(self.tcx, owner_def_id);
-        // Don't try to fully evaluate consts inside code whose bounds can't be satisfied.
-        if self
-            .tcx
-            .instantiate_and_check_impossible_predicates((owner_def_id, identity_args))
-        {
-            return None;
+        let args = self.typeck.node_args(id);
+
+        if !args.is_empty() {
+            let owner_def_id = self.typeck.hir_owner.def_id.to_def_id();
+            let identity_args = ty::GenericArgs::identity_for_item(self.tcx, owner_def_id);
+            // Don't try to fully evaluate consts inside code whose bounds can't be satisfied.
+            if self
+                .tcx
+                .instantiate_and_check_impossible_predicates((owner_def_id, identity_args))
+            {
+                return None;
+            }
         }
 
         self.tcx
-            .const_eval_resolve(
-                self.typing_env,
-                mir::UnevaluatedConst::new(did, self.typeck.node_args(id)),
-                qpath.span(),
-            )
+            .const_eval_resolve(self.typing_env, mir::UnevaluatedConst::new(did, args), qpath.span())
             .ok()
     }
 

--- a/tests/ui/crashes/ice-16950.rs
+++ b/tests/ui/crashes/ice-16950.rs
@@ -1,0 +1,28 @@
+//@check-pass
+#![feature(trivial_bounds)]
+#![allow(dead_code)]
+
+struct Helper<T>(T);
+
+trait Unsized<T: ?Sized> {
+    const SIZE: usize = usize::MAX;
+}
+
+impl<T: ?Sized> Unsized<T> for T {}
+
+impl<T> Helper<T> {
+    const SIZE: usize = size_of::<T>();
+}
+
+struct TrickClippy(str);
+
+impl TrickClippy {
+    fn trick_clippy() -> bool
+    where
+        Self: Sized,
+    {
+        Helper::<Self>::SIZE == str::SIZE
+    }
+}
+
+fn main() {}

--- a/tests/ui/crashes/ice-16950.rs
+++ b/tests/ui/crashes/ice-16950.rs
@@ -1,6 +1,5 @@
 //@check-pass
 #![feature(trivial_bounds)]
-#![allow(dead_code)]
 
 struct Helper<T>(T);
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16690 

changelog: [`absurd_extreme_comparisons`]: avoid ICE when const evaluation encounters unsized generic type args.
