### PR TITLE
Apply safety comment to compound assignment statement

### DIFF
--- a/clippy_lints/src/undocumented_unsafe_blocks.rs
+++ b/clippy_lints/src/undocumented_unsafe_blocks.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 use clippy_config::Conf;
 use clippy_utils::consts::const_item_rhs_to_expr;
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::is_lint_allowed;
 use clippy_utils::source::walk_span_to_context;
 use clippy_utils::visitors::{Descend, for_each_expr};
+use clippy_utils::{higher, is_lint_allowed};
 use hir::HirId;
 use rustc_errors::Applicability;
 use rustc_hir::{self as hir, Block, BlockCheckMode, FnSig, Impl, ItemKind, Node, UnsafeSource};
@@ -172,6 +172,9 @@ impl<'tcx> LateLintPass<'tcx> for UndocumentedUnsafeBlocks {
         else {
             return;
         };
+        // Compound assignments are expanded into a safe block, but the safety
+        // comment apply to the undesugared assignment nevertheless.
+        let expr = higher::CompoundAssignment::hir(expr).map_or(expr, |c| c.init);
         if !is_lint_allowed(cx, UNNECESSARY_SAFETY_COMMENT, stmt.hir_id)
             && !stmt.span.in_external_macro(cx.tcx.sess.source_map())
             && let HasSafetyComment::Yes(pos, _) =

--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -7,8 +7,10 @@ use crate::res::MaybeDef;
 use crate::{is_expn_of, sym};
 
 use rustc_ast::ast;
-use rustc_hir as hir;
-use rustc_hir::{Arm, Block, Expr, ExprKind, HirId, LoopSource, MatchSource, Node, Pat, QPath, StructTailExpr};
+use rustc_hir::{
+    self as hir, Arm, Block, Expr, ExprKind, HirId, LetStmt, LocalSource, LoopSource, MatchSource, Node, Pat, QPath,
+    StructTailExpr,
+};
 use rustc_lint::LateContext;
 use rustc_span::{Span, symbol};
 
@@ -409,6 +411,54 @@ impl<'hir> WhileLet<'hir> {
             });
         }
         None
+    }
+}
+
+/// A desugared compound assignment statement, such as in
+/// `(a, b) = expr`.
+pub struct CompoundAssignment<'hir> {
+    /// The individual assignees
+    pub assignees: Vec<&'hir Expr<'hir>>,
+    /// The initializatiojn expression
+    pub init: &'hir Expr<'hir>,
+}
+
+impl<'hir> CompoundAssignment<'hir> {
+    /// Check if `expr` is a block which is an expansion of a compound assignment.
+    #[inline]
+    pub fn hir(expr: &'hir Expr<'_>) -> Option<Self> {
+        // A compound assignment is unsugared into a block which first assigns the RHS subexpressions to
+        // temporaries, then moves those temporaries to the assignment targets. By doing it this
+        // way, and since the moves cannot fail, the compound assignment either succeeds or not take
+        // place at all if, for example, one of the RHS subcomponent diverges.
+        if let ExprKind::Block(
+            Block {
+                stmts: [assign, rest @ ..],
+                expr: None,
+                ..
+            },
+            None,
+        ) = expr.kind
+            && let hir::StmtKind::Let(LetStmt {
+                init: Some(init),
+                source: LocalSource::AssignDesugar,
+                ..
+            }) = assign.kind
+        {
+            let mut assignees = Vec::with_capacity(rest.len());
+            for stmt in rest {
+                if let hir::StmtKind::Expr(expr) = stmt.kind
+                    && let ExprKind::Assign(target, _, _) = expr.kind
+                {
+                    assignees.push(target);
+                } else {
+                    return None;
+                }
+            }
+            Some(CompoundAssignment { assignees, init })
+        } else {
+            None
+        }
     }
 }
 

--- a/tests/ui/unnecessary_safety_comment.rs
+++ b/tests/ui/unnecessary_safety_comment.rs
@@ -110,3 +110,12 @@ mod issue16553 {
     //! ```
     mod blah {}
 }
+
+fn issue17039() {
+    let mut data = [1u8, 2, 3, 4];
+    let mut slice = data.as_mut_slice();
+
+    let parent;
+    // SAFETY: length is within bounds
+    (parent, slice) = unsafe { slice.split_at_mut_unchecked(slice.len() / 2) };
+}


### PR DESCRIPTION
changelog: [`unnecessary_safety_comment`]: handle compound assignments

Fixes rust-lang/rust-clippy#17039 