### PR TITLE
Add new `try_from_instead_of_from_str` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7404,6 +7404,7 @@ Released 2018-09-13
 [`trivial_regex`]: https://rust-lang.github.io/rust-clippy/master/index.html#trivial_regex
 [`trivially_copy_pass_by_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref
 [`try_err`]: https://rust-lang.github.io/rust-clippy/master/index.html#try_err
+[`try_from_instead_of_from_str`]: https://rust-lang.github.io/rust-clippy/master/index.html#try_from_instead_of_from_str
 [`tuple_array_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#tuple_array_conversions
 [`type_complexity`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
 [`type_id_on_box`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_id_on_box

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7647,6 +7647,7 @@ Released 2018-09-13
 [`trivial_regex`]: https://rust-lang.github.io/rust-clippy/main/index.html#trivial_regex
 [`trivially_copy_pass_by_ref`]: https://rust-lang.github.io/rust-clippy/main/index.html#trivially_copy_pass_by_ref
 [`try_err`]: https://rust-lang.github.io/rust-clippy/main/index.html#try_err
+[`try_from_instead_of_from_str`]: https://rust-lang.github.io/rust-clippy/main/index.html#try_from_instead_of_from_str
 [`tuple_array_conversions`]: https://rust-lang.github.io/rust-clippy/main/index.html#tuple_array_conversions
 [`type_complexity`]: https://rust-lang.github.io/rust-clippy/main/index.html#type_complexity
 [`type_id_on_box`]: https://rust-lang.github.io/rust-clippy/main/index.html#type_id_on_box

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -749,6 +749,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::transmute::UNSOUND_COLLECTION_TRANSMUTE_INFO,
     crate::transmute::USELESS_TRANSMUTE_INFO,
     crate::transmute::WRONG_TRANSMUTE_INFO,
+    crate::try_from_instead_of_from_str::TRY_FROM_INSTEAD_OF_FROM_STR_INFO,
     crate::tuple_array_conversions::TUPLE_ARRAY_CONVERSIONS_INFO,
     crate::types::BORROWED_BOX_INFO,
     crate::types::BOX_COLLECTION_INFO,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -762,6 +762,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::transmute::UNSOUND_COLLECTION_TRANSMUTE_INFO,
     crate::transmute::USELESS_TRANSMUTE_INFO,
     crate::transmute::WRONG_TRANSMUTE_INFO,
+    crate::try_from_instead_of_from_str::TRY_FROM_INSTEAD_OF_FROM_STR_INFO,
     crate::tuple_array_conversions::TUPLE_ARRAY_CONVERSIONS_INFO,
     crate::types::BORROWED_BOX_INFO,
     crate::types::BOX_COLLECTION_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -363,6 +363,7 @@ mod toplevel_ref_arg;
 mod trailing_empty_array;
 mod trait_bounds;
 mod transmute;
+mod try_from_instead_of_from_str;
 mod tuple_array_conversions;
 mod types;
 mod unconditional_recursion;
@@ -859,6 +860,7 @@ rustc_lint::late_lint_methods!(
         ManualPopIf: manual_pop_if::ManualPopIf = manual_pop_if::ManualPopIf::new(tcx, conf),
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
+        TryFromInsteadOfFromStr: try_from_instead_of_from_str::TryFromInsteadOfFromStr = try_from_instead_of_from_str::TryFromInsteadOfFromStr,
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
         // add late passes here, used by `cargo dev new_lint`
     ]]

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -367,6 +367,7 @@ mod toplevel_ref_arg;
 mod trailing_empty_array;
 mod trait_bounds;
 mod transmute;
+mod try_from_instead_of_from_str;
 mod tuple_array_conversions;
 mod types;
 mod unconditional_recursion;
@@ -862,6 +863,7 @@ rustc_lint::late_lint_methods!(
         ManualPopIf: manual_pop_if::ManualPopIf = manual_pop_if::ManualPopIf::new(tcx, conf),
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
+        TryFromInsteadOfFromStr: try_from_instead_of_from_str::TryFromInsteadOfFromStr = try_from_instead_of_from_str::TryFromInsteadOfFromStr,
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -863,7 +863,7 @@ rustc_lint::late_lint_methods!(
         ManualPopIf: manual_pop_if::ManualPopIf = manual_pop_if::ManualPopIf::new(tcx, conf),
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
-        TryFromInsteadOfFromStr: try_from_instead_of_from_str::TryFromInsteadOfFromStr = try_from_instead_of_from_str::TryFromInsteadOfFromStr,
+        TryFromInsteadOfFromStr: try_from_instead_of_from_str::TryFromInsteadOfFromStr = try_from_instead_of_from_str::TryFromInsteadOfFromStr::new(conf),
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -860,7 +860,7 @@ rustc_lint::late_lint_methods!(
         ManualPopIf: manual_pop_if::ManualPopIf = manual_pop_if::ManualPopIf::new(tcx, conf),
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
-        TryFromInsteadOfFromStr: try_from_instead_of_from_str::TryFromInsteadOfFromStr = try_from_instead_of_from_str::TryFromInsteadOfFromStr,
+        TryFromInsteadOfFromStr: try_from_instead_of_from_str::TryFromInsteadOfFromStr = try_from_instead_of_from_str::TryFromInsteadOfFromStr::new(conf),
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
         // add late passes here, used by `cargo dev new_lint`
     ]]

--- a/clippy_lints/src/try_from_instead_of_from_str.rs
+++ b/clippy_lints/src/try_from_instead_of_from_str.rs
@@ -1,4 +1,5 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_config::Conf;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::paths::{PathNS, lookup_path};
 use clippy_utils::source::snippet_opt;
 use clippy_utils::sym;
@@ -6,9 +7,8 @@ use clippy_utils::ty::{implements_trait, ty_from_hir_ty};
 use rustc_errors::Applicability;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{BodyId, GenericArg, Impl, ImplItemKind, Item, ItemKind, LifetimeKind, TraitRef, Ty};
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
 use rustc_middle::ty::{self, Mutability};
-use rustc_session::declare_lint_pass;
 use rustc_span::symbol::kw;
 
 use core::ops::ControlFlow;
@@ -75,7 +75,19 @@ declare_clippy_lint! {
     "TryFrom<str> instead of FromStr"
 }
 
-declare_lint_pass!(TryFromInsteadOfFromStr => [TRY_FROM_INSTEAD_OF_FROM_STR]);
+impl_lint_pass!(TryFromInsteadOfFromStr => [TRY_FROM_INSTEAD_OF_FROM_STR]);
+
+pub struct TryFromInsteadOfFromStr {
+    avoid_breaking_exported_api: bool,
+}
+
+impl TryFromInsteadOfFromStr {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self {
+            avoid_breaking_exported_api: conf.avoid_breaking_exported_api,
+        }
+    }
+}
 
 struct LifetimeVisitor {
     forbidden_lifetime: LocalDefId,
@@ -180,22 +192,36 @@ impl<'tcx> LateLintPass<'tcx> for TryFromInsteadOfFromStr {
             && let Some(generics) = snippet_opt(cx, imp.generics.span)
             && let Some(self_ty) = snippet_opt(cx, imp.self_ty.span)
         {
-            span_lint_and_sugg(
-                cx,
-                TRY_FROM_INSTEAD_OF_FROM_STR,
-                item.span,
-                "`TryFrom<str>` could be `FromStr`",
-                "replace with",
-                format!(
-                    "\
+            let suggestion = format!(
+                "\
 impl{generics} core::str::FromStr for {self_ty} {{
     type Err = {err_ty};
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {fn_body}
 }}"
-                ),
-                Applicability::MaybeIncorrect,
             );
+            if self.avoid_breaking_exported_api {
+                span_lint_and_then(
+                    cx,
+                    TRY_FROM_INSTEAD_OF_FROM_STR,
+                    item.span,
+                    "`TryFrom<str>` could be `FromStr`",
+                    |diag| {
+                        diag.span_suggestion(item.span, "replace with", suggestion, Applicability::Unspecified);
+                        diag.help("`FromStr` can also be implemented alongside `TryFrom` if you want to avoid breaking changes");
+                    },
+                );
+            } else {
+                span_lint_and_sugg(
+                    cx,
+                    TRY_FROM_INSTEAD_OF_FROM_STR,
+                    item.span,
+                    "`TryFrom<str>` could be `FromStr`",
+                    "replace with",
+                    suggestion,
+                    Applicability::MaybeIncorrect,
+                );
+            }
         }
     }
 }

