### PR TITLE
Document MSRV-dependent lint behavior

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -123,7 +123,13 @@ fn main() {
 You can also omit the patch version when specifying the MSRV, so `msrv = 1.30`
 is equivalent to `msrv = 1.30.0`.
 
-Note: `custom_inner_attributes` is an unstable feature, so it has to be enabled explicitly.
+> **Note:** Some lints change their behavior depending on the configured MSRV.
+> In some cases, Clippy may suppress a lint entirely to avoid suggesting APIs or
+> syntax unavailable for the configured MSRV.
+> In other cases, Clippy may emit the lint but choose an older compatible suggestion.
+
+> **Note:** `custom_inner_attributes` is an unstable feature, so it has to be
+> enabled explicitly.
 
 Lints that recognize this configuration option can be
 found [here](https://rust-lang.github.io/rust-clippy/master/index.html#msrv)


### PR DESCRIPTION
Address rust-lang/rust-clippy#8693

This updates the MSRV configuration documentation by adding a short note that some lints may change behavior based on the configured MSRV.

It also formats the existing `custom_inner_attributes` note in the same section as a mdBook note block.

Validation:
- `mdbook build book`
- `git diff --check -- book/src/configuration.md`

changelog: Document that lints may change behavior based on the configured MSRV.

r? @ada4a 