### PR TITLE
move `unnecessary_get_then_check` to `complexity`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4267,7 +4267,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.78.0"]
     pub UNNECESSARY_GET_THEN_CHECK,
-    suspicious,
+    complexity,
     "calling `.get().is_some()` or `.get().is_none()` instead of `.contains()` or `.contains_key()`"
 }
 


### PR DESCRIPTION
The lint fires on `.get(...).is_some()` (or `.is_none()`) against `HashSet`/`BTreeSet`/`HashMap`/`BTreeMap` and suggests `.contains()` / `.contains_key()`. The two forms are semantically equivalent and the suggestion is purely a readability/shortness refactor, so `complexity` reads as a better fit than `suspicious` per the descriptions in the clippy book:

- `suspicious` — "code that is most likely wrong or useless"
- `complexity` — "suggestions on how to simplify your code... in a shorter and more readable way, while preserving the semantics"

rust-lang/rust-clippy#16302 made the same kind of move for `multiple_bound_locations` (`suspicious` -> `style`) with similar reasoning, so there is precedent for adjusting a lint's category when it no longer matches the original placement.

Happy to drop this if the team prefers to keep it in `suspicious`; the issue reporter raised the case and the category boundary is a judgement call.

Fixes rust-lang/rust-clippy#16990.

changelog: move `unnecessary_get_then_check` lint to `complexity` group