### PR TITLE
Update `map_flatten` description

### DIFF
--- a/clippy_lints/src/methods/map_flatten.rs
+++ b/clippy_lints/src/methods/map_flatten.rs
@@ -11,7 +11,7 @@ use rustc_span::symbol::sym;
 
 use super::MAP_FLATTEN;
 
-/// lint use of `map().flatten()` for `Iterators` and 'Options'
+/// lint use of `map().flatten()` for `Iterator`s, 'Option's, and `Result`s.
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, map_arg: &Expr<'_>, map_span: Span) {
     if let Some((caller_ty_name, method_to_use)) = try_get_caller_ty_name_and_method_name(cx, expr, recv, map_arg) {
         let mut applicability = Applicability::MachineApplicable;

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2327,27 +2327,34 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for usage of `_.map(_).flatten(_)` on `Iterator` and `Option`
+    /// Checks for usage of `_.map(_).flatten(_)` on `Iterator`, `Option`, and `Result`.
     ///
     /// ### Why is this bad?
-    /// Readability, this can be written more concisely as
-    /// `_.flat_map(_)` for `Iterator` or `_.and_then(_)` for `Option`
+    /// Readability. This can be written more concisely with `Iterator::flat_map`, `Option::and_then`, and
+    /// `Result::and_then`.
     ///
     /// ### Example
     /// ```no_run
     /// let vec = vec![vec![1]];
-    /// let opt = Some(5);
-    ///
     /// vec.iter().map(|x| x.iter()).flatten();
+    ///
+    /// let opt = Some(5);
     /// opt.map(|x| Some(x * 2)).flatten();
+    ///
+    /// let res: Result<i32, String> = Ok(5);
+    /// res.map(|x| Ok(x * 2)).flatten();
     /// ```
     ///
     /// Use instead:
     /// ```no_run
-    /// # let vec = vec![vec![1]];
-    /// # let opt = Some(5);
+    /// let vec = vec![vec![1]];
     /// vec.iter().flat_map(|x| x.iter());
+    ///
+    /// let opt = Some(5);
     /// opt.and_then(|x| Some(x * 2));
+    ///
+    /// let res: Result<i32, String> = Ok(5);
+    /// res.and_then(|x| Ok(x * 2));
     /// ```
     #[clippy::version = "1.31.0"]
     pub MAP_FLATTEN,


### PR DESCRIPTION
This PR expands the description for `map_flatten` to include `Result` as checked items. The check itself was added in https://github.com/rust-lang/rust-clippy/pull/7522.

changelog: none