### PR TITLE
Fix typos in book

### DIFF
--- a/book/src/lints.md
+++ b/book/src/lints.md
@@ -14,9 +14,9 @@ The different lint groups were defined in the [Clippy 1.0 RFC].
 
 ## Correctness
 
-The `clippy::correctness` group is the only lint group in Clippy which lints are
+The `clippy::correctness` group is the only lint group in Clippy whose lints are
 deny-by-default and abort the compilation when triggered. This is for good
-reason: If you see a `correctness` lint, it means that your code is outright
+reason: if you see a `correctness` lint, it means that your code is outright
 wrong or useless, and you should try to fix it.
 
 Lints in this category are carefully picked and should be free of false


### PR DESCRIPTION
changelog: none

Fixes rust-lang/rust-clippy#16992 