### PR TITLE
ci: declare workflow-level `contents: read` on 6 workflows

### DIFF
--- a/.github/workflows/clippy_changelog.yml
+++ b/.github/workflows/clippy_changelog.yml
@@ -11,6 +11,9 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -9,6 +9,9 @@ env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: -D warnings
 
+permissions:
+  contents: read
+
 jobs:
   clippy_dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy_mq.yml
+++ b/.github/workflows/clippy_mq.yml
@@ -14,6 +14,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   base:
     strategy:

--- a/.github/workflows/clippy_pr.yml
+++ b/.github/workflows/clippy_pr.yml
@@ -16,6 +16,9 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   base:
     # NOTE: If you modify this job, make sure you copy the changes to clippy_mq.yml

--- a/.github/workflows/lintcheck.yml
+++ b/.github/workflows/lintcheck.yml
@@ -17,6 +17,9 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.event.pull_request.number}}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Runs lintcheck on the PR's target branch and stores the results as an artifact
   base:

--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -7,6 +7,9 @@ on:
 env:
   MDBOOK_VERSION: 0.5.1
 
+permissions:
+  contents: read
+
 jobs:
   remark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 6 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.