### PR TITLE
Simplify `is_some() && …unwrap()` to `is_some_and` in `unit_arg`

### DIFF
--- a/clippy_lints/src/unit_types/unit_arg.rs
+++ b/clippy_lints/src/unit_types/unit_arg.rs
@@ -159,7 +159,7 @@ fn lint_unit_args<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, args_to_
 fn is_expr_default_nested<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
     is_expr_default(cx, expr)
         || matches!(expr.kind, ExprKind::Block(block, _)
-        if block.expr.is_some() && is_expr_default_nested(cx, block.expr.unwrap()))
+        if block.expr.is_some_and(|e| is_expr_default_nested(cx, e)))
 }
 
 enum MaybeTypeUncertain<'tcx> {


### PR DESCRIPTION
## Summary

- `is_expr_default_nested` in `clippy_lints/src/unit_types/unit_arg.rs` was
  written as `block.expr.is_some() && is_expr_default_nested(cx, block.expr.unwrap())`,
  which is exactly the pattern that clippy's own `unnecessary_unwrap` lint flags.
- Replace it with `block.expr.is_some_and(|e| is_expr_default_nested(cx, e))`.

changelog: none
