### PR TITLE
Fix `unwrap_or_default` for `vec![]`

### DIFF
--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -182,11 +182,10 @@ fn check_unwrap_or_default(
 
     // needs to target Default::default in particular or be *::new and have a Default impl
     // available
-    if (is_new(fun) && output_type_implements_default(fun))
-        || match call_expr {
-            Some(call_expr) => is_default_equivalent(cx, call_expr),
-            None => is_default_equivalent_call(cx, fun, None) || closure_body_returns_empty_to_string(cx, fun),
-        }
+    if match call_expr {
+        Some(call_expr) => is_default_equivalent(cx, call_expr),
+        None => is_default_equivalent_call(cx, fun, None) || closure_body_returns_empty_to_string(cx, fun),
+    } || (is_new(fun) && output_type_implements_default(fun))
     {
         span_lint_and_sugg(
             cx,

--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -46,8 +46,8 @@ pub(super) fn check<'tcx>(
                     } else {
                         Some(fun.span)
                     };
-                    (!inner_fun_has_args
-                        && !is_nested_expr
+
+                    (!is_nested_expr
                         && check_unwrap_or_default(cx, name, receiver, fun, Some(ex), expr.span, method_span, msrv))
                         || check_or_fn_call(cx, name, method_span, receiver, arg, None, expr.span, fun_span)
                 },

--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -2,7 +2,6 @@ use std::ops::ControlFlow;
 
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::eager_or_lazy::switch_to_lazy_eval;
-use clippy_utils::higher::VecArgs;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
 use clippy_utils::source::snippet_with_context;
@@ -178,12 +177,6 @@ fn check_unwrap_or_default(
         )
     };
     if in_sugg_method_implementation {
-        return false;
-    }
-
-    // `.unwrap_or(vec![])` is as readable as `.unwrap_or_default()`. And if the expression is a
-    // non-empty `Vec`, then it will not be a default value anyway. Bail out in all cases.
-    if call_expr.and_then(|call_expr| VecArgs::hir(cx, call_expr)).is_some() {
         return false;
     }
 

--- a/clippy_lints/src/zero_repeat_side_effects.rs
+++ b/clippy_lints/src/zero_repeat_side_effects.rs
@@ -1,8 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::higher::VecArgs;
+use clippy_utils::is_integer_literal;
 use clippy_utils::source::{snippet, snippet_indent};
-use rustc_ast::LitKind;
-use rustc_data_structures::packed::Pu128;
 use rustc_errors::Applicability;
 use rustc_hir::{ConstArgKind, Expr, ExprKind, LetStmt, LocalSource, Node};
 use rustc_lint::{LateContext, LateLintPass};
@@ -48,8 +47,7 @@ impl LateLintPass<'_> for ZeroRepeatSideEffects {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
         if let Some(args) = VecArgs::hir(cx, expr)
             && let VecArgs::Repeat(inner_expr, len) = args
-            && let ExprKind::Lit(l) = len.kind
-            && let LitKind::Int(Pu128(0), _) = l.node
+            && is_integer_literal(len, 0)
         {
             inner_check(cx, expr, inner_expr, true);
         }
@@ -62,8 +60,7 @@ impl LateLintPass<'_> for ZeroRepeatSideEffects {
             && let ConstArgKind::Anon(anon_const) = const_arg.kind
             && let length_expr = cx.tcx.hir_body(anon_const.body).value
             && !length_expr.span.from_expansion()
-            && let ExprKind::Lit(literal) = length_expr.kind
-            && let LitKind::Int(Pu128(0), _) = literal.node
+            && is_integer_literal(length_expr, 0)
         {
             inner_check(cx, expr, inner_expr, false);
         }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -124,7 +124,9 @@ use crate::consts::{ConstEvalCtxt, Constant};
 use crate::higher::{Range, VecArgs};
 use crate::msrvs::Msrv;
 use crate::res::{MaybeDef, MaybeQPath, MaybeResPath};
-use crate::ty::{adt_and_variant_of_res, can_partially_move_ty, expr_sig, is_copy, is_recursively_primitive_type};
+use crate::ty::{
+    adt_and_variant_of_res, can_partially_move_ty, expr_sig, implements_trait, is_copy, is_recursively_primitive_type,
+};
 use crate::visitors::for_each_expr_without_closures;
 
 /// Methods on `Vec` that also exists on slices.
@@ -667,8 +669,13 @@ pub fn is_default_equivalent(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
                 return exprs.is_empty();
             },
             VecArgs::Repeat(expr, len) => {
-                // TODO: check `vec![x (impl Copy); 0]`
-                return false;
+                let implements_clone = cx.tcx.get_diagnostic_item(sym::Copy).is_some_and(|copy_trait_id| {
+                    let expr_ty = cx.typeck_results().expr_ty(expr);
+                    implements_trait(cx, expr_ty, copy_trait_id, &[])
+                });
+                if implements_clone {
+                    return is_integer_literal(len, 0);
+                }
             },
         }
     }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -121,7 +121,7 @@ use visitors::{Visitable, for_each_unconsumed_temporary};
 
 use crate::ast_utils::unordered_over;
 use crate::consts::{ConstEvalCtxt, Constant};
