### PR TITLE
feat(lint): unordered_methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7364,6 +7364,7 @@ Released 2018-09-13
 [`unneeded_struct_pattern`]: https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern
 [`unneeded_wildcard_pattern`]: https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_wildcard_pattern
 [`unnested_or_patterns`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnested_or_patterns
+[`unordered_methods`]: https://rust-lang.github.io/rust-clippy/master/index.html#unordered_methods
 [`unreachable`]: https://rust-lang.github.io/rust-clippy/master/index.html#unreachable
 [`unreadable_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal
 [`unsafe_derive_deserialize`]: https://rust-lang.github.io/rust-clippy/master/index.html#unsafe_derive_deserialize

--- a/clippy_dev/src/parse/cursor.rs
+++ b/clippy_dev/src/parse/cursor.rs
@@ -110,6 +110,122 @@ impl<'txt> Cursor<'txt> {
         self.next_token = self.inner.advance_token();
     }
 
+    /// Consumes all tokens until the specified identifier is found and returns its
+    /// position. Returns `None` if the identifier could not be found.
+    ///
+    /// The cursor will be positioned immediately after the identifier, or at the end if
+    /// it is not.
+    pub fn find_ident(&mut self, ident: &str) -> Option<u32> {
+        loop {
+            match self.next_token.kind {
+                TokenKind::Ident if self.peek_text() == ident => {
+                    let pos = self.pos;
+                    self.step();
+                    return Some(pos);
+                },
+                TokenKind::Eof => return None,
+                _ => self.step(),
+            }
+        }
+    }
+
+    /// Consumes all tokens until the next identifier is found and captures it. Returns
+    /// `None` if no identifier could be found.
+    ///
+    /// The cursor will be positioned immediately after the identifier, or at the end if
+    /// it is not.
+    pub fn find_any_ident(&mut self) -> Option<Capture> {
+        loop {
+            match self.next_token.kind {
+                TokenKind::Ident => {
+                    let res = Capture {
+                        pos: self.pos,
+                        len: self.next_token.len,
+                    };
+                    self.step();
+                    return Some(res);
+                },
+                TokenKind::Eof => return None,
+                _ => self.step(),
+            }
+        }
+    }
+
+    /// Consume the returns the position of the next non-whitespace token if it's the
+    /// specified identifier. Returns `None` otherwise.
+    pub fn match_ident(&mut self, s: &str) -> Option<u32> {
+        loop {
+            match self.next_token.kind {
+                TokenKind::Ident if s == self.peek_text() => {
+                    let pos = self.pos;
+                    self.step();
+                    return Some(pos);
+                },
+                TokenKind::Whitespace => self.step(),
+                _ => return None,
+            }
+        }
+    }
+
+    /// Consumes and captures the next non-whitespace token if it's an identifier. Returns
+    /// `None` otherwise.
+    pub fn capture_ident(&mut self) -> Option<Capture> {
+        loop {
+            match self.next_token.kind {
+                TokenKind::Ident => {
+                    let pos = self.pos;
+                    let len = self.next_token.len;
+                    self.step();
+                    return Some(Capture { pos, len });
+                },
+                TokenKind::Whitespace => self.step(),
+                _ => return None,
+            }
+        }
+    }
+
+    /// Continually attempt to match the pattern on subsequent tokens until a match is
+    /// found. Returns whether the pattern was successfully matched.
+    ///
+    /// Not generally suitable for multi-token patterns or patterns that can match
+    /// nothing.
+    #[must_use]
+    pub fn find_pat(&mut self, pat: Pat<'_>) -> bool {
+        let mut capture = [].iter_mut();
+        while !self.match_impl(pat, &mut capture) {
+            self.step();
+            if self.at_end() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Attempts to match a sequence of patterns at the current position. Returns whether
+    /// all patterns were successfully matched.
+    ///
+    /// Captures will be written to the given slice in the order they're matched. If a
+    /// capture is matched, but there are no more capture slots this will panic. If the
+    /// match is completed without filling all the capture slots they will be left
+    /// unmodified.
+    ///
+    /// If the match fails the cursor will be positioned at the first failing token.
+    #[must_use]
+    pub fn match_all(&mut self, pats: &[Pat<'_>], captures: &mut [Capture]) -> bool {
+        let mut captures = captures.iter_mut();
+        pats.iter().all(|&p| self.match_impl(p, &mut captures))
+    }
+
+    /// Attempts to match a single pattern at the current position. Returns whether the
+    /// pattern was successfully matched.
+    ///
+    /// If the pattern attempts to capture anything this will panic. If the match fails
+    /// the cursor will be positioned at the first failing token.
+    #[must_use]
+    pub fn match_pat(&mut self, pat: Pat<'_>) -> bool {
+        self.match_impl(pat, &mut [].iter_mut())
+    }
+
     /// Consumes tokens until the given pattern is either fully matched of fails to match.
     /// Returns whether the pattern was fully matched.
     ///
@@ -237,121 +353,5 @@ impl<'txt> Cursor<'txt> {
                 _ => return false,
             }
         }
-    }
-
-    /// Consumes all tokens until the specified identifier is found and returns its
-    /// position. Returns `None` if the identifier could not be found.
-    ///
-    /// The cursor will be positioned immediately after the identifier, or at the end if
-    /// it is not.
-    pub fn find_ident(&mut self, ident: &str) -> Option<u32> {
-        loop {
-            match self.next_token.kind {
-                TokenKind::Ident if self.peek_text() == ident => {
-                    let pos = self.pos;
-                    self.step();
-                    return Some(pos);
-                },
-                TokenKind::Eof => return None,
-                _ => self.step(),
-            }
-        }
-    }
-
-    /// Consumes all tokens until the next identifier is found and captures it. Returns
-    /// `None` if no identifier could be found.
-    ///
-    /// The cursor will be positioned immediately after the identifier, or at the end if
-    /// it is not.
-    pub fn find_any_ident(&mut self) -> Option<Capture> {
-        loop {
-            match self.next_token.kind {
-                TokenKind::Ident => {
-                    let res = Capture {
-                        pos: self.pos,
-                        len: self.next_token.len,
-                    };
-                    self.step();
-                    return Some(res);
-                },
-                TokenKind::Eof => return None,
-                _ => self.step(),
-            }
-        }
-    }
-
-    /// Consume the returns the position of the next non-whitespace token if it's the
-    /// specified identifier. Returns `None` otherwise.
-    pub fn match_ident(&mut self, s: &str) -> Option<u32> {
-        loop {
-            match self.next_token.kind {
-                TokenKind::Ident if s == self.peek_text() => {
-                    let pos = self.pos;
-                    self.step();
-                    return Some(pos);
-                },
-                TokenKind::Whitespace => self.step(),
-                _ => return None,
-            }
-        }
-    }
-
-    /// Consumes and captures the next non-whitespace token if it's an identifier. Returns
-    /// `None` otherwise.
-    pub fn capture_ident(&mut self) -> Option<Capture> {
-        loop {
-            match self.next_token.kind {
-                TokenKind::Ident => {
-                    let pos = self.pos;
-                    let len = self.next_token.len;
-                    self.step();
-                    return Some(Capture { pos, len });
-                },
-                TokenKind::Whitespace => self.step(),
-                _ => return None,
-            }
-        }
-    }
-
-    /// Continually attempt to match the pattern on subsequent tokens until a match is
-    /// found. Returns whether the pattern was successfully matched.
-    ///
-    /// Not generally suitable for multi-token patterns or patterns that can match
-    /// nothing.
-    #[must_use]
-    pub fn find_pat(&mut self, pat: Pat<'_>) -> bool {
-        let mut capture = [].iter_mut();
-        while !self.match_impl(pat, &mut capture) {
-            self.step();
-            if self.at_end() {
-                return false;
-            }
-        }
-        true
-    }
-
-    /// Attempts to match a sequence of patterns at the current position. Returns whether
-    /// all patterns were successfully matched.
-    ///
-    /// Captures will be written to the given slice in the order they're matched. If a
-    /// capture is matched, but there are no more capture slots this will panic. If the
-    /// match is completed without filling all the capture slots they will be left
-    /// unmodified.
-    ///
-    /// If the match fails the cursor will be positioned at the first failing token.
-    #[must_use]
-    pub fn match_all(&mut self, pats: &[Pat<'_>], captures: &mut [Capture]) -> bool {
-        let mut captures = captures.iter_mut();
-        pats.iter().all(|&p| self.match_impl(p, &mut captures))
-    }
-
-    /// Attempts to match a single pattern at the current position. Returns whether the
-    /// pattern was successfully matched.
-    ///
-    /// If the pattern attempts to capture anything this will panic. If the match fails
-    /// the cursor will be positioned at the first failing token.
-    #[must_use]
-    pub fn match_pat(&mut self, pat: Pat<'_>) -> bool {
-        self.match_impl(pat, &mut [].iter_mut())
     }
 }

--- a/clippy_dev/src/utils.rs
+++ b/clippy_dev/src/utils.rs
@@ -341,6 +341,26 @@ pub struct FileUpdater {
 }
 impl FileUpdater {
     #[track_caller]
+    pub fn update_file_checked(
+        &mut self,
+        tool: &str,
+        mode: UpdateMode,
+        path: impl AsRef<Path>,
+        update: &mut dyn FnMut(&Path, &str, &mut String) -> UpdateStatus,
+    ) {
+        self.update_file_checked_inner(tool, mode, path.as_ref(), update);
+    }
+
+    #[track_caller]
+    pub fn update_file(
+        &mut self,
+        path: impl AsRef<Path>,
+        update: &mut dyn FnMut(&Path, &str, &mut String) -> UpdateStatus,
+    ) {
+        self.update_file_inner(path.as_ref(), update);
+    }
+
+    #[track_caller]
     fn update_file_checked_inner(
         &mut self,
         tool: &str,
@@ -372,26 +392,6 @@ impl FileUpdater {
         if update(path, &self.src_buf, &mut self.dst_buf).is_changed() {
             file.replace_contents(self.dst_buf.as_bytes());
         }
-    }
-
-    #[track_caller]
-    pub fn update_file_checked(
-        &mut self,
-        tool: &str,
-        mode: UpdateMode,
-        path: impl AsRef<Path>,
-        update: &mut dyn FnMut(&Path, &str, &mut String) -> UpdateStatus,
-    ) {
-        self.update_file_checked_inner(tool, mode, path.as_ref(), update);
-    }
-
-    #[track_caller]
-    pub fn update_file(
-        &mut self,
-        path: impl AsRef<Path>,
-        update: &mut dyn FnMut(&Path, &str, &mut String) -> UpdateStatus,
-    ) {
-        self.update_file_inner(path.as_ref(), update);
     }
 }
 

--- a/clippy_lints/src/cargo/lint_groups_priority.rs
+++ b/clippy_lints/src/cargo/lint_groups_priority.rs
@@ -24,14 +24,6 @@ struct LintConfig<'a> {
     priority: Option<i64>,
 }
 impl<'a> LintConfig<'a> {
-    fn priority(&self) -> i64 {
-        self.priority.unwrap_or(0)
-    }
-
-    fn is_implicit(&self) -> bool {
-        self.priority.is_none()
-    }
-
     fn parse(value: &'a Spanned<DeValue<'a>>) -> Option<Self> {
         let sp = value.span();
         let (level, priority) = match value.get_ref() {
@@ -49,6 +41,13 @@ impl<'a> LintConfig<'a> {
             _ => return None,
         };
         Some(Self { sp, level, priority })
+    }
+    fn priority(&self) -> i64 {
+        self.priority.unwrap_or(0)
+    }
+
+    fn is_implicit(&self) -> bool {
+        self.priority.is_none()
     }
 }
 

--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -126,6 +126,24 @@ fn read_le_ge<'tcx>(
 }
 
 impl<'a> Conversion<'a> {
+    /// Construct a new conversion without type constraint
+    fn new_any(expr_to_cast: &'a Expr<'_>) -> Conversion<'a> {
+        Conversion {
+            cvt: ConversionType::SignedToUnsigned,
+            expr_to_cast,
+            to_type: None,
+        }
+    }
+
+    /// Try to construct a new conversion if the conversion type is valid
+    fn try_new(expr_to_cast: &'a Expr<'_>, from_type: Symbol, to_type: Symbol) -> Option<Conversion<'a>> {
+        ConversionType::try_new(from_type, to_type).map(|cvt| Conversion {
+            cvt,
+            expr_to_cast,
+            to_type: Some(to_type),
+        })
+    }
+
     /// Combine multiple conversions if the are compatible
     pub fn combine(self, other: Self, cx: &LateContext<'_>, ctxt: SyntaxContext) -> Option<Conversion<'a>> {
         if self.is_compatible(&other, cx, ctxt) {
@@ -149,24 +167,6 @@ impl<'a> Conversion<'a> {
         match (self.to_type, other.to_type) {
             (Some(l), Some(r)) => l == r,
             _ => true,
-        }
-    }
-
-    /// Try to construct a new conversion if the conversion type is valid
-    fn try_new(expr_to_cast: &'a Expr<'_>, from_type: Symbol, to_type: Symbol) -> Option<Conversion<'a>> {
-        ConversionType::try_new(from_type, to_type).map(|cvt| Conversion {
-            cvt,
-            expr_to_cast,
-            to_type: Some(to_type),
-        })
-    }
-
-    /// Construct a new conversion without type constraint
-    fn new_any(expr_to_cast: &'a Expr<'_>) -> Conversion<'a> {
-        Conversion {
-            cvt: ConversionType::SignedToUnsigned,
-            expr_to_cast,
-            to_type: None,
         }
     }
 }

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -780,6 +780,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::unnecessary_wraps::UNNECESSARY_WRAPS_INFO,
     crate::unneeded_struct_pattern::UNNEEDED_STRUCT_PATTERN_INFO,
     crate::unnested_or_patterns::UNNESTED_OR_PATTERNS_INFO,
+    crate::unordered_methods::UNORDERED_METHODS_INFO,
     crate::unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME_INFO,
     crate::unused_async::UNUSED_ASYNC_INFO,
     crate::unused_io_amount::UNUSED_IO_AMOUNT_INFO,

--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -792,26 +792,6 @@ enum TyCoercionStability {
     None,
 }
 impl TyCoercionStability {
-    fn is_deref_stable(self) -> bool {
-        matches!(self, Self::Deref)
-    }
-
-    fn is_reborrow_stable(self) -> bool {
-        matches!(self, Self::Deref | Self::Reborrow)
-    }
-
-    fn for_defined_ty<'tcx>(cx: &LateContext<'tcx>, ty: DefinedTy<'tcx>, for_return: bool) -> Self {
-        match ty {
-            DefinedTy::Hir(ty) => Self::for_hir_ty(ty),
-            DefinedTy::Mir { def_site_def_id, ty } => Self::for_mir_ty(
-                cx.tcx,
-                def_site_def_id,
-                cx.tcx.instantiate_bound_regions_with_erased(ty),
-                for_return,
-            ),
-        }
-    }
-
     // Checks the stability of type coercions when assigned to a binding with the given explicit type.
     //
     // e.g.
@@ -944,6 +924,24 @@ impl TyCoercionStability {
                 | ty::UnsafeBinder(_) => Self::Deref,
             };
         }
+    }
+    fn for_defined_ty<'tcx>(cx: &LateContext<'tcx>, ty: DefinedTy<'tcx>, for_return: bool) -> Self {
+        match ty {
+            DefinedTy::Hir(ty) => Self::for_hir_ty(ty),
+            DefinedTy::Mir { def_site_def_id, ty } => Self::for_mir_ty(
+                cx.tcx,
+                def_site_def_id,
+                cx.tcx.instantiate_bound_regions_with_erased(ty),
+                for_return,
+            ),
+        }
+    }
+    fn is_deref_stable(self) -> bool {
+        matches!(self, Self::Deref)
+    }
+
+    fn is_reborrow_stable(self) -> bool {
+        matches!(self, Self::Deref | Self::Reborrow)
     }
 }
 

--- a/clippy_lints/src/empty_line_after.rs
+++ b/clippy_lints/src/empty_line_after.rs
@@ -133,6 +133,22 @@ struct Stop {
 }
 
 impl Stop {
+    fn from_attr(cx: &EarlyContext<'_>, attr: &Attribute) -> Option<Self> {
+        let SpanData { lo, hi, .. } = attr.span.data();
+        let file = cx.sess().source_map().lookup_source_file(lo);
+
+        Some(Self {
+            span: attr.span,
+            kind: match attr.kind {
+                AttrKind::Normal(_) => StopKind::Attr,
+                AttrKind::DocComment(comment_kind, _) => StopKind::Doc(comment_kind),
+            },
+            first: file.lookup_line(file.relative_position(lo))?,
+            last: file.lookup_line(file.relative_position(hi))?,
+            name: attr.name(),
+        })
+    }
+
     fn is_outer_attr_only(&self) -> bool {
         let Some(name) = self.name else {
             return false;
@@ -208,22 +224,6 @@ impl Stop {
                 suggestions.push((asterisk, String::new()));
             },
         }
-    }
-
-    fn from_attr(cx: &EarlyContext<'_>, attr: &Attribute) -> Option<Self> {
-        let SpanData { lo, hi, .. } = attr.span.data();
-        let file = cx.sess().source_map().lookup_source_file(lo);
-
-        Some(Self {
-            span: attr.span,
-            kind: match attr.kind {
-                AttrKind::Normal(_) => StopKind::Attr,
-                AttrKind::DocComment(comment_kind, _) => StopKind::Doc(comment_kind),
-            },
-            first: file.lookup_line(file.relative_position(lo))?,
-            last: file.lookup_line(file.relative_position(hi))?,
-            name: attr.name(),
-        })
     }
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -379,6 +379,7 @@ mod unnecessary_struct_initialization;
 mod unnecessary_wraps;
 mod unneeded_struct_pattern;
 mod unnested_or_patterns;
+mod unordered_methods;
 mod unsafe_removed_from_name;
 mod unused_async;
 mod unused_io_amount;
@@ -869,6 +870,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(move |_| Box::new(manual_noop_waker::ManualNoopWaker::new(conf))),
         Box::new(|_| Box::new(byte_char_slices::ByteCharSlice)),
         Box::new(|_| Box::new(manual_assert_eq::ManualAssertEq)),
+        Box::new(|_| Box::new(unordered_methods::UnorderedMethods)),
         // add late passes here, used by `cargo dev new_lint`
     ];
     store.late_passes.extend(late_lints);

--- a/clippy_lints/src/methods/filter_map.rs
+++ b/clippy_lints/src/methods/filter_map.rs
@@ -106,6 +106,43 @@ enum CheckResult<'tcx> {
 }
 
 impl<'tcx> OffendingFilterExpr<'tcx> {
+    fn hir(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, filter_param_id: HirId) -> Option<Self> {
+        if let ExprKind::MethodCall(path, receiver, [], _) = expr.kind
+            && let Some(recv_ty) = cx.typeck_results().expr_ty(receiver).peel_refs().ty_adt_def()
+        {
+            // we still want to lint if the expression possibly contains side effects,
+            // *but* it can't be machine-applicable then, because that can change the behavior of the program:
+            // .filter(|x| effect(x).is_some()).map(|x| effect(x).unwrap())
+            // vs.
+            // .filter_map(|x| effect(x))
+            //
+            // the latter only calls `effect` once
+            let side_effect_expr_span = receiver.can_have_side_effects().then_some(receiver.span);
+
+            match (cx.tcx.get_diagnostic_name(recv_ty.did()), path.ident.name) {
+                (Some(sym::Option), sym::is_some) => Some(Self::IsSome {
+                    receiver,
+                    side_effect_expr_span,
+                }),
+                (Some(sym::Result), sym::is_ok) => Some(Self::IsOk {
+                    receiver,
+                    side_effect_expr_span,
+                }),
+                _ => None,
+            }
+        } else if let ExprKind::Match(scrutinee, [arm, _], _) = expr.kind
+            // we know for a fact that the wildcard pattern is the second arm
+            && scrutinee.res_local_id() == Some(filter_param_id)
+            && let PatKind::TupleStruct(QPath::Resolved(_, path), ..) = arm.pat.kind
+            && matching_root_macro_call(cx, expr.span, sym::matches_macro).is_some()
+            && let Some(variant_def_id) = path.res.opt_def_id()
+        {
+            Some(OffendingFilterExpr::Matches { variant_def_id })
+        } else {
+            None
+        }
+    }
+
     pub fn check_map_call(
         &self,
         cx: &LateContext<'tcx>,
@@ -221,43 +258,6 @@ impl<'tcx> OffendingFilterExpr<'tcx> {
                     None
                 }
             },
-        }
-    }
-
-    fn hir(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, filter_param_id: HirId) -> Option<Self> {
-        if let ExprKind::MethodCall(path, receiver, [], _) = expr.kind
-            && let Some(recv_ty) = cx.typeck_results().expr_ty(receiver).peel_refs().ty_adt_def()
-        {
-            // we still want to lint if the expression possibly contains side effects,
-            // *but* it can't be machine-applicable then, because that can change the behavior of the program:
-            // .filter(|x| effect(x).is_some()).map(|x| effect(x).unwrap())
-            // vs.
-            // .filter_map(|x| effect(x))
-            //
-            // the latter only calls `effect` once
-            let side_effect_expr_span = receiver.can_have_side_effects().then_some(receiver.span);
-
-            match (cx.tcx.get_diagnostic_name(recv_ty.did()), path.ident.name) {
-                (Some(sym::Option), sym::is_some) => Some(Self::IsSome {
-                    receiver,
-                    side_effect_expr_span,
-                }),
-                (Some(sym::Result), sym::is_ok) => Some(Self::IsOk {
-                    receiver,
-                    side_effect_expr_span,
-                }),
-                _ => None,
-            }
-        } else if let ExprKind::Match(scrutinee, [arm, _], _) = expr.kind
-            // we know for a fact that the wildcard pattern is the second arm
-            && scrutinee.res_local_id() == Some(filter_param_id)
-            && let PatKind::TupleStruct(QPath::Resolved(_, path), ..) = arm.pat.kind
-            && matching_root_macro_call(cx, expr.span, sym::matches_macro).is_some()
-            && let Some(variant_def_id) = path.res.opt_def_id()
-        {
-            Some(OffendingFilterExpr::Matches { variant_def_id })
-        } else {
-            None
         }
     }
 }

--- a/clippy_lints/src/operators/numeric_arithmetic.rs
+++ b/clippy_lints/src/operators/numeric_arithmetic.rs
@@ -13,10 +13,6 @@ pub struct Context {
     const_span: Option<Span>,
 }
 impl Context {
-    fn skip_expr(&self, e: &hir::Expr<'_>) -> bool {
-        self.expr_id.is_some() || self.const_span.is_some_and(|span| span.contains(e.span))
-    }
-
     pub fn check_binary<'tcx>(
         &mut self,
         cx: &LateContext<'tcx>,
@@ -96,5 +92,9 @@ impl Context {
             return;
         }
         self.const_span = None;
+    }
+
+    fn skip_expr(&self, e: &hir::Expr<'_>) -> bool {
+        self.expr_id.is_some() || self.const_span.is_some_and(|span| span.contains(e.span))
     }
 }

--- a/clippy_lints/src/unordered_methods.rs
+++ b/clippy_lints/src/unordered_methods.rs
@@ -1,0 +1,208 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::res::MaybeDef;
+use clippy_utils::return_ty;
+use rustc_hir::{FnSig, ImplItemKind, Item, ItemKind, OwnerId};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{Adt, Ty, Visibility};
+use rustc_session::impl_lint_pass;
+use rustc_span::def_id::DefId;
+use rustc_span::sym;
+use std::fmt::Formatter;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks that methods within an `impl` block are ordered consistently:
+    /// constructors (`pub fn new() -> Self`) first, then public methods,
+    /// and then private methods.
+    ///
+    /// ### Why is this bad?
+    /// Following a consistent order for methods within an `impl` block improves readability
+    /// and maintainability. Constructors are often the entry point for creating instances
+    /// of a struct, so placing them first makes the API clearer. A logical grouping
+    /// of methods by visibility further enhances code comprehension.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// struct MyStruct;
+    ///
+    /// impl MyStruct {
+    ///     fn do_something_private(&self) {} // Bad: Private method before constructor
+    ///
+    ///     pub fn new() -> Self {
+    ///         MyStruct
+    ///     }
+    ///
+    ///     pub(crate) fn do_something_crate_private(&self) {} // Bad: Crate method before public
+    ///
+    ///     pub fn do_something_public(&self) {}
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// struct MyStruct;
+    ///
+    /// impl MyStruct {
+    ///     pub fn new() -> Self {
+    ///         MyStruct
+    ///     }
+    ///
+    ///     pub fn do_something_public(&self) {}
+    ///
+    ///     pub(crate) fn do_something_crate_private(&self) {}
+    ///
+    ///     fn do_something_private(&self) {}
+    /// }
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub UNORDERED_METHODS,
+    pedantic,
+    "Linter that checks that the constructor is declared before the struct's methods, \
+    and that the public functions are also declared before the crate and private ones"
+}
+
+impl_lint_pass!(UnorderedMethods => [UNORDERED_METHODS]);
+
+#[derive(Clone)]
+pub struct UnorderedMethods;
+
+/// Defines the desired order of method categories.
+/// Higher enum variants mean higher priority (should appear earlier).
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum MethodKind {
+    Constructor,
+    Public,
+    Private,
+}
+
+struct MethodMetadata {
+    kind: MethodKind,
+    name: String,
+}
+
+impl MethodMetadata {
+    fn from<'tcx>(
+        fn_sig: &FnSig<'_>,
+        cx: &LateContext<'tcx>,
+        impl_item_owner_id: OwnerId,
+        self_ty: Ty<'tcx>,
+        fn_name: &str,
+        visibility: Visibility<DefId>,
+    ) -> Option<Self> {
+        if is_constructor(fn_sig, cx, impl_item_owner_id, self_ty) {
+            Some(Self {
+                kind: MethodKind::Constructor,
+                name: fn_name.to_string(),
+            })
+        } else if input_has_self(fn_sig) && visibility.is_public() {
+            Some(Self {
+                kind: MethodKind::Public,
+                name: fn_name.to_string(),
+            })
+        } else if input_has_self(fn_sig) && !visibility.is_public() {
+            Some(Self {
+                kind: MethodKind::Private,
+                name: fn_name.to_string(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl std::fmt::Display for MethodMetadata {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}({})", self.kind, self.name)
+    }
+}
+
+impl LateLintPass<'_> for UnorderedMethods {
+    fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
+        if let ItemKind::Impl(impl_block) = item.kind {
+            // Only check inherent impl blocks (not trait implementations)
+            if impl_block.of_trait.is_some() {
+                return;
+            }
+
+            // Get the `Self` type for the `impl` block
+            let self_ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip();
+
+            let mut last_category: Option<MethodMetadata> = None;
+
+            for &impl_item_id in impl_block.items {
+                let impl_item = cx.tcx.hir_impl_item(impl_item_id);
+
+                // Only consider functions for ordering
+                if let ImplItemKind::Fn(ref sig, _) = impl_item.kind {
+                    let fn_name = impl_item.ident.name.as_str();
+
+                    let visibility = cx.tcx.visibility(impl_item.owner_id.def_id);
+
+                    let Some(current_category) =
+                        MethodMetadata::from(sig, cx, impl_item.owner_id, self_ty, fn_name, visibility)
+                    else {
+                        continue;
+                    };
+
+                    if let Some(lc) = last_category
+                        // If the current method's category is "less than" (lower priority)
+                        // the last encountered category, then it's out of order.
+                        && current_category.kind < lc.kind
+                    {
+                        let msg =
+                            format!("methods are not ordered correctly: `{current_category}` declared after `{lc}`");
+                        span_lint_and_help(
+                            cx,
+                            UNORDERED_METHODS,
+                            impl_item.span,
+                            msg,
+                            None,
+                            "reorder functions to be constructors, public, private",
+                        );
+                    }
+                    last_category = Some(current_category);
+                }
+            }
+        }
+    }
+}
+
+/// `is_constructor` check whether the given function is a constructor.
+/// A constructor must:
+/// - Not have an implicit `self` parameter (&self or &mut self)
+/// - Return Self, the struct type, or Option<Self>/Option<struct type>
+fn is_constructor<'tcx>(
+    fn_sig: &FnSig<'_>,
+    cx: &LateContext<'tcx>,
+    impl_item_owner_id: OwnerId,
+    self_ty: Ty<'tcx>,
+) -> bool {
+    // Check that the function doesn't take &self or &mut self
+    if fn_sig.decl.implicit_self().has_implicit_self() {
+        return false;
+    }
+
+    // Check if the return type matches the struct type
+    let ret_ty = return_ty(cx, impl_item_owner_id);
+
+    // Direct match: returns Self or the struct type
+    if ret_ty == self_ty {
+        return true;
+    }
+
+    // Check for Option<Self> or Option<struct type>
+    if ret_ty.is_diag_item(cx, sym::Option)
+        && let Adt(_, args) = ret_ty.kind()
+        && let Some(inner_ty) = args.first().and_then(|arg| arg.as_type())
+        && inner_ty == self_ty
+    {
+        return true;
+    }
+
+    false
+}
+
+/// `input_has_self` checks whether the input parameters of a function contain the `self`
+/// parameter in any form.
+fn input_has_self(fn_sig: &FnSig<'_>) -> bool {
+    fn_sig.decl.implicit_self().has_implicit_self()
+}

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -206,6 +206,65 @@ impl Hash for Constant {
 }
 
 impl Constant {
+    pub fn new_numeric_max<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Self> {
+        match *ty.kind() {
+            ty::Uint(ty) => Some(Self::Int(match ty.normalize(tcx.sess.target.pointer_width) {
+                UintTy::U8 => u128::from(u8::MAX),
+                UintTy::U16 => u128::from(u16::MAX),
+                UintTy::U32 => u128::from(u32::MAX),
+                UintTy::U64 => u128::from(u64::MAX),
+                UintTy::U128 => u128::MAX,
+                UintTy::Usize => return None,
+            })),
+            ty::Int(ty) => {
+                let val = match ty.normalize(tcx.sess.target.pointer_width) {
+                    IntTy::I8 => i128::from(i8::MAX),
+                    IntTy::I16 => i128::from(i16::MAX),
+                    IntTy::I32 => i128::from(i32::MAX),
+                    IntTy::I64 => i128::from(i64::MAX),
+                    IntTy::I128 => i128::MAX,
+                    IntTy::Isize => return None,
+                };
+                Some(Self::Int(val.cast_unsigned()))
+            },
+            ty::Char => Some(Self::Char(char::MAX)),
+            ty::Float(FloatTy::F32) => Some(Self::F32(f32::INFINITY)),
+            ty::Float(FloatTy::F64) => Some(Self::F64(f64::INFINITY)),
+            _ => None,
+        }
+    }
+
+    fn parse_f16(s: &str) -> Self {
+        let f: Half = s.parse().unwrap();
+        Self::F16(f.to_bits().try_into().unwrap())
+    }
+
+    fn parse_f128(s: &str) -> Self {
+        let f: Quad = s.parse().unwrap();
+        Self::F128(f.to_bits())
+    }
+
+    pub fn new_numeric_min<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Self> {
+        match *ty.kind() {
+            ty::Uint(_) => Some(Self::Int(0)),
+            ty::Int(ty) => {
+                let val = match ty.normalize(tcx.sess.target.pointer_width) {
+                    IntTy::I8 => i128::from(i8::MIN),
+                    IntTy::I16 => i128::from(i16::MIN),
+                    IntTy::I32 => i128::from(i32::MIN),
+                    IntTy::I64 => i128::from(i64::MIN),
+                    IntTy::I128 => i128::MIN,
+                    IntTy::Isize => return None,
+                };
+                Some(Self::Int(val.cast_unsigned()))
+            },
+            ty::Char => Some(Self::Char(char::MIN)),
+            ty::Float(FloatTy::F32) => Some(Self::F32(f32::NEG_INFINITY)),
+            ty::Float(FloatTy::F64) => Some(Self::F64(f64::NEG_INFINITY)),
+            _ => None,
+        }
+    }
+
     pub fn partial_cmp(tcx: TyCtxt<'_>, cmp_type: Ty<'_>, left: &Self, right: &Self) -> Option<Ordering> {
         match (left, right) {
             (Self::Str(ls), Self::Str(rs)) => Some(ls.cmp(rs)),
@@ -282,65 +341,6 @@ impl Constant {
             self = *r;
         }
         self
-    }
-
-    fn parse_f16(s: &str) -> Self {
-        let f: Half = s.parse().unwrap();
-        Self::F16(f.to_bits().try_into().unwrap())
-    }
-
-    fn parse_f128(s: &str) -> Self {
-        let f: Quad = s.parse().unwrap();
-        Self::F128(f.to_bits())
-    }
-
-    pub fn new_numeric_min<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Self> {
-        match *ty.kind() {
-            ty::Uint(_) => Some(Self::Int(0)),
-            ty::Int(ty) => {
-                let val = match ty.normalize(tcx.sess.target.pointer_width) {
-                    IntTy::I8 => i128::from(i8::MIN),
-                    IntTy::I16 => i128::from(i16::MIN),
-                    IntTy::I32 => i128::from(i32::MIN),
-                    IntTy::I64 => i128::from(i64::MIN),
-                    IntTy::I128 => i128::MIN,
-                    IntTy::Isize => return None,
-                };
-                Some(Self::Int(val.cast_unsigned()))
-            },
-            ty::Char => Some(Self::Char(char::MIN)),
-            ty::Float(FloatTy::F32) => Some(Self::F32(f32::NEG_INFINITY)),
-            ty::Float(FloatTy::F64) => Some(Self::F64(f64::NEG_INFINITY)),
-            _ => None,
-        }
-    }
-
-    pub fn new_numeric_max<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Self> {
-        match *ty.kind() {
-            ty::Uint(ty) => Some(Self::Int(match ty.normalize(tcx.sess.target.pointer_width) {
-                UintTy::U8 => u128::from(u8::MAX),
-                UintTy::U16 => u128::from(u16::MAX),
-                UintTy::U32 => u128::from(u32::MAX),
-                UintTy::U64 => u128::from(u64::MAX),
-                UintTy::U128 => u128::MAX,
-                UintTy::Usize => return None,
-            })),
-            ty::Int(ty) => {
-                let val = match ty.normalize(tcx.sess.target.pointer_width) {
-                    IntTy::I8 => i128::from(i8::MAX),
-                    IntTy::I16 => i128::from(i16::MAX),
-                    IntTy::I32 => i128::from(i32::MAX),
-                    IntTy::I64 => i128::from(i64::MAX),
-                    IntTy::I128 => i128::MAX,
-                    IntTy::Isize => return None,
-                };
-                Some(Self::Int(val.cast_unsigned()))
-            },
-            ty::Char => Some(Self::Char(char::MAX)),
-            ty::Float(FloatTy::F32) => Some(Self::F32(f32::INFINITY)),
-            ty::Float(FloatTy::F64) => Some(Self::F64(f64::INFINITY)),
-            _ => None,
-        }
     }
 
     pub fn is_numeric_min<'tcx>(&self, tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
@@ -582,6 +582,36 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
         }
     }
 
+    /// Simple constant folding to determine if an expression is an empty slice, str, array, …
+    /// `None` will be returned if the constness cannot be determined, or if the resolution
+    /// leaves the local crate.
+    pub fn eval_is_empty(&self, e: &Expr<'_>) -> Option<bool> {
+        match e.kind {
+            ExprKind::ConstBlock(ConstBlock { body, .. }) => self.eval_is_empty(self.tcx.hir_body(body).value),
+            ExprKind::DropTemps(e) => self.eval_is_empty(e),
+            ExprKind::Lit(lit) => {
+                if is_direct_expn_of(e.span, sym::cfg).is_some() {
+                    None
+                } else {
+                    match &lit.node {
+                        LitKind::Str(is, _) => Some(is.is_empty()),
+                        LitKind::ByteStr(s, _) | LitKind::CStr(s, _) => Some(s.as_byte_str().is_empty()),
+                        _ => None,
+                    }
+                }
+            },
+            ExprKind::Array(vec) => self.multi(vec).map(|v| v.is_empty()),
+            ExprKind::Repeat(..) => {
+                if let ty::Array(_, n) = self.typeck.expr_ty(e).kind() {
+                    Some(n.try_to_target_usize(self.tcx)? == 0)
+                } else {
+                    span_bug!(e.span, "typeck error");
+                }
+            },
+            _ => None,
+        }
+    }
+
     fn check_ctxt(&self, ctxt: SyntaxContext) {
         if self.ctxt.get() != ctxt {
             self.source.set(ConstantSource::NonLocal);
@@ -660,36 +690,6 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
             {
                 self.check_ctxt(field.span.ctxt());
                 mir_to_const(self.tcx, desired_field, ty)
-            },
-            _ => None,
-        }
-    }
-
-    /// Simple constant folding to determine if an expression is an empty slice, str, array, …
-    /// `None` will be returned if the constness cannot be determined, or if the resolution
-    /// leaves the local crate.
-    pub fn eval_is_empty(&self, e: &Expr<'_>) -> Option<bool> {
-        match e.kind {
-            ExprKind::ConstBlock(ConstBlock { body, .. }) => self.eval_is_empty(self.tcx.hir_body(body).value),
-            ExprKind::DropTemps(e) => self.eval_is_empty(e),
-            ExprKind::Lit(lit) => {
-                if is_direct_expn_of(e.span, sym::cfg).is_some() {
-                    None
-                } else {
-                    match &lit.node {
-                        LitKind::Str(is, _) => Some(is.is_empty()),
-                        LitKind::ByteStr(s, _) | LitKind::CStr(s, _) => Some(s.as_byte_str().is_empty()),
-                        _ => None,
-                    }
-                }
-            },
-            ExprKind::Array(vec) => self.multi(vec).map(|v| v.is_empty()),
-            ExprKind::Repeat(..) => {
-                if let ty::Array(_, n) = self.typeck.expr_ty(e).kind() {
-                    Some(n.try_to_target_usize(self.tcx)? == 0)
-                } else {
-                    span_bug!(e.span, "typeck error");
-                }
             },
             _ => None,
         }

--- a/clippy_utils/src/hir_utils.rs
+++ b/clippy_utils/src/hir_utils.rs
@@ -264,6 +264,277 @@ impl HirEqInterExpr<'_, '_, '_> {
         eq
     }
 
+    pub fn eq_body(&mut self, left: BodyId, right: BodyId) -> bool {
+        // swap out TypeckResults when hashing a body
+        let old_maybe_typeck_results = self.inner.maybe_typeck_results.replace((
+            self.inner.cx.tcx.typeck_body(left),
+            self.inner.cx.tcx.typeck_body(right),
+        ));
+        let res = self.eq_expr(
+            self.inner.cx.tcx.hir_body(left).value,
+            self.inner.cx.tcx.hir_body(right).value,
+        );
+        self.inner.maybe_typeck_results = old_maybe_typeck_results;
+        res
+    }
+
+    #[expect(clippy::too_many_lines)]
+    pub fn eq_expr(&mut self, left: &Expr<'_>, right: &Expr<'_>) -> bool {
+        match self.check_ctxt(left.span.ctxt(), right.span.ctxt()) {
+            None => {
+                if let Some((typeck_lhs, typeck_rhs)) = self.inner.maybe_typeck_results
+                    && typeck_lhs.expr_ty(left) == typeck_rhs.expr_ty(right)
+                    && let (Some(l), Some(r)) = (
+                        ConstEvalCtxt::with_env(self.inner.cx.tcx, self.inner.cx.typing_env(), typeck_lhs)
+                            .eval_local(left, self.eval_ctxt),
+                        ConstEvalCtxt::with_env(self.inner.cx.tcx, self.inner.cx.typing_env(), typeck_rhs)
+                            .eval_local(right, self.eval_ctxt),
+                    )
+                    && l == r
+                {
+                    return true;
+                }
+            },
+            Some(false) => return false,
+            Some(true) => {},
+        }
+
+        let is_eq = match (
+            reduce_exprkind(self.inner.cx, self.eval_ctxt, &left.kind),
+            reduce_exprkind(self.inner.cx, self.eval_ctxt, &right.kind),
+        ) {
+            (ExprKind::AddrOf(lb, l_mut, le), ExprKind::AddrOf(rb, r_mut, re)) => {
+                lb == rb && l_mut == r_mut && self.eq_expr(le, re)
+            },
+            (ExprKind::Array(l), ExprKind::Array(r)) => self.eq_exprs(l, r),
+            (ExprKind::Assign(ll, lr, _), ExprKind::Assign(rl, rr, _)) => {
+                self.inner.allow_side_effects && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
+            },
+            (ExprKind::AssignOp(lo, ll, lr), ExprKind::AssignOp(ro, rl, rr)) => {
+                self.inner.allow_side_effects && lo.node == ro.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
+            },
+            (ExprKind::Block(l, _), ExprKind::Block(r, _)) => self.eq_block(l, r),
+            (ExprKind::Binary(l_op, ll, lr), ExprKind::Binary(r_op, rl, rr)) => {
+                l_op.node == r_op.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
+                    || self.swap_binop(l_op.node, ll, lr).is_some_and(|(l_op, ll, lr)| {
+                        l_op == r_op.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
+                    })
+            },
+            (ExprKind::Break(li, le), ExprKind::Break(ri, re)) => {
+                both(li.label.as_ref(), ri.label.as_ref(), |l, r| l.ident.name == r.ident.name)
+                    && both(le.as_ref(), re.as_ref(), |l, r| self.eq_expr(l, r))
+            },
+            (ExprKind::Call(l_fun, l_args), ExprKind::Call(r_fun, r_args)) => {
+                self.inner.allow_side_effects && self.eq_expr(l_fun, r_fun) && self.eq_exprs(l_args, r_args)
+            },
+            (ExprKind::Cast(lx, lt), ExprKind::Cast(rx, rt)) => {
+                self.eq_expr(lx, rx) && self.eq_ty(lt, rt)
+            },
+            (ExprKind::Closure(_l), ExprKind::Closure(_r)) => false,
+            (ExprKind::ConstBlock(lb), ExprKind::ConstBlock(rb)) => self.eq_body(lb.body, rb.body),
+            (ExprKind::Continue(li), ExprKind::Continue(ri)) => {
+                both(li.label.as_ref(), ri.label.as_ref(), |l, r| l.ident.name == r.ident.name)
+            },
+            (ExprKind::DropTemps(le), ExprKind::DropTemps(re)) => self.eq_expr(le, re),
+            (ExprKind::Field(l_f_exp, l_f_ident), ExprKind::Field(r_f_exp, r_f_ident)) => {
+                l_f_ident.name == r_f_ident.name && self.eq_expr(l_f_exp, r_f_exp)
+            },
+            (ExprKind::Index(la, li, _), ExprKind::Index(ra, ri, _)) => self.eq_expr(la, ra) && self.eq_expr(li, ri),
+            (ExprKind::If(lc, lt, le), ExprKind::If(rc, rt, re)) => {
+                self.eq_expr(lc, rc) && self.eq_expr(lt, rt)
+                    && both(le.as_ref(), re.as_ref(), |l, r| self.eq_expr(l, r))
+            },
+            (ExprKind::Let(l), ExprKind::Let(r)) => {
+                self.eq_pat(l.pat, r.pat)
+                    && both(l.ty.as_ref(), r.ty.as_ref(), |l, r| self.eq_ty(l, r))
+                    && self.eq_expr(l.init, r.init)
+            },
+            (ExprKind::Lit(l), ExprKind::Lit(r)) => {
+                if self.check_ctxt(l.span.ctxt(), r.span.ctxt()) == Some(false) {
+                    return false;
+                }
+                l.node == r.node
+            },
+            (ExprKind::Loop(lb, ll, lls, _), ExprKind::Loop(rb, rl, rls, _)) => {
+                lls == rls && self.eq_block(lb, rb)
+                    && both(ll.as_ref(), rl.as_ref(), |l, r| l.ident.name == r.ident.name)
+            },
+            (ExprKind::Match(le, la, ls), ExprKind::Match(re, ra, rs)) => {
+                (ls == rs || (matches!((ls, rs), (TryDesugar(_), TryDesugar(_)))))
+                    && self.eq_expr(le, re)
+                    && over(la, ra, |l, r| {
+                        self.eq_pat(l.pat, r.pat)
+                            && both(l.guard.as_ref(), r.guard.as_ref(), |l, r| self.eq_expr(l, r))
+                            && self.eq_expr(l.body, r.body)
+                    })
+            },
+            (
+                ExprKind::MethodCall(l_path, l_receiver, l_args, _),
+                ExprKind::MethodCall(r_path, r_receiver, r_args, _),
+            ) => {
+                self.inner.allow_side_effects
+                    && self.eq_path_segment(l_path, r_path)
+                    && self.eq_expr(l_receiver, r_receiver)
+                    && self.eq_exprs(l_args, r_args)
+            },
+            (ExprKind::UnsafeBinderCast(lkind, le, None), ExprKind::UnsafeBinderCast(rkind, re, None)) =>
+                lkind == rkind && self.eq_expr(le, re),
+            (ExprKind::UnsafeBinderCast(lkind, le, Some(lt)), ExprKind::UnsafeBinderCast(rkind, re, Some(rt))) =>
+                lkind == rkind && self.eq_expr(le, re) && self.eq_ty(lt, rt),
+            (ExprKind::OffsetOf(l_container, l_fields), ExprKind::OffsetOf(r_container, r_fields)) => {
+                self.eq_ty(l_container, r_container) && over(l_fields, r_fields, |l, r| l.name == r.name)
+            },
+            (ExprKind::Path(l), ExprKind::Path(r)) => self.eq_qpath(l, r),
+            (ExprKind::Repeat(le, ll), ExprKind::Repeat(re, rl)) => {
+                self.eq_expr(le, re) && self.eq_const_arg(ll, rl)
+            },
+            (ExprKind::Ret(l), ExprKind::Ret(r)) => both(l.as_ref(), r.as_ref(), |l, r| self.eq_expr(l, r)),
+            (ExprKind::Struct(l_path, lf, lo), ExprKind::Struct(r_path, rf, ro)) => {
+                self.eq_qpath(l_path, r_path)
+                    && match (lo, ro) {
+                        (StructTailExpr::Base(l),StructTailExpr::Base(r)) => self.eq_expr(l, r),
+                        (StructTailExpr::None, StructTailExpr::None) |
+                        (StructTailExpr::DefaultFields(_), StructTailExpr::DefaultFields(_)) => true,
+                        _ => false,
+                    }
+                    && over(lf, rf, |l, r| self.eq_expr_field(l, r))
+            },
+            (ExprKind::Tup(l_tup), ExprKind::Tup(r_tup)) => self.eq_exprs(l_tup, r_tup),
+            (ExprKind::Use(l_expr, _), ExprKind::Use(r_expr, _)) => self.eq_expr(l_expr, r_expr),
+            (ExprKind::Type(le, lt), ExprKind::Type(re, rt)) => self.eq_expr(le, re) && self.eq_ty(lt, rt),
+            (ExprKind::Unary(l_op, le), ExprKind::Unary(r_op, re)) => l_op == r_op && self.eq_expr(le, re),
+            (ExprKind::Yield(le, _), ExprKind::Yield(re, _)) => return self.eq_expr(le, re),
+            (
+                // Else branches for branches above, grouped as per `match_same_arms`.
+                | ExprKind::AddrOf(..)
+                | ExprKind::Array(..)
+                | ExprKind::Assign(..)
+                | ExprKind::AssignOp(..)
+                | ExprKind::Binary(..)
+                | ExprKind::Become(..)
+                | ExprKind::Block(..)
+                | ExprKind::Break(..)
+                | ExprKind::Call(..)
+                | ExprKind::Cast(..)
+                | ExprKind::ConstBlock(..)
+                | ExprKind::Continue(..)
+                | ExprKind::DropTemps(..)
+                | ExprKind::Field(..)
+                | ExprKind::Index(..)
+                | ExprKind::If(..)
+                | ExprKind::Let(..)
+                | ExprKind::Lit(..)
+                | ExprKind::Loop(..)
+                | ExprKind::Match(..)
+                | ExprKind::MethodCall(..)
+                | ExprKind::OffsetOf(..)
+                | ExprKind::Path(..)
+                | ExprKind::Repeat(..)
+                | ExprKind::Ret(..)
+                | ExprKind::Struct(..)
+                | ExprKind::Tup(..)
+                | ExprKind::Use(..)
+                | ExprKind::Type(..)
+                | ExprKind::Unary(..)
+                | ExprKind::Yield(..)
+                | ExprKind::UnsafeBinderCast(..)
+
+                // --- Special cases that do not have a positive branch.
+
+                // `Err` represents an invalid expression, so let's never assume that
+                // an invalid expressions is equal to anything.
+                | ExprKind::Err(..)
+
+                // For the time being, we always consider that two closures are unequal.
+                // This behavior may change in the future.
+                | ExprKind::Closure(..)
+                // For the time being, we always consider that two instances of InlineAsm are different.
+                // This behavior may change in the future.
+                | ExprKind::InlineAsm(_)
+                , _
+            ) => false,
+        };
+        (is_eq && (!self.should_ignore(left) || !self.should_ignore(right)))
+            || self
+                .inner
+                .maybe_typeck_results
+                .is_some_and(|(left_typeck_results, right_typeck_results)| {
+                    self.inner
+                        .expr_fallback
+                        .as_mut()
+                        .is_some_and(|f| f(left_typeck_results, left, right_typeck_results, right))
+                })
+    }
+
+    pub fn eq_path(&mut self, left: &Path<'_>, right: &Path<'_>) -> bool {
+        match (left.res, right.res) {
+            (Res::Local(l), Res::Local(r)) => l == r || self.locals.get(&l) == Some(&r),
+            (Res::Local(_), _) | (_, Res::Local(_)) => false,
+            (Res::Def(l_kind, l), Res::Def(r_kind, r))
+                if l_kind == r_kind
+                    && let DefKind::Const { .. }
+                    | DefKind::Static { .. }
+                    | DefKind::Fn
+                    | DefKind::TyAlias
+                    | DefKind::Use
+                    | DefKind::Mod = l_kind =>
+            {
+                (l == r || self.local_items.get(&l) == Some(&r)) && self.eq_path_segments(left.segments, right.segments)
+            },
+            _ => self.eq_path_segments(left.segments, right.segments),
+        }
+    }
+
+    pub fn eq_path_segments<'tcx>(
+        &mut self,
+        mut left: &'tcx [PathSegment<'tcx>],
+        mut right: &'tcx [PathSegment<'tcx>],
+    ) -> bool {
+        if let PathCheck::Resolution = self.inner.path_check
+            && let Some(left_seg) = generic_path_segments(left)
+            && let Some(right_seg) = generic_path_segments(right)
+        {
+            // If we compare by resolution, then only check the last segments that could possibly have generic
+            // arguments
+            left = left_seg;
+            right = right_seg;
+        }
+
+        over(left, right, |l, r| self.eq_path_segment(l, r))
+    }
+
+    pub fn eq_path_segment(&mut self, left: &PathSegment<'_>, right: &PathSegment<'_>) -> bool {
+        if !self.eq_path_parameters(left.args(), right.args()) {
+            return false;
+        }
+
+        if let PathCheck::Resolution = self.inner.path_check
+            && left.res != Res::Err
+            && right.res != Res::Err
+        {
+            left.res == right.res
+        } else {
+            // The == of idents doesn't work with different contexts,
+            // we have to be explicit about hygiene
+            left.ident.name == right.ident.name
+        }
+    }
+
+    pub fn eq_ty(&mut self, left: &Ty<'_>, right: &Ty<'_>) -> bool {
+        match (&left.kind, &right.kind) {
+            (TyKind::Slice(l_vec), TyKind::Slice(r_vec)) => self.eq_ty(l_vec, r_vec),
+            (TyKind::Array(lt, ll), TyKind::Array(rt, rl)) => self.eq_ty(lt, rt) && self.eq_const_arg(ll, rl),
+            (TyKind::Ptr(l_mut), TyKind::Ptr(r_mut)) => l_mut.mutbl == r_mut.mutbl && self.eq_ty(l_mut.ty, r_mut.ty),
+            (TyKind::Ref(_, l_rmut), TyKind::Ref(_, r_rmut)) => {
+                l_rmut.mutbl == r_rmut.mutbl && self.eq_ty(l_rmut.ty, r_rmut.ty)
+            },
+            (TyKind::Path(l), TyKind::Path(r)) => self.eq_qpath(l, r),
+            (TyKind::Tup(l), TyKind::Tup(r)) => over(l, r, |l, r| self.eq_ty(l, r)),
+            (TyKind::Infer(()), TyKind::Infer(())) => true,
+            _ => false,
+        }
+    }
+
     fn eq_fn_sig(&mut self, left: &FnSig<'_>, right: &FnSig<'_>) -> bool {
         left.header.safety == right.header.safety
             && left.header.constness == right.header.constness
@@ -482,208 +753,6 @@ impl HirEqInterExpr<'_, '_, '_> {
         })
     }
 
-    pub fn eq_body(&mut self, left: BodyId, right: BodyId) -> bool {
-        // swap out TypeckResults when hashing a body
-        let old_maybe_typeck_results = self.inner.maybe_typeck_results.replace((
-            self.inner.cx.tcx.typeck_body(left),
-            self.inner.cx.tcx.typeck_body(right),
-        ));
-        let res = self.eq_expr(
-            self.inner.cx.tcx.hir_body(left).value,
-            self.inner.cx.tcx.hir_body(right).value,
-        );
-        self.inner.maybe_typeck_results = old_maybe_typeck_results;
-        res
-    }
-
-    #[expect(clippy::too_many_lines)]
-    pub fn eq_expr(&mut self, left: &Expr<'_>, right: &Expr<'_>) -> bool {
-        match self.check_ctxt(left.span.ctxt(), right.span.ctxt()) {
-            None => {
-                if let Some((typeck_lhs, typeck_rhs)) = self.inner.maybe_typeck_results
-                    && typeck_lhs.expr_ty(left) == typeck_rhs.expr_ty(right)
-                    && let (Some(l), Some(r)) = (
-                        ConstEvalCtxt::with_env(self.inner.cx.tcx, self.inner.cx.typing_env(), typeck_lhs)
-                            .eval_local(left, self.eval_ctxt),
-                        ConstEvalCtxt::with_env(self.inner.cx.tcx, self.inner.cx.typing_env(), typeck_rhs)
-                            .eval_local(right, self.eval_ctxt),
-                    )
-                    && l == r
-                {
-                    return true;
-                }
-            },
-            Some(false) => return false,
-            Some(true) => {},
-        }
-
-        let is_eq = match (
-            reduce_exprkind(self.inner.cx, self.eval_ctxt, &left.kind),
-            reduce_exprkind(self.inner.cx, self.eval_ctxt, &right.kind),
-        ) {
-            (ExprKind::AddrOf(lb, l_mut, le), ExprKind::AddrOf(rb, r_mut, re)) => {
-                lb == rb && l_mut == r_mut && self.eq_expr(le, re)
-            },
-            (ExprKind::Array(l), ExprKind::Array(r)) => self.eq_exprs(l, r),
-            (ExprKind::Assign(ll, lr, _), ExprKind::Assign(rl, rr, _)) => {
-                self.inner.allow_side_effects && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
-            },
-            (ExprKind::AssignOp(lo, ll, lr), ExprKind::AssignOp(ro, rl, rr)) => {
-                self.inner.allow_side_effects && lo.node == ro.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
-            },
-            (ExprKind::Block(l, _), ExprKind::Block(r, _)) => self.eq_block(l, r),
-            (ExprKind::Binary(l_op, ll, lr), ExprKind::Binary(r_op, rl, rr)) => {
-                l_op.node == r_op.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
-                    || self.swap_binop(l_op.node, ll, lr).is_some_and(|(l_op, ll, lr)| {
-                        l_op == r_op.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
-                    })
-            },
-            (ExprKind::Break(li, le), ExprKind::Break(ri, re)) => {
-                both(li.label.as_ref(), ri.label.as_ref(), |l, r| l.ident.name == r.ident.name)
-                    && both(le.as_ref(), re.as_ref(), |l, r| self.eq_expr(l, r))
-            },
-            (ExprKind::Call(l_fun, l_args), ExprKind::Call(r_fun, r_args)) => {
-                self.inner.allow_side_effects && self.eq_expr(l_fun, r_fun) && self.eq_exprs(l_args, r_args)
-            },
-            (ExprKind::Cast(lx, lt), ExprKind::Cast(rx, rt)) => {
-                self.eq_expr(lx, rx) && self.eq_ty(lt, rt)
-            },
-            (ExprKind::Closure(_l), ExprKind::Closure(_r)) => false,
-            (ExprKind::ConstBlock(lb), ExprKind::ConstBlock(rb)) => self.eq_body(lb.body, rb.body),
-            (ExprKind::Continue(li), ExprKind::Continue(ri)) => {
-                both(li.label.as_ref(), ri.label.as_ref(), |l, r| l.ident.name == r.ident.name)
-            },
-            (ExprKind::DropTemps(le), ExprKind::DropTemps(re)) => self.eq_expr(le, re),
-            (ExprKind::Field(l_f_exp, l_f_ident), ExprKind::Field(r_f_exp, r_f_ident)) => {
-                l_f_ident.name == r_f_ident.name && self.eq_expr(l_f_exp, r_f_exp)
-            },
-            (ExprKind::Index(la, li, _), ExprKind::Index(ra, ri, _)) => self.eq_expr(la, ra) && self.eq_expr(li, ri),
-            (ExprKind::If(lc, lt, le), ExprKind::If(rc, rt, re)) => {
-                self.eq_expr(lc, rc) && self.eq_expr(lt, rt)
-                    && both(le.as_ref(), re.as_ref(), |l, r| self.eq_expr(l, r))
-            },
-            (ExprKind::Let(l), ExprKind::Let(r)) => {
-                self.eq_pat(l.pat, r.pat)
-                    && both(l.ty.as_ref(), r.ty.as_ref(), |l, r| self.eq_ty(l, r))
-                    && self.eq_expr(l.init, r.init)
-            },
-            (ExprKind::Lit(l), ExprKind::Lit(r)) => {
-                if self.check_ctxt(l.span.ctxt(), r.span.ctxt()) == Some(false) {
-                    return false;
-                }
-                l.node == r.node
-            },
-            (ExprKind::Loop(lb, ll, lls, _), ExprKind::Loop(rb, rl, rls, _)) => {
-                lls == rls && self.eq_block(lb, rb)
-                    && both(ll.as_ref(), rl.as_ref(), |l, r| l.ident.name == r.ident.name)
-            },
-            (ExprKind::Match(le, la, ls), ExprKind::Match(re, ra, rs)) => {
-                (ls == rs || (matches!((ls, rs), (TryDesugar(_), TryDesugar(_)))))
-                    && self.eq_expr(le, re)
-                    && over(la, ra, |l, r| {
-                        self.eq_pat(l.pat, r.pat)
-                            && both(l.guard.as_ref(), r.guard.as_ref(), |l, r| self.eq_expr(l, r))
-                            && self.eq_expr(l.body, r.body)
-                    })
-            },
-            (
-                ExprKind::MethodCall(l_path, l_receiver, l_args, _),
-                ExprKind::MethodCall(r_path, r_receiver, r_args, _),
-            ) => {
-                self.inner.allow_side_effects
-                    && self.eq_path_segment(l_path, r_path)
-                    && self.eq_expr(l_receiver, r_receiver)
-                    && self.eq_exprs(l_args, r_args)
-            },
-            (ExprKind::UnsafeBinderCast(lkind, le, None), ExprKind::UnsafeBinderCast(rkind, re, None)) =>
-                lkind == rkind && self.eq_expr(le, re),
-            (ExprKind::UnsafeBinderCast(lkind, le, Some(lt)), ExprKind::UnsafeBinderCast(rkind, re, Some(rt))) =>
-                lkind == rkind && self.eq_expr(le, re) && self.eq_ty(lt, rt),
-            (ExprKind::OffsetOf(l_container, l_fields), ExprKind::OffsetOf(r_container, r_fields)) => {
-                self.eq_ty(l_container, r_container) && over(l_fields, r_fields, |l, r| l.name == r.name)
-            },
-            (ExprKind::Path(l), ExprKind::Path(r)) => self.eq_qpath(l, r),
-            (ExprKind::Repeat(le, ll), ExprKind::Repeat(re, rl)) => {
-                self.eq_expr(le, re) && self.eq_const_arg(ll, rl)
-            },
-            (ExprKind::Ret(l), ExprKind::Ret(r)) => both(l.as_ref(), r.as_ref(), |l, r| self.eq_expr(l, r)),
-            (ExprKind::Struct(l_path, lf, lo), ExprKind::Struct(r_path, rf, ro)) => {
-                self.eq_qpath(l_path, r_path)
-                    && match (lo, ro) {
-                        (StructTailExpr::Base(l),StructTailExpr::Base(r)) => self.eq_expr(l, r),
-                        (StructTailExpr::None, StructTailExpr::None) |
-                        (StructTailExpr::DefaultFields(_), StructTailExpr::DefaultFields(_)) => true,
-                        _ => false,
-                    }
-                    && over(lf, rf, |l, r| self.eq_expr_field(l, r))
-            },
-            (ExprKind::Tup(l_tup), ExprKind::Tup(r_tup)) => self.eq_exprs(l_tup, r_tup),
-            (ExprKind::Use(l_expr, _), ExprKind::Use(r_expr, _)) => self.eq_expr(l_expr, r_expr),
-            (ExprKind::Type(le, lt), ExprKind::Type(re, rt)) => self.eq_expr(le, re) && self.eq_ty(lt, rt),
-            (ExprKind::Unary(l_op, le), ExprKind::Unary(r_op, re)) => l_op == r_op && self.eq_expr(le, re),
-            (ExprKind::Yield(le, _), ExprKind::Yield(re, _)) => return self.eq_expr(le, re),
-            (
-                // Else branches for branches above, grouped as per `match_same_arms`.
-                | ExprKind::AddrOf(..)
-                | ExprKind::Array(..)
-                | ExprKind::Assign(..)
-                | ExprKind::AssignOp(..)
-                | ExprKind::Binary(..)
-                | ExprKind::Become(..)
-                | ExprKind::Block(..)
-                | ExprKind::Break(..)
-                | ExprKind::Call(..)
-                | ExprKind::Cast(..)
-                | ExprKind::ConstBlock(..)
-                | ExprKind::Continue(..)
-                | ExprKind::DropTemps(..)
-                | ExprKind::Field(..)
-                | ExprKind::Index(..)
-                | ExprKind::If(..)
-                | ExprKind::Let(..)
-                | ExprKind::Lit(..)
-                | ExprKind::Loop(..)
-                | ExprKind::Match(..)
-                | ExprKind::MethodCall(..)
-                | ExprKind::OffsetOf(..)
-                | ExprKind::Path(..)
-                | ExprKind::Repeat(..)
-                | ExprKind::Ret(..)
-                | ExprKind::Struct(..)
-                | ExprKind::Tup(..)
-                | ExprKind::Use(..)
-                | ExprKind::Type(..)
-                | ExprKind::Unary(..)
-                | ExprKind::Yield(..)
-                | ExprKind::UnsafeBinderCast(..)
-
-                // --- Special cases that do not have a positive branch.
-
-                // `Err` represents an invalid expression, so let's never assume that
-                // an invalid expressions is equal to anything.
-                | ExprKind::Err(..)
-
-                // For the time being, we always consider that two closures are unequal.
-                // This behavior may change in the future.
-                | ExprKind::Closure(..)
-                // For the time being, we always consider that two instances of InlineAsm are different.
-                // This behavior may change in the future.
-                | ExprKind::InlineAsm(_)
-                , _
-            ) => false,
-        };
-        (is_eq && (!self.should_ignore(left) || !self.should_ignore(right)))
-            || self
-                .inner
-                .maybe_typeck_results
-                .is_some_and(|(left_typeck_results, right_typeck_results)| {
-                    self.inner
-                        .expr_fallback
-                        .as_mut()
-                        .is_some_and(|f| f(left_typeck_results, left, right_typeck_results, right))
-                })
-    }
-
     fn eq_exprs(&mut self, left: &[Expr<'_>], right: &[Expr<'_>]) -> bool {
         over(left, right, |l, r| self.eq_expr(l, r))
     }
@@ -835,81 +904,12 @@ impl HirEqInterExpr<'_, '_, '_> {
         }
     }
 
-    pub fn eq_path(&mut self, left: &Path<'_>, right: &Path<'_>) -> bool {
-        match (left.res, right.res) {
-            (Res::Local(l), Res::Local(r)) => l == r || self.locals.get(&l) == Some(&r),
-            (Res::Local(_), _) | (_, Res::Local(_)) => false,
-            (Res::Def(l_kind, l), Res::Def(r_kind, r))
-                if l_kind == r_kind
-                    && let DefKind::Const { .. }
-                    | DefKind::Static { .. }
-                    | DefKind::Fn
-                    | DefKind::TyAlias
-                    | DefKind::Use
-                    | DefKind::Mod = l_kind =>
-            {
-                (l == r || self.local_items.get(&l) == Some(&r)) && self.eq_path_segments(left.segments, right.segments)
-            },
-            _ => self.eq_path_segments(left.segments, right.segments),
-        }
-    }
-
     fn eq_path_parameters(&mut self, left: &GenericArgs<'_>, right: &GenericArgs<'_>) -> bool {
         if left.parenthesized == right.parenthesized {
             over(left.args, right.args, |l, r| self.eq_generic_arg(l, r)) // FIXME(flip1995): may not work
                 && over(left.constraints, right.constraints, |l, r| self.eq_assoc_eq_constraint(l, r))
         } else {
             false
-        }
-    }
-
-    pub fn eq_path_segments<'tcx>(
-        &mut self,
-        mut left: &'tcx [PathSegment<'tcx>],
-        mut right: &'tcx [PathSegment<'tcx>],
-    ) -> bool {
-        if let PathCheck::Resolution = self.inner.path_check
-            && let Some(left_seg) = generic_path_segments(left)
-            && let Some(right_seg) = generic_path_segments(right)
-        {
-            // If we compare by resolution, then only check the last segments that could possibly have generic
-            // arguments
-            left = left_seg;
-            right = right_seg;
-        }
-
-        over(left, right, |l, r| self.eq_path_segment(l, r))
-    }
-
-    pub fn eq_path_segment(&mut self, left: &PathSegment<'_>, right: &PathSegment<'_>) -> bool {
-        if !self.eq_path_parameters(left.args(), right.args()) {
-            return false;
-        }
-
-        if let PathCheck::Resolution = self.inner.path_check
-            && left.res != Res::Err
-            && right.res != Res::Err
-        {
-            left.res == right.res
-        } else {
-            // The == of idents doesn't work with different contexts,
-            // we have to be explicit about hygiene
-            left.ident.name == right.ident.name
-        }
-    }
-
-    pub fn eq_ty(&mut self, left: &Ty<'_>, right: &Ty<'_>) -> bool {
-        match (&left.kind, &right.kind) {
-            (TyKind::Slice(l_vec), TyKind::Slice(r_vec)) => self.eq_ty(l_vec, r_vec),
-            (TyKind::Array(lt, ll), TyKind::Array(rt, rl)) => self.eq_ty(lt, rt) && self.eq_const_arg(ll, rl),
-            (TyKind::Ptr(l_mut), TyKind::Ptr(r_mut)) => l_mut.mutbl == r_mut.mutbl && self.eq_ty(l_mut.ty, r_mut.ty),
-            (TyKind::Ref(_, l_rmut), TyKind::Ref(_, r_rmut)) => {
-                l_rmut.mutbl == r_rmut.mutbl && self.eq_ty(l_rmut.ty, r_rmut.ty)
-            },
-            (TyKind::Path(l), TyKind::Path(r)) => self.eq_qpath(l, r),
-            (TyKind::Tup(l), TyKind::Tup(r)) => over(l, r, |l, r| self.eq_ty(l, r)),
-            (TyKind::Infer(()), TyKind::Infer(())) => true,
-            _ => false,
         }
     }
 

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -1142,6 +1142,12 @@ impl<'tcx> InteriorMut<'tcx> {
         self.interior_mut_ty_chain_inner(cx, ty, 0)
     }
 
+    /// Check if given type has interior mutability such as [`std::cell::Cell`] or
+    /// [`std::cell::RefCell`] etc.
+    pub fn is_interior_mut_ty(&mut self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+        self.interior_mut_ty_chain(cx, ty).is_some()
+    }
+
     fn interior_mut_ty_chain_inner(
         &mut self,
         cx: &LateContext<'tcx>,
@@ -1214,12 +1220,6 @@ impl<'tcx> InteriorMut<'tcx> {
             self.tys.insert(ty, Some(list));
             list
         })
-    }
-
-    /// Check if given type has interior mutability such as [`std::cell::Cell`] or
-    /// [`std::cell::RefCell`] etc.
-    pub fn is_interior_mut_ty(&mut self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-        self.interior_mut_ty_chain(cx, ty).is_some()
     }
 }
 

--- a/tests/ui/unordered_methods.rs
+++ b/tests/ui/unordered_methods.rs
@@ -1,0 +1,44 @@
+#![allow(unused)]
+#![warn(clippy::unordered_methods)]
+
+// Impl methods
+struct A;
+impl A {
+    fn do_nothing() {}
+
+    fn fo(&self) {}
+
+    pub fn foo(&self) {}
+    //~^ unordered_methods
+
+    pub fn my_constructor() -> Self {
+        //~^ unordered_methods
+        A
+    }
+}
+
+struct B;
+impl B {
+    pub fn my_constructor() -> Self {
+        B
+    }
+
+    pub fn my_constructor2() -> Self {
+        B
+    }
+}
+
+struct C;
+impl C {
+    pub fn foo(&self) {}
+
+    pub fn maybe_constructor() -> Option<Self> {
+        //~^ unordered_methods
+        Option::Some(C)
+    }
+}
+
+fn main() {
+    let a = A::my_constructor();
+    a.foo();
+}

--- a/tests/ui/unordered_methods.stderr
+++ b/tests/ui/unordered_methods.stderr
@@ -1,0 +1,34 @@
+error: methods are not ordered correctly: `Public(foo)` declared after `Private(fo)`
+  --> tests/ui/unordered_methods.rs:11:5
+   |
+LL |     pub fn foo(&self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: reorder functions to be constructors, public, private
+   = note: `-D clippy::unordered-methods` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unordered_methods)]`
+
+error: methods are not ordered correctly: `Constructor(my_constructor)` declared after `Public(foo)`
+  --> tests/ui/unordered_methods.rs:14:5
+   |
+LL | /     pub fn my_constructor() -> Self {
+LL | |
+LL | |         A
+LL | |     }
+   | |_____^
+   |
+   = help: reorder functions to be constructors, public, private
+
+error: methods are not ordered correctly: `Constructor(maybe_constructor)` declared after `Public(foo)`
+  --> tests/ui/unordered_methods.rs:35:5
+   |
+LL | /     pub fn maybe_constructor() -> Option<Self> {
+LL | |
+LL | |         Option::Some(C)
+LL | |     }
+   | |_____^
+   |
+   = help: reorder functions to be constructors, public, private
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
New linter: `unordered_methods`

I would like to propose adding a new linter `unordered_methods`.

The goal of this linter is to have a consistent method declaration inside a `Impl` block.
This linter checks that inside a `Impl` block the "constructors" are declared before the public methods, and the public methods are declared before the private ones.

So the order of declaration should be:

- "Constructors"
- Public methods
- Private methods

Constructors are the starting point to create struct instances, so placing them first makes the API clearer. 
A logical grouping of methods by visibility further enhances code comprehension and help
to make code consistent.

I opened the PR as draft, to receive any kind of feedback and/or suggestions.

Thanks and regards!

PS: I would also like to thanks you all for this amazing tool.
PS2: I needed to update many other files to honor `unordered_methods`.

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: adding a new linter `unordered_methods`.

## Glossary of terms

Constructor: Despite having read [constructors][constructors], I would consider a "constructor" a function inside an `Impl` block that in its input parameters there is no `self` in any kind of form, and the return type is the struct of that `Impl` block.

[constructors]: https://doc.rust-lang.org/nomicon/constructors.html