### PR TITLE
fix `unfulfilled_lint_expectations` incorrectly triggered by `#[expect(clippy::let_and_return)]`

### DIFF
--- a/clippy_lints/src/returns/let_and_return.rs
+++ b/clippy_lints/src/returns/let_and_return.rs
@@ -7,7 +7,7 @@ use clippy_utils::{binary_expr_needs_parentheses, fn_def_id, span_contains_non_w
 use core::ops::ControlFlow;
 use rustc_errors::Applicability;
 use rustc_hir::{Block, Expr, PatKind, StmtKind};
-use rustc_lint::{LateContext, LintContext};
+use rustc_lint::{LateContext, Level, LintContext};
 use rustc_middle::ty::GenericArgKind;
 use rustc_span::edition::Edition;
 
@@ -28,7 +28,16 @@ pub(super) fn check_block<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'_>) 
         && !initexpr.span.in_external_macro(cx.sess().source_map())
         && !retexpr.span.in_external_macro(cx.sess().source_map())
         && !local.span.from_expansion()
-        && !span_contains_non_whitespace(cx, stmt.span.between(retexpr.span), false)
+        // If the return expression has lint-level attributes,
+        // skip the non whitespace check.
+        // Non-lint attrs like `#[cfg]` should still block.
+        && {
+            let retexpr_attrs = cx.tcx.hir_attrs(retexpr.hir_id);
+            retexpr_attrs
+            .iter()
+            .any(|a| a.name().is_some_and(|name| Level::from_symbol(name).is_some()))
+                || !span_contains_non_whitespace(cx, stmt.span.between(retexpr.span), false)
+        }
     {
         span_lint_hir_and_then(
             cx,

--- a/clippy_lints/src/returns/let_and_return.rs
+++ b/clippy_lints/src/returns/let_and_return.rs
@@ -6,8 +6,8 @@ use clippy_utils::visitors::for_each_expr;
 use clippy_utils::{binary_expr_needs_parentheses, fn_def_id, span_contains_non_whitespace};
 use core::ops::ControlFlow;
 use rustc_errors::Applicability;
-use rustc_hir::{Block, Expr, PatKind, StmtKind};
-use rustc_lint::{LateContext, LintContext as _};
+use rustc_hir::{Block, Expr, PatKind, Stmt, StmtKind};
+use rustc_lint::{LateContext, Level, LintContext as _};
 use rustc_middle::ty::GenericArgKind;
 use rustc_span::edition::Edition;
 
@@ -28,7 +28,7 @@ pub(super) fn check_block<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'_>) 
         && !initexpr.span.in_external_macro(cx.sess().source_map())
         && !retexpr.span.in_external_macro(cx.sess().source_map())
         && !local.span.from_expansion()
-        && !span_contains_non_whitespace(cx, stmt.span.between(retexpr.span), false)
+        && has_lint_attrs_or_only_whitespace_between(cx, retexpr, stmt)
     {
         span_lint_hir_and_then(
             cx,
@@ -85,4 +85,17 @@ fn last_statement_borrows<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) 
         }
     })
     .is_some()
+}
+
+/// Returns true if the return expression has lint-level attributes,
+/// or if there is only whitespace between `let` and return expression.
+/// Non-lint attrs like `#[cfg]` should still block.
+fn has_lint_attrs_or_only_whitespace_between(cx: &LateContext<'_>, retexpr: &Expr<'_>, stmt: &Stmt<'_>) -> bool {
+    // TODO: Turn into find_attr! when lint level attr parsing is done.
+    let retexpr_attrs = cx.tcx.hir_attrs(retexpr.hir_id);
+
+    retexpr_attrs
+        .iter()
+        .any(|a| a.name().is_some_and(|name| Level::from_symbol(name).is_some()))
+        || !span_contains_non_whitespace(cx, stmt.span.between(retexpr.span), false)
 }

--- a/tests/ui/let_and_return.edition2021.fixed
+++ b/tests/ui/let_and_return.edition2021.fixed
@@ -278,6 +278,24 @@ fn has_comment() -> Vec<usize> {
     v
 }
 
+mod issue16451 {
+
+    fn expect_on_return_expr() -> std::collections::BTreeMap<(), ()> {
+        let stuff = std::collections::BTreeMap::new();
+
+        // TODO: Fill `stuff`
+
+        #[expect(clippy::let_and_return)]
+        stuff
+    }
+
+    fn cfg_on_return_expr() -> i32 {
+        let x = 5;
+        #[cfg(debug_assertions)]
+        x
+    }
+}
+
 fn wrongly_unmangled_macros() -> i32 {
     let x = 1;
     macro_rules! plus_one {

--- a/tests/ui/let_and_return.edition2021.stderr
+++ b/tests/ui/let_and_return.edition2021.stderr
@@ -149,7 +149,7 @@ LL ~             ({ true } || { false } && { 2 <= 3 })
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:290:5
+  --> tests/ui/let_and_return.rs:308:5
    |
 LL |     let y = plus_one!(x);
    |     --------------------- unnecessary `let` binding

--- a/tests/ui/let_and_return.edition2024.fixed
+++ b/tests/ui/let_and_return.edition2024.fixed
@@ -278,6 +278,24 @@ fn has_comment() -> Vec<usize> {
     v
 }
 
+mod issue16451 {
+
+    fn expect_on_return_expr() -> std::collections::BTreeMap<(), ()> {
+        let stuff = std::collections::BTreeMap::new();
+
+        // TODO: Fill `stuff`
+
+        #[expect(clippy::let_and_return)]
+        stuff
+    }
+
+    fn cfg_on_return_expr() -> i32 {
+        let x = 5;
+        #[cfg(debug_assertions)]
+        x
+    }
+}
+
 fn wrongly_unmangled_macros() -> i32 {
     let x = 1;
     macro_rules! plus_one {

--- a/tests/ui/let_and_return.edition2024.stderr
+++ b/tests/ui/let_and_return.edition2024.stderr
@@ -225,7 +225,7 @@ LL +     }?
    |
 
 error: returning the result of a `let` binding from a block
-  --> tests/ui/let_and_return.rs:290:5
+  --> tests/ui/let_and_return.rs:308:5
    |
 LL |     let y = plus_one!(x);
    |     --------------------- unnecessary `let` binding

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -278,6 +278,24 @@ fn has_comment() -> Vec<usize> {
     v
 }
 
+mod issue16451 {
+
+    fn expect_on_return_expr() -> std::collections::BTreeMap<(), ()> {
+        let stuff = std::collections::BTreeMap::new();
+
+        // TODO: Fill `stuff`
+
+        #[expect(clippy::let_and_return)]
+        stuff
+    }
+
+    fn cfg_on_return_expr() -> i32 {
+        let x = 5;
+        #[cfg(debug_assertions)]
+        x
+    }
+}
+
 fn wrongly_unmangled_macros() -> i32 {
     let x = 1;
     macro_rules! plus_one {


### PR DESCRIPTION
fixes rust-lang/rust-clippy#16451 

when return expression has lint level attributes, skip the non whitespace check and let the lint fire normally so `#[expect]` can fulfil it.

changelog: [`let_and_return`]: fix `#[expect]` on return expression causing spurious `unfulfilled_lint_expectations`