### PR TITLE
Avoid unnecessary `String` allocations in `MinifyingSugg` arithmetic ops

### DIFF
--- a/clippy_lints/src/loops/manual_memcpy.rs
+++ b/clippy_lints/src/loops/manual_memcpy.rs
@@ -230,6 +230,10 @@ impl<'a> MinifyingSugg<'a> {
     fn into_sugg(self) -> Sugg<'a> {
         self.0
     }
+
+    fn is_zero(&self) -> bool {
+        matches!(&self.0, Sugg::NonParen(s) | Sugg::MaybeParen(s) if s == "0")
+    }
 }
 
 impl<'a> From<Sugg<'a>> for MinifyingSugg<'a> {
@@ -241,9 +245,9 @@ impl<'a> From<Sugg<'a>> for MinifyingSugg<'a> {
 impl std::ops::Add for &MinifyingSugg<'static> {
     type Output = MinifyingSugg<'static>;
     fn add(self, rhs: &MinifyingSugg<'static>) -> MinifyingSugg<'static> {
-        match (self.to_string().as_str(), rhs.to_string().as_str()) {
-            ("0", _) => rhs.clone(),
-            (_, "0") => self.clone(),
+        match (self.is_zero(), rhs.is_zero()) {
+            (true, _) => rhs.clone(),
+            (_, true) => self.clone(),
             (_, _) => (&self.0 + &rhs.0).into(),
         }
     }
@@ -252,11 +256,14 @@ impl std::ops::Add for &MinifyingSugg<'static> {
 impl std::ops::Sub for &MinifyingSugg<'static> {
     type Output = MinifyingSugg<'static>;
     fn sub(self, rhs: &MinifyingSugg<'static>) -> MinifyingSugg<'static> {
-        match (self.to_string().as_str(), rhs.to_string().as_str()) {
-            (_, "0") => self.clone(),
-            ("0", _) => (-rhs.0.clone()).into(),
-            (x, y) if x == y => sugg::ZERO.into(),
-            (_, _) => (&self.0 - &rhs.0).into(),
+        if rhs.is_zero() {
+            self.clone()
+        } else if self.is_zero() {
+            (-rhs.0.clone()).into()
+        } else if self.to_string() == rhs.to_string() {
+            sugg::ZERO.into()
+        } else {
+            (&self.0 - &rhs.0).into()
         }
     }
 }
@@ -264,9 +271,9 @@ impl std::ops::Sub for &MinifyingSugg<'static> {
 impl std::ops::Add<&MinifyingSugg<'static>> for MinifyingSugg<'static> {
     type Output = MinifyingSugg<'static>;
     fn add(self, rhs: &MinifyingSugg<'static>) -> MinifyingSugg<'static> {
-        match (self.to_string().as_str(), rhs.to_string().as_str()) {
-            ("0", _) => rhs.clone(),
-            (_, "0") => self,
+        match (self.is_zero(), rhs.is_zero()) {
+            (true, _) => rhs.clone(),
+            (_, true) => self,
             (_, _) => (self.0 + &rhs.0).into(),
         }
     }
@@ -275,11 +282,14 @@ impl std::ops::Add<&MinifyingSugg<'static>> for MinifyingSugg<'static> {
 impl std::ops::Sub<&MinifyingSugg<'static>> for MinifyingSugg<'static> {
     type Output = MinifyingSugg<'static>;
     fn sub(self, rhs: &MinifyingSugg<'static>) -> MinifyingSugg<'static> {
-        match (self.to_string().as_str(), rhs.to_string().as_str()) {
-            (_, "0") => self,
-            ("0", _) => (-rhs.0.clone()).into(),
-            (x, y) if x == y => sugg::ZERO.into(),
-            (_, _) => (self.0 - &rhs.0).into(),
+        if rhs.is_zero() {
+            self
+        } else if self.is_zero() {
+            (-rhs.0.clone()).into()
+        } else if self.to_string() == rhs.to_string() {
+            sugg::ZERO.into()
+        } else {
+            (self.0 - &rhs.0).into()
         }
     }
 }


### PR DESCRIPTION
## Summary

In `clippy_lints/src/loops/manual_memcpy.rs`, the four `Add`/`Sub` trait impls on `MinifyingSugg` used the pattern:

```rust
match (self.to_string().as_str(), rhs.to_string().as_str()) {
    ("0", _) => rhs.clone(),
    (_, "0") => self.clone(),
    ...
}
```

Every call therefore allocated two `String`s purely so they could be matched against the literal `"0"`. The allocations were discarded immediately afterwards.

This PR:

- Adds an inline `is_zero()` helper that pattern-matches `Sugg::NonParen("0")` without allocating. In this lint's data flow `Sugg::NonParen` is the only variant that can carry the textual value `"0"` (see `sugg::ZERO` and the literal path in `get_offset`), so the check is equivalent to the original `to_string() == "0"`.
- Rewrites the four `Add`/`Sub` impls to use `is_zero()` for the zero-side fast paths.
- Keeps `self.to_string() == rhs.to_string()` for the `a - a = 0` collapse inside `Sub`, but only as the final branch — it now only runs when both operands are confirmed non-zero, so the common case is fully allocation-free.

changelog: none