--- a/clippy_lints/src/try_from_instead_of_from_str.rs
+++ b/clippy_lints/src/try_from_instead_of_from_str.rs
@@ -1,4 +1,5 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_config::Conf;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::paths::{PathNS, lookup_path};
 use clippy_utils::source::snippet_opt;
 use clippy_utils::sym;
@@ -8,7 +9,7 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{BodyId, GenericArg, Impl, ImplItemKind, Item, ItemKind, LifetimeKind, TraitRef, Ty};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Mutability};
-use rustc_session::declare_lint_pass;
+use rustc_session::impl_lint_pass;
 use rustc_span::symbol::kw;
 
 use core::ops::ControlFlow;
@@ -75,7 +76,19 @@ declare_clippy_lint! {
     "TryFrom<str> instead of FromStr"
 }
 
-declare_lint_pass!(TryFromInsteadOfFromStr => [TRY_FROM_INSTEAD_OF_FROM_STR]);
+impl_lint_pass!(TryFromInsteadOfFromStr => [TRY_FROM_INSTEAD_OF_FROM_STR]);
+
+pub struct TryFromInsteadOfFromStr {
+    avoid_breaking_exported_api: bool,
+}
+
+impl TryFromInsteadOfFromStr {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self {
+            avoid_breaking_exported_api: conf.avoid_breaking_exported_api,
+        }
+    }
+}
 
 struct LifetimeVisitor {
     forbidden_lifetime: LocalDefId,
@@ -180,22 +193,36 @@ impl<'tcx> LateLintPass<'tcx> for TryFromInsteadOfFromStr {
             && let Some(generics) = snippet_opt(cx, imp.generics.span)
             && let Some(self_ty) = snippet_opt(cx, imp.self_ty.span)
         {
-            span_lint_and_sugg(
-                cx,
-                TRY_FROM_INSTEAD_OF_FROM_STR,
-                item.span,
-                "`TryFrom<str>` could be `FromStr`",
-                "replace with",
-                format!(
-                    "\
+            let suggestion = format!(
+                "\
 impl{generics} core::str::FromStr for {self_ty} {{
     type Err = {err_ty};
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {fn_body}
 }}"
-                ),
-                Applicability::MaybeIncorrect,
             );
+            if self.avoid_breaking_exported_api {
+                span_lint_and_then(
+                    cx,
+                    TRY_FROM_INSTEAD_OF_FROM_STR,
+                    item.span,
+                    "`TryFrom<str>` could be `FromStr`",
+                    |diag| {
+                        diag.span_suggestion(item.span, "replace with", suggestion, Applicability::Unspecified);
+                        diag.help("`FromStr` can also be implemented alongside `TryFrom` if you want to avoid breaking changes");
+                    },
+                );
+            } else {
+                span_lint_and_sugg(
+                    cx,
+                    TRY_FROM_INSTEAD_OF_FROM_STR,
+                    item.span,
+                    "`TryFrom<str>` could be `FromStr`",
+                    "replace with",
+                    suggestion,
+                    Applicability::MaybeIncorrect,
+                );
+            }
         }
     }
 }

