### PR TITLE
perf: skip nonstandard_macro_braces work when the lint is disabled

### DIFF
--- a/clippy_lints/src/nonstandard_macro_braces.rs
+++ b/clippy_lints/src/nonstandard_macro_braces.rs
@@ -6,7 +6,7 @@ use rustc_ast::ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::Applicability;
 use rustc_hir::def_id::DefId;
-use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_session::impl_lint_pass;
 use rustc_span::Span;
 use rustc_span::hygiene::{ExpnKind, MacroKind};
@@ -115,6 +115,19 @@ impl EarlyLintPass for MacroBraces {
 }
 
 fn is_offending_macro(cx: &EarlyContext<'_>, span: Span, mac_braces: &MacroBraces) -> Option<MacroInfo> {
+    let mut ctxt = span.ctxt();
+    // Most nodes in a crate aren't produced by a macro and never match below; bail before the
+    // lint-level lookup so the common (non-macro) case stays as cheap as it was originally.
+    if ctxt.is_root() {
+        return None;
+    }
+    // `NONSTANDARD_MACRO_BRACES` is allow-by-default. Now that we know this span came from a macro,
+    // a per-node lint-level lookup is worth it: when the lint isn't enabled here we can skip the
+    // macro-backtrace walk and brace-map lookups entirely, since nothing could be emitted anyway.
+    if cx.get_lint_level_spec(NONSTANDARD_MACRO_BRACES).is_allow() {
+        return None;
+    }
+
     let unnested_or_local = |span: Span| {
         !span.from_expansion()
             || span
@@ -123,7 +136,6 @@ fn is_offending_macro(cx: &EarlyContext<'_>, span: Span, mac_braces: &MacroBrace
                 .is_some_and(|e| e.macro_def_id.is_some_and(DefId::is_local))
     };
 
-    let mut ctxt = span.ctxt();
     while !ctxt.is_root() {
         let expn_data = ctxt.outer_expn_data();
         if let ExpnKind::Macro(MacroKind::Bang, mac_name) = expn_data.kind


### PR DESCRIPTION
`NONSTANDARD_MACRO_BRACES` is a nursery (allow-by-default) lint, but `is_offending_macro` ran on every item, stmt, expr and ty regardless of whether the lint was enabled. For each node it walked the full macro backtrace (which clones `ExpnData` and re-enters the hygiene thread-local once per level) and hashed macro names against the brace map. When the lint is disabled none of that can produce a warning, so it is all wasted.

The fix adds two early returns at the top of `is_offending_macro`:

1. If the span is not from a macro, return right away. This matches what the original loop already did, but it happens before the lint-level lookup so ordinary non-macro nodes stay as cheap as before.
2. If the span is from a macro but the lint is allowed at that node, skip the walk.

When the lint is enabled the second guard is never taken, so behaviour is unchanged.

Benchmarked with callgrind so the numbers are deterministic and machine-independent. Release `cargo-clippy` run under `valgrind --tool=callgrind --trace-children=yes`, with dependencies pre-warmed so the measured run only re-lints the workspace crate. The figure is the summed `clippy-driver` instruction count (Ir). Two drivers built against identical libs, differing only in this change:

| crate | Ir before | Ir after | change |
|-------|-----------|----------|--------|
| wasmi | 12,471,491,702 | 11,362,130,905 | -8.90% |
| serde | 3,361,612,726 | 3,347,918,880 | -0.41% |
| ripgrep | 1,319,816,618 | 1,318,269,988 | -0.12% |

The saving is concentrated on macro-heavy code such as wasmi. On crates that use few macros it is small, which is what the guard is meant to do.

changelog: none
