### PR TITLE
ast_utils module cleanup

### DIFF
--- a/clippy_utils/src/ast_utils/mod.rs
+++ b/clippy_utils/src/ast_utils/mod.rs
@@ -65,7 +65,7 @@ pub fn eq_pat(l: &Pat, r: &Pat) -> bool {
     }
 }
 
-pub fn eq_range_end(l: RangeEnd, r: RangeEnd) -> bool {
+fn eq_range_end(l: RangeEnd, r: RangeEnd) -> bool {
     match (l, r) {
         (RangeEnd::Excluded, RangeEnd::Excluded) => true,
         (RangeEnd::Included(l), RangeEnd::Included(r)) => {
@@ -82,7 +82,7 @@ pub fn eq_field_pat(l: &PatField, r: &PatField) -> bool {
         && over(&l.attrs, &r.attrs, eq_attr)
 }
 
-pub fn eq_qself(l: &QSelf, r: &QSelf) -> bool {
+fn eq_qself(l: &QSelf, r: &QSelf) -> bool {
     l.position == r.position && eq_ty(&l.ty, &r.ty)
 }
 
@@ -98,11 +98,11 @@ pub fn eq_path(l: &Path, r: &Path) -> bool {
     over(&l.segments, &r.segments, eq_path_seg)
 }
 
-pub fn eq_path_seg(l: &PathSegment, r: &PathSegment) -> bool {
+fn eq_path_seg(l: &PathSegment, r: &PathSegment) -> bool {
     eq_id(l.ident, r.ident) && both(l.args.as_ref(), r.args.as_ref(), |l, r| eq_generic_args(l, r))
 }
 
-pub fn eq_generic_args(l: &GenericArgs, r: &GenericArgs) -> bool {
+fn eq_generic_args(l: &GenericArgs, r: &GenericArgs) -> bool {
     match (l, r) {
         (AngleBracketed(l), AngleBracketed(r)) => over(&l.args, &r.args, eq_angle_arg),
         (Parenthesized(l), Parenthesized(r)) => {
@@ -112,7 +112,7 @@ pub fn eq_generic_args(l: &GenericArgs, r: &GenericArgs) -> bool {
     }
 }
 
-pub fn eq_angle_arg(l: &AngleBracketedArg, r: &AngleBracketedArg) -> bool {
+fn eq_angle_arg(l: &AngleBracketedArg, r: &AngleBracketedArg) -> bool {
     match (l, r) {
         (AngleBracketedArg::Arg(l), AngleBracketedArg::Arg(r)) => eq_generic_arg(l, r),
         (AngleBracketedArg::Constraint(l), AngleBracketedArg::Constraint(r)) => eq_assoc_item_constraint(l, r),
@@ -120,7 +120,7 @@ pub fn eq_angle_arg(l: &AngleBracketedArg, r: &AngleBracketedArg) -> bool {
     }
 }
 
-pub fn eq_generic_arg(l: &GenericArg, r: &GenericArg) -> bool {
+fn eq_generic_arg(l: &GenericArg, r: &GenericArg) -> bool {
     match (l, r) {
         (GenericArg::Lifetime(l), GenericArg::Lifetime(r)) => eq_id(l.ident, r.ident),
         (GenericArg::Type(l), GenericArg::Type(r)) => eq_ty(l, r),
@@ -129,11 +129,11 @@ pub fn eq_generic_arg(l: &GenericArg, r: &GenericArg) -> bool {
     }
 }
 
-pub fn eq_expr_opt(l: Option<&Expr>, r: Option<&Expr>) -> bool {
+fn eq_expr_opt(l: Option<&Expr>, r: Option<&Expr>) -> bool {
     both(l, r, eq_expr)
 }
 
-pub fn eq_struct_rest(l: &StructRest, r: &StructRest) -> bool {
+fn eq_struct_rest(l: &StructRest, r: &StructRest) -> bool {
     match (l, r) {
         (StructRest::Base(lb), StructRest::Base(rb)) => eq_expr(lb, rb),
         (StructRest::Rest(_), StructRest::Rest(_)) | (StructRest::None, StructRest::None) => true,
@@ -142,7 +142,7 @@ pub fn eq_struct_rest(l: &StructRest, r: &StructRest) -> bool {
 }
 
 #[expect(clippy::too_many_lines, reason = "big match statement")]
-pub fn eq_expr(l: &Expr, r: &Expr) -> bool {
+fn eq_expr(l: &Expr, r: &Expr) -> bool {
     use ExprKind::*;
     if !over(&l.attrs, &r.attrs, eq_attr) {
         return false;
@@ -270,14 +270,14 @@ fn eq_coroutine_kind(a: Option<CoroutineKind>, b: Option<CoroutineKind>) -> bool
     )
 }
 
-pub fn eq_field(l: &ExprField, r: &ExprField) -> bool {
+fn eq_field(l: &ExprField, r: &ExprField) -> bool {
     l.is_placeholder == r.is_placeholder
         && eq_id(l.ident, r.ident)
         && eq_expr(&l.expr, &r.expr)
         && over(&l.attrs, &r.attrs, eq_attr)
 }
 
-pub fn eq_arm(l: &Arm, r: &Arm) -> bool {
+fn eq_arm(l: &Arm, r: &Arm) -> bool {
     l.is_placeholder == r.is_placeholder
         && eq_pat(&l.pat, &r.pat)
         && eq_expr_opt(l.body.as_deref(), r.body.as_deref())
@@ -285,15 +285,15 @@ pub fn eq_arm(l: &Arm, r: &Arm) -> bool {
         && over(&l.attrs, &r.attrs, eq_attr)
 }
 
-pub fn eq_label(l: Option<&Label>, r: Option<&Label>) -> bool {
+fn eq_label(l: Option<&Label>, r: Option<&Label>) -> bool {
     both(l, r, |l, r| eq_id(l.ident, r.ident))
 }
 
-pub fn eq_block(l: &Block, r: &Block) -> bool {
+fn eq_block(l: &Block, r: &Block) -> bool {
     l.rules == r.rules && over(&l.stmts, &r.stmts, eq_stmt)
 }
 
-pub fn eq_stmt(l: &Stmt, r: &Stmt) -> bool {
+fn eq_stmt(l: &Stmt, r: &Stmt) -> bool {
     use StmtKind::*;
     match (&l.kind, &r.kind) {
         (Let(l), Let(r)) => {
@@ -312,7 +312,7 @@ pub fn eq_stmt(l: &Stmt, r: &Stmt) -> bool {
     }
 }
 
-pub fn eq_local_kind(l: &LocalKind, r: &LocalKind) -> bool {
+fn eq_local_kind(l: &LocalKind, r: &LocalKind) -> bool {
     use LocalKind::*;
     match (l, r) {
         (Decl, Decl) => true,
@@ -322,12 +322,12 @@ pub fn eq_local_kind(l: &LocalKind, r: &LocalKind) -> bool {
     }
 }
 
-pub fn eq_item<K>(l: &Item<K>, r: &Item<K>, mut eq_kind: impl FnMut(&K, &K) -> bool) -> bool {
+fn eq_item<K>(l: &Item<K>, r: &Item<K>, mut eq_kind: impl FnMut(&K, &K) -> bool) -> bool {
     over(&l.attrs, &r.attrs, eq_attr) && eq_vis(&l.vis, &r.vis) && eq_kind(&l.kind, &r.kind)
 }
 
 #[expect(clippy::too_many_lines, reason = "big match statement")]
-pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
+fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
     use ItemKind::*;
     match (l, r) {
         (ExternCrate(ls, li), ExternCrate(rs, ri)) => ls == rs && eq_id(*li, *ri),
@@ -532,7 +532,7 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
     }
 }
 
-pub fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
+fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
     use ForeignItemKind::*;
     match (l, r) {
         (
@@ -614,7 +614,7 @@ pub fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
     }
 }
 
-pub fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
+fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
     use AssocItemKind::*;
     match (l, r) {
         (
@@ -700,7 +700,7 @@ pub fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
     }
 }
 
-pub fn eq_variant(l: &Variant, r: &Variant) -> bool {
+fn eq_variant(l: &Variant, r: &Variant) -> bool {
     l.is_placeholder == r.is_placeholder
         && over(&l.attrs, &r.attrs, eq_attr)
         && eq_vis(&l.vis, &r.vis)
@@ -711,7 +711,7 @@ pub fn eq_variant(l: &Variant, r: &Variant) -> bool {
         })
 }
 
-pub fn eq_variant_data(l: &VariantData, r: &VariantData) -> bool {
+fn eq_variant_data(l: &VariantData, r: &VariantData) -> bool {
     use VariantData::*;
     match (l, r) {
         (Unit(_), Unit(_)) => true,
@@ -722,7 +722,7 @@ pub fn eq_variant_data(l: &VariantData, r: &VariantData) -> bool {
     }
 }
 
-pub fn eq_struct_field(l: &FieldDef, r: &FieldDef) -> bool {
+fn eq_struct_field(l: &FieldDef, r: &FieldDef) -> bool {
     l.is_placeholder == r.is_placeholder
         && over(&l.attrs, &r.attrs, eq_attr)
         && eq_vis(&l.vis, &r.vis)
@@ -730,7 +730,7 @@ pub fn eq_struct_field(l: &FieldDef, r: &FieldDef) -> bool {
         && eq_ty(&l.ty, &r.ty)
 }
 
-pub fn eq_fn_sig(l: &FnSig, r: &FnSig) -> bool {
+fn eq_fn_sig(l: &FnSig, r: &FnSig) -> bool {
     eq_fn_decl(&l.decl, &r.decl) && eq_fn_header(&l.header, &r.header)
 }
 
@@ -747,7 +747,7 @@ fn eq_opt_coroutine_kind(l: Option<CoroutineKind>, r: Option<CoroutineKind>) -> 
     )
 }
 
-pub fn eq_fn_header(l: &FnHeader, r: &FnHeader) -> bool {
+fn eq_fn_header(l: &FnHeader, r: &FnHeader) -> bool {
     matches!(l.safety, Safety::Default) == matches!(r.safety, Safety::Default)
         && eq_opt_coroutine_kind(l.coroutine_kind, r.coroutine_kind)
         && matches!(l.constness, Const::No) == matches!(r.constness, Const::No)
@@ -755,7 +755,7 @@ pub fn eq_fn_header(l: &FnHeader, r: &FnHeader) -> bool {
 }
 
 #[expect(clippy::ref_option, reason = "This is the type how it is stored in the AST")]
-pub fn eq_opt_fn_contract(l: &Option<Box<FnContract>>, r: &Option<Box<FnContract>>) -> bool {
+fn eq_opt_fn_contract(l: &Option<Box<FnContract>>, r: &Option<Box<FnContract>>) -> bool {
     match (l, r) {
         (Some(l), Some(r)) => {
             eq_expr_opt(l.requires.as_deref(), r.requires.as_deref())
@@ -766,14 +766,14 @@ pub fn eq_opt_fn_contract(l: &Option<Box<FnContract>>, r: &Option<Box<FnContract
     }
 }
 
-pub fn eq_generics(l: &Generics, r: &Generics) -> bool {
+fn eq_generics(l: &Generics, r: &Generics) -> bool {
     over(&l.params, &r.params, eq_generic_param)
         && over(&l.where_clause.predicates, &r.where_clause.predicates, |l, r| {
             eq_where_predicate(l, r)
         })
 }
 
-pub fn eq_where_predicate(l: &WherePredicate, r: &WherePredicate) -> bool {
+fn eq_where_predicate(l: &WherePredicate, r: &WherePredicate) -> bool {
     use WherePredicateKind::*;
     over(&l.attrs, &r.attrs, eq_attr)
         && match (&l.kind, &r.kind) {
@@ -791,15 +791,15 @@ pub fn eq_where_predicate(l: &WherePredicate, r: &WherePredicate) -> bool {
         }
 }
 
-pub fn eq_use_tree(l: &UseTree, r: &UseTree) -> bool {
+fn eq_use_tree(l: &UseTree, r: &UseTree) -> bool {
     eq_path(&l.prefix, &r.prefix) && eq_use_tree_kind(&l.kind, &r.kind)
 }
 
-pub fn eq_anon_const(l: &AnonConst, r: &AnonConst) -> bool {
+fn eq_anon_const(l: &AnonConst, r: &AnonConst) -> bool {
     eq_expr(&l.value, &r.value)
 }
 
-pub fn eq_const_item_rhs(l: &ConstItemRhsKind, r: &ConstItemRhsKind) -> bool {
+fn eq_const_item_rhs(l: &ConstItemRhsKind, r: &ConstItemRhsKind) -> bool {
     use ConstItemRhsKind::*;
     match (l, r) {
         (TypeConst { rhs: Some(l) }, TypeConst { rhs: Some(r) }) => eq_anon_const(l, r),
@@ -814,7 +814,7 @@ pub fn eq_const_item_rhs(l: &ConstItemRhsKind, r: &ConstItemRhsKind) -> bool {
     }
 }
 
-pub fn eq_use_tree_kind(l: &UseTreeKind, r: &UseTreeKind) -> bool {
+fn eq_use_tree_kind(l: &UseTreeKind, r: &UseTreeKind) -> bool {
     use UseTreeKind::*;
     match (l, r) {
         (Glob(_), Glob(_)) => true,
@@ -824,7 +824,7 @@ pub fn eq_use_tree_kind(l: &UseTreeKind, r: &UseTreeKind) -> bool {
     }
 }
 
-pub fn eq_defaultness(l: Defaultness, r: Defaultness) -> bool {
+fn eq_defaultness(l: Defaultness, r: Defaultness) -> bool {
     matches!(
         (l, r),
         (Defaultness::Implicit, Defaultness::Implicit)
@@ -833,7 +833,7 @@ pub fn eq_defaultness(l: Defaultness, r: Defaultness) -> bool {
     )
 }
 
-pub fn eq_vis(l: &Visibility, r: &Visibility) -> bool {
+fn eq_vis(l: &Visibility, r: &Visibility) -> bool {
     use VisibilityKind::*;
     match (&l.kind, &r.kind) {
         (Public, Public) | (Inherited, Inherited) => true,
@@ -842,7 +842,7 @@ pub fn eq_vis(l: &Visibility, r: &Visibility) -> bool {
     }
 }
 
-pub fn eq_impl_restriction(l: &ImplRestriction, r: &ImplRestriction) -> bool {
+fn eq_impl_restriction(l: &ImplRestriction, r: &ImplRestriction) -> bool {
     eq_restriction_kind(&l.kind, &r.kind)
 }
 
@@ -865,7 +865,7 @@ fn eq_restriction_kind(l: &RestrictionKind, r: &RestrictionKind) -> bool {
     }
 }
 
-pub fn eq_fn_decl(l: &FnDecl, r: &FnDecl) -> bool {
+fn eq_fn_decl(l: &FnDecl, r: &FnDecl) -> bool {
     eq_fn_ret_ty(&l.output, &r.output)
         && over(&l.inputs, &r.inputs, |l, r| {
             l.is_placeholder == r.is_placeholder
@@ -875,7 +875,7 @@ pub fn eq_fn_decl(l: &FnDecl, r: &FnDecl) -> bool {
         })
 }
 
-pub fn eq_closure_binder(l: &ClosureBinder, r: &ClosureBinder) -> bool {
+fn eq_closure_binder(l: &ClosureBinder, r: &ClosureBinder) -> bool {
     match (l, r) {
         (ClosureBinder::NotPresent, ClosureBinder::NotPresent) => true,
         (ClosureBinder::For { generic_params: lp, .. }, ClosureBinder::For { generic_params: rp, .. }) => {
@@ -885,7 +885,7 @@ pub fn eq_closure_binder(l: &ClosureBinder, r: &ClosureBinder) -> bool {
     }
 }
 
-pub fn eq_fn_ret_ty(l: &FnRetTy, r: &FnRetTy) -> bool {
+fn eq_fn_ret_ty(l: &FnRetTy, r: &FnRetTy) -> bool {
     match (l, r) {
         (FnRetTy::Default(_), FnRetTy::Default(_)) => true,
         (FnRetTy::Ty(l), FnRetTy::Ty(r)) => eq_ty(l, r),
@@ -893,7 +893,7 @@ pub fn eq_fn_ret_ty(l: &FnRetTy, r: &FnRetTy) -> bool {
     }
 }
 
-pub fn eq_ty(l: &Ty, r: &Ty) -> bool {
+fn eq_ty(l: &Ty, r: &Ty) -> bool {
     use TyKind::*;
     match (&l.kind, &r.kind) {
         (Paren(l), _) => eq_ty(l, r),
@@ -925,7 +925,7 @@ pub fn eq_ty(l: &Ty, r: &Ty) -> bool {
     }
 }
 
-pub fn eq_ext(l: &Extern, r: &Extern) -> bool {
+fn eq_ext(l: &Extern, r: &Extern) -> bool {
     use Extern::*;
     match (l, r) {
         (None, None) | (Implicit(_), Implicit(_)) => true,
@@ -934,11 +934,11 @@ pub fn eq_ext(l: &Extern, r: &Extern) -> bool {
     }
 }
 
-pub fn eq_str_lit(l: &StrLit, r: &StrLit) -> bool {
+fn eq_str_lit(l: &StrLit, r: &StrLit) -> bool {
     l.style == r.style && l.symbol == r.symbol && l.suffix == r.suffix
 }
 
-pub fn eq_poly_ref_trait(l: &PolyTraitRef, r: &PolyTraitRef) -> bool {
+fn eq_poly_ref_trait(l: &PolyTraitRef, r: &PolyTraitRef) -> bool {
     l.modifiers == r.modifiers
         && eq_path(&l.trait_ref.path, &r.trait_ref.path)
         && over(&l.bound_generic_params, &r.bound_generic_params, |l, r| {
@@ -946,7 +946,7 @@ pub fn eq_poly_ref_trait(l: &PolyTraitRef, r: &PolyTraitRef) -> bool {
         })
 }
 
-pub fn eq_generic_param(l: &GenericParam, r: &GenericParam) -> bool {
+fn eq_generic_param(l: &GenericParam, r: &GenericParam) -> bool {
     use GenericParamKind::*;
     l.is_placeholder == r.is_placeholder
         && eq_id(l.ident, r.ident)
@@ -971,19 +971,11 @@ pub fn eq_generic_param(l: &GenericParam, r: &GenericParam) -> bool {
         && over(&l.attrs, &r.attrs, eq_attr)
 }
 
-pub fn eq_generic_bound(l: &GenericBound, r: &GenericBound) -> bool {
+fn eq_generic_bound(l: &GenericBound, r: &GenericBound) -> bool {
     use GenericBound::*;
     match (l, r) {
         (Trait(ptr1), Trait(ptr2)) => eq_poly_ref_trait(ptr1, ptr2),
         (Outlives(l), Outlives(r)) => eq_id(l.ident, r.ident),
-        _ => false,
-    }
-}
-
-pub fn eq_precise_capture(l: &PreciseCapturingArg, r: &PreciseCapturingArg) -> bool {
-    match (l, r) {
-        (PreciseCapturingArg::Lifetime(l), PreciseCapturingArg::Lifetime(r)) => l.ident == r.ident,
-        (PreciseCapturingArg::Arg(l, _), PreciseCapturingArg::Arg(r, _)) => l.segments[0].ident == r.segments[0].ident,
         _ => false,
     }
 }
@@ -996,7 +988,7 @@ fn eq_term(l: &Term, r: &Term) -> bool {
     }
 }
 
-pub fn eq_assoc_item_constraint(l: &AssocItemConstraint, r: &AssocItemConstraint) -> bool {
+fn eq_assoc_item_constraint(l: &AssocItemConstraint, r: &AssocItemConstraint) -> bool {
     use AssocItemConstraintKind::*;
     eq_id(l.ident, r.ident)
         && match (&l.kind, &r.kind) {
@@ -1006,11 +998,11 @@ pub fn eq_assoc_item_constraint(l: &AssocItemConstraint, r: &AssocItemConstraint
         }
 }
 
-pub fn eq_mac_call(l: &MacCall, r: &MacCall) -> bool {
+fn eq_mac_call(l: &MacCall, r: &MacCall) -> bool {
     eq_path(&l.path, &r.path) && eq_delim_args(&l.args, &r.args)
 }
 
-pub fn eq_attr(l: &Attribute, r: &Attribute) -> bool {
+fn eq_attr(l: &Attribute, r: &Attribute) -> bool {
     use AttrKind::*;
     l.style == r.style
         && match (&l.kind, &r.kind) {
@@ -1022,7 +1014,7 @@ pub fn eq_attr(l: &Attribute, r: &Attribute) -> bool {
         }
 }
 
-pub fn eq_attr_item_kind(l: &AttrItemKind, r: &AttrItemKind) -> bool {
+fn eq_attr_item_kind(l: &AttrItemKind, r: &AttrItemKind) -> bool {
     match (l, r) {
         (AttrItemKind::Unparsed(l), AttrItemKind::Unparsed(r)) => eq_attr_args(l, r),
         (AttrItemKind::Parsed(_l), AttrItemKind::Parsed(_r)) => todo!(),
@@ -1030,7 +1022,7 @@ pub fn eq_attr_item_kind(l: &AttrItemKind, r: &AttrItemKind) -> bool {
     }
 }
 
-pub fn eq_attr_args(l: &AttrArgs, r: &AttrArgs) -> bool {
+fn eq_attr_args(l: &AttrArgs, r: &AttrArgs) -> bool {
     use AttrArgs::*;
     match (l, r) {
         (Empty, Empty) => true,
@@ -1040,7 +1032,7 @@ pub fn eq_attr_args(l: &AttrArgs, r: &AttrArgs) -> bool {
     }
 }
 
-pub fn eq_delim_args(l: &DelimArgs, r: &DelimArgs) -> bool {
+fn eq_delim_args(l: &DelimArgs, r: &DelimArgs) -> bool {
     l.delim == r.delim
         && l.tokens.len() == r.tokens.len()
         && l.tokens.iter().zip(r.tokens.iter()).all(|(a, b)| a.eq_unspanned(b))


### PR DESCRIPTION
Remove an unused function, and remove `pub` on functions not used from outside the module.

changelog: none