### PR TITLE
Add MSRV behavior sections to lint docs

### DIFF
--- a/clippy_lints/src/almost_complete_range.rs
+++ b/clippy_lints/src/almost_complete_range.rs
@@ -26,7 +26,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.68.0"]
     pub ALMOST_COMPLETE_RANGE,
     suspicious,
-    "almost complete range"
+    "almost complete range",
+    @msrv_behavior = "When the configured MSRV is at least 1.26, this lint suggests `..=` for inclusive ranges. For range patterns on older MSRVs, it suggests the older `...` syntax instead; expression ranges do not get a suggestion on older MSRVs."
 }
 
 impl_lint_pass!(AlmostCompleteRange => [ALMOST_COMPLETE_RANGE]);

--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -36,7 +36,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub APPROX_CONSTANT,
     correctness,
-    "the approximate of a known float constant (in `std::fXX::consts`)"
+    "the approximate of a known float constant (in `std::fXX::consts`)",
+    @msrv_behavior = "Approximate constants whose standard-library constant stabilized later are only linted when the configured MSRV supports them: `LOG2_10` and `LOG10_2` require 1.43, and `TAU` requires 1.47."
 }
 
 impl_lint_pass!(ApproxConstant => [APPROX_CONSTANT]);

--- a/clippy_lints/src/assertions_on_constants.rs
+++ b/clippy_lints/src/assertions_on_constants.rs
@@ -29,7 +29,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.34.0"]
     pub ASSERTIONS_ON_CONSTANTS,
     style,
-    "`assert!(true)` / `assert!(false)` will be optimized out by the compiler, and should probably be replaced by a `panic!()` or `unreachable!()`"
+    "`assert!(true)` / `assert!(false)` will be optimized out by the compiler, and should probably be replaced by a `panic!()` or `unreachable!()`",
+    @msrv_behavior = "Assertions on local constants are linted for all MSRVs. Assertions on non-local constants outside always-const contexts are only linted when the configured MSRV is at least 1.57 (suggesting an anonymous const) or 1.79 (suggesting a const block)."
 }
 
 impl_lint_pass!(AssertionsOnConstants => [ASSERTIONS_ON_CONSTANTS]);

--- a/clippy_lints/src/assigning_clones.rs
+++ b/clippy_lints/src/assigning_clones.rs
@@ -50,7 +50,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.78.0"]
     pub ASSIGNING_CLONES,
     pedantic,
-    "assigning the result of cloning may be inefficient"
+    "assigning the result of cloning may be inefficient",
+    @msrv_behavior = "This lint always checks assignments from `Clone::clone`. It only checks assignments from `ToOwned::to_owned` when the configured MSRV is at least 1.63, because that case suggests `clone_into()`."
 }
 
 impl_lint_pass!(AssigningClones => [ASSIGNING_CLONES]);

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -55,7 +55,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.70.0"]
     pub ALLOW_ATTRIBUTES,
     restriction,
-    "`#[allow]` will not trigger if a warning isn't found. `#[expect]` triggers if there are no warnings."
+    "`#[allow]` will not trigger if a warning isn't found. `#[expect]` triggers if there are no warnings.",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.81, because it suggests `#[expect]`, which was stabilized in that version."
 }
 
 declare_clippy_lint! {
@@ -78,7 +79,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.61.0"]
     pub ALLOW_ATTRIBUTES_WITHOUT_REASON,
     restriction,
-    "ensures that all `allow` and `expect` attributes have a reason"
+    "ensures that all `allow` and `expect` attributes have a reason",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.81, because the `reason` argument to lint attributes requires that version."
 }
 
 declare_clippy_lint! {
@@ -132,7 +134,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.32.0"]
     pub DEPRECATED_CFG_ATTR,
     complexity,
-    "usage of `cfg_attr(rustfmt)` instead of tool attributes"
+    "usage of `cfg_attr(rustfmt)` instead of tool attributes",
+    @msrv_behavior = "`cfg_attr(rustfmt, rustfmt_skip)` is only linted when the configured MSRV is at least 1.30. Other deprecated `cargo-clippy` cfg checks are not MSRV-gated."
 }
 
 declare_clippy_lint! {
@@ -363,7 +366,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.85.0"]
     pub REPR_PACKED_WITHOUT_ABI,
     suspicious,
-    "ensures that `repr(packed)` always comes with a qualified ABI"
+    "ensures that `repr(packed)` always comes with a qualified ABI",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.74, because it may suggest explicit `repr(Rust, packed)`."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -46,7 +46,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub NONMINIMAL_BOOL,
     pedantic,
-    "boolean expressions that can be written more concisely"
+    "boolean expressions that can be written more concisely",
+    @msrv_behavior = "This lint only suggests `is_none_or` when the configured MSRV is at least 1.82. Other boolean simplifications are not MSRV-gated."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -145,7 +145,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.60.0"]
     pub BORROW_AS_PTR,
     pedantic,
-    "borrowing just to cast to a raw pointer"
+    "borrowing just to cast to a raw pointer",
+    @msrv_behavior = "When the configured MSRV is at least 1.82, this lint suggests the `&raw` syntax. On older MSRVs, it suggests `std::ptr::addr_of!` or `std::ptr::addr_of_mut!` instead."
 }
 
 declare_clippy_lint! {
@@ -168,7 +169,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.62.0"]
     pub CAST_ABS_TO_UNSIGNED,
     suspicious,
-    "casting the result of `abs()` to an unsigned integer can panic"
+    "casting the result of `abs()` to an unsigned integer can panic",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.51, because it suggests `unsigned_abs`."
 }
 
 declare_clippy_lint! {
@@ -238,7 +240,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub CAST_LOSSLESS,
     pedantic,
-    "casts using `as` that are known to be lossless, e.g., `x as u64` where `x: u8`"
+    "casts using `as` that are known to be lossless, e.g., `x as u64` where `x: u8`",
+    @msrv_behavior = "Lossless casts from `bool` are only linted when the configured MSRV is at least 1.28, because that version provides `From<bool>` conversions."
 }
 
 declare_clippy_lint! {
@@ -335,7 +338,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub CAST_POSSIBLE_WRAP,
     pedantic,
-    "casts that may cause wrapping around the value, e.g., `x as i32` where `x: u32` and `x > i32::MAX`"
+    "casts that may cause wrapping around the value, e.g., `x as i32` where `x: u32` and `x > i32::MAX`",
+    @msrv_behavior = "When the configured MSRV is at least 1.87, this lint may suggest integer sign-cast methods for wrapping casts."
 }
 
 declare_clippy_lint! {
@@ -411,7 +415,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub CAST_SIGN_LOSS,
     pedantic,
-    "casts from signed types to unsigned types, e.g., `x as u32` where `x: i32`"
+    "casts from signed types to unsigned types, e.g., `x as u32` where `x: i32`",
+    @msrv_behavior = "When the configured MSRV is at least 1.87, this lint may suggest integer sign-cast methods for signed-to-unsigned casts."
 }
 
 declare_clippy_lint! {
@@ -456,7 +461,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.61.0"]
     pub CAST_SLICE_DIFFERENT_SIZES,
     correctness,
-    "casting using `as` between raw pointers to slices of types with different sizes"
+    "casting using `as` between raw pointers to slices of types with different sizes",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.42, because it suggests raw slice pointer APIs."
 }
 
 declare_clippy_lint! {
@@ -483,7 +489,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.65.0"]
     pub CAST_SLICE_FROM_RAW_PARTS,
     suspicious,
-    "casting a slice created from a pointer and length to a slice pointer"
+    "casting a slice created from a pointer and length to a slice pointer",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.42, because it suggests raw slice pointer APIs."
 }
 
 declare_clippy_lint! {
@@ -724,7 +731,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.51.0"]
     pub PTR_AS_PTR,
     pedantic,
-    "casting using `as` between raw pointers that doesn't change their constness, where `pointer::cast` could take the place of `as`"
+    "casting using `as` between raw pointers that doesn't change their constness, where `pointer::cast` could take the place of `as`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.38, because it suggests raw pointer `cast`."
 }
 
 declare_clippy_lint! {
@@ -760,7 +768,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.72.0"]
     pub PTR_CAST_CONSTNESS,
     pedantic,
-    "casting using `as` on raw pointers to change constness when specialized methods apply"
+    "casting using `as` on raw pointers to change constness when specialized methods apply",
+    @msrv_behavior = "Null pointer constness casts can be linted for all MSRVs. Other raw pointer constness casts are only linted when the configured MSRV is at least 1.65, because they suggest `cast_mut` or `cast_const`."
 }
 
 declare_clippy_lint! {
@@ -843,7 +852,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub ZERO_PTR,
     style,
-    "using `0 as *{const, mut} T`"
+    "using `0 as *{const, mut} T`",
+    @msrv_behavior = "This lint can be emitted outside const contexts on all configured MSRVs. In const contexts, it is only emitted when the configured MSRV is at least 1.24, because it suggests `ptr::null` or `ptr::null_mut`."
 }
 
 impl_lint_pass!(Casts => [

--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -31,7 +31,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.37.0"]
     pub CHECKED_CONVERSIONS,
     pedantic,
-    "`try_from` could replace manual bounds checking when casting"
+    "`try_from` could replace manual bounds checking when casting",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.34, because it suggests `TryFrom`."
 }
 
 impl_lint_pass!(CheckedConversions => [CHECKED_CONVERSIONS]);

--- a/clippy_lints/src/cloned_ref_to_slice_refs.rs
+++ b/clippy_lints/src/cloned_ref_to_slice_refs.rs
@@ -48,7 +48,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.89.0"]
     pub CLONED_REF_TO_SLICE_REFS,
     perf,
-    "cloning a reference for slice references"
+    "cloning a reference for slice references",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV supports `slice::from_ref`: at least 1.28 outside const contexts, or at least 1.63 in const contexts."
 }
 
 impl_lint_pass!(ClonedRefToSliceRefs<'_> => [CLONED_REF_TO_SLICE_REFS]);

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -76,7 +76,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub COLLAPSIBLE_IF,
     style,
-    "nested `if`s that can be collapsed (e.g., `if x { if y { ... } }`"
+    "nested `if`s that can be collapsed (e.g., `if x { if y { ... } }`",
+    @msrv_behavior = "Nested `if let` conditions are only collapsed into if-let chains when the crate uses Rust 2024 edition and the configured MSRV is at least 1.88. Other collapsible `if` suggestions are not gated by this MSRV check."
 }
 
 impl_lint_pass!(CollapsibleIf => [COLLAPSIBLE_ELSE_IF, COLLAPSIBLE_IF]);

