### PR TITLE
Avoid invalid map_entry suggestions when non-Copy keys are reused

### DIFF
--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -150,49 +150,49 @@ impl<'tcx> LateLintPass<'tcx> for HashMapPass {
                     entry = map_ty.entry_path(),
                 ))
             }
-        } else {
-            if then_search.edits.is_empty() {
-                // no insertions
-                return;
-            }
-
+        } else if then_search.edits.is_empty() {
+            // no insertions
+            return;
+        } else if then_search.is_key_used_and_no_copy {
+            // If there are other uses of the key, and the key is not copy,
+            // we cannot perform a fix automatically, but continue to emit a lint.
+            None
+        } else if !then_search.allow_insert_closure {
             // if .. { insert }
-            if !then_search.allow_insert_closure {
-                let (body_str, entry_kind) = if contains_expr.negated {
-                    then_search.snippet_vacant(cx, then_expr.span, &mut app)
+            let (body_str, entry_kind) = if contains_expr.negated {
+                then_search.snippet_vacant(cx, then_expr.span, &mut app)
+            } else {
+                then_search.snippet_occupied(cx, then_expr.span, &mut app)
+            };
+            Some(format!(
+                "if let {}::{entry_kind} = {map_str}.entry({key_str}) {body_str}",
+                map_ty.entry_path(),
+            ))
+        } else if let Some(insertion) = then_search.as_single_insertion()
+            && let span_in_between = then_expr.span.shrink_to_lo().between(insertion.call.span)
+            && let span_in_between = span_in_between.split_at(1).1
+            && !span_contains_non_whitespace(cx, span_in_between, true)
+        {
+            let value_str = snippet_with_context(cx, insertion.value.span, then_expr.span.ctxt(), "..", &mut app).0;
+            if contains_expr.negated {
+                if insertion.value.can_have_side_effects() {
+                    Some(format!("{map_str}.entry({key_str}).or_insert_with(|| {value_str});"))
                 } else {
-                    then_search.snippet_occupied(cx, then_expr.span, &mut app)
-                };
-                Some(format!(
-                    "if let {}::{entry_kind} = {map_str}.entry({key_str}) {body_str}",
-                    map_ty.entry_path(),
-                ))
-            } else if let Some(insertion) = then_search.as_single_insertion()
-                && let span_in_between = then_expr.span.shrink_to_lo().between(insertion.call.span)
-                && let span_in_between = span_in_between.split_at(1).1
-                && !span_contains_non_whitespace(cx, span_in_between, true)
-            {
-                let value_str = snippet_with_context(cx, insertion.value.span, then_expr.span.ctxt(), "..", &mut app).0;
-                if contains_expr.negated {
-                    if insertion.value.can_have_side_effects() {
-                        Some(format!("{map_str}.entry({key_str}).or_insert_with(|| {value_str});"))
-                    } else {
-                        Some(format!("{map_str}.entry({key_str}).or_insert({value_str});"))
-                    }
-                } else {
-                    // TODO: suggest using `if let Some(v) = map.get_mut(k) { .. }` here.
-                    // This would need to be a different lint.
-                    return;
+                    Some(format!("{map_str}.entry({key_str}).or_insert({value_str});"))
                 }
             } else {
-                let block_str = then_search.snippet_closure(cx, then_expr.span, &mut app);
-                if contains_expr.negated {
-                    Some(format!("{map_str}.entry({key_str}).or_insert_with(|| {block_str});"))
-                } else {
-                    // TODO: suggest using `if let Some(v) = map.get_mut(k) { .. }` here.
-                    // This would need to be a different lint.
-                    return;
-                }
+                // TODO: suggest using `if let Some(v) = map.get_mut(k) { .. }` here.
+                // This would need to be a different lint.
+                return;
+            }
+        } else {
+            let block_str = then_search.snippet_closure(cx, then_expr.span, &mut app);
+            if contains_expr.negated {
+                Some(format!("{map_str}.entry({key_str}).or_insert_with(|| {block_str});"))
+            } else {
+                // TODO: suggest using `if let Some(v) = map.get_mut(k) { .. }` here.
+                // This would need to be a different lint.
+                return;
             }
         };
 
@@ -419,7 +419,9 @@ impl<'tcx> InsertSearcher<'_, 'tcx> {
         let in_tail_pos = self.in_tail_pos;
         let allow_insert_closure = self.allow_insert_closure;
         let is_single_insert = self.is_single_insert;
-        walk_expr(self, e.key);
+        if !self.spanless_eq.eq_expr(self.ctxt, self.key, e.key) {
+            walk_expr(self, e.key);
+        }
         walk_expr(self, e.value);
         self.in_tail_pos = in_tail_pos;
         self.allow_insert_closure = allow_insert_closure;

--- a/tests/ui/entry_unfixable.rs
+++ b/tests/ui/entry_unfixable.rs
@@ -48,6 +48,14 @@ fn issue9925(mut hm: HashMap<String, bool>) {
     }
 }
 
+fn issue17081(mut hm: HashMap<String, bool>, key: String) {
+    if !hm.contains_key(&key) {
+        //~^ map_entry
+        let _ = key.clone();
+        hm.insert(key, true);
+    }
+}
+
 mod issue9470 {
     use std::collections::HashMap;
     use std::sync::Mutex;

--- a/tests/ui/entry_unfixable.stderr
+++ b/tests/ui/entry_unfixable.stderr
@@ -29,7 +29,19 @@ LL | |     }
    = help: consider using the `Entry` API: https://doc.rust-lang.org/std/collections/struct.HashMap.html#entry-api
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
-  --> tests/ui/entry_unfixable.rs:80:13
+  --> tests/ui/entry_unfixable.rs:52:5
+   |
+LL | /     if !hm.contains_key(&key) {
+LL | |
+LL | |         let _ = key.clone();
+LL | |         hm.insert(key, true);
+LL | |     }
+   | |_____^
+   |
+   = help: consider using the `Entry` API: https://doc.rust-lang.org/std/collections/struct.HashMap.html#entry-api
+
+error: usage of `contains_key` followed by `insert` on a `HashMap`
+  --> tests/ui/entry_unfixable.rs:88:13
    |
 LL | /             if self.globals.contains_key(&name) {
 LL | |
@@ -42,5 +54,5 @@ LL | |             }
    |
    = help: consider using the `Entry` API: https://doc.rust-lang.org/std/collections/struct.HashMap.html#entry-api
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17081.

Suppresses the automatic `map_entry` suggestion for no-`else` cases where the entry key is non-`Copy` and is still used in the transformed body. The insert key itself is not counted as an extra key use, so insert-only cases remain eligible for suggestions.

Adds a UI regression covering a key use before insertion.

changelog: [`map_entry`]: avoid machine-applicable suggestions when non-`Copy` keys are reused in no-`else` branches

Verification:
- `cargo fmt --check`
- `git diff --check`