### PR TITLE
fix: [`suboptimal_flops`] false negative with ambiguous float literals

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic/lib.rs
+++ b/clippy_lints/src/floating_point_arithmetic/lib.rs
@@ -5,13 +5,15 @@ use rustc_hir::{Expr, ExprKind, UnOp};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
 
-// Adds type suffixes and parenthesis to method receivers if necessary
+// Adds type suffixes and parenthesis to method receivers if necessary, and returns whether a suffix
+// was added.
 pub(super) fn prepare_receiver_sugg<'a>(
     cx: &LateContext<'_>,
     mut expr: &'a Expr<'a>,
     app: &mut Applicability,
-) -> Sugg<'a> {
+) -> (Sugg<'a>, bool) {
     let mut suggestion = Sugg::hir_with_applicability(cx, expr, "_", app);
+    let mut suffix_was_added = false;
 
     if let ExprKind::Unary(UnOp::Neg, inner_expr) = expr.kind {
         expr = inner_expr;
@@ -36,7 +38,8 @@ pub(super) fn prepare_receiver_sugg<'a>(
             Sugg::MaybeParen(_) | Sugg::UnOp(UnOp::Neg, _) => Sugg::MaybeParen(op),
             _ => Sugg::NonParen(op),
         };
+        suffix_was_added = true;
     }
 
-    suggestion.maybe_paren()
+    (suggestion.maybe_paren(), suffix_was_added)
 }

--- a/clippy_lints/src/floating_point_arithmetic/ln1p.rs
+++ b/clippy_lints/src/floating_point_arithmetic/ln1p.rs
@@ -33,7 +33,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>) 
             "ln(1 + x) can be computed more accurately",
             |diag| {
                 let mut app = Applicability::MachineApplicable;
-                let recv = super::lib::prepare_receiver_sugg(cx, recv, &mut app);
+                let (recv, _) = super::lib::prepare_receiver_sugg(cx, recv, &mut app);
                 diag.span_suggestion(expr.span, "consider using", format!("{recv}.ln_1p()"), app);
             },
         );

--- a/clippy_lints/src/floating_point_arithmetic/mul_add.rs
+++ b/clippy_lints/src/floating_point_arithmetic/mul_add.rs
@@ -1,10 +1,12 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{get_parent_expr, has_ambiguous_literal_in_expr, sym};
+use clippy_utils::ty::expr_type_is_certain;
+use clippy_utils::{get_parent_expr, sym};
 use rustc_ast::AssignOpKind;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, PathSegment};
 use rustc_lint::LateContext;
+use rustc_middle::ty;
 use rustc_span::Spanned;
 
 use super::SUBOPTIMAL_FLOPS;
@@ -65,24 +67,15 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
         return;
     }
 
-    // Check if any variable in the expression has an ambiguous type (could be f32 or f64)
-    // see: https://github.com/rust-lang/rust-clippy/issues/14897
-    let has_ambiguous_type = |expr: &Expr<'_>| {
-        (matches!(expr.kind, ExprKind::Path(_)) || matches!(expr.kind, ExprKind::Call(_, _)))
-            && has_ambiguous_literal_in_expr(cx, expr)
-    };
-
-    let (recv, arg1, arg2, is_from_rhs) = if let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, rhs)
-        && cx.typeck_results().expr_ty(lhs).is_floating_point()
-        && !has_ambiguous_type(inner_lhs)
+    let (recv, arg1, arg2, is_from_rhs, lhs_typ) = if let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, rhs)
+        && let ty::Float(float_ty) = cx.typeck_results().expr_ty(lhs).kind()
     {
-        (inner_lhs, inner_rhs, lhs, true)
+        (inner_lhs, inner_rhs, lhs, true, float_ty)
     } else if !is_assign
         && let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, lhs)
-        && cx.typeck_results().expr_ty(rhs).is_floating_point()
-        && !has_ambiguous_type(inner_lhs)
+        && let ty::Float(float_ty) = cx.typeck_results().expr_ty(rhs).kind()
     {
-        (inner_lhs, inner_rhs, rhs, false)
+        (inner_lhs, inner_rhs, rhs, false, float_ty)
     } else {
         return;
     };