--- a/clippy_lints/src/try_from_instead_of_from_str.rs
+++ b/clippy_lints/src/try_from_instead_of_from_str.rs
@@ -1,0 +1,201 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::paths::{PathNS, lookup_path};
+use clippy_utils::source::snippet_opt;
+use clippy_utils::sym;
+use clippy_utils::ty::{implements_trait, ty_from_hir_ty};
+use rustc_errors::Applicability;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::{BodyId, GenericArg, Impl, ImplItemKind, Item, ItemKind, LifetimeKind, TraitRef, Ty};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, Mutability};
+use rustc_session::declare_lint_pass;
+use rustc_span::symbol::kw;
+
+use core::ops::ControlFlow;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for implementations of `TryFrom<&str>` which could be implementations of `FromStr`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `FromStr` is the idiomatic trait for parsing a string and should be preferred over `TryFrom`
+    /// when doing so. Implementing `FromStr` allows the the use of `str::parse` to make the intent
+    /// of the conversion clearer at the conversion site.
+    ///
+    /// ### Known problems
+    ///
+    /// It's not always possible to convert a `TryFrom<&str>` implementation into a `FromStr` one.
+    /// For example:
+    ///
+    /// ```no_run
+    /// # struct T;
+    /// // Cannot be converted into a `FromStr` impl because the `Error`
+    /// // associated type has a lifetime, which cannot be constrained in
+    /// // `FromStr`.
+    /// impl<'a> TryFrom<&'a str> for T {
+    ///     type Error = &'a str;
+    ///
+    ///     fn try_from(_value: &str) -> Result<Self, Self::Error> {
+    ///         Ok(T)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### Example
+    ///
+    /// ```no_run
+    /// # struct MyType;
+    /// # struct MyError;
+    /// impl TryFrom<&str> for MyType {
+    ///     type Error = MyError;
+    ///     fn try_from(value: &str) -> Result<Self, Self::Error> {
+    /// #       Ok(MyType)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```no_run
+    /// # use std::str::FromStr;
+    /// # struct MyType;
+    /// # struct MyError;
+    /// impl FromStr for MyType {
+    ///     type Err = MyError;
+    ///     fn from_str(value: &str) -> Result<Self, Self::Err> {
+    /// #       Ok(MyType)
+    ///     }
+    /// }
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub TRY_FROM_INSTEAD_OF_FROM_STR,
+    style,
+    "TryFrom<str> instead of FromStr"
+}
+
+declare_lint_pass!(TryFromInsteadOfFromStr => [TRY_FROM_INSTEAD_OF_FROM_STR]);
+
+struct LifetimeVisitor {
+    forbidden_lifetime: LocalDefId,
+}
+
+impl<'tcx> rustc_hir::intravisit::Visitor<'tcx> for LifetimeVisitor {
+    type Result = ControlFlow<(), ()>;
+
+    fn visit_lifetime(&mut self, lifetime: &'tcx rustc_hir::Lifetime) -> Self::Result {
+        if let LifetimeKind::Param(def_id) = lifetime.kind
+            && def_id == self.forbidden_lifetime
+        {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    }
+}
+
+// In this function, we check that the error type doesn't use the same lifetime as
+// `TryFrom<&'a str>`.
+fn check_lifetimes(ty: &Ty<'_>, imp: &Impl<'_>, trait_ref: &TraitRef<'_>) -> bool {
+    let Some(forbidden_lifetime) = get_try_from_str_lifetime(trait_ref) else {
+        return true;
+    };
+
+    let mut visitor = LifetimeVisitor { forbidden_lifetime };
+
+    if rustc_hir::intravisit::walk_unambig_ty(&mut visitor, ty).is_break()
+        || rustc_hir::intravisit::walk_unambig_ty(&mut visitor, imp.self_ty).is_break()
+    {
+        return false;
+    }
+
+    // And finally we check that the `&str` lifetime is not used in the impl generics.
+    imp.generics
+        .predicates
+        .iter()
+        .all(|pred| rustc_hir::intravisit::walk_where_predicate(&mut visitor, pred).is_continue())
+}
+
+fn get_impl_items<'tcx>(cx: &LateContext<'tcx>, imp: &Impl<'_>) -> Option<(&'tcx Ty<'tcx>, BodyId)> {
+    if let &[item1, item2] = &imp.items {
+        match (
+            cx.tcx.hir_expect_impl_item(item1.owner_id.def_id).kind,
+            cx.tcx.hir_expect_impl_item(item2.owner_id.def_id).kind,
+        ) {
+            (ImplItemKind::Type(ty), ImplItemKind::Fn(_, body_id))
+            | (ImplItemKind::Fn(_, body_id), ImplItemKind::Type(ty)) => Some((ty, body_id)),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+fn get_try_from_str_lifetime(trait_ref: &TraitRef<'_>) -> Option<LocalDefId> {
+    if let Some(segment) = trait_ref.path.segments.last()
+        && let Some(args) = segment.args
+        && let Some(ty) = args.args.iter().find_map(|arg| match arg {
+            GenericArg::Type(ty) => Some(ty),
+            _ => None,
+        })
+        && let rustc_hir::TyKind::Ref(lifetime, ..) = ty.kind
+        && lifetime.ident.name != kw::UnderscoreLifetime
+        && let LifetimeKind::Param(def_id) = lifetime.kind
+    {
+        Some(def_id)
+    } else {
+        None
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for TryFromInsteadOfFromStr {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if let ItemKind::Impl(imp) = &item.kind
+            && let Some(of_trait) = imp.of_trait
+            // It should only have an associated type (`Error`) and a method (`try_from`).
+            && let Some((err_ty, fn_body)) = get_impl_items(cx, imp)
+            && let Some(trait_def_id) = of_trait.trait_ref.trait_def_id()
+            && let impl_def_id = item.owner_id.to_def_id()
+            && let trait_ref = cx.tcx.impl_trait_ref(impl_def_id)
+            && let instantiated_trait_ref = trait_ref.instantiate_identity().skip_normalization()
+            // We check if the "from" item is a non-mutable `str`.
+            && let [_, from_arg] = &**instantiated_trait_ref.args
+            && let Some(from_ty) = from_arg.as_type()
+            && let ty::Ref(_, inner_ty, Mutability::Not) = from_ty.kind()
+            && inner_ty.is_str()
+            // We check that the trait is `TryFrom`.
+            && cx.tcx.is_diagnostic_item(sym::TryFrom, trait_def_id)
+            // We check that our type doesn't already implement `FromStr`.
+            && !lookup_path(cx.tcx, PathNS::Type, &[sym::core, sym::str, sym::FromStr])
+                .into_iter()
+                .any(|def_id| {
+                    implements_trait(cx, ty_from_hir_ty(cx, imp.self_ty), def_id, &[])
+                })
+            // We check that the lifetime used by `TryFrom::Error` is not used anywhere else.
+            && check_lifetimes(err_ty, imp, &of_trait.trait_ref)
+            // We retrieve all snippets for lint suggestion.
+            && let Some(fn_body) = snippet_opt(cx, cx.tcx.hir_span_with_body(fn_body.hir_id))
+            && let Some(err_ty) = snippet_opt(cx, err_ty.span)
+            && let Some(generics) = snippet_opt(cx, imp.generics.span)
+            && let Some(self_ty) = snippet_opt(cx, imp.self_ty.span)
+        {
+            span_lint_and_sugg(
+                cx,
+                TRY_FROM_INSTEAD_OF_FROM_STR,
+                item.span,
+                "`TryFrom<str>` could be `FromStr`",
+                "replace with",
+                format!(
+                    "\
+impl{generics} core::str::FromStr for {self_ty} {{
+    type Err = {err_ty};
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {fn_body}
+}}"
+                ),
+                Applicability::MaybeIncorrect,
+            );
+        }
+    }
+}

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -63,6 +63,7 @@ generate! {
     Error,
     File,
     FileType,
+    FromStr,
     FsOpenOptions,
     FsPermissions,
     HashMapEntry,

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -64,6 +64,7 @@ generate! {
     Error,
     File,
     FileType,
+    FromStr,
     FsOpenOptions,
     FsPermissions,
     HashMapEntry,

--- a/tests/ui/try_from_instead_of_from_str.fixed
+++ b/tests/ui/try_from_instead_of_from_str.fixed
@@ -1,0 +1,122 @@
+#![warn(clippy::try_from_instead_of_from_str)]
+#![allow(dead_code, clippy::elidable_lifetime_names)]
+
+struct MyType;
+
+impl core::str::FromStr for MyType {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(MyType)
+    }
+}
+
+struct Bar;
+
+impl core::str::FromStr for Bar {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Bar)
+    }
+}
+
+struct Tarte<'a>(&'a ());
+
+// We ensure that we generate the `impl<'a>` generics correctly and that
+// lifetimes on the `Self` type are allowed.
+impl<'a> core::str::FromStr for Tarte<'a> {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Tarte(&()))
+    }
+}
+
+struct Foo;
+
+// Should not generate a warning because the `Error` associated type
+// has a lifetime, which cannot be constrained in `FromStr`.
+impl<'a> TryFrom<&'a str> for Foo {
+    type Error = &'a str;
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Foo)
+    }
+}
+
+struct Foo2;
+
+// Same here. The `Error` associated type has a lifetime so no suggestion.
+impl<'a> TryFrom<&'a str> for Foo2 {
+    type Error = Tarte<'a>;
+
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Foo2)
+    }
+}
+
+struct Lifetime1;
+
+struct LifetimeErr1<'a>(&'a ());
+
+// This should not lint because the error type uses an unconstrained lifetime (`'a`).
+impl<'a> TryFrom<&'a str> for Lifetime1 {
+    type Error = LifetimeErr1<'a>;
+
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Lifetime1)
+    }
+}
+
+struct Lifetime2;
+struct LifetimeErr2<T>(T);
+
+// This should not lint because the error type uses an unconstrained lifetime (`'a` in `&'a i8`).
+impl<'a> TryFrom<&'a str> for Lifetime2 {
+    type Error = LifetimeErr2<for<'b> fn(&'b u32, &'a i8)>;
+
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Lifetime2)
+    }
+}
+
+struct Lifetime3;
+
+// This	one should lint because there is no unconstrained lifetimes (`dyn` and `for`).
+impl core::str::FromStr for Lifetime3 {
+    type Err = LifetimeErr2<for<'b> fn(&'b u32)>;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Lifetime3)
+    }
+}
+
+struct Lifetime4<T>(T);
+
+// This	one should lint because there is no unconstrained lifetimes (constrained by `Self`).
+impl<'a> core::str::FromStr for Lifetime4<&'a ()> {
+    type Err = LifetimeErr2<&'a ()>;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Lifetime4(&()))
+    }
+}
+
+// Should not lint because it already implements `FromStr`.
+struct Already;
+
+impl TryFrom<&str> for Already {
+    type Error = ();
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Already)
+    }
+}
+
+impl std::str::FromStr for Already {
+    type Err = ();
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        Ok(Already)
+    }
+}
+
+fn main() {}

