### PR TITLE
Cleanup/error messages

### DIFF
--- a/tests/ui-toml/impl_trait_in_params/impl_trait_in_params.rs
+++ b/tests/ui-toml/impl_trait_in_params/impl_trait_in_params.rs
@@ -11,6 +11,6 @@ trait Private {
 }
 
 pub trait Public {
-    fn t(_: impl Trait); //~ ERROR: `impl Trait` used as a function parameter
+    fn t(_: impl Trait); //~ impl_trait_in_params
     fn tt<T: Trait>(_: T);
 }

--- a/tests/ui/double_ended_iterator_last.fixed
+++ b/tests/ui/double_ended_iterator_last.fixed
@@ -2,7 +2,7 @@
 
 // Typical case
 pub fn last_arg(s: &str) -> Option<&str> {
-    s.split(' ').next_back() //~ ERROR: called `Iterator::last` on a `DoubleEndedIterator`
+    s.split(' ').next_back() //~ double_ended_iterator_last
 }
 
 fn main() {
@@ -19,7 +19,7 @@ fn main() {
             Some(())
         }
     }
-    let _ = DeIterator.next_back(); //~ ERROR: called `Iterator::last` on a `DoubleEndedIterator`
+    let _ = DeIterator.next_back(); //~ double_ended_iterator_last
     // Should not apply to other methods of Iterator
     let _ = DeIterator.count();
 

--- a/tests/ui/double_ended_iterator_last.rs
+++ b/tests/ui/double_ended_iterator_last.rs
@@ -2,7 +2,7 @@
 
 // Typical case
 pub fn last_arg(s: &str) -> Option<&str> {
-    s.split(' ').last() //~ ERROR: called `Iterator::last` on a `DoubleEndedIterator`
+    s.split(' ').last() //~ double_ended_iterator_last
 }
 
 fn main() {
@@ -19,7 +19,7 @@ fn main() {
             Some(())
         }
     }
-    let _ = DeIterator.last(); //~ ERROR: called `Iterator::last` on a `DoubleEndedIterator`
+    let _ = DeIterator.last(); //~ double_ended_iterator_last
     // Should not apply to other methods of Iterator
     let _ = DeIterator.count();
 

--- a/tests/ui/duplicated_attributes.rs
+++ b/tests/ui/duplicated_attributes.rs
@@ -1,9 +1,9 @@
 //@aux-build:proc_macro_attr.rs
-#![warn(clippy::duplicated_attributes, clippy::duplicated_attributes)] //~ ERROR: duplicated attribute
+#![warn(clippy::duplicated_attributes, clippy::duplicated_attributes)] //~ duplicated_attributes
 #![feature(rustc_attrs)]
 #![cfg(any(unix, windows))]
 #![allow(dead_code)]
-#![allow(dead_code)] //~ ERROR: duplicated attribute
+#![allow(dead_code)] //~ duplicated_attributes
 #![cfg(any(unix, windows))] // Should not warn!
 
 #[macro_use]
@@ -11,7 +11,7 @@ extern crate proc_macro_attr;
 
 #[cfg(any(unix, windows, target_os = "linux"))]
 #[allow(dead_code)]
-#[allow(dead_code)] //~ ERROR: duplicated attribute
+#[allow(dead_code)] //~ duplicated_attributes
 #[cfg(any(unix, windows, target_os = "linux"))] // Should not warn!
 fn foo() {}
 

