### PR TITLE
Fix `unwrap_expect_used` in test modules defined by complex configuration predicates (#16369)

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2475,15 +2475,50 @@ pub fn is_test_function(tcx: TyCtxt<'_>, fn_def_id: LocalDefId) -> bool {
     }
 }
 
-/// Checks if `id` has a `#[cfg(test)]` attribute applied
+/// Checks if the provided `CfgEntry` evaluation to `true` implies something one the value of the
+/// `test` attribute.
 ///
-/// This only checks directly applied attributes, to see if a node is inside a `#[cfg(test)]` parent
-/// use [`is_in_cfg_test`]
+/// When the predicate can be determined statically, returns `Some(true)` or `Some(false)`,
+/// depending on whether the entry implies `test` or `not(test)` respectively.
+/// If nothing can be said regarding the value of `test`, returns `None`.
+fn cfg_implies_test(cfg: &CfgEntry) -> Option<bool> {
+    match cfg {
+        CfgEntry::NameValue { name: sym::test, .. } => Some(true),
+        CfgEntry::All(subs, _) => subs
+            .iter()
+            .map(|item| cfg_implies_test(item))
+            .reduce(|a, b| match (a, b) {
+                (Some(true), Some(true)) => Some(true),
+                (Some(false), Some(false)) => Some(false),
+                (None, Some(a)) | (Some(a), None) => Some(a),
+                _ => None,
+            })
+            .unwrap_or(None),
+        CfgEntry::Any(subs, _) => subs
+            .iter()
+            .map(|item| cfg_implies_test(item))
+            .reduce(|a, b| match (a, b) {
+                (Some(true), Some(true)) => Some(true),
+                (Some(false), Some(false)) => Some(false),
+                _ => None,
+            })
+            .unwrap_or(None),
+        _ => None,
+    }
+}
+
+/// Checks if `id` has a `ConfigurationPredicate` attribute applied that evaluates to true only if
+/// the `test` attribute is enabled.
+///
+/// This only checks directly applied attributes, to see if a node is inside a parent with such
+/// property, use [`is_in_cfg_test`]
 pub fn is_cfg_test(tcx: TyCtxt<'_>, id: HirId) -> bool {
     if let Some(cfgs) = find_attr!(tcx, id, CfgTrace(cfgs) => cfgs)
         && cfgs
             .iter()
-            .any(|(cfg, _)| matches!(cfg, CfgEntry::NameValue { name: sym::test, .. }))
+            // If the dependency cannot be determined statically, we conservatively assume that it does compile even
+            // without `test` enabled.
+            .any(|(cfg, _)| matches!(cfg_implies_test(cfg), Some(true)))
     {
         true
     } else {

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(macro_metavar_expr)]
 #![feature(rustc_private)]
 #![feature(unwrap_infallible)]
+#![feature(control_flow_into_value)]
 #![recursion_limit = "512"]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::must_use_candidate)]
 #![warn(
@@ -2475,36 +2476,51 @@ pub fn is_test_function(tcx: TyCtxt<'_>, fn_def_id: LocalDefId) -> bool {
     }
 }
 
-/// Checks if the provided `CfgEntry` evaluation to `true` implies something one the value of the
-/// `test` attribute.
+/// Checks if the provided `CfgEntry` evaluation to `true` implies the `test` attribute is equal to
+/// `value`.
 ///
