### PR TITLE
Add Ada to the rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -109,4 +109,5 @@ users_on_vacation = [
     "@Jarcho",
     "@y21",
     "@samueltardieu",
+    "@ada4a",
 ]


### PR DESCRIPTION
Looks like Ada never got added to the rotation.

changelog: none

r? ada4a
