### PR TITLE
Add a clippy attribute #[clippy::no_dead_field_warning] to prevent certain types from propagating dead field warnings

### DIFF
--- a/clippy_lints/src/missing_fields_in_debug.rs
+++ b/clippy_lints/src/missing_fields_in_debug.rs
@@ -2,13 +2,13 @@ use std::ops::ControlFlow;
 
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::{MaybeDef, MaybeResPath};
-use clippy_utils::sym;
 use clippy_utils::visitors::{Visitable, for_each_expr};
+use clippy_utils::{is_clippy_no_dead_field_warning_attr, sym};
 use rustc_ast::LitKind;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Block, Expr, ExprKind, Impl, Item, ItemKind, LangItem, Node, QPath, TyKind, VariantData};
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty::{Ty, TypeckResults};
 use rustc_session::declare_lint_pass;
 use rustc_span::{Span, Symbol};
@@ -185,6 +185,9 @@ fn check_struct<'tcx>(
         .filter_map(|field| {
             if field_accesses.contains(&field.ident.name)
                 || field.ty.basic_res().is_lang_item(cx, LangItem::PhantomData)
+                // We exclude certain types (e.g. PhantomData, PhantomPinned) marked with
+                // this attribute
+                || is_clippy_no_dead_field_warning_attr(cx.sess(), cx.tcx, field.ty.basic_res())
             {
                 None
             } else {

--- a/clippy_lints/src/pub_underscore_fields.rs
+++ b/clippy_lints/src/pub_underscore_fields.rs
@@ -1,10 +1,10 @@
 use clippy_config::Conf;
 use clippy_config::types::PubUnderscoreFieldsBehaviour;
-use clippy_utils::attrs::is_doc_hidden;
+use clippy_utils::attrs::{is_clippy_no_dead_field_warning_attr, is_doc_hidden};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::res::{MaybeDef, MaybeResPath};
 use rustc_hir::{FieldDef, Item, ItemKind, LangItem};
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::impl_lint_pass;
 
 declare_clippy_lint! {
@@ -77,6 +77,7 @@ impl<'tcx> LateLintPass<'tcx> for PubUnderscoreFields {
                 && !is_doc_hidden(cx.tcx.hir_attrs(field.hir_id))
                 // We ignore fields that are `PhantomData`.
                 && !field.ty.basic_res().is_lang_item(cx, LangItem::PhantomData)
+                && !is_clippy_no_dead_field_warning_attr(cx.sess(), cx.tcx, field.ty.basic_res())
             {
                 span_lint_hir_and_then(
                     cx,

--- a/clippy_utils/src/attrs.rs
+++ b/clippy_utils/src/attrs.rs
@@ -4,6 +4,7 @@ use crate::source::SpanRangeExt;
 use crate::{sym, tokenize_with_text};
 use rustc_ast::attr::AttributeExt;
 use rustc_errors::Applicability;
+use rustc_hir::def::Res;
 use rustc_hir::find_attr;
 use rustc_lexer::TokenKind;
 use rustc_lint::LateContext;
@@ -89,6 +90,20 @@ pub fn is_proc_macro(attrs: &[impl AttributeExt]) -> bool {
 /// Checks whether `attrs` contain `#[doc(hidden)]`
 pub fn is_doc_hidden(attrs: &[impl AttributeExt]) -> bool {
     attrs.iter().any(AttributeExt::is_doc_hidden)
+}
+
+/// Checks whether the original type is marked as `#[clippy::no_dead_field_warning]`
+pub fn is_clippy_no_dead_field_warning_attr(sess: &Session, tcx: TyCtxt<'_>, res: &Res) -> bool {
+    res.opt_def_id().is_some_and(|def_id| {
+        get_builtin_attr(
+            sess,
+            #[allow(deprecated)]
+            tcx.get_all_attrs(def_id),
+            sym::no_dead_field_warning,
+        )
+        .next()
+        .is_some()
+    })
 }
 
 /// Checks whether the given ADT, or any of its fields/variants, are marked as `#[non_exhaustive]`

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -440,6 +440,7 @@ generate! {
     next_if_eq,
     next_multiple_of,
     next_tuple,
+    no_dead_field_warning,
     nth,
     ok,
     ok_or,


### PR DESCRIPTION
# Summary

Note this is my first time contributing to the clippy repo. 

This PR introduces a new clippy attribute to prevent certain types from emitting dead field warnings. This is useful in the event that you have a certain marker type, like `PhantomData` or `PhantomPinned`, that you don't want dead field warnings to be propagated when that type/struct is a field member of another struct. While `PhantomData` is handled already in `missing_fields_in_debug.rs` and `pub_underscore_fields.rs`, `PhantomPinned` does not have the same treatment and it can't be treated the same either because it doesn't have a `LangItem` symbol. This clippy attribute has its own general use case if other people have marker (or general) types that they don't want dead field warnings to be emitted.

There were discussion occurring in the issue that brought up how [`PhantomPinned` emits dead field warnings](https://github.com/rust-lang/rust/issues/154888#issue-4212098984) and we came to an agreement that instead of introducing a `LangItem` for each `Phantom*` member to prevent dead field warning (especially since `PhantomPinned` will be deprecated soon at least from the comments I'm reading), it would better to use an attribute that could be shared among these `Phantom*` marker types.

In my [original PR](https://github.com/rust-lang/rust/pull/154978#issuecomment-4462368891), I initially created rustc built in attribute to use within the clippy dead field warning scripts, but on review and feedback, we thought it would be better to create a clippy attribute instead for this. I did create a clippy attribute in the original PR (though this PR renames it from `no_dead_code_warning` to `no_dead_field_warning`), but I was redirected to making the PR here instead. I plan to remove the `field.ty.basic_res().is_lang_item(cx, LangItem::PhantomData)` lines in a future PR if this gets approved.

Please let me know if I did anything incorrect with making a clippy built in attribute or if there's anything else that I need to do.

changelog: [`no_dead_field_warning`] introduces a new clippy attribute `#[clippy::no_dead_field_warning]` to prevent certain types from propagating dead field warnings.
