### PR TITLE
Obtaining the metadata of a const pointer is a const operation

### DIFF
--- a/clippy_utils/src/qualify_min_const_fn.rs
+++ b/clippy_utils/src/qualify_min_const_fn.rs
@@ -14,7 +14,7 @@ use rustc_infer::traits::Obligation;
 use rustc_lint::LateContext;
 use rustc_middle::mir::{
     Body, CastKind, NonDivergingIntrinsic, Operand, Place, ProjectionElem, Rvalue, Statement, StatementKind,
-    Terminator, TerminatorKind,
+    Terminator, TerminatorKind, UnOp,
 };
 use rustc_middle::traits::{BuiltinImplSource, ImplSource, ObligationCause};
 use rustc_middle::ty::adjustment::PointerCoercion;
@@ -142,6 +142,7 @@ fn check_rvalue<'tcx>(
         Rvalue::Repeat(operand, _)
         | Rvalue::Use(operand, _)
         | Rvalue::WrapUnsafeBinder(operand, _)
+        | Rvalue::UnaryOp(UnOp::PtrMetadata, operand)
         | Rvalue::Cast(
             CastKind::PointerWithExposedProvenance
             | CastKind::IntToInt
@@ -205,10 +206,13 @@ fn check_rvalue<'tcx>(
         },
         Rvalue::UnaryOp(_, operand) => {
             let ty = operand.ty(body, cx.tcx);
-            if ty.is_integral() || ty.is_bool() {
+            if ty.is_integral() | ty.is_bool() {
                 check_operand(cx, operand, span, body, msrv)
             } else {
-                Err((span, "only int and `bool` operations are stable in const fn".into()))
+                Err((
+                    span,
+                    "only int, `bool`, and pointer metadata operations are stable in const fn".into(),
+                ))
             }
         },
         Rvalue::Aggregate(_, operands) => {

--- a/tests/ui/missing_const_for_fn/could_be_const.fixed
+++ b/tests/ui/missing_const_for_fn/could_be_const.fixed
@@ -278,3 +278,9 @@ mod issue_15079 {
         }
     }
 }
+
+pub const fn issue17119(s: &str) -> bool {
+    //~^ missing_const_for_fn
+    let [_] = s.as_bytes() else { return false };
+    true
+}

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -278,3 +278,9 @@ mod issue_15079 {
         }
     }
 }
+
+pub fn issue17119(s: &str) -> bool {
+    //~^ missing_const_for_fn
+    let [_] = s.as_bytes() else { return false };
+    true
+}

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -402,5 +402,20 @@ help: make the function `const`
 LL |         pub const fn new_1_61() -> Self {
    |             +++++
 
-error: aborting due to 30 previous errors
+error: this could be a `const fn`
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:282:1
+   |
+LL | / pub fn issue17119(s: &str) -> bool {
+LL | |
+LL | |     let [_] = s.as_bytes() else { return false };
+LL | |     true
+LL | | }
+   | |_^
+   |
+help: make the function `const`
+   |
+LL | pub const fn issue17119(s: &str) -> bool {
+   |     +++++
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
changelog: [`missing_const_for_fn`]: lint more cases involving pointer metadata (such as slices length)

Fixes rust-lang/rust-clippy#17119 