### PR TITLE
Remove broken suggestion for blocks_in_conditions

### DIFF
--- a/clippy_lints/src/blocks_in_conditions.rs
+++ b/clippy_lints/src/blocks_in_conditions.rs
@@ -1,8 +1,8 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::snippet_block_with_applicability;
 use clippy_utils::{contains_return, higher, is_from_proc_macro};
 use rustc_errors::Applicability;
-use rustc_hir::{BlockCheckMode, Expr, ExprKind, MatchSource};
+use rustc_hir::{BlockCheckMode, Expr, ExprKind, MatchSource, Node};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::declare_lint_pass;
 
@@ -109,19 +109,35 @@ impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
                     if span.from_expansion() || expr.span.from_expansion() || is_from_proc_macro(cx, cond) {
                         return;
                     }
-                    // move block higher
-                    let mut applicability = Applicability::MachineApplicable;
-                    span_lint_and_sugg(
+
+                    span_lint_and_then(
                         cx,
                         BLOCKS_IN_CONDITIONS,
                         expr.span.with_hi(cond.span.hi()),
                         complex_block_message,
-                        "try",
-                        format!(
-                            "let res = {}; {keyword} res",
-                            snippet_block_with_applicability(cx, block.span, "..", Some(expr.span), &mut applicability),
-                        ),
-                        applicability,
+                        |diag| {
+                            // Only suggest fix where let binding is easy to apply i.e. parent node is a block.
+                            // See issue #17068
+                            if let Node::Block(_) | Node::Stmt(_) = cx.tcx.parent_hir_node(expr.hir_id) {
+                                // move block higher
+                                let mut applicability = Applicability::MachineApplicable;
+                                diag.span_suggestion(
+                                    expr.span.with_hi(cond.span.hi()),
+                                    "try",
+                                    format!(
+                                        "let res = {}; {keyword} res",
+                                        snippet_block_with_applicability(
+                                            cx,
+                                            block.span,
+                                            "..",
+                                            Some(expr.span),
+                                            &mut applicability
+                                        ),
+                                    ),
+                                    applicability,
+                                );
+                            }
+                        },
                     );
                 }
             }

--- a/clippy_lints/src/blocks_in_conditions.rs
+++ b/clippy_lints/src/blocks_in_conditions.rs
@@ -1,8 +1,8 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::snippet_block_with_applicability;
 use clippy_utils::{contains_return, higher, is_from_proc_macro, leaks_droppable_temporary};
 use rustc_errors::Applicability;
-use rustc_hir::{BlockCheckMode, Expr, ExprKind, MatchSource};
+use rustc_hir::{BlockCheckMode, Expr, ExprKind, MatchSource, Node};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 
@@ -107,7 +107,7 @@ impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
                             BLOCKS_IN_CONDITIONS,
                             cond.span,
                             BRACED_EXPR_MESSAGE,
-                            "try",
+                            "remove the braces",
                             snippet_block_with_applicability(cx, ex.span, "..", Some(expr.span), &mut applicability),
                             applicability,
                         );
@@ -117,19 +117,35 @@ impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
                     if span.from_expansion() || is_from_proc_macro(cx, cond) {
                         return;
                     }
-                    // move block higher
-                    let mut applicability = Applicability::MachineApplicable;
-                    span_lint_and_sugg(
+
+                    span_lint_and_then(
                         cx,
                         BLOCKS_IN_CONDITIONS,
                         expr.span.with_hi(cond.span.hi()),
                         complex_block_message,
-                        "try",
-                        format!(
-                            "let res = {}; {keyword} res",
-                            snippet_block_with_applicability(cx, block.span, "..", Some(expr.span), &mut applicability),
-                        ),
-                        applicability,
+                        |diag| {
+                            // Only suggest fix where let binding is easy to apply i.e. parent node is a block.
+                            // See issue #17068
+                            if let Node::Block(_) | Node::Stmt(_) = cx.tcx.parent_hir_node(expr.hir_id) {
+                                // move block higher
+                                let mut applicability = Applicability::MachineApplicable;
+                                diag.span_suggestion(
+                                    expr.span.with_hi(cond.span.hi()),
+                                    "use a binding instead",
+                                    format!(
+                                        "let res = {}; {keyword} res",
+                                        snippet_block_with_applicability(
+                                            cx,
+                                            block.span,
+                                            "..",
+                                            Some(expr.span),
+                                            &mut applicability
+                                        ),
+                                    ),
+                                    applicability,
+                                );
+                            }
+                        },
                     );
                 }
             }