@@ -98,7 +91,9 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
                 if let BinOpKind::Sub = op { -sugg } else { sugg }
             };
             let mut app = Applicability::MachineApplicable;
-            let recv_sugg = super::lib::prepare_receiver_sugg(cx, recv, &mut app);
+
+            let (recv_sugg, suffix_was_added) = super::lib::prepare_receiver_sugg(cx, recv, &mut app);
+
             let (arg1, arg2) = if is_from_rhs {
                 (
                     maybe_neg_sugg(arg1, &mut app),
@@ -110,13 +105,21 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
                     maybe_neg_sugg(arg2, &mut app),
                 )
             };
+
+            let mul_add_call = if suffix_was_added || expr_type_is_certain(cx, recv) {
+                format!("{recv_sugg}.mul_add({arg1}, {arg2})")
+            } else {
+                // If the receiver contains an ambiguous literal, we need to call `mul_add` with its inferred type.
+                format!("{}::mul_add({recv_sugg}, {arg1}, {arg2})", lhs_typ.name_str())
+            };
+
             diag.span_suggestion(
                 expr.span,
                 "consider using",
                 if is_assign {
-                    format!("{arg2} = {recv_sugg}.mul_add({arg1}, {arg2})")
+                    format!("{arg2} = {mul_add_call}")
                 } else {
-                    format!("{recv_sugg}.mul_add({arg1}, {arg2})")
+                    mul_add_call
                 },
                 app,
             );

--- a/clippy_lints/src/floating_point_arithmetic/powf.rs
+++ b/clippy_lints/src/floating_point_arithmetic/powf.rs
@@ -54,7 +54,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>, 
             "exponent for bases 2 and e can be computed more accurately",
             |diag| {
                 let mut app = Applicability::MachineApplicable;
-                let recv = super::lib::prepare_receiver_sugg(cx, &args[0], &mut app);
+                let (recv, _) = super::lib::prepare_receiver_sugg(cx, &args[0], &mut app);
                 diag.span_suggestion(expr.span, "consider using", format!("{recv}.{method}()"), app);
             },
         );