--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -53,7 +53,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.57.0"]
     pub DERIVABLE_IMPLS,
     complexity,
-    "manual implementation of the `Default` trait which is equal to a derive"
+    "manual implementation of the `Default` trait which is equal to a derive",
+    @msrv_behavior = "Manual `Default` implementations for structs can be linted on all configured MSRVs. Enum implementations are only linted when the configured MSRV is at least 1.62, because `#[default]` on enum variants is available from that version."
 }
 
 impl_lint_pass!(DerivableImpls => [DERIVABLE_IMPLS]);

--- a/clippy_lints/src/duration_suboptimal_units.rs
+++ b/clippy_lints/src/duration_suboptimal_units.rs
@@ -45,7 +45,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.95.0"]
     pub DURATION_SUBOPTIMAL_UNITS,
     pedantic,
-    "constructing a `Duration` using a smaller unit when a larger unit would be more readable"
+    "constructing a `Duration` using a smaller unit when a larger unit would be more readable",
+    @msrv_behavior = "This lint only suggests larger `Duration` constructors that are available for the configured MSRV. It can suggest nanos/micros from 1.27, millis/secs from 1.3, and mins/hours from 1.91."
 }
 
 impl_lint_pass!(DurationSuboptimalUnits => [DURATION_SUBOPTIMAL_UNITS]);

--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -165,7 +165,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.66.0"]
     pub UNINLINED_FORMAT_ARGS,
     pedantic,
-    "using non-inlined variables in `format!` calls"
+    "using non-inlined variables in `format!` calls",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.58, because it suggests captured format arguments."
 }
 
 declare_clippy_lint! {
@@ -200,7 +201,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.87.0"]
     pub UNNECESSARY_DEBUG_FORMATTING,
     pedantic,
-    "`Debug` formatting applied to an `OsStr` or `Path` when `.display()` is available"
+    "`Debug` formatting applied to an `OsStr` or `Path` when `.display()` is available",
+    @msrv_behavior = "`Path` debug formatting is linted for all MSRVs. `OsStr` debug formatting is only linted when the configured MSRV is at least 1.87, because it suggests `OsStr::display`."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -49,7 +49,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.51.0"]
     pub FROM_OVER_INTO,
     style,
-    "Warns on implementations of `Into<..>` to use `From<..>`"
+    "Warns on implementations of `Into<..>` to use `From<..>`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.41, because coherence changes in that version make the suggested `From` implementation broadly equivalent."
 }
 
 impl_lint_pass!(FromOverInto => [FROM_OVER_INTO]);

--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -424,7 +424,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.49.0"]
     pub RESULT_UNIT_ERR,
     style,
-    "public function returning `Result` with an `Err` type of `()`"
+    "public function returning `Result` with an `Err` type of `()`",
+    @msrv_behavior = "In `no_std` crates, this lint is only emitted when the configured MSRV is at least 1.81, because `Error` is available in `core` from that version."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/if_then_some_else_none.rs
+++ b/clippy_lints/src/if_then_some_else_none.rs
@@ -47,7 +47,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.53.0"]
     pub IF_THEN_SOME_ELSE_NONE,
     restriction,
-    "Finds if-else that could be written using either `bool::then` or `bool::then_some`"
+    "Finds if-else that could be written using either `bool::then` or `bool::then_some`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.50, because it suggests `bool::then`. When the configured MSRV is at least 1.62 and eager evaluation is suitable, it suggests `bool::then_some` instead."
 }
 
 impl_lint_pass!(IfThenSomeElseNone => [IF_THEN_SOME_ELSE_NONE]);

--- a/clippy_lints/src/implicit_saturating_sub.rs
+++ b/clippy_lints/src/implicit_saturating_sub.rs
@@ -46,7 +46,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.44.0"]
     pub IMPLICIT_SATURATING_SUB,
     style,
-    "Perform saturating subtraction instead of implicitly checking lower bound of data type"
+    "Perform saturating subtraction instead of implicitly checking lower bound of data type",
+    @msrv_behavior = "This lint is emitted for all MSRVs outside const contexts. In const contexts, it is only emitted when the configured MSRV is at least 1.47."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/index_refutable_slice.rs
+++ b/clippy_lints/src/index_refutable_slice.rs
@@ -50,7 +50,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.59.0"]
     pub INDEX_REFUTABLE_SLICE,
     pedantic,
-    "avoid indexing on slices which could be destructed"
+    "avoid indexing on slices which could be destructed",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.42, because it suggests subslice patterns."
 }
 
 impl_lint_pass!(IndexRefutableSlice => [INDEX_REFUTABLE_SLICE]);

--- a/clippy_lints/src/legacy_numeric_constants.rs
+++ b/clippy_lints/src/legacy_numeric_constants.rs
@@ -32,7 +32,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.79.0"]
     pub LEGACY_NUMERIC_CONSTANTS,
     style,
-    "checks for usage of legacy std numeric constants and methods"
+    "checks for usage of legacy std numeric constants and methods",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.43, because it suggests primitive numeric associated constants such as `i32::MAX`."
 }
 
 impl_lint_pass!(LegacyNumericConstants => [LEGACY_NUMERIC_CONSTANTS]);

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -85,7 +85,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub LEN_ZERO,
     style,