-use crate::higher::Range;
+use crate::higher::{Range, VecArgs};
 use crate::msrvs::Msrv;
 use crate::res::{MaybeDef, MaybeQPath, MaybeResPath};
 use crate::ty::{adt_and_variant_of_res, can_partially_move_ty, expr_sig, is_copy, is_recursively_primitive_type};
@@ -661,6 +661,18 @@ pub fn is_default_equivalent_call(
 ///
 /// It doesn't cover all cases, like struct literals, but it is a close approximation.
 pub fn is_default_equivalent(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
+    if let Some(vec_args) = VecArgs::hir(cx, e) {
+        match vec_args {
+            VecArgs::Vec(exprs) => {
+                return exprs.is_empty();
+            },
+            VecArgs::Repeat(expr, len) => {
+                // TODO: check `vec![x (impl Copy); 0]`
+                return false;
+            },
+        }
+    }
+
     match &e.kind {
         ExprKind::Lit(lit) => match lit.node {
             LitKind::Bool(false) | LitKind::Int(Pu128(0), _) => true,

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -35,6 +35,20 @@ fn or_fun_call() {
         }
     }
 
+    struct NewWithDefault;
+
+    impl NewWithDefault {
+        fn new() -> Self {
+            NewWithDefault
+        }
+    }
+
+    impl Default for NewWithDefault {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     enum Enum {
         A(i32),
     }
@@ -99,6 +113,14 @@ fn or_fun_call() {
 
     let real_default = None::<FakeDefault>;
     real_default.unwrap_or_default();
+    //~^ unwrap_or_default
+
+    let self_new = None::<NewWithDefault>;
+    self_new.unwrap_or_default();
+    //~^ unwrap_or_default
+
+    let self_else_new = None::<NewWithDefault>;
+    self_else_new.unwrap_or_default();
     //~^ unwrap_or_default
 
     let with_vec: Option<Vec<i32>> = Some(vec![1]);

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -35,6 +35,20 @@ fn or_fun_call() {
         }
     }
 
+    struct NewWithDefault;
+
+    impl NewWithDefault {
+        fn new() -> Self {
+            NewWithDefault
+        }
+    }
+
+    impl Default for NewWithDefault {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     enum Enum {
         A(i32),
     }
@@ -99,6 +113,14 @@ fn or_fun_call() {
 
     let real_default = None::<FakeDefault>;
     real_default.unwrap_or(<FakeDefault as Default>::default());
+    //~^ unwrap_or_default
+
+    let self_new = None::<NewWithDefault>;
+    self_new.unwrap_or(<NewWithDefault>::new());
+    //~^ unwrap_or_default
+
+    let self_else_new = None::<NewWithDefault>;
+    self_else_new.unwrap_or_else(<NewWithDefault>::new);
     //~^ unwrap_or_default
 
     let with_vec: Option<Vec<i32>> = Some(vec![1]);

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -1,5 +1,5 @@
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:53:22
+  --> tests/ui/or_fun_call.rs:67:22
    |
 LL |     with_constructor.unwrap_or(make());
    |                      ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(make)`
@@ -8,7 +8,7 @@ LL |     with_constructor.unwrap_or(make());
    = help: to override `-D warnings` add `#[allow(clippy::or_fun_call)]`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:57:14
+  --> tests/ui/or_fun_call.rs:71:14
    |
 LL |     with_new.unwrap_or(Vec::new());
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
@@ -17,205 +17,217 @@ LL |     with_new.unwrap_or(Vec::new());
    = help: to override `-D warnings` add `#[allow(clippy::unwrap_or_default)]`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:61:21
+  --> tests/ui/or_fun_call.rs:75:21
    |
 LL |     with_const_args.unwrap_or(Vec::with_capacity(12));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Vec::with_capacity(12))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:65:14
+  --> tests/ui/or_fun_call.rs:79:14
    |
 LL |     with_err.unwrap_or(make());
    |              ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| make())`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:69:19
+  --> tests/ui/or_fun_call.rs:83:19
    |
 LL |     with_err_args.unwrap_or(Vec::with_capacity(12));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:73:24
+  --> tests/ui/or_fun_call.rs:87:24
    |
 LL |     with_default_trait.unwrap_or(Default::default());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:77:23
+  --> tests/ui/or_fun_call.rs:91:23
    |
 LL |     with_default_type.unwrap_or(u64::default());
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:97:18
+  --> tests/ui/or_fun_call.rs:111:18
    |
 LL |     self_default.unwrap_or(<FakeDefault>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(<FakeDefault>::default)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:101:18
+  --> tests/ui/or_fun_call.rs:115:18
    |
 LL |     real_default.unwrap_or(<FakeDefault as Default>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:105:14
+  --> tests/ui/or_fun_call.rs:119:14
+   |
+LL |     self_new.unwrap_or(<NewWithDefault>::new());
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
+
+error: use of `unwrap_or_else` to construct default value
+  --> tests/ui/or_fun_call.rs:123:19
+   |
+LL |     self_else_new.unwrap_or_else(<NewWithDefault>::new);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
+
+error: use of `unwrap_or` to construct default value
+  --> tests/ui/or_fun_call.rs:127:14
    |
 LL |     with_vec.unwrap_or(Vec::new());
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:109:21
+  --> tests/ui/or_fun_call.rs:131:21
    |
 LL |     without_default.unwrap_or(Foo::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(Foo::new)`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:113:19
+  --> tests/ui/or_fun_call.rs:135:19
    |
 LL |     map.entry(42).or_insert(String::new());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:117:23
+  --> tests/ui/or_fun_call.rs:139:23
    |
 LL |     map_vec.entry(42).or_insert(Vec::new());
    |                       ^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:121:21
+  --> tests/ui/or_fun_call.rs:143:21
    |
 LL |     btree.entry(42).or_insert(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> tests/ui/or_fun_call.rs:125:25
+  --> tests/ui/or_fun_call.rs:147:25
    |
 LL |     btree_vec.entry(42).or_insert(Vec::new());
    |                         ^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:129:21
+  --> tests/ui/or_fun_call.rs:151:21
    |
 LL |     let _ = stringy.unwrap_or(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `ok_or`
-  --> tests/ui/or_fun_call.rs:134:17
+  --> tests/ui/or_fun_call.rs:156:17
    |
 LL |     let _ = opt.ok_or(format!("{} world.", hello));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ok_or_else(|| format!("{} world.", hello))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:139:21
+  --> tests/ui/or_fun_call.rs:161:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:142:21
+  --> tests/ui/or_fun_call.rs:164:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: function call inside of `or`
-  --> tests/ui/or_fun_call.rs:167:35
+  --> tests/ui/or_fun_call.rs:189:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_else(|| Some("b".to_string()))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:210:18
+  --> tests/ui/or_fun_call.rs:232:18
    |
 LL |             None.unwrap_or(ptr_to_ref(s));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:218:14
+  --> tests/ui/or_fun_call.rs:240:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:221:14
+  --> tests/ui/or_fun_call.rs:243:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:297:25
+  --> tests/ui/or_fun_call.rs:319:25
    |
 LL |         let _ = Some(4).map_or(g(), |v| v);
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(g, |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:299:25
+  --> tests/ui/or_fun_call.rs:321:25
    |
 LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:302:25
+  --> tests/ui/or_fun_call.rs:324:25
    |
 LL |         let _ = Some(4).map_or("asd".to_string().len() as i32, f);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| "asd".to_string().len() as i32, f)`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:333:18
+  --> tests/ui/or_fun_call.rs:355:18
    |
 LL |         with_new.unwrap_or_else(Vec::new);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:337:28
+  --> tests/ui/or_fun_call.rs:359:28
    |
 LL |         with_default_trait.unwrap_or_else(Default::default);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:341:27
+  --> tests/ui/or_fun_call.rs:363:27
    |
 LL |         with_default_type.unwrap_or_else(u64::default);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:345:22
+  --> tests/ui/or_fun_call.rs:367:22
    |
 LL |         real_default.unwrap_or_else(<FakeDefault as Default>::default);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:349:23
+  --> tests/ui/or_fun_call.rs:371:23
    |
 LL |         map.entry(42).or_insert_with(String::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/or_fun_call.rs:353:25
+  --> tests/ui/or_fun_call.rs:375:25
    |
 LL |         btree.entry(42).or_insert_with(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/or_fun_call.rs:357:25
+  --> tests/ui/or_fun_call.rs:379:25
    |
 LL |         let _ = stringy.unwrap_or_else(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:399:17
+  --> tests/ui/or_fun_call.rs:421:17
    |
 LL |     let _ = opt.unwrap_or({ f() }); // suggest `.unwrap_or_else(f)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(f)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:404:17
+  --> tests/ui/or_fun_call.rs:426:17
    |
 LL |     let _ = opt.unwrap_or(f() + 1); // suggest `.unwrap_or_else(|| f() + 1)`
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| f() + 1)`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:409:17
+  --> tests/ui/or_fun_call.rs:431:17
    |
 LL |       let _ = opt.unwrap_or({
    |  _________________^
@@ -235,82 +247,82 @@ LL ~     });
    |
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:415:17
+  --> tests/ui/or_fun_call.rs:437:17
    |
 LL |     let _ = opt.map_or(f() + 1, |v| v); // suggest `.map_or_else(|| f() + 1, |v| v)`
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|| f() + 1, |v| v)`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:420:17
+  --> tests/ui/or_fun_call.rs:442:17
    |
 LL |     let _ = opt.unwrap_or({ i32::default() });
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:427:21
+  --> tests/ui/or_fun_call.rs:449:21
    |
 LL |     let _ = opt_foo.unwrap_or(Foo { val: String::default() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Foo { val: String::default() })`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:442:19
+  --> tests/ui/or_fun_call.rs:464:19
    |
 LL |         let _ = x.map_or(g(), |v| v);
    |                   ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|_| g(), |v| v)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:444:19
+  --> tests/ui/or_fun_call.rs:466:19
    |
 LL |         let _ = x.map_or(g(), f);
    |                   ^^^^^^^^^^^^^^ help: try: `map_or_else(|_| g(), f)`
 
 error: function call inside of `map_or`
-  --> tests/ui/or_fun_call.rs:447:19
+  --> tests/ui/or_fun_call.rs:469:19
    |
 LL |         let _ = x.map_or("asd".to_string().len() as i32, f);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(|_| "asd".to_string().len() as i32, f)`
 
 error: function call inside of `get_or_insert`
-  --> tests/ui/or_fun_call.rs:458:15
+  --> tests/ui/or_fun_call.rs:480:15
    |
 LL |     let _ = x.get_or_insert(g());
    |               ^^^^^^^^^^^^^^^^^^ help: try: `get_or_insert_with(g)`
 
 error: function call inside of `and`
-  --> tests/ui/or_fun_call.rs:468:15
+  --> tests/ui/or_fun_call.rs:490:15
    |
 LL |     let _ = x.and(g());
    |               ^^^^^^^^ help: try: `and_then(|_| g())`
 
 error: function call inside of `and`
-  --> tests/ui/or_fun_call.rs:478:15
+  --> tests/ui/or_fun_call.rs:500:15
    |
 LL |     let _ = x.and(g());
    |               ^^^^^^^^ help: try: `and_then(|_| g())`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:484:17
+  --> tests/ui/or_fun_call.rs:506:17
    |
 LL |     let _ = opt.unwrap_or(Default::default());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: function call inside of `unwrap_or`
-  --> tests/ui/or_fun_call.rs:486:17
+  --> tests/ui/or_fun_call.rs:508:17
    |
 LL |     let _ = res.unwrap_or(Default::default());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| Default::default())`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:492:17
+  --> tests/ui/or_fun_call.rs:514:17
    |
 LL |     let _ = opt.unwrap_or(Default::default());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> tests/ui/or_fun_call.rs:494:17
+  --> tests/ui/or_fun_call.rs:516:17
    |
 LL |     let _ = res.unwrap_or(Default::default());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
-error: aborting due to 49 previous errors
+error: aborting due to 51 previous errors
 

--- a/tests/ui/unwrap_or_else_default.fixed
+++ b/tests/ui/unwrap_or_else_default.fixed
@@ -79,6 +79,17 @@ fn unwrap_or_else_default() {
     with_empty_vec_macro.unwrap_or_default();
     //~^ unwrap_or_default
 
+    let with_zero_repeat_copy_vec_macro: Option<Vec<u64>> = None;
+    with_zero_repeat_copy_vec_macro.unwrap_or_default();
+    //~^ unwrap_or_default
+
+    let with_zero_repeat_clone_vec_macro: Option<Vec<Box<u64>>> = None;
+    with_zero_repeat_clone_vec_macro.unwrap_or({
+        Box::new(123);
+        vec![] as std::vec::Vec<std::boxed::Box<u64>>
+    });
+    //~^ zero_repeat_side_effects
+
     let empty_string = None::<String>;
     empty_string.unwrap_or_default();
     //~^ unwrap_or_default

--- a/tests/ui/unwrap_or_else_default.fixed
+++ b/tests/ui/unwrap_or_else_default.fixed
@@ -72,6 +72,13 @@ fn unwrap_or_else_default() {
     with_default_type.unwrap_or_default();
     //~^ unwrap_or_default
 
+    let with_nonempty_vec_macro: Option<Vec<u64>> = None;
+    with_nonempty_vec_macro.unwrap_or(vec![1]);
+
+    let with_empty_vec_macro: Option<Vec<u64>> = None;
+    with_empty_vec_macro.unwrap_or_default();
+    //~^ unwrap_or_default
+
     let empty_string = None::<String>;
     empty_string.unwrap_or_default();
     //~^ unwrap_or_default

--- a/tests/ui/unwrap_or_else_default.rs
+++ b/tests/ui/unwrap_or_else_default.rs
@@ -72,6 +72,13 @@ fn unwrap_or_else_default() {
     with_default_type.unwrap_or_else(Vec::new);
     //~^ unwrap_or_default
 
+    let with_nonempty_vec_macro: Option<Vec<u64>> = None;
+    with_nonempty_vec_macro.unwrap_or(vec![1]);
+
+    let with_empty_vec_macro: Option<Vec<u64>> = None;
+    with_empty_vec_macro.unwrap_or(vec![]);
+    //~^ unwrap_or_default
+
     let empty_string = None::<String>;
     empty_string.unwrap_or_else(|| "".to_string());
     //~^ unwrap_or_default

--- a/tests/ui/unwrap_or_else_default.rs
+++ b/tests/ui/unwrap_or_else_default.rs
@@ -79,6 +79,14 @@ fn unwrap_or_else_default() {
     with_empty_vec_macro.unwrap_or(vec![]);
     //~^ unwrap_or_default
 
+    let with_zero_repeat_copy_vec_macro: Option<Vec<u64>> = None;
+    with_zero_repeat_copy_vec_macro.unwrap_or(vec![123; 0]);
+    //~^ unwrap_or_default
+
+    let with_zero_repeat_clone_vec_macro: Option<Vec<Box<u64>>> = None;
+    with_zero_repeat_clone_vec_macro.unwrap_or(vec![Box::new(123); 0]);
+    //~^ zero_repeat_side_effects
+
     let empty_string = None::<String>;
     empty_string.unwrap_or_else(|| "".to_string());
     //~^ unwrap_or_default

--- a/tests/ui/unwrap_or_else_default.stderr
+++ b/tests/ui/unwrap_or_else_default.stderr
@@ -31,23 +31,33 @@ error: use of `unwrap_or` to construct default value
 LL |     with_empty_vec_macro.unwrap_or(vec![]);
    |                          ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
+error: use of `unwrap_or` to construct default value
+  --> tests/ui/unwrap_or_else_default.rs:83:37
+   |
+LL |     with_zero_repeat_copy_vec_macro.unwrap_or(vec![123; 0]);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
+
+error: expression with side effects as the initial value in a zero-sized array initializer
+  --> tests/ui/unwrap_or_else_default.rs:87:48
+   |
+LL |     with_zero_repeat_clone_vec_macro.unwrap_or(vec![Box::new(123); 0]);
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::zero-repeat-side-effects` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::zero_repeat_side_effects)]`
+help: consider performing the side effect separately
+   |
+LL ~     with_zero_repeat_clone_vec_macro.unwrap_or({
+LL +         Box::new(123);
+LL +         vec![] as std::vec::Vec<std::boxed::Box<u64>>
+LL ~     });
+   |
+
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:83:18
+  --> tests/ui/unwrap_or_else_default.rs:91:18
    |
 LL |     empty_string.unwrap_or_else(|| "".to_string());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
-
-error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:88:12
-   |
-LL |     option.unwrap_or_else(Vec::new).push(1);
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
-
-error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:92:12
-   |
-LL |     option.unwrap_or_else(Vec::new).push(1);
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
   --> tests/ui/unwrap_or_else_default.rs:96:12
@@ -86,16 +96,28 @@ LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:133:12
+  --> tests/ui/unwrap_or_else_default.rs:120:12
+   |
+LL |     option.unwrap_or_else(Vec::new).push(1);
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
+
+error: use of `unwrap_or_else` to construct default value
+  --> tests/ui/unwrap_or_else_default.rs:124:12
+   |
+LL |     option.unwrap_or_else(Vec::new).push(1);
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
+
+error: use of `unwrap_or_else` to construct default value
+  --> tests/ui/unwrap_or_else_default.rs:141:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:151:32
+  --> tests/ui/unwrap_or_else_default.rs:159:32
    |
 LL |     let _ = inner_map.entry(0).or_insert_with(Default::default);
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
-error: aborting due to 16 previous errors
+error: aborting due to 18 previous errors
 

--- a/tests/ui/unwrap_or_else_default.stderr
+++ b/tests/ui/unwrap_or_else_default.stderr
@@ -25,71 +25,77 @@ error: use of `unwrap_or_else` to construct default value
 LL |     with_default_type.unwrap_or_else(Vec::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
+error: use of `unwrap_or` to construct default value
+  --> tests/ui/unwrap_or_else_default.rs:79:26
+   |
+LL |     with_empty_vec_macro.unwrap_or(vec![]);
+   |                          ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
+
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:76:18
+  --> tests/ui/unwrap_or_else_default.rs:83:18
    |
 LL |     empty_string.unwrap_or_else(|| "".to_string());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:81:12
+  --> tests/ui/unwrap_or_else_default.rs:88:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:85:12
+  --> tests/ui/unwrap_or_else_default.rs:92:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:89:12
+  --> tests/ui/unwrap_or_else_default.rs:96:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:93:12
+  --> tests/ui/unwrap_or_else_default.rs:100:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:97:12
+  --> tests/ui/unwrap_or_else_default.rs:104:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:101:12
+  --> tests/ui/unwrap_or_else_default.rs:108:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:105:12
+  --> tests/ui/unwrap_or_else_default.rs:112:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:109:12
+  --> tests/ui/unwrap_or_else_default.rs:116:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:126:12
+  --> tests/ui/unwrap_or_else_default.rs:133:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> tests/ui/unwrap_or_else_default.rs:144:32
+  --> tests/ui/unwrap_or_else_default.rs:151:32
    |
 LL |     let _ = inner_map.entry(0).or_insert_with(Default::default);
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
-error: aborting due to 15 previous errors
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17032)*

changelog: [`unwrap_or_default`]: fix for `vec![]`, suggestion for `vec![x; 0]` if x impls Copy

fixes: rust-lang/rust-clippy#16432

---

This was a part of the workshop "Crafting errors like rustc" by @jdonszelmann and @estebank at RustWeek 2026.