--- a/tests/ui/blocks_in_conditions.stderr
+++ b/tests/ui/blocks_in_conditions.stderr
@@ -10,7 +10,7 @@ LL | |     } {
    |
    = note: `-D clippy::blocks-in-conditions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::blocks_in_conditions)]`
-help: try
+help: use a binding instead
    |
 LL ~     let res = {
 LL +
@@ -23,13 +23,13 @@ error: omit braces around single expression condition
   --> tests/ui/blocks_in_conditions.rs:36:8
    |
 LL |     if { true } { 6 } else { 10 }
-   |        ^^^^^^^^ help: try: `true`
+   |        ^^^^^^^^ help: remove the braces: `true`
 
 error: omit braces around single expression condition
   --> tests/ui/blocks_in_conditions.rs:136:15
    |
 LL |         match { Foo.foo() } {
-   |               ^^^^^^^^^^^^^ help: try: `Foo.foo()`
+   |               ^^^^^^^^^^^^^ help: remove the braces: `Foo.foo()`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/blocks_in_conditions_2021.stderr
+++ b/tests/ui/blocks_in_conditions_2021.stderr
@@ -10,7 +10,7 @@ LL | |     } {
    |
    = note: `-D clippy::blocks-in-conditions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::blocks_in_conditions)]`
-help: try
+help: use a binding instead
    |
 LL ~     let res = {
 LL +

--- a/tests/ui/blocks_in_conditions_unfixable.rs
+++ b/tests/ui/blocks_in_conditions_unfixable.rs
@@ -1,0 +1,25 @@
+fn issue_17068() {
+    fn nop() {}
+
+    match Some(()) {
+        Some(()) => match {
+            //~^ ERROR: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
+            nop();
+            42
+        } {
+            42 => nop(),
+            _ => nop(),
+        },
+        None => nop(),
+    }
+
+    let _x = if {
+        //~^ ERROR: in an `if` condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
+        let v = 1;
+        v == 1
+    } {
+        1
+    } else {
+        2
+    };
+}

--- a/tests/ui/blocks_in_conditions_unfixable.stderr
+++ b/tests/ui/blocks_in_conditions_unfixable.stderr
@@ -1,0 +1,27 @@
+error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
+  --> tests/ui/blocks_in_conditions_unfixable.rs:5:21
+   |
+LL |   ...   Some(()) => match {
+   |  ___________________^
+LL | | ...
+LL | | ...       nop();
+LL | | ...       42
+LL | | ...   } {
+   | |_______^
+   |
+   = note: `-D clippy::blocks-in-conditions` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::blocks_in_conditions)]`
+
+error: in an `if` condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
+  --> tests/ui/blocks_in_conditions_unfixable.rs:16:14
+   |
+LL |       let _x = if {
+   |  ______________^
+LL | |
+LL | |         let v = 1;
+LL | |         v == 1
+LL | |     } {
+   | |_____^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
The suggested fix for `blocks_in_conditions` when the keyword receiving the condition does not have a block or statement as a parent results in invalid code.

An example: 
```rust
fn main() {
    match Some(()) {
        Some(()) => match {
            nop();
            42
        } {
            42 => nop(),
            _ => nop(),
        },
        None => nop(),
    }
}

fn nop() {}
```

This change just skips the suggestion entirely because it would either:
+ Need to show a placeholder for the block after the condition, as the whole thing needs to be wrapped in a new block
+ Need to show the whole following block wrapped in a new block

For example the suggested fix for above would be:
```rust
    match Some(()) {
        Some(()) => {
            let res = {
                nop();
                42
            };
            match res {
                42 => nop(),
                _ => nop(),
            }
        },
        None => nop(),
    }
```

And I couldn't get the formatting looking nice. If that's unacceptable I can take another run at it.

changelog: [`blocks_in_conditions`]: Remove broken suggestions for conditions lacking a parent block.

fixes rust-lang/rust-clippy#17068 