### PR TITLE
Fix `manual_range_contains` NAN handling

### DIFF
--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -20,7 +20,7 @@ use std::cmp::Ordering;
 declare_clippy_lint! {
     /// ### What it does
     /// Checks for expressions like `x >= 3 && x < 8` that could
-    /// be more readably expressed as `(3..8).contains(x)`.
+    /// be more readably expressed as `(3..8).contains(&x)`.
     ///
     /// ### Why is this bad?
     /// `contains` expresses the intent better and has less
@@ -38,6 +38,12 @@ declare_clippy_lint! {
     ///# let x = 6;
     /// assert!((3..8).contains(&x));
     /// ```
+    ///
+    /// ### Limitations
+    /// Out-of-range checks on floating-point types, such as `q < 0.0 || q > 1.0`,
+    /// are not linted. For `NaN`, that expression is `false`, but
+    /// `!(0.0..=1.0).contains(&q)` is `true`, so the suggested rewrite would
+    /// change control flow.
     #[clippy::version = "1.49.0"]
     pub MANUAL_RANGE_CONTAINS,
     style,
@@ -250,6 +256,11 @@ fn check_possible_range_contains(
                 applicability,
             );
         } else if !combine_and && ord == Some(l.ord) {
+            // For floating-point types, `q < lo || q > hi` evaluates to `false` for NaN,
+            // but `!(lo..=hi).contains(&q)` evaluates to `true` for NaN, so not linting.
+            if matches!(cx.typeck_results().expr_ty(l.expr).kind(), ty::Float(_)) {
+                return;
+            }
             // `!_.contains(_)`
             // order lower bound and upper bound
             let (l_span, u_span, l_inc, u_inc) = if l.ord == Ordering::Less {

--- a/tests/ui/range_contains.fixed
+++ b/tests/ui/range_contains.fixed
@@ -56,8 +56,7 @@ fn main() {
     let y = 3.;
     (0. ..1.).contains(&y);
     //~^ manual_range_contains
-    !(0. ..=1.).contains(&y);
-    //~^ manual_range_contains
+    y < 0. || y > 1.; // no lint: float `||` differs in NaN handling (fix #16706)
 
     // handle negatives #8721
     (-10..=10).contains(&x);
@@ -95,4 +94,24 @@ fn msrv_1_35() {
     let x = 5;
     (8..35).contains(&x);
     //~^ manual_range_contains
+}
+
+// Fix #16706
+fn float_nan_no_lint() {
+    let q = 0.5_f64;
+    // these still lint — float && (in-range) is fine, NaN semantics match
+    (0.0..1.0).contains(&q);
+    //~^ manual_range_contains
+    (0.0..=1.0).contains(&q);
+    //~^ manual_range_contains
+
+    // these do NOT lint — float || (out-of-range) NaN semantics differ
+    q < 0.0 || q > 1.0; // no lint
+    q < 0.0 || q >= 1.0; // no lint
+
+    let r = 0.5_f32;
+    (0.0..1.0).contains(&r);
+    //~^ manual_range_contains
+
+    r < 0.0 || r > 1.0; // no lint
 }

--- a/tests/ui/range_contains.rs
+++ b/tests/ui/range_contains.rs
@@ -56,8 +56,7 @@ fn main() {
     let y = 3.;
     y >= 0. && y < 1.;
     //~^ manual_range_contains
-    y < 0. || y > 1.;
-    //~^ manual_range_contains
+    y < 0. || y > 1.; // no lint: float `||` differs in NaN handling (fix #16706)
 
     // handle negatives #8721
     x >= -10 && x <= 10;
@@ -95,4 +94,24 @@ fn msrv_1_35() {
     let x = 5;
     x >= 8 && x < 35;
     //~^ manual_range_contains
+}
+
+// Fix #16706
+fn float_nan_no_lint() {
+    let q = 0.5_f64;
+    // these still lint — float && (in-range) is fine, NaN semantics match
+    q >= 0.0 && q < 1.0;
+    //~^ manual_range_contains
+    q >= 0.0 && q <= 1.0;
+    //~^ manual_range_contains
+
+    // these do NOT lint — float || (out-of-range) NaN semantics differ
+    q < 0.0 || q > 1.0; // no lint
+    q < 0.0 || q >= 1.0; // no lint
+
+    let r = 0.5_f32;
+    r >= 0.0 && r < 1.0;
+    //~^ manual_range_contains
+
+    r < 0.0 || r > 1.0; // no lint
 }

--- a/tests/ui/range_contains.stderr
+++ b/tests/ui/range_contains.stderr
@@ -79,53 +79,65 @@ error: manual `Range::contains` implementation
 LL |     y >= 0. && y < 1.;
    |     ^^^^^^^^^^^^^^^^^ help: use: `(0. ..1.).contains(&y)`
 
-error: manual `!RangeInclusive::contains` implementation
-  --> tests/ui/range_contains.rs:59:5
-   |
-LL |     y < 0. || y > 1.;
-   |     ^^^^^^^^^^^^^^^^ help: use: `!(0. ..=1.).contains(&y)`
-
 error: manual `RangeInclusive::contains` implementation
-  --> tests/ui/range_contains.rs:63:5
+  --> tests/ui/range_contains.rs:62:5
    |
 LL |     x >= -10 && x <= 10;
    |     ^^^^^^^^^^^^^^^^^^^ help: use: `(-10..=10).contains(&x)`
 
 error: manual `RangeInclusive::contains` implementation
-  --> tests/ui/range_contains.rs:66:5
+  --> tests/ui/range_contains.rs:65:5
    |
 LL |     y >= -3. && y <= 3.;
    |     ^^^^^^^^^^^^^^^^^^^ help: use: `(-3. ..=3.).contains(&y)`
 
 error: manual `RangeInclusive::contains` implementation
-  --> tests/ui/range_contains.rs:72:30
+  --> tests/ui/range_contains.rs:71:30
    |
 LL |     (x >= 0) && (x <= 10) && (z >= 0) && (z <= 10);
    |                              ^^^^^^^^^^^^^^^^^^^^^ help: use: `(0..=10).contains(&z)`
 
 error: manual `RangeInclusive::contains` implementation
-  --> tests/ui/range_contains.rs:72:5
+  --> tests/ui/range_contains.rs:71:5
    |
 LL |     (x >= 0) && (x <= 10) && (z >= 0) && (z <= 10);
    |     ^^^^^^^^^^^^^^^^^^^^^ help: use: `(0..=10).contains(&x)`
 
 error: manual `!Range::contains` implementation
-  --> tests/ui/range_contains.rs:75:29
+  --> tests/ui/range_contains.rs:74:29
    |
 LL |     (x < 0) || (x >= 10) || (z < 0) || (z >= 10);
    |                             ^^^^^^^^^^^^^^^^^^^^ help: use: `!(0..10).contains(&z)`
 
 error: manual `!Range::contains` implementation
-  --> tests/ui/range_contains.rs:75:5
+  --> tests/ui/range_contains.rs:74:5
    |
 LL |     (x < 0) || (x >= 10) || (z < 0) || (z >= 10);
    |     ^^^^^^^^^^^^^^^^^^^^ help: use: `!(0..10).contains(&x)`
 
 error: manual `Range::contains` implementation
-  --> tests/ui/range_contains.rs:96:5
+  --> tests/ui/range_contains.rs:95:5
    |
 LL |     x >= 8 && x < 35;
    |     ^^^^^^^^^^^^^^^^ help: use: `(8..35).contains(&x)`
 
-error: aborting due to 21 previous errors
+error: manual `Range::contains` implementation
+  --> tests/ui/range_contains.rs:103:5
+   |
+LL |     q >= 0.0 && q < 1.0;
+   |     ^^^^^^^^^^^^^^^^^^^ help: use: `(0.0..1.0).contains(&q)`
+
+error: manual `RangeInclusive::contains` implementation
+  --> tests/ui/range_contains.rs:105:5
+   |
+LL |     q >= 0.0 && q <= 1.0;
+   |     ^^^^^^^^^^^^^^^^^^^^ help: use: `(0.0..=1.0).contains(&q)`
+
+error: manual `Range::contains` implementation
+  --> tests/ui/range_contains.rs:113:5
+   |
+LL |     r >= 0.0 && r < 1.0;
+   |     ^^^^^^^^^^^^^^^^^^^ help: use: `(0.0..1.0).contains(&r)`
+
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION

 For floating-point out-of-range checks like `q < 0.0 || q > 1.0`, the manual form is `false` for `NaN`, but the lint’s suggestion `!(0.0..=1.0).contains(&q)` is `true`, which changes control flow.

This PR skips linting for floating-point out-of-range patterns combined with `||` or `|`, documents the limitation, and adds UI tests.
 
In-range float checks such as `q >= 0.0 && q < 1.0` are still linted, since rewriting to `.contains()` preserves `NaN` behavior there.

Edit: 
I chose to skip linting rather than suggest `&& !q.is_nan()`. 
Adding an `is_nan()` guard would be more verbose than the original code.
Assumes `NaN` handling the author may not want.

changelog: [`manual_range_contains`] : fix NaN handling

fixes rust-lang/rust-clippy#16706