-    "checking `.len() == 0` or `.len() > 0` (or similar) when `.is_empty()` could be used instead"
+    "checking `.len() == 0` or `.len() > 0` (or similar) when `.is_empty()` could be used instead",
+    @msrv_behavior = "This lint only suggests `is_empty()` for types where an `is_empty` method is available for the configured MSRV. Arrays, slices, and `str` are not MSRV-gated."
 }
 
 impl_lint_pass!(LenZero => [COMPARISON_TO_EMPTY, LEN_ZERO]);

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -121,7 +121,8 @@ declare_clippy_lint! {
     pub NEEDLESS_LIFETIMES,
     complexity,
     "using explicit lifetimes for references in function arguments when elision rules \
-     would allow omitting them"
+     would allow omitting them",
+    @msrv_behavior = "This lint keeps explicit self type lifetimes before Rust 1.81, where eliding them could be rejected."
 }
 
 impl_lint_pass!(Lifetimes => [

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -204,7 +204,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub EXPLICIT_ITER_LOOP,
     pedantic,
-    "for-looping over `_.iter()` or `_.iter_mut()` when `&_` or `&mut _` would do"
+    "for-looping over `_.iter()` or `_.iter_mut()` when `&_` or `&mut _` would do",
+    @msrv_behavior = "This lint does not fire for iterating over arrays by value when the configured MSRV is below 1.53, or over `Box` types when below 1.80, as those types did not implement `IntoIterator` in those versions."
 }
 
 declare_clippy_lint! {
@@ -362,7 +363,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.52.0"]
     pub MANUAL_FLATTEN,
     complexity,
-    "for loops over `Option`s or `Result`s with a single expression can be simplified"
+    "for loops over `Option`s or `Result`s with a single expression can be simplified",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.29, because it suggests `Iterator::flatten`."
 }
 
 declare_clippy_lint! {
@@ -416,7 +418,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.86.0"]
     pub MANUAL_SLICE_FILL,
     style,
-    "manually filling a slice with a value"
+    "manually filling a slice with a value",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.50, because it suggests `slice::fill`."
 }
 
 declare_clippy_lint! {
@@ -607,7 +610,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.47.0"]
     pub SAME_ITEM_PUSH,
     style,
-    "the same item is pushed inside of a for loop"
+    "the same item is pushed inside of a for loop",
+    @msrv_behavior = "When the configured MSRV is at least 1.82, this lint can suggest `std::iter::repeat_n`; otherwise it suggests older alternatives."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/manual_abs_diff.rs
+++ b/clippy_lints/src/manual_abs_diff.rs
@@ -38,7 +38,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.88.0"]
     pub MANUAL_ABS_DIFF,
     complexity,
-    "using an if-else pattern instead of `abs_diff`"
+    "using an if-else pattern instead of `abs_diff`",
+    @msrv_behavior = "This lint is only emitted for primitive integers when the configured MSRV is at least 1.60, and for `Duration` when the configured MSRV is at least 1.81, because those versions provide `abs_diff`."
 }
 
 impl_lint_pass!(ManualAbsDiff => [MANUAL_ABS_DIFF]);

--- a/clippy_lints/src/manual_bits.rs
+++ b/clippy_lints/src/manual_bits.rs
@@ -31,7 +31,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.60.0"]
     pub MANUAL_BITS,
     style,
-    "manual implementation of `size_of::<T>() * 8` can be simplified with `T::BITS`"
+    "manual implementation of `size_of::<T>() * 8` can be simplified with `T::BITS`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.53, because it suggests integer `BITS` associated constants."
 }
 
 impl_lint_pass!(ManualBits => [MANUAL_BITS]);

--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -86,7 +86,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.66.0"]
     pub MANUAL_CLAMP,
     complexity,
-    "using a clamp pattern instead of the clamp function"
+    "using a clamp pattern instead of the clamp function",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.50, because it suggests `clamp()`."
 }
 
 impl_lint_pass!(ManualClamp => [MANUAL_CLAMP]);

--- a/clippy_lints/src/manual_float_methods.rs
+++ b/clippy_lints/src/manual_float_methods.rs
@@ -36,7 +36,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.73.0"]
     pub MANUAL_IS_FINITE,
     style,
-    "use dedicated method to check if a float is finite"
+    "use dedicated method to check if a float is finite",
+    @msrv_behavior = "This lint is emitted for all MSRVs outside const contexts. In const contexts, it is only emitted when the configured MSRV is at least 1.83."
 }
 
 declare_clippy_lint! {
@@ -60,7 +61,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.73.0"]
     pub MANUAL_IS_INFINITE,
     style,
-    "use dedicated method to check if a float is infinite"
+    "use dedicated method to check if a float is infinite",
+    @msrv_behavior = "This lint is emitted for all MSRVs outside const contexts. In const contexts, it is only emitted when the configured MSRV is at least 1.83."
 }
 
 impl_lint_pass!(ManualFloatMethods => [MANUAL_IS_FINITE, MANUAL_IS_INFINITE]);

--- a/clippy_lints/src/manual_hash_one.rs
+++ b/clippy_lints/src/manual_hash_one.rs
@@ -44,7 +44,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.75.0"]
     pub MANUAL_HASH_ONE,
     complexity,
-    "manual implementations of `BuildHasher::hash_one`"
+    "manual implementations of `BuildHasher::hash_one`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.71, because it suggests `BuildHasher::hash_one`."
 }
 
 impl_lint_pass!(ManualHashOne => [MANUAL_HASH_ONE]);

--- a/clippy_lints/src/manual_ilog2.rs
+++ b/clippy_lints/src/manual_ilog2.rs
@@ -34,7 +34,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.94.0"]
     pub MANUAL_ILOG2,
     pedantic,
-    "manually reimplementing `ilog2`"
+    "manually reimplementing `ilog2`",
+    @msrv_behavior = "For `N - x.leading_zeros()` patterns, this lint is only emitted when the configured MSRV is at least 1.67. For `x.ilog(2)` patterns, the configured MSRV does not affect lint behavior, since `ilog` and `ilog2` were stabilized simultaneously."
 }
 
 impl_lint_pass!(ManualIlog2 => [MANUAL_ILOG2]);

--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -55,7 +55,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.67.0"]
     pub MANUAL_IS_ASCII_CHECK,
     style,
-    "use dedicated method to check ascii range"
+    "use dedicated method to check ascii range",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.24. In const contexts, this lint is only emitted when the configured MSRV is at least 1.47."
 }
 
 impl_lint_pass!(ManualIsAsciiCheck => [MANUAL_IS_ASCII_CHECK]);

--- a/clippy_lints/src/manual_is_power_of_two.rs
+++ b/clippy_lints/src/manual_is_power_of_two.rs
@@ -32,7 +32,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.83.0"]
     pub MANUAL_IS_POWER_OF_TWO,
     pedantic,
-    "manually reimplementing `is_power_of_two`"
+    "manually reimplementing `is_power_of_two`",
+    @msrv_behavior = "This lint can be emitted outside const contexts on all configured MSRVs. In const contexts, it is only emitted when the configured MSRV is at least 1.32, because it suggests const-stable `is_power_of_two`."
 }
 
 impl_lint_pass!(ManualIsPowerOfTwo => [MANUAL_IS_POWER_OF_TWO]);

--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -45,7 +45,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.67.0"]
     pub MANUAL_LET_ELSE,
     pedantic,
-    "manual implementation of a let...else statement"
+    "manual implementation of a let...else statement",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.65, because it suggests `let...else`."
 }
 
 impl<'tcx> QuestionMark {

--- a/clippy_lints/src/manual_main_separator_str.rs
+++ b/clippy_lints/src/manual_main_separator_str.rs
@@ -30,7 +30,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.70.0"]
     pub MANUAL_MAIN_SEPARATOR_STR,
     complexity,
