### PR TITLE
`duration_suboptimal_units`: print the complete method name in the suggestion

### DIFF
--- a/clippy_lints/src/duration_suboptimal_units.rs
+++ b/clippy_lints/src/duration_suboptimal_units.rs
@@ -109,7 +109,7 @@ impl LateLintPass<'_> for DurationSuboptimalUnits {
                         (arg.span, promoted_value.to_string()),
                     ];
                     diag.multipart_suggestion(
-                        format!("try using {promoted_constructor}"),
+                        format!("try using `Duration::{promoted_constructor}`"),
                         suggestions,
                         Applicability::MachineApplicable,
                     );

--- a/tests/ui/duration_suboptimal_units.stderr
+++ b/tests/ui/duration_suboptimal_units.stderr
@@ -6,7 +6,7 @@ LL |     let dur = Duration::from_secs(60 * 3);
    |
    = note: `-D clippy::duration-suboptimal-units` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::duration_suboptimal_units)]`
-help: try using from_mins
+help: try using `Duration::from_mins`
    |
 LL -     let dur = Duration::from_secs(60 * 3);
 LL +     let dur = Duration::from_mins(3);
@@ -18,7 +18,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_secs(10 * 60);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_mins
+help: try using `Duration::from_mins`
    |
 LL -     let dur = Duration::from_secs(10 * 60);
 LL +     let dur = Duration::from_mins(10);
@@ -30,7 +30,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_mins(24 * 60);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -     let dur = Duration::from_mins(24 * 60);
 LL +     let dur = Duration::from_hours(24);
@@ -42,7 +42,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_millis(5 * 1000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_secs
+help: try using `Duration::from_secs`
    |
 LL -     let dur = Duration::from_millis(5 * 1000);
 LL +     let dur = Duration::from_secs(5);
@@ -54,7 +54,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_nanos(13 * 60 * 60 * 1_000 * 1_000 * 1_000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -     let dur = Duration::from_nanos(13 * 60 * 60 * 1_000 * 1_000 * 1_000);
 LL +     let dur = Duration::from_hours(13);
@@ -66,7 +66,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |         let dur = Duration::from_millis(1000 * 5);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_secs
+help: try using `Duration::from_secs`
    |
 LL -         let dur = Duration::from_millis(1000 * 5);
 LL +         let dur = Duration::from_secs(5);
@@ -78,7 +78,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |         let dur = Duration::from_millis(11000);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_secs
+help: try using `Duration::from_secs`
    |
 LL -         let dur = Duration::from_millis(11000);
 LL +         let dur = Duration::from_secs(11);
@@ -90,7 +90,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |         let dur = Duration::from_secs(39600);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -         let dur = Duration::from_secs(39600);
 LL +         let dur = Duration::from_hours(11);
@@ -102,7 +102,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |         let dur = Duration::from_secs(3 * 60);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_mins
+help: try using `Duration::from_mins`
    |
 LL -         let dur = Duration::from_secs(3 * 60);
 LL +         let dur = Duration::from_mins(3);
@@ -114,7 +114,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |         let dur = Duration::from_mins(24 * 60);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -         let dur = Duration::from_mins(24 * 60);
 LL +         let dur = Duration::from_hours(24);
@@ -126,7 +126,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     std::time::Duration::from_secs(12 * 60);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_mins
+help: try using `Duration::from_mins`
    |
 LL -     std::time::Duration::from_secs(12 * 60);
 LL +     std::time::Duration::from_mins(12);
@@ -138,7 +138,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     assert_eq!(Duration::from_secs(60 * 60), Duration::from_mins(6));
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -     assert_eq!(Duration::from_secs(60 * 60), Duration::from_mins(6));
 LL +     assert_eq!(Duration::from_hours(1), Duration::from_mins(6));
@@ -154,7 +154,7 @@ LL |     let dur = mac!(duration);
    |               -------------- in this macro invocation
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: try using from_mins
+help: try using `Duration::from_mins`
    |
 LL -         Duration::from_secs(60 * 5)
 LL +         Duration::from_mins(5)
@@ -166,7 +166,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     _ = Duration::from_secs(67_768_040_922_076_800);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -     _ = Duration::from_secs(67_768_040_922_076_800);
 LL +     _ = Duration::from_hours(18824455811688);
@@ -178,7 +178,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_millis(20_000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_secs
+help: try using `Duration::from_secs`
    |
 LL -     let dur = Duration::from_millis(20_000);
 LL +     let dur = Duration::from_secs(20);
@@ -190,7 +190,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_mins(720);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -     let dur = Duration::from_mins(720);
 LL +     let dur = Duration::from_hours(12);
@@ -202,7 +202,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_secs(660);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_mins
+help: try using `Duration::from_mins`
    |
 LL -     let dur = Duration::from_secs(660);
 LL +     let dur = Duration::from_mins(11);
@@ -214,7 +214,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_secs(60 * 5);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_mins
+help: try using `Duration::from_mins`
    |
 LL -     let dur = Duration::from_secs(60 * 5);
 LL +     let dur = Duration::from_mins(5);
@@ -226,7 +226,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_mins(60 * 2);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -     let dur = Duration::from_mins(60 * 2);
 LL +     let dur = Duration::from_hours(2);
@@ -238,7 +238,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_mins(60 * 24);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_hours
+help: try using `Duration::from_hours`
    |
 LL -     let dur = Duration::from_mins(60 * 24);
 LL +     let dur = Duration::from_hours(24);

--- a/tests/ui/duration_suboptimal_units_days_weeks.stderr
+++ b/tests/ui/duration_suboptimal_units_days_weeks.stderr
@@ -6,7 +6,7 @@ LL |     let dur = Duration::from_secs(6000);
    |
    = note: `-D clippy::duration-suboptimal-units` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::duration_suboptimal_units)]`
-help: try using from_mins
+help: try using `Duration::from_mins`
    |
 LL -     let dur = Duration::from_secs(6000);
 LL +     let dur = Duration::from_mins(100);
@@ -18,7 +18,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_hours(24000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_days
+help: try using `Duration::from_days`
    |
 LL -     let dur = Duration::from_hours(24000);
 LL +     let dur = Duration::from_days(1000);
@@ -30,7 +30,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_nanos(13 * 7 * 24 * 60 * 60 * 1_000 * 1_000 * 1_000);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_weeks
+help: try using `Duration::from_weeks`
    |
 LL -     let dur = Duration::from_nanos(13 * 7 * 24 * 60 * 60 * 1_000 * 1_000 * 1_000);
 LL +     let dur = Duration::from_weeks(13);
@@ -42,7 +42,7 @@ error: constructing a `Duration` using a smaller unit when a larger unit would b
 LL |     let dur = Duration::from_hours(24 * 7);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try using from_weeks
+help: try using `Duration::from_weeks`
    |
 LL -     let dur = Duration::from_hours(24 * 7);
 LL +     let dur = Duration::from_weeks(1);


### PR DESCRIPTION
changelog: [`duration_suboptimal_units`]: print the complete method name in the suggestion