--- a/tests/ui/try_from_instead_of_from_str.rs
+++ b/tests/ui/try_from_instead_of_from_str.rs
@@ -1,0 +1,127 @@
+#![warn(clippy::try_from_instead_of_from_str)]
+#![allow(dead_code, clippy::elidable_lifetime_names)]
+
+struct MyType;
+
+impl TryFrom<&str> for MyType {
+    //~^ try_from_instead_of_from_str
+
+    type Error = ();
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(MyType)
+    }
+}
+
+struct Bar;
+
+impl TryFrom<&str> for Bar {
+    //~^ try_from_instead_of_from_str
+
+    type Error = &'static str;
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Bar)
+    }
+}
+
+struct Tarte<'a>(&'a ());
+
+// We ensure that we generate the `impl<'a>` generics correctly and that
+// lifetimes on the `Self` type are allowed.
+impl<'a> TryFrom<&str> for Tarte<'a> {
+    //~^ try_from_instead_of_from_str
+
+    type Error = &'static str;
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Tarte(&()))
+    }
+}
+
+struct Foo;
+
+// Should not generate a warning because the `Error` associated type
+// has a lifetime, which cannot be constrained in `FromStr`.
+impl<'a> TryFrom<&'a str> for Foo {
+    type Error = &'a str;
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Foo)
+    }
+}
+
+struct Foo2;
+
+// Same here. The `Error` associated type has a lifetime so no suggestion.
+impl<'a> TryFrom<&'a str> for Foo2 {
+    type Error = Tarte<'a>;
+
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Foo2)
+    }
+}
+
+struct Lifetime1;
+
+struct LifetimeErr1<'a>(&'a ());
+
+// This should not lint because the error type uses an unconstrained lifetime (`'a`).
+impl<'a> TryFrom<&'a str> for Lifetime1 {
+    type Error = LifetimeErr1<'a>;
+
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Lifetime1)
+    }
+}
+
+struct Lifetime2;
+struct LifetimeErr2<T>(T);
+
+// This should not lint because the error type uses an unconstrained lifetime (`'a` in `&'a i8`).
+impl<'a> TryFrom<&'a str> for Lifetime2 {
+    type Error = LifetimeErr2<for<'b> fn(&'b u32, &'a i8)>;
+
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Lifetime2)
+    }
+}
+
+struct Lifetime3;
+
+// This	one should lint because there is no unconstrained lifetimes (`dyn` and `for`).
+impl TryFrom<&str> for Lifetime3 {
+    //~^ try_from_instead_of_from_str
+    type Error = LifetimeErr2<for<'b> fn(&'b u32)>;
+
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Lifetime3)
+    }
+}
+
+struct Lifetime4<T>(T);
+
+// This	one should lint because there is no unconstrained lifetimes (constrained by `Self`).
+impl<'a> TryFrom<&str> for Lifetime4<&'a ()> {
+    //~^ try_from_instead_of_from_str
+    type Error = LifetimeErr2<&'a ()>;
+
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Lifetime4(&()))
+    }
+}
+
+// Should not lint because it already implements `FromStr`.
+struct Already;
+
+impl TryFrom<&str> for Already {
+    type Error = ();
+    fn try_from(_value: &str) -> Result<Self, Self::Error> {
+        Ok(Already)
+    }
+}
+
+impl std::str::FromStr for Already {
+    type Err = ();
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        Ok(Already)
+    }
+}
+
+fn main() {}