-    "`&std::path::MAIN_SEPARATOR.to_string()` can be replaced by `std::path::MAIN_SEPARATOR_STR`"
+    "`&std::path::MAIN_SEPARATOR.to_string()` can be replaced by `std::path::MAIN_SEPARATOR_STR`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.68, because it suggests `std::path::MAIN_SEPARATOR_STR`."
 }
 
 impl_lint_pass!(ManualMainSeparatorStr => [MANUAL_MAIN_SEPARATOR_STR]);

--- a/clippy_lints/src/manual_non_exhaustive.rs
+++ b/clippy_lints/src/manual_non_exhaustive.rs
@@ -58,7 +58,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.45.0"]
     pub MANUAL_NON_EXHAUSTIVE,
     style,
-    "manual implementations of the non-exhaustive pattern can be simplified using #[non_exhaustive]"
+    "manual implementations of the non-exhaustive pattern can be simplified using #[non_exhaustive]",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.40, because it suggests `#[non_exhaustive]`."
 }
 
 impl_lint_pass!(ManualNonExhaustive => [MANUAL_NON_EXHAUSTIVE]);

--- a/clippy_lints/src/manual_noop_waker.rs
+++ b/clippy_lints/src/manual_noop_waker.rs
@@ -34,7 +34,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.96.0"]
     pub MANUAL_NOOP_WAKER,
     complexity,
-    "manual implementations of noop wakers can be simplified using Waker::noop()"
+    "manual implementations of noop wakers can be simplified using Waker::noop()",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.85, because it suggests `Waker::noop()`."
 }
 
 impl_lint_pass!(ManualNoopWaker => [MANUAL_NOOP_WAKER]);

--- a/clippy_lints/src/manual_option_as_slice.rs
+++ b/clippy_lints/src/manual_option_as_slice.rs
@@ -37,7 +37,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.86.0"]
     pub MANUAL_OPTION_AS_SLICE,
     complexity,
-    "manual `Option::as_slice`"
+    "manual `Option::as_slice`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.75, because it suggests `Option::as_slice`. In const contexts, it requires at least 1.84."
 }
 
 impl_lint_pass!(ManualOptionAsSlice => [MANUAL_OPTION_AS_SLICE]);

--- a/clippy_lints/src/manual_pop_if.rs
+++ b/clippy_lints/src/manual_pop_if.rs
@@ -54,7 +54,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.95.0"]
     pub MANUAL_POP_IF,
     complexity,
-    "manual implementation of `pop_if` methods"
+    "manual implementation of `pop_if` methods",
+    @msrv_behavior = "This lint is only emitted for `Vec` when the configured MSRV is at least 1.86, and for `VecDeque` when the configured MSRV is at least 1.93. `BinaryHeap` cases are only linted when the unstable `binary_heap_pop_if` feature is enabled."
 }
 
 impl_lint_pass!(ManualPopIf => [MANUAL_POP_IF]);

--- a/clippy_lints/src/manual_rem_euclid.rs
+++ b/clippy_lints/src/manual_rem_euclid.rs
@@ -32,7 +32,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.64.0"]
     pub MANUAL_REM_EUCLID,
     complexity,
-    "manually reimplementing `rem_euclid`"
+    "manually reimplementing `rem_euclid`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.38, because it suggests `rem_euclid`. In const contexts, it requires at least 1.52."
 }
 
 impl_lint_pass!(ManualRemEuclid => [MANUAL_REM_EUCLID]);

--- a/clippy_lints/src/manual_retain.rs
+++ b/clippy_lints/src/manual_retain.rs
@@ -41,7 +41,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.64.0"]
     pub MANUAL_RETAIN,
     perf,
-    "`retain()` is simpler and the same functionalities"
+    "`retain()` is simpler and the same functionalities",
+    @msrv_behavior = "`Vec` and `VecDeque` retain suggestions are not MSRV-gated. This lint only checks `String` patterns when the configured MSRV is at least 1.26, `HashMap` and `HashSet` patterns at least 1.18, `BTreeMap` and `BTreeSet` patterns at least 1.53, and `BinaryHeap` patterns at least 1.70."
 }
 
 impl_lint_pass!(ManualRetain => [MANUAL_RETAIN]);

--- a/clippy_lints/src/manual_slice_size_calculation.rs
+++ b/clippy_lints/src/manual_slice_size_calculation.rs
@@ -36,7 +36,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.70.0"]
     pub MANUAL_SLICE_SIZE_CALCULATION,
     complexity,
-    "manual slice size calculation"
+    "manual slice size calculation",
+    @msrv_behavior = "This lint can be emitted outside const contexts on all configured MSRVs. In const contexts, it is only emitted when the configured MSRV is at least 1.85, because it suggests const-stable `size_of_val`."
 }
 
 impl_lint_pass!(ManualSliceSizeCalculation => [MANUAL_SLICE_SIZE_CALCULATION]);

--- a/clippy_lints/src/manual_strip.rs
+++ b/clippy_lints/src/manual_strip.rs
@@ -46,7 +46,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.48.0"]
     pub MANUAL_STRIP,
     complexity,
-    "suggests using `strip_{prefix,suffix}` over `str::{starts,ends}_with` and slicing"
+    "suggests using `strip_{prefix,suffix}` over `str::{starts,ends}_with` and slicing",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.45, because it suggests `strip_prefix` or `strip_suffix`."
 }
 
 impl_lint_pass!(ManualStrip => [MANUAL_STRIP]);

--- a/clippy_lints/src/manual_take.rs
+++ b/clippy_lints/src/manual_take.rs
@@ -37,7 +37,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.95.0"]
     pub MANUAL_TAKE,
     complexity,
-    "manual `mem::take` implementation"
+    "manual `mem::take` implementation",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.40, because it suggests `mem::take`."
 }
 
 impl_lint_pass!(ManualTake => [MANUAL_TAKE]);

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -360,7 +360,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.47.0"]
     pub MATCH_LIKE_MATCHES_MACRO,
     style,
