### PR TITLE
clippy_lints: support iter_mut in ITER_NEXT_SLICE fixes #17115

### DIFF
--- a/clippy_lints/src/methods/iter_next_slice.rs
+++ b/clippy_lints/src/methods/iter_next_slice.rs
@@ -1,3 +1,4 @@
+use super::ITER_NEXT_SLICE;
 use super::utils::derefs_to_slice;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::res::MaybeDef;
@@ -8,11 +9,15 @@ use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
 use rustc_middle::ty;
+use rustc_span::Symbol;
 use rustc_span::symbol::sym;
 
-use super::ITER_NEXT_SLICE;
-
-pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, caller_expr: &'tcx hir::Expr<'_>) {
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx hir::Expr<'_>,
+    caller_expr: &'tcx hir::Expr<'_>,
+    method_name: Symbol,
+) {
     // Skip lint if the `iter().next()` expression is a for loop argument,
     // since it is already covered by `&loops::ITER_NEXT_LOOP`
     let mut parent_expr_opt = get_parent_expr(cx, expr);
@@ -22,7 +27,11 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, cal
         }
         parent_expr_opt = get_parent_expr(cx, parent_expr);
     }
-
+    let replacement = if method_name == sym::iter_mut {
+        "first_mut"
+    } else {
+        "first"
+    };
     if derefs_to_slice(cx, caller_expr, cx.typeck_results().expr_ty(caller_expr)).is_some() {
         // caller is a Slice
         if let hir::ExprKind::Index(caller_var, index_expr, _) = &caller_expr.kind
@@ -38,8 +47,9 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, cal
             let mut applicability = Applicability::MachineApplicable;
             let suggest = if start_idx == 0 {
                 format!(
-                    "{}.first()",
-                    snippet_with_applicability(cx, caller_var.span, "..", &mut applicability)
+                    "{}.{}()",
+                    snippet_with_applicability(cx, caller_var.span, "..", &mut applicability),
+                    replacement
                 )
             } else {
                 format!(
@@ -51,7 +61,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, cal
                 cx,
                 ITER_NEXT_SLICE,
                 expr.span,
-                "using `.iter().next()` on a Slice without end index",
+                format!("using `.{method_name}.next()` on a Slice without end index"),
                 "try calling",
                 suggest,
                 applicability,
@@ -64,11 +74,12 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, cal
             cx,
             ITER_NEXT_SLICE,
             expr.span,
-            "using `.iter().next()` on an array",
+            format!("using `.{method_name}.next()` on an array"),
             "try calling",
             format!(
-                "{}.first()",
-                snippet_with_applicability(cx, caller_expr.span, "..", &mut applicability)
+                "{}.{}()",
+                snippet_with_applicability(cx, caller_expr.span, "..", &mut applicability),
+                replacement
             ),
             applicability,
         );

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1359,29 +1359,33 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for usage of `iter().next()` on a Slice or an Array
+    /// Checks for usage of `iter().next()` or `iter_mut().next()` on a Slice or an Array
     ///
     /// ### Why is this bad?
-    /// These can be shortened into `.get()`
+    /// These can be shortened into `.first()` or `.first_mut()`
     ///
     /// ### Example
     /// ```no_run
     /// # let a = [1, 2, 3];
     /// # let b = vec![1, 2, 3];
+    /// # let mut c = vec![1, 2, 3];
     /// a[2..].iter().next();
     /// b.iter().next();
+    /// c.iter_mut().next();
     /// ```
     /// should be written as:
     /// ```no_run
     /// # let a = [1, 2, 3];
     /// # let b = vec![1, 2, 3];
+    /// # let mut c = vec![1, 2, 3];
     /// a.get(2);
-    /// b.get(0);
+    /// b.first();
+    /// c.first_mut();
     /// ```
     #[clippy::version = "1.46.0"]
     pub ITER_NEXT_SLICE,
     style,
-    "using `.iter().next()` on a sliced array, which can be shortened to just `.get()`"
+    "using `.iter().next()` or `.iter_mut().next()` on a sliced array, which can be shortened to just `.first()` or `.first_mut()`"
 }
 
 declare_clippy_lint! {
@@ -5588,7 +5592,7 @@ impl Methods {
                                 filter_next::check(cx, expr, recv2, arg, filter_next::Direction::Forward);
                             },
                             (sym::filter_map, [arg]) => filter_map_next::check(cx, expr, recv2, arg, self.msrv),
-                            (sym::iter, []) => iter_next_slice::check(cx, expr, recv2),
+                            (sym::iter | sym::iter_mut, []) => iter_next_slice::check(cx, expr, recv2, name2),
                             (sym::skip, [arg]) => iter_skip_next::check(cx, expr, recv2, arg),
                             (sym::skip_while, [_]) => skip_while_next::check(cx, expr),
                             (sym::rev, []) => manual_next_back::check(cx, expr, recv, recv2),

--- a/tests/ui/iter_next_slice.fixed
+++ b/tests/ui/iter_next_slice.fixed
@@ -25,4 +25,13 @@ fn main() {
     let o = Some(5);
     o.iter().next();
     // Shouldn't be linted since this is not a Slice or an Array
+
+    let mut s_mut = [1, 2, 3];
+    let mut v_mut = vec![1, 2, 3];
+
+    let _: Option<&mut i32> = s_mut.first_mut();
+    //~^ iter_next_slice
+
+    let _ = v_mut.first_mut();
+    //~^ iter_next_slice
 }

--- a/tests/ui/iter_next_slice.rs
+++ b/tests/ui/iter_next_slice.rs
@@ -25,4 +25,13 @@ fn main() {
     let o = Some(5);
     o.iter().next();
     // Shouldn't be linted since this is not a Slice or an Array
+
+    let mut s_mut = [1, 2, 3];
+    let mut v_mut = vec![1, 2, 3];
+
+    let _: Option<&mut i32> = s_mut.iter_mut().next();
+    //~^ iter_next_slice
+
+    let _ = v_mut.iter_mut().next();
+    //~^ iter_next_slice
 }

--- a/tests/ui/iter_next_slice.stderr
+++ b/tests/ui/iter_next_slice.stderr
@@ -1,4 +1,4 @@
-error: using `.iter().next()` on an array
+error: using `.iter.next()` on an array
   --> tests/ui/iter_next_slice.rs:9:13
    |
 LL |     let _ = s.iter().next();
@@ -7,23 +7,35 @@ LL |     let _ = s.iter().next();
    = note: `-D clippy::iter-next-slice` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::iter_next_slice)]`
 
-error: using `.iter().next()` on a Slice without end index
+error: using `.iter.next()` on a Slice without end index
   --> tests/ui/iter_next_slice.rs:13:13
    |
 LL |     let _ = s[2..].iter().next();
    |             ^^^^^^^^^^^^^^^^^^^^ help: try calling: `s.get(2)`
 
-error: using `.iter().next()` on a Slice without end index
+error: using `.iter.next()` on a Slice without end index
   --> tests/ui/iter_next_slice.rs:17:13
    |
 LL |     let _ = v[5..].iter().next();
    |             ^^^^^^^^^^^^^^^^^^^^ help: try calling: `v.get(5)`
 
-error: using `.iter().next()` on an array
+error: using `.iter.next()` on an array
   --> tests/ui/iter_next_slice.rs:21:13
    |
 LL |     let _ = v.iter().next();
    |             ^^^^^^^^^^^^^^^ help: try calling: `v.first()`
 
-error: aborting due to 4 previous errors
+error: using `.iter_mut.next()` on an array
+  --> tests/ui/iter_next_slice.rs:32:31
+   |
+LL |     let _: Option<&mut i32> = s_mut.iter_mut().next();
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^ help: try calling: `s_mut.first_mut()`
+
+error: using `.iter_mut.next()` on an array
+  --> tests/ui/iter_next_slice.rs:35:13
+   |
+LL |     let _ = v_mut.iter_mut().next();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ help: try calling: `v_mut.first_mut()`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17122)*

```
changelog: [`iter_next_slice`]: Extend lint to support `iter_mut()`
```
fixes rust-lang/rust-clippy#17115

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo dev fmt`

changelog: This PR extends the iter_next_slice lint to also detect and suggest replacements for .iter_mut().next() calls on slices and arrays, providing consistent behavior for mutable iterators.