### PR TITLE
Fix error message for useless_borrows_in_formatting for mutable borrows

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use rustc_ast::FormatTrait::{Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex};
 use rustc_ast::{
     BorrowKind, FormatArgPosition, FormatArgPositionKind, FormatArgsPiece, FormatArgumentKind, FormatCount,
-    FormatOptions, FormatPlaceholder,
+    FormatOptions, FormatPlaceholder, Mutability,
 };
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::Applicability;
@@ -451,6 +451,10 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
     }
 
     fn check_useless_borrows_in_formatting(&self, placeholder: &FormatPlaceholder, arg_expr: &Expr<'tcx>) {
+        // Updated while peeling:
+        let mut only_mutable = true;
+        let mut has_mutable = false;
+
         if !arg_expr.span.from_expansion()
             && !is_from_proc_macro(self.cx, arg_expr)
             && let Some(fmt_trait) = match placeholder.format_trait {
@@ -461,11 +465,13 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
             && let Some(sized_trait) = self.cx.tcx.lang_items().sized_trait()
             && let peeled_expr = peel_hir_expr_while(arg_expr, |e| {
                 // Need to handle `&&&T` to `&T` when a single ref is still required
-                if let ExprKind::AddrOf(BorrowKind::Ref, _, e) = e.kind
+                if let ExprKind::AddrOf(BorrowKind::Ref, m, e) = e.kind
                     && let ty = self.cx.typeck_results().expr_ty(e)
                     && implements_trait(self.cx, ty, sized_trait, &[])
                     && implements_trait(self.cx, ty, fmt_trait, &[])
                 {
+                    only_mutable = only_mutable && m == Mutability::Mut;
+                    has_mutable = has_mutable || m == Mutability::Mut;
                     Some(e)
                 } else {
                     None
@@ -475,12 +481,19 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
             && let Some(peeled_snippet) = snippet_opt(self.cx, peeled_expr.span)
         {
             let name = self.cx.tcx.item_name(self.macro_call.def_id);
+            let message = if only_mutable {
+                "remove the redundant `&mut`"
+            } else if has_mutable {
+                "remove the redundant `&`/`&mut`"
+            } else {
+                "remove the redundant `&`"
+            };
             span_lint_and_sugg(
                 self.cx,
                 USELESS_BORROWS_IN_FORMATTING,
                 arg_expr.span,
                 format!("redundant reference in `{name}!` argument"),
-                "remove the redundant `&`",
+                message,
                 peeled_snippet,
                 Applicability::MachineApplicable,
             );

--- a/tests/ui/useless_borrows_in_formatting.fixed
+++ b/tests/ui/useless_borrows_in_formatting.fixed
@@ -5,9 +5,12 @@
 #![allow(unused, clippy::useless_format)]
 
 fn main() {
-    let s: &str = "hello";
+    let mut s: &str = "hello";
     println!("{}", s); //~ useless_borrows_in_formatting
     println!("{:?}", s); //~ useless_borrows_in_formatting
+    println!("{}", s); //~ useless_borrows_in_formatting
+    println!("{}", s); //~ useless_borrows_in_formatting
+    println!("{}", s); //~ useless_borrows_in_formatting
     println!("{}", s); //~ useless_borrows_in_formatting
 
     let string = String::from("world");

--- a/tests/ui/useless_borrows_in_formatting.rs
+++ b/tests/ui/useless_borrows_in_formatting.rs
@@ -5,10 +5,13 @@
 #![allow(unused, clippy::useless_format)]
 
 fn main() {
-    let s: &str = "hello";
+    let mut s: &str = "hello";
     println!("{}", &s); //~ useless_borrows_in_formatting
     println!("{:?}", &s); //~ useless_borrows_in_formatting
     println!("{}", &&s); //~ useless_borrows_in_formatting
+    println!("{}", &&mut s); //~ useless_borrows_in_formatting
+    println!("{}", &mut &s); //~ useless_borrows_in_formatting
+    println!("{}", &mut s); //~ useless_borrows_in_formatting
 
     let string = String::from("world");
     println!("{}", &string); //~ useless_borrows_in_formatting

--- a/tests/ui/useless_borrows_in_formatting.stderr
+++ b/tests/ui/useless_borrows_in_formatting.stderr
@@ -20,73 +20,91 @@ LL |     println!("{}", &&s);
    |                    ^^^ help: remove the redundant `&`: `s`
 
 error: redundant reference in `println!` argument
+  --> tests/ui/useless_borrows_in_formatting.rs:12:20
+   |
+LL |     println!("{}", &&mut s);
+   |                    ^^^^^^^ help: remove the redundant `&`/`&mut`: `s`
+
+error: redundant reference in `println!` argument
+  --> tests/ui/useless_borrows_in_formatting.rs:13:20
+   |
+LL |     println!("{}", &mut &s);
+   |                    ^^^^^^^ help: remove the redundant `&`/`&mut`: `s`
+
+error: redundant reference in `println!` argument
   --> tests/ui/useless_borrows_in_formatting.rs:14:20
+   |
+LL |     println!("{}", &mut s);
+   |                    ^^^^^^ help: remove the redundant `&mut`: `s`
+
+error: redundant reference in `println!` argument
+  --> tests/ui/useless_borrows_in_formatting.rs:17:20
    |
 LL |     println!("{}", &string);
    |                    ^^^^^^^ help: remove the redundant `&`: `string`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:15:22
+  --> tests/ui/useless_borrows_in_formatting.rs:18:22
    |
 LL |     println!("{:?}", &string);
    |                      ^^^^^^^ help: remove the redundant `&`: `string`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:16:20
+  --> tests/ui/useless_borrows_in_formatting.rs:19:20
    |
 LL |     println!("{}", &&string);
    |                    ^^^^^^^^ help: remove the redundant `&`: `string`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:17:20
+  --> tests/ui/useless_borrows_in_formatting.rs:20:20
    |
 LL |     println!("{}", &&string[..2]);
    |                    ^^^^^^^^^^^^^ help: remove the redundant `&`: `&string[..2]`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:18:22
+  --> tests/ui/useless_borrows_in_formatting.rs:21:22
    |
 LL |     println!("{:?}", &&string[..2]);
    |                      ^^^^^^^^^^^^^ help: remove the redundant `&`: `&string[..2]`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:24:20
+  --> tests/ui/useless_borrows_in_formatting.rs:27:20
    |
 LL |     println!("{}", &n);
    |                    ^^ help: remove the redundant `&`: `n`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:25:22
+  --> tests/ui/useless_borrows_in_formatting.rs:28:22
    |
 LL |     println!("{:?}", &n);
    |                      ^^ help: remove the redundant `&`: `n`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:26:20
+  --> tests/ui/useless_borrows_in_formatting.rs:29:20
    |
 LL |     println!("{}", &&n);
    |                    ^^^ help: remove the redundant `&`: `n`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:30:20
+  --> tests/ui/useless_borrows_in_formatting.rs:33:20
    |
 LL |     println!("{}", &slice[0]);
    |                    ^^^^^^^^^ help: remove the redundant `&`: `slice[0]`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:31:22
+  --> tests/ui/useless_borrows_in_formatting.rs:34:22
    |
 LL |     println!("{:?}", &slice[0]);
    |                      ^^^^^^^^^ help: remove the redundant `&`: `slice[0]`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:32:20
+  --> tests/ui/useless_borrows_in_formatting.rs:35:20
    |
 LL |     println!("{}", &&slice[0]);
    |                    ^^^^^^^^^^ help: remove the redundant `&`: `slice[0]`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:37:9
+  --> tests/ui/useless_borrows_in_formatting.rs:40:9
    |
 LL | /         &[
 LL | |
@@ -107,160 +125,160 @@ LL +         ]
    |
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:45:22
+  --> tests/ui/useless_borrows_in_formatting.rs:48:22
    |
 LL |     println!("{:?}", &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:49:26
+  --> tests/ui/useless_borrows_in_formatting.rs:52:26
    |
 LL |     println!("{:016x?}", &[a[0], a[1], a[0], a[1]]);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `[a[0], a[1], a[0], a[1]]`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:53:22
+  --> tests/ui/useless_borrows_in_formatting.rs:56:22
    |
 LL |     println!("{:?}", &&slice[0..1]);
    |                      ^^^^^^^^^^^^^ help: remove the redundant `&`: `&slice[0..1]`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:62:20
+  --> tests/ui/useless_borrows_in_formatting.rs:65:20
    |
 LL |     println!("{}", &w.0);
    |                    ^^^^ help: remove the redundant `&`: `w.0`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:63:22
+  --> tests/ui/useless_borrows_in_formatting.rs:66:22
    |
 LL |     println!("{:?}", &w.0);
    |                      ^^^^ help: remove the redundant `&`: `w.0`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:64:20
+  --> tests/ui/useless_borrows_in_formatting.rs:67:20
    |
 LL |     println!("{}", &&w.0);
    |                    ^^^^^ help: remove the redundant `&`: `w.0`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:69:20
+  --> tests/ui/useless_borrows_in_formatting.rs:72:20
    |
 LL |     println!("{}", &w.0);
    |                    ^^^^ help: remove the redundant `&`: `w.0`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:70:22
+  --> tests/ui/useless_borrows_in_formatting.rs:73:22
    |
 LL |     println!("{:?}", &w.0);
    |                      ^^^^ help: remove the redundant `&`: `w.0`
-
-error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:71:20
-   |
-LL |     println!("{}", &&w.0);
-   |                    ^^^^^ help: remove the redundant `&`: `w.0`
 
 error: redundant reference in `println!` argument
   --> tests/ui/useless_borrows_in_formatting.rs:74:20
+   |
+LL |     println!("{}", &&w.0);
+   |                    ^^^^^ help: remove the redundant `&`: `w.0`
+
+error: redundant reference in `println!` argument
+  --> tests/ui/useless_borrows_in_formatting.rs:77:20
    |
 LL |     println!("{}", &*a);
    |                    ^^^ help: remove the redundant `&`: `*a`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:75:22
+  --> tests/ui/useless_borrows_in_formatting.rs:78:22
    |
 LL |     println!("{:?}", &*a);
    |                      ^^^ help: remove the redundant `&`: `*a`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:79:20
+  --> tests/ui/useless_borrows_in_formatting.rs:82:20
    |
 LL |     println!("{}", &(n));
    |                    ^^^^ help: remove the redundant `&`: `(n)`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:80:22
+  --> tests/ui/useless_borrows_in_formatting.rs:83:22
    |
 LL |     println!("{:?}", &(n + 1));
    |                      ^^^^^^^^ help: remove the redundant `&`: `(n + 1)`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:81:20
+  --> tests/ui/useless_borrows_in_formatting.rs:84:20
    |
 LL |     println!("{}", &(String::from("paren")));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `(String::from("paren"))`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:84:20
+  --> tests/ui/useless_borrows_in_formatting.rs:87:20
    |
 LL |     println!("{}", &{ n });
    |                    ^^^^^^ help: remove the redundant `&`: `{ n }`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:85:22
+  --> tests/ui/useless_borrows_in_formatting.rs:88:22
    |
 LL |     println!("{:?}", &{ n + 1 });
    |                      ^^^^^^^^^^ help: remove the redundant `&`: `{ n + 1 }`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:86:20
+  --> tests/ui/useless_borrows_in_formatting.rs:89:20
    |
 LL |     println!("{}", &{ String::from("block") });
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `{ String::from("block") }`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:91:27
+  --> tests/ui/useless_borrows_in_formatting.rs:94:27
    |
 LL |     println!("{0:1$.2$}", &v1, &v2, &v3);
    |                           ^^^ help: remove the redundant `&`: `v1`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:91:32
+  --> tests/ui/useless_borrows_in_formatting.rs:94:32
    |
 LL |     println!("{0:1$.2$}", &v1, &v2, &v3);
    |                                ^^^ help: remove the redundant `&`: `v2`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:91:37
+  --> tests/ui/useless_borrows_in_formatting.rs:94:37
    |
 LL |     println!("{0:1$.2$}", &v1, &v2, &v3);
    |                                     ^^^ help: remove the redundant `&`: `v3`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:95:28
+  --> tests/ui/useless_borrows_in_formatting.rs:98:28
    |
 LL |     println!("{0:1$.2$?}", &v1, &v2, &v3);
    |                            ^^^ help: remove the redundant `&`: `v1`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:95:33
+  --> tests/ui/useless_borrows_in_formatting.rs:98:33
    |
 LL |     println!("{0:1$.2$?}", &v1, &v2, &v3);
    |                                 ^^^ help: remove the redundant `&`: `v2`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:95:38
+  --> tests/ui/useless_borrows_in_formatting.rs:98:38
    |
 LL |     println!("{0:1$.2$?}", &v1, &v2, &v3);
    |                                      ^^^ help: remove the redundant `&`: `v3`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:99:27
+  --> tests/ui/useless_borrows_in_formatting.rs:102:27
    |
 LL |     println!("{0:1$.2$}", &v1, v2, v3);
    |                           ^^^ help: remove the redundant `&`: `v1`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:100:31
+  --> tests/ui/useless_borrows_in_formatting.rs:103:31
    |
 LL |     println!("{0:1$.2$}", v1, &v2, v3);
    |                               ^^^ help: remove the redundant `&`: `v2`
 
 error: redundant reference in `println!` argument
-  --> tests/ui/useless_borrows_in_formatting.rs:101:35
+  --> tests/ui/useless_borrows_in_formatting.rs:104:35
    |
 LL |     println!("{0:1$.2$}", v1, v2, &v3);
    |                                   ^^^ help: remove the redundant `&`: `v3`
 
-error: aborting due to 41 previous errors
+error: aborting due to 44 previous errors
 


### PR DESCRIPTION
changelog: [`useless_borrows_in_formatting`]: If `&mut` references, or mixed `&`/`&mut` references get passed to formatting, the error now acknowledges that instead of only mentioning `&`s