-    "a match that could be written with the matches! macro"
+    "a match that could be written with the matches! macro",
+    @msrv_behavior = "This lint only suggests `matches!` when the configured MSRV is at least 1.42, and avoids or-pattern suggestions before 1.53."
 }
 
 declare_clippy_lint! {
@@ -722,7 +723,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.31.0"]
     pub REDUNDANT_PATTERN_MATCHING,
     style,
-    "use the proper utility function avoiding an `if let`"
+    "use the proper utility function avoiding an `if let`",
+    @msrv_behavior = "This lint only suggests `matches!` when the configured MSRV is at least 1.42."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -64,7 +64,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.87.0"]
     pub MEM_REPLACE_OPTION_WITH_SOME,
     style,
-    "replacing an `Option` with `Some` instead of `replace()`"
+    "replacing an `Option` with `Some` instead of `replace()`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.31, because it suggests `Option::replace`."
 }
 
 declare_clippy_lint! {
@@ -89,7 +90,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.42.0"]
     pub MEM_REPLACE_WITH_DEFAULT,
     style,
-    "replacing a value of type `T` with `T::default()` instead of using `std::mem::take`"
+    "replacing a value of type `T` with `T::default()` instead of using `std::mem::take`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.40, because it suggests `std::mem::take`."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -274,7 +274,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.51.0"]
     pub CASE_SENSITIVE_FILE_EXTENSION_COMPARISONS,
     pedantic,
-    "Checks for calls to ends_with with case-sensitive file extensions"
+    "Checks for calls to ends_with with case-sensitive file extensions",
+    @msrv_behavior = "When the configured MSRV is at least 1.70, this lint suggests `Option::is_some_and`; otherwise it suggests `map_or(false, ...)`."
 }
 
 declare_clippy_lint! {
@@ -423,7 +424,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.53.0"]
     pub CLONED_INSTEAD_OF_COPIED,
     pedantic,
-    "used `cloned` where `copied` could be used instead"
+    "used `cloned` where `copied` could be used instead",
+    @msrv_behavior = "`Option::cloned` is linted when the configured MSRV is at least 1.35. Iterator `cloned` calls are linted when the configured MSRV is at least 1.36, because `Iterator::copied` is available from that version."
 }
 
 declare_clippy_lint! {
@@ -449,7 +451,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.65.0"]
     pub COLLAPSIBLE_STR_REPLACE,
     perf,
-    "collapse consecutive calls to str::replace (2 or more) into a single call"
+    "collapse consecutive calls to str::replace (2 or more) into a single call",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.58, because it suggests pattern arrays in `str::replace`."
 }
 
 declare_clippy_lint! {
@@ -560,7 +563,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.62.0"]
     pub ERR_EXPECT,
     style,
-    r#"using `.err().expect("")` when `.expect_err("")` can be used"#
+    r#"using `.err().expect("")` when `.expect_err("")` can be used"#,
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.17, because it suggests `Result::expect_err`."
 }
 
 declare_clippy_lint! {
@@ -782,7 +786,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.36.0"]
     pub FILTER_MAP_NEXT,
     pedantic,
-    "using combination of `filter_map` and `next` which can usually be written as a single method call"
+    "using combination of `filter_map` and `next` which can usually be written as a single method call",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.30, because it suggests `Iterator::find_map`."
 }
 
 declare_clippy_lint! {
@@ -1079,7 +1084,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.40.0"]
     pub INEFFICIENT_TO_STRING,
     pedantic,
-    "using `to_string` on `&&T` where `T: ToString`"
+    "using `to_string` on `&&T` where `T: ToString`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is below 1.82, because Rust 1.82 specializes `ToString` for references."
 }
 
 declare_clippy_lint! {
@@ -1158,7 +1164,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.87.0"]
     pub IO_OTHER_ERROR,
     style,
-    "calling `std::io::Error::new(std::io::ErrorKind::Other, _)`"
+    "calling `std::io::Error::new(std::io::ErrorKind::Other, _)`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.74, because it suggests `std::io::Error::other`."
 }
 
 declare_clippy_lint! {
@@ -1221,7 +1228,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.62.0"]
     pub IS_DIGIT_ASCII_RADIX,
     style,
-    "use of `char::is_digit(..)` with literal radix of 10 or 16"
+    "use of `char::is_digit(..)` with literal radix of 10 or 16",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.24, because it suggests ASCII digit methods."
 }
 
 declare_clippy_lint! {
@@ -1298,7 +1306,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.77.0"]
     pub ITER_FILTER_IS_OK,
     pedantic,
-    "filtering an iterator over `Result`s for `Ok` can be achieved with `flatten`"
+    "filtering an iterator over `Result`s for `Ok` can be achieved with `flatten`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.29, because it suggests `Iterator::flatten`."
 }
 
 declare_clippy_lint! {
@@ -1322,7 +1331,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.77.0"]
     pub ITER_FILTER_IS_SOME,
     pedantic,
-    "filtering an iterator over `Option`s for `Some` can be achieved with `flatten`"
+    "filtering an iterator over `Option`s for `Some` can be achieved with `flatten`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.29, because it suggests `Iterator::flatten`."
 }
 
 declare_clippy_lint! {
@@ -1353,7 +1363,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.66.0"]
     pub ITER_KV_MAP,
     complexity,
-    "iterating on map using `iter` when `keys` or `values` would do"
+    "iterating on map using `iter` when `keys` or `values` would do",
+    @msrv_behavior = "`iter().map(...)` is linted for all MSRVs. `into_iter().map(...)` is only linted when the configured MSRV is at least 1.54, because it suggests `into_keys` or `into_values`."
 }
 
 declare_clippy_lint! {
@@ -1734,7 +1745,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.70.0"]
     pub LINES_FILTER_MAP_OK,
     suspicious,
-    "filtering `std::io::Lines` with `filter_map()`, `flat_map()`, or `flatten()` might cause an infinite loop"
+    "filtering `std::io::Lines` with `filter_map()`, `flat_map()`, or `flatten()` might cause an infinite loop",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.57, because it suggests `Iterator::map_while`."
 }
 
 declare_clippy_lint! {
@@ -1768,7 +1780,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.78.0"]
     pub MANUAL_C_STR_LITERALS,
     complexity,
-    r#"creating a `CStr` through functions when `c""` literals can be used"#
+    r#"creating a `CStr` through functions when `c""` literals can be used"#,
+    @msrv_behavior = r#"This lint is only emitted when the configured MSRV is at least 1.77, because it suggests `c"..."` C string literals."#
 }
 
 declare_clippy_lint! {
@@ -1891,7 +1904,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.81.0"]
     pub MANUAL_INSPECT,
     complexity,
-    "use of `map` returning the original item"
+    "use of `map` returning the original item",
+    @msrv_behavior = "Iterator cases are not MSRV-gated. Option and Result cases are only linted when the configured MSRV is at least 1.76, because they suggest `inspect`."
 }
 
 declare_clippy_lint! {
@@ -1930,7 +1944,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.77.0"]
     pub MANUAL_IS_VARIANT_AND,
     pedantic,
-    "using `.map(f).unwrap_or_default()` or `.map(f) == Some/Ok(true)`, which are more succinctly expressed as `is_some_and(f)` or `is_ok_and(f)`"
+    "using `.map(f).unwrap_or_default()` or `.map(f) == Some/Ok(true)`, which are more succinctly expressed as `is_some_and(f)` or `is_ok_and(f)`",
+    @msrv_behavior = "Some checks are MSRV-gated. `map(<f>).unwrap_or_default()` suggestions require at least 1.70, and `is_none_or` suggestions require at least 1.82. Other `is_some_and` and `is_ok_and` suggestions are not currently MSRV-gated."
 }
 
 declare_clippy_lint! {
@@ -2007,7 +2022,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.95.0"]
     pub MANUAL_OPTION_ZIP,
     complexity,
-    "manual reimplementation of `Option::zip`"
+    "manual reimplementation of `Option::zip`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.46, because it suggests `Option::zip`."
 }
 
 declare_clippy_lint! {
@@ -2030,7 +2046,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.86.0"]
     pub MANUAL_REPEAT_N,
     style,
-    "detect `repeat().take()` that can be replaced with `repeat_n()`"
+    "detect `repeat().take()` that can be replaced with `repeat_n()`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.82, because it suggests `std::iter::repeat_n`."
 }
 
 declare_clippy_lint! {
@@ -2095,7 +2112,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.57.0"]
     pub MANUAL_SPLIT_ONCE,
     complexity,
-    "replace `.splitn(2, pat)` with `.split_once(pat)`"
+    "replace `.splitn(2, pat)` with `.split_once(pat)`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.52, because it suggests `str::split_once`."
 }
 
 declare_clippy_lint! {
@@ -2117,7 +2135,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.54.0"]
     pub MANUAL_STR_REPEAT,
     perf,
-    "manual implementation of `str::repeat`"
+    "manual implementation of `str::repeat`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.16, because it suggests `str::repeat`."
 }
 
 declare_clippy_lint! {
@@ -2146,7 +2165,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.72.0"]
     pub MANUAL_TRY_FOLD,
     perf,
-    "checks for usage of `Iterator::fold` with a type that implements `Try`"
+    "checks for usage of `Iterator::fold` with a type that implements `Try`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.27, because it suggests `Iterator::try_fold`."
 }
 
 declare_clippy_lint! {
@@ -2200,7 +2220,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub MAP_CLONE,
     style,
-    "using `iterator.map(|x| x.clone())`, or dereferencing closures for `Copy` types"
+    "using `iterator.map(|x| x.clone())`, or dereferencing closures for `Copy` types",
+    @msrv_behavior = "When an explicit closure copies iterator elements, this lint suggests `copied()` if the configured MSRV is at least 1.36. Otherwise, it suggests `cloned()`.\n\nThe MSRV does not affect suggestions for explicit `Clone::clone` function paths; those still use `copied()` for `Copy` types and `cloned()` otherwise."
 }
 
 declare_clippy_lint! {
@@ -2412,7 +2433,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.45.0"]
     pub MAP_UNWRAP_OR,
     pedantic,
-    "using `.map(f).unwrap_or(a)` or `.map(f).unwrap_or_else(func)`, which are more succinctly expressed as `map_or(a, f)` or `map_or_else(a, f)`"
+    "using `.map(f).unwrap_or(a)` or `.map(f).unwrap_or_else(func)`, which are more succinctly expressed as `map_or(a, f)` or `map_or_else(a, f)`",
+    @msrv_behavior = "`Option` cases can be linted on all configured MSRVs. `Result` cases are only linted when the configured MSRV is at least 1.41, because they suggest `Result::map_or`. When the configured MSRV is at least 1.70, boolean `unwrap_or(false)` cases suggest `is_some_and()` or `is_ok_and()` instead of `map_or()`."
 }
 
 declare_clippy_lint! {
@@ -2446,7 +2468,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.84.0"]
     pub MAP_WITH_UNUSED_ARGUMENT_OVER_RANGES,
     restriction,
-    "map of a trivial closure (not dependent on parameter) over a range"
+    "map of a trivial closure (not dependent on parameter) over a range",
+    @msrv_behavior = "When eager evaluation is suitable, this lint suggests `repeat_n` if the configured MSRV is at least 1.82, otherwise it suggests `repeat().take(...)`. For lazy closures, it only emits when the configured MSRV is at least 1.28, because it suggests `repeat_with().take(...)`."
 }
 
 declare_clippy_lint! {
@@ -2865,7 +2888,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.42.0"]
     pub OPTION_AS_REF_DEREF,
     complexity,
-    "using `as_ref().map(Deref::deref)`, which is more succinctly expressed as `as_deref()`"
+    "using `as_ref().map(Deref::deref)`, which is more succinctly expressed as `as_deref()`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.40, because it suggests `Option::as_deref` or `Option::as_deref_mut`."
 }
 
 declare_clippy_lint! {
@@ -2951,7 +2975,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub OR_FUN_CALL,
     nursery,
-    "using any `*or` method with a function call, which suggests `*or_else`"
+    "using any `*or` method with a function call, which suggests `*or_else`",
+    @msrv_behavior = "Result `unwrap_or_default` suggestions are only emitted when the configured MSRV is at least 1.16. Other `Option` suggestions are not MSRV-gated."
 }
 
 declare_clippy_lint! {
@@ -3058,7 +3083,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.74.0"]
     pub PATH_ENDS_WITH_EXT,
     suspicious,
-    "attempting to compare file extensions using `Path::ends_with`"
+    "attempting to compare file extensions using `Path::ends_with`",
+    @msrv_behavior = "When the configured MSRV is at least 1.70, this lint suggests `Option::is_some_and`; otherwise it suggests `map_or(false, ...)`."
 }
 
 declare_clippy_lint! {
@@ -3092,7 +3118,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.94.0"]
     pub PTR_OFFSET_BY_LITERAL,
     pedantic,
-    "unneeded pointer offset"
+    "unneeded pointer offset",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.26, because it suggests pointer `add` or `sub` methods."
 }
 
 declare_clippy_lint! {
@@ -3129,7 +3156,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.30.0"]
     pub PTR_OFFSET_WITH_CAST,
     complexity,
-    "unneeded pointer offset cast"
+    "unneeded pointer offset cast",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.26, because it suggests pointer `add` or `sub` methods."
 }
 
 declare_clippy_lint! {
@@ -3460,7 +3488,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.67.0"]
     pub SEEK_FROM_CURRENT,
     complexity,
-    "use dedicated method for seek from current position"
+    "use dedicated method for seek from current position",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.51, because it suggests `stream_position`."
 }
 
 declare_clippy_lint! {
@@ -3491,7 +3520,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.67.0"]
     pub SEEK_TO_START_INSTEAD_OF_REWIND,
     complexity,
-    "jumping to the start of stream using `seek` method"
+    "jumping to the start of stream using `seek` method",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.55, because it suggests `rewind`."
 }
 
 declare_clippy_lint! {
@@ -3624,7 +3654,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.97.0"]
     pub SOME_FILTER,
     complexity,
-    "using `Some(x).filter(|_| predicate)`, which is more succinctly expressed as `predicate.then(x)`"
+    "using `Some(x).filter(|_| predicate)`, which is more succinctly expressed as `predicate.then(x)`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.62, because it suggests `bool::then_some`."
 }
 
 declare_clippy_lint! {
@@ -4400,7 +4431,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.84.0"]
     pub UNNECESSARY_MAP_OR,
     style,
-    "reduce unnecessary calls to `.map_or(bool, …)`"
+    "reduce unnecessary calls to `.map_or(bool, …)`",
+    @msrv_behavior = "This lint can suggest direct comparisons on all configured MSRVs. It only suggests `is_some_and` or `is_ok_and` when the configured MSRV is at least 1.70, and only suggests `is_none_or` when the configured MSRV is at least 1.82."
 }
 
 declare_clippy_lint! {
@@ -4540,7 +4572,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.59.0"]
     pub UNNECESSARY_TO_OWNED,
     perf,
-    "unnecessary calls to `to_owned`-like functions"
+    "unnecessary calls to `to_owned`-like functions",
+    @msrv_behavior = "When this lint suggests iterator adapters for `Copy` items, it uses `copied()` only when the configured MSRV is at least 1.36; otherwise it uses `cloned()`."
 }
 
 declare_clippy_lint! {
@@ -4681,7 +4714,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.86.0"]
     pub USELESS_NONZERO_NEW_UNCHECKED,
     complexity,
-    "using `NonZero::new_unchecked()` in a `const` context"
+    "using `NonZero::new_unchecked()` in a `const` context",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.83, because it suggests `Option::unwrap` in const contexts."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -69,7 +69,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.34.0"]
     pub MISSING_CONST_FOR_FN,
     nursery,
