### PR TITLE
perf: skip disabled off-by-default doc reparses

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -906,29 +906,35 @@ fn check_attrs(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, attrs: &[
         return Some(DocHeaders::default());
     }
 
-    check_for_code_clusters(
-        cx,
-        pulldown_cmark::Parser::new_with_broken_link_callback(
+    // Only emits the allow-by-default `DOC_LINK_CODE`; skip its extra markdown reparse when it's off.
+    if !clippy_utils::is_lint_allowed(cx, DOC_LINK_CODE, cx.last_node_with_lint_attrs) {
+        check_for_code_clusters(
+            cx,
+            pulldown_cmark::Parser::new_with_broken_link_callback(
+                &doc,
+                main_body_opts() - Options::ENABLE_SMART_PUNCTUATION,
+                Some(&mut fake_broken_link_callback),
+            )
+            .into_offset_iter(),
             &doc,
-            main_body_opts() - Options::ENABLE_SMART_PUNCTUATION,
-            Some(&mut fake_broken_link_callback),
-        )
-        .into_offset_iter(),
-        &doc,
-        Fragments {
-            doc: &doc,
-            fragments: &fragments,
-        },
-    );
+            Fragments {
+                doc: &doc,
+                fragments: &fragments,
+            },
+        );
+    }
 
-    doc_paragraphs_missing_punctuation::check(
-        cx,
-        &doc,
-        Fragments {
-            doc: &doc,
-            fragments: &fragments,
-        },
-    );
+    // Same for the allow-by-default `DOC_PARAGRAPHS_MISSING_PUNCTUATION`, which also reparses.
+    if !clippy_utils::is_lint_allowed(cx, DOC_PARAGRAPHS_MISSING_PUNCTUATION, cx.last_node_with_lint_attrs) {
+        doc_paragraphs_missing_punctuation::check(
+            cx,
+            &doc,
+            Fragments {
+                doc: &doc,
+                fragments: &fragments,
+            },
+        );
+    }
 
     // NOTE: check_doc uses it own cb function,
     // to avoid causing duplicated diagnostics for the broken link checker.


### PR DESCRIPTION
`check_attrs` reparses each doc comment's markdown three times: once in `check_for_code_clusters` (which only emits `doc_link_code`), once in `doc_paragraphs_missing_punctuation` (its own parser), and once in the main `check_doc` pass that drives the default-on doc lints.

`doc_link_code` (nursery) and `doc_paragraphs_missing_punctuation` (restriction) are both allow-by-default, so on the default configuration those first two reparses produce nothing and are wasted work on every documented item.

The fix guards each of the two calls behind `is_lint_allowed`. The lookup is node-accurate, so an item that opts in with `#[warn(...)]` is still checked. When either lint is enabled the matching guard is never taken, so behaviour is unchanged.

Benchmarked with callgrind so the numbers are deterministic and machine-independent. Release `cargo-clippy` run under `valgrind --tool=callgrind --trace-children=yes`, with dependencies pre-warmed so the measured run only re-lints the workspace crate. The figure is the summed `clippy-driver` instruction count (Ir). Two drivers built against identical libs, differing only in this change. Diagnostics are byte-identical:

| crate | Ir before | Ir after | change |
|-------|-----------|----------|--------|
| regex | 816,516,180 | 798,724,559 | -2.18% |
| syn | 2,115,732,774 | 2,101,254,856 | -0.68% |
| ripgrep | 1,319,816,618 | 1,316,825,621 | -0.23% |

changelog: none