--- a/tests/ui/try_from_instead_of_from_str.stderr
+++ b/tests/ui/try_from_instead_of_from_str.stderr
@@ -1,0 +1,112 @@
+error: `TryFrom<str>` could be `FromStr`
+  --> tests/ui/try_from_instead_of_from_str.rs:6:1
+   |
+LL | / impl TryFrom<&str> for MyType {
+LL | |
+LL | |
+LL | |     type Error = ();
+...  |
+LL | | }
+   | |_^
+   |
+   = note: `-D clippy::try-from-instead-of-from-str` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::try_from_instead_of_from_str)]`
+help: replace with
+   |
+LL + impl core::str::FromStr for MyType {
+LL +     type Err = ();
+LL + 
+LL +     fn from_str(value: &str) -> Result<Self, Self::Err> {
+LL +         Ok(MyType)
+LL +     }
+LL + }
+   |
+
+error: `TryFrom<str>` could be `FromStr`
+  --> tests/ui/try_from_instead_of_from_str.rs:17:1
+   |
+LL | / impl TryFrom<&str> for Bar {
+LL | |
+LL | |
+LL | |     type Error = &'static str;
+...  |
+LL | | }
+   | |_^
+   |
+help: replace with
+   |
+LL + impl core::str::FromStr for Bar {
+LL +     type Err = &'static str;
+LL + 
+LL +     fn from_str(value: &str) -> Result<Self, Self::Err> {
+LL +         Ok(Bar)
+LL +     }
+LL + }
+   |
+
+error: `TryFrom<str>` could be `FromStr`
+  --> tests/ui/try_from_instead_of_from_str.rs:30:1
+   |
+LL | / impl<'a> TryFrom<&str> for Tarte<'a> {
+LL | |
+LL | |
+LL | |     type Error = &'static str;
+...  |
+LL | | }
+   | |_^
+   |
+help: replace with
+   |
+LL + impl<'a> core::str::FromStr for Tarte<'a> {
+LL +     type Err = &'static str;
+LL + 
+LL +     fn from_str(value: &str) -> Result<Self, Self::Err> {
+LL +         Ok(Tarte(&()))
+LL +     }
+LL + }
+   |
+
+error: `TryFrom<str>` could be `FromStr`
+  --> tests/ui/try_from_instead_of_from_str.rs:89:1
+   |
+LL | / impl TryFrom<&str> for Lifetime3 {
+LL | |
+LL | |     type Error = LifetimeErr2<for<'b> fn(&'b u32)>;
+...  |
+LL | | }
+   | |_^
+   |
+help: replace with
+   |
+LL + impl core::str::FromStr for Lifetime3 {
+LL +     type Err = LifetimeErr2<for<'b> fn(&'b u32)>;
+LL + 
+LL +     fn from_str(value: &str) -> Result<Self, Self::Err> {
+LL +         Ok(Lifetime3)
+LL +     }
+LL + }
+   |
+
+error: `TryFrom<str>` could be `FromStr`
+  --> tests/ui/try_from_instead_of_from_str.rs:101:1
+   |
+LL | / impl<'a> TryFrom<&str> for Lifetime4<&'a ()> {
+LL | |
+LL | |     type Error = LifetimeErr2<&'a ()>;
+...  |
+LL | | }
+   | |_^
+   |
+help: replace with
+   |
+LL + impl<'a> core::str::FromStr for Lifetime4<&'a ()> {
+LL +     type Err = LifetimeErr2<&'a ()>;
+LL + 
+LL +     fn from_str(value: &str) -> Result<Self, Self::Err> {
+LL +         Ok(Lifetime4(&()))
+LL +     }
+LL + }
+   |
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/try_from_instead_of_from_str.stderr
+++ b/tests/ui/try_from_instead_of_from_str.stderr
@@ -9,6 +9,7 @@ LL | |     type Error = ();
 LL | | }
    | |_^
    |
+   = help: `FromStr` can also be implemented alongside `TryFrom` if you want to avoid breaking changes
    = note: `-D clippy::try-from-instead-of-from-str` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::try_from_instead_of_from_str)]`
 help: replace with