-    "Lint functions definitions that could be made `const fn`"
+    "Lint functions definitions that could be made `const fn`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.46. It additionally requires at least 1.62 for `const extern \"C\" fn` and at least 1.83 for other const extern ABIs."
 }
 
 impl_lint_pass!(MissingConstForFn => [MISSING_CONST_FOR_FN]);

--- a/clippy_lints/src/missing_const_for_thread_local.rs
+++ b/clippy_lints/src/missing_const_for_thread_local.rs
@@ -39,7 +39,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.77.0"]
     pub MISSING_CONST_FOR_THREAD_LOCAL,
     perf,
-    "suggest using `const` in `thread_local!` macro"
+    "suggest using `const` in `thread_local!` macro",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.59 and the initializer can be evaluated as a const expression for the configured MSRV."
 }
 
 impl_lint_pass!(MissingConstForThreadLocal => [MISSING_CONST_FOR_THREAD_LOCAL]);

--- a/clippy_lints/src/needless_borrows_for_generic_args.rs
+++ b/clippy_lints/src/needless_borrows_for_generic_args.rs
@@ -54,7 +54,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.74.0"]
     pub NEEDLESS_BORROWS_FOR_GENERIC_ARGS,
     style,
-    "taking a reference that is going to be automatically dereferenced"
+    "taking a reference that is going to be automatically dereferenced",
+    @msrv_behavior = "This lint avoids suggestions that rely on array `IntoIterator` by value before Rust 1.53."
 }
 
 impl_lint_pass!(NeedlessBorrowsForGenericArgs<'_> => [

--- a/clippy_lints/src/non_std_lazy_statics.rs
+++ b/clippy_lints/src/non_std_lazy_statics.rs
@@ -42,7 +42,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.86.0"]
     pub NON_STD_LAZY_STATICS,
     pedantic,
-    "lazy static that could be replaced by `std::sync::LazyLock`"
+    "lazy static that could be replaced by `std::sync::LazyLock`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.80 and the crate uses `std`, because it suggests `std::sync::LazyLock`."
 }
 
 impl_lint_pass!(NonStdLazyStatic => [NON_STD_LAZY_STATICS]);

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -690,7 +690,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.83.0"]
     pub MANUAL_DIV_CEIL,
     complexity,