--- a/tests/ui/floating_point_mul_add.fixed
+++ b/tests/ui/floating_point_mul_add.fixed
@@ -72,32 +72,46 @@ fn _issue11831() {
 
 fn _issue14897() {
     let x = 1.0;
-    let _ = x * 2.0 + 0.5; // should not suggest mul_add
-    let _ = 0.5 + x * 2.0; // should not suggest mul_add
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
-    let _ = 1.2 + x * 1.2; // should not suggest mul_add
+    let _ = f64::mul_add(x, 2.0, 0.5);
+    //~^ suboptimal_flops
+
+    let x = 1.0;
+    let _ = f64::mul_add(x, 2.0, 0.5);
+    //~^ suboptimal_flops
+    let _ = f64::mul_add(x, 1.2, 0.5);
+    //~^ suboptimal_flops
+    let _ = f64::mul_add(x, 1.2, 1.2);
+    //~^ suboptimal_flops
 
     let x = -1.0;
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = f64::mul_add(x, 1.2, 0.5);
+    //~^ suboptimal_flops
 
     let x = { 4.0 };
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = f64::mul_add(x, 1.2, 0.5);
+    //~^ suboptimal_flops
 
     let x = if 1 > 2 { 1.0 } else { 2.0 };
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = f64::mul_add(x, 1.2, 0.5);
+    //~^ suboptimal_flops
 
     let x = 2.4 + 1.2;
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = f64::mul_add(x, 1.2, 0.5);
+    //~^ suboptimal_flops
 
     let f = || 4.0;
     let x = f();
-    let _ = 0.5 + f() * 1.2; // should not suggest mul_add
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = f64::mul_add(f(), 1.2, 0.5);
+    //~^ suboptimal_flops
+
+    let _ = f64::mul_add(x, 1.2, 0.5);
+    //~^ suboptimal_flops
 
     let x = 0.1;
     let y = x;
     let z = y;
-    let _ = 0.5 + z * 1.2; // should not suggest mul_add
+    let _ = f64::mul_add(z, 1.2, 0.5);
+    //~^ suboptimal_flops
 
     let _ = 2.0f64.mul_add(x, 0.5);
     //~^ suboptimal_flops
@@ -123,5 +137,42 @@ fn issue16573() {
     //~^ suboptimal_flops
 
     a = b.mul_add(-c, a);
+    //~^ suboptimal_flops
+}
+
+fn issue16954() {
+    let k = 2.0_f32;
+
+    let k3 = k * k * k;
+    let y = k3 + 0.1;
+    let _ = y.mul_add(-0.3, 1.0);
+    //~^ suboptimal_flops
+
+    let k3 = k * k * k;
+    let y = k3 + 0.1_f32;
+    let _ = y.mul_add(-0.3, 1.0);
+    //~^ suboptimal_flops
+
+    let k3 = k * k * k;
+    let y: f32 = k3 + 0.1;
+    let _ = y.mul_add(-0.3, 1.0);
+    //~^ suboptimal_flops
+
+    const OFFSET: f32 = 0.1;
+    let k3 = k * k * k;
+    let y = k3 + OFFSET;
+    let _ = y.mul_add(-0.3, 1.0);
+    //~^ suboptimal_flops
+
+    let x = 0.1;
+    let y = 0.2;
+    let z = 0.3;
+    let _ = f32::mul_add(y, z, x);
+    //~^ suboptimal_flops
+    let _ = f32::mul_add(y, z, x);
+    //~^ suboptimal_flops
+
+    let a: f32 = 0.1;
+    let _ = a.mul_add(z, y);
     //~^ suboptimal_flops
 }

--- a/tests/ui/floating_point_mul_add.rs
+++ b/tests/ui/floating_point_mul_add.rs
@@ -72,32 +72,46 @@ fn _issue11831() {
 
 fn _issue14897() {
     let x = 1.0;
-    let _ = x * 2.0 + 0.5; // should not suggest mul_add
-    let _ = 0.5 + x * 2.0; // should not suggest mul_add
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
-    let _ = 1.2 + x * 1.2; // should not suggest mul_add
+    let _ = x * 2.0 + 0.5;
+    //~^ suboptimal_flops
+
+    let x = 1.0;
+    let _ = 0.5 + x * 2.0;
+    //~^ suboptimal_flops
+    let _ = 0.5 + x * 1.2;
+    //~^ suboptimal_flops
+    let _ = 1.2 + x * 1.2;
+    //~^ suboptimal_flops
 
     let x = -1.0;
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = 0.5 + x * 1.2;
+    //~^ suboptimal_flops
 
     let x = { 4.0 };
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = 0.5 + x * 1.2;
+    //~^ suboptimal_flops
 
     let x = if 1 > 2 { 1.0 } else { 2.0 };
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = 0.5 + x * 1.2;
+    //~^ suboptimal_flops
 
     let x = 2.4 + 1.2;
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = 0.5 + x * 1.2;
+    //~^ suboptimal_flops
 
     let f = || 4.0;
     let x = f();
-    let _ = 0.5 + f() * 1.2; // should not suggest mul_add
-    let _ = 0.5 + x * 1.2; // should not suggest mul_add
+    let _ = 0.5 + f() * 1.2;
+    //~^ suboptimal_flops
+
+    let _ = 0.5 + x * 1.2;
+    //~^ suboptimal_flops
 
     let x = 0.1;
     let y = x;
     let z = y;
-    let _ = 0.5 + z * 1.2; // should not suggest mul_add
+    let _ = 0.5 + z * 1.2;
+    //~^ suboptimal_flops
 
     let _ = 0.5 + 2.0 * x;
     //~^ suboptimal_flops
@@ -123,5 +137,42 @@ fn issue16573() {
     //~^ suboptimal_flops
 
     a -= b * c;
+    //~^ suboptimal_flops
+}
+
+fn issue16954() {
+    let k = 2.0_f32;
+
+    let k3 = k * k * k;
+    let y = k3 + 0.1;
+    let _ = 1.0 - y * 0.3;
+    //~^ suboptimal_flops
+
+    let k3 = k * k * k;
+    let y = k3 + 0.1_f32;
+    let _ = 1.0 - y * 0.3;
+    //~^ suboptimal_flops
+
+    let k3 = k * k * k;
+    let y: f32 = k3 + 0.1;
+    let _ = 1.0 - y * 0.3;
+    //~^ suboptimal_flops
+
+    const OFFSET: f32 = 0.1;
+    let k3 = k * k * k;
+    let y = k3 + OFFSET;
+    let _ = 1.0 - y * 0.3;
+    //~^ suboptimal_flops
+
+    let x = 0.1;
+    let y = 0.2;
+    let z = 0.3;
+    let _ = x + y * z;
+    //~^ suboptimal_flops
+    let _ = y * z + x;
+    //~^ suboptimal_flops
+
+    let a: f32 = 0.1;
+    let _ = y + a * z;
     //~^ suboptimal_flops
 }

--- a/tests/ui/floating_point_mul_add.stderr
+++ b/tests/ui/floating_point_mul_add.stderr
@@ -81,46 +81,154 @@ LL |     let _ = a - (b * u as f64);
    |             ^^^^^^^^^^^^^^^^^^ help: consider using: `b.mul_add(-(u as f64), a)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:102:13
+  --> tests/ui/floating_point_mul_add.rs:75:13
+   |
+LL |     let _ = x * 2.0 + 0.5;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 2.0, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:79:13
+   |
+LL |     let _ = 0.5 + x * 2.0;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 2.0, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:81:13
+   |
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:83:13
+   |
+LL |     let _ = 1.2 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 1.2)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:87:13
+   |
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:91:13
+   |
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:95:13
+   |
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:99:13
+   |
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:104:13
+   |
+LL |     let _ = 0.5 + f() * 1.2;
+   |             ^^^^^^^^^^^^^^^ help: consider using: `f64::mul_add(f(), 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:107:13
+   |
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:113:13
+   |
+LL |     let _ = 0.5 + z * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(z, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:116:13
    |
 LL |     let _ = 0.5 + 2.0 * x;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(x, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:104:13
+  --> tests/ui/floating_point_mul_add.rs:118:13
    |
 LL |     let _ = 2.0 * x + 0.5;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(x, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:107:13
+  --> tests/ui/floating_point_mul_add.rs:121:13
    |
 LL |     let _ = x + 2.0 * 4.0;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4.0, x)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:111:13
+  --> tests/ui/floating_point_mul_add.rs:125:13
    |
 LL |     let _ = y * 2.0 + 0.5;
    |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(2.0, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:113:13
+  --> tests/ui/floating_point_mul_add.rs:127:13
    |
 LL |     let _ = 1.0 * 2.0 + 0.5;
    |             ^^^^^^^^^^^^^^^ help: consider using: `1.0f64.mul_add(2.0, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:122:5
+  --> tests/ui/floating_point_mul_add.rs:136:5
    |
 LL |     a += b * c;
    |     ^^^^^^^^^^ help: consider using: `a = b.mul_add(c, a)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:125:5
+  --> tests/ui/floating_point_mul_add.rs:139:5
    |
 LL |     a -= b * c;
    |     ^^^^^^^^^^ help: consider using: `a = b.mul_add(-c, a)`
 
-error: aborting due to 20 previous errors
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:148:13
+   |
+LL |     let _ = 1.0 - y * 0.3;
+   |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(-0.3, 1.0)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:153:13
+   |
+LL |     let _ = 1.0 - y * 0.3;
+   |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(-0.3, 1.0)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:158:13
+   |
+LL |     let _ = 1.0 - y * 0.3;
+   |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(-0.3, 1.0)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:164:13
+   |
+LL |     let _ = 1.0 - y * 0.3;
+   |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(-0.3, 1.0)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:170:13
+   |
+LL |     let _ = x + y * z;
+   |             ^^^^^^^^^ help: consider using: `f32::mul_add(y, z, x)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:172:13
+   |
+LL |     let _ = y * z + x;
+   |             ^^^^^^^^^ help: consider using: `f32::mul_add(y, z, x)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:176:13
+   |
+LL |     let _ = y + a * z;
+   |             ^^^^^^^^^ help: consider using: `a.mul_add(z, y)`
+
+error: aborting due to 38 previous errors
 


### PR DESCRIPTION
changelog: [`suboptimal_flops`] false negative with ambiguous float literals

Fixes rust-lang/rust-clippy#16954 
