### PR TITLE
Add manual_isolate_lowest_one lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6906,6 +6906,7 @@ Released 2018-09-13
 [`manual_is_multiple_of`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
 [`manual_is_power_of_two`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_power_of_two
 [`manual_is_variant_and`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_variant_and
+[`manual_isolate_lowest_one`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_isolate_lowest_one
 [`manual_let_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else
 [`manual_main_separator_str`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_main_separator_str
 [`manual_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_map

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -925,6 +925,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`manual_hash_one`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_hash_one)
 * [`manual_is_ascii_check`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_ascii_check)
 * [`manual_is_power_of_two`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_power_of_two)
+* [`manual_isolate_lowest_one`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_isolate_lowest_one)
 * [`manual_let_else`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else)
 * [`manual_midpoint`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_midpoint)
 * [`manual_non_exhaustive`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -786,6 +786,7 @@ define_Conf! {
         manual_hash_one,
         manual_is_ascii_check,
         manual_is_power_of_two,
+        manual_isolate_lowest_one,
         manual_let_else,
         manual_midpoint,
         manual_non_exhaustive,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -612,6 +612,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::operators::INVALID_UPCAST_COMPARISONS_INFO,
     crate::operators::MANUAL_DIV_CEIL_INFO,
     crate::operators::MANUAL_IS_MULTIPLE_OF_INFO,
+    crate::operators::MANUAL_ISOLATE_LOWEST_ONE_INFO,
     crate::operators::MANUAL_MIDPOINT_INFO,
     crate::operators::MISREFACTORED_ASSIGN_OP_INFO,
     crate::operators::MODULO_ARITHMETIC_INFO,

--- a/clippy_lints/src/operators/manual_isolate_lowest_one.rs
+++ b/clippy_lints/src/operators/manual_isolate_lowest_one.rs
@@ -1,0 +1,167 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::res::MaybeResPath;
+use clippy_utils::sugg::Sugg;
+use clippy_utils::sym;
+use rustc_ast::BinOpKind;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, UnOp};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+use rustc_span::Span;
+
+use super::MANUAL_ISOLATE_LOWEST_ONE;
+
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    op: BinOpKind,
+    lhs: &'tcx Expr<'tcx>,
+    rhs: &'tcx Expr<'tcx>,
+    msrv: Msrv,
+) {
+    if op != BinOpKind::BitAnd || expr.span.from_expansion() || lhs.span.from_expansion() || rhs.span.from_expansion() {
+        return;
+    }
+
+    // x & x.wrapping_neg()
+    if let Some(base) = matching_wrapping_neg(lhs, rhs)
+        // x.wrapping_neg() & x
+        .or_else(|| matching_wrapping_neg(rhs, lhs))
+        && is_primitive_int(cx, base)
+    {
+        maybe_emit_lint(cx, expr.span, base, msrv, false);
+    } else if let Some(base) = matching_neg(lhs, rhs)
+        // x & -x or -x & x
+        .or_else(|| matching_neg(rhs, lhs))
+        && is_signed_int(cx, base)
+    {
+        maybe_emit_lint(cx, expr.span, base, msrv, false);
+    } else if let Some(base) = matching_nonzero_wrapping_neg(lhs, rhs)
+        // nz.get() & nz.get().wrapping_neg() or reversed
+        .or_else(|| matching_nonzero_wrapping_neg(rhs, lhs))
+        && is_nonzero_int(cx, base)
+    {
+        maybe_emit_lint(cx, expr.span, base, msrv, true);
+    } else if let Some(base) = matching_nonzero_neg(lhs, rhs)
+        // nz.get() & -nz.get() or reversed
+        .or_else(|| matching_nonzero_neg(rhs, lhs))
+        && is_nonzero_signed_int(cx, base)
+    {
+        maybe_emit_lint(cx, expr.span, base, msrv, true);
+    }
+}
+
+fn maybe_emit_lint(cx: &LateContext<'_>, span: Span, base: &Expr<'_>, msrv: Msrv, add_get: bool) {
+    if !msrv.meets(cx, msrvs::ISOLATE_LOWEST_ONE) {
+        return;
+    }
+
+    let mut applicability = Applicability::MachineApplicable;
+    let snippet = Sugg::hir_with_applicability(cx, base, "_", &mut applicability);
+    let get = if add_get { ".get()" } else { "" };
+
+    span_lint_and_sugg(
+        cx,
+        MANUAL_ISOLATE_LOWEST_ONE,
+        span,
+        "manual implementation of `isolate_lowest_one`",
+        "consider using `.isolate_lowest_one()`",
+        format!("{}.isolate_lowest_one(){get}", snippet.maybe_paren()),
+        applicability,
+    );
+}
+
+fn matching_wrapping_neg<'tcx>(base: &'tcx Expr<'tcx>, negated: &Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    let receiver = wrapping_neg_receiver(negated)?;
+    is_same_local_path(base, receiver).then_some(base)
+}
+
+fn matching_neg<'tcx>(base: &'tcx Expr<'tcx>, negated: &Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    if let ExprKind::Unary(UnOp::Neg, inner) = negated.kind
+        && is_same_local_path(base, inner)
+    {
+        Some(base)
+    } else {
+        None
+    }
+}
+
+fn matching_nonzero_wrapping_neg<'tcx>(base_get: &'tcx Expr<'tcx>, negated: &Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    let base = get_receiver(base_get)?;
+    let receiver = wrapping_neg_receiver(negated)?;
+    let negated_base = get_receiver(receiver)?;
+    is_same_local_path(base, negated_base).then_some(base)
+}
+
+fn matching_nonzero_neg<'tcx>(base_get: &'tcx Expr<'tcx>, negated: &Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    let base = get_receiver(base_get)?;
+    if let ExprKind::Unary(UnOp::Neg, inner) = negated.kind {
+        let negated_base = get_receiver(inner)?;
+        is_same_local_path(base, negated_base).then_some(base)
+    } else {
+        None
+    }
+}
+
+fn wrapping_neg_receiver<'tcx>(expr: &Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    if let ExprKind::MethodCall(method_name, receiver, [], _) = expr.kind
+        && method_name.ident.name == sym::wrapping_neg
+    {
+        Some(receiver)
+    } else {
+        None
+    }
+}
+
+fn get_receiver<'tcx>(expr: &Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    if let ExprKind::MethodCall(method_name, receiver, [], _) = expr.kind
+        && method_name.ident.name == sym::get
+        && is_local_path(receiver)
+    {
+        Some(receiver)
+    } else {
+        None
+    }
+}
+
+fn is_same_local_path(left: &Expr<'_>, right: &Expr<'_>) -> bool {
+    !left.span.from_expansion()
+        && !right.span.from_expansion()
+        && matches!((left.res_local_id(), right.res_local_id()), (Some(left), Some(right)) if left == right)
+}
+
+fn is_local_path(expr: &Expr<'_>) -> bool {
+    expr.res_local_id().is_some()
+}
+
+fn is_primitive_int(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    matches!(
+        cx.typeck_results().expr_ty_adjusted(expr).kind(),
+        ty::Int(_) | ty::Uint(_)
+    )
+}
+
+fn is_signed_int(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    matches!(cx.typeck_results().expr_ty_adjusted(expr).kind(), ty::Int(_))
+}
+
+fn is_nonzero_int(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    if let ty::Adt(adt, args) = cx.typeck_results().expr_ty_adjusted(expr).kind()
+        && cx.tcx.is_diagnostic_item(sym::NonZero, adt.did())
+    {
+        matches!(args.type_at(0).kind(), ty::Int(_) | ty::Uint(_))
+    } else {
+        false
+    }
+}
+
+fn is_nonzero_signed_int(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    if let ty::Adt(adt, args) = cx.typeck_results().expr_ty_adjusted(expr).kind()
+        && cx.tcx.is_diagnostic_item(sym::NonZero, adt.did())
+    {
+        matches!(args.type_at(0).kind(), ty::Int(_))
+    } else {
+        false
+    }
+}

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -16,6 +16,7 @@ mod integer_division_remainder_used;
 mod invalid_upcast_comparisons;
 mod manual_div_ceil;
 mod manual_is_multiple_of;
