### PR TITLE
Do not trigger `integer_division_remainder_used` in macros

### DIFF
--- a/clippy_lints/src/operators/integer_division_remainder_used.rs
+++ b/clippy_lints/src/operators/integer_division_remainder_used.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint;
 use rustc_ast::BinOpKind;
 use rustc_hir::Expr;
-use rustc_lint::LateContext;
+use rustc_lint::{LateContext, LintContext as _};
 use rustc_middle::ty;
 use rustc_span::Span;
 
@@ -13,11 +13,12 @@ pub(super) fn check(cx: &LateContext<'_>, op: BinOpKind, lhs: &Expr<'_>, rhs: &E
         && let rhs_ty = cx.typeck_results().expr_ty(rhs)
         && let ty::Int(_) | ty::Uint(_) = lhs_ty.peel_refs().kind()
         && let ty::Int(_) | ty::Uint(_) = rhs_ty.peel_refs().kind()
+        && !span.in_external_macro(cx.sess().source_map())
     {
         span_lint(
             cx,
             INTEGER_DIVISION_REMAINDER_USED,
-            span.source_callsite(),
+            span,
             format!("use of `{}` has been disallowed in this context", op.as_str()),
         );
     }

--- a/tests/ui/integer_division_remainder_used.rs
+++ b/tests/ui/integer_division_remainder_used.rs
@@ -1,3 +1,4 @@
+//@aux-build: proc_macros.rs
 #![warn(clippy::integer_division_remainder_used)]
 #![expect(clippy::op_ref)]
 
@@ -46,4 +47,18 @@ fn main() {
     let w = CustomOps(3);
     let x = CustomOps(4);
     let z = w % x;
+
+    macro_rules! mac {
+        ($a:expr, $b:expr) => {
+            a % b
+            //~^ integer_division_remainder_used
+        };
+    }
+    // should not trigger if from expansion in external macro
+    let issue17048 = mac!(a, b);
+    let issue17048 = proc_macros::external! {{
+        let a = 10;
+        let b = 5;
+        a % b
+    }};
 }

--- a/tests/ui/integer_division_remainder_used.rs
+++ b/tests/ui/integer_division_remainder_used.rs
@@ -1,3 +1,4 @@
+//@aux-build: proc_macros.rs
 #![warn(clippy::integer_division_remainder_used)]
 #![expect(clippy::op_ref)]
 
@@ -53,4 +54,18 @@ fn main() {
     let w = CustomOps(3);
     let x = CustomOps(4);
     let z = w % x;
+
+    macro_rules! mac {
+        ($a:expr, $b:expr) => {
+            $a % $b
+            //~^ integer_division_remainder_used
+        };
+    }
+    // should not trigger if from expansion in external macro
+    let issue17048 = mac!(a, b);
+    let issue17048 = proc_macros::external! {{
+        let a = 10;
+        let b = 5;
+        a % b
+    }};
 }

--- a/tests/ui/integer_division_remainder_used.stderr
+++ b/tests/ui/integer_division_remainder_used.stderr
@@ -1,5 +1,5 @@
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:9:14
+  --> tests/ui/integer_division_remainder_used.rs:10:14
    |
 LL |         Self(self.0 / rhs.0)
    |              ^^^^^^^^^^^^^^
@@ -8,52 +8,63 @@ LL |         Self(self.0 / rhs.0)
    = help: to override `-D warnings` add `#[allow(clippy::integer_division_remainder_used)]`
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:17:14
+  --> tests/ui/integer_division_remainder_used.rs:18:14
    |
 LL |         Self(self.0 % rhs.0)
    |              ^^^^^^^^^^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:26:13
+  --> tests/ui/integer_division_remainder_used.rs:27:13
    |
 LL |     let c = a / b;
    |             ^^^^^
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:28:13
+  --> tests/ui/integer_division_remainder_used.rs:29:13
    |
 LL |     let d = a % b;
    |             ^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:30:13
+  --> tests/ui/integer_division_remainder_used.rs:31:13
    |
 LL |     let e = &a / b;
    |             ^^^^^^
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:32:13
+  --> tests/ui/integer_division_remainder_used.rs:33:13
    |
 LL |     let f = a % &b;
    |             ^^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:34:13
+  --> tests/ui/integer_division_remainder_used.rs:35:13
    |
 LL |     let g = &a / &b;
    |             ^^^^^^^
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:36:13
+  --> tests/ui/integer_division_remainder_used.rs:37:13
    |
 LL |     let h = &10 % b;
    |             ^^^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:38:13
+  --> tests/ui/integer_division_remainder_used.rs:39:13
    |
 LL |     let i = a / &4;
    |             ^^^^^^
 
-error: aborting due to 9 previous errors
+error: use of `%` has been disallowed in this context
+  --> tests/ui/integer_division_remainder_used.rs:53:13
+   |
+LL |             a % b
+   |             ^^^^^
+...
+LL |     let issue17048 = mac!(a, b);
+   |                      ---------- in this macro invocation
+   |
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/integer_division_remainder_used.stderr
+++ b/tests/ui/integer_division_remainder_used.stderr
@@ -1,5 +1,5 @@
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:9:14
+  --> tests/ui/integer_division_remainder_used.rs:10:14
    |
 LL |         Self(self.0 / rhs.0)
    |              ^^^^^^^^^^^^^^
@@ -8,64 +8,75 @@ LL |         Self(self.0 / rhs.0)
    = help: to override `-D warnings` add `#[allow(clippy::integer_division_remainder_used)]`
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:17:14
+  --> tests/ui/integer_division_remainder_used.rs:18:14
    |
 LL |         Self(self.0 % rhs.0)
    |              ^^^^^^^^^^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:26:13
+  --> tests/ui/integer_division_remainder_used.rs:27:13
    |
 LL |     let c = a / b;
    |             ^^^^^
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:28:13
+  --> tests/ui/integer_division_remainder_used.rs:29:13
    |
 LL |     let d = a % b;
    |             ^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:30:13
+  --> tests/ui/integer_division_remainder_used.rs:31:13
    |
 LL |     let e = &a / b;
    |             ^^^^^^
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:32:13
+  --> tests/ui/integer_division_remainder_used.rs:33:13
    |
 LL |     let f = a % &b;
    |             ^^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:34:13
+  --> tests/ui/integer_division_remainder_used.rs:35:13
    |
 LL |     let g = &a / &b;
    |             ^^^^^^^
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:36:13
+  --> tests/ui/integer_division_remainder_used.rs:37:13
    |
 LL |     let h = &10 % b;
    |             ^^^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:38:13
+  --> tests/ui/integer_division_remainder_used.rs:39:13
    |
 LL |     let i = a / &4;
    |             ^^^^^^
 
 error: use of `/` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:43:5
+  --> tests/ui/integer_division_remainder_used.rs:44:5
    |
 LL |     j /= 2;
    |     ^^^^^^
 
 error: use of `%` has been disallowed in this context
-  --> tests/ui/integer_division_remainder_used.rs:45:5
+  --> tests/ui/integer_division_remainder_used.rs:46:5
    |
 LL |     j %= 3;
    |     ^^^^^^
 
-error: aborting due to 11 previous errors
+error: use of `%` has been disallowed in this context
+  --> tests/ui/integer_division_remainder_used.rs:60:13
+   |
+LL |             $a % $b
+   |             ^^^^^^^
+...
+LL |     let issue17048 = mac!(a, b);
+   |                      ---------- in this macro invocation
+   |
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
changelog: [`integer_division_remainder_used`]: do not trigger in macros

Fixes rust-lang/rust-clippy#17048 