### PR TITLE
Do not trigger `clippy::exit` when expression comes from an external macro

### DIFF
--- a/clippy_lints/src/exit.rs
+++ b/clippy_lints/src/exit.rs
@@ -69,6 +69,7 @@ impl<'tcx> LateLintPass<'tcx> for Exit {
             // in compilation contexts like --all-targets (which include --tests), you get false positives
             // because in a test context, main is not the entrypoint function
             && ident.name != sym::main
+            && !e.span.in_external_macro(cx.tcx.sess.source_map())
         {
             span_lint(cx, EXIT, e.span, "usage of `process::exit`");
         }

--- a/tests/ui/exit1.rs
+++ b/tests/ui/exit1.rs
@@ -1,3 +1,4 @@
+//@aux-build: proc_macros.rs
 #![warn(clippy::exit)]
 
 fn not_main() {
@@ -13,4 +14,22 @@ fn main() {
     };
     not_main();
     std::process::exit(1);
+}
+
+fn issue17082() {
+    macro_rules! mac {
+        ($x:expr) => {{
+            $x;
+        }};
+        (ex $x:expr) => {{
+            std::process::exit($x);
+            //~^ exit
+        }};
+    }
+    mac!(std::process::exit(1));
+    //~^ exit
+    mac!(ex 1);
+    proc_macros::external! {
+        std::process::exit(1);
+    }
 }

--- a/tests/ui/exit1.stderr
+++ b/tests/ui/exit1.stderr
@@ -1,5 +1,5 @@
 error: usage of `process::exit`
-  --> tests/ui/exit1.rs:5:9
+  --> tests/ui/exit1.rs:6:9
    |
 LL |         std::process::exit(4);
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -7,5 +7,22 @@ LL |         std::process::exit(4);
    = note: `-D clippy::exit` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::exit)]`
 
-error: aborting due to 1 previous error
+error: usage of `process::exit`
+  --> tests/ui/exit1.rs:29:10
+   |
+LL |     mac!(std::process::exit(1));
+   |          ^^^^^^^^^^^^^^^^^^^^^
+
+error: usage of `process::exit`
+  --> tests/ui/exit1.rs:25:13
+   |
+LL |             std::process::exit($x);
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     mac!(ex 1);
+   |     ---------- in this macro invocation
+   |
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
changelog: [`exit`]: do not trigger when the call to `exit()` comes from an external macro

Fixes rust-lang/rust-clippy#17082