-/// When the predicate can be determined statically, returns `Some(true)` or `Some(false)`,
-/// depending on whether the entry implies `test` or `not(test)` respectively.
-/// If nothing can be said regarding the value of `test`, returns `None`.
-fn cfg_implies_test(cfg: &CfgEntry) -> Option<bool> {
-    match cfg {
-        CfgEntry::NameValue { name: sym::test, .. } => Some(true),
-        CfgEntry::All(subs, _) => subs
-            .iter()
-            .map(cfg_implies_test)
-            .reduce(|a, b| match (a, b) {
-                (Some(true), Some(true)) => Some(true),
-                (Some(false), Some(false)) => Some(false),
-                (None, Some(a)) | (Some(a), None) => Some(a),
-                _ => None,
-            })
-            .unwrap_or(None),
-        CfgEntry::Any(subs, _) => subs
-            .iter()
-            .map(cfg_implies_test)
-            .reduce(|a, b| match (a, b) {
-                (Some(true), Some(true)) => Some(true),
-                (Some(false), Some(false)) => Some(false),
-                _ => None,
-            })
-            .unwrap_or(None),
-        _ => None,
+/// Returns `Some(true)` if $$cfg \implies test = value$$ is a tautology.
+/// Returns `Some(false)` if $$cfg \implies test = value$$ is a contradiction.
+/// If the algorithm cannot determine the implication, returns `None`.
+///
+/// # Note
+/// This function is not a generic implication check and might return `None` even if the implication
+/// could be proven. But itshould be sufficient for most real world configuration predicates.
+fn cfg_implies_test_is(value: bool, cfg: &CfgEntry) -> Option<bool> {
+    /// Evaluates the Shannon cofactor of `cfg` with respect to `test = value`.
+    ///
+    /// Returns `Some(true)` if the cofactor is a tautology, `Some(false)` if it's a contradiction,
+    /// and `None` if the algorithm cannot determine the cofactor's value.
+    fn evaluate_shannon_cofactor(cfg: &CfgEntry, value: bool) -> Option<bool> {
+        match cfg {
+            CfgEntry::NameValue { name: sym::test, .. } => Some(value),
+            CfgEntry::All(subs, _) => subs
+                .iter()
+                .try_fold(Some(true), |a, c| match evaluate_shannon_cofactor(c, value) {
+                    Some(false) => ControlFlow::Break(Some(false)),
+                    Some(true) => ControlFlow::Continue(a),
+                    None => ControlFlow::Continue(None),
+                })
+                .into_value(),
+            CfgEntry::Any(subs, _) => subs
+                .iter()
+                .try_fold(Some(false), |a, c| match evaluate_shannon_cofactor(c, value) {
+                    Some(true) => ControlFlow::Break(Some(true)),
+                    Some(false) => ControlFlow::Continue(a),
+                    None => ControlFlow::Continue(None),
+                })
+                .into_value(),
+            CfgEntry::Not(sub, _) => evaluate_shannon_cofactor(sub, value).map(|x| !x),
+            CfgEntry::Bool(val, _) => Some(*val),
+            CfgEntry::NameValue { .. } | CfgEntry::Version { .. } => None,
+        }
     }
+
+    // According to Boole's expansion theorem, $$cfg = (test \land cfg_{test}) \lor (\lnot test
+    // \land cfg_{\lnot test})$$
+    // Therefore, $$cfg \implies test = value$$ is equivalent to $$cfg_{test=\lnot value}$$ being a
+    // contradiction.
+    evaluate_shannon_cofactor(cfg, !value).map(|x| !x)
 }
 
 /// Checks if `id` has a `ConfigurationPredicate` attribute applied that evaluates to true only if
@@ -2518,7 +2534,7 @@ pub fn is_cfg_test(tcx: TyCtxt<'_>, id: HirId) -> bool {
             .iter()
             // If the dependency cannot be determined statically, we conservatively assume that it does compile even
             // without `test` enabled.
-            .any(|(cfg, _)| matches!(cfg_implies_test(cfg), Some(true)))
+            .any(|(cfg, _)| matches!(cfg_implies_test_is(true, cfg), Some(true)))
     {
         true
     } else {

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2485,7 +2485,7 @@ pub fn is_test_function(tcx: TyCtxt<'_>, fn_def_id: LocalDefId) -> bool {
 ///
 /// # Note
 /// This function is not a generic implication check and might return `None` even if the implication
-/// could be proven. But itshould be sufficient for most real world configuration predicates.
+/// could be proven. But it should be sufficient for most real world configuration predicates.
 fn cfg_implies_test_is(value: bool, cfg: &CfgEntry) -> Option<bool> {
     /// Evaluates the Shannon cofactor of `cfg` with respect to `test = value`.
     ///

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2486,7 +2486,7 @@ fn cfg_implies_test(cfg: &CfgEntry) -> Option<bool> {
         CfgEntry::NameValue { name: sym::test, .. } => Some(true),
         CfgEntry::All(subs, _) => subs
             .iter()
-            .map(|item| cfg_implies_test(item))
+            .map(cfg_implies_test)
             .reduce(|a, b| match (a, b) {
                 (Some(true), Some(true)) => Some(true),
                 (Some(false), Some(false)) => Some(false),
@@ -2496,7 +2496,7 @@ fn cfg_implies_test(cfg: &CfgEntry) -> Option<bool> {
             .unwrap_or(None),
         CfgEntry::Any(subs, _) => subs
             .iter()
-            .map(|item| cfg_implies_test(item))
+            .map(cfg_implies_test)
             .reduce(|a, b| match (a, b) {
                 (Some(true), Some(true)) => Some(true),
                 (Some(false), Some(false)) => Some(false),

--- a/tests/ui-toml/unwrap_used/clippy.toml
+++ b/tests/ui-toml/unwrap_used/clippy.toml
@@ -1,2 +1,3 @@
 allow-unwrap-in-consts = false
 allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/tests/ui-toml/unwrap_used/unwrap_used_in_test.rs
+++ b/tests/ui-toml/unwrap_used/unwrap_used_in_test.rs
@@ -1,0 +1,40 @@
+//@compile-flags: --test
+
+#![allow(clippy::unnecessary_literal_unwrap)]
+#![warn(clippy::unwrap_used)]
+#![warn(clippy::expect_used)]
+
+#[test]
+fn test() {
+    Some(3).unwrap();
+    Some(3).expect("");
+}
+
+mod issue16369 {
+    #[cfg(all(test, variant = "variant"))]
+    mod all {
+        // should not lint modules configured as `test`
+        fn test_fn() {
+            let _a: u8 = Some(2).unwrap();
+            let _a: u8 = Some(3).expect("");
+        }
+    }
+
+    #[cfg(any(test, true))]
+    mod any {
+        // should lint modules that can can be compiled without the `test` attribute
+        fn test_fn() {
+            let _a: u8 = Some(2).unwrap(); //~ unwrap_used
+            let _a: u8 = Some(3).expect(""); //~ expect_used
+        }
+    }
+
+    #[cfg(any(test, all(test, true)))]
+    mod complex {
+        // should not lint in `test` modules even if the `cfg` is complex
+        fn test_fn() {
+            let _a: u8 = Some(2).unwrap();
+            let _a: u8 = Some(3).expect("");
+        }
+    }
+}

--- a/tests/ui-toml/unwrap_used/unwrap_used_in_test.rs
+++ b/tests/ui-toml/unwrap_used/unwrap_used_in_test.rs
@@ -22,7 +22,7 @@ mod issue16369 {
 
     #[cfg(any(test, true))]
     mod any {
-        // should lint modules that can can be compiled without the `test` attribute
+        // should lint modules that can be compiled without the `test` attribute
         fn test_fn() {
             let _a: u8 = Some(2).unwrap(); //~ unwrap_used
             let _a: u8 = Some(3).expect(""); //~ expect_used

--- a/tests/ui-toml/unwrap_used/unwrap_used_in_test.stderr
+++ b/tests/ui-toml/unwrap_used/unwrap_used_in_test.stderr
@@ -1,0 +1,22 @@
+error: used `unwrap()` on an `Option` value
+  --> tests/ui-toml/unwrap_used/unwrap_used_in_test.rs:27:26
+   |
+LL |             let _a: u8 = Some(2).unwrap();
+   |                          ^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+   = note: `-D clippy::unwrap-used` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unwrap_used)]`
+
+error: used `expect()` on an `Option` value
+  --> tests/ui-toml/unwrap_used/unwrap_used_in_test.rs:28:26
+   |
+LL |             let _a: u8 = Some(3).expect("");
+   |                          ^^^^^^^^^^^^^^^^^^
+   |
+   = note: if this value is `None`, it will panic
+   = note: `-D clippy::expect-used` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::expect_used)]`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This PR fixes detection of `test` contexts in complex scenarios (e.g., #[cfg(all(test, ...))]). This allows the `unwrap_used` and `expect_used` lints to correctly suppress warnings in test contexts with compound cfg conditions.

Note that this also updates the behavior of lints that indirectly depend on `is_cfg_test` (around 20 lints).

Fixes rust-lang/rust-clippy#16369 

changelog: [`unwrap_expect_used`]: Fix in test modules defined by complex configuration predicates
