### PR TITLE
let_underscore_future: skip bindings with an explicit type annotation

### DIFF
--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -162,7 +162,8 @@ impl<'tcx> LateLintPass<'tcx> for LetUnderscore {
                         );
                     },
                 );
-            } else if let Some(future_trait_def_id) = cx.tcx.lang_items().future_trait()
+            } else if local.ty.is_none()
+                && let Some(future_trait_def_id) = cx.tcx.lang_items().future_trait()
                 && implements_trait(cx, cx.typeck_results().expr_ty(init), future_trait_def_id, &[])
             {
                 #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]

--- a/tests/ui/let_underscore_future.rs
+++ b/tests/ui/let_underscore_future.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::pin::Pin;
 
 async fn some_async_fn() {}
 
@@ -9,6 +10,10 @@ fn custom() -> impl Future<Output = ()> {
 }
 
 fn do_something_to_future(future: &mut impl Future<Output = ()>) {}
+
+fn boxed() -> Pin<Box<dyn Future<Output = ()>>> {
+    Box::pin(async {})
+}
 
 fn main() {
     let _ = some_async_fn();
@@ -21,4 +26,7 @@ fn main() {
     do_something_to_future(&mut future);
     let _ = future;
     //~^ let_underscore_future
+
+    // Typed bindings are an intentional discard, see also `let_underscore_untyped`.
+    let _: Pin<Box<dyn Future<Output = ()>>> = boxed();
 }

--- a/tests/ui/let_underscore_future.stderr
+++ b/tests/ui/let_underscore_future.stderr
@@ -1,5 +1,5 @@
 error: non-binding `let` on a future
-  --> tests/ui/let_underscore_future.rs:14:5
+  --> tests/ui/let_underscore_future.rs:19:5
    |
 LL |     let _ = some_async_fn();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let _ = some_async_fn();
    = help: to override `-D warnings` add `#[allow(clippy::let_underscore_future)]`
 
 error: non-binding `let` on a future
-  --> tests/ui/let_underscore_future.rs:17:5
+  --> tests/ui/let_underscore_future.rs:22:5
    |
 LL |     let _ = custom();
    |     ^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     let _ = custom();
    = help: consider awaiting the future or dropping explicitly with `std::mem::drop`
 
 error: non-binding `let` on a future
-  --> tests/ui/let_underscore_future.rs:22:5
+  --> tests/ui/let_underscore_future.rs:27:5
    |
 LL |     let _ = future;
    |     ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently `let_underscore_future` fires on `let _: T = expr` even when the user writes the type explicitly. The reporter's argument is that a typed `let _:` is an intentional discard, separate practice from the unannotated form. This is the same rationale `let_underscore_untyped` documents.

This gates the lint on `local.ty.is_none()` so `let _: Pin<Box<dyn Future<Output = ()>>> = foo();` no longer warns, while bare `let _ = foo();` still does.

Test case added under `tests/ui/let_underscore_future.rs` covering both shapes; `.stderr` updated for the line-number shift.

Fixes rust-lang/rust-clippy#16991

----

changelog: none