### PR TITLE
`redundant_pattern_match`: improve suggestions

### DIFF
--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -1,5 +1,5 @@
 use super::REDUNDANT_PATTERN_MATCHING;
-use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::sugg::{Sugg, make_unop};
 use clippy_utils::ty::needs_ordered_drop;
@@ -12,7 +12,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Arm, Expr, ExprKind, Node, Pat, PatExpr, PatExprKind, PatKind, QPath, UnOp};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, GenericArgKind, Ty};
-use rustc_span::{Span, Symbol};
+use rustc_span::{Span, Symbol, kw};
 use std::fmt::Write;
 use std::ops::ControlFlow;
 
@@ -24,7 +24,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         ..
     }) = higher::WhileLet::hir(expr)
     {
-        find_method_sugg_for_if_let(cx, expr, let_pat, let_expr, "while", false, let_span);
+        find_method_sugg_for_if_let(cx, expr, let_pat, let_expr, kw::While, false, let_span);
         find_if_let_true(cx, let_pat, let_expr, let_span);
     }
 }
@@ -38,7 +38,7 @@ pub(super) fn check_if_let<'tcx>(
     let_span: Span,
 ) {
     find_if_let_true(cx, pat, scrutinee, let_span);
-    find_method_sugg_for_if_let(cx, expr, pat, scrutinee, "if", has_else, let_span);
+    find_method_sugg_for_if_let(cx, expr, pat, scrutinee, kw::If, has_else, let_span);
 }
 
 /// Looks for:
@@ -78,29 +78,28 @@ fn find_match_true<'tcx>(
         && let PatExprKind::Lit { lit, negated: false } = lit.kind
         && let LitKind::Bool(pat_is_true) = lit.node
     {
-        let mut applicability = Applicability::MachineApplicable;
+        span_lint_and_then(cx, REDUNDANT_PATTERN_MATCHING, span, message, |diag| {
+            let mut applicability = Applicability::MachineApplicable;
 
-        let mut sugg = Sugg::hir_with_context(
-            cx,
-            scrutinee,
-            scrutinee.span.source_callsite().ctxt(),
-            "..",
-            &mut applicability,
-        );
+            let mut sugg = Sugg::hir_with_context(
+                cx,
+                scrutinee,
+                scrutinee.span.source_callsite().ctxt(),
+                "..",
+                &mut applicability,
+            );
 
-        if !pat_is_true {
-            sugg = make_unop("!", sugg);
-        }
+            if !pat_is_true {
+                sugg = make_unop("!", sugg);
+            }
 
-        span_lint_and_sugg(
-            cx,
-            REDUNDANT_PATTERN_MATCHING,
-            span,
-            message,
-            "consider using the condition directly",
-            sugg.into_string(),
-            applicability,
-        );
+            diag.span_suggestion(
+                span,
+                "consider using the condition directly",
+                sugg.into_string(),
+                applicability,
+            );
+        });
     }
 }
 
@@ -179,7 +178,7 @@ fn find_method_sugg_for_if_let<'tcx>(
     expr: &'tcx Expr<'_>,
     let_pat: &Pat<'_>,
     let_expr: &'tcx Expr<'_>,
-    keyword: &'static str,
+    keyword: Symbol,
     has_else: bool,
     let_span: Span,
 ) {
@@ -196,25 +195,8 @@ fn find_method_sugg_for_if_let<'tcx>(
         return;
     };
 
-    // If this is the last expression in a block or there is an else clause then the whole
-    // type needs to be considered, not just the inner type of the branch being matched on.
-    // Note the last expression in a block is dropped after all local bindings.
-    let check_ty = if has_else
-        || (keyword == "if" && matches!(cx.tcx.hir_parent_iter(expr.hir_id).next(), Some((_, Node::Block(..)))))
-    {
-        op_ty
-    } else {
-        inner_ty
-    };
-
-    // All temporaries created in the scrutinee expression are dropped at the same time as the
-    // scrutinee would be, so they have to be considered as well.
-    // e.g. in `if let Some(x) = foo.lock().unwrap().baz.as_ref() { .. }` the lock will be held
-    // for the duration if body.
-    let needs_drop = needs_ordered_drop(cx, check_ty) || any_temporaries_need_ordered_drop(cx, let_expr);
-
     // check that `while_let_on_iterator` lint does not trigger
-    if keyword == "while"
+    if keyword == kw::While
         && let ExprKind::MethodCall(method_path, _, [], _) = let_expr.kind
         && method_path.ident.name == sym::next
         && cx.ty_based_def(let_expr).opt_parent(cx).is_diag_item(cx, sym::Iterator)
@@ -222,18 +204,36 @@ fn find_method_sugg_for_if_let<'tcx>(
         return;
     }
 
-    let result_expr = match &let_expr.kind {
-        ExprKind::AddrOf(_, _, borrowed) => borrowed,
-        ExprKind::Unary(UnOp::Deref, deref) => deref,
-        _ => let_expr,
-    };
-
     span_lint_and_then(
         cx,
         REDUNDANT_PATTERN_MATCHING,
         let_pat.span,
         format!("redundant pattern matching, consider using `{good_method}`"),
         |diag| {
+            // If this is the last expression in a block or there is an else clause then the whole
+            // type needs to be considered, not just the inner type of the branch being matched on.
+            // Note the last expression in a block is dropped after all local bindings.
+            let check_ty = if has_else
+                || (keyword == kw::If
+                    && matches!(cx.tcx.hir_parent_iter(expr.hir_id).next(), Some((_, Node::Block(..)))))
+            {
+                op_ty
+            } else {
+                inner_ty
+            };
+
+            // All temporaries created in the scrutinee expression are dropped at the same time as the
+            // scrutinee would be, so they have to be considered as well.
+            // e.g. in `if let Some(x) = foo.lock().unwrap().baz.as_ref() { .. }` the lock will be held
+            // for the duration if body.
+            let needs_drop = needs_ordered_drop(cx, check_ty) || any_temporaries_need_ordered_drop(cx, let_expr);
+
+            let result_expr = match &let_expr.kind {
+                ExprKind::AddrOf(_, _, borrowed) => borrowed,
+                ExprKind::Unary(UnOp::Deref, deref) => deref,
+                _ => let_expr,
+            };
+
             // if/while let ... = ... { ... }
             // ^^^^^^^^^^^^^^^^^^^^^^^^^^^
             let expr_span = expr.span;
@@ -289,27 +289,28 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op
 
         let expr_span = is_expn_of(expr.span, sym::matches).unwrap_or(expr.span);
 
-        let result_expr = match &op.kind {
-            ExprKind::AddrOf(_, _, borrowed) => borrowed,
-            _ => op,
-        };
-        let mut app = Applicability::MachineApplicable;
-        let receiver_sugg = Sugg::hir_with_context(cx, result_expr, expr_span.ctxt(), "_", &mut app).maybe_paren();
-        let mut sugg = format!("{receiver_sugg}.{good_method}");
-
-        if let Some(guard) = maybe_guard {
-            let guard = Sugg::hir_with_context(cx, guard, expr_span.ctxt(), "..", &mut app);
-            let _ = write!(sugg, " && {}", guard.maybe_paren());
-        }
-
-        span_lint_and_sugg(
+        span_lint_and_then(
             cx,
             REDUNDANT_PATTERN_MATCHING,
             expr_span,
             format!("redundant pattern matching, consider using `{good_method}`"),
-            "try",
-            sugg,
-            app,
+            |diag| {
+                let mut app = Applicability::MachineApplicable;
+                let ctxt = expr_span.ctxt();
+                let result_expr = match &op.kind {
+                    ExprKind::AddrOf(_, _, borrowed) => borrowed,
+                    _ => op,
+                };
+                let receiver_sugg = Sugg::hir_with_context(cx, result_expr, ctxt, "_", &mut app).maybe_paren();
+                let mut sugg = format!("{receiver_sugg}.{good_method}");
+
+                if let Some(guard) = maybe_guard {
+                    let guard = Sugg::hir_with_context(cx, guard, ctxt, "..", &mut app);
+                    let _ = write!(sugg, " && {}", guard.maybe_paren());
+                }
+
+                diag.span_suggestion(expr_span, "try", sugg, app);
+            },
         );
     }
 }

--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -93,7 +93,7 @@ fn find_match_true<'tcx>(
                 sugg = make_unop("!", sugg);
             }
 
