### PR TITLE
Fix redundant closure call async false positive

### DIFF
--- a/clippy_lints/src/redundant_closure_call.rs
+++ b/clippy_lints/src/redundant_closure_call.rs
@@ -5,7 +5,9 @@ use hir::Param;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::intravisit::{Visitor as HirVisitor, Visitor};
-use rustc_hir::{ClosureKind, CoroutineDesugaring, CoroutineKind, CoroutineSource, ExprKind, intravisit as hir_visit};
+use rustc_hir::{
+    CaptureBy, ClosureKind, CoroutineDesugaring, CoroutineKind, CoroutineSource, ExprKind, intravisit as hir_visit,
+};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty;
@@ -52,20 +54,23 @@ impl<'tcx> Visitor<'tcx> for ReturnVisitor {
     }
 }
 
-/// Checks if the body is owned by an async closure.
-/// Returns true for `async || whatever_expression`, but false for `|| async { whatever_expression
-/// }`.
-fn is_async_closure(body: &hir::Body<'_>) -> bool {
-    if let ExprKind::Closure(innermost_closure_generated_by_desugar) = body.value.kind
-        // checks whether it is `async || whatever_expression`
-        && let ClosureKind::Coroutine(CoroutineKind::Desugared(CoroutineDesugaring::Async, CoroutineSource::Closure))
-            = innermost_closure_generated_by_desugar.kind
-    {
-        true
-    } else {
-        false
-    }
+/// Checks if the expression contains a return statement of any kind using `ReturnVisitor`.
+fn contains_early_return<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> bool {
+    let mut visitor = ReturnVisitor;
+    visitor.visit_expr(expr).is_break()
 }
+
+/// Matches the inner closure of an async closure like `async || { 42 }`.
+const DESUGARED_ASYNC_CLOSURE_KIND: ClosureKind = ClosureKind::Coroutine(CoroutineKind::Desugared(
+    CoroutineDesugaring::Async,
+    CoroutineSource::Closure,
+));
+
+/// Matches the inner closure of a closure returning an async block like `|| async { 42 }`.
+const DESUGARED_ASYNC_BLOCK_CLOSURE_KIND: ClosureKind = ClosureKind::Coroutine(CoroutineKind::Desugared(
+    CoroutineDesugaring::Async,
+    CoroutineSource::Block,
+));
 
 /// Tries to find the innermost closure:
 /// ```rust,ignore
@@ -84,32 +89,56 @@ fn find_innermost_closure<'tcx>(
     &'tcx hir::FnDecl<'tcx>,
     ty::Asyncness,
     &'tcx [Param<'tcx>],
+    CaptureBy,
 )> {
     let mut data = None;
 
     while let ExprKind::Closure(closure) = expr.kind
         && let body = cx.tcx.hir_body(closure.body)
-        && {
-            let mut visitor = ReturnVisitor;
-            !visitor.visit_expr(body.value).is_break()
-        }
+        && !contains_early_return(body.value)
         && steps > 0
     {
+        let mut unwrapped_body_value = body.value;
+        let mut asyncness = ty::Asyncness::No;
+        let mut capture_clause = closure.capture_clause;
+
+        if let ExprKind::Closure(inner_closure) = body.value.kind {
+            if matches!(inner_closure.kind, DESUGARED_ASYNC_CLOSURE_KIND) {
+                asyncness = ty::Asyncness::Yes;
+                unwrapped_body_value = cx.tcx.hir_body(inner_closure.body).value;
+            } else if matches!(inner_closure.kind, DESUGARED_ASYNC_BLOCK_CLOSURE_KIND) {
+                asyncness = ty::Asyncness::Yes;
+                capture_clause = inner_closure.capture_clause;
+                unwrapped_body_value = cx.tcx.hir_body(inner_closure.body).value;
+            }
+
+            if contains_early_return(unwrapped_body_value) {
+                break;
+            }
+        }
+
         expr = body.value;
         data = Some((
-            body.value,
+            unwrapped_body_value,
             closure.fn_decl,
-            if is_async_closure(body) {
-                ty::Asyncness::Yes
-            } else {
-                ty::Asyncness::No
-            },
+            asyncness,
             body.params,
+            capture_clause,
         ));
         steps -= 1;
     }
 
     data
+}
+
+/// Returns the capture keyword for a closure. One of:
+/// `move`, `use`, or nothing for capture by reference.
+fn capture_keyword(capture_clause: CaptureBy) -> &'static str {
+    match capture_clause {
+        CaptureBy::Value { .. } => "move ",
+        CaptureBy::Use { .. } => "use ",
+        CaptureBy::Ref => "",
+    }
 }
 
 /// "Walks up" the chain of calls to find the outermost call expression, and returns the depth:
@@ -156,7 +185,8 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClosureCall {
             // We don't want to suggest replacing `x!()()` with `x!()`.
             && recv.span.ctxt().outer_expn() == expr.span.ctxt().outer_expn()
             && let (full_expr, call_depth) = get_parent_call_exprs(cx, expr)
-            && let Some((body, fn_decl, coroutine_kind, params)) = find_innermost_closure(cx, recv, call_depth)
+            && let Some((mut body, fn_decl, coroutine_kind, params, capture_clause)) =
+                find_innermost_closure(cx, recv, call_depth)
             // outside macros we lint properly. Inside macros, we lint only ||() style closures.
             && (!matches!(expr.span.ctxt().outer_expn_data().kind, ExpnKind::Macro(_, _)) || params.is_empty())
         {
@@ -171,38 +201,30 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClosureCall {
                         let mut hint =
                             Sugg::hir_with_context(cx, body, full_expr.span.ctxt(), "..", &mut applicability);
 
-                        if coroutine_kind.is_async()
-                            && let ExprKind::Closure(closure) = body.kind
-                        {
-                            // Like `async fn`, async closures are wrapped in an additional block
-                            // to move all of the closure's arguments into the future.
-
-                            let async_closure_body = cx.tcx.hir_body(closure.body).value;
-                            let ExprKind::Block(block, _) = async_closure_body.kind else {
-                                return;
-                            };
-                            let Some(block_expr) = block.expr else {
-                                return;
-                            };
-                            let ExprKind::DropTemps(body_expr) = block_expr.kind else {
-                                return;
-                            };
+                        if coroutine_kind.is_async() {
+                            if let ExprKind::Closure(closure) = body.kind {
+                                // Like `async fn`, async closures are wrapped in an additional block
+                                // to move all of the closure's arguments into the future.
+                                body = cx.tcx.hir_body(closure.body).value;
+                            }
 
                             // `async x` is a syntax error, so it becomes `async { x }`
-                            if !matches!(body_expr.kind, ExprKind::Block(_, _)) {
+                            if let ExprKind::Block(block, _) = body.kind
+                                && let Some(block_expr) = block.expr
+                                && let ExprKind::DropTemps(body_expr) = block_expr.kind
+                                && !matches!(body_expr.kind, ExprKind::Block(_, _))
+                            {
                                 hint = hint.blockify();
                             }
 
-                            hint = hint.asyncify();
-                        }
-
-                        // If the closure body is a block with a single expression, suggest just the inner expression,
-                        // not the block. Example: `(|| { Some(true) })()` should suggest
-                        // `Some(true)`
-                        if let ExprKind::Block(block, _) = body.kind
+                            hint = Sugg::NonParen(format!("async {}{hint}", capture_keyword(capture_clause)).into());
+                        } else if let ExprKind::Block(block, _) = body.kind
                             && block.stmts.is_empty()
                             && let Some(expr) = block.expr
                         {
+                            // If the (non-async) closure body is a block with a single expression,
+                            // suggest just the inner expression, not the block.
+                            // Example: `(|| { Some(true) })()` should suggest `Some(true)`
                             hint = Sugg::hir_with_context(cx, expr, full_expr.span.ctxt(), "..", &mut applicability)
                                 .maybe_paren();
                         }

--- a/tests/ui/redundant_closure_call_early.rs
+++ b/tests/ui/redundant_closure_call_early.rs
@@ -2,7 +2,6 @@
 
 #![expect(incomplete_features)]
 #![feature(ergonomic_clones)]
-#![warn(clippy::redundant_closure_call)]
 
 fn main() {
     let mut i = 1;
@@ -16,10 +15,10 @@ fn main() {
     //~^ redundant_closure_call
 
     // don't lint these
-    #[allow(clippy::needless_return)]
+    #[expect(clippy::needless_return)]
     (|| return 2)();
     (|| -> Option<i32> { None? })();
-    #[allow(clippy::try_err)]
+    #[expect(clippy::try_err)]
     (|| -> Result<i32, i32> { Err(2)? })();
 
     // don't lint async equivalents either

--- a/tests/ui/redundant_closure_call_early.rs
+++ b/tests/ui/redundant_closure_call_early.rs
@@ -1,5 +1,7 @@
 // non rustfixable, see redundant_closure_call_fixable.rs
 
+#![expect(incomplete_features)]
+#![feature(ergonomic_clones)]
 #![warn(clippy::redundant_closure_call)]
 
 fn main() {
@@ -19,4 +21,55 @@ fn main() {
     (|| -> Option<i32> { None? })();
     #[allow(clippy::try_err)]
     (|| -> Result<i32, i32> { Err(2)? })();
+
+    // don't lint async equivalents either
+    #[expect(clippy::needless_return)]
+    (|| async { return })();
+    (|| async {
+        let x: Option<i32> = None;
+        x?;
+        Some(1)
+    })();
+    #[expect(clippy::try_err)]
+    (|| async {
+        Err::<(), i32>(2)?;
+        Ok::<(), i32>(())
+    })();
+
+    #[expect(clippy::needless_return)]
+    (|| async move { return })();
+    (|| async move {
+        let x: Option<i32> = None;
+        x?;
+        Some(1)
+    })();
+
+    #[expect(clippy::needless_return)]
+    (async || return)();
+    (async || {
+        let x: Option<i32> = None;
+        x?;
+        Some(1)
+    })();
+    #[expect(clippy::try_err)]
+    (async || {
+        Err::<(), i32>(2)?;
+        Ok::<(), i32>(())
+    })();
+
+    #[expect(clippy::needless_return)]
+    (async move || return)();
+    (async move || {
+        let x: Option<i32> = None;
+        x?;
+        Some(1)
+    })();
+
+    #[expect(clippy::needless_return)]
+    (async use || return)();
+    (async use || {
+        let x: Option<i32> = None;
+        x?;
+        Some(1)
+    })();
 }

--- a/tests/ui/redundant_closure_call_early.stderr
+++ b/tests/ui/redundant_closure_call_early.stderr
@@ -1,5 +1,5 @@
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_early.rs:11:17
+  --> tests/ui/redundant_closure_call_early.rs:10:17
    |
 LL |     let mut k = (|m| m + 1)(i);
    |                 ^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let mut k = (|m| m + 1)(i);
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_call)]`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_early.rs:15:9
+  --> tests/ui/redundant_closure_call_early.rs:14:9
    |
 LL |     k = (|a, b| a * b)(1, 5);
    |         ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/redundant_closure_call_early.stderr
+++ b/tests/ui/redundant_closure_call_early.stderr
@@ -1,5 +1,5 @@
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_early.rs:9:17
+  --> tests/ui/redundant_closure_call_early.rs:11:17
    |
 LL |     let mut k = (|m| m + 1)(i);
    |                 ^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let mut k = (|m| m + 1)(i);
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_call)]`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_early.rs:13:9
+  --> tests/ui/redundant_closure_call_early.rs:15:9
    |
 LL |     k = (|a, b| a * b)(1, 5);
    |         ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/redundant_closure_call_fixable.fixed
+++ b/tests/ui/redundant_closure_call_fixable.fixed
@@ -1,3 +1,5 @@
+#![expect(incomplete_features)]
+#![feature(ergonomic_clones)]
 #![warn(clippy::redundant_closure_call)]
 #![allow(clippy::redundant_async_block)]
 #![allow(clippy::type_complexity)]
@@ -110,6 +112,37 @@ mod issue11707 {
 
     fn demo() {
         spawn_on(async move {});
+        //~^ redundant_closure_call
+    }
+
+    fn demo_with_captures() {
+        let name = String::from("world");
+        spawn_on(async move { drop(format!("hello, {name}")) });
+        //~^ redundant_closure_call
+    }
+
+    fn demo_async_move_closure() {
+        let name = String::from("world");
+        spawn_on(async move { drop(format!("hello, {name}")) });
+        //~^ redundant_closure_call
+    }
+}
+
+mod issue16232 {
+    use core::future::Future;
+
+    fn spawn_on(fut: impl Future<Output = ()>) {}
+
+    fn closure_async_use_block() {
+        let name = String::from("world");
+        #[rustfmt::skip]
+        spawn_on(async use { drop(format!("hello, {name:?}")) });
+        //~^ redundant_closure_call
+    }
+
+    fn async_use_closure() {
+        let name = String::from("world");
+        spawn_on(async use { drop(format!("hello, {name}")) });
         //~^ redundant_closure_call
     }
 }

--- a/tests/ui/redundant_closure_call_fixable.fixed
+++ b/tests/ui/redundant_closure_call_fixable.fixed
@@ -1,9 +1,6 @@
+#![expect(unused)]
 #![expect(incomplete_features)]
 #![feature(ergonomic_clones)]
-#![warn(clippy::redundant_closure_call)]
-#![allow(clippy::redundant_async_block)]
-#![allow(clippy::type_complexity)]
-#![allow(unused)]
 
 async fn something() -> u32 {
     21
@@ -69,6 +66,7 @@ fn issue9956() {
     // nested async closures
     let a = async { 1 };
     //~^ redundant_closure_call
+    #[expect(clippy::redundant_async_block)]
     let h = async { a.await };
 
     // macro expansion tests
@@ -85,6 +83,7 @@ fn issue9956() {
     assert_eq!(a, 123);
 
     // chaining calls, but not closures
+    #[expect(clippy::type_complexity)]
     fn x() -> fn() -> fn() -> fn() -> i32 {
         || || || 42
     }

--- a/tests/ui/redundant_closure_call_fixable.rs
+++ b/tests/ui/redundant_closure_call_fixable.rs
@@ -1,3 +1,5 @@
+#![expect(incomplete_features)]
+#![feature(ergonomic_clones)]
 #![warn(clippy::redundant_closure_call)]
 #![allow(clippy::redundant_async_block)]
 #![allow(clippy::type_complexity)]
@@ -110,6 +112,37 @@ mod issue11707 {
 
     fn demo() {
         spawn_on((|| async move {})());
+        //~^ redundant_closure_call
+    }
+
+    fn demo_with_captures() {
+        let name = String::from("world");
+        spawn_on((|| async move { drop(format!("hello, {name}")) })());
+        //~^ redundant_closure_call
+    }
+
+    fn demo_async_move_closure() {
+        let name = String::from("world");
+        spawn_on((async move || drop(format!("hello, {name}")))());
+        //~^ redundant_closure_call
+    }
+}
+
+mod issue16232 {
+    use core::future::Future;
+
+    fn spawn_on(fut: impl Future<Output = ()>) {}
+
+    fn closure_async_use_block() {
+        let name = String::from("world");
+        #[rustfmt::skip]
+        spawn_on((|| async use { drop(format!("hello, {name:?}")) })());
+        //~^ redundant_closure_call
+    }
+
+    fn async_use_closure() {
+        let name = String::from("world");
+        spawn_on((async use || drop(format!("hello, {name}")))());
         //~^ redundant_closure_call
     }
 }

--- a/tests/ui/redundant_closure_call_fixable.rs
+++ b/tests/ui/redundant_closure_call_fixable.rs
@@ -1,9 +1,6 @@
+#![expect(unused)]
 #![expect(incomplete_features)]
 #![feature(ergonomic_clones)]
-#![warn(clippy::redundant_closure_call)]
-#![allow(clippy::redundant_async_block)]
-#![allow(clippy::type_complexity)]
-#![allow(unused)]
 
 async fn something() -> u32 {
     21
@@ -69,6 +66,7 @@ fn issue9956() {
     // nested async closures
     let a = (|| || || || async || 1)()()()()();
     //~^ redundant_closure_call
+    #[expect(clippy::redundant_async_block)]
     let h = async { a.await };
 
     // macro expansion tests
@@ -85,6 +83,7 @@ fn issue9956() {
     assert_eq!(a, 123);
 
     // chaining calls, but not closures
+    #[expect(clippy::type_complexity)]
     fn x() -> fn() -> fn() -> fn() -> i32 {
         || || || 42
     }

--- a/tests/ui/redundant_closure_call_fixable.stderr
+++ b/tests/ui/redundant_closure_call_fixable.stderr
@@ -1,5 +1,5 @@
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:15:13
+  --> tests/ui/redundant_closure_call_fixable.rs:17:13
    |
 LL |     let a = (|| 42)();
    |             ^^^^^^^^^ help: try doing something like: `42`
@@ -8,7 +8,7 @@ LL |     let a = (|| 42)();
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_call)]`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:17:13
+  --> tests/ui/redundant_closure_call_fixable.rs:19:13
    |
 LL |       let b = (async || {
    |  _____________^
@@ -30,7 +30,7 @@ LL ~     };
    |
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:23:13
+  --> tests/ui/redundant_closure_call_fixable.rs:25:13
    |
 LL |       let c = (|| {
    |  _____________^
@@ -52,13 +52,13 @@ LL ~     };
    |
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:29:13
+  --> tests/ui/redundant_closure_call_fixable.rs:31:13
    |
 LL |     let d = (async || something().await)();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async { something().await }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:39:13
+  --> tests/ui/redundant_closure_call_fixable.rs:41:13
    |
 LL |             (|| m!())()
    |             ^^^^^^^^^^^ help: try doing something like: `m!()`
@@ -69,7 +69,7 @@ LL |     m2!();
    = note: this error originates in the macro `m2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:34:13
+  --> tests/ui/redundant_closure_call_fixable.rs:36:13
    |
 LL |             (|| 0)()
    |             ^^^^^^^^ help: try doing something like: `0`
@@ -80,94 +80,118 @@ LL |     m2!();
    = note: this error originates in the macro `m` which comes from the expansion of the macro `m2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:49:16
+  --> tests/ui/redundant_closure_call_fixable.rs:51:16
    |
 LL |     assert_eq!((|| || 43)()(), 42);
    |                ^^^^^^^^^^^^^^ help: try doing something like: `43`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:59:10
+  --> tests/ui/redundant_closure_call_fixable.rs:61:10
    |
 LL |     dbg!((|| 42)());
    |          ^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:63:13
+  --> tests/ui/redundant_closure_call_fixable.rs:65:13
    |
 LL |     let a = (|| || || 123)();
    |             ^^^^^^^^^^^^^^^^ help: try doing something like: `|| || 123`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:68:13
+  --> tests/ui/redundant_closure_call_fixable.rs:70:13
    |
 LL |     let a = (|| || || || async || 1)()()()()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async { 1 }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:78:13
+  --> tests/ui/redundant_closure_call_fixable.rs:80:13
    |
 LL |     let a = (|| echo!(|| echo!(|| 1)))()()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `1`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:81:13
+  --> tests/ui/redundant_closure_call_fixable.rs:83:13
    |
 LL |     let a = (|| echo!((|| 123)))()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `123`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:95:11
+  --> tests/ui/redundant_closure_call_fixable.rs:97:11
    |
 LL |     bar()((|| || 42)()(), 5);
    |           ^^^^^^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:97:9
+  --> tests/ui/redundant_closure_call_fixable.rs:99:9
    |
 LL |     foo((|| || 42)()(), 5);
    |         ^^^^^^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:102:5
+  --> tests/ui/redundant_closure_call_fixable.rs:104:5
    |
 LL |     (|| async {})().await;
    |     ^^^^^^^^^^^^^^^ help: try doing something like: `async {}`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:112:18
+  --> tests/ui/redundant_closure_call_fixable.rs:114:18
    |
 LL |         spawn_on((|| async move {})());
    |                  ^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async move {}`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:118:28
+  --> tests/ui/redundant_closure_call_fixable.rs:120:18
+   |
+LL |         spawn_on((|| async move { drop(format!("hello, {name}")) })());
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async move { drop(format!("hello, {name}")) }`
+
+error: try not to call a closure in the expression where it is declared
+  --> tests/ui/redundant_closure_call_fixable.rs:126:18
+   |
+LL |         spawn_on((async move || drop(format!("hello, {name}")))());
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async move { drop(format!("hello, {name}")) }`
+
+error: try not to call a closure in the expression where it is declared
+  --> tests/ui/redundant_closure_call_fixable.rs:139:18
+   |
+LL |         spawn_on((|| async use { drop(format!("hello, {name:?}")) })());
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async use { drop(format!("hello, {name:?}")) }`
+
+error: try not to call a closure in the expression where it is declared
+  --> tests/ui/redundant_closure_call_fixable.rs:145:18
+   |
+LL |         spawn_on((async use || drop(format!("hello, {name}")))());
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async use { drop(format!("hello, {name}")) }`
+
+error: try not to call a closure in the expression where it is declared
+  --> tests/ui/redundant_closure_call_fixable.rs:151:28
    |
 LL |     std::convert::identity((|| 13_i32 + 36_i32)()).leading_zeros();
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `13_i32 + 36_i32`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:150:5
+  --> tests/ui/redundant_closure_call_fixable.rs:183:5
    |
 LL |     (|| { Some(true) })() == Some(true);
    |     ^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `Some(true)`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:152:5
+  --> tests/ui/redundant_closure_call_fixable.rs:185:5
    |
 LL |     (|| Some(true))() == Some(true);
    |     ^^^^^^^^^^^^^^^^^ help: try doing something like: `Some(true)`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:154:5
+  --> tests/ui/redundant_closure_call_fixable.rs:187:5
    |
 LL |     (|| { Some(if 1 > 2 {1} else {2}) })() == Some(2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `Some(if 1 > 2 {1} else {2})`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:156:5
+  --> tests/ui/redundant_closure_call_fixable.rs:189:5
    |
 LL |     (|| { Some( 1 > 2 ) })() == Some(true);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `Some( 1 > 2 )`
 
-error: aborting due to 21 previous errors
+error: aborting due to 25 previous errors
 

--- a/tests/ui/redundant_closure_call_fixable.stderr
+++ b/tests/ui/redundant_closure_call_fixable.stderr
@@ -1,5 +1,5 @@
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:17:13
+  --> tests/ui/redundant_closure_call_fixable.rs:14:13
    |
 LL |     let a = (|| 42)();
    |             ^^^^^^^^^ help: try doing something like: `42`
@@ -8,7 +8,7 @@ LL |     let a = (|| 42)();
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_call)]`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:19:13
+  --> tests/ui/redundant_closure_call_fixable.rs:16:13
    |
 LL |       let b = (async || {
    |  _____________^
@@ -30,7 +30,7 @@ LL ~     };
    |
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:25:13
+  --> tests/ui/redundant_closure_call_fixable.rs:22:13
    |
 LL |       let c = (|| {
    |  _____________^
@@ -52,13 +52,13 @@ LL ~     };
    |
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:31:13
+  --> tests/ui/redundant_closure_call_fixable.rs:28:13
    |
 LL |     let d = (async || something().await)();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async { something().await }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:41:13
+  --> tests/ui/redundant_closure_call_fixable.rs:38:13
    |
 LL |             (|| m!())()
    |             ^^^^^^^^^^^ help: try doing something like: `m!()`
@@ -69,7 +69,7 @@ LL |     m2!();
    = note: this error originates in the macro `m2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:36:13
+  --> tests/ui/redundant_closure_call_fixable.rs:33:13
    |
 LL |             (|| 0)()
    |             ^^^^^^^^ help: try doing something like: `0`
@@ -80,115 +80,115 @@ LL |     m2!();
    = note: this error originates in the macro `m` which comes from the expansion of the macro `m2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:51:16
+  --> tests/ui/redundant_closure_call_fixable.rs:48:16
    |
 LL |     assert_eq!((|| || 43)()(), 42);
    |                ^^^^^^^^^^^^^^ help: try doing something like: `43`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:61:10
+  --> tests/ui/redundant_closure_call_fixable.rs:58:10
    |
 LL |     dbg!((|| 42)());
    |          ^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:65:13
+  --> tests/ui/redundant_closure_call_fixable.rs:62:13
    |
 LL |     let a = (|| || || 123)();
    |             ^^^^^^^^^^^^^^^^ help: try doing something like: `|| || 123`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:70:13
+  --> tests/ui/redundant_closure_call_fixable.rs:67:13
    |
 LL |     let a = (|| || || || async || 1)()()()()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async { 1 }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:80:13
+  --> tests/ui/redundant_closure_call_fixable.rs:78:13
    |
 LL |     let a = (|| echo!(|| echo!(|| 1)))()()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `1`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:83:13
+  --> tests/ui/redundant_closure_call_fixable.rs:81:13
    |
 LL |     let a = (|| echo!((|| 123)))()();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `123`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:97:11
+  --> tests/ui/redundant_closure_call_fixable.rs:96:11
    |
 LL |     bar()((|| || 42)()(), 5);
    |           ^^^^^^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:99:9
+  --> tests/ui/redundant_closure_call_fixable.rs:98:9
    |
 LL |     foo((|| || 42)()(), 5);
    |         ^^^^^^^^^^^^^^ help: try doing something like: `42`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:104:5
+  --> tests/ui/redundant_closure_call_fixable.rs:103:5
    |
 LL |     (|| async {})().await;
    |     ^^^^^^^^^^^^^^^ help: try doing something like: `async {}`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:114:18
+  --> tests/ui/redundant_closure_call_fixable.rs:113:18
    |
 LL |         spawn_on((|| async move {})());
    |                  ^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async move {}`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:120:18
+  --> tests/ui/redundant_closure_call_fixable.rs:119:18
    |
 LL |         spawn_on((|| async move { drop(format!("hello, {name}")) })());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async move { drop(format!("hello, {name}")) }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:126:18
+  --> tests/ui/redundant_closure_call_fixable.rs:125:18
    |
 LL |         spawn_on((async move || drop(format!("hello, {name}")))());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async move { drop(format!("hello, {name}")) }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:139:18
+  --> tests/ui/redundant_closure_call_fixable.rs:138:18
    |
 LL |         spawn_on((|| async use { drop(format!("hello, {name:?}")) })());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async use { drop(format!("hello, {name:?}")) }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:145:18
+  --> tests/ui/redundant_closure_call_fixable.rs:144:18
    |
 LL |         spawn_on((async use || drop(format!("hello, {name}")))());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `async use { drop(format!("hello, {name}")) }`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:151:28
+  --> tests/ui/redundant_closure_call_fixable.rs:150:28
    |
 LL |     std::convert::identity((|| 13_i32 + 36_i32)()).leading_zeros();
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `13_i32 + 36_i32`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:183:5
+  --> tests/ui/redundant_closure_call_fixable.rs:182:5
    |
 LL |     (|| { Some(true) })() == Some(true);
    |     ^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `Some(true)`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:185:5
+  --> tests/ui/redundant_closure_call_fixable.rs:184:5
    |
 LL |     (|| Some(true))() == Some(true);
    |     ^^^^^^^^^^^^^^^^^ help: try doing something like: `Some(true)`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:187:5
+  --> tests/ui/redundant_closure_call_fixable.rs:186:5
    |
 LL |     (|| { Some(if 1 > 2 {1} else {2}) })() == Some(2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `Some(if 1 > 2 {1} else {2})`
 
 error: try not to call a closure in the expression where it is declared
-  --> tests/ui/redundant_closure_call_fixable.rs:189:5
+  --> tests/ui/redundant_closure_call_fixable.rs:188:5
    |
 LL |     (|| { Some( 1 > 2 ) })() == Some(true);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try doing something like: `Some( 1 > 2 )`

--- a/tests/ui/redundant_closure_call_late.rs
+++ b/tests/ui/redundant_closure_call_late.rs
@@ -1,9 +1,8 @@
 // non rustfixable, see redundant_closure_call_fixable.rs
-
-#![warn(clippy::redundant_closure_call)]
-#![allow(clippy::needless_late_init)]
+#![expect(unused_assignments)]
 
 fn main() {
+    #[expect(unused_variables)]
     let mut i = 1;
 
     // don't lint here, the closure is used more than once
@@ -31,6 +30,7 @@ fn main() {
     i = shadowed_closure();
 
     // Fix FP in #5916
+    #[expect(unused_variables)]
     let mut x;
     let create = || 2 * 2;
     x = create();

--- a/tests/ui/redundant_closure_call_late.stderr
+++ b/tests/ui/redundant_closure_call_late.stderr
@@ -1,5 +1,5 @@
 error: closure called just once immediately after it was declared
-  --> tests/ui/redundant_closure_call_late.rs:16:5
+  --> tests/ui/redundant_closure_call_late.rs:15:5
    |
 LL |     i = redun_closure();
    |     ^^^^^^^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL |     i = redun_closure();
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_call)]`
 
 error: closure called just once immediately after it was declared
-  --> tests/ui/redundant_closure_call_late.rs:21:5
+  --> tests/ui/redundant_closure_call_late.rs:20:5
    |
 LL |     i = shadowed_closure();
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: closure called just once immediately after it was declared
-  --> tests/ui/redundant_closure_call_late.rs:25:5
+  --> tests/ui/redundant_closure_call_late.rs:24:5
    |
 LL |     i = shadowed_closure();
    |     ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Previously, async closures containing early returns which were immediately called triggered the `redundant_closure_call` lint. Regular non-async closures with these early return statements did not trigger these lints.

Async closures of both kinds (`async || {}` and `|| async {}`) trigger some desugaring which needs to be appropriately handled when looking for early return statements. This commit implements that logic.

fixes: rust-lang/rust-clippy#16232 

changelog: [`redundant_closure_call`]: Fix false positive on async closures with early returns