### PR TITLE
fix: `missing-docs-allow-unused` for `_`-prefixed associated consts

### DIFF
--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -69,6 +69,10 @@ impl MissingDoc {
         }
     }
 
+    fn is_allow_unused_name(&self, name: &str) -> bool {
+        self.allow_unused && name.starts_with('_')
+    }
+
     fn is_missing_docs(&self, cx: &LateContext<'_>, def_id: LocalDefId, hir_id: HirId) -> bool {
         if cx.tcx.sess.opts.test {
             return false;
@@ -166,6 +170,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
         };
 
         if !item.span.from_expansion()
+            && !self.is_allow_unused_name(cx.tcx.item_name(item.owner_id.def_id).as_str())
             && self.is_missing_docs(cx, item.owner_id.def_id, item.hir_id())
             && !is_from_proc_macro(cx, item)
         {
@@ -200,6 +205,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
             && self.automatically_derived_depth == 0
             && self.in_body.is_none()
             && !item.span.from_expansion()
+            && !self.is_allow_unused_name(item.ident.name.as_str())
             && self.is_missing_docs(cx, item.owner_id.def_id, item.hir_id())
             && !is_from_proc_macro(cx, item)
         {
@@ -221,6 +227,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
             && let ItemKind::Impl(impl_) = parent.kind
             && impl_.of_trait.is_none()
             && !item.span.from_expansion()
+            && !self.is_allow_unused_name(item.ident.name.as_str())
             && self.is_missing_docs(cx, item.owner_id.def_id, item.hir_id())
             && !is_from_proc_macro(cx, item)
         {
@@ -252,7 +259,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
             && self.in_body.is_none()
             && !field.is_positional()
             && !field.span.from_expansion()
-            && !(self.allow_unused && field.ident.name.as_str().starts_with('_'))
+            && !self.is_allow_unused_name(field.ident.name.as_str())
             && self.is_missing_docs(cx, field.def_id, field.hir_id)
             && !is_from_proc_macro(cx, field)
         {

--- a/tests/ui-toml/missing_docs_in_private_items/missing_docs_in_private_items.crate_root.stderr
+++ b/tests/ui-toml/missing_docs_in_private_items/missing_docs_in_private_items.crate_root.stderr
@@ -496,5 +496,11 @@ error: missing documentation for a struct
 LL |         pub struct VisFromOutside;
    |                    ^^^^^^^^^^^^^^
 
-error: aborting due to 82 previous errors
+error: missing documentation for an associated constant
+  --> tests/ui-toml/missing_docs_in_private_items/missing_docs_in_private_items.rs:1171:11
+   |
+LL |     const _SIZE_ASSERT: () = {};
+   |           ^^^^^^^^^^^^
+
+error: aborting due to 83 previous errors
 

--- a/tests/ui-toml/missing_docs_in_private_items/missing_docs_in_private_items.default.stderr
+++ b/tests/ui-toml/missing_docs_in_private_items/missing_docs_in_private_items.default.stderr
@@ -700,5 +700,11 @@ error: missing documentation for a struct
 LL |         pub struct VisFromOutside;
    |                    ^^^^^^^^^^^^^^
 
-error: aborting due to 116 previous errors
+error: missing documentation for an associated constant
+  --> tests/ui-toml/missing_docs_in_private_items/missing_docs_in_private_items.rs:1171:11
+   |
+LL |     const _SIZE_ASSERT: () = {};
+   |           ^^^^^^^^^^^^
+
+error: aborting due to 117 previous errors
 

--- a/tests/ui-toml/missing_docs_in_private_items/missing_docs_in_private_items.rs
+++ b/tests/ui-toml/missing_docs_in_private_items/missing_docs_in_private_items.rs
@@ -1165,3 +1165,8 @@ external! {
         pub struct VisFromOutside; //~ missing_docs_in_private_items
     )}
 }
+
+pub struct SizeCheck;
+impl SizeCheck {
+    const _SIZE_ASSERT: () = {}; //~[default,crate_root] missing_docs_in_private_items
+}


### PR DESCRIPTION
changelog: [`missing_docs_in_private_items`] add `missing-docs-allow-unused` for `_`-prefixed associated consts

Fixes rust-lang/rust-clippy#17052 