-    "manually reimplementing `div_ceil`"
+    "manually reimplementing `div_ceil`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.73, because it suggests `div_ceil`."
 }
 
 declare_clippy_lint! {
@@ -719,7 +720,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.90.0"]
     pub MANUAL_IS_MULTIPLE_OF,
     complexity,
-    "manual implementation of `.is_multiple_of()`"
+    "manual implementation of `.is_multiple_of()`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.87, because it suggests `is_multiple_of`."
 }
 
 declare_clippy_lint! {
@@ -743,7 +745,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.87.0"]
     pub MANUAL_MIDPOINT,
     pedantic,
-    "manual implementation of `midpoint` which can overflow"
+    "manual implementation of `midpoint` which can overflow",
+    @msrv_behavior = "This lint is only emitted for unsigned integer and float operands when the configured MSRV is at least 1.85, and for signed integer operands when the configured MSRV is at least 1.87, because those versions provide `midpoint`."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -49,7 +49,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub QUESTION_MARK,
     style,
-    "checks for expressions that could be replaced by the `?` operator"
+    "checks for expressions that could be replaced by the `?` operator",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.13, because it suggests the `?` operator."
 }
 
 impl_lint_pass!(QuestionMark => [MANUAL_LET_ELSE, QUESTION_MARK]);

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -41,7 +41,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.49.0"]
     pub MANUAL_RANGE_CONTAINS,
     style,
-    "manually reimplementing {`Range`, `RangeInclusive`}`::contains`"
+    "manually reimplementing {`Range`, `RangeInclusive`}`::contains`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.35, because it suggests `Range::contains` or `RangeInclusive::contains`."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -32,7 +32,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub REDUNDANT_FIELD_NAMES,
     style,
-    "checks for fields in struct literals where shorthands could be used"
+    "checks for fields in struct literals where shorthands could be used",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.17, because it suggests field init shorthand."
 }
 
 impl_lint_pass!(RedundantFieldNames => [REDUNDANT_FIELD_NAMES]);

--- a/clippy_lints/src/redundant_static_lifetimes.rs
+++ b/clippy_lints/src/redundant_static_lifetimes.rs
@@ -31,7 +31,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.37.0"]
     pub REDUNDANT_STATIC_LIFETIMES,
     style,
-    "Using explicit `'static` lifetime for constants or statics when elision rules would allow omitting them."
+    "Using explicit `'static` lifetime for constants or statics when elision rules would allow omitting them.",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.17, because `'static` lifetime elision in constants and statics is available from that version."
 }
 
 impl_lint_pass!(RedundantStaticLifetimes => [REDUNDANT_STATIC_LIFETIMES]);

--- a/clippy_lints/src/repeat_vec_with_capacity.rs
+++ b/clippy_lints/src/repeat_vec_with_capacity.rs
@@ -57,7 +57,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.76.0"]
     pub REPEAT_VEC_WITH_CAPACITY,
     suspicious,
-    "repeating a `Vec::with_capacity` expression which does not retain capacity"
+    "repeating a `Vec::with_capacity` expression which does not retain capacity",
+    @msrv_behavior = "`vec![Vec::with_capacity(_); n]` is linted for all MSRVs. `iter::repeat(Vec::with_capacity(_))` is only linted when the configured MSRV is at least 1.28, because the suggestion uses `iter::repeat_with`."
 }
 
 impl_lint_pass!(RepeatVecWithCapacity => [REPEAT_VEC_WITH_CAPACITY]);

--- a/clippy_lints/src/std_instead_of_core.rs
+++ b/clippy_lints/src/std_instead_of_core.rs
@@ -60,7 +60,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.64.0"]
     pub STD_INSTEAD_OF_ALLOC,
     restriction,
-    "type is imported from std when available in alloc"
+    "type is imported from std when available in alloc",
+    @msrv_behavior = "This lint only suggests moving an item from `std` to `alloc` when that item and its re-export path are stable for the configured MSRV."
 }
 
 declare_clippy_lint! {
@@ -83,7 +84,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.64.0"]
     pub STD_INSTEAD_OF_CORE,
     restriction,
-    "type is imported from std when available in core"
+    "type is imported from std when available in core",
+    @msrv_behavior = "This lint only suggests moving an item from `std` to `core` when that item and its re-export path are stable for the configured MSRV."
 }
 
 impl_lint_pass!(StdReexports => [

--- a/clippy_lints/src/string_patterns.rs
+++ b/clippy_lints/src/string_patterns.rs
@@ -37,7 +37,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.81.0"]
     pub MANUAL_PATTERN_CHAR_COMPARISON,
     style,
-    "manual char comparison in string patterns"
+    "manual char comparison in string patterns",
+    @msrv_behavior = "This lint only suggests character arrays for string patterns when the configured MSRV is at least 1.58."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/strlen_on_c_strings.rs
+++ b/clippy_lints/src/strlen_on_c_strings.rs
@@ -34,7 +34,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.55.0"]
     pub STRLEN_ON_C_STRINGS,
     complexity,
-    "using `libc::strlen` on a `CString` or `CStr` value, while `count_bytes()` can be used instead"
+    "using `libc::strlen` on a `CString` or `CStr` value, while `count_bytes()` can be used instead",
+    @msrv_behavior = "When the configured MSRV is at least 1.79, this lint suggests `count_bytes()`. On older MSRVs, it suggests `to_bytes().len()`."
 }
 
 impl_lint_pass!(StrlenOnCStrings => [STRLEN_ON_C_STRINGS]);

--- a/clippy_lints/src/time_subtraction.rs
+++ b/clippy_lints/src/time_subtraction.rs
@@ -70,7 +70,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.67.0"]
     pub UNCHECKED_TIME_SUBTRACTION,
     pedantic,
-    "finds unchecked subtraction involving 'Duration' or 'Instant'"
+    "finds unchecked subtraction involving 'Duration' or 'Instant'",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.34 for unchecked `Instant - Duration` and `Duration - Duration` subtraction. `Instant::now() - instant` is handled by `manual_instant_elapsed` and is not MSRV-gated."
 }
 
 impl_lint_pass!(UncheckedTimeSubtraction => [

--- a/clippy_lints/src/to_digit_is_some.rs
+++ b/clippy_lints/src/to_digit_is_some.rs
@@ -32,7 +32,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.41.0"]
     pub TO_DIGIT_IS_SOME,
     style,
-    "`char.is_digit()` is clearer"
+    "`char.is_digit()` is clearer",
+    @msrv_behavior = "This lint is emitted for all MSRVs outside const contexts. In const contexts, it is only emitted when the configured MSRV is at least 1.87."
 }
 
 impl_lint_pass!(ToDigitIsSome => [TO_DIGIT_IS_SOME]);

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -83,7 +83,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.38.0"]
     pub TYPE_REPETITION_IN_BOUNDS,
     nursery,
-    "types are repeated unnecessarily in trait bounds, use `+` instead of using `T: _, T: _`"
+    "types are repeated unnecessarily in trait bounds, use `+` instead of using `T: _, T: _`",
+    @msrv_behavior = "This lint avoids suggestions that would combine `?Sized` in a `where` clause before Rust 1.15, where that form was not accepted."
 }
 
 impl_lint_pass!(TraitBounds => [

--- a/clippy_lints/src/transmute/mod.rs
+++ b/clippy_lints/src/transmute/mod.rs
@@ -288,7 +288,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub TRANSMUTE_PTR_TO_PTR,
     pedantic,
-    "transmutes from a pointer to a pointer / a reference to a reference"
+    "transmutes from a pointer to a pointer / a reference to a reference",
+    @msrv_behavior = "When the configured MSRV is at least 1.38, this lint can suggest `pointer::cast` for raw pointer transmutes that keep constness. When it is at least 1.65, it can suggest `cast_mut` or `cast_const` for constness-only pointer casts. Otherwise, it falls back to suggesting an `as` cast."
 }
 
 declare_clippy_lint! {
@@ -316,7 +317,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub TRANSMUTE_PTR_TO_REF,
     complexity,
-    "transmutes from a pointer to a reference type"
+    "transmutes from a pointer to a reference type",
+    @msrv_behavior = "When the configured MSRV is at least 1.38 and the pointee type is sized, this lint can suggest `pointer::cast` before dereferencing. On older MSRVs, it falls back to an `as` cast before dereferencing."
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/tuple_array_conversions.rs
+++ b/clippy_lints/src/tuple_array_conversions.rs
@@ -38,7 +38,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.72.0"]
     pub TUPLE_ARRAY_CONVERSIONS,
     nursery,
-    "checks for tuple<=>array conversions that are not done with `.into()`"
+    "checks for tuple<=>array conversions that are not done with `.into()`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.71, because it suggests tuple/array conversions using `.into()`."
 }
 
 impl_lint_pass!(TupleArrayConversions => [TUPLE_ARRAY_CONVERSIONS]);

--- a/clippy_lints/src/unnested_or_patterns.rs
+++ b/clippy_lints/src/unnested_or_patterns.rs
@@ -45,7 +45,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.46.0"]
     pub UNNESTED_OR_PATTERNS,
     pedantic,
-    "unnested or-patterns, e.g., `Foo(Bar) | Foo(Baz) instead of `Foo(Bar | Baz)`"
+    "unnested or-patterns, e.g., `Foo(Bar) | Foo(Baz) instead of `Foo(Bar | Baz)`",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.53, because it suggests nested or-patterns."
 }
 
 impl_lint_pass!(UnnestedOrPatterns => [UNNESTED_OR_PATTERNS]);

