### PR TITLE
Remove redundant `format!("{}", ..)` around `def_path_str` in `unnecessary_literal_unwrap`

### DIFF
--- a/clippy_lints/src/methods/unnecessary_literal_unwrap.rs
+++ b/clippy_lints/src/methods/unnecessary_literal_unwrap.rs
@@ -92,7 +92,7 @@ pub(super) fn check(
             (sym::None, sym::unwrap_or_default, _) => {
                 let ty = cx.typeck_results().expr_ty(expr);
                 let default_ty_string = if let ty::Adt(def, ..) = ty.kind() {
-                    with_forced_trimmed_paths!(format!("{}", cx.tcx.def_path_str(def.did())))
+                    with_forced_trimmed_paths!(cx.tcx.def_path_str(def.did()))
                 } else {
                     "Default".to_string()
                 };


### PR DESCRIPTION
## Summary

In `clippy_lints/src/methods/unnecessary_literal_unwrap.rs`, the `None.unwrap_or_default()` branch builds a suggestion string like:

```rust
with_forced_trimmed_paths!(format!("{}", cx.tcx.def_path_str(def.did())))
```

`def_path_str` already returns a `String`, so the surrounding `format!("{}", ..)` is the textbook `useless_format` pattern that clippy itself lints against — it allocates a second `String` and copies the contents through the `Display` impl for no reason.

`with_forced_trimmed_paths!` is a thread-local-scoped macro that takes any expression, so passing the `String` through directly preserves identical behavior while avoiding the extra allocation and copy.

changelog: none
