### PR TITLE
Document MSRV-dependent lint behavior

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -123,7 +123,11 @@ fn main() {
 You can also omit the patch version when specifying the MSRV, so `msrv = 1.30`
 is equivalent to `msrv = 1.30.0`.
 
-Note: `custom_inner_attributes` is an unstable feature, so it has to be enabled explicitly.
+> **Note:** Some lints change their behavior depending on the configured MSRV.
+> In some cases, Clippy may suppress a lint entirely to avoid suggesting APIs or syntax unavailable for the configured MSRV.
+> In other cases, Clippy may emit the lint but choose an older compatible suggestion.
+
+> **Note:** `custom_inner_attributes` is an unstable feature, so it has to be enabled explicitly.
 
 Lints that recognize this configuration option can be
 found [here](https://rust-lang.github.io/rust-clippy/master/index.html#msrv)


### PR DESCRIPTION
Closes rust-lang/rust-clippy#8693

This adds a short user-facing note explaining that some lints may adjust their behavior based on the configured MSRV.

The issue originally discussed per-lint MSRV behavior documentation, but based on the maintenance concerns raised in the discussion, this PR keeps the change limited to the general configuration documentation.

Validation:
- `mdbook build book`
- `git diff --check -- book/src/configuration.md`

r? @ada4a