### PR TITLE
Fix `explicit_counter_loop` FP when the counter is only modified inside the `else` block of `let...else` binding.

### DIFF
--- a/clippy_lints/src/loops/utils.rs
+++ b/clippy_lints/src/loops/utils.rs
@@ -46,6 +46,17 @@ impl<'a, 'tcx> IncrementVisitor<'a, 'tcx> {
 }
 
 impl<'tcx> Visitor<'tcx> for IncrementVisitor<'_, 'tcx> {
+    fn visit_local(&mut self, l: &'tcx LetStmt<'tcx>) {
+        if let Some(init) = l.init {
+            self.visit_expr(init);
+            if let Some(els) = l.els {
+                self.depth += 1;
+                self.visit_block(els);
+                self.depth -= 1;
+            }
+        }
+    }
+
     fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
         // If node is a variable
         if let Some(def_id) = expr.res_local_id() {

--- a/tests/ui/explicit_counter_loop.rs
+++ b/tests/ui/explicit_counter_loop.rs
@@ -363,3 +363,24 @@ pub fn issue_16642() {
         base += 1;
     }
 }
+
+fn issue_17014(v: Vec<u8>) {
+    let mut count = 0;
+    for item in &v {
+        let Some(_) = Some(0) else {
+            count += 1;
+            continue;
+        };
+    }
+
+    let mut count = 0;
+    for item in &v {
+        //~^ explicit_counter_loop
+        let Some(_) = ({
+            count += 1;
+            Some(0)
+        }) else {
+            continue;
+        };
+    }
+}

--- a/tests/ui/explicit_counter_loop.stderr
+++ b/tests/ui/explicit_counter_loop.stderr
@@ -105,5 +105,11 @@ error: the variable `base` is used as a loop counter
 LL |     for _ in 5..MAX {
    |     ^^^^^^^^^^^^^^^ help: consider using: `for (base, _) in (100..).zip((5..MAX))`
 
-error: aborting due to 17 previous errors
+error: the variable `count` is used as a loop counter
+  --> tests/ui/explicit_counter_loop.rs:377:5
+   |
+LL |     for item in &v {
+   |     ^^^^^^^^^^^^^^ help: consider using: `for (count, item) in v.iter().enumerate()`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Fixes: rust-lang/rust-clippy#17014

changelog: [`explicit_counter_loop`]: Fix FP when the counter is only modified inside the `else` block of `let...else` binding.