### PR TITLE
Improve needless update lint text

### DIFF
--- a/clippy_lints/src/needless_update.rs
+++ b/clippy_lints/src/needless_update.rs
@@ -34,11 +34,10 @@ declare_clippy_lint! {
     ///
     /// Use instead:
     /// ```rust,ignore
-    /// // Missing field `z`
     /// Point {
     ///     x: 1,
     ///     y: 1,
-    ///     ..zero_point
+    ///     z: 1
     /// };
     /// ```
     #[clippy::version = "pre 1.29.0"]


### PR DESCRIPTION
The main value of this help text is only provided when the developer already provided all the fields. So a better example is showing the developer that this lint can be used to clean up those struct initalizations.

Besides the lint already points to the ...zero_point line so the developer is inclined to remove it.

I think the changelog is effectively none since I'm really just trying to improve the lints website.

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none