-            diag.span_suggestion(
+            diag.span_suggestion_verbose(
                 span,
                 "consider using the condition directly",
                 sugg.into_string(),
@@ -208,7 +208,7 @@ fn find_method_sugg_for_if_let<'tcx>(
         cx,
         REDUNDANT_PATTERN_MATCHING,
         let_pat.span,
-        format!("redundant pattern matching, consider using `{good_method}`"),
+        "redundant pattern matching",
         |diag| {
             // If this is the last expression in a block or there is an else clause then the whole
             // type needs to be considered, not just the inner type of the branch being matched on.
@@ -253,7 +253,12 @@ fn find_method_sugg_for_if_let<'tcx>(
                 .maybe_paren()
                 .to_string();
 
-            diag.span_suggestion(span, "try", format!("{keyword} {sugg}.{good_method}"), app);
+            diag.span_suggestion_verbose(
+                span,
+                format!("consider using `{good_method}`"),
+                format!("{keyword} {sugg}.{good_method}"),
+                app,
+            );
 
             if needs_drop {
                 diag.note("this will change drop order of the result, as well as all temporaries");
@@ -293,7 +298,7 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op
             cx,
             REDUNDANT_PATTERN_MATCHING,
             expr_span,
-            format!("redundant pattern matching, consider using `{good_method}`"),
+            "redundant pattern matching",
             |diag| {
                 let mut app = Applicability::MachineApplicable;
                 let ctxt = expr_span.ctxt();
@@ -309,7 +314,7 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op
                     let _ = write!(sugg, " && {}", guard.maybe_paren());
                 }
 
-                diag.span_suggestion(expr_span, "try", sugg, app);
+                diag.span_suggestion_verbose(expr_span, format!("consider using `{good_method}`"), sugg, app);
             },
         );
     }

--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -267,6 +267,26 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op
     if let Ok(arms) = arms.try_into() // TODO: use `slice::as_array` once stabilized
         && let Some((good_method, maybe_guard)) = found_good_method(cx, arms)
     {
+        let has_nested_let_chain = maybe_guard.is_some_and(|guard|
+            // wow, the HIR for match guards in `PAT if let PAT = expr && expr => ...` is annoying!
+            // `guard` here is `Guard::If` with the let expression somewhere deep in the tree of exprs,
+            // counter to the intuition that it should be `Guard::IfLet`, so we need another check
+            // to see that there aren't any let chains anywhere in the guard, as that would break
+            // if we suggest `t.is_none() && (let X = y && z)` for:
+            // `match t { None if let X = y && z => true, _ => false }`
+            for_each_expr_without_closures(guard, |expr| {
+                if matches!(expr.kind, ExprKind::Let(..)) {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            })
+            .is_some());
+
+        if has_nested_let_chain {
+            return;
+        }
+
         let expr_span = is_expn_of(expr.span, sym::matches).unwrap_or(expr.span);
 
         let result_expr = match &op.kind {
@@ -278,25 +298,6 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op
         let mut sugg = format!("{receiver_sugg}.{good_method}");
 
         if let Some(guard) = maybe_guard {
-            // wow, the HIR for match guards in `PAT if let PAT = expr && expr => ...` is annoying!
-            // `guard` here is `Guard::If` with the let expression somewhere deep in the tree of exprs,
-            // counter to the intuition that it should be `Guard::IfLet`, so we need another check
-            // to see that there aren't any let chains anywhere in the guard, as that would break
-            // if we suggest `t.is_none() && (let X = y && z)` for:
-            // `match t { None if let X = y && z => true, _ => false }`
-            let has_nested_let_chain = for_each_expr_without_closures(guard, |expr| {
-                if matches!(expr.kind, ExprKind::Let(..)) {
-                    ControlFlow::Break(())
-                } else {
-                    ControlFlow::Continue(())
-                }
-            })
-            .is_some();
-
-            if has_nested_let_chain {
-                return;
-            }
-
             let guard = Sugg::hir_with_context(cx, guard, expr_span.ctxt(), "..", &mut app);
             let _ = write!(sugg, " && {}", guard.maybe_paren());
         }

--- a/tests/ui/crashes/ice-7169.stderr
+++ b/tests/ui/crashes/ice-7169.stderr
@@ -1,11 +1,16 @@
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/crashes/ice-7169.rs:10:12
    |
 LL |     if let Ok(_) = Ok::<_, ()>(A::<String>::default()) {}
-   |     -------^^^^^-------------------------------------- help: try: `if Ok::<_, ()>(A::<String>::default()).is_ok()`
+   |            ^^^^^
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using `is_ok()`
+   |
+LL -     if let Ok(_) = Ok::<_, ()>(A::<String>::default()) {}
+LL +     if Ok::<_, ()>(A::<String>::default()).is_ok() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -19,7 +19,7 @@ LL -     };
 LL +     let _y = matches!(x, Some(0));
    |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/match_like_matches_macro.rs:21:14
    |
 LL |       let _w = match x {
@@ -27,12 +27,20 @@ LL |       let _w = match x {
 LL | |         Some(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try: `x.is_some()`
+   | |_____^
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using `is_some()`
+   |
+LL -     let _w = match x {
+LL -         Some(_) => true,
+LL -         _ => false,
+LL -     };
+LL +     let _w = x.is_some();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/match_like_matches_macro.rs:28:14
    |
 LL |       let _z = match x {
@@ -40,7 +48,16 @@ LL |       let _z = match x {
 LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
-   | |_____^ help: try: `x.is_none()`
+   | |_____^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _z = match x {
+LL -         Some(_) => false,
+LL -         None => true,
+LL -     };
+LL +     let _z = x.is_none();
+   |
 
 error: match expression looks like `matches!` macro
   --> tests/ui/match_like_matches_macro.rs:35:15

--- a/tests/ui/match_ref_pats.stderr
+++ b/tests/ui/match_ref_pats.stderr
@@ -36,20 +36,31 @@ LL ~         Some(v) => println!("{:?}", v),
 LL ~         None => println!("none"),
    |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/match_ref_pats.rs:45:12
    |
 LL |     if let &None = a {
-   |     -------^^^^^---- help: try: `if a.is_none()`
+   |            ^^^^^
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using `is_none()`
+   |
+LL -     if let &None = a {
+LL +     if a.is_none() {
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/match_ref_pats.rs:51:12
    |
 LL |     if let &None = &b {
-   |     -------^^^^^----- help: try: `if b.is_none()`
+   |            ^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     if let &None = &b {
+LL +     if b.is_none() {
+   |
 
 error: you don't need to add `&` to all patterns
   --> tests/ui/match_ref_pats.rs:112:9

--- a/tests/ui/redundant_pattern_matching_drop_order.stderr
+++ b/tests/ui/redundant_pattern_matching_drop_order.stderr
@@ -1,172 +1,292 @@
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:15:12
    |
 LL |     if let Ok(_) = m.lock() {}
-   |     -------^^^^^----------- help: try: `if m.lock().is_ok()`
+   |            ^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using `is_ok()`
+   |
+LL -     if let Ok(_) = m.lock() {}
+LL +     if m.lock().is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:17:12
    |
 LL |     if let Err(_) = Err::<(), _>(m.lock().unwrap().0) {}
-   |     -------^^^^^^------------------------------------ help: try: `if Err::<(), _>(m.lock().unwrap().0).is_err()`
+   |            ^^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_err()`
+   |
+LL -     if let Err(_) = Err::<(), _>(m.lock().unwrap().0) {}
+LL +     if Err::<(), _>(m.lock().unwrap().0).is_err() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:21:16
    |
 LL |         if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
-   |         -------^^^^^----------------------------------------- help: try: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
+   |                ^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_ok()`
+   |
+LL -         if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
+LL +         if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:24:12
    |
 LL |     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {
-   |     -------^^^^^----------------------------------------- help: try: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
+   |            ^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_ok()`
+   |
+LL -     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {
+LL +     if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok() {
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:28:12
    |
 LL |     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
-   |     -------^^^^^----------------------------------------- help: try: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
+   |            ^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
+LL +     if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:30:12
    |
 LL |     if let Err(_) = Err::<std::sync::MutexGuard<()>, _>(()) {}
-   |     -------^^^^^^------------------------------------------ help: try: `if Err::<std::sync::MutexGuard<()>, _>(()).is_err()`
+   |            ^^^^^^
+   |
+help: consider using `is_err()`
+   |
+LL -     if let Err(_) = Err::<std::sync::MutexGuard<()>, _>(()) {}
+LL +     if Err::<std::sync::MutexGuard<()>, _>(()).is_err() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:33:12
    |
 LL |     if let Ok(_) = Ok::<_, ()>(String::new()) {}
-   |     -------^^^^^----------------------------- help: try: `if Ok::<_, ()>(String::new()).is_ok()`
+   |            ^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     if let Ok(_) = Ok::<_, ()>(String::new()) {}
+LL +     if Ok::<_, ()>(String::new()).is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:35:12
    |
 LL |     if let Err(_) = Err::<(), _>((String::new(), ())) {}
-   |     -------^^^^^^------------------------------------ help: try: `if Err::<(), _>((String::new(), ())).is_err()`
+   |            ^^^^^^
+   |
+help: consider using `is_err()`
+   |
+LL -     if let Err(_) = Err::<(), _>((String::new(), ())) {}
+LL +     if Err::<(), _>((String::new(), ())).is_err() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:39:12
    |
 LL |     if let Some(_) = Some(m.lock()) {}
-   |     -------^^^^^^^----------------- help: try: `if Some(m.lock()).is_some()`
+   |            ^^^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = Some(m.lock()) {}
+LL +     if Some(m.lock()).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:41:12
    |
 LL |     if let Some(_) = Some(m.lock().unwrap().0) {}
-   |     -------^^^^^^^---------------------------- help: try: `if Some(m.lock().unwrap().0).is_some()`
+   |            ^^^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = Some(m.lock().unwrap().0) {}
+LL +     if Some(m.lock().unwrap().0).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:45:16
    |
 LL |         if let None = None::<std::sync::MutexGuard<()>> {}
-   |         -------^^^^------------------------------------ help: try: `if None::<std::sync::MutexGuard<()>>.is_none()`
+   |                ^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_none()`
+   |
+LL -         if let None = None::<std::sync::MutexGuard<()>> {}
+LL +         if None::<std::sync::MutexGuard<()>>.is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:48:12
    |
 LL |     if let None = None::<std::sync::MutexGuard<()>> {
-   |     -------^^^^------------------------------------ help: try: `if None::<std::sync::MutexGuard<()>>.is_none()`
+   |            ^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_none()`
+   |
+LL -     if let None = None::<std::sync::MutexGuard<()>> {
+LL +     if None::<std::sync::MutexGuard<()>>.is_none() {
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:53:12
    |
 LL |     if let None = None::<std::sync::MutexGuard<()>> {}
-   |     -------^^^^------------------------------------ help: try: `if None::<std::sync::MutexGuard<()>>.is_none()`
+   |            ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     if let None = None::<std::sync::MutexGuard<()>> {}
+LL +     if None::<std::sync::MutexGuard<()>>.is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:56:12
    |
 LL |     if let Some(_) = Some(String::new()) {}
-   |     -------^^^^^^^---------------------- help: try: `if Some(String::new()).is_some()`
+   |            ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = Some(String::new()) {}
+LL +     if Some(String::new()).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:58:12
    |
 LL |     if let Some(_) = Some((String::new(), ())) {}
-   |     -------^^^^^^^---------------------------- help: try: `if Some((String::new(), ())).is_some()`
+   |            ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = Some((String::new(), ())) {}
+LL +     if Some((String::new(), ())).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:62:12
    |
 LL |     if let Ready(_) = Ready(m.lock()) {}
-   |     -------^^^^^^^^------------------ help: try: `if Ready(m.lock()).is_ready()`
+   |            ^^^^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_ready()`
+   |
+LL -     if let Ready(_) = Ready(m.lock()) {}
+LL +     if Ready(m.lock()).is_ready() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:64:12
    |
 LL |     if let Ready(_) = Ready(m.lock().unwrap().0) {}
-   |     -------^^^^^^^^----------------------------- help: try: `if Ready(m.lock().unwrap().0).is_ready()`
+   |            ^^^^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_ready()`
+   |
+LL -     if let Ready(_) = Ready(m.lock().unwrap().0) {}
+LL +     if Ready(m.lock().unwrap().0).is_ready() {}
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:68:16
    |
 LL |         if let Pending = Pending::<std::sync::MutexGuard<()>> {}
-   |         -------^^^^^^^--------------------------------------- help: try: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
+   |                ^^^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_pending()`
+   |
+LL -         if let Pending = Pending::<std::sync::MutexGuard<()>> {}
+LL +         if Pending::<std::sync::MutexGuard<()>>.is_pending() {}
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:71:12
    |
 LL |     if let Pending = Pending::<std::sync::MutexGuard<()>> {
-   |     -------^^^^^^^--------------------------------------- help: try: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
+   |            ^^^^^^^
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+help: consider using `is_pending()`
+   |
+LL -     if let Pending = Pending::<std::sync::MutexGuard<()>> {
+LL +     if Pending::<std::sync::MutexGuard<()>>.is_pending() {
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:76:12
    |
 LL |     if let Pending = Pending::<std::sync::MutexGuard<()>> {}
-   |     -------^^^^^^^--------------------------------------- help: try: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
+   |            ^^^^^^^
+   |
+help: consider using `is_pending()`
+   |
+LL -     if let Pending = Pending::<std::sync::MutexGuard<()>> {}
+LL +     if Pending::<std::sync::MutexGuard<()>>.is_pending() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:79:12
    |
 LL |     if let Ready(_) = Ready(String::new()) {}
-   |     -------^^^^^^^^----------------------- help: try: `if Ready(String::new()).is_ready()`
+   |            ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     if let Ready(_) = Ready(String::new()) {}
+LL +     if Ready(String::new()).is_ready() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_drop_order.rs:81:12
    |
 LL |     if let Ready(_) = Ready((String::new(), ())) {}
-   |     -------^^^^^^^^----------------------------- help: try: `if Ready((String::new(), ())).is_ready()`
+   |            ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     if let Ready(_) = Ready((String::new(), ())) {}
+LL +     if Ready((String::new(), ())).is_ready() {}
+   |
 
 error: aborting due to 22 previous errors
 

--- a/tests/ui/redundant_pattern_matching_if_let_true.stderr
+++ b/tests/ui/redundant_pattern_matching_if_let_true.stderr
@@ -2,46 +2,87 @@ error: using `if let` to pattern match a bool
   --> tests/ui/redundant_pattern_matching_if_let_true.rs:22:8
    |
 LL |     if let true = k > 1 {}
-   |        ^^^^^^^^^^^^^^^^ help: consider using the condition directly: `k > 1`
+   |        ^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using the condition directly
+   |
+LL -     if let true = k > 1 {}
+LL +     if k > 1 {}
+   |
 
 error: using `if let` to pattern match a bool
   --> tests/ui/redundant_pattern_matching_if_let_true.rs:24:8
    |
 LL |     if let false = k > 5 {}
-   |        ^^^^^^^^^^^^^^^^^ help: consider using the condition directly: `!(k > 5)`
+   |        ^^^^^^^^^^^^^^^^^
+   |
+help: consider using the condition directly
+   |
+LL -     if let false = k > 5 {}
+LL +     if !(k > 5) {}
+   |
 
 error: using `if let` to pattern match a bool
   --> tests/ui/redundant_pattern_matching_if_let_true.rs:26:8
    |
 LL |     if let (true) = k > 1 {}
-   |        ^^^^^^^^^^^^^^^^^^ help: consider using the condition directly: `k > 1`
+   |        ^^^^^^^^^^^^^^^^^^
+   |
+help: consider using the condition directly
+   |
+LL -     if let (true) = k > 1 {}
+LL +     if k > 1 {}
+   |
 
 error: using `if let` to pattern match a bool
   --> tests/ui/redundant_pattern_matching_if_let_true.rs:29:11
    |
 LL |     while let true = k > 1 {
-   |           ^^^^^^^^^^^^^^^^ help: consider using the condition directly: `k > 1`
+   |           ^^^^^^^^^^^^^^^^
+   |
+help: consider using the condition directly
+   |
+LL -     while let true = k > 1 {
+LL +     while k > 1 {
+   |
 
 error: using `if let` to pattern match a bool
   --> tests/ui/redundant_pattern_matching_if_let_true.rs:33:11
    |
 LL |     while let true = condition!() {
-   |           ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using the condition directly: `condition!()`
+   |           ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using the condition directly
+   |
+LL -     while let true = condition!() {
+LL +     while condition!() {
+   |
 
 error: using `matches!` to pattern match a bool
   --> tests/ui/redundant_pattern_matching_if_let_true.rs:38:5
    |
 LL |     matches!(k > 5, true);
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using the condition directly: `k > 5`
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using the condition directly
+   |
+LL -     matches!(k > 5, true);
+LL +     k > 5;
+   |
 
 error: using `matches!` to pattern match a bool
   --> tests/ui/redundant_pattern_matching_if_let_true.rs:40:5
    |
 LL |     matches!(k > 5, false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using the condition directly: `!(k > 5)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using the condition directly
+   |
+LL -     matches!(k > 5, false);
+LL +     !(k > 5);
+   |
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/redundant_pattern_matching_ipaddr.stderr
+++ b/tests/ui/redundant_pattern_matching_ipaddr.stderr
@@ -1,49 +1,90 @@
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:14:12
    |
 LL |     if let V4(_) = &ipaddr {}
-   |     -------^^^^^---------- help: try: `if ipaddr.is_ipv4()`
+   |            ^^^^^
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using `is_ipv4()`
+   |
+LL -     if let V4(_) = &ipaddr {}
+LL +     if ipaddr.is_ipv4() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:17:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
-   |     -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |            ^^^^^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
+LL +     if V4(Ipv4Addr::LOCALHOST).is_ipv4() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:20:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
-   |     -------^^^^^-------------------------- help: try: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |            ^^^^^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
+LL +     if V6(Ipv6Addr::LOCALHOST).is_ipv6() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:24:8
    |
 LL |     if matches!(V4(Ipv4Addr::LOCALHOST), V4(_)) {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     if matches!(V4(Ipv4Addr::LOCALHOST), V4(_)) {}
+LL +     if V4(Ipv4Addr::LOCALHOST).is_ipv4() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:28:8
    |
 LL |     if matches!(V6(Ipv6Addr::LOCALHOST), V6(_)) {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     if matches!(V6(Ipv6Addr::LOCALHOST), V6(_)) {}
+LL +     if V6(Ipv6Addr::LOCALHOST).is_ipv6() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:31:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
-   |     ----------^^^^^-------------------------- help: try: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |               ^^^^^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
+LL +     while V4(Ipv4Addr::LOCALHOST).is_ipv4() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:34:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
-   |     ----------^^^^^-------------------------- help: try: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |               ^^^^^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
+LL +     while V6(Ipv6Addr::LOCALHOST).is_ipv6() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:45:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
@@ -51,9 +92,19 @@ LL | |
 LL | |         V4(_) => true,
 LL | |         V6(_) => false,
 LL | |     };
-   | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   | |_____^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     match V4(Ipv4Addr::LOCALHOST) {
+LL -
+LL -         V4(_) => true,
+LL -         V6(_) => false,
+LL -     };
+LL +     V4(Ipv4Addr::LOCALHOST).is_ipv4();
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:51:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
@@ -61,9 +112,19 @@ LL | |
 LL | |         V4(_) => false,
 LL | |         V6(_) => true,
 LL | |     };
-   | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv6()`
+   | |_____^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     match V4(Ipv4Addr::LOCALHOST) {
+LL -
+LL -         V4(_) => false,
+LL -         V6(_) => true,
+LL -     };
+LL +     V4(Ipv4Addr::LOCALHOST).is_ipv6();
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:57:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
@@ -71,9 +132,19 @@ LL | |
 LL | |         V4(_) => false,
 LL | |         V6(_) => true,
 LL | |     };
-   | |_____^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   | |_____^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     match V6(Ipv6Addr::LOCALHOST) {
+LL -
+LL -         V4(_) => false,
+LL -         V6(_) => true,
+LL -     };
+LL +     V6(Ipv6Addr::LOCALHOST).is_ipv6();
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:63:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
@@ -81,51 +152,103 @@ LL | |
 LL | |         V4(_) => true,
 LL | |         V6(_) => false,
 LL | |     };
-   | |_____^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv4()`
+   | |_____^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     match V6(Ipv6Addr::LOCALHOST) {
+LL -
+LL -         V4(_) => true,
+LL -         V6(_) => false,
+LL -     };
+LL +     V6(Ipv6Addr::LOCALHOST).is_ipv4();
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:69:20
    |
 LL |     let _ = if let V4(_) = V4(Ipv4Addr::LOCALHOST) {
-   |             -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |                    ^^^^^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     let _ = if let V4(_) = V4(Ipv4Addr::LOCALHOST) {
+LL +     let _ = if V4(Ipv4Addr::LOCALHOST).is_ipv4() {
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:78:20
    |
 LL |     let _ = if let V4(_) = gen_ipaddr() {
-   |             -------^^^^^--------------- help: try: `if gen_ipaddr().is_ipv4()`
+   |                    ^^^^^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     let _ = if let V4(_) = gen_ipaddr() {
+LL +     let _ = if gen_ipaddr().is_ipv4() {
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:81:19
    |
 LL |     } else if let V6(_) = gen_ipaddr() {
-   |            -------^^^^^--------------- help: try: `if gen_ipaddr().is_ipv6()`
+   |                   ^^^^^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     } else if let V6(_) = gen_ipaddr() {
+LL +     } else if gen_ipaddr().is_ipv6() {
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:94:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
-   |     -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |            ^^^^^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
+LL +     if V4(Ipv4Addr::LOCALHOST).is_ipv4() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:97:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
-   |     -------^^^^^-------------------------- help: try: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |            ^^^^^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
+LL +     if V6(Ipv6Addr::LOCALHOST).is_ipv6() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:100:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
-   |     ----------^^^^^-------------------------- help: try: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |               ^^^^^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
+LL +     while V4(Ipv4Addr::LOCALHOST).is_ipv4() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:103:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
-   |     ----------^^^^^-------------------------- help: try: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |               ^^^^^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
+LL +     while V6(Ipv6Addr::LOCALHOST).is_ipv6() {}
+   |
 
-error: redundant pattern matching, consider using `is_ipv4()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:106:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
@@ -133,9 +256,19 @@ LL | |
 LL | |         V4(_) => true,
 LL | |         V6(_) => false,
 LL | |     };
-   | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   | |_____^
+   |
+help: consider using `is_ipv4()`
+   |
+LL -     match V4(Ipv4Addr::LOCALHOST) {
+LL -
+LL -         V4(_) => true,
+LL -         V6(_) => false,
+LL -     };
+LL +     V4(Ipv4Addr::LOCALHOST).is_ipv4();
+   |
 
-error: redundant pattern matching, consider using `is_ipv6()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_ipaddr.rs:112:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
@@ -143,7 +276,17 @@ LL | |
 LL | |         V4(_) => false,
 LL | |         V6(_) => true,
 LL | |     };
-   | |_____^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   | |_____^
+   |
+help: consider using `is_ipv6()`
+   |
+LL -     match V6(Ipv6Addr::LOCALHOST) {
+LL -
+LL -         V4(_) => false,
+LL -         V6(_) => true,
+LL -     };
+LL +     V6(Ipv6Addr::LOCALHOST).is_ipv6();
+   |
 
 error: aborting due to 20 previous errors
 

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -1,61 +1,114 @@
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:11:5
    |
 LL |     matches!(maybe_some, None if !boolean)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_some.is_none() && (!boolean)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using `is_none()`
+   |
+LL -     matches!(maybe_some, None if !boolean)
+LL +     maybe_some.is_none() && (!boolean)
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:16:13
    |
 LL |     let _ = matches!(maybe_some, None if boolean || boolean2); // guard needs parentheses
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_some.is_none() && (boolean || boolean2)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = matches!(maybe_some, None if boolean || boolean2); // guard needs parentheses
+LL +     let _ = maybe_some.is_none() && (boolean || boolean2); // guard needs parentheses
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:32:12
    |
 LL |     if let None = None::<()> {}
-   |     -------^^^^------------- help: try: `if None::<()>.is_none()`
+   |            ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     if let None = None::<()> {}
+LL +     if None::<()>.is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:35:12
    |
 LL |     if let Some(_) = Some(42) {}
-   |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
+   |            ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = Some(42) {}
+LL +     if Some(42).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:38:12
    |
 LL |     if let Some(_) = Some(42) {
-   |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
+   |            ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = Some(42) {
+LL +     if Some(42).is_some() {
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:45:15
    |
 LL |     while let Some(_) = Some(42) {}
-   |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
+   |               ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     while let Some(_) = Some(42) {}
+LL +     while Some(42).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:48:15
    |
 LL |     while let None = Some(42) {}
-   |     ----------^^^^----------- help: try: `while Some(42).is_none()`
+   |               ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     while let None = Some(42) {}
+LL +     while Some(42).is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:51:15
    |
 LL |     while let None = None::<()> {}
-   |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
+   |               ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     while let None = None::<()> {}
+LL +     while None::<()>.is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:55:15
    |
 LL |     while let Some(_) = v.pop() {
-   |     ----------^^^^^^^---------- help: try: `while v.pop().is_some()`
+   |               ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     while let Some(_) = v.pop() {
+LL +     while v.pop().is_some() {
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:64:5
    |
 LL | /     match Some(42) {
@@ -63,9 +116,19 @@ LL | |
 LL | |         Some(_) => true,
 LL | |         None => false,
 LL | |     };
-   | |_____^ help: try: `Some(42).is_some()`
+   | |_____^
+   |
+help: consider using `is_some()`
+   |
+LL -     match Some(42) {
+LL -
+LL -         Some(_) => true,
+LL -         None => false,
+LL -     };
+LL +     Some(42).is_some();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:70:5
    |
 LL | /     match None::<()> {
@@ -73,9 +136,19 @@ LL | |
 LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
-   | |_____^ help: try: `None::<()>.is_none()`
+   | |_____^
+   |
+help: consider using `is_none()`
+   |
+LL -     match None::<()> {
+LL -
+LL -         Some(_) => false,
+LL -         None => true,
+LL -     };
+LL +     None::<()>.is_none();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:76:13
    |
 LL |       let _ = match None::<()> {
@@ -84,57 +157,115 @@ LL | |
 LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
-   | |_____^ help: try: `None::<()>.is_none()`
+   | |_____^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = match None::<()> {
+LL -
+LL -         Some(_) => false,
+LL -         None => true,
+LL -     };
+LL +     let _ = None::<()>.is_none();
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:83:20
    |
 LL |     let _ = if let Some(_) = opt { true } else { false };
-   |             -------^^^^^^^------ help: try: `if opt.is_some()`
+   |                    ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     let _ = if let Some(_) = opt { true } else { false };
+LL +     let _ = if opt.is_some() { true } else { false };
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:90:20
    |
 LL |     let _ = if let Some(_) = gen_opt() {
-   |             -------^^^^^^^------------ help: try: `if gen_opt().is_some()`
+   |                    ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     let _ = if let Some(_) = gen_opt() {
+LL +     let _ = if gen_opt().is_some() {
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:93:19
    |
 LL |     } else if let None = gen_opt() {
-   |            -------^^^^------------ help: try: `if gen_opt().is_none()`
+   |                   ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     } else if let None = gen_opt() {
+LL +     } else if gen_opt().is_none() {
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:100:12
    |
 LL |     if let Some(..) = gen_opt() {}
-   |     -------^^^^^^^^------------ help: try: `if gen_opt().is_some()`
+   |            ^^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     if let Some(..) = gen_opt() {}
+LL +     if gen_opt().is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:116:12
    |
 LL |     if let Some(_) = Some(42) {}
-   |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
+   |            ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = Some(42) {}
+LL +     if Some(42).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:119:12
    |
 LL |     if let None = None::<()> {}
-   |     -------^^^^------------- help: try: `if None::<()>.is_none()`
+   |            ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     if let None = None::<()> {}
+LL +     if None::<()>.is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:122:15
    |
 LL |     while let Some(_) = Some(42) {}
-   |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
+   |               ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     while let Some(_) = Some(42) {}
+LL +     while Some(42).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:125:15
    |
 LL |     while let None = None::<()> {}
-   |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
+   |               ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     while let None = None::<()> {}
+LL +     while None::<()>.is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:128:5
    |
 LL | /     match Some(42) {
@@ -142,9 +273,19 @@ LL | |
 LL | |         Some(_) => true,
 LL | |         None => false,
 LL | |     };
-   | |_____^ help: try: `Some(42).is_some()`
+   | |_____^
+   |
+help: consider using `is_some()`
+   |
+LL -     match Some(42) {
+LL -
+LL -         Some(_) => true,
+LL -         None => false,
+LL -     };
+LL +     Some(42).is_some();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:134:5
    |
 LL | /     match None::<()> {
@@ -152,21 +293,43 @@ LL | |
 LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
-   | |_____^ help: try: `None::<()>.is_none()`
+   | |_____^
+   |
+help: consider using `is_none()`
+   |
+LL -     match None::<()> {
+LL -
+LL -         Some(_) => false,
+LL -         None => true,
+LL -     };
+LL +     None::<()>.is_none();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:143:12
    |
 LL |     if let None = *(&None::<()>) {}
-   |     -------^^^^----------------- help: try: `if (&None::<()>).is_none()`
+   |            ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     if let None = *(&None::<()>) {}
+LL +     if (&None::<()>).is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:145:12
    |
 LL |     if let None = *&None::<()> {}
-   |     -------^^^^--------------- help: try: `if (&None::<()>).is_none()`
+   |            ^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     if let None = *&None::<()> {}
+LL +     if (&None::<()>).is_none() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:152:5
    |
 LL | /     match x {
@@ -174,9 +337,19 @@ LL | |
 LL | |         Some(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try: `x.is_some()`
+   | |_____^
+   |
+help: consider using `is_some()`
+   |
+LL -     match x {
+LL -
+LL -         Some(_) => true,
+LL -         _ => false,
+LL -     };
+LL +     x.is_some();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:158:5
    |
 LL | /     match x {
@@ -184,9 +357,19 @@ LL | |
 LL | |         None => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try: `x.is_none()`
+   | |_____^
+   |
+help: consider using `is_none()`
+   |
+LL -     match x {
+LL -
+LL -         None => true,
+LL -         _ => false,
+LL -     };
+LL +     x.is_none();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:164:5
    |
 LL | /     match x {
@@ -194,9 +377,19 @@ LL | |
 LL | |         Some(_) => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try: `x.is_none()`
+   | |_____^
+   |
+help: consider using `is_none()`
+   |
+LL -     match x {
+LL -
+LL -         Some(_) => false,
+LL -         _ => true,
+LL -     };
+LL +     x.is_none();
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:170:5
    |
 LL | /     match x {
@@ -204,49 +397,101 @@ LL | |
 LL | |         None => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try: `x.is_some()`
+   | |_____^
+   |
+help: consider using `is_some()`
+   |
+LL -     match x {
+LL -
+LL -         None => false,
+LL -         _ => true,
+LL -     };
+LL +     x.is_some();
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:186:13
    |
 LL |     let _ = matches!(x, Some(_));
-   |             ^^^^^^^^^^^^^^^^^^^^ help: try: `x.is_some()`
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     let _ = matches!(x, Some(_));
+LL +     let _ = x.is_some();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:189:13
    |
 LL |     let _ = matches!(x, None);
-   |             ^^^^^^^^^^^^^^^^^ help: try: `x.is_none()`
+   |             ^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = matches!(x, None);
+LL +     let _ = x.is_none();
+   |
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:200:17
    |
 LL |         let _ = matches!(*p, None);
-   |                 ^^^^^^^^^^^^^^^^^^ help: try: `(*p).is_none()`
+   |                 ^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -         let _ = matches!(*p, None);
+LL +         let _ = (*p).is_none();
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:208:16
    |
 LL |         if let Some(_) = x? {
-   |         -------^^^^^^^----- help: try: `if x?.is_some()`
+   |                ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -         if let Some(_) = x? {
+LL +         if x?.is_some() {
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:228:16
    |
 LL |         if let Some(_) = x.await {
-   |         -------^^^^^^^---------- help: try: `if x.await.is_some()`
+   |                ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -         if let Some(_) = x.await {
+LL +         if x.await.is_some() {
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:241:12
    |
 LL |     if let Some(_) = (x! {}) {};
-   |     -------^^^^^^^---------- help: try: `if x! {}.is_some()`
+   |            ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = (x! {}) {};
+LL +     if x! {}.is_some() {};
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_option.rs:243:15
    |
 LL |     while let Some(_) = (x! {}) {}
-   |     ----------^^^^^^^---------- help: try: `while x! {}.is_some()`
+   |               ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     while let Some(_) = (x! {}) {}
+LL +     while x! {}.is_some() {}
+   |
 
 error: aborting due to 35 previous errors
 

--- a/tests/ui/redundant_pattern_matching_poll.stderr
+++ b/tests/ui/redundant_pattern_matching_poll.stderr
@@ -1,55 +1,102 @@
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:13:12
    |
 LL |     if let Pending = Pending::<()> {}
-   |     -------^^^^^^^---------------- help: try: `if Pending::<()>.is_pending()`
+   |            ^^^^^^^
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using `is_pending()`
+   |
+LL -     if let Pending = Pending::<()> {}
+LL +     if Pending::<()>.is_pending() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:16:12
    |
 LL |     if let Ready(_) = Ready(42) {}
-   |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
+   |            ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     if let Ready(_) = Ready(42) {}
+LL +     if Ready(42).is_ready() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:19:12
    |
 LL |     if let Ready(_) = Ready(42) {
-   |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
+   |            ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     if let Ready(_) = Ready(42) {
+LL +     if Ready(42).is_ready() {
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:27:8
    |
 LL |     if matches!(Ready(42), Ready(_)) {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Ready(42).is_ready()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     if matches!(Ready(42), Ready(_)) {}
+LL +     if Ready(42).is_ready() {}
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:31:8
    |
 LL |     if matches!(Pending::<()>, Pending) {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Pending::<()>.is_pending()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_pending()`
+   |
+LL -     if matches!(Pending::<()>, Pending) {}
+LL +     if Pending::<()>.is_pending() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:34:15
    |
 LL |     while let Ready(_) = Ready(42) {}
-   |     ----------^^^^^^^^------------ help: try: `while Ready(42).is_ready()`
+   |               ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     while let Ready(_) = Ready(42) {}
+LL +     while Ready(42).is_ready() {}
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:37:15
    |
 LL |     while let Pending = Ready(42) {}
-   |     ----------^^^^^^^------------ help: try: `while Ready(42).is_pending()`
+   |               ^^^^^^^
+   |
+help: consider using `is_pending()`
+   |
+LL -     while let Pending = Ready(42) {}
+LL +     while Ready(42).is_pending() {}
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:40:15
    |
 LL |     while let Pending = Pending::<()> {}
-   |     ----------^^^^^^^---------------- help: try: `while Pending::<()>.is_pending()`
+   |               ^^^^^^^
+   |
+help: consider using `is_pending()`
+   |
+LL -     while let Pending = Pending::<()> {}
+LL +     while Pending::<()>.is_pending() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:47:5
    |
 LL | /     match Ready(42) {
@@ -57,9 +104,19 @@ LL | |
 LL | |         Ready(_) => true,
 LL | |         Pending => false,
 LL | |     };
-   | |_____^ help: try: `Ready(42).is_ready()`
+   | |_____^
+   |
+help: consider using `is_ready()`
+   |
+LL -     match Ready(42) {
+LL -
+LL -         Ready(_) => true,
+LL -         Pending => false,
+LL -     };
+LL +     Ready(42).is_ready();
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:53:5
    |
 LL | /     match Pending::<()> {
@@ -67,9 +124,19 @@ LL | |
 LL | |         Ready(_) => false,
 LL | |         Pending => true,
 LL | |     };
-   | |_____^ help: try: `Pending::<()>.is_pending()`
+   | |_____^
+   |
+help: consider using `is_pending()`
+   |
+LL -     match Pending::<()> {
+LL -
+LL -         Ready(_) => false,
+LL -         Pending => true,
+LL -     };
+LL +     Pending::<()>.is_pending();
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:59:13
    |
 LL |       let _ = match Pending::<()> {
@@ -78,51 +145,103 @@ LL | |
 LL | |         Ready(_) => false,
 LL | |         Pending => true,
 LL | |     };
-   | |_____^ help: try: `Pending::<()>.is_pending()`
+   | |_____^
+   |
+help: consider using `is_pending()`
+   |
+LL -     let _ = match Pending::<()> {
+LL -
+LL -         Ready(_) => false,
+LL -         Pending => true,
+LL -     };
+LL +     let _ = Pending::<()>.is_pending();
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:66:20
    |
 LL |     let _ = if let Ready(_) = poll { true } else { false };
-   |             -------^^^^^^^^------- help: try: `if poll.is_ready()`
+   |                    ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     let _ = if let Ready(_) = poll { true } else { false };
+LL +     let _ = if poll.is_ready() { true } else { false };
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:71:20
    |
 LL |     let _ = if let Ready(_) = gen_poll() {
-   |             -------^^^^^^^^------------- help: try: `if gen_poll().is_ready()`
+   |                    ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     let _ = if let Ready(_) = gen_poll() {
+LL +     let _ = if gen_poll().is_ready() {
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:74:19
    |
 LL |     } else if let Pending = gen_poll() {
-   |            -------^^^^^^^------------- help: try: `if gen_poll().is_pending()`
+   |                   ^^^^^^^
+   |
+help: consider using `is_pending()`
+   |
+LL -     } else if let Pending = gen_poll() {
+LL +     } else if gen_poll().is_pending() {
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:91:12
    |
 LL |     if let Ready(_) = Ready(42) {}
-   |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
+   |            ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     if let Ready(_) = Ready(42) {}
+LL +     if Ready(42).is_ready() {}
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:94:12
    |
 LL |     if let Pending = Pending::<()> {}
-   |     -------^^^^^^^---------------- help: try: `if Pending::<()>.is_pending()`
+   |            ^^^^^^^
+   |
+help: consider using `is_pending()`
+   |
+LL -     if let Pending = Pending::<()> {}
+LL +     if Pending::<()>.is_pending() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:97:15
    |
 LL |     while let Ready(_) = Ready(42) {}
-   |     ----------^^^^^^^^------------ help: try: `while Ready(42).is_ready()`
+   |               ^^^^^^^^
+   |
+help: consider using `is_ready()`
+   |
+LL -     while let Ready(_) = Ready(42) {}
+LL +     while Ready(42).is_ready() {}
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:100:15
    |
 LL |     while let Pending = Pending::<()> {}
-   |     ----------^^^^^^^---------------- help: try: `while Pending::<()>.is_pending()`
+   |               ^^^^^^^
+   |
+help: consider using `is_pending()`
+   |
+LL -     while let Pending = Pending::<()> {}
+LL +     while Pending::<()>.is_pending() {}
+   |
 
-error: redundant pattern matching, consider using `is_ready()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:103:5
    |
 LL | /     match Ready(42) {
@@ -130,9 +249,19 @@ LL | |
 LL | |         Ready(_) => true,
 LL | |         Pending => false,
 LL | |     };
-   | |_____^ help: try: `Ready(42).is_ready()`
+   | |_____^
+   |
+help: consider using `is_ready()`
+   |
+LL -     match Ready(42) {
+LL -
+LL -         Ready(_) => true,
+LL -         Pending => false,
+LL -     };
+LL +     Ready(42).is_ready();
+   |
 
-error: redundant pattern matching, consider using `is_pending()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_poll.rs:109:5
    |
 LL | /     match Pending::<()> {
@@ -140,7 +269,17 @@ LL | |
 LL | |         Ready(_) => false,
 LL | |         Pending => true,
 LL | |     };
-   | |_____^ help: try: `Pending::<()>.is_pending()`
+   | |_____^
+   |
+help: consider using `is_pending()`
+   |
+LL -     match Pending::<()> {
+LL -
+LL -         Ready(_) => false,
+LL -         Pending => true,
+LL -     };
+LL +     Pending::<()>.is_pending();
+   |
 
 error: aborting due to 20 previous errors
 

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -1,37 +1,66 @@
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:14:12
    |
 LL |     if let Ok(_) = &result {}
-   |     -------^^^^^---------- help: try: `if result.is_ok()`
+   |            ^^^^^
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
+help: consider using `is_ok()`
+   |
+LL -     if let Ok(_) = &result {}
+LL +     if result.is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:17:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
-   |     -------^^^^^--------------------- help: try: `if Ok::<i32, i32>(42).is_ok()`
+   |            ^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     if let Ok(_) = Ok::<i32, i32>(42) {}
+LL +     if Ok::<i32, i32>(42).is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:20:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
-   |     -------^^^^^^---------------------- help: try: `if Err::<i32, i32>(42).is_err()`
+   |            ^^^^^^
+   |
+help: consider using `is_err()`
+   |
+LL -     if let Err(_) = Err::<i32, i32>(42) {}
+LL +     if Err::<i32, i32>(42).is_err() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:23:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
-   |     ----------^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_ok()`
+   |               ^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     while let Ok(_) = Ok::<i32, i32>(10) {}
+LL +     while Ok::<i32, i32>(10).is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:26:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
-   |     ----------^^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_err()`
+   |               ^^^^^^
+   |
+help: consider using `is_err()`
+   |
+LL -     while let Err(_) = Ok::<i32, i32>(10) {}
+LL +     while Ok::<i32, i32>(10).is_err() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:37:5
    |
 LL | /     match Ok::<i32, i32>(42) {
@@ -39,9 +68,19 @@ LL | |
 LL | |         Ok(_) => true,
 LL | |         Err(_) => false,
 LL | |     };
-   | |_____^ help: try: `Ok::<i32, i32>(42).is_ok()`
+   | |_____^
+   |
+help: consider using `is_ok()`
+   |
+LL -     match Ok::<i32, i32>(42) {
+LL -
+LL -         Ok(_) => true,
+LL -         Err(_) => false,
+LL -     };
+LL +     Ok::<i32, i32>(42).is_ok();
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:43:5
    |
 LL | /     match Ok::<i32, i32>(42) {
@@ -49,9 +88,19 @@ LL | |
 LL | |         Ok(_) => false,
 LL | |         Err(_) => true,
 LL | |     };
-   | |_____^ help: try: `Ok::<i32, i32>(42).is_err()`
+   | |_____^
+   |
+help: consider using `is_err()`
+   |
+LL -     match Ok::<i32, i32>(42) {
+LL -
+LL -         Ok(_) => false,
+LL -         Err(_) => true,
+LL -     };
+LL +     Ok::<i32, i32>(42).is_err();
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:49:5
    |
 LL | /     match Err::<i32, i32>(42) {
@@ -59,9 +108,19 @@ LL | |
 LL | |         Ok(_) => false,
 LL | |         Err(_) => true,
 LL | |     };
-   | |_____^ help: try: `Err::<i32, i32>(42).is_err()`
+   | |_____^
+   |
+help: consider using `is_err()`
+   |
+LL -     match Err::<i32, i32>(42) {
+LL -
+LL -         Ok(_) => false,
+LL -         Err(_) => true,
+LL -     };
+LL +     Err::<i32, i32>(42).is_err();
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:55:5
    |
 LL | /     match Err::<i32, i32>(42) {
@@ -69,75 +128,151 @@ LL | |
 LL | |         Ok(_) => true,
 LL | |         Err(_) => false,
 LL | |     };
-   | |_____^ help: try: `Err::<i32, i32>(42).is_ok()`
+   | |_____^
+   |
+help: consider using `is_ok()`
+   |
+LL -     match Err::<i32, i32>(42) {
+LL -
+LL -         Ok(_) => true,
+LL -         Err(_) => false,
+LL -     };
+LL +     Err::<i32, i32>(42).is_ok();
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:61:20
    |
 LL |     let _ = if let Ok(_) = Ok::<usize, ()>(4) { true } else { false };
-   |             -------^^^^^--------------------- help: try: `if Ok::<usize, ()>(4).is_ok()`
+   |                    ^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     let _ = if let Ok(_) = Ok::<usize, ()>(4) { true } else { false };
+LL +     let _ = if Ok::<usize, ()>(4).is_ok() { true } else { false };
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:70:20
    |
 LL |     let _ = if let Ok(_) = gen_res() {
-   |             -------^^^^^------------ help: try: `if gen_res().is_ok()`
+   |                    ^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     let _ = if let Ok(_) = gen_res() {
+LL +     let _ = if gen_res().is_ok() {
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:73:19
    |
 LL |     } else if let Err(_) = gen_res() {
-   |            -------^^^^^^------------ help: try: `if gen_res().is_err()`
+   |                   ^^^^^^
+   |
+help: consider using `is_err()`
+   |
+LL -     } else if let Err(_) = gen_res() {
+LL +     } else if gen_res().is_err() {
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:97:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
-   |         ----------^^^^^^^----------------------- help: try: `while r#try!(result_opt()).is_some()`
+   |                   ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -         while let Some(_) = r#try!(result_opt()) {}
+LL +         while r#try!(result_opt()).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:99:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
-   |         -------^^^^^^^----------------------- help: try: `if r#try!(result_opt()).is_some()`
+   |                ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -         if let Some(_) = r#try!(result_opt()) {}
+LL +         if r#try!(result_opt()).is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:106:12
    |
 LL |     if let Some(_) = m!() {}
-   |     -------^^^^^^^------- help: try: `if m!().is_some()`
+   |            ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     if let Some(_) = m!() {}
+LL +     if m!().is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_some()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:108:15
    |
 LL |     while let Some(_) = m!() {}
-   |     ----------^^^^^^^------- help: try: `while m!().is_some()`
+   |               ^^^^^^^
+   |
+help: consider using `is_some()`
+   |
+LL -     while let Some(_) = m!() {}
+LL +     while m!().is_some() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:127:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
-   |     -------^^^^^--------------------- help: try: `if Ok::<i32, i32>(42).is_ok()`
+   |            ^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     if let Ok(_) = Ok::<i32, i32>(42) {}
+LL +     if Ok::<i32, i32>(42).is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:130:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
-   |     -------^^^^^^---------------------- help: try: `if Err::<i32, i32>(42).is_err()`
+   |            ^^^^^^
+   |
+help: consider using `is_err()`
+   |
+LL -     if let Err(_) = Err::<i32, i32>(42) {}
+LL +     if Err::<i32, i32>(42).is_err() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:133:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
-   |     ----------^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_ok()`
+   |               ^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     while let Ok(_) = Ok::<i32, i32>(10) {}
+LL +     while Ok::<i32, i32>(10).is_ok() {}
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:136:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
-   |     ----------^^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_err()`
+   |               ^^^^^^
+   |
+help: consider using `is_err()`
+   |
+LL -     while let Err(_) = Ok::<i32, i32>(10) {}
+LL +     while Ok::<i32, i32>(10).is_err() {}
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:139:5
    |
 LL | /     match Ok::<i32, i32>(42) {
@@ -145,9 +280,19 @@ LL | |
 LL | |         Ok(_) => true,
 LL | |         Err(_) => false,
 LL | |     };
-   | |_____^ help: try: `Ok::<i32, i32>(42).is_ok()`
+   | |_____^
+   |
+help: consider using `is_ok()`
+   |
+LL -     match Ok::<i32, i32>(42) {
+LL -
+LL -         Ok(_) => true,
+LL -         Err(_) => false,
+LL -     };
+LL +     Ok::<i32, i32>(42).is_ok();
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:145:5
    |
 LL | /     match Err::<i32, i32>(42) {
@@ -155,9 +300,19 @@ LL | |
 LL | |         Ok(_) => false,
 LL | |         Err(_) => true,
 LL | |     };
-   | |_____^ help: try: `Err::<i32, i32>(42).is_err()`
+   | |_____^
+   |
+help: consider using `is_err()`
+   |
+LL -     match Err::<i32, i32>(42) {
+LL -
+LL -         Ok(_) => false,
+LL -         Err(_) => true,
+LL -     };
+LL +     Err::<i32, i32>(42).is_err();
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:156:5
    |
 LL | /     match x {
@@ -165,9 +320,19 @@ LL | |
 LL | |         Ok(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try: `x.is_ok()`
+   | |_____^
+   |
+help: consider using `is_ok()`
+   |
+LL -     match x {
+LL -
+LL -         Ok(_) => true,
+LL -         _ => false,
+LL -     };
+LL +     x.is_ok();
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:162:5
    |
 LL | /     match x {
@@ -175,9 +340,19 @@ LL | |
 LL | |         Ok(_) => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try: `x.is_err()`
+   | |_____^
+   |
+help: consider using `is_err()`
+   |
+LL -     match x {
+LL -
+LL -         Ok(_) => false,
+LL -         _ => true,
+LL -     };
+LL +     x.is_err();
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:168:5
    |
 LL | /     match x {
@@ -185,9 +360,19 @@ LL | |
 LL | |         Err(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try: `x.is_err()`
+   | |_____^
+   |
+help: consider using `is_err()`
+   |
+LL -     match x {
+LL -
+LL -         Err(_) => true,
+LL -         _ => false,
+LL -     };
+LL +     x.is_err();
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:174:5
    |
 LL | /     match x {
@@ -195,21 +380,43 @@ LL | |
 LL | |         Err(_) => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try: `x.is_ok()`
+   | |_____^
+   |
+help: consider using `is_ok()`
+   |
+LL -     match x {
+LL -
+LL -         Err(_) => false,
+LL -         _ => true,
+LL -     };
+LL +     x.is_ok();
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:196:13
    |
 LL |     let _ = matches!(x, Ok(_));
-   |             ^^^^^^^^^^^^^^^^^^ help: try: `x.is_ok()`
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     let _ = matches!(x, Ok(_));
+LL +     let _ = x.is_ok();
+   |
 
-error: redundant pattern matching, consider using `is_err()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:199:13
    |
 LL |     let _ = matches!(x, Err(_));
-   |             ^^^^^^^^^^^^^^^^^^^ help: try: `x.is_err()`
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_err()`
+   |
+LL -     let _ = matches!(x, Err(_));
+LL +     let _ = x.is_err();
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:216:13
    |
 LL |       let _ = match test_expr!(42) {
@@ -218,13 +425,29 @@ LL | |
 LL | |         Ok(_) => true,
 LL | |         Err(_) => false,
 LL | |     };
-   | |_____^ help: try: `test_expr!(42).is_ok()`
+   | |_____^
+   |
+help: consider using `is_ok()`
+   |
+LL -     let _ = match test_expr!(42) {
+LL -
+LL -         Ok(_) => true,
+LL -         Err(_) => false,
+LL -     };
+LL +     let _ = test_expr!(42).is_ok();
+   |
 
-error: redundant pattern matching, consider using `is_ok()`
+error: redundant pattern matching
   --> tests/ui/redundant_pattern_matching_result.rs:229:13
    |
 LL |     let _ = matches!(x, Ok(_) if test_guard!(42));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.is_ok() && test_guard!(42)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_ok()`
+   |
+LL -     let _ = matches!(x, Ok(_) if test_guard!(42));
+LL +     let _ = x.is_ok() && test_guard!(42);
+   |
 
 error: aborting due to 30 previous errors
 


### PR DESCRIPTION
- don't put the suggestion into the main lint message
- use verbose suggestions, to avoid awkward span highlighting

changelog: [`redundant_pattern_match`]: improve suggestions