### PR TITLE
Fix #6817: Trigger float_cmp_const for assert_eq! with const floats

### DIFF
--- a/clippy_lints/src/operators/float_cmp.rs
+++ b/clippy_lints/src/operators/float_cmp.rs
@@ -1,13 +1,70 @@
 use clippy_utils::consts::{ConstEvalCtxt, Constant};
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::macros::{find_assert_eq_args, first_node_macro_backtrace, macro_backtrace};
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{parent_item_name, sym};
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, UnOp};
+use rustc_span::SyntaxContext;
 use rustc_lint::LateContext;
 use rustc_middle::ty;
 
 use super::{FLOAT_CMP, FLOAT_CMP_CONST};
+
+pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
+    if let Some(macro_call) = first_node_macro_backtrace(cx, e).find(|macro_call| {
+        matches!(
+            cx.tcx.get_diagnostic_name(macro_call.def_id),
+            Some(
+                sym::assert_eq_macro
+                    | sym::assert_ne_macro
+                    | sym::debug_assert_eq_macro
+                    | sym::debug_assert_ne_macro
+            )
+        )
+    }) && let Some((lhs, rhs, _)) = find_assert_eq_args(cx, e, macro_call.expn)
+        && is_float(cx, lhs)
+    {
+        let ecx = ConstEvalCtxt::new(cx);
+        let ctxt = macro_call.span.ctxt();
+
+        let has_const = is_float_const(&ecx, lhs, ctxt) || is_float_const(&ecx, rhs, ctxt);
+        if !has_const {
+            return;
+        }
+
+        let is_comparing_arrays = is_array(cx, lhs) || is_array(cx, rhs);
+        let msg = if is_comparing_arrays {
+            "strict comparison of `f32` or `f64` constant arrays"
+        } else {
+            "strict comparison of `f32` or `f64` constant"
+        };
+
+        clippy_utils::diagnostics::span_lint(cx, FLOAT_CMP_CONST, macro_call.span, msg);
+    }
+}
+
+fn is_float_const(ecx: &ConstEvalCtxt<'_>, expr: &Expr<'_>, ctxt: SyntaxContext) -> bool {
+    match ecx.eval_with_source(expr, ctxt) {
+        Some((c, s)) if !is_allowed(&c) => !s.is_local(),
+        Some(_) => false,
+        None => false,
+    }
+}
+
+fn is_inside_assert_eq(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    macro_backtrace(expr.span).any(|mc| {
+        matches!(
+            cx.tcx.get_diagnostic_name(mc.def_id),
+            Some(
+                sym::assert_eq_macro
+                    | sym::assert_ne_macro
+                    | sym::debug_assert_eq_macro
+                    | sym::debug_assert_ne_macro
+            )
+        )
+    })
+}
 
 pub(crate) fn check<'tcx>(
     cx: &LateContext<'tcx>,
