### PR TITLE
Add `disallowed_pub_api_types` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6745,6 +6745,7 @@ Released 2018-09-13
 [`disallowed_method`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_method
 [`disallowed_methods`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods
 [`disallowed_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_names
+[`disallowed_pub_api_types`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_pub_api_types
 [`disallowed_script_idents`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_script_idents
 [`disallowed_type`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_type
 [`disallowed_types`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_types
@@ -7578,6 +7579,7 @@ Released 2018-09-13
 [`disallowed-macros`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-macros
 [`disallowed-methods`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-methods
 [`disallowed-names`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-names
+[`disallowed-pub-api-types`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-pub-api-types
 [`disallowed-types`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-types
 [`doc-valid-idents`]: https://doc.rust-lang.org/clippy/lint_configuration.html#doc-valid-idents
 [`enable-raw-pointer-heuristic-for-send`]: https://doc.rust-lang.org/clippy/lint_configuration.html#enable-raw-pointer-heuristic-for-send

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -585,6 +585,23 @@ default configuration of Clippy. By default, any configuration will replace the 
 * [`disallowed_names`](https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_names)
 
 
+## `disallowed-pub-api-types`
+The list of disallowed types in public APIs, written as fully qualified paths.
+
+**Fields:**
+- `path` (required): the fully qualified path to the type that should be disallowed
+- `reason` (optional): explanation why this type is disallowed
+- `replacement` (optional): suggested alternative type
+- `allow-invalid` (optional, `false` by default): when set to `true`, it will ignore this entry
+  if the path doesn't exist, instead of emitting an error
+
+**Default Value:** `[]`
+
+---
+**Affected lints:**
+* [`disallowed_pub_api_types`](https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_pub_api_types)
+
+
 ## `disallowed-types`
 The list of disallowed types, written as fully qualified paths.
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -628,6 +628,17 @@ define_Conf! {
     /// default configuration of Clippy. By default, any configuration will replace the default value.
     #[lints(disallowed_names)]
     disallowed_names: Vec<String> = DEFAULT_DISALLOWED_NAMES.iter().map(ToString::to_string).collect(),
+    /// The list of disallowed types in public APIs, written as fully qualified paths.
+    ///
+    /// **Fields:**
+    /// - `path` (required): the fully qualified path to the type that should be disallowed
+    /// - `reason` (optional): explanation why this type is disallowed
+    /// - `replacement` (optional): suggested alternative type
+    /// - `allow-invalid` (optional, `false` by default): when set to `true`, it will ignore this entry
+    ///   if the path doesn't exist, instead of emitting an error
+    #[disallowed_paths_allow_replacements = true]
+    #[lints(disallowed_pub_api_types)]
+    disallowed_pub_api_types: Vec<DisallowedPath> = Vec::new(),
     /// The list of disallowed types, written as fully qualified paths.
     ///
     /// **Fields:**

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -109,6 +109,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::disallowed_macros::DISALLOWED_MACROS_INFO,
     crate::disallowed_methods::DISALLOWED_METHODS_INFO,
     crate::disallowed_names::DISALLOWED_NAMES_INFO,
+    crate::disallowed_pub_api_types::DISALLOWED_PUB_API_TYPES_INFO,
     crate::disallowed_script_idents::DISALLOWED_SCRIPT_IDENTS_INFO,
     crate::disallowed_types::DISALLOWED_TYPES_INFO,
     crate::doc::DOC_BROKEN_LINK_INFO,

--- a/clippy_lints/src/disallowed_pub_api_types.rs
+++ b/clippy_lints/src/disallowed_pub_api_types.rs
@@ -1,0 +1,141 @@
+use clippy_config::Conf;
+use clippy_config::types::{DisallowedPath, create_disallowed_map};
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::paths::PathNS;
+use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::DefIdMap;
+use rustc_hir::intravisit::{Visitor, VisitorExt, walk_ty};
+use rustc_hir::{AmbigArg, FnRetTy, ImplItem, ImplItemKind, Item, ItemKind, TraitItem, TraitItemKind, Ty, TyKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TyCtxt;
+use rustc_session::impl_lint_pass;
+use rustc_span::Span;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Denies the configured types in clippy.toml from being used in the public API (function parameters or return types).
+    ///
+    /// ### Why is this bad?
+    /// Some types are undesirable in public APIs (e.g. `anyhow::Result`).
+    ///
+    /// ### Example
+    /// ```rust,ignore
+    /// pub fn foo() -> anyhow::Result<()> {
+    ///     Ok(())
+    /// }
+    /// ```
+    #[clippy::version = "1.80.0"]
+    pub DISALLOWED_PUB_API_TYPES,
+    style,
+    "use of disallowed types in public API"
+}
+
+impl_lint_pass!(DisallowedPubApiTypes => [DISALLOWED_PUB_API_TYPES]);
+
+pub struct DisallowedPubApiTypes {
+    def_ids: DefIdMap<(&'static str, &'static DisallowedPath)>,
+    prim_tys: FxHashMap<rustc_hir::PrimTy, (&'static str, &'static DisallowedPath)>,
+}
+
+impl DisallowedPubApiTypes {
+    pub fn new(tcx: TyCtxt<'_>, conf: &'static Conf) -> Self {
+        let (def_ids, prim_tys) = create_disallowed_map(
+            tcx,
+            &conf.disallowed_pub_api_types,
+            PathNS::Type,
+            def_kind_predicate,
+            "type",
+            true,
+        );
+        Self { def_ids, prim_tys }
+    }
+
+    fn check_res_emit(&self, cx: &LateContext<'_>, res: &Res, span: Span) {
+        let (path, disallowed_path) = match res {
+            Res::Def(_, did) if let Some(&x) = self.def_ids.get(did) => x,
+            Res::PrimTy(prim) if let Some(&x) = self.prim_tys.get(prim) => x,
+            _ => return,
+        };
+        span_lint_and_then(
+            cx,
+            DISALLOWED_PUB_API_TYPES,
+            span,
+            format!("using a disallowed type `{path}` in a public API"),
+            disallowed_path.diag_amendment(span),
+        );
+    }
+}
+
+pub fn def_kind_predicate(def_kind: DefKind) -> bool {
+    matches!(
+        def_kind,
+        DefKind::Struct
+            | DefKind::Union
+            | DefKind::Enum
+            | DefKind::Trait
+            | DefKind::TyAlias
+            | DefKind::ForeignTy
+            | DefKind::AssocTy
+    )
+}
+
+struct TyVisitor<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    lint: &'a DisallowedPubApiTypes,
+}
+
+impl<'tcx> Visitor<'tcx> for TyVisitor<'_, 'tcx> {
+    fn visit_ty(&mut self, ty: &'tcx Ty<'tcx, AmbigArg>) {
+        if let TyKind::Path(path) = &ty.kind {
+            let res = self.cx.qpath_res(path, ty.hir_id);
+            self.lint.check_res_emit(self.cx, &res, ty.span);
+        }
+        walk_ty(self, ty);
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for DisallowedPubApiTypes {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if let ItemKind::Fn { ref sig, .. } = item.kind
+            && cx.effective_visibilities.is_exported(item.owner_id.def_id)
+        {
+            let mut visitor = TyVisitor { cx, lint: self };
+            for ty in sig.decl.inputs {
+                visitor.visit_ty_unambig(ty);
+            }
+            if let FnRetTy::Return(ty) = sig.decl.output {
+                visitor.visit_ty_unambig(ty);
+            }
+        }
+    }
+
+    fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx ImplItem<'tcx>) {
+        if let ImplItemKind::Fn(ref sig, _) = item.kind
+            && clippy_utils::trait_ref_of_method(cx, item.owner_id).is_none()
+            && cx.effective_visibilities.is_exported(item.owner_id.def_id)
+        {
+            let mut visitor = TyVisitor { cx, lint: self };
+            for ty in sig.decl.inputs {
+                visitor.visit_ty_unambig(ty);
+            }
+            if let FnRetTy::Return(ty) = sig.decl.output {
+                visitor.visit_ty_unambig(ty);
+            }
+        }
+    }
+
+    fn check_trait_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx TraitItem<'tcx>) {
+        if let TraitItemKind::Fn(ref sig, _) = item.kind
+            && cx.effective_visibilities.is_exported(item.owner_id.def_id)
+        {
+            let mut visitor = TyVisitor { cx, lint: self };
+            for ty in sig.decl.inputs {
+                visitor.visit_ty_unambig(ty);
+            }
+            if let FnRetTy::Return(ty) = sig.decl.output {
+                visitor.visit_ty_unambig(ty);
+            }
+        }
+    }
+}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -108,6 +108,7 @@ mod disallowed_fields;
 mod disallowed_macros;
 mod disallowed_methods;
 mod disallowed_names;