--- a/clippy_lints/src/unused_trait_names.rs
+++ b/clippy_lints/src/unused_trait_names.rs
@@ -42,7 +42,8 @@ declare_clippy_lint! {
     #[clippy::version = "1.83.0"]
     pub UNUSED_TRAIT_NAMES,
     restriction,
-    "use items that import a trait but only use it anonymously"
+    "use items that import a trait but only use it anonymously",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.33, because it suggests underscore imports."
 }
 
 impl_lint_pass!(UnusedTraitNames => [UNUSED_TRAIT_NAMES]);

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -77,7 +77,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub UNNECESSARY_UNWRAP,
     complexity,
-    "checks for calls of `unwrap[_err]()` that cannot fail"
+    "checks for calls of `unwrap[_err]()` that cannot fail",
+    @msrv_behavior = "When the crate uses Rust 2024 edition and the configured MSRV is at least 1.88, this lint may suggest `if let` chains in help text. Otherwise it suggests `match` for those cases."
 }
 
 impl_lint_pass!(Unwrap => [PANICKING_UNWRAP, UNNECESSARY_UNWRAP]);

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -53,7 +53,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub USE_SELF,
     nursery,
-    "unnecessary structure name repetition whereas `Self` is applicable"
+    "unnecessary structure name repetition whereas `Self` is applicable",
+    @msrv_behavior = "This lint is only emitted when the configured MSRV is at least 1.37, because `Self` in this context depends on the type alias enum variants feature."
 }
 
 impl_lint_pass!(UseSelf => [USE_SELF]);

--- a/clippy_lints/src/useless_vec.rs
+++ b/clippy_lints/src/useless_vec.rs
@@ -80,7 +80,8 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub USELESS_VEC,
     perf,
-    "useless `vec!`"
+    "useless `vec!`",
+    @msrv_behavior = "Most `vec!`-to-array or slice suggestions do not depend on MSRV. In `for` loops, this lint only suggests replacing `vec![...]` with an array when the configured MSRV is at least 1.53, because arrays implement `IntoIterator` by value from that version."
 }
 
 impl_lint_pass!(UselessVec => [USELESS_VEC]);

--- a/declare_clippy_lint/src/lib.rs
+++ b/declare_clippy_lint/src/lib.rs
@@ -104,6 +104,7 @@ pub struct LintInfo {
     pub lint: &'static Lint,
     pub category: LintCategory,
     pub explanation: &'static str,
+    pub msrv_behavior: Option<&'static str>,
     /// e.g. `clippy_lints/src/absolute_paths.rs#43`
     pub location: &'static str,
     pub version: &'static str,
@@ -118,6 +119,17 @@ impl LintInfo {
     }
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __clippy_lint_optional_msrv_behavior {
+    () => {
+        None
+    };
+    ($msrv_behavior:literal) => {
+        Some(concat!($msrv_behavior, "\n"))
+    };
+}
+
 #[macro_export]
 macro_rules! declare_clippy_lint_inner {
     (
@@ -127,6 +139,7 @@ macro_rules! declare_clippy_lint_inner {
         $level:ident,
         $category:ident,
         $desc:literal
+        $(, @msrv_behavior = $msrv_behavior:literal)?
         $(, @eval_always = $eval_always:literal)?
     ) => {
         $crate::rustc_session::declare_tool_lint! {
@@ -143,6 +156,7 @@ macro_rules! declare_clippy_lint_inner {
             lint: $lint_name,
             category: $crate::LintCategory::$category,
             explanation: concat!($($docs,"\n",)*),
+            msrv_behavior: $crate::__clippy_lint_optional_msrv_behavior!($($msrv_behavior)?),
             location: concat!(file!(), "#L", line!()),
             version: $version,
         };

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -630,6 +630,10 @@ impl LintMetadata {
                 writeln!(&mut docs, " * {past_name}").unwrap();
             }
         }
+        if let Some(msrv_behavior) = lint.msrv_behavior {
+            docs.push_str("\n### MSRV behavior\n\n");
+            docs.push_str(msrv_behavior);
+        }
         let configs: Vec<_> = configs
             .iter()
             .filter(|conf| conf.lints.contains(&name.as_str()))


### PR DESCRIPTION
## Summary

Addresses rust-lang/rust-clippy#8693

This PR adds `### MSRV behavior` sections to generated Clippy lint docs for lints whose user-visible behavior depends on the configured `msrv`.

## Approach

- Adds `msrv_behavior: Option<&'static str>` to `LintInfo`
- Extends `declare_clippy_lint!` with an optional `@msrv_behavior = "..."`
  field
- Renders a `### MSRV behavior` section in generated lint documentation when the field is set

## Coverage

This documents currently identified user-visible MSRV-dependent behavior across Clippy lints, including the examples from rust-lang/rust-clippy#8693:

- `map_clone`
- `filter_map_next`

The documented behavior includes:

- lints suppressed entirely below a minimum MSRV
- lints that change their suggestion based on MSRV
- lints where const-context behavior differs from non-const behavior
- lints where only specific type/API subsets are MSRV-gated

The added descriptions were checked against the corresponding lint implementations, especially to distinguish cases where the whole lint is gated by MSRV from cases where only a suggestion or a specific code path is gated.

## Notes

A few lints already use `msrv` but are not listed in `clippy_config/src/conf.rs`'s `#[lints(...)]`, so they currently do not show a Configuration section. This appears to be a pre-existing issue and is not introduced by this PR.

## Test plan

- `cargo fmt --check`
- `cargo dev fmt --check`
- `cargo test --test compile-test --no-run`
- `cargo test --test config-metadata`
- `cargo dev update_lints --check`
- `COLLECT_METADATA=1 cargo test --test compile-test ui_test -- --nocapture`
- `git diff --check`

changelog: none