@@ -17,6 +74,12 @@ pub(crate) fn check<'tcx>(
     right: &'tcx Expr<'_>,
 ) {
     if (op == BinOpKind::Eq || op == BinOpKind::Ne) && is_float(cx, left) {
+        // Skip if inside assert_eq!/assert_ne! macro to avoid double-linting
+        // (handled by check_assert)
+        if is_inside_assert_eq(cx, expr) {
+            return;
+        }
+
         let ecx = ConstEvalCtxt::new(cx);
         let ctxt = expr.span.ctxt();
         let left_is_local = match ecx.eval_with_source(left, ctxt) {

--- a/clippy_lints/src/operators/float_cmp.rs
+++ b/clippy_lints/src/operators/float_cmp.rs
@@ -42,8 +42,7 @@ pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
 fn is_float_const(ecx: &ConstEvalCtxt<'_>, expr: &Expr<'_>, ctxt: SyntaxContext) -> bool {
     match ecx.eval_with_source(expr, ctxt) {
         Some((c, s)) if !is_allowed(&c) => !s.is_local(),
-        Some(_) => false,
-        None => false,
+        _ => false,
     }
 }
 

--- a/clippy_lints/src/operators/float_cmp.rs
+++ b/clippy_lints/src/operators/float_cmp.rs
@@ -5,9 +5,9 @@ use clippy_utils::sugg::Sugg;
 use clippy_utils::{parent_item_name, sym};
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, UnOp};
-use rustc_span::SyntaxContext;
 use rustc_lint::LateContext;
 use rustc_middle::ty;
+use rustc_span::SyntaxContext;
 
 use super::{FLOAT_CMP, FLOAT_CMP_CONST};
 
@@ -15,12 +15,7 @@ pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
     if let Some(macro_call) = first_node_macro_backtrace(cx, e).find(|macro_call| {
         matches!(
             cx.tcx.get_diagnostic_name(macro_call.def_id),
-            Some(
-                sym::assert_eq_macro
-                    | sym::assert_ne_macro
-                    | sym::debug_assert_eq_macro
-                    | sym::debug_assert_ne_macro
-            )
+            Some(sym::assert_eq_macro | sym::assert_ne_macro | sym::debug_assert_eq_macro | sym::debug_assert_ne_macro)
         )
     }) && let Some((lhs, rhs, _)) = find_assert_eq_args(cx, e, macro_call.expn)
         && is_float(cx, lhs)
@@ -56,12 +51,7 @@ fn is_inside_assert_eq(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     macro_backtrace(expr.span).any(|mc| {
         matches!(
             cx.tcx.get_diagnostic_name(mc.def_id),
-            Some(
-                sym::assert_eq_macro
-                    | sym::assert_ne_macro
-                    | sym::debug_assert_eq_macro
-                    | sym::debug_assert_ne_macro
-            )
+            Some(sym::assert_eq_macro | sym::assert_ne_macro | sym::debug_assert_eq_macro | sym::debug_assert_ne_macro)
         )
     })
 }

--- a/clippy_lints/src/operators/float_cmp.rs
+++ b/clippy_lints/src/operators/float_cmp.rs
@@ -13,9 +13,9 @@ use rustc_span::SyntaxContext;
 use super::{FLOAT_CMP, FLOAT_CMP_CONST};
 
 pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
-    if let Some(macro_call) = first_node_macro_backtrace(cx, e).find(|macro_call| {
-        is_assert_eq_diag(cx, macro_call.def_id)
-    }) && let Some((lhs, rhs, _)) = find_assert_eq_args(cx, e, macro_call.expn)
+    if let Some(macro_call) =
+        first_node_macro_backtrace(cx, e).find(|macro_call| is_assert_eq_diag(cx, macro_call.def_id))
+        && let Some((lhs, rhs, _)) = find_assert_eq_args(cx, e, macro_call.expn)
         && is_float(cx, lhs)
     {
         let ecx = ConstEvalCtxt::new(cx);

--- a/clippy_lints/src/operators/float_cmp.rs
+++ b/clippy_lints/src/operators/float_cmp.rs
@@ -4,6 +4,7 @@ use clippy_utils::macros::{find_assert_eq_args, first_node_macro_backtrace, macr
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{parent_item_name, sym};
 use rustc_errors::Applicability;
+use rustc_hir::def_id::DefId;
 use rustc_hir::{BinOpKind, Expr, ExprKind, UnOp};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
@@ -13,10 +14,7 @@ use super::{FLOAT_CMP, FLOAT_CMP_CONST};
 
 pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
     if let Some(macro_call) = first_node_macro_backtrace(cx, e).find(|macro_call| {
-        matches!(
-            cx.tcx.get_diagnostic_name(macro_call.def_id),
-            Some(sym::assert_eq_macro | sym::assert_ne_macro | sym::debug_assert_eq_macro | sym::debug_assert_ne_macro)
-        )
+        is_assert_eq_diag(cx, macro_call.def_id)
     }) && let Some((lhs, rhs, _)) = find_assert_eq_args(cx, e, macro_call.expn)
         && is_float(cx, lhs)
     {
@@ -46,13 +44,15 @@ fn is_float_const(ecx: &ConstEvalCtxt<'_>, expr: &Expr<'_>, ctxt: SyntaxContext)
     }
 }
 
+fn is_assert_eq_diag(cx: &LateContext<'_>, def_id: DefId) -> bool {
+    matches!(
+        cx.tcx.get_diagnostic_name(def_id),
+        Some(sym::assert_eq_macro | sym::assert_ne_macro | sym::debug_assert_eq_macro | sym::debug_assert_ne_macro)
+    )
+}
+
 fn is_inside_assert_eq(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    macro_backtrace(expr.span).any(|mc| {
-        matches!(
-            cx.tcx.get_diagnostic_name(mc.def_id),
-            Some(sym::assert_eq_macro | sym::assert_ne_macro | sym::debug_assert_eq_macro | sym::debug_assert_ne_macro)
-        )
-    })
+    macro_backtrace(expr.span).any(|mc| is_assert_eq_diag(cx, mc.def_id))
 }
 
 pub(crate) fn check<'tcx>(

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -1013,6 +1013,7 @@ impl Operators {
 impl<'tcx> LateLintPass<'tcx> for Operators {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
         eq_op::check_assert(cx, e);
+        float_cmp::check_assert(cx, e);
         match e.kind {
             ExprKind::Binary(op, lhs, rhs) => {
                 if !e.span.from_expansion() {

--- a/tests/ui/float_cmp_const.rs
+++ b/tests/ui/float_cmp_const.rs
@@ -47,6 +47,17 @@ fn main() {
     ONE != f32::INFINITY;
     ONE == f32::NEG_INFINITY;
 
+    // assert_eq with const floats
+    assert_eq!(ONE, 1.0);
+    //~^ float_cmp_const
+
+    assert_ne!(ONE, 2.0);
+    //~^ float_cmp_const
+
+    let local = 0.9;
+    assert_eq!(local, ONE);
+    //~^ float_cmp_const
+
     // no errors, but will warn clippy::float_cmp if '#![allow(float_cmp)]' above is removed
     let w = 1.1;
     v == w;

--- a/tests/ui/float_cmp_const.stderr
+++ b/tests/ui/float_cmp_const.stderr
@@ -43,11 +43,29 @@ error: strict comparison of `f32` or `f64` constant
 LL |     v != ONE;
    |     ^^^^^^^^ help: consider comparing them within some margin of error: `(v - ONE).abs() > error_margin`
 
+error: strict comparison of `f32` or `f64` constant
+  --> tests/ui/float_cmp_const.rs:51:5
+   |
+LL |     assert_eq!(ONE, 1.0);
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: strict comparison of `f32` or `f64` constant
+  --> tests/ui/float_cmp_const.rs:54:5
+   |
+LL |     assert_ne!(ONE, 2.0);
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: strict comparison of `f32` or `f64` constant
+  --> tests/ui/float_cmp_const.rs:58:5
+   |
+LL |     assert_eq!(local, ONE);
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
 error: strict comparison of `f32` or `f64` constant arrays
-  --> tests/ui/float_cmp_const.rs:68:5
+  --> tests/ui/float_cmp_const.rs:79:5
    |
 LL |     NON_ZERO_ARRAY == NON_ZERO_ARRAY2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#6817

This PR modifies float_cmp to detect when a strict comparison of floating-point constants happens inside assertion macros (assert_eq!, assert_ne!, etc.) and correctly emits float_cmp_const instead of the general float_cmp lint. It avoids double-linting by skipping the standard check when the expression is inside an assertion macro.

changelog: Fix [`float_cmp_const`] not triggering on `assert_eq!`