+mod disallowed_pub_api_types;
 mod disallowed_script_idents;
 mod disallowed_types;
 mod doc;
@@ -718,6 +719,7 @@ rustc_lint::late_lint_methods!(
         IfThenSomeElseNone: if_then_some_else_none::IfThenSomeElseNone = if_then_some_else_none::IfThenSomeElseNone::new(conf),
         BoolAssertComparison: bool_assert_comparison::BoolAssertComparison = bool_assert_comparison::BoolAssertComparison,
         UnusedAsync: unused_async::UnusedAsync = <unused_async::UnusedAsync>::default(),
+        DisallowedPubApiTypes: disallowed_pub_api_types::DisallowedPubApiTypes = disallowed_pub_api_types::DisallowedPubApiTypes::new(tcx, conf),
         DisallowedTypes: disallowed_types::DisallowedTypes = disallowed_types::DisallowedTypes::new(tcx, conf),
         ImportRename: missing_enforced_import_rename::ImportRename = missing_enforced_import_rename::ImportRename::new(tcx, conf),
         StrlenOnCStrings: strlen_on_c_strings::StrlenOnCStrings = strlen_on_c_strings::StrlenOnCStrings::new(conf),

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -202,6 +202,7 @@ pub fn find_crates(tcx: TyCtxt<'_>, name: Symbol) -> &'static [DefId] {
     let map = BY_NAME.get_or_init(|| {
         let mut map = FxHashMap::default();
         map.insert(tcx.crate_name(LOCAL_CRATE), vec![LOCAL_CRATE.as_def_id()]);
+        map.insert(rustc_span::symbol::kw::Crate, vec![LOCAL_CRATE.as_def_id()]);
         for &num in tcx.crates(()) {
             map.entry(tcx.crate_name(num)).or_default().push(num.as_def_id());
         }

--- a/tests/ui-toml/disallowed_pub_api_types/clippy.toml
+++ b/tests/ui-toml/disallowed_pub_api_types/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-pub-api-types = [
+    "std::result::Result",
+    "std::option::Option",
+    "crate::InputOnly",
+]

--- a/tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs
+++ b/tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs
@@ -1,0 +1,74 @@
+#![warn(clippy::disallowed_pub_api_types)]
+#![allow(clippy::result_unit_err, clippy::unused_self)]
+
+pub fn bad_pub_fn() -> Result<(), ()> {
+    //~^ disallowed_pub_api_types
+    Ok(())
+}
+
+pub fn bad_pub_fn_arg(_arg: Result<(), ()>) {
+    //~^ disallowed_pub_api_types
+}
+
+fn private_fn() -> Result<(), ()> {
+    // should not trigger
+    Ok(())
+}
+
+fn private_fn_arg(_arg: Result<(), ()>) {
+    // should not trigger
+}
+
+pub struct Struct;
+
+impl Struct {
+    pub fn bad_method(&self) -> Option<i32> {
+        //~^ disallowed_pub_api_types
+        Some(42)
+    }
+
+    pub fn bad_method_arg(&self, _arg: Option<i32>) {
+        //~^ disallowed_pub_api_types
+    }
+
+    fn private_method(&self) -> Option<i32> {
+        Some(42)
+    }
+
+    fn private_method_arg(&self, _arg: Option<i32>) {}
+}
+
+pub trait Trait {
+    fn bad_trait_method() -> Result<(), ()>;
+    //~^ disallowed_pub_api_types
+
+    fn bad_trait_method_arg(_arg: Result<(), ()>);
+    //~^ disallowed_pub_api_types
+}
+
+pub enum NestedStruct {
+    One(Result<(), ()>),
+    Two(Option<i32>),
+    Three(String),
+}
+
+pub fn get_nested_struct() -> NestedStruct {
+    // Should not trigger. Wrapping the type is fine
+    NestedStruct::One(Ok(()))
+}
+
+pub enum InputOnly {
+    Pretty,
+    Raw,
+}
+
+pub fn get_input_type() -> crate::InputOnly {
+    //~^ disallowed_pub_api_types
+    InputOnly::Pretty
+}
+
+pub fn bad_pub_fn_input_only_arg(_arg: crate::InputOnly) {
+    //~^ disallowed_pub_api_types
+}
+
+fn main() {}

--- a/tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.stderr
+++ b/tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.stderr
@@ -1,0 +1,53 @@
+error: using a disallowed type `std::result::Result` in a public API
+  --> tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs:4:24
+   |
+LL | pub fn bad_pub_fn() -> Result<(), ()> {
+   |                        ^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::disallowed-pub-api-types` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::disallowed_pub_api_types)]`
+
+error: using a disallowed type `std::result::Result` in a public API
+  --> tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs:9:29
+   |
+LL | pub fn bad_pub_fn_arg(_arg: Result<(), ()>) {
+   |                             ^^^^^^^^^^^^^^
+
+error: using a disallowed type `std::option::Option` in a public API
+  --> tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs:25:33
+   |
+LL |     pub fn bad_method(&self) -> Option<i32> {
+   |                                 ^^^^^^^^^^^
+
+error: using a disallowed type `std::option::Option` in a public API
+  --> tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs:30:40
+   |
+LL |     pub fn bad_method_arg(&self, _arg: Option<i32>) {
+   |                                        ^^^^^^^^^^^
+
+error: using a disallowed type `std::result::Result` in a public API
+  --> tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs:42:30
+   |
+LL |     fn bad_trait_method() -> Result<(), ()>;
+   |                              ^^^^^^^^^^^^^^
+
+error: using a disallowed type `std::result::Result` in a public API
+  --> tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs:45:35
+   |
+LL |     fn bad_trait_method_arg(_arg: Result<(), ()>);
+   |                                   ^^^^^^^^^^^^^^
+
+error: using a disallowed type `crate::InputOnly` in a public API
+  --> tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs:65:28
+   |
+LL | pub fn get_input_type() -> crate::InputOnly {
+   |                            ^^^^^^^^^^^^^^^^
+
+error: using a disallowed type `crate::InputOnly` in a public API
+  --> tests/ui-toml/disallowed_pub_api_types/disallowed_pub_api_types.rs:70:40
+   |
+LL | pub fn bad_pub_fn_input_only_arg(_arg: crate::InputOnly) {
+   |                                        ^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -42,6 +42,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            disallowed-macros
            disallowed-methods
            disallowed-names
+           disallowed-pub-api-types
            disallowed-types
            doc-valid-idents
            enable-raw-pointer-heuristic-for-send
@@ -143,6 +144,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            disallowed-macros
            disallowed-methods
            disallowed-names
+           disallowed-pub-api-types
            disallowed-types
            doc-valid-idents
            enable-raw-pointer-heuristic-for-send
@@ -244,6 +246,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            disallowed-macros
            disallowed-methods
            disallowed-names
+           disallowed-pub-api-types
            disallowed-types
            doc-valid-idents
            enable-raw-pointer-heuristic-for-send


### PR DESCRIPTION
changelog: [`disallowed_pub_api_types`]: New lint that checks the parameters and return values of all `pub` functions, methods, and trait methods within a crate, emitting a warning if any proscribed types are used.

Configurable via `disallowed-pub-api-types` in `clippy.toml`. This is intended to prevent internal error types (e.g., `anyhow::Result`) from leaking into public APIs.

