### PR TITLE
Add check for midpoint using multiplication by 0.5 and >> 1

### DIFF
--- a/clippy_lints/src/operators/manual_midpoint.rs
+++ b/clippy_lints/src/operators/manual_midpoint.rs
@@ -18,22 +18,34 @@ pub(super) fn check<'tcx>(
     right: &'tcx Expr<'_>,
     msrv: Msrv,
 ) {
+    let (maybe_add_expr, require_uint) =
+        if op == BinOpKind::Div && (is_integer_literal(right, 2) || is_float_literal(right, 2.0)) {
+            (left, false)
+        } else if op == BinOpKind::Mul && is_float_literal(left, 0.5) {
+            (right, false)
+        } else if op == BinOpKind::Mul && is_float_literal(right, 0.5) {
+            (left, false)
+        } else if op == BinOpKind::Shr && is_integer_literal(right, 1) {
+            (left, true)
+        } else {
+            return;
+        };
+
     if !left.span.from_expansion()
         && !right.span.from_expansion()
-        && op == BinOpKind::Div
-        && (is_integer_literal(right, 2) || is_float_literal(right, 2.0))
-        && let Some((ll_expr, lr_expr)) = add_operands(left)
-        && add_operands(ll_expr).is_none() && add_operands(lr_expr).is_none()
-        && let left_ty = cx.typeck_results().expr_ty_adjusted(ll_expr)
-        && let right_ty = cx.typeck_results().expr_ty_adjusted(lr_expr)
+        && let Some((add_l_expr, add_r_expr)) = add_operands(maybe_add_expr)
+        && add_operands(add_l_expr).is_none() && add_operands(add_r_expr).is_none()
+        && let left_ty = cx.typeck_results().expr_ty_adjusted(add_l_expr)
+        && let right_ty = cx.typeck_results().expr_ty_adjusted(add_r_expr)
         && left_ty == right_ty
+        && (!require_uint || matches!(left_ty.kind(), ty::Uint(_)))
         // Do not lint on `(_+1)/2` and `(1+_)/2`, it is likely a `div_ceil()` operation
-        && !is_integer_literal(ll_expr, 1) && !is_integer_literal(lr_expr, 1)
+        && !is_integer_literal(add_l_expr, 1) && !is_integer_literal(add_r_expr, 1)
         && is_midpoint_implemented(cx, left_ty, msrv)
     {
         let mut app = Applicability::MachineApplicable;
-        let left_sugg = Sugg::hir_with_context(cx, ll_expr, expr.span.ctxt(), "..", &mut app);
-        let right_sugg = Sugg::hir_with_context(cx, lr_expr, expr.span.ctxt(), "..", &mut app);
+        let left_sugg = Sugg::hir_with_context(cx, add_l_expr, expr.span.ctxt(), "..", &mut app);
+        let right_sugg = Sugg::hir_with_context(cx, add_r_expr, expr.span.ctxt(), "..", &mut app);
         let sugg = format!("{left_ty}::midpoint({left_sugg}, {right_sugg})");
         span_lint_and_sugg(
             cx,

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -727,18 +727,27 @@ declare_clippy_lint! {
     /// Checks for manual implementation of `midpoint`.
     ///
     /// ### Why is this bad?
-    /// Using `(x + y) / 2` might cause an overflow on the intermediate
-    /// addition result.
+    /// Using `(x + y) / 2` or `(x + y) >> 1` on integer types might cause an overflow on the
+    /// intermediate addition result. The latter will only warn for unsigned integer types.
+    /// Similar for floating-point `(x + y) / 2.0` and `(x + y) * 0.5`.
     ///
     /// ### Example
     /// ```no_run
     /// # let a: u32 = 0;
     /// let c = (a + 10) / 2;
+    /// let d = (a + 10) >> 1;
+    /// let b: f32 = 0.0;
+    /// let e = (b + 10.0) / 2.0;
+    /// let f = (b + 10.0) * 0.5;
     /// ```
     /// Use instead:
     /// ```no_run
     /// # let a: u32 = 0;
     /// let c = u32::midpoint(a, 10);
+    /// let d = u32::midpoint(a, 10);
+    /// let b: f32 = 0.0;
+    /// let e = f32::midpoint(b, 10.0);
+    /// let f = f32::midpoint(b, 10.0);
     /// ```
     #[clippy::version = "1.87.0"]
     pub MANUAL_MIDPOINT,

--- a/tests/ui/manual_midpoint.fixed
+++ b/tests/ui/manual_midpoint.fixed
@@ -28,9 +28,12 @@ fn older_msrv() {
 fn main() {
     let a: u32 = 10;
     let _ = u32::midpoint(a, 5); //~ ERROR: manual implementation of `midpoint`
+    let _ = u32::midpoint(a, 5); //~ ERROR: manual implementation of `midpoint`
 
     let f: f32 = 10.0;
     let _ = f32::midpoint(f, 5.0); //~ ERROR: manual implementation of `midpoint`
+    let _ = f32::midpoint(f, 10.0); //~ ERROR: manual implementation of `midpoint`
+    let _ = f32::midpoint(f, 10.0); //~ ERROR: manual implementation of `midpoint`
 
     let _: u32 = 5 + u32::midpoint(8, 8) + 2; //~ ERROR: manual implementation of `midpoint`
     let _: u32 = const { u32::midpoint(8, 8) }; //~ ERROR: manual implementation of `midpoint`
@@ -52,6 +55,7 @@ fn main() {
     // Do not lint on signed integer types
     let i: i32 = 10;
     let _ = (i + 5) / 2;
+    let _ = (i + 5) >> 1;
 
     // Do not lint on (x+1)/2 or (1+x)/2 as this looks more like a `div_ceil()` operation
     let _ = (i + 1) / 2;

--- a/tests/ui/manual_midpoint.rs
+++ b/tests/ui/manual_midpoint.rs
@@ -28,9 +28,12 @@ fn older_msrv() {
 fn main() {
     let a: u32 = 10;
     let _ = (a + 5) / 2; //~ ERROR: manual implementation of `midpoint`
+    let _ = (a + 5) >> 1; //~ ERROR: manual implementation of `midpoint`
 
     let f: f32 = 10.0;
     let _ = (f + 5.0) / 2.0; //~ ERROR: manual implementation of `midpoint`
+    let _ = (f + 10.0) * 0.5; //~ ERROR: manual implementation of `midpoint`
+    let _ = 0.5 * (f + 10.0); //~ ERROR: manual implementation of `midpoint`
 
     let _: u32 = 5 + (8 + 8) / 2 + 2; //~ ERROR: manual implementation of `midpoint`
     let _: u32 = const { (8 + 8) / 2 }; //~ ERROR: manual implementation of `midpoint`
@@ -52,6 +55,7 @@ fn main() {
     // Do not lint on signed integer types
     let i: i32 = 10;
     let _ = (i + 5) / 2;
+    let _ = (i + 5) >> 1;
 
     // Do not lint on (x+1)/2 or (1+x)/2 as this looks more like a `div_ceil()` operation
     let _ = (i + 1) / 2;

--- a/tests/ui/manual_midpoint.stderr
+++ b/tests/ui/manual_midpoint.stderr
@@ -8,58 +8,76 @@ LL |     let _ = (a + 5) / 2;
    = help: to override `-D warnings` add `#[allow(clippy::manual_midpoint)]`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:33:13
+  --> tests/ui/manual_midpoint.rs:31:13
+   |
+LL |     let _ = (a + 5) >> 1;
+   |             ^^^^^^^^^^^^ help: use `u32::midpoint` instead: `u32::midpoint(a, 5)`
+
+error: manual implementation of `midpoint` which can overflow
+  --> tests/ui/manual_midpoint.rs:34:13
    |
 LL |     let _ = (f + 5.0) / 2.0;
    |             ^^^^^^^^^^^^^^^ help: use `f32::midpoint` instead: `f32::midpoint(f, 5.0)`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:35:22
+  --> tests/ui/manual_midpoint.rs:35:13
+   |
+LL |     let _ = (f + 10.0) * 0.5;
+   |             ^^^^^^^^^^^^^^^^ help: use `f32::midpoint` instead: `f32::midpoint(f, 10.0)`
+
+error: manual implementation of `midpoint` which can overflow
+  --> tests/ui/manual_midpoint.rs:36:13
+   |
+LL |     let _ = 0.5 * (f + 10.0);
+   |             ^^^^^^^^^^^^^^^^ help: use `f32::midpoint` instead: `f32::midpoint(f, 10.0)`
+
+error: manual implementation of `midpoint` which can overflow
+  --> tests/ui/manual_midpoint.rs:38:22
    |
 LL |     let _: u32 = 5 + (8 + 8) / 2 + 2;
    |                      ^^^^^^^^^^^ help: use `u32::midpoint` instead: `u32::midpoint(8, 8)`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:36:26
+  --> tests/ui/manual_midpoint.rs:39:26
    |
 LL |     let _: u32 = const { (8 + 8) / 2 };
    |                          ^^^^^^^^^^^ help: use `u32::midpoint` instead: `u32::midpoint(8, 8)`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:37:26
+  --> tests/ui/manual_midpoint.rs:40:26
    |
 LL |     let _: f64 = const { (8.0f64 + 8.) / 2. };
    |                          ^^^^^^^^^^^^^^^^^^ help: use `f64::midpoint` instead: `f64::midpoint(8.0f64, 8.)`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:38:18
+  --> tests/ui/manual_midpoint.rs:41:18
    |
 LL |     let _: u32 = (u32::default() + u32::default()) / 2;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `u32::midpoint` instead: `u32::midpoint(u32::default(), u32::default())`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:39:18
+  --> tests/ui/manual_midpoint.rs:42:18
    |
 LL |     let _: u32 = (two!() + two!()) / 2;
    |                  ^^^^^^^^^^^^^^^^^^^^^ help: use `u32::midpoint` instead: `u32::midpoint(two!(), two!())`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:61:13
+  --> tests/ui/manual_midpoint.rs:65:13
    |
 LL |     let _ = (f + 1.0) / 2.0;
    |             ^^^^^^^^^^^^^^^ help: use `f32::midpoint` instead: `f32::midpoint(f, 1.0)`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:62:13
+  --> tests/ui/manual_midpoint.rs:66:13
    |
 LL |     let _ = (1.0 + f) / 2.0;
    |             ^^^^^^^^^^^^^^^ help: use `f32::midpoint` instead: `f32::midpoint(1.0, f)`
 
 error: manual implementation of `midpoint` which can overflow
-  --> tests/ui/manual_midpoint.rs:73:13
+  --> tests/ui/manual_midpoint.rs:77:13
    |
 LL |     let _ = (i + 10) / 2;
    |             ^^^^^^^^^^^^ help: use `i32::midpoint` instead: `i32::midpoint(i, 10)`
 
-error: aborting due to 10 previous errors
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#17022 see issue for more input. Also, the corresponding PR for rustc is now merged to midpoint will multiply with 0.5 instead of dividing by 2.

changelog: [`manual_midpoint`] warns on expressions like `(a + b) * 0.5` and `(a + b) >> 1`.
