### PR TITLE
Extend extra_unused_lifetimes for spurious for<'a>

### DIFF
--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -9,14 +9,14 @@ use rustc_errors::Applicability;
 use rustc_hir::FnRetTy::Return;
 use rustc_hir::intravisit::nested_filter::{self as hir_nested_filter, NestedFilter};
 use rustc_hir::intravisit::{
-    Visitor, VisitorExt, walk_fn_decl, walk_generic_args, walk_generics, walk_impl_item_ref, walk_param_bound,
-    walk_poly_trait_ref, walk_trait_ref, walk_ty, walk_unambig_ty, walk_where_predicate,
+    Visitor, VisitorExt, walk_fn_decl, walk_generic_args, walk_generic_param, walk_generics, walk_impl_item_ref,
+    walk_param_bound, walk_poly_trait_ref, walk_trait_ref, walk_ty, walk_unambig_ty, walk_where_predicate,
 };
 use rustc_hir::{
     AmbigArg, BodyId, FnDecl, FnPtrTy, FnSig, GenericArg, GenericArgs, GenericBound, GenericParam, GenericParamKind,
     Generics, HirId, Impl, ImplItem, ImplItemKind, Item, ItemKind, Lifetime, LifetimeKind, LifetimeParamKind, Node,
-    PolyTraitRef, PredicateOrigin, TraitFn, TraitItem, TraitItemKind, Ty, TyKind, WhereBoundPredicate, WherePredicate,
-    WherePredicateKind, lang_items,
+    PolyTraitRef, PredicateOrigin, TraitFn, TraitItem, TraitItemKind, TraitRef, Ty, TyKind, WhereBoundPredicate,
+    WherePredicate, WherePredicateKind, lang_items,
 };
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::hir::nested_filter as middle_nested_filter;
@@ -158,6 +158,10 @@ impl<'tcx> LateLintPass<'tcx> for Lifetimes {
         {
             report_extra_impl_lifetimes(cx, impl_);
         }
+    }
+
+    fn check_poly_trait_ref(&mut self, cx: &LateContext<'tcx>, poly_trait_ref: &'tcx PolyTraitRef<'tcx>) {
+        report_extra_trait_object_lifetimes(cx, poly_trait_ref.bound_generic_params, &poly_trait_ref.trait_ref);
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx ImplItem<'_>) {
@@ -587,9 +591,8 @@ impl<'cx, 'tcx, F> LifetimeChecker<'cx, 'tcx, F>
 where
     F: NestedFilter<'tcx>,
 {
-    fn new(cx: &'cx LateContext<'tcx>, generics: &'tcx Generics<'_>) -> LifetimeChecker<'cx, 'tcx, F> {
-        let map = generics
-            .params
+    fn new(cx: &'cx LateContext<'tcx>, generic_params: &'tcx [GenericParam<'_>]) -> LifetimeChecker<'cx, 'tcx, F> {
+        let map = generic_params
             .iter()
             .filter_map(|par| match par.kind {
                 GenericParamKind::Lifetime {
@@ -598,6 +601,7 @@ where
                 _ => None,
             })
             .collect();
+
         Self {
             cx,
             map,
@@ -711,8 +715,36 @@ fn is_candidate_for_elision(fd: &FnDecl<'_>) -> bool {
     }
 }
 
+fn report_extra_trait_object_lifetimes<'tcx>(
+    cx: &LateContext<'tcx>,
+    generic_params: &'tcx [GenericParam<'_>],
+    trait_ref: &'tcx TraitRef<'tcx>,
+) {
+    let mut checker = LifetimeChecker::<hir_nested_filter::None>::new(cx, generic_params);
+
+    for param in generic_params {
+        walk_generic_param(&mut checker, param);
+    }
+
+    walk_trait_ref(&mut checker, trait_ref);
+
+    for (def_id, usages) in checker.map {
+        if usages
+            .iter()
+            .all(|usage| usage.in_where_predicate && !usage.in_bounded_ty && !usage.in_generics_arg)
+        {
+            span_lint(
+                cx,
+                EXTRA_UNUSED_LIFETIMES,
+                cx.tcx.def_span(def_id),
+                "this lifetime isn't used in the type",
+            );
+        }
+    }
+}
+
 fn report_extra_lifetimes<'tcx>(cx: &LateContext<'tcx>, func: &'tcx FnDecl<'_>, generics: &'tcx Generics<'_>) {
-    let mut checker = LifetimeChecker::<hir_nested_filter::None>::new(cx, generics);
+    let mut checker = LifetimeChecker::<hir_nested_filter::None>::new(cx, generics.params);
 
     walk_generics(&mut checker, generics);
     walk_fn_decl(&mut checker, func);
@@ -733,7 +765,7 @@ fn report_extra_lifetimes<'tcx>(cx: &LateContext<'tcx>, func: &'tcx FnDecl<'_>, 
 }
 
 fn report_extra_impl_lifetimes<'tcx>(cx: &LateContext<'tcx>, impl_: &'tcx Impl<'_>) {
-    let mut checker = LifetimeChecker::<middle_nested_filter::All>::new(cx, impl_.generics);
+    let mut checker = LifetimeChecker::<middle_nested_filter::All>::new(cx, impl_.generics.params);
 
     walk_generics(&mut checker, impl_.generics);
     if let Some(of_trait) = impl_.of_trait {

--- a/tests/ui/extra_unused_lifetimes.rs
+++ b/tests/ui/extra_unused_lifetimes.rs
@@ -19,6 +19,39 @@ fn used_lt<'a>(x: &'a u8) {}
 fn unused_lt<'a>(x: u8) {}
 //~^ extra_unused_lifetimes
 
+struct BoxedFoo(Box<dyn for<'a> Fn()>);
+//~^ extra_unused_lifetimes
+
+struct BoxedFooFine(Box<dyn for<'a> Fn(&'a u32)>);
+
+fn unused_for_return() -> impl for<'a> Fn()
+//~^ extra_unused_lifetimes
+{
+    || unimplemented!()
+}
+
+trait SimpleTrait<'a> {}
+
+trait SimplerTrait {}
+
+impl dyn for<'a> SimpleTrait<'a> {}
+
+impl dyn for<'a> SimplerTrait {}
+//~^ extra_unused_lifetimes
+
+impl<T: for<'a> SimpleTrait<'a>> SimplerTrait for T {}
+
+impl<T: for<'a> SimplerTrait> SimpleTrait<'_> for T {}
+//~^ extra_unused_lifetimes
+
+async fn unused_impl_for<F>(body: impl for<'a> FnOnce(u32) -> F)
+//~^ extra_unused_lifetimes
+where
+    F: Future<Output = ()>,
+{
+    unimplemented!()
+}
+
 fn unused_lt_transitive<'a, 'b: 'a>(x: &'b u8) {
     // 'a is useless here since it's not directly bound
 }

--- a/tests/ui/extra_unused_lifetimes.stderr
+++ b/tests/ui/extra_unused_lifetimes.stderr
@@ -7,41 +7,71 @@ LL | fn unused_lt<'a>(x: u8) {}
    = note: `-D clippy::extra-unused-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::extra_unused_lifetimes)]`
 
+error: this lifetime isn't used in the type
+  --> tests/ui/extra_unused_lifetimes.rs:22:29
+   |
+LL | struct BoxedFoo(Box<dyn for<'a> Fn()>);
+   |                             ^^
+
+error: this lifetime isn't used in the type
+  --> tests/ui/extra_unused_lifetimes.rs:27:36
+   |
+LL | fn unused_for_return() -> impl for<'a> Fn()
+   |                                    ^^
+
+error: this lifetime isn't used in the type
+  --> tests/ui/extra_unused_lifetimes.rs:39:14
+   |
+LL | impl dyn for<'a> SimplerTrait {}
+   |              ^^
+
+error: this lifetime isn't used in the type
+  --> tests/ui/extra_unused_lifetimes.rs:44:13
+   |
+LL | impl<T: for<'a> SimplerTrait> SimpleTrait<'_> for T {}
+   |             ^^
+
+error: this lifetime isn't used in the type
+  --> tests/ui/extra_unused_lifetimes.rs:47:44
+   |
+LL | async fn unused_impl_for<F>(body: impl for<'a> FnOnce(u32) -> F)
+   |                                            ^^
+
 error: this lifetime isn't used in the function definition
-  --> tests/ui/extra_unused_lifetimes.rs:47:10
+  --> tests/ui/extra_unused_lifetimes.rs:80:10
    |
 LL |     fn x<'a>(&self) {}
    |          ^^
 
 error: this lifetime isn't used in the function definition
-  --> tests/ui/extra_unused_lifetimes.rs:74:22
+  --> tests/ui/extra_unused_lifetimes.rs:107:22
    |
 LL |         fn unused_lt<'a>(x: u8) {}
    |                      ^^
 
 error: this lifetime isn't used in the impl
-  --> tests/ui/extra_unused_lifetimes.rs:86:10
+  --> tests/ui/extra_unused_lifetimes.rs:119:10
    |
 LL |     impl<'a> std::ops::AddAssign<&Scalar> for &mut Scalar {
    |          ^^
 
 error: this lifetime isn't used in the impl
-  --> tests/ui/extra_unused_lifetimes.rs:93:10
+  --> tests/ui/extra_unused_lifetimes.rs:126:10
    |
 LL |     impl<'b> Scalar {
    |          ^^
 
 error: this lifetime isn't used in the function definition
-  --> tests/ui/extra_unused_lifetimes.rs:95:26
+  --> tests/ui/extra_unused_lifetimes.rs:128:26
    |
 LL |         pub fn something<'c>() -> Self {
    |                          ^^
 
 error: this lifetime isn't used in the impl
-  --> tests/ui/extra_unused_lifetimes.rs:125:10
+  --> tests/ui/extra_unused_lifetimes.rs:158:10
    |
 LL |     impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
    |          ^^
 
-error: aborting due to 7 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
changelog: [`extra_unused_lifetimes`]: Detect unused `for<'a>` lifetime bounds

This fixes rust-lang/rust-clippy#13812 and rust-lang/rust-clippy#14334.

---

This was done as part of the "Crafting errors like rustc" workshop at Rustweek :D

r? @jdonszelmann 