### PR TITLE
Suggest `if let` in more cases

### DIFF
--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -3,7 +3,7 @@ use clippy_utils::source::{
     SpanRangeExt, expr_block, snippet, snippet_block_with_context, snippet_with_applicability, snippet_with_context,
 };
 use clippy_utils::ty::{implements_trait, peel_and_count_ty_refs};
-use clippy_utils::{is_lint_allowed, is_unit_expr, peel_blocks, peel_hir_pat_refs, peel_n_hir_expr_refs, sym};
+use clippy_utils::{is_lint_allowed, is_unit_expr, is_wild, peel_blocks, peel_hir_pat_refs, peel_n_hir_expr_refs, sym};
 use core::ops::ControlFlow;
 use rustc_arena::DroplessArena;
 use rustc_errors::{Applicability, Diag};
@@ -25,6 +25,65 @@ fn empty_arm_has_comment(cx: &LateContext<'_>, span: Span) -> bool {
     span.check_source_text(cx, |text| text.as_bytes().windows(2).any(|w| w == b"//" || w == b"/*"))
 }
 
+/// Checks if an arm contains expressions or statements.
+/// This is a very naive check, as it just checks if the arm is a block or contains comments, but it
+/// satisfies our current test cases.
+fn arm_has_code(cx: &LateContext<'_>, arm: &Arm<'_>) -> bool {
+    if is_unit_expr(peel_blocks(arm.body)) && !empty_arm_has_comment(cx, arm.body.span) {
+        false
+    } else {
+        matches!(arm.body.kind, ExprKind::Block(_block, _))
+    }
+}
+
+fn check_single_match<'tcx>(
+    cx: &LateContext<'tcx>,
+    ex: &'tcx Expr<'_>,
+    expr: &'tcx Expr<'_>,
+    contains_comments: bool,
+    arm1: &'tcx Arm<'_>,
+    arm2: &'tcx Arm<'_>,
+) {
+    let els = if is_unit_expr(peel_blocks(arm2.body)) && !empty_arm_has_comment(cx, arm2.body.span) {
+        None
+    } else if let ExprKind::Block(block, _) = arm2.body.kind {
+        if matches!((block.stmts, block.expr), ([], Some(_)) | ([_], None)) {
+            // single statement/expr "else" block, don't lint
+            return;
+        }
+        // block with 2+ statements or 1 expr and 1+ statement
+        Some(arm2.body)
+    } else {
+        // not a block or an empty block w/ comments, don't lint
+        return;
+    };
+
+    let typeck = cx.typeck_results();
+    if *typeck.expr_ty(ex).peel_refs().kind() != ty::Bool || is_lint_allowed(cx, MATCH_BOOL, ex.hir_id) {
+        let mut v = PatVisitor {
+            typeck,
+            has_enum: false,
+        };
+        if v.visit_pat(arm2.pat).is_break() {
+            return;
+        }
+        if v.has_enum {
+            let cx = PatCtxt {
+                tcx: cx.tcx,
+                typeck,
+                arena: DroplessArena::default(),
+            };
+            let mut state = PatState::Other;
+            if !(state.add_pat(&cx, arm2.pat) || state.add_pat(&cx, arm1.pat)) {
+                // Don't lint if the pattern contains an enum which doesn't have a wild match.
+                return;
+            }
+        }
+
+        report_single_pattern(cx, ex, arm1, expr, els, contains_comments);
+    }
+}
+
 pub(crate) fn check<'tcx>(
     cx: &LateContext<'tcx>,
     ex: &'tcx Expr<'_>,
