### PR TITLE
fix arithmetic side effects false positive

### DIFF
--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -330,12 +330,12 @@ impl<'tcx> LateLintPass<'tcx> for ArithmeticSideEffects {
 /// Detects a type-casting conversion and returns the type of the original expression. For
 /// example, `let foo = u64::from(bar)`.
 fn find_original_primitive_ty<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>) -> Option<Ty<'tcx>> {
-    if let hir::ExprKind::Call(path, [arg]) = &expr.kind
-        && path.res(cx).opt_def_id().is_diag_item(&cx.tcx, sym::from_fn)
-    {
-        Some(cx.typeck_results().expr_ty(arg))
-    } else {
-        None
+    match &expr.kind {
+        hir::ExprKind::Call(path, [arg]) if path.res(cx).opt_def_id().is_diag_item(&cx.tcx, sym::from_fn) => {
+            Some(cx.typeck_results().expr_ty(arg))
+        },
+        hir::ExprKind::Cast(arg, _) => Some(cx.typeck_results().expr_ty(arg)),
+        _ => None,
     }
 }
 

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -742,4 +742,24 @@ pub fn type_conversion_does_not_escape_its_context() {
     //~^ arithmetic_side_effects
 }
 
+pub fn issue_17005() {
+    fn id_u8() -> u8 {
+        0
+    }
+    fn id_u16() -> u16 {
+        0
+    }
+    fn id_u32() -> u32 {
+        0
+    }
+
+    // cast from a smaller unsigned type, sum cannot overflow
+    let _ = 1u32 + id_u8() as u32;
+    let _ = 1u32 + id_u16() as u32;
+    let _ = 1u64 + id_u8() as u64;
+    let _ = 1u64 + id_u16() as u64;
+    let _ = 1u64 + id_u32() as u64;
+    let _ = 0xf301_0000u32 + id_u16() as u32;
+}
+
 fn main() {}


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17005 

changelog: [`arithmetic_side_effects`]: don't lint when one operand is an `as` cast from a smaller integer type