### PR TITLE
fix rust-clippy: map_clone should suggest 'cloned' for MSRV < 1.36

### DIFF
--- a/clippy_lints/src/methods/map_clone.rs
+++ b/clippy_lints/src/methods/map_clone.rs
@@ -172,6 +172,9 @@ fn lint_explicit_closure(cx: &LateContext<'_>, replace: Span, root: Span, is_cop
 
     let (message, sugg_method) = if is_copy && msrv.meets(cx, msrvs::ITERATOR_COPIED) {
         ("you are using an explicit closure for copying elements", "copied")
+    } else if is_copy {
+        // `copied()` was stabilized in 1.36, so for lower MSRV use `cloned` instead
+        ("you are using an explicit closure for cloning elements", "cloned")
     } else {
         ("you are using an explicit closure for cloning elements", "cloned")
     };


### PR DESCRIPTION
changelog: [map_clone]: fix lint suggestion for MSRV below 1.36 — when the type is Copy but MSRV < 1.36, suggest cloned() instead of copied() since copied() was stabilized in Rust 1.36.

Fixes rust-lang/rust-clippy#8623