### PR TITLE
Add new lint: `manual_assert_matches`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6978,6 +6978,7 @@ Released 2018-09-13
 [`manual_abs_diff`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_abs_diff
 [`manual_assert`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_assert
 [`manual_assert_eq`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_assert_eq
+[`manual_assert_matches`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_assert_matches
 [`manual_async_fn`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_async_fn
 [`manual_bit_width`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_bit_width
 [`manual_bits`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_bits

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -949,6 +949,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`len_zero`](https://rust-lang.github.io/rust-clippy/master/index.html#len_zero)
 * [`lines_filter_map_ok`](https://rust-lang.github.io/rust-clippy/master/index.html#lines_filter_map_ok)
 * [`manual_abs_diff`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_abs_diff)
+* [`manual_assert_matches`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_assert_matches)
 * [`manual_bits`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_bits)
 * [`manual_c_str_literals`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals)
 * [`manual_clamp`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -804,6 +804,7 @@ define_Conf! {
         len_zero,
         lines_filter_map_ok,
         manual_abs_diff,
+        manual_assert_matches,
         manual_bits,
         manual_c_str_literals,
         manual_clamp,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -303,6 +303,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::manual_abs_diff::MANUAL_ABS_DIFF_INFO,
     crate::manual_assert::MANUAL_ASSERT_INFO,
     crate::manual_assert_eq::MANUAL_ASSERT_EQ_INFO,
+    crate::manual_assert_matches::MANUAL_ASSERT_MATCHES_INFO,
     crate::manual_async_fn::MANUAL_ASYNC_FN_INFO,
     crate::manual_bits::MANUAL_BITS_INFO,
     crate::manual_checked_ops::MANUAL_CHECKED_OPS_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -202,6 +202,7 @@ mod main_recursion;
 mod manual_abs_diff;
 mod manual_assert;
 mod manual_assert_eq;
+mod manual_assert_matches;
 mod manual_async_fn;
 mod manual_bits;
 mod manual_checked_ops;
@@ -861,6 +862,7 @@ rustc_lint::late_lint_methods!(
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
+        ManualAssertMatches: manual_assert_matches::ManualAssertMatches = manual_assert_matches::ManualAssertMatches,
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
         RedundantElse: redundant_else::RedundantElse = redundant_else::RedundantElse,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -862,10 +862,10 @@ rustc_lint::late_lint_methods!(
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
-        ManualAssertMatches: manual_assert_matches::ManualAssertMatches = manual_assert_matches::ManualAssertMatches,
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
         RedundantElse: redundant_else::RedundantElse = redundant_else::RedundantElse,
+        ManualAssertMatches: manual_assert_matches::ManualAssertMatches = manual_assert_matches::ManualAssertMatches::new(conf, format_args.clone()),
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/manual_assert_matches.rs
+++ b/clippy_lints/src/manual_assert_matches.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::macros::{
@@ -131,26 +129,31 @@ impl<'tcx> LateLintPass<'tcx> for ManualAssertMatches {
             };
             let match_pat = match_pat.as_str();
 
-            let mut guard: Cow<'static, str> = Cow::Borrowed("");
-            if let Some(match_guard) = match_guard {
-                let Some(source) = match_guard.span.get_source_text(cx) else {
-                    return;
-                };
-                let source = source.as_str();
-                guard = Cow::Owned(format!(" if {source}"));
-            }
+            let guard = match match_guard {
+                Some(match_guard) if let Some(source) = match_guard.span.get_source_text(cx) => {
+                    let source = source.as_str();
+                    format!(" if {source}")
+                },
+                _ => String::new(),
+            };
 
-            let mut format_args: Cow<'static, str> = Cow::Borrowed("");
-            if let PanicCall::Format(format_expr) = panic_call
-                && let Some(args) = self.format_args.get(cx, format_expr, root_mac_call.expn)
-            {
-                let span = format_args_inputs_span(args);
-                let Some(source) = span.get_source_text(cx) else {
+            let format_args = match panic_call {
+                PanicCall::Display(display) if let Some(source) = display.span.get_source_text(cx) => {
+                    format!(", \"{{}}\", {source}")
+                },
+                PanicCall::Format(format_expr)
+                    if let Some(args) = self.format_args.get(cx, format_expr, root_mac_call.expn)
+                        && let span = format_args_inputs_span(args)
+                        && let Some(source) = span.get_source_text(cx) =>
+                {
+                    let source = source.as_str();
+                    format!(", {source}")
+                },
+                PanicCall::DefaultMessage => String::new(),
+                _ => {
                     return;
-                };
-                let source = source.as_str();
-                format_args = Cow::Owned(format!(", {source}"));
-            }
+                },
+            };
 
             let msg = format!("manual `core::{assert_macro_name}_matches` implementation");
             let sugg = format!("core::{assert_macro_name}_matches!({match_arg}, {match_pat}{guard}{format_args})");

--- a/clippy_lints/src/manual_assert_matches.rs
+++ b/clippy_lints/src/manual_assert_matches.rs
@@ -153,7 +153,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualAssertMatches {
             }
 
             let msg = format!("manual `core::{assert_macro_name}_matches` implementation");
-            let sugg = format!("core::{assert_macro_name}_matches!({match_arg}, {match_pat}{guard}{format_args});");
+            let sugg = format!("core::{assert_macro_name}_matches!({match_arg}, {match_pat}{guard}{format_args})");
             span_lint_and_sugg(
                 cx,
                 MANUAL_ASSERT_MATCHES,

--- a/clippy_lints/src/manual_assert_matches.rs
+++ b/clippy_lints/src/manual_assert_matches.rs
@@ -1,0 +1,168 @@
+use std::borrow::Cow;
+
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::macros::{
+    FormatArgsStorage, HirNode, PanicCall, find_assert_args, format_args_inputs_span, root_macro_call,
+    root_macro_call_first_node,
+};
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::source::{HasSession, SpanRangeExt};
+use clippy_utils::ty::has_debug_impl;
+use clippy_utils::{is_in_const_context, is_span_assert, sym};
+use rustc_errors::Applicability;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::impl_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for usage of `assert!(matches!(...))` / `debug_assert!(matches!(...))` which can be replaced with
+    /// `core::assert_matches!(...)` / `core::debug_assert_matches!(...)`.
+    ///
+    /// ### Why is this bad?
+    /// `assert!(matches!(...))` only communicates that the assertion failed in the panic message, while
+    /// `core::assert_matches!(...)` also includes the `Debug` representation of the value being matched on.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #[derive(Debug)]
+    /// enum A {
+    ///     X,
+    ///     Y,
+    /// }
+    ///
+    /// fn main() {
+    ///     let a = A::X;
+    ///     assert!(matches!(a, A::Y));
+    /// }
+    /// ```
+    /// produces:
+    /// ```ignore
+    /// assertion failed: matches!(a, A::Y)
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// #[derive(Debug)]
+    /// enum A {
+    ///     X,
+    ///     Y,
+    /// }
+    ///
+    /// fn main() {
+    ///     let a = A::X;
+    ///     core::assert_matches!(a, A::Y);
+    /// }
+    /// ```
+    /// which produces:
+    /// ```ignore
+    /// assertion `left matches right` failed
+    ///   left: X
+    ///  right: A::Y
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub MANUAL_ASSERT_MATCHES,
+    pedantic,
+    "usage of `assert!(matches!(...))` or `debug_assert!(matches!(...))`"
+}
+
+impl_lint_pass!(ManualAssertMatches => [MANUAL_ASSERT_MATCHES]);
+
+pub struct ManualAssertMatches {
+    msrv: Msrv,
+    format_args: FormatArgsStorage,
+}
+
+impl ManualAssertMatches {
+    pub fn new(conf: &'static Conf, format_args: FormatArgsStorage) -> Self {
+        Self {
+            msrv: conf.msrv,
+            format_args,
+        }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for ManualAssertMatches {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &rustc_hir::Expr<'tcx>) {
+        if !self.msrv.meets(cx, msrvs::ASSERT_MATCHES) {
+            return;
+        }
+
+        if let Some(root_mac_call) = root_macro_call_first_node(cx, expr)
+            && let Some(root_mac_name) = cx.tcx.get_diagnostic_name(root_mac_call.def_id)
+            && let Some((assert_expr, panic_call)) = find_assert_args(cx, expr, root_mac_call.expn)
+            && let rustc_hir::ExprKind::Match(
+                match_arg,
+                [
+                    rustc_hir::Arm {
+                        pat: match_pat,
+                        guard: match_guard,
+                        ..
+                    },
+                    _,
+                ],
+                _,
+            ) = assert_expr.kind
+            && let Some(inner_mac_call) = root_macro_call(assert_expr.span())
+            && let Some(sym::matches_macro) = cx.tcx.get_diagnostic_name(inner_mac_call.def_id)
+            && has_debug_impl(
+                cx,
+                cx.tcx.typeck(match_arg.hir_id.owner.def_id).node_type(match_arg.hir_id),
+            )
+            && !is_in_const_context(cx)
+            && !root_mac_call.span.in_external_macro(cx.sess().source_map())
+            && is_span_assert(cx, root_mac_call.span)
+        {
+            let assert_macro_name = match root_mac_name {
+                sym::assert_macro => "assert",
+                sym::debug_assert_macro => "debug_assert",
+                _ => {
+                    return;
+                },
+            };
+
+            let Some(match_arg) = match_arg.span.get_source_text(cx) else {
+                return;
+            };
+            let match_arg = match_arg.as_str();
+
+            let Some(match_pat) = match_pat.span.get_source_text(cx) else {
+                return;
+            };
+            let match_pat = match_pat.as_str();
+
+            let mut guard: Cow<'static, str> = Cow::Borrowed("");
+            if let Some(match_guard) = match_guard {
+                let Some(source) = match_guard.span.get_source_text(cx) else {
+                    return;
+                };
+                let source = source.as_str();
+                guard = Cow::Owned(format!(" if {source}"));
+            }
+
+            let mut format_args: Cow<'static, str> = Cow::Borrowed("");
+            if let PanicCall::Format(format_expr) = panic_call
+                && let Some(args) = self.format_args.get(cx, format_expr, root_mac_call.expn)
+            {
+                let span = format_args_inputs_span(args);
+                let Some(source) = span.get_source_text(cx) else {
+                    return;
+                };
+                let source = source.as_str();
+                format_args = Cow::Owned(format!(", {source}"));
+            }
+
+            let msg = format!("manual `core::{assert_macro_name}_matches` implementation");
+            let sugg = format!("core::{assert_macro_name}_matches!({match_arg}, {match_pat}{guard}{format_args});");
+            span_lint_and_sugg(
+                cx,
+                MANUAL_ASSERT_MATCHES,
+                root_mac_call.span,
+                msg,
+                "use",
+                sugg,
+                Applicability::MachineApplicable,
+            );
+        }
+    }
+}

--- a/clippy_lints/src/manual_assert_matches.rs
+++ b/clippy_lints/src/manual_assert_matches.rs
@@ -5,11 +5,11 @@ use clippy_utils::macros::{
     root_macro_call_first_node,
 };
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::source::{HasSession, SpanRangeExt};
+use clippy_utils::source::SpanExt;
 use clippy_utils::ty::has_debug_impl;
 use clippy_utils::{is_in_const_context, is_span_assert, sym};
 use rustc_errors::Applicability;
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::impl_lint_pass;
 
 declare_clippy_lint! {
@@ -119,18 +119,18 @@ impl<'tcx> LateLintPass<'tcx> for ManualAssertMatches {
                 },
             };
 
-            let Some(match_arg) = match_arg.span.get_source_text(cx) else {
+            let Some(match_arg) = match_arg.span.get_text(cx) else {
                 return;
             };
             let match_arg = match_arg.as_str();
 
-            let Some(match_pat) = match_pat.span.get_source_text(cx) else {
+            let Some(match_pat) = match_pat.span.get_text(cx) else {
                 return;
             };
             let match_pat = match_pat.as_str();
 
             let guard = match match_guard {
-                Some(match_guard) if let Some(source) = match_guard.span.get_source_text(cx) => {
+                Some(match_guard) if let Some(source) = match_guard.span.get_text(cx) => {
                     let source = source.as_str();
                     format!(" if {source}")
                 },
@@ -141,13 +141,13 @@ impl<'tcx> LateLintPass<'tcx> for ManualAssertMatches {
             };
 
             let format_args = match panic_call {
-                PanicCall::Display(display) if let Some(source) = display.span.get_source_text(cx) => {
+                PanicCall::Display(display) if let Some(source) = display.span.get_text(cx) => {
                     format!(", \"{{}}\", {source}")
                 },
                 PanicCall::Format(format_expr)
                     if let Some(args) = self.format_args.get(cx, format_expr, root_mac_call.expn)
                         && let span = format_args_inputs_span(args)
-                        && let Some(source) = span.get_source_text(cx) =>
+                        && let Some(source) = span.get_text(cx) =>
                 {
                     let source = source.as_str();
                     format!(", {source}")

--- a/clippy_lints/src/manual_assert_matches.rs
+++ b/clippy_lints/src/manual_assert_matches.rs
@@ -134,7 +134,10 @@ impl<'tcx> LateLintPass<'tcx> for ManualAssertMatches {
                     let source = source.as_str();
                     format!(" if {source}")
                 },
-                _ => String::new(),
+                None => String::new(),
+                _ => {
+                    return;
+                },
             };
 
             let format_args = match panic_call {

--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -651,3 +651,24 @@ pub fn is_span_match(cx: &impl LintContext, span: Span) -> bool {
 pub fn is_span_if(cx: &impl LintContext, span: Span) -> bool {
     span_matches_pat(cx.sess(), span, Pat::Str("if"), Pat::Str("}"))
 }
+
+/// Checks if the span actually refers to an `assert`/`debug_assert` macro call
+pub fn is_span_assert(cx: &impl LintContext, span: Span) -> bool {
+    span_matches_pat(
+        cx.sess(),
+        span,
+        Pat::MultiStr(&[
+            "assert",
+            "core::assert",
+            "std::assert",
+            "::core::assert",
+            "::std::assert",
+            "debug_assert",
+            "core::debug_assert",
+            "std::debug_assert",
+            "::core::debug_assert",
+            "::std::debug_assert",
+        ]),
+        Pat::Str(""),
+    )
+}

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -65,7 +65,7 @@ pub mod usage;
 pub mod visitors;
 
 pub use self::attrs::*;
-pub use self::check_proc_macro::{is_from_proc_macro, is_span_if, is_span_match};
+pub use self::check_proc_macro::{is_from_proc_macro, is_span_assert, is_span_if, is_span_match};
 pub use self::hir_utils::{
     HirEqInterExpr, SpanlessEq, SpanlessHash, both, count_eq, eq_expr_value, has_ambiguous_literal_in_expr, hash_expr,
     hash_stmt, is_bool, over,
@@ -845,10 +845,10 @@ pub fn capture_local_usage(cx: &LateContext<'_>, e: &Expr<'_>) -> CaptureKind {
         capture
     }
 
-    debug_assert!(matches!(
+    core::debug_assert_matches!(
         e.kind,
         ExprKind::Path(QPath::Resolved(None, Path { res: Res::Local(_), .. }))
-    ));
+    );
 
     let mut capture = CaptureKind::Value;
     let mut capture_expr_ty = e;

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -25,6 +25,7 @@ macro_rules! msrv_aliases {
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
     1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
+    1,96,0 { ASSERT_MATCHES }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }
     1,91,0 { DURATION_FROM_MINUTES_HOURS }
     1,88,0 { LET_CHAINS, AS_CHUNKS }

--- a/tests/config-metadata.rs
+++ b/tests/config-metadata.rs
@@ -63,8 +63,9 @@ fn changelog() {
     .unwrap();
     let expected = re.replace(&current, format!("$1\n{configs}\n$2"));
 
-    assert!(
-        matches!(expected, Cow::Owned(_)),
+    core::assert_matches!(
+        expected,
+        Cow::Owned(_),
         "failed to find configuration section in `{path}`"
     );
 

--- a/tests/ui/manual_assert_matches.fixed
+++ b/tests/ui/manual_assert_matches.fixed
@@ -1,0 +1,78 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::manual_assert_matches)]
+#![allow(clippy::eq_op)]
+#![allow(clippy::match_single_binding)]
+#![allow(clippy::assertions_on_constants)]
+
+extern crate proc_macros;
+
+#[clippy::msrv = "1.95"]
+fn msrv_1_95() {
+    assert!(matches!(1, 1));
+}
+
+#[clippy::msrv = "1.96"]
+fn msrv_1_96() {
+    core::assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+}
+
+fn main() {
+    core::assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+    core::assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+    core::assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+    core::assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+
+    core::debug_assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+    core::debug_assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+    core::debug_assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+    core::debug_assert_matches!(1, 1);;
+    //~^ manual_assert_matches
+
+    core::assert_matches!(1, 1, "hello");;
+    //~^ manual_assert_matches
+    #[rustfmt::skip]
+    core::assert_matches!(Some(1 + 2), Some(3 | 4) if true, "{} {} {} {}",
+        "this",
+        "is",
+        "a",
+        "test");;
+    #[rustfmt::skip]
+    core::assert_matches!((vec![1, 2, 3].as_slice(), Some("hello".to_string())), ([1, ..], Some(ref s)) if s.starts_with('h'), "expected {:?} to match",
+        (vec![1, 2, 3], Some("hello")));;
+
+    // Don't lint: argument to `assert!` is not exactly `matches!(...)`.
+    assert!(matches!(1, 1) || (1 + 1 == 2), "hello");
+
+    // Don't lint: the value being matched on is not `Debug`.
+    enum NotDebug {
+        Foo,
+        Bar,
+    };
+    assert!(matches!(NotDebug::Foo, NotDebug::Bar));
+    assert!(matches!(
+        {
+            match 0 {
+                _ => (),
+            };
+            NotDebug::Foo
+        },
+        NotDebug::Bar
+    ));
+
+    // Don't lint: in const context.
+    const {
+        assert!(matches!(1, 1));
+    }
+
+    // Don't lint: in external/proc macro.
+    proc_macros::external! { assert!(matches!(1, 1)) };
+    proc_macros::with_span! { span assert!(matches!(1, 1)) };
+}

--- a/tests/ui/manual_assert_matches.fixed
+++ b/tests/ui/manual_assert_matches.fixed
@@ -13,40 +13,40 @@ fn msrv_1_95() {
 
 #[clippy::msrv = "1.96"]
 fn msrv_1_96() {
-    core::assert_matches!(1, 1);;
+    core::assert_matches!(1, 1);
     //~^ manual_assert_matches
 }
 
 fn main() {
-    core::assert_matches!(1, 1);;
+    core::assert_matches!(1, 1);
     //~^ manual_assert_matches
-    core::assert_matches!(1, 1);;
+    core::assert_matches!(1, 1);
     //~^ manual_assert_matches
-    core::assert_matches!(1, 1);;
+    core::assert_matches!(1, 1);
     //~^ manual_assert_matches
-    core::assert_matches!(1, 1);;
-    //~^ manual_assert_matches
-
-    core::debug_assert_matches!(1, 1);;
-    //~^ manual_assert_matches
-    core::debug_assert_matches!(1, 1);;
-    //~^ manual_assert_matches
-    core::debug_assert_matches!(1, 1);;
-    //~^ manual_assert_matches
-    core::debug_assert_matches!(1, 1);;
+    core::assert_matches!(1, 1);
     //~^ manual_assert_matches
 
-    core::assert_matches!(1, 1, "hello");;
+    core::debug_assert_matches!(1, 1);
+    //~^ manual_assert_matches
+    core::debug_assert_matches!(1, 1);
+    //~^ manual_assert_matches
+    core::debug_assert_matches!(1, 1);
+    //~^ manual_assert_matches
+    core::debug_assert_matches!(1, 1);
+    //~^ manual_assert_matches
+
+    core::assert_matches!(1, 1, "hello");
     //~^ manual_assert_matches
     #[rustfmt::skip]
     core::assert_matches!(Some(1 + 2), Some(3 | 4) if true, "{} {} {} {}",
         "this",
         "is",
         "a",
-        "test");;
+        "test");
     #[rustfmt::skip]
     core::assert_matches!((vec![1, 2, 3].as_slice(), Some("hello".to_string())), ([1, ..], Some(ref s)) if s.starts_with('h'), "expected {:?} to match",
-        (vec![1, 2, 3], Some("hello")));;
+        (vec![1, 2, 3], Some("hello")));
 
     // Don't lint: argument to `assert!` is not exactly `matches!(...)`.
     assert!(matches!(1, 1) || (1 + 1 == 2), "hello");

--- a/tests/ui/manual_assert_matches.fixed
+++ b/tests/ui/manual_assert_matches.fixed
@@ -38,6 +38,8 @@ fn main() {
 
     core::assert_matches!(1, 1, "hello");
     //~^ manual_assert_matches
+    core::assert_matches!(1, 1, "{}", 1);
+    //~^ manual_assert_matches
     #[rustfmt::skip]
     core::assert_matches!(Some(1 + 2), Some(3 | 4) if true, "{} {} {} {}",
         "this",

--- a/tests/ui/manual_assert_matches.rs
+++ b/tests/ui/manual_assert_matches.rs
@@ -1,0 +1,87 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::manual_assert_matches)]
+#![allow(clippy::eq_op)]
+#![allow(clippy::match_single_binding)]
+#![allow(clippy::assertions_on_constants)]
+
+extern crate proc_macros;
+
+#[clippy::msrv = "1.95"]
+fn msrv_1_95() {
+    assert!(matches!(1, 1));
+}
+
+#[clippy::msrv = "1.96"]
+fn msrv_1_96() {
+    assert!(matches!(1, 1));
+    //~^ manual_assert_matches
+}
+
+fn main() {
+    assert!(matches!(1, 1));
+    //~^ manual_assert_matches
+    std::assert!(matches!(1, 1));
+    //~^ manual_assert_matches
+    assert!(std::matches!(1, 1));
+    //~^ manual_assert_matches
+    std::assert!(std::matches!(1, 1));
+    //~^ manual_assert_matches
+
+    debug_assert!(matches!(1, 1));
+    //~^ manual_assert_matches
+    std::debug_assert!(matches!(1, 1));
+    //~^ manual_assert_matches
+    debug_assert!(std::matches!(1, 1));
+    //~^ manual_assert_matches
+    std::debug_assert!(std::matches!(1, 1));
+    //~^ manual_assert_matches
+
+    assert!(matches!(1, 1), "hello");
+    //~^ manual_assert_matches
+    #[rustfmt::skip]
+    assert!(//~ manual_assert_matches
+        matches!(Some(1 + 2), Some(3 | 4) if true),
+        "{} {} {} {}",
+        "this",
+        "is",
+        "a",
+        "test"
+    );
+    #[rustfmt::skip]
+    assert!(//~ manual_assert_matches
+        matches!(
+            (vec![1, 2, 3].as_slice(), Some("hello".to_string())),
+            ([1, ..], Some(ref s)) if s.starts_with('h')
+        ),
+        "expected {:?} to match",
+        (vec![1, 2, 3], Some("hello")),
+    );
+
+    // Don't lint: argument to `assert!` is not exactly `matches!(...)`.
+    assert!(matches!(1, 1) || (1 + 1 == 2), "hello");
+
+    // Don't lint: the value being matched on is not `Debug`.
+    enum NotDebug {
+        Foo,
+        Bar,
+    };
+    assert!(matches!(NotDebug::Foo, NotDebug::Bar));
+    assert!(matches!(
+        {
+            match 0 {
+                _ => (),
+            };
+            NotDebug::Foo
+        },
+        NotDebug::Bar
+    ));
+
+    // Don't lint: in const context.
+    const {
+        assert!(matches!(1, 1));
+    }
+
+    // Don't lint: in external/proc macro.
+    proc_macros::external! { assert!(matches!(1, 1)) };
+    proc_macros::with_span! { span assert!(matches!(1, 1)) };
+}

--- a/tests/ui/manual_assert_matches.rs
+++ b/tests/ui/manual_assert_matches.rs
@@ -38,6 +38,8 @@ fn main() {
 
     assert!(matches!(1, 1), "hello");
     //~^ manual_assert_matches
+    assert!(matches!(1, 1), "{}", 1);
+    //~^ manual_assert_matches
     #[rustfmt::skip]
     assert!(//~ manual_assert_matches
         matches!(Some(1 + 2), Some(3 | 4) if true),

--- a/tests/ui/manual_assert_matches.stderr
+++ b/tests/ui/manual_assert_matches.stderr
@@ -1,0 +1,104 @@
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:16:5
+   |
+LL |     assert!(matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+   |
+   = note: `-D clippy::manual-assert-matches` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_assert_matches)]`
+
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:21:5
+   |
+LL |     assert!(matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:23:5
+   |
+LL |     std::assert!(matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:25:5
+   |
+LL |     assert!(std::matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:27:5
+   |
+LL |     std::assert!(std::matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+
+error: manual `core::debug_assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:30:5
+   |
+LL |     debug_assert!(matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1);`
+
+error: manual `core::debug_assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:32:5
+   |
+LL |     std::debug_assert!(matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1);`
+
+error: manual `core::debug_assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:34:5
+   |
+LL |     debug_assert!(std::matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1);`
+
+error: manual `core::debug_assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:36:5
+   |
+LL |     std::debug_assert!(std::matches!(1, 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1);`
+
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:39:5
+   |
+LL |     assert!(matches!(1, 1), "hello");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1, "hello");`
+
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:42:5
+   |
+LL | /     assert!(
+LL | |         matches!(Some(1 + 2), Some(3 | 4) if true),
+LL | |         "{} {} {} {}",
+LL | |         "this",
+...  |
+LL | |         "test"
+LL | |     );
+   | |_____^
+   |
+help: use
+   |
+LL ~     core::assert_matches!(Some(1 + 2), Some(3 | 4) if true, "{} {} {} {}",
+LL +         "this",
+LL +         "is",
+LL +         "a",
+LL ~         "test");;
+   |
+
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:51:5
+   |
+LL | /     assert!(
+LL | |         matches!(
+LL | |             (vec![1, 2, 3].as_slice(), Some("hello".to_string())),
+LL | |             ([1, ..], Some(ref s)) if s.starts_with('h')
+...  |
+LL | |         (vec![1, 2, 3], Some("hello")),
+LL | |     );
+   | |_____^
+   |
+help: use
+   |
+LL ~     core::assert_matches!((vec![1, 2, 3].as_slice(), Some("hello".to_string())), ([1, ..], Some(ref s)) if s.starts_with('h'), "expected {:?} to match",
+LL ~         (vec![1, 2, 3], Some("hello")));;
+   |
+
+error: aborting due to 12 previous errors
+

--- a/tests/ui/manual_assert_matches.stderr
+++ b/tests/ui/manual_assert_matches.stderr
@@ -62,7 +62,13 @@ LL |     assert!(matches!(1, 1), "hello");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1, "hello")`
 
 error: manual `core::assert_matches` implementation
-  --> tests/ui/manual_assert_matches.rs:42:5
+  --> tests/ui/manual_assert_matches.rs:41:5
+   |
+LL |     assert!(matches!(1, 1), "{}", 1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1, "{}", 1)`
+
+error: manual `core::assert_matches` implementation
+  --> tests/ui/manual_assert_matches.rs:44:5
    |
 LL | /     assert!(
 LL | |         matches!(Some(1 + 2), Some(3 | 4) if true),
@@ -83,7 +89,7 @@ LL ~         "test");
    |
 
 error: manual `core::assert_matches` implementation
-  --> tests/ui/manual_assert_matches.rs:51:5
+  --> tests/ui/manual_assert_matches.rs:53:5
    |
 LL | /     assert!(
 LL | |         matches!(
@@ -100,5 +106,5 @@ LL ~     core::assert_matches!((vec![1, 2, 3].as_slice(), Some("hello".to_string
 LL ~         (vec![1, 2, 3], Some("hello")));
    |
 
-error: aborting due to 12 previous errors
+error: aborting due to 13 previous errors
 

--- a/tests/ui/manual_assert_matches.stderr
+++ b/tests/ui/manual_assert_matches.stderr
@@ -2,7 +2,7 @@ error: manual `core::assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:16:5
    |
 LL |     assert!(matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1)`
    |
    = note: `-D clippy::manual-assert-matches` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_assert_matches)]`
@@ -11,55 +11,55 @@ error: manual `core::assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:21:5
    |
 LL |     assert!(matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1)`
 
 error: manual `core::assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:23:5
    |
 LL |     std::assert!(matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1)`
 
 error: manual `core::assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:25:5
    |
 LL |     assert!(std::matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1)`
 
 error: manual `core::assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:27:5
    |
 LL |     std::assert!(std::matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1)`
 
 error: manual `core::debug_assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:30:5
    |
 LL |     debug_assert!(matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1)`
 
 error: manual `core::debug_assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:32:5
    |
 LL |     std::debug_assert!(matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1)`
 
 error: manual `core::debug_assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:34:5
    |
 LL |     debug_assert!(std::matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1)`
 
 error: manual `core::debug_assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:36:5
    |
 LL |     std::debug_assert!(std::matches!(1, 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1);`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::debug_assert_matches!(1, 1)`
 
 error: manual `core::assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:39:5
    |
 LL |     assert!(matches!(1, 1), "hello");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1, "hello");`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `core::assert_matches!(1, 1, "hello")`
 
 error: manual `core::assert_matches` implementation
   --> tests/ui/manual_assert_matches.rs:42:5
@@ -79,7 +79,7 @@ LL ~     core::assert_matches!(Some(1 + 2), Some(3 | 4) if true, "{} {} {} {}",
 LL +         "this",
 LL +         "is",
 LL +         "a",
-LL ~         "test");;
+LL ~         "test");
    |
 
 error: manual `core::assert_matches` implementation
@@ -97,7 +97,7 @@ LL | |     );
 help: use
    |
 LL ~     core::assert_matches!((vec![1, 2, 3].as_slice(), Some("hello".to_string())), ([1, ..], Some(ref s)) if s.starts_with('h'), "expected {:?} to match",
-LL ~         (vec![1, 2, 3], Some("hello")));;
+LL ~         (vec![1, 2, 3], Some("hello")));
    |
 
 error: aborting due to 12 previous errors


### PR DESCRIPTION
Close https://github.com/rust-lang/rust-clippy/issues/17111

changelog: [`manual_assert_matches`]: Add new lint: `manual_assert_matches`