+mod manual_isolate_lowest_one;
 mod manual_midpoint;
 mod misrefactored_assign_op;
 mod modulo_arithmetic;
@@ -724,6 +725,30 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for manual implementations of isolating the lowest set bit.
+    ///
+    /// ### Why is this bad?
+    /// The manual bit-twiddling forms are harder to read than the standard library method.
+    /// Using `-x` can also overflow for signed minimum values.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let x: u32 = 5;
+    /// let lsb = x & x.wrapping_neg();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let x: u32 = 5;
+    /// let lsb = x.isolate_lowest_one();
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub MANUAL_ISOLATE_LOWEST_ONE,
+    complexity,
+    "manual implementation of `isolate_lowest_one`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for manual implementation of `midpoint`.
     ///
     /// ### Why is this bad?
@@ -980,6 +1005,7 @@ impl_lint_pass!(Operators => [
     INTEGER_DIVISION_REMAINDER_USED,
     INVALID_UPCAST_COMPARISONS,
     MANUAL_DIV_CEIL,
+    MANUAL_ISOLATE_LOWEST_ONE,
     MANUAL_IS_MULTIPLE_OF,
     MANUAL_MIDPOINT,
     MISREFACTORED_ASSIGN_OP,
@@ -1027,6 +1053,7 @@ impl<'tcx> LateLintPass<'tcx> for Operators {
                     needless_bitwise_bool::check(cx, e, op.node, lhs, rhs);
                     manual_midpoint::check(cx, e, op.node, lhs, rhs, self.msrv);
                     manual_is_multiple_of::check(cx, e, op.node, lhs, rhs, self.msrv);
+                    manual_isolate_lowest_one::check(cx, e, op.node, lhs, rhs, self.msrv);
                     decimal_bitwise_operands::check(cx, op.node, lhs, rhs);
                 }
                 self.arithmetic_context.check_binary(cx, e, op.node, lhs, rhs);

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -23,6 +23,7 @@ macro_rules! msrv_aliases {
 
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
+    1,97,0 { ISOLATE_LOWEST_ONE }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }
     1,91,0 { DURATION_FROM_MINUTES_HOURS }
     1,88,0 { LET_CHAINS }

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -648,6 +648,7 @@ generate! {
     warnings,
     wildcard_imports,
     with_capacity,
+    wrapping_neg,
     wrapping_offset,
     write,
     write_unaligned,

--- a/tests/ui/manual_isolate_lowest_one.fixed
+++ b/tests/ui/manual_isolate_lowest_one.fixed
@@ -1,0 +1,92 @@
+#![warn(clippy::manual_isolate_lowest_one)]
+
+use std::num::NonZero;
+
+fn main() {
+    let x_u32: u32 = 5;
+    let _ = x_u32.isolate_lowest_one();
+    //~^ manual_isolate_lowest_one
+
+    let x_i32: i32 = 5;
+    let _ = x_i32.isolate_lowest_one();
+    //~^ manual_isolate_lowest_one
+
+    let x_u64: u64 = 5;
+    let _ = x_u64.isolate_lowest_one();
+    //~^ manual_isolate_lowest_one
+
+    let x_i64: i64 = 5;
+    let _ = x_i64.isolate_lowest_one();
+    //~^ manual_isolate_lowest_one
+
+    let nz_u32 = NonZero::<u32>::new(5).unwrap();
+    let _ = nz_u32.isolate_lowest_one().get();
+    //~^ manual_isolate_lowest_one
+    let _ = nz_u32.isolate_lowest_one().get();
+    //~^ manual_isolate_lowest_one
+
+    let nz_i32 = NonZero::<i32>::new(5).unwrap();
+    let _ = nz_i32.isolate_lowest_one().get();
+    //~^ manual_isolate_lowest_one
+    let _ = nz_i32.isolate_lowest_one().get();
+    //~^ manual_isolate_lowest_one
+
+    let other: u32 = 6;
+    let _ = x_u32 & other.wrapping_neg();
+    let _ = x_u32 | x_u32.wrapping_neg();
+    let _ = x_u32 & x_u32.wrapping_sub(1);
+    let _ = next_u32() & next_u32().wrapping_neg();
+
+    let values = [x_u32];
+    let _ = values[0] & values[0].wrapping_neg();
+    let _ = x_u32.count_ones() & x_u32.count_ones().wrapping_neg();
+    let other_nz = NonZero::<u32>::new(6).unwrap();
+    let _ = nz_u32.get() & other_nz.get().wrapping_neg();
+    let _ = next_nonzero_u32().get() & next_nonzero_u32().get().wrapping_neg();
+
+    macro_rules! x_u32_from_macro {
+        () => {
+            x_u32
+        };
+    }
+    macro_rules! wrapping_neg_from_macro {
+        () => {
+            x_u32.wrapping_neg()
+        };
+    }
+    macro_rules! bitand_wrapping_neg_from_macro {
+        () => {
+            x_u32 & x_u32.wrapping_neg()
+        };
+    }
+    macro_rules! neg_i32_from_macro {
+        () => {
+            -x_i32
+        };
+    }
+
+    let _ = x_u32_from_macro!() & x_u32.wrapping_neg();
+    let _ = x_u32 & wrapping_neg_from_macro!();
+    let _ = bitand_wrapping_neg_from_macro!();
+    let _ = x_i32 & neg_i32_from_macro!();
+    let _ = neg_i32_from_macro!() & x_i32;
+}
+
+#[clippy::msrv = "1.96"]
+fn older_msrv(x: u32) {
+    let _ = x & x.wrapping_neg();
+}
+
+#[clippy::msrv = "1.97"]
+fn meets_msrv(x: u32) {
+    let _ = x.isolate_lowest_one();
+    //~^ manual_isolate_lowest_one
+}
+
+fn next_u32() -> u32 {
+    5
+}
+
+fn next_nonzero_u32() -> NonZero<u32> {
+    NonZero::new(5).unwrap()
+}

--- a/tests/ui/manual_isolate_lowest_one.rs
+++ b/tests/ui/manual_isolate_lowest_one.rs
@@ -1,0 +1,92 @@
+#![warn(clippy::manual_isolate_lowest_one)]
+
+use std::num::NonZero;
+
+fn main() {
+    let x_u32: u32 = 5;
+    let _ = x_u32 & x_u32.wrapping_neg();
+    //~^ manual_isolate_lowest_one
+
+    let x_i32: i32 = 5;
+    let _ = x_i32 & -x_i32;
+    //~^ manual_isolate_lowest_one
+
+    let x_u64: u64 = 5;
+    let _ = x_u64.wrapping_neg() & x_u64;
+    //~^ manual_isolate_lowest_one
+
+    let x_i64: i64 = 5;
+    let _ = -x_i64 & x_i64;
+    //~^ manual_isolate_lowest_one
+
+    let nz_u32 = NonZero::<u32>::new(5).unwrap();
+    let _ = nz_u32.get() & nz_u32.get().wrapping_neg();
+    //~^ manual_isolate_lowest_one
+    let _ = nz_u32.get().wrapping_neg() & nz_u32.get();
+    //~^ manual_isolate_lowest_one
+
+    let nz_i32 = NonZero::<i32>::new(5).unwrap();
+    let _ = nz_i32.get() & -nz_i32.get();
+    //~^ manual_isolate_lowest_one
+    let _ = -nz_i32.get() & nz_i32.get();
+    //~^ manual_isolate_lowest_one
+
+    let other: u32 = 6;
+    let _ = x_u32 & other.wrapping_neg();
+    let _ = x_u32 | x_u32.wrapping_neg();
+    let _ = x_u32 & x_u32.wrapping_sub(1);
+    let _ = next_u32() & next_u32().wrapping_neg();
+
+    let values = [x_u32];
+    let _ = values[0] & values[0].wrapping_neg();
+    let _ = x_u32.count_ones() & x_u32.count_ones().wrapping_neg();
+    let other_nz = NonZero::<u32>::new(6).unwrap();
+    let _ = nz_u32.get() & other_nz.get().wrapping_neg();
+    let _ = next_nonzero_u32().get() & next_nonzero_u32().get().wrapping_neg();
+
+    macro_rules! x_u32_from_macro {
+        () => {
+            x_u32
+        };
+    }
+    macro_rules! wrapping_neg_from_macro {
+        () => {
+            x_u32.wrapping_neg()
+        };
+    }
+    macro_rules! bitand_wrapping_neg_from_macro {
+        () => {
+            x_u32 & x_u32.wrapping_neg()
+        };
+    }
+    macro_rules! neg_i32_from_macro {
+        () => {
+            -x_i32
+        };
+    }
+
+    let _ = x_u32_from_macro!() & x_u32.wrapping_neg();
+    let _ = x_u32 & wrapping_neg_from_macro!();
+    let _ = bitand_wrapping_neg_from_macro!();
+    let _ = x_i32 & neg_i32_from_macro!();
+    let _ = neg_i32_from_macro!() & x_i32;
+}
+
+#[clippy::msrv = "1.96"]
+fn older_msrv(x: u32) {
+    let _ = x & x.wrapping_neg();
+}
+
+#[clippy::msrv = "1.97"]
+fn meets_msrv(x: u32) {
+    let _ = x & x.wrapping_neg();
+    //~^ manual_isolate_lowest_one
+}
+
+fn next_u32() -> u32 {
+    5
+}
+
+fn next_nonzero_u32() -> NonZero<u32> {
+    NonZero::new(5).unwrap()
+}

--- a/tests/ui/manual_isolate_lowest_one.stderr
+++ b/tests/ui/manual_isolate_lowest_one.stderr
@@ -1,0 +1,59 @@
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:7:13
+   |
+LL |     let _ = x_u32 & x_u32.wrapping_neg();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `x_u32.isolate_lowest_one()`
+   |
+   = note: `-D clippy::manual-isolate-lowest-one` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_isolate_lowest_one)]`
+
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:11:13
+   |
+LL |     let _ = x_i32 & -x_i32;
+   |             ^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `x_i32.isolate_lowest_one()`
+
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:15:13
+   |
+LL |     let _ = x_u64.wrapping_neg() & x_u64;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `x_u64.isolate_lowest_one()`
+
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:19:13
+   |
+LL |     let _ = -x_i64 & x_i64;
+   |             ^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `x_i64.isolate_lowest_one()`
+
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:23:13
+   |
+LL |     let _ = nz_u32.get() & nz_u32.get().wrapping_neg();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `nz_u32.isolate_lowest_one().get()`
+
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:25:13
+   |
+LL |     let _ = nz_u32.get().wrapping_neg() & nz_u32.get();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `nz_u32.isolate_lowest_one().get()`
+
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:29:13
+   |
+LL |     let _ = nz_i32.get() & -nz_i32.get();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `nz_i32.isolate_lowest_one().get()`
+
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:31:13
+   |
+LL |     let _ = -nz_i32.get() & nz_i32.get();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `nz_i32.isolate_lowest_one().get()`
+
+error: manual implementation of `isolate_lowest_one`
+  --> tests/ui/manual_isolate_lowest_one.rs:82:13
+   |
+LL |     let _ = x & x.wrapping_neg();
+   |             ^^^^^^^^^^^^^^^^^^^^ help: consider using `.isolate_lowest_one()`: `x.isolate_lowest_one()`
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17037)*

changelog: new lint: [`manual_isolate_lowest_one`]

Adds a new `manual_isolate_lowest_one` lint for manual lowest-set-bit isolation patterns that can be written with `.isolate_lowest_one()`.

This detects simple local expressions in the following forms:

- `x & x.wrapping_neg()`
- `x.wrapping_neg() & x`
- `x & -x` for signed integers
- `-x & x` for signed integers
- `nz.get() & nz.get().wrapping_neg()` for `NonZero<T>` integer locals
- `nz.get() & -nz.get()` for signed `NonZero<T>` integer locals

The implementation intentionally limits suggestions to simple local paths so rustfix does not change evaluation count for non-trivial expressions. For `NonZero<T>::get()` forms, the suggestion preserves the original primitive result type by using `nz.isolate_lowest_one().get()`.

Validation:

- `cargo fmt`
- `cargo check -p clippy_lints`
- `TESTNAME=manual_isolate_lowest_one cargo uitest`
- `cargo dev fmt --check`
- `git diff --check`

Note: `cargo test --test dogfood` was attempted locally but hit the existing Windows `tikv_jemalloc_sys` crate resolution issue before reaching a PR-specific failure. The focused lint UI test and `clippy_lints` check pass.