--- a/tests/ui/empty_enum_variants_with_brackets.fixed
+++ b/tests/ui/empty_enum_variants_with_brackets.fixed
@@ -93,7 +93,7 @@ enum TestEnumWithFeatures {
 enum Foo {
     Variant1(i32),
     Variant2,
-    Variant3, //~ ERROR: enum variant has empty brackets
+    Variant3, //~ empty_enum_variants_with_brackets
 }
 
 #[derive(Clone)]

--- a/tests/ui/empty_enum_variants_with_brackets.rs
+++ b/tests/ui/empty_enum_variants_with_brackets.rs
@@ -93,7 +93,7 @@ enum TestEnumWithFeatures {
 enum Foo {
     Variant1(i32),
     Variant2,
-    Variant3(), //~ ERROR: enum variant has empty brackets
+    Variant3(), //~ empty_enum_variants_with_brackets
 }
 
 #[derive(Clone)]

--- a/tests/ui/ignored_unit_patterns.fixed
+++ b/tests/ui/ignored_unit_patterns.fixed
@@ -13,8 +13,8 @@ fn foo() -> Result<(), ()> {
 
 fn main() {
     match foo() {
-        Ok(()) => {},  //~ ERROR: matching over `()` is more explicit
-        Err(()) => {}, //~ ERROR: matching over `()` is more explicit
+        Ok(()) => {},  //~ ignored_unit_patterns
+        Err(()) => {}, //~ ignored_unit_patterns
     }
     if let Ok(()) = foo() {}
     //~^ ERROR: matching over `()` is more explicit

--- a/tests/ui/ignored_unit_patterns.rs
+++ b/tests/ui/ignored_unit_patterns.rs
@@ -13,8 +13,8 @@ fn foo() -> Result<(), ()> {
 
 fn main() {
     match foo() {
-        Ok(_) => {},  //~ ERROR: matching over `()` is more explicit
-        Err(_) => {}, //~ ERROR: matching over `()` is more explicit
+        Ok(_) => {},  //~ ignored_unit_patterns
+        Err(_) => {}, //~ ignored_unit_patterns
     }
     if let Ok(_) = foo() {}
     //~^ ERROR: matching over `()` is more explicit

--- a/tests/ui/manual_midpoint.fixed
+++ b/tests/ui/manual_midpoint.fixed
@@ -27,19 +27,19 @@ fn older_msrv() {
 #[clippy::msrv = "1.85"]
 fn main() {
     let a: u32 = 10;
-    let _ = u32::midpoint(a, 5); //~ ERROR: manual implementation of `midpoint`
-    let _ = u32::midpoint(a, 5); //~ ERROR: manual implementation of `midpoint`
+    let _ = u32::midpoint(a, 5); //~ manual_midpoint
+    let _ = u32::midpoint(a, 5); //~ manual_midpoint
 
     let f: f32 = 10.0;
-    let _ = f32::midpoint(f, 5.0); //~ ERROR: manual implementation of `midpoint`
-    let _ = f32::midpoint(f, 10.0); //~ ERROR: manual implementation of `midpoint`
-    let _ = f32::midpoint(f, 10.0); //~ ERROR: manual implementation of `midpoint`
+    let _ = f32::midpoint(f, 5.0); //~ manual_midpoint
+    let _ = f32::midpoint(f, 10.0); //~ manual_midpoint
+    let _ = f32::midpoint(f, 10.0); //~ manual_midpoint
 
-    let _: u32 = 5 + u32::midpoint(8, 8) + 2; //~ ERROR: manual implementation of `midpoint`
-    let _: u32 = const { u32::midpoint(8, 8) }; //~ ERROR: manual implementation of `midpoint`
-    let _: f64 = const { f64::midpoint(8.0f64, 8.) }; //~ ERROR: manual implementation of `midpoint`
-    let _: u32 = u32::midpoint(u32::default(), u32::default()); //~ ERROR: manual implementation of `midpoint`
-    let _: u32 = u32::midpoint(two!(), two!()); //~ ERROR: manual implementation of `midpoint`
+    let _: u32 = 5 + u32::midpoint(8, 8) + 2; //~ manual_midpoint
+    let _: u32 = const { u32::midpoint(8, 8) }; //~ manual_midpoint
+    let _: f64 = const { f64::midpoint(8.0f64, 8.) }; //~ manual_midpoint
+    let _: u32 = u32::midpoint(u32::default(), u32::default()); //~ manual_midpoint
+    let _: u32 = u32::midpoint(two!(), two!()); //~ manual_midpoint
 
     // Do not lint in presence of an addition with more than 2 operands
     let _: u32 = (10 + 20 + 30) / 2;
@@ -62,8 +62,8 @@ fn main() {
     let _ = (1 + i) / 2;
 
     // But if we see (x+1.0)/2.0 or (x+1.0)/2.0, it is probably a midpoint operation
-    let _ = f32::midpoint(f, 1.0); //~ ERROR: manual implementation of `midpoint`
-    let _ = f32::midpoint(1.0, f); //~ ERROR: manual implementation of `midpoint`
+    let _ = f32::midpoint(f, 1.0); //~ manual_midpoint
+    let _ = f32::midpoint(1.0, f); //~ manual_midpoint
 }
 
 #[clippy::msrv = "1.86"]
@@ -74,5 +74,5 @@ fn older_signed_midpoint(i: i32) {
 
 #[clippy::msrv = "1.87"]
 fn signed_midpoint(i: i32) {
-    let _ = i32::midpoint(i, 10); //~ ERROR: manual implementation of `midpoint`
+    let _ = i32::midpoint(i, 10); //~ manual_midpoint
 }

--- a/tests/ui/manual_midpoint.rs
+++ b/tests/ui/manual_midpoint.rs
@@ -27,19 +27,19 @@ fn older_msrv() {
 #[clippy::msrv = "1.85"]
 fn main() {
     let a: u32 = 10;
-    let _ = (a + 5) / 2; //~ ERROR: manual implementation of `midpoint`
-    let _ = (a + 5) >> 1; //~ ERROR: manual implementation of `midpoint`
+    let _ = (a + 5) / 2; //~ manual_midpoint
+    let _ = (a + 5) >> 1; //~ manual_midpoint
 
     let f: f32 = 10.0;
-    let _ = (f + 5.0) / 2.0; //~ ERROR: manual implementation of `midpoint`
-    let _ = (f + 10.0) * 0.5; //~ ERROR: manual implementation of `midpoint`
-    let _ = 0.5 * (f + 10.0); //~ ERROR: manual implementation of `midpoint`
+    let _ = (f + 5.0) / 2.0; //~ manual_midpoint
+    let _ = (f + 10.0) * 0.5; //~ manual_midpoint
+    let _ = 0.5 * (f + 10.0); //~ manual_midpoint
 
-    let _: u32 = 5 + (8 + 8) / 2 + 2; //~ ERROR: manual implementation of `midpoint`
-    let _: u32 = const { (8 + 8) / 2 }; //~ ERROR: manual implementation of `midpoint`
-    let _: f64 = const { (8.0f64 + 8.) / 2. }; //~ ERROR: manual implementation of `midpoint`
-    let _: u32 = (u32::default() + u32::default()) / 2; //~ ERROR: manual implementation of `midpoint`
-    let _: u32 = (two!() + two!()) / 2; //~ ERROR: manual implementation of `midpoint`
+    let _: u32 = 5 + (8 + 8) / 2 + 2; //~ manual_midpoint
+    let _: u32 = const { (8 + 8) / 2 }; //~ manual_midpoint
+    let _: f64 = const { (8.0f64 + 8.) / 2. }; //~ manual_midpoint
+    let _: u32 = (u32::default() + u32::default()) / 2; //~ manual_midpoint
+    let _: u32 = (two!() + two!()) / 2; //~ manual_midpoint
 
     // Do not lint in presence of an addition with more than 2 operands
     let _: u32 = (10 + 20 + 30) / 2;
@@ -62,8 +62,8 @@ fn main() {
     let _ = (1 + i) / 2;
 
     // But if we see (x+1.0)/2.0 or (x+1.0)/2.0, it is probably a midpoint operation
-    let _ = (f + 1.0) / 2.0; //~ ERROR: manual implementation of `midpoint`
-    let _ = (1.0 + f) / 2.0; //~ ERROR: manual implementation of `midpoint`
+    let _ = (f + 1.0) / 2.0; //~ manual_midpoint
+    let _ = (1.0 + f) / 2.0; //~ manual_midpoint
 }
 
 #[clippy::msrv = "1.86"]
@@ -74,5 +74,5 @@ fn older_signed_midpoint(i: i32) {
 
 #[clippy::msrv = "1.87"]
 fn signed_midpoint(i: i32) {
-    let _ = (i + 10) / 2; //~ ERROR: manual implementation of `midpoint`
+    let _ = (i + 10) / 2; //~ manual_midpoint
 }

--- a/tests/ui/mixed_attributes_style.rs
+++ b/tests/ui/mixed_attributes_style.rs
@@ -7,7 +7,7 @@
 #[macro_use]
 extern crate proc_macro_attr;
 
-#[allow(unused)] //~ ERROR: item has both inner and outer attributes
+#[allow(unused)] //~ mixed_attributes_style
 fn foo1() {
     #![allow(unused)]
 }
@@ -22,7 +22,7 @@ fn foo3() {
 }
 
 /// linux
-//~^ ERROR: item has both inner and outer attributes
+//~^ mixed_attributes_style
 fn foo4() {
     //! windows
 }
@@ -36,7 +36,7 @@ fn foo6() {
     //! windows
 }
 
-#[allow(unused)] //~ ERROR: item has both inner and outer attributes
+#[allow(unused)] //~ mixed_attributes_style
 mod bar {
     #![allow(unused)]
 }
@@ -66,7 +66,7 @@ mod issue_12530 {
     mod tests {
         #![allow(clippy::unreadable_literal)]
 
-        #[allow(dead_code)] //~ ERROR: item has both inner and outer attributes
+        #[allow(dead_code)] //~ mixed_attributes_style
         mod inner_mod {
             #![allow(dead_code)]
         }
@@ -77,18 +77,18 @@ mod issue_12530 {
     }
     /// Nested mod
     mod nested_mod {
-        #[allow(dead_code)] //~ ERROR: item has both inner and outer attributes
+        #[allow(dead_code)] //~ mixed_attributes_style
         mod inner_mod {
             #![allow(dead_code)]
         }
     }
     /// Nested mod
-    //~^ ERROR: item has both inner and outer attributes
+    //~^ mixed_attributes_style
     #[allow(unused)]
     mod nest_mod_2 {
         #![allow(unused)]
 
-        #[allow(dead_code)] //~ ERROR: item has both inner and outer attributes
+        #[allow(dead_code)] //~ mixed_attributes_style
         mod inner_mod {
             #![allow(dead_code)]
         }

--- a/tests/ui/unused_format_specs_width.rs
+++ b/tests/ui/unused_format_specs_width.rs
@@ -6,32 +6,32 @@
 
 fn main() {
     // Integer formats with # (alternate): 0x/0o/0b prefix makes min width 4
-    println!("{:#02X}", 1u8); //~ ERROR: format width has no effect on the output
-    println!("{:#2X}", 1u8); //~ ERROR: format width has no effect on the output
-    println!("{:#02x}", 1u8); //~ ERROR: format width has no effect on the output
-    println!("{:#02o}", 1u8); //~ ERROR: format width has no effect on the output
-    println!("{:#02b}", 1u8); //~ ERROR: format width has no effect on the output
+    println!("{:#02X}", 1u8); //~ unused_format_specs
+    println!("{:#2X}", 1u8); //~ unused_format_specs
+    println!("{:#02x}", 1u8); //~ unused_format_specs
+    println!("{:#02o}", 1u8); //~ unused_format_specs
+    println!("{:#02b}", 1u8); //~ unused_format_specs
 
     // Exponent formats: min width 4 (e.g. 1e0)
-    println!("{:02e}", 1u8); //~ ERROR: format width has no effect on the output
-    println!("{:02E}", 1u8); //~ ERROR: format width has no effect on the output
-    println!("{:2e}", 1.0); //~ ERROR: format width has no effect on the output
-    println!("{:2E}", 1.0); //~ ERROR: format width has no effect on the output
-    println!("{:2e}", 0.1); //~ ERROR: format width has no effect on the output
-    println!("{:2E}", 0.1); //~ ERROR: format width has no effect on the output
+    println!("{:02e}", 1u8); //~ unused_format_specs
+    println!("{:02E}", 1u8); //~ unused_format_specs
+    println!("{:2e}", 1.0); //~ unused_format_specs
+    println!("{:2E}", 1.0); //~ unused_format_specs
+    println!("{:2e}", 0.1); //~ unused_format_specs
+    println!("{:2E}", 0.1); //~ unused_format_specs
 
     // Pointer: min width 4 (0x1)
-    println!("{:2p}", 0 as *const usize); //~ ERROR: format width has no effect on the output
-    println!("{:02p}", 1 as *const usize); //~ ERROR: format width has no effect on the output
+    println!("{:2p}", 0 as *const usize); //~ unused_format_specs
+    println!("{:02p}", 1 as *const usize); //~ unused_format_specs
 
     // Width 2 still too small for exponent; precision+width
-    println!("{:2.2e}", 1.0); //~ ERROR: format width has no effect on the output
-    println!("{:2.2E}", 1.0); //~ ERROR: format width has no effect on the output
-    println!("{:2.2e}", 0.1); //~ ERROR: format width has no effect on the output
-    println!("{:2.2E}", 0.1); //~ ERROR: format width has no effect on the output
+    println!("{:2.2e}", 1.0); //~ unused_format_specs
+    println!("{:2.2E}", 1.0); //~ unused_format_specs
+    println!("{:2.2e}", 0.1); //~ unused_format_specs
+    println!("{:2.2E}", 0.1); //~ unused_format_specs
 
     // Width 3 is exactly the minimum for alternate hex, still warn
-    println!("{:#03X}", 1u8); //~ ERROR: format width has no effect on the output
+    println!("{:#03X}", 1u8); //~ unused_format_specs
 
     // Not linted: width more than 3, or no # for x/o/b
     println!("{:#04X}", 1u8);


### PR DESCRIPTION
Convert error messages to lint name instead of the "older" description format.

changelog: none