### PR TITLE
Add new `matches_instead_of_eq` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7060,6 +7060,7 @@ Released 2018-09-13
 [`match_str_case_mismatch`]: https://rust-lang.github.io/rust-clippy/master/index.html#match_str_case_mismatch
 [`match_wild_err_arm`]: https://rust-lang.github.io/rust-clippy/master/index.html#match_wild_err_arm
 [`match_wildcard_for_single_variants`]: https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants
+[`matches_instead_of_eq`]: https://rust-lang.github.io/rust-clippy/master/index.html#matches_instead_of_eq
 [`maybe_infinite_iter`]: https://rust-lang.github.io/rust-clippy/master/index.html#maybe_infinite_iter
 [`maybe_misused_cfg`]: https://rust-lang.github.io/rust-clippy/master/index.html#maybe_misused_cfg
 [`mem_discriminant_non_enum`]: https://rust-lang.github.io/rust-clippy/master/index.html#mem_discriminant_non_enum

--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -101,7 +101,7 @@ fn fmt_conf(check: bool) -> Result<(), Error> {
             pos += x.len;
             (start as usize, x)
         })
-        .filter(|(_, t)| !matches!(t.kind, TokenKind::Whitespace))
+        .filter(|(_, t)| t.kind != TokenKind::Whitespace)
     {
         match (state, t.kind) {
             (State::Start, TokenKind::LineComment { doc_style: Some(_) }) => {

--- a/clippy_dev/src/parse.rs
+++ b/clippy_dev/src/parse.rs
@@ -387,7 +387,7 @@ impl<'cx> ParseCxImpl<'cx> {
                     );
                 },
                 mac @ ("declare_lint_pass" | "impl_lint_pass") if cursor.match_all(PASS_DECL_TOKENS, &mut captures) => {
-                    let mac = if matches!(mac, "declare_lint_pass") {
+                    let mac = if mac == "declare_lint_pass" {
                         LintPassMac::Declare
                     } else {
                         LintPassMac::Impl

--- a/clippy_dev/src/parse/cursor.rs
+++ b/clippy_dev/src/parse/cursor.rs
@@ -155,7 +155,7 @@ impl<'txt> Cursor<'txt> {
                 },
                 (Pat::DoubleColon, TokenKind::Colon) => {
                     self.step();
-                    if matches!(self.next_token.kind, TokenKind::Colon) {
+                    if self.next_token.kind == TokenKind::Colon {
                         self.step();
                         return true;
                     }
@@ -163,7 +163,7 @@ impl<'txt> Cursor<'txt> {
                 },
                 (Pat::FatArrow, TokenKind::Eq) => {
                     self.step();
-                    if matches!(self.next_token.kind, TokenKind::Gt) {
+                    if self.next_token.kind == TokenKind::Gt {
                         self.step();
                         return true;
                     }

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -587,7 +587,7 @@ impl EarlyLintPass for PostExpansionEarlyAttributes {
         if let Some(items) = &attr.meta_item_list()
             && let Some(name) = attr.name()
         {
-            if matches!(name, sym::allow) && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
+            if name == sym::allow && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
                 allow_attributes::check(cx, attr);
             }
             if matches!(name, sym::allow | sym::expect) && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {

--- a/clippy_lints/src/cargo/multiple_crate_versions.rs
+++ b/clippy_lints/src/cargo/multiple_crate_versions.rs
@@ -59,13 +59,9 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata, allowed_duplicate
 
 fn is_normal_dep(nodes: &[Node], local_id: &PackageId, dep_id: &PackageId) -> bool {
     fn depends_on(node: &Node, dep_id: &PackageId) -> bool {
-        node.deps.iter().any(|dep| {
-            dep.pkg == *dep_id
-                && dep
-                    .dep_kinds
-                    .iter()
-                    .any(|info| matches!(info.kind, DependencyKind::Normal))
-        })
+        node.deps
+            .iter()
+            .any(|dep| dep.pkg == *dep_id && dep.dep_kinds.iter().any(|info| info.kind == DependencyKind::Normal))
     }
 
     nodes

--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -159,7 +159,7 @@ pub(super) fn check(
             format!("casting `{cast_from}` to `{cast_to}` may truncate the value")
         },
 
-        (ty::Float(FloatTy::F64), None) if matches!(cast_to.kind(), &ty::Float(FloatTy::F32)) => {
+        (ty::Float(FloatTy::F64), None) if cast_to.kind() == &ty::Float(FloatTy::F32) => {
             "casting `f64` to `f32` may truncate the value".to_string()
         },
 

--- a/clippy_lints/src/casts/cast_sign_loss.rs
+++ b/clippy_lints/src/casts/cast_sign_loss.rs
@@ -342,7 +342,7 @@ fn exprs_with_add_binop_peeled<'e>(expr: &'e Expr<'_>) -> Vec<&'e Expr<'e>> {
     for_each_expr_without_closures(expr, |sub_expr| -> ControlFlow<Infallible, Descend> {
         // We don't check for add methods here, but we could.
         if let ExprKind::Binary(op, _lhs, _rhs) = sub_expr.kind {
-            if matches!(op.node, BinOpKind::Add) {
+            if op.node == BinOpKind::Add {
                 // For binary operators where both sides contribute to the sign of the result,
                 // collect all their operands, recursively. This ignores overflow.
                 ControlFlow::Continue(Descend::Yes)

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -322,7 +322,7 @@ pub(super) fn parens_around(expr: &Expr<'_>) -> Vec<(Span, String)> {
 fn span_extract_keyword(cx: &LateContext<'_>, span: Span, keyword: &str) -> Option<Span> {
     span.with_source_text(cx, |snippet| {
         tokenize_with_text(snippet)
-            .filter(|(t, s, _)| matches!(t, TokenKind::Ident if *s == keyword))
+            .filter(|(t, s, _)| *t == TokenKind::Ident && *s == keyword)
             .map(|(_, _, inner)| {
                 span.split_at(u32::try_from(inner.start).unwrap())
                     .1

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -346,6 +346,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::matches::MATCH_STR_CASE_MISMATCH_INFO,
     crate::matches::MATCH_WILD_ERR_ARM_INFO,
     crate::matches::MATCH_WILDCARD_FOR_SINGLE_VARIANTS_INFO,
+    crate::matches::MATCHES_INSTEAD_OF_EQ_INFO,
     crate::matches::NEEDLESS_MATCH_INFO,
     crate::matches::REDUNDANT_GUARDS_INFO,
     crate::matches::REDUNDANT_PATTERN_MATCHING_INFO,

--- a/clippy_lints/src/disallowed_fields.rs
+++ b/clippy_lints/src/disallowed_fields.rs
@@ -68,7 +68,7 @@ impl DisallowedFields {
             tcx,
             &conf.disallowed_fields,
             PathNS::Field,
-            |def_kind| matches!(def_kind, DefKind::Field),
+            |def_kind| def_kind == DefKind::Field,
             "field",
             false,
         );

--- a/clippy_lints/src/disallowed_macros.rs
+++ b/clippy_lints/src/disallowed_macros.rs
@@ -108,7 +108,7 @@ impl DisallowedMacros {
             if let Some(&(path, disallowed_path)) = self.disallowed.get(&mac.def_id) {
                 let msg = format!("use of a disallowed macro `{path}`");
                 let add_note = disallowed_path.diag_amendment(mac.span);
-                if matches!(mac.kind, MacroKind::Derive)
+                if mac.kind == MacroKind::Derive
                     && let Some(derive_src) = derive_src
                 {
                     span_lint_hir_and_then(
@@ -164,7 +164,7 @@ impl LateLintPass<'_> for DisallowedMacros {
         if matches!(
             item.kind,
             ItemKind::Struct(..) | ItemKind::Enum(..) | ItemKind::Union(..)
-        ) && macro_backtrace(item.span).all(|m| !matches!(m.kind, MacroKind::Derive))
+        ) && macro_backtrace(item.span).all(|m| m.kind != MacroKind::Derive)
         {
             self.derive_src = Some(item.owner_id);
         }

--- a/clippy_lints/src/floating_point_arithmetic/powi.rs
+++ b/clippy_lints/src/floating_point_arithmetic/powi.rs
@@ -44,7 +44,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>, 
                     // Negate expr if original code has subtraction and expr is on the right side
                     let maybe_neg_sugg = |expr, hir_id, app: &mut _| {
                         let sugg = Sugg::hir_with_applicability(cx, expr, "_", app);
-                        if matches!(op, BinOpKind::Sub) && hir_id == rhs.hir_id {
+                        if op == BinOpKind::Sub && hir_id == rhs.hir_id {
                             -sugg
                         } else {
                             sugg

--- a/clippy_lints/src/functions/misnamed_getters.rs
+++ b/clippy_lints/src/functions/misnamed_getters.rs
@@ -49,10 +49,7 @@ pub fn check_fn(cx: &LateContext<'_>, kind: FnKind<'_>, decl: &FnDecl<'_>, body:
     {
         if let ExprKind::Block(unsafe_block, _) = block_expr.kind
             && unsafe_block.stmts.is_empty()
-            && matches!(
-                unsafe_block.rules,
-                BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided)
-            )
+            && unsafe_block.rules == BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided)
             && let Some(unsafe_block_expr) = unsafe_block.expr
         {
             unsafe_block_expr

--- a/clippy_lints/src/len_without_is_empty.rs
+++ b/clippy_lints/src/len_without_is_empty.rs
@@ -111,7 +111,7 @@ fn check_trait_items(cx: &LateContext<'_>, visited_trait: &Item<'_>, ident: Iden
                 [Some(Ident {
                     name: kw::SelfLower,
                     ..
-                })],
+                })]
             )
     }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -582,7 +582,7 @@ rustc_lint::late_lint_methods!(
         DefaultNumericFallback: default_numeric_fallback::DefaultNumericFallback = default_numeric_fallback::DefaultNumericFallback,
         NonOctalUnixPermissions: non_octal_unix_permissions::NonOctalUnixPermissions = non_octal_unix_permissions::NonOctalUnixPermissions,
         ApproxConstant: approx_const::ApproxConstant = approx_const::ApproxConstant::new(conf),
-        Matches: matches::Matches = matches::Matches::new(conf),
+        Matches: matches::Matches<'tcx> = matches::Matches::new(conf),
         ManualNonExhaustive: manual_non_exhaustive::ManualNonExhaustive = manual_non_exhaustive::ManualNonExhaustive::new(conf),
         ManualStrip: manual_strip::ManualStrip = manual_strip::ManualStrip::new(conf),
         CheckedConversions: checked_conversions::CheckedConversions = checked_conversions::CheckedConversions::new(conf),

--- a/clippy_lints/src/loops/explicit_into_iter_loop.rs
+++ b/clippy_lints/src/loops/explicit_into_iter_loop.rs
@@ -70,7 +70,7 @@ pub(super) fn check(cx: &LateContext<'_>, self_arg: &Expr<'_>, call_expr: &Expr<
                 target,
             },
         ] => {
-            if self_ty == target && matches!(mutbl, AutoBorrowMutability::Not) {
+            if self_ty == target && mutbl == AutoBorrowMutability::Not {
                 AdjustKind::None
             } else {
                 AdjustKind::reborrow(mutbl)

--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -244,7 +244,7 @@ impl TypeClampability {
     }
 
     fn is_float(self) -> bool {
-        matches!(self, TypeClampability::Float)
+        self == TypeClampability::Float
     }
 }
 

--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -180,7 +180,7 @@ fn emit_manual_let_else(
             let (sn_else, else_is_mac_call) = snippet_with_context(cx, else_body.span, span.ctxt(), "", &mut app);
 
             let else_bl = if let ExprKind::Block(block, None) = else_body.kind
-                && matches!(block.rules, BlockCheckMode::DefaultBlock)
+                && block.rules == BlockCheckMode::DefaultBlock
                 && !else_is_mac_call
             {
                 sn_else.into_owned()

--- a/clippy_lints/src/matches/manual_utils.rs
+++ b/clippy_lints/src/matches/manual_utils.rs
@@ -141,11 +141,7 @@ where
             }
 
             // `ref` and `ref mut` annotations were handled earlier.
-            let annotation = if matches!(annotation, BindingMode::MUT) {
-                "mut "
-            } else {
-                ""
-            };
+            let annotation = if annotation == BindingMode::MUT { "mut " } else { "" };
 
             format!("|{annotation}{some_binding}| {closure_body}")
         }

--- a/clippy_lints/src/matches/matches_instead_of_eq.rs
+++ b/clippy_lints/src/matches/matches_instead_of_eq.rs
@@ -93,15 +93,25 @@ pub(super) fn check(
                 }
             }
 
-            span_lint_and_sugg(
-                cx,
-                MATCHES_INSTEAD_OF_EQ,
-                span,
-                format!("this expression can be replaced with a `{comparison}` comparison"),
-                "replace with",
-                format!("{derefs1}{snippet1} {comparison} {derefs2}{snippet2}"),
-                Applicability::MaybeIncorrect,
-            );
+            cx.tcx.for_each_relevant_impl(partial_eq_def_id, expr_ty, |impl_id| {
+                if !cx.tcx.is_automatically_derived(impl_id) {
+                    return;
+                }
+
+                let trait_ref = cx.tcx.impl_trait_ref(impl_id);
+                if trait_ref.instantiate_identity().skip_norm_wip().args.type_at(1) != ty2 {
+                    return;
+                }
+                span_lint_and_sugg(
+                    cx,
+                    MATCHES_INSTEAD_OF_EQ,
+                    span,
+                    format!("this expression can be replaced with a `{comparison}` comparison"),
+                    "replace with",
+                    format!("{derefs1}{snippet1} {comparison} {derefs2}{snippet2}"),
+                    Applicability::MaybeIncorrect,
+                );
+            });
         } else {
             // If for unknown reasons, `snippet_opt` failed...
             span_lint_and_help(

--- a/clippy_lints/src/matches/matches_instead_of_eq.rs
+++ b/clippy_lints/src/matches/matches_instead_of_eq.rs
@@ -1,0 +1,117 @@
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
+use clippy_utils::source::snippet_opt;
+use clippy_utils::ty::implements_trait;
+use clippy_utils::{get_parent_expr, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{ExprKind, Pat, PatKind, UnOp};
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, Ty};
+use rustc_span::Span;
+
+use super::MATCHES_INSTEAD_OF_EQ;
+
+fn snippet_and_ty_of_arm<'tcx>(cx: &LateContext<'tcx>, arm: &rustc_hir::Arm<'_>) -> Option<(String, Ty<'tcx>)> {
+    if let PatKind::Expr(expr) = arm.pat.kind
+        && let Some(snippet) = snippet_opt(cx, expr.span)
+        && let Some(ty) = cx.typeck_results().node_type_opt(expr.hir_id)
+    {
+        Some((snippet, ty))
+    } else {
+        None
+    }
+}
+
+fn get_correct_eq_span(cx: &LateContext<'_>, expr: &rustc_hir::Expr<'_>) -> (Span, &'static str) {
+    if let Some(parent) = get_parent_expr(cx, expr)
+        && let ExprKind::Unary(UnOp::Not, _) = parent.kind
+    {
+        (parent.span.source_callsite(), "!=")
+    } else {
+        (expr.span.source_callsite(), "==")
+    }
+}
+
+// Returns `true` if the pattern can be used in a `==` comparison.
+fn is_valid_pattern_for_eq(pat: &Pat<'_>) -> bool {
+    match pat.kind {
+        PatKind::Or(..)
+        | PatKind::Struct(..)
+        | PatKind::TupleStruct(..)
+        | PatKind::Never
+        | PatKind::Binding(..)
+        | PatKind::Wild
+        | PatKind::Missing
+        | PatKind::Guard(..)
+        | PatKind::Err(_)
+        | PatKind::Slice(_, Some(_), _) => false,
+        PatKind::Slice(part1, None, part2) => {
+            part1.iter().all(|p| is_valid_pattern_for_eq(p)) && part2.iter().all(|p| is_valid_pattern_for_eq(p))
+        },
+        PatKind::Ref(pat, _, _) | PatKind::Deref(pat) | PatKind::Box(pat) => is_valid_pattern_for_eq(pat),
+        PatKind::Tuple(pats, dotdot_pos) => {
+            // If `dotdot_pos <= pat.len`, then it means there is a `..`.
+            dotdot_pos.as_opt_usize().unwrap_or(0) > pats.len() && pats.iter().all(|p| is_valid_pattern_for_eq(p))
+        },
+        PatKind::Expr(_) | PatKind::Range(..) => true,
+    }
+}
+
+pub(super) fn check(
+    cx: &LateContext<'_>,
+    expr: &rustc_hir::Expr<'_>,
+    ex: &rustc_hir::Expr<'_>,
+    arms: &[rustc_hir::Arm<'_>],
+) {
+    let Some(partial_eq_def_id) = cx.tcx.get_diagnostic_item(sym::PartialEq) else {
+        return;
+    };
+    let mut expr_ty = cx.typeck_results().expr_ty(ex);
+    if !implements_trait(cx, expr_ty, partial_eq_def_id, &[expr_ty.into()]) {
+        return;
+    }
+    if arms
+        .iter()
+        .any(|arm| is_valid_pattern_for_eq(arm.pat) && arm.guard.is_none())
+    {
+        if let Some((snippet2, mut ty2)) = arms.iter().find_map(|arm| snippet_and_ty_of_arm(cx, arm))
+            && let ExprKind::Match(m, ..) = expr.kind
+            && let Some(snippet1) = snippet_opt(cx, m.span)
+        {
+            let (span, comparison) = get_correct_eq_span(cx, expr);
+            let mut derefs1 = String::new();
+            let mut derefs2 = String::new();
+            while !implements_trait(cx, expr_ty, partial_eq_def_id, &[ty2.into()]) {
+                if let ty::Ref(_, inner_ty, _) = expr_ty.kind() {
+                    expr_ty = *inner_ty;
+                    derefs1.push('*');
+                } else if let ty::Ref(_, inner_ty, _) = ty2.kind() {
+                    ty2 = *inner_ty;
+                    derefs2.push('*');
+                } else {
+                    // Hum... okay?
+                    return;
+                }
+            }
+
+            span_lint_and_sugg(
+                cx,
+                MATCHES_INSTEAD_OF_EQ,
+                span,
+                format!("this expression can be replaced with a `{comparison}` comparison"),
+                "replace with",
+                format!("{derefs1}{snippet1} {comparison} {derefs2}{snippet2}"),
+                Applicability::MaybeIncorrect,
+            );
+        } else {
+            // If for unknown reasons, `snippet_opt` failed...
+            span_lint_and_help(
+                cx,
+                MATCHES_INSTEAD_OF_EQ,
+                expr.span.source_callsite(),
+                "this expression can be replaced with a `==` comparison",
+                None,
+                "this type implements `PartialEq`, so you can use `==` instead of `matches!`",
+            );
+        }
+    }
+}

--- a/clippy_lints/src/matches/matches_instead_of_eq.rs
+++ b/clippy_lints/src/matches/matches_instead_of_eq.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
+use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_opt;
 use clippy_utils::ty::implements_trait;
 use clippy_utils::{get_parent_expr, sym};
@@ -72,56 +72,44 @@ pub(super) fn check(
     if arms
         .iter()
         .any(|arm| is_valid_pattern_for_eq(arm.pat) && arm.guard.is_none())
+        && let Some((snippet2, mut ty2)) = arms.iter().find_map(|arm| snippet_and_ty_of_arm(cx, arm))
+        && let ExprKind::Match(m, ..) = expr.kind
+        && let Some(snippet1) = snippet_opt(cx, m.span)
     {
-        if let Some((snippet2, mut ty2)) = arms.iter().find_map(|arm| snippet_and_ty_of_arm(cx, arm))
-            && let ExprKind::Match(m, ..) = expr.kind
-            && let Some(snippet1) = snippet_opt(cx, m.span)
-        {
-            let (span, comparison) = get_correct_eq_span(cx, expr);
-            let mut derefs1 = String::new();
-            let mut derefs2 = String::new();
-            while !implements_trait(cx, expr_ty, partial_eq_def_id, &[ty2.into()]) {
-                if let ty::Ref(_, inner_ty, _) = expr_ty.kind() {
-                    expr_ty = *inner_ty;
-                    derefs1.push('*');
-                } else if let ty::Ref(_, inner_ty, _) = ty2.kind() {
-                    ty2 = *inner_ty;
-                    derefs2.push('*');
-                } else {
-                    // Hum... okay?
-                    return;
-                }
+        let (span, comparison) = get_correct_eq_span(cx, expr);
+        let mut derefs1 = String::new();
+        let mut derefs2 = String::new();
+        while !implements_trait(cx, expr_ty, partial_eq_def_id, &[ty2.into()]) {
+            if let ty::Ref(_, inner_ty, _) = expr_ty.kind() {
+                expr_ty = *inner_ty;
+                derefs1.push('*');
+            } else if let ty::Ref(_, inner_ty, _) = ty2.kind() {
+                ty2 = *inner_ty;
+                derefs2.push('*');
+            } else {
+                // Hum... okay?
+                return;
+            }
+        }
+
+        cx.tcx.for_each_relevant_impl(partial_eq_def_id, expr_ty, |impl_id| {
+            if !cx.tcx.is_automatically_derived(impl_id) {
+                return;
             }
 
-            cx.tcx.for_each_relevant_impl(partial_eq_def_id, expr_ty, |impl_id| {
-                if !cx.tcx.is_automatically_derived(impl_id) {
-                    return;
-                }
-
-                let trait_ref = cx.tcx.impl_trait_ref(impl_id);
-                if trait_ref.instantiate_identity().skip_norm_wip().args.type_at(1) != ty2 {
-                    return;
-                }
-                span_lint_and_sugg(
-                    cx,
-                    MATCHES_INSTEAD_OF_EQ,
-                    span,
-                    format!("this expression can be replaced with a `{comparison}` comparison"),
-                    "replace with",
-                    format!("{derefs1}{snippet1} {comparison} {derefs2}{snippet2}"),
-                    Applicability::MaybeIncorrect,
-                );
-            });
-        } else {
-            // If for unknown reasons, `snippet_opt` failed...
-            span_lint_and_help(
+            let trait_ref = cx.tcx.impl_trait_ref(impl_id);
+            if trait_ref.instantiate_identity().skip_norm_wip().args.type_at(1) != ty2 {
+                return;
+            }
+            span_lint_and_sugg(
                 cx,
                 MATCHES_INSTEAD_OF_EQ,
-                expr.span.source_callsite(),
-                "this expression can be replaced with a `==` comparison",
-                None,
-                "this type implements `PartialEq`, so you can use `==` instead of `matches!`",
+                span,
+                format!("this expression can be replaced with a `{comparison}` comparison"),
+                "replace with",
+                format!("{derefs1}{snippet1} {comparison} {derefs2}{snippet2}"),
+                Applicability::MaybeIncorrect,
             );
-        }
+        });
     }
 }

--- a/clippy_lints/src/matches/matches_instead_of_eq.rs
+++ b/clippy_lints/src/matches/matches_instead_of_eq.rs
@@ -2,18 +2,24 @@ use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_opt;
 use clippy_utils::ty::implements_trait;
 use clippy_utils::{get_parent_expr, sym};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::Applicability;
 use rustc_hir::{ExprKind, Pat, PatKind, UnOp};
 use rustc_lint::LateContext;
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::Span;
+use rustc_span::def_id::DefId;
 
 use super::MATCHES_INSTEAD_OF_EQ;
 
 fn snippet_and_ty_of_arm<'tcx>(cx: &LateContext<'tcx>, arm: &rustc_hir::Arm<'_>) -> Option<(String, Ty<'tcx>)> {
-    if let PatKind::Expr(expr) = arm.pat.kind
-        && let Some(snippet) = snippet_opt(cx, expr.span)
-        && let Some(ty) = cx.typeck_results().node_type_opt(expr.hir_id)
+    let (span, hir_id) = match arm.pat.kind {
+        PatKind::Expr(expr) => (expr.span, expr.hir_id),
+        PatKind::TupleStruct(..) => (arm.pat.span, arm.pat.hir_id),
+        _ => return None,
+    };
+    if let Some(snippet) = snippet_opt(cx, span)
+        && let Some(ty) = cx.typeck_results().node_type_opt(hir_id)
     {
         Some((snippet, ty))
     } else {
@@ -36,7 +42,6 @@ fn is_valid_pattern_for_eq(pat: &Pat<'_>) -> bool {
     match pat.kind {
         PatKind::Or(..)
         | PatKind::Struct(..)
-        | PatKind::TupleStruct(..)
         | PatKind::Never
         | PatKind::Binding(..)
         | PatKind::Wild
@@ -48,19 +53,100 @@ fn is_valid_pattern_for_eq(pat: &Pat<'_>) -> bool {
             part1.iter().all(|p| is_valid_pattern_for_eq(p)) && part2.iter().all(|p| is_valid_pattern_for_eq(p))
         },
         PatKind::Ref(pat, _, _) | PatKind::Deref(pat) | PatKind::Box(pat) => is_valid_pattern_for_eq(pat),
-        PatKind::Tuple(pats, dotdot_pos) => {
-            // If `dotdot_pos <= pat.len`, then it means there is a `..`.
-            dotdot_pos.as_opt_usize().unwrap_or(0) > pats.len() && pats.iter().all(|p| is_valid_pattern_for_eq(p))
+        PatKind::Tuple(pats, dotdot_pos) | PatKind::TupleStruct(_, pats, dotdot_pos) => {
+            dotdot_pos.as_opt_usize().is_none() && pats.iter().all(|p| is_valid_pattern_for_eq(p))
         },
         PatKind::Expr(_) | PatKind::Range(..) => true,
     }
 }
 
-pub(super) fn check(
-    cx: &LateContext<'_>,
+fn is_deriving_partial_eq<'tcx>(tcx: TyCtxt<'tcx>, partial_eq_def_id: DefId, ty: Ty<'tcx>) -> bool {
+    let mut is_automatically_derived = false;
+    tcx.for_each_relevant_impl(partial_eq_def_id, ty, |impl_id| {
+        is_automatically_derived = is_automatically_derived || tcx.is_automatically_derived(impl_id);
+    });
+    is_automatically_derived
+}
+
+fn is_fully_automatically_derived<'tcx>(
+    cx: &LateContext<'tcx>,
+    ty: Ty<'tcx>,
+    automatically_derived_partial_eq_map: &mut FxHashMap<Ty<'tcx>, bool>,
+    partial_eq_def_id: DefId,
+) -> bool {
+    if let Some(is_automatically_derived) = automatically_derived_partial_eq_map.get(&ty) {
+        return *is_automatically_derived;
+    }
+    if !is_deriving_partial_eq(cx.tcx, partial_eq_def_id, ty) {
+        automatically_derived_partial_eq_map.insert(ty, false);
+        return false;
+    }
+    let (adt, generics) = match ty.peel_refs().kind() {
+        ty::Adt(adt_def, generics) => (adt_def, generics),
+        ty::Bool
+        | ty::Char
+        | ty::Int(_)
+        | ty::Uint(_)
+        | ty::Float(_)
+        | ty::Str
+        | ty::RawPtr(..)
+        | ty::FnDef(..)
+        | ty::Never
+        | ty::FnPtr(..) => return true,
+        ty::Array(ty, _) | ty::Ref(_, ty, _) | ty::Slice(ty) => {
+            return is_fully_automatically_derived(cx, *ty, automatically_derived_partial_eq_map, partial_eq_def_id);
+        },
+        ty::Tuple(tys) => {
+            return tys.iter().all(|ty| {
+                is_fully_automatically_derived(cx, ty, automatically_derived_partial_eq_map, partial_eq_def_id)
+            });
+        },
+        ty::Pat(..)
+        | ty::Alias(..) // FIXME: Should be handled correctly
+        | ty::Foreign(..) // FIXME: Should be handled correctly
+        | ty::Dynamic(..)
+        | ty::Param(..)
+        | ty::Bound(..)
+        | ty::Placeholder(..)
+        | ty::Infer(..)
+        | ty::Error(..)
+        | ty::Closure(..)
+        | ty::CoroutineClosure(..)
+        | ty::UnsafeBinder(..)
+        | ty::CoroutineWitness(..)
+        | ty::Coroutine(..) => return false,
+    };
+    for variant in adt.variants() {
+        for field in &variant.fields {
+            let field_ty = field.ty(cx.tcx, generics).skip_norm_wip();
+            if let Some(is_automatically_derived) = automatically_derived_partial_eq_map.get(&field_ty) {
+                // We stop at the first occurrence of non-automatically derived `ty`.
+                if !*is_automatically_derived {
+                    // We add a new entry into our map for this type.
+                    automatically_derived_partial_eq_map.insert(ty, false);
+                    return false;
+                }
+                continue;
+            }
+            if !is_deriving_partial_eq(cx.tcx, partial_eq_def_id, field_ty) {
+                // We add a new entry into our map for both this type and the field's type.
+                automatically_derived_partial_eq_map.insert(ty, false);
+                automatically_derived_partial_eq_map.insert(field_ty, false);
+                return false;
+            }
+            automatically_derived_partial_eq_map.insert(field_ty, true);
+        }
+    }
+    automatically_derived_partial_eq_map.insert(ty, true);
+    true
+}
+
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
     expr: &rustc_hir::Expr<'_>,
     ex: &rustc_hir::Expr<'_>,
     arms: &[rustc_hir::Arm<'_>],
+    automatically_derived_partial_eq_map: &mut FxHashMap<Ty<'tcx>, bool>,
 ) {
     let Some(partial_eq_def_id) = cx.tcx.get_diagnostic_item(sym::PartialEq) else {
         return;
@@ -69,11 +155,11 @@ pub(super) fn check(
     if !implements_trait(cx, expr_ty, partial_eq_def_id, &[expr_ty.into()]) {
         return;
     }
-    if arms
-        .iter()
-        .any(|arm| is_valid_pattern_for_eq(arm.pat) && arm.guard.is_none())
+    if let ExprKind::Match(m, ..) = expr.kind
+        && arms
+            .iter()
+            .any(|arm| arm.guard.is_none() && is_valid_pattern_for_eq(arm.pat))
         && let Some((snippet2, mut ty2)) = arms.iter().find_map(|arm| snippet_and_ty_of_arm(cx, arm))
-        && let ExprKind::Match(m, ..) = expr.kind
         && let Some(snippet1) = snippet_opt(cx, m.span)
     {
         let (span, comparison) = get_correct_eq_span(cx, expr);
@@ -92,6 +178,10 @@ pub(super) fn check(
             }
         }
 
+        if !is_fully_automatically_derived(cx, expr_ty, automatically_derived_partial_eq_map, partial_eq_def_id) {
+            return;
+        }
+
         cx.tcx.for_each_relevant_impl(partial_eq_def_id, expr_ty, |impl_id| {
             if !cx.tcx.is_automatically_derived(impl_id) {
                 return;
@@ -99,6 +189,9 @@ pub(super) fn check(
 
             let trait_ref = cx.tcx.impl_trait_ref(impl_id);
             if trait_ref.instantiate_identity().skip_norm_wip().args.type_at(1) != ty2 {
+                return;
+            }
+            if !is_fully_automatically_derived(cx, ty2, automatically_derived_partial_eq_map, partial_eq_def_id) {
                 return;
             }
             span_lint_and_sugg(

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -14,6 +14,7 @@ mod match_single_binding;
 mod match_str_case_mismatch;
 mod match_wild_enum;
 mod match_wild_err_arm;
+mod matches_instead_of_eq;
 mod needless_match;
 mod overlapping_arms;
 mod redundant_guards;
@@ -591,6 +592,39 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for the use of `matches!` with types that automatically derive `PartialEq`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using `matches!` instead of `==` or `!=` makes the code more verbose.
+    ///
+    /// ### Example
+    ///
+    /// ```no_run
+    /// let x = Foo::Bar;
+    /// if matches!(x, Foo::Bar) {
+    ///     // ...
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```no_run
+    /// # #[derive(PartialEq)]
+    /// # enum Foo { Bar }
+    /// let x = Foo::Bar;
+    /// if x == Foo::Bar {
+    ///     // ...
+    /// }
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub MATCHES_INSTEAD_OF_EQ,
+    pedantic,
+    "usage of `matches!` when `==` could be used"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for unnecessary `match` or match-like `if let` returns for `Option` and `Result`
     /// when function signatures are the same.
     ///
@@ -1015,6 +1049,7 @@ impl_lint_pass!(Matches => [
     MANUAL_OK_ERR,
     MANUAL_UNWRAP_OR,
     MANUAL_UNWRAP_OR_DEFAULT,
+    MATCHES_INSTEAD_OF_EQ,
     MATCH_AS_REF,
     MATCH_BOOL,
     MATCH_LIKE_MATCHES_MACRO,
@@ -1065,6 +1100,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
             {
                 redundant_pattern_match::check_match(cx, expr, ex, arms);
                 redundant_pattern_match::check_matches_true(cx, expr, arm, ex);
+                matches_instead_of_eq::check(cx, expr, ex, arms);
             }
 
             if source == MatchSource::Normal && !is_span_match(cx, expr.span) {

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -601,6 +601,7 @@ declare_clippy_lint! {
     /// ### Example
     ///
     /// ```no_run
+    /// # enum Foo { Bar }
     /// let x = Foo::Bar;
     /// if matches!(x, Foo::Bar) {
     ///     // ...
@@ -1134,7 +1135,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                         _ => true,
                     });
                     while let Some((t, ..)) = iter.next() {
-                        if matches!(t, TokenKind::Pound)
+                        if t == TokenKind::Pound
                             && matches!(iter.next(), Some((TokenKind::OpenBracket, ..)))
                             && matches!(iter.next(), Some((TokenKind::Ident, "cfg", _)))
                         {

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -31,9 +31,11 @@ use clippy_utils::source::SpanExt;
 use clippy_utils::{
     higher, is_direct_expn_of, is_in_const_context, is_lint_allowed, is_span_match, sym, tokenize_with_text,
 };
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::{Arm, Expr, ExprKind, LetStmt, MatchSource, Pat, PatKind};
 use rustc_lexer::{TokenKind, is_whitespace};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::ty::Ty;
 use rustc_session::impl_lint_pass;
 use rustc_span::Span;
 
@@ -1042,7 +1044,7 @@ declare_clippy_lint! {
     "a wildcard pattern used with others patterns in same match arm"
 }
 
-impl_lint_pass!(Matches => [
+impl_lint_pass!(Matches<'_> => [
     COLLAPSIBLE_MATCH,
     INFALLIBLE_DESTRUCTURING_MATCH,
     MANUAL_FILTER,
@@ -1073,21 +1075,23 @@ impl_lint_pass!(Matches => [
     WILDCARD_IN_OR_PATTERNS,
 ]);
 
-pub struct Matches {
+pub struct Matches<'tcx> {
     msrv: Msrv,
     infallible_destructuring_match_linted: bool,
+    automatically_derived_partial_eq_map: FxHashMap<Ty<'tcx>, bool>,
 }
 
-impl Matches {
+impl Matches<'_> {
     pub fn new(conf: &'static Conf) -> Self {
         Self {
             msrv: conf.msrv,
             infallible_destructuring_match_linted: false,
+            automatically_derived_partial_eq_map: FxHashMap::default(),
         }
     }
 }
 
-impl<'tcx> LateLintPass<'tcx> for Matches {
+impl<'tcx> LateLintPass<'tcx> for Matches<'tcx> {
     #[expect(clippy::too_many_lines)]
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if is_direct_expn_of(expr.span, sym::matches).is_none() && expr.span.in_external_macro(cx.sess().source_map()) {
@@ -1101,7 +1105,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
             {
                 redundant_pattern_match::check_match(cx, expr, ex, arms);
                 redundant_pattern_match::check_matches_true(cx, expr, arm, ex);
-                matches_instead_of_eq::check(cx, expr, ex, arms);
+                matches_instead_of_eq::check(cx, expr, ex, arms, &mut self.automatically_derived_partial_eq_map);
             }
 
             if source == MatchSource::Normal && !is_span_match(cx, expr.span) {

--- a/clippy_lints/src/matches/redundant_guards.rs
+++ b/clippy_lints/src/matches/redundant_guards.rs
@@ -65,7 +65,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'tcx>], msrv:
         // `Some(x) if x == Some(2)`
         // `Some(x) if Some(2) == x`
         else if let ExprKind::Binary(bin_op, local, pat) = guard.kind
-            && matches!(bin_op.node, BinOpKind::Eq)
+            && bin_op.node == BinOpKind::Eq
             // Ensure they have the same type. If they don't, we'd need deref coercion which isn't
             // possible (currently) in a pattern. In some cases, you can use something like
             // `as_deref` or similar but in general, we shouldn't lint this as it'd create an

--- a/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
+++ b/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
@@ -54,10 +54,8 @@ pub(super) fn check<'tcx>(
                     match use_expr.kind {
                         ExprKind::Call(_, [recv]) | ExprKind::MethodCall(_, recv, [], _)
                             if recv.hir_id == use_ctxt.child_id
-                                && matches!(
-                                    use_expr.span.ctxt().outer_expn_data().kind,
-                                    ExpnKind::Desugaring(DesugaringKind::ForLoop),
-                                ) =>
+                                && use_expr.span.ctxt().outer_expn_data().kind
+                                    == ExpnKind::Desugaring(DesugaringKind::ForLoop) =>
                         {
                             diag.span_suggestion(
                                 call_span,

--- a/clippy_lints/src/methods/filter_map_bool_then.rs
+++ b/clippy_lints/src/methods/filter_map_bool_then.rs
@@ -112,6 +112,6 @@ fn can_filter_and_then_move_to_closure<'tcx>(
         param_bindings.contains(hir_id)
             || !then_captures
                 .get(hir_id)
-                .is_some_and(|then_cap| matches!(*filter_cap | *then_cap, CaptureKind::Ref(Mutability::Mut)))
+                .is_some_and(|then_cap| (*filter_cap | *then_cap) == CaptureKind::Ref(Mutability::Mut))
     })
 }

--- a/clippy_lints/src/methods/iter_overeager_cloned.rs
+++ b/clippy_lints/src/methods/iter_overeager_cloned.rs
@@ -163,7 +163,7 @@ fn param_captured_by_move_block(cx: &LateContext<'_>, expr: &Expr<'_>, param: &P
             ..
         }) = e.kind
             && cx.tcx.closure_captures(*def_id).iter().any(|capture| {
-                matches!(capture.info.capture_kind, UpvarCapture::ByValue)
+                capture.info.capture_kind == UpvarCapture::ByValue
                     && matches!(capture.place.base, PlaceBase::Upvar(upvar) if param_hir_ids.contains(&upvar.var_path.hir_id))
             })
         {

--- a/clippy_lints/src/methods/manual_inspect.rs
+++ b/clippy_lints/src/methods/manual_inspect.rs
@@ -17,7 +17,7 @@ use super::MANUAL_INSPECT;
 #[expect(clippy::too_many_lines)]
 pub(crate) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, name: Symbol, name_span: Span, msrv: Msrv) {
     if let ExprKind::Closure(c) = arg.kind
-        && matches!(c.kind, ClosureKind::Closure)
+        && c.kind == ClosureKind::Closure
         && let typeck = cx.typeck_results()
         && let Some(fn_def) = typeck.type_dependent_def(expr.hir_id)
         && (fn_def.opt_parent(cx).is_diag_item(cx, sym::Iterator)

--- a/clippy_lints/src/methods/map_clone.rs
+++ b/clippy_lints/src/methods/map_clone.rs
@@ -77,7 +77,7 @@ pub(super) fn check(cx: &LateContext<'_>, e: &hir::Expr<'_>, recv: &hir::Expr<'_
                                 {
                                     let obj_ty = cx.typeck_results().expr_ty(obj);
                                     if let ty::Ref(_, ty, mutability) = obj_ty.kind() {
-                                        if matches!(mutability, Mutability::Not) {
+                                        if *mutability == Mutability::Not {
                                             let copy = is_copy(cx, *ty);
                                             lint_explicit_closure(cx, e.span, recv.span, copy, msrv);
                                         }

--- a/clippy_lints/src/methods/map_unwrap_or.rs
+++ b/clippy_lints/src/methods/map_unwrap_or.rs
@@ -140,7 +140,7 @@ pub(super) fn check<'tcx>(
             (expr.span.with_lo(unwrap_recv.span.hi()), String::new()),
         ];
 
-        if matches!(suggest_kind, SuggestedKind::Other) {
+        if suggest_kind == SuggestedKind::Other {
             suggestion.push((map_arg_span.with_hi(map_arg_span.lo()), format!("{unwrap_snippet}, ")));
         }
 

--- a/clippy_lints/src/methods/needless_collect.rs
+++ b/clippy_lints/src/methods/needless_collect.rs
@@ -729,7 +729,7 @@ fn get_captured_ids(cx: &LateContext<'_>, ty: Ty<'_>) -> HirIdSet {
                         .unwrap()
                         .into_iter()
                         .for_each(|(hir_id, capture_kind)| {
-                            if matches!(capture_kind, CaptureKind::Ref(Mutability::Mut)) {
+                            if capture_kind == CaptureKind::Ref(Mutability::Mut) {
                                 set.insert(hir_id);
                             }
                         });

--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -149,7 +149,7 @@ fn check_unwrap_or_default(
     let is_new = |fun: &hir::Expr<'_>| {
         if let hir::ExprKind::Path(ref qpath) = fun.kind {
             let path = last_path_segment(qpath).ident.name;
-            matches!(path, sym::new)
+            path == sym::new
         } else {
             false
         }

--- a/clippy_lints/src/methods/should_implement_trait.rs
+++ b/clippy_lints/src/methods/should_implement_trait.rs
@@ -29,7 +29,7 @@ pub(super) fn check_impl_item<'tcx>(
         && first_arg_ty_opt
             .is_none_or(|first_arg_ty| method_config.self_kind.matches(cx, self_ty, first_arg_ty))
         && sig.header.is_safe()
-        && matches!(sig.header.constness, hir::Constness::NotConst)
+        && sig.header.constness == hir::Constness::NotConst
         && !sig.header.is_async()
         && sig.header.abi == ExternAbi::Rust
         && method_config.lifetime_param_cond(impl_item)

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -69,7 +69,7 @@ fn check(cx: &LateContext<'_>, item: OwnerId, sp: Span) {
         && !find_attr!(cx.tcx.hir_attrs(item.into()), Inline(..))
         // Rust `inline` doesn't mean anything with external linkage.
         && !cx.tcx.codegen_fn_attrs(item.def_id).contains_extern_indicator()
-        && !cx.tcx.crate_types().iter().any(|&t| matches!(t, CrateType::ProcMacro))
+        && !cx.tcx.crate_types().contains(&CrateType::ProcMacro)
         && !sp.in_external_macro(cx.tcx.sess.source_map())
     {
         span_lint(

--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -202,7 +202,7 @@ impl ArithmeticSideEffects {
                 {
                     return;
                 },
-                (Some(_), Some(_)) if matches!((lhs_ref_counter, rhs_ref_counter), (0, 0)) => return,
+                (Some(_), Some(_)) if (lhs_ref_counter, rhs_ref_counter) == (0, 0) => return,
                 _ => {},
             }
         }

--- a/clippy_lints/src/operators/assign_op_pattern.rs
+++ b/clippy_lints/src/operators/assign_op_pattern.rs
@@ -157,7 +157,7 @@ fn mut_borrows_in_expr(cx: &LateContext<'_>, e: &hir::Expr<'_>) -> HirIdSet {
     struct S(HirIdSet);
     impl Delegate<'_> for S {
         fn borrow(&mut self, place: &PlaceWithHirId<'_>, _: HirId, kind: BorrowKind) {
-            if matches!(kind, BorrowKind::Mutable) {
+            if kind == BorrowKind::Mutable {
                 self.0.insert(match place.place.base {
                     PlaceBase::Local(id) => id,
                     PlaceBase::Upvar(id) => id.var_path.hir_id,

--- a/clippy_lints/src/ptr/ptr_arg.rs
+++ b/clippy_lints/src/ptr/ptr_arg.rs
@@ -30,7 +30,7 @@ pub(super) fn check_body<'tcx>(
     sig: &FnSig<'tcx>,
     is_trait_item: bool,
 ) {
-    if !matches!(sig.header.abi, ExternAbi::Rust) {
+    if sig.header.abi != ExternAbi::Rust {
         // Ignore `extern` functions with non-Rust calling conventions
         return;
     }
@@ -66,7 +66,7 @@ pub(super) fn check_body<'tcx>(
 }
 
 pub(super) fn check_trait_item<'tcx>(cx: &LateContext<'tcx>, item_id: OwnerId, sig: &FnSig<'tcx>) {
-    if !matches!(sig.header.abi, ExternAbi::Rust) {
+    if sig.header.abi != ExternAbi::Rust {
         // Ignore `extern` functions with non-Rust calling conventions
         return;
     }

--- a/clippy_lints/src/redundant_async_block.rs
+++ b/clippy_lints/src/redundant_async_block.rs
@@ -72,13 +72,11 @@ impl<'tcx> LateLintPass<'tcx> for RedundantAsyncBlock {
 fn desugar_async_block<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) -> Option<&'tcx Expr<'tcx>> {
     if let ExprKind::Closure(Closure { body, def_id, kind, .. }) = expr.kind
         && let body = cx.tcx.hir_body(*body)
-        && matches!(
-            kind,
-            ClosureKind::Coroutine(CoroutineKind::Desugared(
+        && *kind
+            == ClosureKind::Coroutine(CoroutineKind::Desugared(
                 CoroutineDesugaring::Async,
-                CoroutineSource::Block
+                CoroutineSource::Block,
             ))
-        )
     {
         cx.typeck_results()
             .closure_min_captures
@@ -87,7 +85,7 @@ fn desugar_async_block<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) -> Op
                 m.values().all(|places| {
                     places
                         .iter()
-                        .all(|place| matches!(place.info.capture_kind, UpvarCapture::ByValue))
+                        .all(|place| place.info.capture_kind == UpvarCapture::ByValue)
                 })
             })
             .then_some(body.value)

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -326,7 +326,7 @@ fn base_local_and_movability<'tcx>(
 
     for (base, elem) in place.as_ref().iter_projections() {
         let base_ty = base.ty(&mir.local_decls, cx.tcx).ty;
-        deref |= matches!(elem, mir::ProjectionElem::Deref);
+        deref |= elem == mir::ProjectionElem::Deref;
         field |= matches!(elem, mir::ProjectionElem::Field(..)) && has_drop(cx, base_ty);
         slice |= matches!(elem, mir::ProjectionElem::Index(..)) && !is_copy(cx, base_ty);
     }

--- a/clippy_lints/src/redundant_closure_call.rs
+++ b/clippy_lints/src/redundant_closure_call.rs
@@ -103,10 +103,10 @@ fn find_innermost_closure<'tcx>(
         let mut capture_clause = closure.capture_clause;
 
         if let ExprKind::Closure(inner_closure) = body.value.kind {
-            if matches!(inner_closure.kind, DESUGARED_ASYNC_CLOSURE_KIND) {
+            if inner_closure.kind == DESUGARED_ASYNC_CLOSURE_KIND {
                 asyncness = ty::Asyncness::Yes;
                 unwrapped_body_value = cx.tcx.hir_body(inner_closure.body).value;
-            } else if matches!(inner_closure.kind, DESUGARED_ASYNC_BLOCK_CLOSURE_KIND) {
+            } else if inner_closure.kind == DESUGARED_ASYNC_BLOCK_CLOSURE_KIND {
                 asyncness = ty::Asyncness::Yes;
                 capture_clause = inner_closure.capture_clause;
                 unwrapped_body_value = cx.tcx.hir_body(inner_closure.body).value;

--- a/clippy_lints/src/redundant_locals.rs
+++ b/clippy_lints/src/redundant_locals.rs
@@ -103,7 +103,7 @@ fn is_by_value_closure_capture(cx: &LateContext<'_>, redefinition: HirId, root_v
 
     cx.tcx.is_closure_like(closure_def_id.to_def_id())
         && cx.tcx.closure_captures(closure_def_id).iter().any(|c| {
-            matches!(c.info.capture_kind, UpvarCapture::ByValue)
+            c.info.capture_kind == UpvarCapture::ByValue
                 && matches!(c.place.base, PlaceBase::Upvar(upvar) if upvar.var_path.hir_id == root_variable)
         })
 }

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -232,7 +232,7 @@ fn is_trivial_regex(s: &regex_syntax::hir::Hir) -> Option<&'static str> {
         Empty | Look(_) => Some("the regex is unlikely to be useful as it is"),
         Literal(_) => Some("consider using `str::contains`"),
         Alternation(ref exprs) => {
-            if exprs.iter().all(|e| matches!(e.kind(), Empty)) {
+            if exprs.iter().all(|e| *e.kind() == Empty) {
                 Some("the regex is unlikely to be useful as it is")
             } else {
                 None

--- a/clippy_lints/src/replace_box.rs
+++ b/clippy_lints/src/replace_box.rs
@@ -167,7 +167,7 @@ impl<'tcx> Delegate<'tcx> for MovedVariablesCtxt<'_> {
                 .place
                 .projections
                 .iter()
-                .filter(|x| matches!(x.kind, ProjectionKind::Deref))
+                .filter(|x| x.kind == ProjectionKind::Deref)
             // Either no deref or multiple derefs
             && (projections.next().is_none() || projections.next().is_some())
         {

--- a/clippy_lints/src/time_subtraction.rs
+++ b/clippy_lints/src/time_subtraction.rs
@@ -91,7 +91,7 @@ impl UncheckedTimeSubtraction {
 impl LateLintPass<'_> for UncheckedTimeSubtraction {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &'_ Expr<'_>) {
         let (lhs, rhs) = match expr.kind {
-            ExprKind::Binary(op, lhs, rhs) if matches!(op.node, BinOpKind::Sub,) => (lhs, rhs),
+            ExprKind::Binary(op, lhs, rhs) if op.node == BinOpKind::Sub => (lhs, rhs),
             ExprKind::MethodCall(_, lhs, [rhs], _) if cx.ty_based_def(expr).is_diag_item(cx, sym::sub) => (lhs, rhs),
             _ => return,
         };
@@ -157,7 +157,7 @@ fn is_instant_now_call(cx: &LateContext<'_>, expr_block: &'_ Expr<'_>) -> bool {
 /// Returns true if this subtraction is part of a chain like `(a - b) - c`
 fn is_chained_time_subtraction(cx: &LateContext<'_>, lhs: &Expr<'_>) -> bool {
     if let ExprKind::Binary(op, inner_lhs, inner_rhs) = &lhs.kind
-        && matches!(op.node, BinOpKind::Sub)
+        && op.node == BinOpKind::Sub
     {
         let typeck = cx.typeck_results();
         let left_ty = typeck.expr_ty(inner_lhs);

--- a/clippy_lints/src/unnecessary_literal_bound.rs
+++ b/clippy_lints/src/unnecessary_literal_bound.rs
@@ -60,7 +60,7 @@ fn extract_anonymous_ref<'tcx>(hir_ty: &Ty<'tcx>) -> Option<&'tcx Ty<'tcx>> {
         return None;
     };
 
-    if !lifetime.is_anonymous() || !matches!(mutbl, Mutability::Not) {
+    if !lifetime.is_anonymous() || mutbl != Mutability::Not {
         return None;
     }
 

--- a/clippy_utils/src/ast_utils/mod.rs
+++ b/clippy_utils/src/ast_utils/mod.rs
@@ -471,9 +471,9 @@ fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
             }),
         ) => {
             eq_impl_restriction(liprt, riprt)
-                && matches!(lc, ast::Const::No) == matches!(rc, ast::Const::No)
+                && (*lc == ast::Const::No) == (*rc == ast::Const::No)
                 && la == ra
-                && matches!(lu, Safety::Default) == matches!(ru, Safety::Default)
+                && (*lu == Safety::Default) == (*ru == Safety::Default)
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
                 && over(lb, rb, eq_generic_bound)
@@ -493,7 +493,7 @@ fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
                 constness: rc,
             }),
         ) => {
-            matches!(lc, ast::Const::No) == matches!(rc, ast::Const::No)
+            (*lc == ast::Const::No) == (*rc == ast::Const::No)
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
                 && over(lb, rb, eq_generic_bound)
@@ -516,10 +516,10 @@ fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
         ) => {
             eq_generics(lg, rg)
                 && both(lot.as_deref(), rot.as_deref(), |l, r| {
-                    matches!(l.safety, Safety::Default) == matches!(r.safety, Safety::Default)
-                        && matches!(l.polarity, ImplPolarity::Positive) == matches!(r.polarity, ImplPolarity::Positive)
+                    (l.safety == Safety::Default) == (r.safety == Safety::Default)
+                        && (l.polarity == ImplPolarity::Positive) == (r.polarity == ImplPolarity::Positive)
                         && eq_defaultness(l.defaultness, r.defaultness)
-                        && matches!(lc, ast::Const::No) == matches!(rc, ast::Const::No)
+                        && (*lc == ast::Const::No) == (*rc == ast::Const::No)
                         && eq_path(&l.trait_ref.path, &r.trait_ref.path)
                 })
                 && eq_ty(lst, rst)
@@ -750,9 +750,9 @@ fn eq_opt_coroutine_kind(l: Option<CoroutineKind>, r: Option<CoroutineKind>) -> 
 }
 
 fn eq_fn_header(l: &FnHeader, r: &FnHeader) -> bool {
-    matches!(l.safety, Safety::Default) == matches!(r.safety, Safety::Default)
+    (l.safety == Safety::Default) == (r.safety == Safety::Default)
         && eq_opt_coroutine_kind(l.coroutine_kind, r.coroutine_kind)
-        && matches!(l.constness, Const::No) == matches!(r.constness, Const::No)
+        && (l.constness == Const::No) == (r.constness == Const::No)
         && eq_ext(&l.ext, &r.ext)
 }
 

--- a/clippy_utils/src/attrs.rs
+++ b/clippy_utils/src/attrs.rs
@@ -114,7 +114,7 @@ pub fn span_contains_cfg(cx: &LateContext<'_>, s: Span) -> bool {
         let mut iter = tokenize_with_text(src);
 
         // Search for the token sequence [`#`, `[`, `cfg`]
-        while iter.any(|(t, ..)| matches!(t, TokenKind::Pound)) {
+        while iter.any(|(t, ..)| t == TokenKind::Pound) {
             let mut iter = iter.by_ref().skip_while(|(t, ..)| {
                 matches!(
                     t,

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -1113,7 +1113,7 @@ pub fn mir_to_const<'tcx>(tcx: TyCtxt<'tcx>, val: ConstValue, ty: Ty<'tcx>) -> O
             ty::RawPtr(_, _) => Some(Constant::RawPtr(int.to_bits(int.size()))),
             _ => None,
         },
-        (_, ty::Ref(_, inner_ty, _)) if matches!(inner_ty.kind(), ty::Str) => {
+        (_, ty::Ref(_, inner_ty, _)) if *inner_ty.kind() == ty::Str => {
             let data = val.try_get_slice_bytes_for_diagnostics(tcx)?;
             String::from_utf8(data.to_owned()).ok().map(Constant::Str)
         },

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -273,7 +273,7 @@ pub fn is_diagnostic_item_or_ctor(cx: &LateContext<'_>, did: DefId, item: Symbol
         DefKind::Ctor(..) => cx.tcx.parent(did),
         // Constructors for types in external crates seem to have `DefKind::Variant`
         DefKind::Variant => match cx.tcx.opt_parent(did) {
-            Some(did) if matches!(cx.tcx.def_kind(did), DefKind::Variant) => did,
+            Some(did) if cx.tcx.def_kind(did) == DefKind::Variant => did,
             _ => did,
         },
         _ => did,
@@ -288,7 +288,7 @@ pub fn is_lang_item_or_ctor(cx: &LateContext<'_>, did: DefId, item: LangItem) ->
         DefKind::Ctor(..) => cx.tcx.parent(did),
         // Constructors for types in external crates seem to have `DefKind::Variant`
         DefKind::Variant => match cx.tcx.opt_parent(did) {
-            Some(did) if matches!(cx.tcx.def_kind(did), DefKind::Variant) => did,
+            Some(did) if cx.tcx.def_kind(did) == DefKind::Variant => did,
             _ => did,
         },
         _ => did,

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -325,8 +325,7 @@ fn with_leading_whitespace_inner(lines: &[RelativeBytePos], src: &str, range: Ra
         && ends_with_line_comment_or_broken(&start[prev_start..])
         && let next_line = lines.partition_point(|&pos| pos.to_usize() < range.end)
         && let next_start = lines.get(next_line).map_or(src.len(), |&x| x.to_usize())
-        && tokenize(src.get(range.end..next_start)?, FrontmatterAllowed::No)
-            .any(|t| !matches!(t.kind, TokenKind::Whitespace))
+        && tokenize(src.get(range.end..next_start)?, FrontmatterAllowed::No).any(|t| t.kind != TokenKind::Whitespace)
     {
         Some(range.start)
     } else {

--- a/tests/ui/matches_instead_of_eq.fixed
+++ b/tests/ui/matches_instead_of_eq.fixed
@@ -22,6 +22,14 @@ enum Foo2 {
 #[derive(PartialEq)]
 struct Empty;
 
+struct Manual;
+
+impl PartialEq for Manual {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
 fn main() {
     let x = Empty;
     let _val = x == Empty;
@@ -67,4 +75,8 @@ fn main() {
 
     // Should not emit the lint.
     let _val = matches!(x, Foo2::Bar(..) | Foo2::Baz { .. });
+
+    let x = Manual;
+    // Should not emit the lint since `Manual` implements `PartialEq` manually.
+    let _val = matches!(x, Manual);
 }

--- a/tests/ui/matches_instead_of_eq.fixed
+++ b/tests/ui/matches_instead_of_eq.fixed
@@ -1,0 +1,70 @@
+#![warn(clippy::matches_instead_of_eq)]
+#![allow(dead_code)]
+
+enum Foo {
+    Bar,
+    Baz,
+}
+
+#[derive(PartialEq)]
+enum EvenOdd {
+    Even,
+    Odd,
+    Unknown,
+}
+
+#[derive(PartialEq)]
+enum Foo2 {
+    Bar(u8, u8),
+    Baz { x: u8, y: u8 },
+}
+
+#[derive(PartialEq)]
+struct Empty;
+
+fn main() {
+    let x = Empty;
+    let _val = x == Empty;
+    //~^ matches_instead_of_eq
+
+    let x = EvenOdd::Even;
+    let _val = x == EvenOdd::Odd;
+    //~^ matches_instead_of_eq
+
+    let x = EvenOdd::Even;
+    // Should suggest `!=` and not `==`.
+    let _val = x != EvenOdd::Odd;
+    //~^ matches_instead_of_eq
+
+    let x = &EvenOdd::Even;
+    // Should suggest `*x` and not `x`.
+    let _val = *x == EvenOdd::Odd;
+    //~^ matches_instead_of_eq
+
+    let y = EvenOdd::Odd;
+    // Should not emit because of the guard.
+    let _val = matches!(x, EvenOdd::Even if y != EvenOdd::Odd);
+
+    let x = &[EvenOdd::Odd];
+    // Should not emit because of the `..`.
+    let _val = matches!(x, [..]);
+
+    let x = Foo::Bar;
+    // Should not emit the lint since `Foo` doesn't implement `PartialEq`
+    let _val = matches!(x, Foo::Bar);
+
+    let x = EvenOdd::Odd;
+    // Should not emit the lint because of the `|`.
+    let _val = matches!(x, EvenOdd::Even | EvenOdd::Odd);
+
+    let x = Foo2::Bar(1, 2);
+    // Should not emit the lint.
+    let _val = matches!(x, Foo2::Bar(_, _));
+
+    let x = Foo2::Baz { x: 1, y: 2 };
+    // Should not emit the lint.
+    let _val = matches!(x, Foo2::Baz { .. });
+
+    // Should not emit the lint.
+    let _val = matches!(x, Foo2::Bar(..) | Foo2::Baz { .. });
+}

--- a/tests/ui/matches_instead_of_eq.fixed
+++ b/tests/ui/matches_instead_of_eq.fixed
@@ -30,6 +30,9 @@ impl PartialEq for Manual {
     }
 }
 
+#[derive(PartialEq)]
+struct ContainsManual(Manual);
+
 fn main() {
     let x = Empty;
     let _val = x == Empty;
@@ -79,4 +82,9 @@ fn main() {
     let x = Manual;
     // Should not emit the lint since `Manual` implements `PartialEq` manually.
     let _val = matches!(x, Manual);
+
+    let x = ContainsManual(x);
+    // Should not emit the lint since `ContainsManual` contains `Manual` which implements
+    // `PartialEq` manually.
+    let _val = matches!(x, ContainsManual(Manual));
 }

--- a/tests/ui/matches_instead_of_eq.rs
+++ b/tests/ui/matches_instead_of_eq.rs
@@ -22,6 +22,14 @@ enum Foo2 {
 #[derive(PartialEq)]
 struct Empty;
 
+struct Manual;
+
+impl PartialEq for Manual {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
 fn main() {
     let x = Empty;
     let _val = matches!(x, Empty);
@@ -67,4 +75,8 @@ fn main() {
 
     // Should not emit the lint.
     let _val = matches!(x, Foo2::Bar(..) | Foo2::Baz { .. });
+
+    let x = Manual;
+    // Should not emit the lint since `Manual` implements `PartialEq` manually.
+    let _val = matches!(x, Manual);
 }

--- a/tests/ui/matches_instead_of_eq.rs
+++ b/tests/ui/matches_instead_of_eq.rs
@@ -1,0 +1,70 @@
+#![warn(clippy::matches_instead_of_eq)]
+#![allow(dead_code)]
+
+enum Foo {
+    Bar,
+    Baz,
+}
+
+#[derive(PartialEq)]
+enum EvenOdd {
+    Even,
+    Odd,
+    Unknown,
+}
+
+#[derive(PartialEq)]
+enum Foo2 {
+    Bar(u8, u8),
+    Baz { x: u8, y: u8 },
+}
+
+#[derive(PartialEq)]
+struct Empty;
+
+fn main() {
+    let x = Empty;
+    let _val = matches!(x, Empty);
+    //~^ matches_instead_of_eq
+
+    let x = EvenOdd::Even;
+    let _val = matches!(x, EvenOdd::Odd);
+    //~^ matches_instead_of_eq
+
+    let x = EvenOdd::Even;
+    // Should suggest `!=` and not `==`.
+    let _val = !matches!(x, EvenOdd::Odd);
+    //~^ matches_instead_of_eq
+
+    let x = &EvenOdd::Even;
+    // Should suggest `*x` and not `x`.
+    let _val = matches!(x, EvenOdd::Odd);
+    //~^ matches_instead_of_eq
+
+    let y = EvenOdd::Odd;
+    // Should not emit because of the guard.
+    let _val = matches!(x, EvenOdd::Even if y != EvenOdd::Odd);
+
+    let x = &[EvenOdd::Odd];
+    // Should not emit because of the `..`.
+    let _val = matches!(x, [..]);
+
+    let x = Foo::Bar;
+    // Should not emit the lint since `Foo` doesn't implement `PartialEq`
+    let _val = matches!(x, Foo::Bar);
+
+    let x = EvenOdd::Odd;
+    // Should not emit the lint because of the `|`.
+    let _val = matches!(x, EvenOdd::Even | EvenOdd::Odd);
+
+    let x = Foo2::Bar(1, 2);
+    // Should not emit the lint.
+    let _val = matches!(x, Foo2::Bar(_, _));
+
+    let x = Foo2::Baz { x: 1, y: 2 };
+    // Should not emit the lint.
+    let _val = matches!(x, Foo2::Baz { .. });
+
+    // Should not emit the lint.
+    let _val = matches!(x, Foo2::Bar(..) | Foo2::Baz { .. });
+}

--- a/tests/ui/matches_instead_of_eq.rs
+++ b/tests/ui/matches_instead_of_eq.rs
@@ -30,6 +30,9 @@ impl PartialEq for Manual {
     }
 }
 
+#[derive(PartialEq)]
+struct ContainsManual(Manual);
+
 fn main() {
     let x = Empty;
     let _val = matches!(x, Empty);
@@ -79,4 +82,9 @@ fn main() {
     let x = Manual;
     // Should not emit the lint since `Manual` implements `PartialEq` manually.
     let _val = matches!(x, Manual);
+
+    let x = ContainsManual(x);
+    // Should not emit the lint since `ContainsManual` contains `Manual` which implements
+    // `PartialEq` manually.
+    let _val = matches!(x, ContainsManual(Manual));
 }

--- a/tests/ui/matches_instead_of_eq.stderr
+++ b/tests/ui/matches_instead_of_eq.stderr
@@ -1,5 +1,5 @@
 error: this expression can be replaced with a `==` comparison
-  --> tests/ui/matches_instead_of_eq.rs:35:16
+  --> tests/ui/matches_instead_of_eq.rs:38:16
    |
 LL |     let _val = matches!(x, Empty);
    |                ^^^^^^^^^^^^^^^^^^ help: replace with: `x == Empty`
@@ -8,19 +8,19 @@ LL |     let _val = matches!(x, Empty);
    = help: to override `-D warnings` add `#[allow(clippy::matches_instead_of_eq)]`
 
 error: this expression can be replaced with a `==` comparison
-  --> tests/ui/matches_instead_of_eq.rs:39:16
+  --> tests/ui/matches_instead_of_eq.rs:42:16
    |
 LL |     let _val = matches!(x, EvenOdd::Odd);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `x == EvenOdd::Odd`
 
 error: this expression can be replaced with a `!=` comparison
-  --> tests/ui/matches_instead_of_eq.rs:44:16
+  --> tests/ui/matches_instead_of_eq.rs:47:16
    |
 LL |     let _val = !matches!(x, EvenOdd::Odd);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `x != EvenOdd::Odd`
 
 error: this expression can be replaced with a `==` comparison
-  --> tests/ui/matches_instead_of_eq.rs:49:16
+  --> tests/ui/matches_instead_of_eq.rs:52:16
    |
 LL |     let _val = matches!(x, EvenOdd::Odd);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `*x == EvenOdd::Odd`

--- a/tests/ui/matches_instead_of_eq.stderr
+++ b/tests/ui/matches_instead_of_eq.stderr
@@ -1,5 +1,5 @@
 error: this expression can be replaced with a `==` comparison
-  --> tests/ui/matches_instead_of_eq.rs:27:16
+  --> tests/ui/matches_instead_of_eq.rs:35:16
    |
 LL |     let _val = matches!(x, Empty);
    |                ^^^^^^^^^^^^^^^^^^ help: replace with: `x == Empty`
@@ -8,19 +8,19 @@ LL |     let _val = matches!(x, Empty);
    = help: to override `-D warnings` add `#[allow(clippy::matches_instead_of_eq)]`
 
 error: this expression can be replaced with a `==` comparison
-  --> tests/ui/matches_instead_of_eq.rs:31:16
+  --> tests/ui/matches_instead_of_eq.rs:39:16
    |
 LL |     let _val = matches!(x, EvenOdd::Odd);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `x == EvenOdd::Odd`
 
 error: this expression can be replaced with a `!=` comparison
-  --> tests/ui/matches_instead_of_eq.rs:36:16
+  --> tests/ui/matches_instead_of_eq.rs:44:16
    |
 LL |     let _val = !matches!(x, EvenOdd::Odd);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `x != EvenOdd::Odd`
 
 error: this expression can be replaced with a `==` comparison
-  --> tests/ui/matches_instead_of_eq.rs:41:16
+  --> tests/ui/matches_instead_of_eq.rs:49:16
    |
 LL |     let _val = matches!(x, EvenOdd::Odd);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `*x == EvenOdd::Odd`

--- a/tests/ui/matches_instead_of_eq.stderr
+++ b/tests/ui/matches_instead_of_eq.stderr
@@ -1,0 +1,29 @@
+error: this expression can be replaced with a `==` comparison
+  --> tests/ui/matches_instead_of_eq.rs:27:16
+   |
+LL |     let _val = matches!(x, Empty);
+   |                ^^^^^^^^^^^^^^^^^^ help: replace with: `x == Empty`
+   |
+   = note: `-D clippy::matches-instead-of-eq` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::matches_instead_of_eq)]`
+
+error: this expression can be replaced with a `==` comparison
+  --> tests/ui/matches_instead_of_eq.rs:31:16
+   |
+LL |     let _val = matches!(x, EvenOdd::Odd);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `x == EvenOdd::Odd`
+
+error: this expression can be replaced with a `!=` comparison
+  --> tests/ui/matches_instead_of_eq.rs:36:16
+   |
+LL |     let _val = !matches!(x, EvenOdd::Odd);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `x != EvenOdd::Odd`
+
+error: this expression can be replaced with a `==` comparison
+  --> tests/ui/matches_instead_of_eq.rs:41:16
+   |
+LL |     let _val = matches!(x, EvenOdd::Odd);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `*x == EvenOdd::Odd`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17018)*

Fixes rust-lang/rust-clippy#14688.

r? @samueltardieu 

changelog: Add new pedantic `matches_instead_of_eq` lint