@@ -39,43 +98,16 @@ pub(crate) fn check<'tcx>(
         // the lint noisy in unnecessary situations
         && !matches!(arm1.pat.kind, PatKind::Or(..))
     {
-        let els = if is_unit_expr(peel_blocks(arm2.body)) && !empty_arm_has_comment(cx, arm2.body.span) {
-            None
-        } else if let ExprKind::Block(block, _) = arm2.body.kind {
-            if matches!((block.stmts, block.expr), ([], Some(_)) | ([_], None)) {
-                // single statement/expr "else" block, don't lint
-                return;
-            }
-            // block with 2+ statements or 1 expr and 1+ statement
-            Some(arm2.body)
-        } else {
-            // not a block or an empty block w/ comments, don't lint
-            return;
-        };
+        check_single_match(cx, ex, expr, contains_comments, arm1, arm2);
 
-        let typeck = cx.typeck_results();
-        if *typeck.expr_ty(ex).peel_refs().kind() != ty::Bool || is_lint_allowed(cx, MATCH_BOOL, ex.hir_id) {
-            let mut v = PatVisitor {
-                typeck,
-                has_enum: false,
-            };
-            if v.visit_pat(arm2.pat).is_break() {
-                return;
-            }
-            if v.has_enum {
-                let cx = PatCtxt {
-                    tcx: cx.tcx,
-                    typeck,
-                    arena: DroplessArena::default(),
-                };
-                let mut state = PatState::Other;
-                if !(state.add_pat(&cx, arm2.pat) || state.add_pat(&cx, arm1.pat)) {
-                    // Don't lint if the pattern contains an enum which doesn't have a wild match.
-                    return;
-                }
-            }
-
-            report_single_pattern(cx, ex, arm1, expr, els, contains_comments);
+        // Make sure we match symmetrically on enums, regardless of the order of the match
+        if cx.typeck_results().expr_ty(ex).peel_refs().is_enum()
+            // Prevent false positives by excluding bindings, wildcards and empty arms
+            && !matches!(arm2.pat.kind, PatKind::Binding(..))
+            && !is_wild(arm2.pat)
+            && !arm_has_code(cx, arm2)
+        {
+            check_single_match(cx, ex, expr, contains_comments, arm2, arm1);
         }
     }
 }

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -105,7 +105,7 @@ pub(crate) fn check<'tcx>(
             // Prevent false positives by excluding bindings, wildcards and empty arms
             && !matches!(arm2.pat.kind, PatKind::Binding(..))
             && !is_wild(arm2.pat)
-            && !arm_has_code(cx, arm2)
+            && (!arm_has_code(cx, arm1) || !arm_has_code(cx, arm2))
         {
             check_single_match(cx, ex, expr, contains_comments, arm2, arm1);
         }

