### PR TITLE
Changelog for Clippy 1.96 🦀

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,101 @@ document.
 
 ## Unreleased / Beta / In Rust Nightly
 
-[df995e...master](https://github.com/rust-lang/rust-clippy/compare/df995e...master)
+[88f787...master](https://github.com/rust-lang/rust-clippy/compare/88f787...master)
+
+## Rust 1.96
+
+Current stable, released 2026-05-28
+
+[View all 48 merged pull requests](https://github.com/rust-lang/rust-clippy/pulls?q=merged%3A2026-02-24T12%3A30%3A17Z..2026-04-03T17%3A32%3A48Z+base%3Amaster)
+
+### New Lints
+
+* Added [`manual_noop_waker`] to `complexity`
+  [#16687](https://github.com/rust-lang/rust-clippy/pull/16687)
+* Added [`manual_option_zip`] to `complexity`
+  [#16600](https://github.com/rust-lang/rust-clippy/pull/16600)
+* Added [`manual_pop_if`] to `complexity`
+  [#16582](https://github.com/rust-lang/rust-clippy/pull/16582)
+
+### Enhancements
+
+* [`explicit_counter_loop`] suggest `(init..).take(n)` when loop variable is unused and range is
+  `0..n`
+  [#16658](https://github.com/rust-lang/rust-clippy/pull/16658)
+* [`iter_kv_map`] handle identity map for `map` and `flat_map`
+  [#16743](https://github.com/rust-lang/rust-clippy/pull/16743)
+* [`manual_noop_waker`] add an MSRV check
+  [#16850](https://github.com/rust-lang/rust-clippy/pull/16850)
+* [`manual_pop_if`] in case the popped value is used, just emit the lint with no suggestion
+  [#16683](https://github.com/rust-lang/rust-clippy/pull/16683)
+* [`manual_pop_if`] also cover `.pop().unwrap_unchecked()`
+  [#16683](https://github.com/rust-lang/rust-clippy/pull/16683)
+* [`manual_pop_if`] detect manual implementations of `BinaryHeap::pop_if()`
+  [#16734](https://github.com/rust-lang/rust-clippy/pull/16734)
+* [`unnecessary_option_map_or_else`] function definitions are no longer traversed when checking if
+  an expression is the identity
+  [#15889](https://github.com/rust-lang/rust-clippy/pull/15889)
+* [`unnecessary_result_map_or_else`] function definitions are no longer traversed when checking if
+  an expression is the identity
+  [#15889](https://github.com/rust-lang/rust-clippy/pull/15889)
+* [`question_mark`] fix suggestion-caused error caused by semicolon inference relying only on
+  parent-node shape
+  [#16656](https://github.com/rust-lang/rust-clippy/pull/16656)
+* Format-related lints now handle `core::panic!`
+  [#16597](https://github.com/rust-lang/rust-clippy/pull/16597)
+* [`explicit_counter_loop`] fix FN when the initializer is not integral
+  [#16647](https://github.com/rust-lang/rust-clippy/pull/16647)
+* [`suboptimal_flops`] fix FN on add and sub assign
+  [#16625](https://github.com/rust-lang/rust-clippy/pull/16625)
+* [`infinite_loop`] fix wrong suggestion to add `-> !` when the loop is inside a conditional branch
+  [#16619](https://github.com/rust-lang/rust-clippy/pull/16619)
+* [`unnecessary_cast`] preserve parentheses in presence of cascaded casts
+  [#16483](https://github.com/rust-lang/rust-clippy/pull/16483)
+* [`cmp_owned`] fix wrong suggestions on `PathBuf`
+  [#16628](https://github.com/rust-lang/rust-clippy/pull/16628)
+* [`redundant_closure`] fix wrong suggestions when local is dereferenced to callable
+  [#16648](https://github.com/rust-lang/rust-clippy/pull/16648)
+
+### False Positive Fixes
+
+* [`collapsible_if`] fix FP when the inner if contains cfg
+  [#16757](https://github.com/rust-lang/rust-clippy/pull/16757)
+* [`collapsible_match`] fix FP when the pat binding is moved or mutated
+  [#16708](https://github.com/rust-lang/rust-clippy/pull/16708)
+* [`collapsible_match`] fix a case where a suggested transformation changes runtime behavior
+  [#16878](https://github.com/rust-lang/rust-clippy/pull/16878)
+* [`match_same_arms`] fix FP with associated consts
+  [#16701](https://github.com/rust-lang/rust-clippy/pull/16701)
+* [`semicolon_inside_block`] fix FP in `try` blocks where moving `;` changes the block's return
+  type and causes type errors
+  [#16697](https://github.com/rust-lang/rust-clippy/pull/16697)
+* [`unnecessary_safety_comment`] fix FP on code blocks inside inner docs
+  [#16559](https://github.com/rust-lang/rust-clippy/pull/16559)
+* [`doc_paragraphs_missing_punctuation`] no longer lints punctuated paragraphs with a trailing
+  emoji
+  [#16514](https://github.com/rust-lang/rust-clippy/pull/16514)
+
+### ICE Fixes
+
+* [`match_same_arms`] fix ICE in `match_same_arms`
+  [#16685](https://github.com/rust-lang/rust-clippy/pull/16685)
+* [`nonminimal_bool`] fix ICE in `swap_binop()` by using the proper `TypeckResults`
+  [#16659](https://github.com/rust-lang/rust-clippy/pull/16659)
+* Fix ICE when using the `min_generic_const_args` incomplete feature
+  [#16692](https://github.com/rust-lang/rust-clippy/pull/16692)
+
+### Documentation Improvements
+
+* [`similar_names`] changed the lint docs to reflect its actual behavior
+  [#16300](https://github.com/rust-lang/rust-clippy/pull/16300)
+
+### Performance Improvements
+
+* [`repeat_vec_with_capacity`] optimized by 96.876% (784M -> 24M instructions)
+  [#16756](https://github.com/rust-lang/rust-clippy/pull/16756)
+* [`manual_is_ascii_check`] optimized by 97.125% (822M -> 23M instructions)
+  [#16755](https://github.com/rust-lang/rust-clippy/pull/16755)
 
 ## Rust 1.95
 

--- a/clippy_lints/src/manual_pop_if.rs
+++ b/clippy_lints/src/manual_pop_if.rs
@@ -51,7 +51,7 @@ declare_clippy_lint! {
     /// deque.pop_back_if(|x| *x > 5);
     /// deque.pop_front_if(|x| *x > 5);
     /// ```
-    #[clippy::version = "1.95.0"]
+    #[clippy::version = "1.96.0"]
     pub MANUAL_POP_IF,
     complexity,
     "manual implementation of `pop_if` methods"

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2004,7 +2004,7 @@ declare_clippy_lint! {
     /// let b: Option<i32> = Some(2);
     /// let _ = a.zip(b);
     /// ```
-    #[clippy::version = "1.95.0"]
+    #[clippy::version = "1.96.0"]
     pub MANUAL_OPTION_ZIP,
     complexity,
     "manual reimplementation of `Option::zip`"


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17066)*

Violets are red,
Roses are blue,
This month is RustWeek,
And borrow-checkers too.

----

Unfortunately, no nominations from the previous one 😿 So take it [from 1.94](https://github.com/rust-lang/rust-clippy/pull/16653)

<img width="1032" height="1548" alt="image" src="https://github.com/user-attachments/assets/02ba1c12-e712-4d90-8914-ed3a404b094c" />

Pochoclo from @Phosphorus-M doing cat things — because pawsitivity and important meowtters come first 😸

----

Cats for the next release can be nominated in the comments🙏🙏🙏 

changelog: none

r? flip1995