@@ -33,6 +34,7 @@ LL | |     type Error = &'static str;
 LL | | }
    | |_^
    |
+   = help: `FromStr` can also be implemented alongside `TryFrom` if you want to avoid breaking changes
 help: replace with
    |
 LL + impl core::str::FromStr for Bar {
@@ -55,6 +57,7 @@ LL | |     type Error = &'static str;
 LL | | }
    | |_^
    |
+   = help: `FromStr` can also be implemented alongside `TryFrom` if you want to avoid breaking changes
 help: replace with
    |
 LL + impl<'a> core::str::FromStr for Tarte<'a> {
@@ -76,6 +79,7 @@ LL | |     type Error = LifetimeErr2<for<'b> fn(&'b u32)>;
 LL | | }
    | |_^
    |
+   = help: `FromStr` can also be implemented alongside `TryFrom` if you want to avoid breaking changes
 help: replace with
    |
 LL + impl core::str::FromStr for Lifetime3 {
@@ -97,6 +101,7 @@ LL | |     type Error = LifetimeErr2<&'a ()>;
 LL | | }
    | |_^
    |
+   = help: `FromStr` can also be implemented alongside `TryFrom` if you want to avoid breaking changes
 help: replace with
    |
 LL + impl<'a> core::str::FromStr for Lifetime4<&'a ()> {


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17030)*

Fixes rust-lang/rust-clippy#14522.

One big thing: I'm not sure if the lint name is good, so very much up to debate.

changelog: Add new `try_from_instead_of_from_str` lint