--- a/tests/ui/cognitive_complexity.rs
+++ b/tests/ui/cognitive_complexity.rs
@@ -316,11 +316,8 @@ pub fn read_file(input_path: &str) -> String {
 
     let mut bytes = Vec::new();
 
-    match file.read_to_end(&mut bytes) {
-        Ok(..) => {},
-        Err(_) => {
-            panic!("Can't read {}", input_path);
-        },
+    if file.read_to_end(&mut bytes).is_err() {
+        panic!("Can't read {}", input_path);
     };
 
     match String::from_utf8(bytes) {

--- a/tests/ui/cognitive_complexity.stderr
+++ b/tests/ui/cognitive_complexity.stderr
@@ -113,7 +113,7 @@ LL | pub fn read_file(input_path: &str) -> String {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:337:4
+  --> tests/ui/cognitive_complexity.rs:334:4
    |
 LL | fn void(void: Void) {
    |    ^^^^
@@ -121,7 +121,7 @@ LL | fn void(void: Void) {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (8/1)
-  --> tests/ui/cognitive_complexity.rs:390:4
+  --> tests/ui/cognitive_complexity.rs:387:4
    |
 LL | fn early_ret() -> i32 {
    |    ^^^^^^^^^
@@ -129,7 +129,7 @@ LL | fn early_ret() -> i32 {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:413:13
+  --> tests/ui/cognitive_complexity.rs:410:13
    |
 LL |     let x = |a: i32, b: i32| -> i32 {
    |             ^^^^^^^^^^^^^^^^
@@ -137,7 +137,7 @@ LL |     let x = |a: i32, b: i32| -> i32 {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:428:8
+  --> tests/ui/cognitive_complexity.rs:425:8
    |
 LL |     fn moo(&self) {
    |        ^^^
@@ -145,7 +145,7 @@ LL |     fn moo(&self) {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:439:14
+  --> tests/ui/cognitive_complexity.rs:436:14
    |
 LL |     async fn a() {
    |              ^
@@ -153,7 +153,7 @@ LL |     async fn a() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:448:22
+  --> tests/ui/cognitive_complexity.rs:445:22
    |
 LL |         pub async fn async_method() {
    |                      ^^^^^^^^^^^^
@@ -161,7 +161,7 @@ LL |         pub async fn async_method() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:459:8
+  --> tests/ui/cognitive_complexity.rs:456:8
    |
 LL |     fn foo() {
    |        ^^^
@@ -169,7 +169,7 @@ LL |     fn foo() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:466:8
+  --> tests/ui/cognitive_complexity.rs:463:8
    |
 LL |     fn bar() {
    |        ^^^
@@ -177,7 +177,7 @@ LL |     fn bar() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:478:8
+  --> tests/ui/cognitive_complexity.rs:475:8
    |
 LL |     fn bad() {
    |        ^^^
@@ -185,7 +185,7 @@ LL |     fn bad() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:493:8
+  --> tests/ui/cognitive_complexity.rs:490:8
    |
 LL |     fn bad_again() {
    |        ^^^^^^^^^

--- a/tests/ui/infinite_loops.rs
+++ b/tests/ui/infinite_loops.rs
@@ -541,6 +541,8 @@ mod issue16155 {
 
     use super::do_something;
 
+    fn dummy() {}
+
     fn let_then_else(cond: bool) {
         let true = cond else { loop {} };
         //~^ infinite_loop
@@ -555,7 +557,7 @@ mod issue16155 {
 
     fn loop_in_one_match_arm(x: Option<i32>) {
         match x {
-            Some(_) => {},
+            Some(_) => dummy(),
             None => loop {},
             //~^ infinite_loop
         }

--- a/tests/ui/infinite_loops.stderr
+++ b/tests/ui/infinite_loops.stderr
@@ -343,7 +343,7 @@ LL | |         }
    = help: if this is not intended, try adding a `break` or `return` to the loop
 
 error: infinite loop detected
-  --> tests/ui/infinite_loops.rs:545:32
+  --> tests/ui/infinite_loops.rs:547:32
    |
 LL |         let true = cond else { loop {} };
    |                                ^^^^^^^
@@ -351,7 +351,7 @@ LL |         let true = cond else { loop {} };
    = help: if this is not intended, try adding a `break` or `return` to the loop
 
 error: infinite loop detected
-  --> tests/ui/infinite_loops.rs:551:13
+  --> tests/ui/infinite_loops.rs:553:13
    |
 LL |             loop {}
    |             ^^^^^^^
@@ -359,7 +359,7 @@ LL |             loop {}
    = help: if this is not intended, try adding a `break` or `return` to the loop
 
 error: infinite loop detected
-  --> tests/ui/infinite_loops.rs:559:21
+  --> tests/ui/infinite_loops.rs:561:21
    |
 LL |             None => loop {},
    |                     ^^^^^^^
@@ -367,7 +367,7 @@ LL |             None => loop {},
    = help: if this is not intended, try adding a `break` or `return` to the loop
 
 error: infinite loop detected
-  --> tests/ui/infinite_loops.rs:568:13
+  --> tests/ui/infinite_loops.rs:570:13
    |
 LL |             loop {}
    |             ^^^^^^^
@@ -375,19 +375,7 @@ LL |             loop {}
    = help: if this is not intended, try adding a `break` or `return` to the loop
 
 error: infinite loop detected
-  --> tests/ui/infinite_loops.rs:576:13
-   |
-LL |             loop {}
-   |             ^^^^^^^
-   |
-   = help: if this is not intended, try adding a `break` or `return` to the loop
-help: if this is intentional, consider specifying `!` as function return
-   |
-LL |     fn all_branches_diverge_if(cond: bool) -> ! {
-   |                                            ++++
-
-error: infinite loop detected
-  --> tests/ui/infinite_loops.rs:579:13
+  --> tests/ui/infinite_loops.rs:578:13
    |
 LL |             loop {}
    |             ^^^^^^^
@@ -399,7 +387,19 @@ LL |     fn all_branches_diverge_if(cond: bool) -> ! {
    |                                            ++++
 
 error: infinite loop detected
-  --> tests/ui/infinite_loops.rs:586:24
+  --> tests/ui/infinite_loops.rs:581:13
+   |
+LL |             loop {}
+   |             ^^^^^^^
+   |
+   = help: if this is not intended, try adding a `break` or `return` to the loop
+help: if this is intentional, consider specifying `!` as function return
+   |
+LL |     fn all_branches_diverge_if(cond: bool) -> ! {
+   |                                            ++++
+
+error: infinite loop detected
+  --> tests/ui/infinite_loops.rs:588:24
    |
 LL |             Some(_) => loop {},
    |                        ^^^^^^^
@@ -411,7 +411,7 @@ LL |     fn all_branches_diverge_match(x: Option<i32>) -> ! {
    |                                                   ++++
 
 error: infinite loop detected
-  --> tests/ui/infinite_loops.rs:587:21
+  --> tests/ui/infinite_loops.rs:589:21
    |
 LL |             None => loop {},
    |                     ^^^^^^^

--- a/tests/ui/ref_patterns.rs
+++ b/tests/ui/ref_patterns.rs
@@ -1,12 +1,16 @@
 #![allow(unused)]
 #![warn(clippy::ref_patterns)]
 
+fn dummy() {}
+
 fn use_in_pattern() {
     let opt = Some(5);
     match opt {
-        None => {},
-        Some(ref opt) => {},
-        //~^ ref_patterns
+        None => dummy(),
+        Some(ref opt) => {
+            //~^ ref_patterns
+            dummy()
+        },
     }
 }
 

--- a/tests/ui/ref_patterns.stderr
+++ b/tests/ui/ref_patterns.stderr
@@ -1,7 +1,7 @@
 error: usage of ref pattern
-  --> tests/ui/ref_patterns.rs:8:14
+  --> tests/ui/ref_patterns.rs:10:14
    |
-LL |         Some(ref opt) => {},
+LL |         Some(ref opt) => {
    |              ^^^^^^^
    |
    = help: consider using `&` for clarity instead
@@ -9,7 +9,7 @@ LL |         Some(ref opt) => {},
    = help: to override `-D warnings` add `#[allow(clippy::ref_patterns)]`
 
 error: usage of ref pattern
-  --> tests/ui/ref_patterns.rs:15:9
+  --> tests/ui/ref_patterns.rs:19:9
    |
 LL |     let ref y = x;
    |         ^^^^^
@@ -17,7 +17,7 @@ LL |     let ref y = x;
    = help: consider using `&` for clarity instead
 
 error: usage of ref pattern
-  --> tests/ui/ref_patterns.rs:19:21
+  --> tests/ui/ref_patterns.rs:23:21
    |
 LL | fn use_in_parameter(ref x: i32) {}
    |                     ^^^^^

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -57,6 +57,18 @@ fn single_match_know_enum() {
     if let Ok(y) = y { dummy() };
     //~^^^^ single_match
 
+    #[rustfmt::skip]
+    if let Ok(y) = y {
+        dummy()
+    };
+    //~^^^^^^ single_match
+
+    #[rustfmt::skip]
+    if let Ok(y) = y {
+        dummy()
+    };
+    //~^^^^^^ single_match
+
     if let Err(..) = y { dummy() }
     //~^^^^ single_match
 

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -57,6 +57,9 @@ fn single_match_know_enum() {
     if let Ok(y) = y { dummy() };
     //~^^^^ single_match
 
+    if let Err(..) = y { dummy() }
+    //~^^^^ single_match
+
     let c = Cow::Borrowed("");
 
     if let Cow::Borrowed(..) = c { dummy() };

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -75,6 +75,12 @@ fn single_match_know_enum() {
     };
     //~^^^^ single_match
 
+    match y {
+        Ok(_) => (),
+        Err(..) => dummy(),
+    }
+    //~^^^^ single_match
+
     let c = Cow::Borrowed("");
 
     match c {

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -75,6 +75,24 @@ fn single_match_know_enum() {
     };
     //~^^^^ single_match
 
+    #[rustfmt::skip]
+    match y {
+        Ok(y) => {
+            dummy()
+        }
+        Err(..) => (),
+    };
+    //~^^^^^^ single_match
+
+    #[rustfmt::skip]
+    match y {
+        Err(..) => (),
+        Ok(y) => {
+            dummy()
+        }
+    };
+    //~^^^^^^ single_match
+
     match y {
         Ok(_) => (),
         Err(..) => dummy(),

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -57,7 +57,42 @@ LL | |     };
    | |_____^ help: try: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:78:5
+  --> tests/ui/single_match.rs:79:5
+   |
+LL | /     match y {
+LL | |         Ok(y) => {
+LL | |             dummy()
+...  |
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     if let Ok(y) = y {
+LL +         dummy()
+LL ~     };
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> tests/ui/single_match.rs:88:5
+   |
+LL | /     match y {
+LL | |         Err(..) => (),
+LL | |         Ok(y) => {
+LL | |             dummy()
+LL | |         }
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     if let Ok(y) = y {
+LL +         dummy()
+LL ~     };
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> tests/ui/single_match.rs:96:5
    |
 LL | /     match y {
 LL | |         Ok(_) => (),
@@ -66,7 +101,7 @@ LL | |     }
    | |_____^ help: try: `if let Err(..) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:86:5
+  --> tests/ui/single_match.rs:104:5
    |
 LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
@@ -75,7 +110,7 @@ LL | |     };
    | |_____^ help: try: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:108:5
+  --> tests/ui/single_match.rs:126:5
    |
 LL | /     match x {
 LL | |         "test" => println!(),
@@ -84,7 +119,7 @@ LL | |     }
    | |_____^ help: try: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:122:5
+  --> tests/ui/single_match.rs:140:5
    |
 LL | /     match x {
 LL | |         Foo::A => println!(),
@@ -93,7 +128,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:129:5
+  --> tests/ui/single_match.rs:147:5
    |
 LL | /     match x {
 LL | |         FOO_C => println!(),
@@ -102,7 +137,7 @@ LL | |     }
    | |_____^ help: try: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:135:5
+  --> tests/ui/single_match.rs:153:5
    |
 LL | /     match &&x {
 LL | |         Foo::A => println!(),
@@ -111,7 +146,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:142:5
+  --> tests/ui/single_match.rs:160:5
    |
 LL | /     match &x {
 LL | |         Foo::A => println!(),
@@ -120,7 +155,7 @@ LL | |     }
    | |_____^ help: try: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:160:5
+  --> tests/ui/single_match.rs:178:5
    |
 LL | /     match x {
 LL | |         Bar::A => println!(),
@@ -129,7 +164,7 @@ LL | |     }
    | |_____^ help: try: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:169:5
+  --> tests/ui/single_match.rs:187:5
    |
 LL | /     match x {
 LL | |         None => println!(),
@@ -138,7 +173,7 @@ LL | |     };
    | |_____^ help: try: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:192:5
+  --> tests/ui/single_match.rs:210:5
    |
 LL | /     match x {
 LL | |         (Some(_), _) => {},
@@ -147,7 +182,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:199:5
+  --> tests/ui/single_match.rs:217:5
    |
 LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
@@ -156,7 +191,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:206:5
+  --> tests/ui/single_match.rs:224:5
    |
 LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},
@@ -165,7 +200,7 @@ LL | |     }
    | |_____^ help: try: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:279:5
+  --> tests/ui/single_match.rs:297:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -185,7 +220,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:288:5
+  --> tests/ui/single_match.rs:306:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]
@@ -207,7 +242,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:369:5
+  --> tests/ui/single_match.rs:387:5
    |
 LL | /     match Ok::<_, u32>(Some(A)) {
 LL | |         Ok(Some(A)) => println!(),
@@ -216,7 +251,7 @@ LL | |     }
    | |_____^ help: try: `if let Ok(Some(A)) = Ok::<_, u32>(Some(A)) { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:385:5
+  --> tests/ui/single_match.rs:403:5
    |
 LL | /     match &Some(A) {
 LL | |         Some(A | B) => println!(),
@@ -225,7 +260,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(A | B) = &Some(A) { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:393:5
+  --> tests/ui/single_match.rs:411:5
    |
 LL | /     match &s[0..3] {
 LL | |         b"foo" => println!(),
@@ -234,7 +269,7 @@ LL | |     }
    | |_____^ help: try: `if &s[0..3] == b"foo" { println!() }`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:408:5
+  --> tests/ui/single_match.rs:426:5
    |
 LL | /     match DATA {
 LL | |         DATA => println!(),
@@ -243,7 +278,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:414:5
+  --> tests/ui/single_match.rs:432:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -252,7 +287,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:421:5
+  --> tests/ui/single_match.rs:439:5
    |
 LL | /     match i {
 LL | |         i => {
@@ -272,7 +307,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:430:5
+  --> tests/ui/single_match.rs:448:5
    |
 LL | /     match i {
 LL | |         i => {},
@@ -281,7 +316,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:436:5
+  --> tests/ui/single_match.rs:454:5
    |
 LL | /     match i {
 LL | |         i => (),
@@ -290,7 +325,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:442:5
+  --> tests/ui/single_match.rs:460:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -299,7 +334,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:450:5
+  --> tests/ui/single_match.rs:468:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -311,7 +346,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:459:5
+  --> tests/ui/single_match.rs:477:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -331,7 +366,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:485:5
+  --> tests/ui/single_match.rs:503:5
    |
 LL | /     match mac!(some) {
 LL | |         Some(u) => println!("{u}"),
@@ -340,7 +375,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(u) = mac!(some) { println!("{u}") }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:493:5
+  --> tests/ui/single_match.rs:511:5
    |
 LL | /     match mac!(str) {
 LL | |         "foo" => println!("eq"),
@@ -348,5 +383,5 @@ LL | |         _ => (),
 LL | |     }
    | |_____^ help: try: `if mac!(str) == "foo" { println!("eq") }`
 
-error: aborting due to 32 previous errors
+error: aborting due to 34 previous errors
 

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -57,7 +57,16 @@ LL | |     };
    | |_____^ help: try: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:80:5
+  --> tests/ui/single_match.rs:78:5
+   |
+LL | /     match y {
+LL | |         Ok(_) => (),
+LL | |         Err(..) => dummy(),
+LL | |     }
+   | |_____^ help: try: `if let Err(..) = y { dummy() }`
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> tests/ui/single_match.rs:86:5
    |
 LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
@@ -66,7 +75,7 @@ LL | |     };
    | |_____^ help: try: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:102:5
+  --> tests/ui/single_match.rs:108:5
    |
 LL | /     match x {
 LL | |         "test" => println!(),
@@ -75,7 +84,7 @@ LL | |     }
    | |_____^ help: try: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:116:5
+  --> tests/ui/single_match.rs:122:5
    |
 LL | /     match x {
 LL | |         Foo::A => println!(),
@@ -84,7 +93,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:123:5
+  --> tests/ui/single_match.rs:129:5
    |
 LL | /     match x {
 LL | |         FOO_C => println!(),
@@ -93,7 +102,7 @@ LL | |     }
    | |_____^ help: try: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:129:5
+  --> tests/ui/single_match.rs:135:5
    |
 LL | /     match &&x {
 LL | |         Foo::A => println!(),
@@ -102,7 +111,7 @@ LL | |     }
    | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:136:5
+  --> tests/ui/single_match.rs:142:5
    |
 LL | /     match &x {
 LL | |         Foo::A => println!(),
@@ -111,7 +120,7 @@ LL | |     }
    | |_____^ help: try: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:154:5
+  --> tests/ui/single_match.rs:160:5
    |
 LL | /     match x {
 LL | |         Bar::A => println!(),
@@ -120,7 +129,7 @@ LL | |     }
    | |_____^ help: try: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:163:5
+  --> tests/ui/single_match.rs:169:5
    |
 LL | /     match x {
 LL | |         None => println!(),
@@ -129,7 +138,7 @@ LL | |     };
    | |_____^ help: try: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:186:5
+  --> tests/ui/single_match.rs:192:5
    |
 LL | /     match x {
 LL | |         (Some(_), _) => {},
@@ -138,7 +147,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:193:5
+  --> tests/ui/single_match.rs:199:5
    |
 LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
@@ -147,7 +156,7 @@ LL | |     }
    | |_____^ help: try: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:200:5
+  --> tests/ui/single_match.rs:206:5
    |
 LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},
@@ -156,7 +165,7 @@ LL | |     }
    | |_____^ help: try: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:273:5
+  --> tests/ui/single_match.rs:279:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -176,7 +185,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:282:5
+  --> tests/ui/single_match.rs:288:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]
@@ -198,7 +207,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:363:5
+  --> tests/ui/single_match.rs:369:5
    |
 LL | /     match Ok::<_, u32>(Some(A)) {
 LL | |         Ok(Some(A)) => println!(),
@@ -207,7 +216,7 @@ LL | |     }
    | |_____^ help: try: `if let Ok(Some(A)) = Ok::<_, u32>(Some(A)) { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:379:5
+  --> tests/ui/single_match.rs:385:5
    |
 LL | /     match &Some(A) {
 LL | |         Some(A | B) => println!(),
@@ -216,7 +225,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(A | B) = &Some(A) { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:387:5
+  --> tests/ui/single_match.rs:393:5
    |
 LL | /     match &s[0..3] {
 LL | |         b"foo" => println!(),
@@ -225,7 +234,7 @@ LL | |     }
    | |_____^ help: try: `if &s[0..3] == b"foo" { println!() }`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:402:5
+  --> tests/ui/single_match.rs:408:5
    |
 LL | /     match DATA {
 LL | |         DATA => println!(),
@@ -234,7 +243,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:408:5
+  --> tests/ui/single_match.rs:414:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -243,7 +252,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:415:5
+  --> tests/ui/single_match.rs:421:5
    |
 LL | /     match i {
 LL | |         i => {
@@ -263,7 +272,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:424:5
+  --> tests/ui/single_match.rs:430:5
    |
 LL | /     match i {
 LL | |         i => {},
@@ -272,7 +281,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:430:5
+  --> tests/ui/single_match.rs:436:5
    |
 LL | /     match i {
 LL | |         i => (),
@@ -281,7 +290,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:436:5
+  --> tests/ui/single_match.rs:442:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -290,7 +299,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:444:5
+  --> tests/ui/single_match.rs:450:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -302,7 +311,7 @@ LL | |     }
    = note: you might want to preserve the comments from inside the `match`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:453:5
+  --> tests/ui/single_match.rs:459:5
    |
 LL | /     match x.pop() {
 LL | |         // bla
@@ -322,7 +331,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match.rs:479:5
+  --> tests/ui/single_match.rs:485:5
    |
 LL | /     match mac!(some) {
 LL | |         Some(u) => println!("{u}"),
@@ -331,7 +340,7 @@ LL | |     }
    | |_____^ help: try: `if let Some(u) = mac!(some) { println!("{u}") }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> tests/ui/single_match.rs:487:5
+  --> tests/ui/single_match.rs:493:5
    |
 LL | /     match mac!(str) {
 LL | |         "foo" => println!("eq"),
@@ -339,5 +348,5 @@ LL | |         _ => (),
 LL | |     }
    | |_____^ help: try: `if mac!(str) == "foo" { println!("eq") }`
 
-error: aborting due to 31 previous errors
+error: aborting due to 32 previous errors
 


### PR DESCRIPTION
Given the following Clippy currently doesn't trigger a `single_match` lint:

```rust
match x {
    Ok(_) => {},
    Err(a) => { do_something(a) },
}
```

whereas Clippy *does* trigger a `single_match` lint if the arms are switched around:

```rust
match x {
    Err(a) => { do_something(a) },
    Ok(_) => {},
}
```

This commit updates the `single_match` lint to trigger in both cases.

changelog: [`single_match`]: Suggest `if let` in more cases

Possibly fixes rust-lang/rust-clippy#2567 (If I understand the issue correctly).