### PR TITLE
add new lint: `too_many_fields`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7383,6 +7383,7 @@ Released 2018-09-13
 [`todo`]: https://rust-lang.github.io/rust-clippy/master/index.html#todo
 [`too_long_first_doc_paragraph`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
 [`too_many_arguments`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
+[`too_many_fields`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_fields
 [`too_many_lines`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines
 [`toplevel_ref_arg`]: https://rust-lang.github.io/rust-clippy/master/index.html#toplevel_ref_arg
 [`trailing_empty_array`]: https://rust-lang.github.io/rust-clippy/master/index.html#trailing_empty_array
@@ -7618,6 +7619,7 @@ Released 2018-09-13
 [`suppress-restriction-lint-in-const`]: https://doc.rust-lang.org/clippy/lint_configuration.html#suppress-restriction-lint-in-const
 [`too-large-for-stack`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-large-for-stack
 [`too-many-arguments-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-arguments-threshold
+[`too-many-fields-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-fields-threshold
 [`too-many-lines-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-lines-threshold
 [`trait-assoc-item-kinds-order`]: https://doc.rust-lang.org/clippy/lint_configuration.html#trait-assoc-item-kinds-order
 [`trivial-copy-size-limit`]: https://doc.rust-lang.org/clippy/lint_configuration.html#trivial-copy-size-limit

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -1115,6 +1115,17 @@ The maximum number of argument a function or method can have
 * [`too_many_arguments`](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments)
 
 
+## `too-many-fields-threshold`
+The maximum number of fields a struct can have.
+Use `0` to lint on any non-unit struct.
+
+**Default Value:** `10`
+
+---
+**Affected lints:**
+* [`too_many_fields`](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_fields)
+
+
 ## `too-many-lines-threshold`
 The maximum number of lines a function or method can have
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -884,6 +884,10 @@ define_Conf! {
     /// The maximum number of argument a function or method can have
     #[lints(too_many_arguments)]
     too_many_arguments_threshold: u64 = 7,
+    /// The maximum number of fields a struct can have.
+    /// Use `0` to lint on any non-unit struct.
+    #[lints(too_many_fields)]
+    too_many_fields_threshold: u64 = 10,
     /// The maximum number of lines a function or method can have
     #[lints(too_many_lines)]
     too_many_lines_threshold: u64 = 100,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -730,6 +730,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::time_subtraction::UNCHECKED_TIME_SUBTRACTION_INFO,
     crate::to_digit_is_some::TO_DIGIT_IS_SOME_INFO,
     crate::to_string_trait_impl::TO_STRING_TRAIT_IMPL_INFO,
+    crate::too_many_fields::TOO_MANY_FIELDS_INFO,
     crate::toplevel_ref_arg::TOPLEVEL_REF_ARG_INFO,
     crate::trailing_empty_array::TRAILING_EMPTY_ARRAY_INFO,
     crate::trait_bounds::TRAIT_DUPLICATION_IN_BOUNDS_INFO,

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -359,6 +359,7 @@ struct Insertion<'tcx> {
 /// * Determine if there's any sub-expression that can't be placed in a closure.
 /// * Determine if there's only a single insert statement. `or_insert` can be used in this case.
 #[expect(clippy::struct_excessive_bools)]
+#[expect(clippy::too_many_fields)]
 struct InsertSearcher<'cx, 'tcx> {
     cx: &'cx LateContext<'tcx>,
     /// The map expression used in the contains call.

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -358,6 +358,7 @@ mod tests_outside_test_module;
 mod time_subtraction;
 mod to_digit_is_some;
 mod to_string_trait_impl;
+mod too_many_fields;
 mod toplevel_ref_arg;
 mod trailing_empty_array;
 mod trait_bounds;
@@ -857,6 +858,7 @@ rustc_lint::late_lint_methods!(
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
+        TooManyFields: too_many_fields::TooManyFields = too_many_fields::TooManyFields::new(conf),
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5025,6 +5025,7 @@ impl_lint_pass!(Methods => [
 ]);
 
 #[expect(clippy::struct_excessive_bools)]
+#[expect(clippy::too_many_fields)]
 pub struct Methods {
     avoid_breaking_exported_api: bool,
     msrv: Msrv,

--- a/clippy_lints/src/too_many_fields.rs
+++ b/clippy_lints/src/too_many_fields.rs
@@ -1,0 +1,114 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::has_repr_attr;
+use rustc_hir::{Item, ItemKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::impl_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for structs with too many fields.
+    ///
+    /// ### Why is this bad?
+    /// Large structs are often a sign that a type is taking on too many
+    /// responsibilities at once.
+    ///
+    /// As more fields accumulate, it gets harder to work with logically related
+    /// subsections of the state. In particular, mutable borrowing often becomes
+    /// awkward because independent operations still have to borrow the same large
+    /// struct.
+    ///
+    /// Grouping related fields into smaller helper structs can make the code
+    /// easier to read, easier to borrow from, and easier to extend with methods.
+    ///
+    /// The `too-many-fields-threshold` configuration accepts `0`, which lints on
+    /// any non-unit struct.
+    ///
+    /// ### Example
+    /// ```rust,ignore
+    /// struct RenderContext {
+    ///     theme: Theme,
+    ///     font_size: u16,
+    ///     font_family: String,
+    ///     line_height: u16,
+    ///     margin_top: u16,
+    ///     margin_right: u16,
+    ///     margin_bottom: u16,
+    ///     margin_left: u16,
+    ///     page_width: u16,
+    ///     page_height: u16,
+    ///     show_line_numbers: bool,
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    /// ```rust,ignore
+    /// struct Typography {
+    ///     font_size: u16,
+    ///     font_family: String,
+    ///     line_height: u16,
+    /// }
+    ///
+    /// struct Margins {
+    ///     top: u16,
+    ///     right: u16,
+    ///     bottom: u16,
+    ///     left: u16,
+    /// }
+    ///
+    /// struct RenderContext {
+    ///     theme: Theme,
+    ///     typography: Typography,
+    ///     margins: Margins,
+    ///     page_width: u16,
+    ///     page_height: u16,
+    ///     show_line_numbers: bool,
+    /// }
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub TOO_MANY_FIELDS,
+    pedantic,
+    "using too many fields in a struct"
+}
+
+impl_lint_pass!(TooManyFields => [TOO_MANY_FIELDS]);
+
+pub struct TooManyFields {
+    too_many_fields_threshold: u64,
+}
+
+impl TooManyFields {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self {
+            too_many_fields_threshold: conf.too_many_fields_threshold,
+        }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for TooManyFields {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if let ItemKind::Struct(_, _, variant_data) = &item.kind
+            && variant_data.fields().len() as u64 > self.too_many_fields_threshold
+            && !has_repr_attr(cx, item.hir_id())
+            && !item.span.from_expansion()
+        {
+            let fields = variant_data.fields().len();
+            let help = if self.too_many_fields_threshold > 0 {
+                "consider grouping related fields into a separate struct"
+            } else {
+                "only fieldless structs are allowed"
+            };
+            span_lint_and_help(
+                cx,
+                TOO_MANY_FIELDS,
+                item.span,
+                format!(
+                    "this struct has too many fields ({fields}/{})",
+                    self.too_many_fields_threshold
+                ),
+                None,
+                help,
+            );
+        }
+    }
+}

--- a/declare_clippy_lint/src/lib.rs
+++ b/declare_clippy_lint/src/lib.rs
@@ -8,6 +8,7 @@ use rustc_lint::{Lint, LintId, LintStore};
 pub extern crate rustc_session;
 
 #[derive(Default)]
+#[allow(clippy::too_many_fields)]
 pub struct LintListBuilder {
     lints: Vec<&'static Lint>,
     all: Vec<LintId>,

--- a/lintcheck/src/config.rs
+++ b/lintcheck/src/config.rs
@@ -3,6 +3,7 @@ use std::num::NonZero;
 use std::path::PathBuf;
 
 #[expect(clippy::struct_excessive_bools)]
+#[expect(clippy::too_many_fields)]
 #[derive(Parser, Clone, Debug)]
 #[command(args_conflicts_with_subcommands = true)]
 pub(crate) struct LintcheckConfig {

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -83,6 +83,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            third-party
            too-large-for-stack
            too-many-arguments-threshold
+           too-many-fields-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
            trivial-copy-size-limit
@@ -184,6 +185,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            third-party
            too-large-for-stack
            too-many-arguments-threshold
+           too-many-fields-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
            trivial-copy-size-limit
@@ -285,6 +287,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            third-party
            too-large-for-stack
            too-many-arguments-threshold
+           too-many-fields-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
            trivial-copy-size-limit

--- a/tests/ui-toml/too_many_fields/clippy.toml
+++ b/tests/ui-toml/too_many_fields/clippy.toml
@@ -1,0 +1,1 @@
+too-many-fields-threshold = 0

--- a/tests/ui-toml/too_many_fields/test.rs
+++ b/tests/ui-toml/too_many_fields/test.rs
@@ -1,0 +1,15 @@
+#![warn(clippy::too_many_fields)]
+
+struct S {
+    //~^ too_many_fields
+    a: u8,
+}
+
+struct Tuple(
+    //~^ too_many_fields
+    u8,
+);
+
+struct Unit;
+
+fn main() {}

--- a/tests/ui-toml/too_many_fields/test.stderr
+++ b/tests/ui-toml/too_many_fields/test.stderr
@@ -1,0 +1,26 @@
+error: this struct has too many fields (1/0)
+  --> tests/ui-toml/too_many_fields/test.rs:3:1
+   |
+LL | / struct S {
+LL | |
+LL | |     a: u8,
+LL | | }
+   | |_^
+   |
+   = help: only fieldless structs are allowed
+   = note: `-D clippy::too-many-fields` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::too_many_fields)]`
+
+error: this struct has too many fields (1/0)
+  --> tests/ui-toml/too_many_fields/test.rs:8:1
+   |
+LL | / struct Tuple(
+LL | |
+LL | |     u8,
+LL | | );
+   | |__^
+   |
+   = help: only fieldless structs are allowed
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/too_many_fields.rs
+++ b/tests/ui/too_many_fields.rs
@@ -1,0 +1,96 @@
+#![warn(clippy::too_many_fields)]
+
+macro_rules! foo {
+    () => {
+        struct MacroFoo {
+            a: u8,
+            b: u8,
+            c: u8,
+            d: u8,
+            e: u8,
+            f: u8,
+            g: u8,
+            h: u8,
+            i: u8,
+            j: u8,
+            k: u8,
+        }
+    };
+}
+
+foo!();
+
+struct TenFields {
+    a: u8,
+    b: u8,
+    c: u8,
+    d: u8,
+    e: u8,
+    f: u8,
+    g: u8,
+    h: u8,
+    i: u8,
+    j: u8,
+}
+
+struct ElevenFields {
+    //~^ too_many_fields
+    a: u8,
+    b: u8,
+    c: u8,
+    d: u8,
+    e: u8,
+    f: u8,
+    g: u8,
+    h: u8,
+    i: u8,
+    j: u8,
+    k: u8,
+}
+
+struct TupleFields(
+    //~^ too_many_fields
+    u8,
+    u8,
+    u8,
+    u8,
+    u8,
+    u8,
+    u8,
+    u8,
+    u8,
+    u8,
+    u8,
+);
+
+#[repr(C)]
+struct ReprFields {
+    a: u8,
+    b: u8,
+    c: u8,
+    d: u8,
+    e: u8,
+    f: u8,
+    g: u8,
+    h: u8,
+    i: u8,
+    j: u8,
+    k: u8,
+}
+
+fn main() {
+    struct LocalFields {
+        //~^ too_many_fields
+        a: u8,
+        b: u8,
+        c: u8,
+        d: u8,
+        e: u8,
+        f: u8,
+        g: u8,
+        h: u8,
+        i: u8,
+        j: u8,
+        k: u8,
+    }
+}

--- a/tests/ui/too_many_fields.stderr
+++ b/tests/ui/too_many_fields.stderr
@@ -1,0 +1,46 @@
+error: this struct has too many fields (11/10)
+  --> tests/ui/too_many_fields.rs:36:1
+   |
+LL | / struct ElevenFields {
+LL | |
+LL | |     a: u8,
+LL | |     b: u8,
+...  |
+LL | |     k: u8,
+LL | | }
+   | |_^
+   |
+   = help: consider grouping related fields into a separate struct
+   = note: `-D clippy::too-many-fields` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::too_many_fields)]`
+
+error: this struct has too many fields (11/10)
+  --> tests/ui/too_many_fields.rs:51:1
+   |
+LL | / struct TupleFields(
+LL | |
+LL | |     u8,
+LL | |     u8,
+...  |
+LL | |     u8,
+LL | | );
+   | |__^
+   |
+   = help: consider grouping related fields into a separate struct
+
+error: this struct has too many fields (11/10)
+  --> tests/ui/too_many_fields.rs:82:5
+   |
+LL | /     struct LocalFields {
+LL | |
+LL | |         a: u8,
+LL | |         b: u8,
+...  |
+LL | |         k: u8,
+LL | |     }
+   | |_____^
+   |
+   = help: consider grouping related fields into a separate struct
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This adds a new pedantic lint, in a similar vein to `too_many_arguments` and `too_many_lines`, but this time for number of fields on a struct. The initial thought came from [a couple months ago](https://masto.ai/@seanmonstar/116279272708071555), after noticing some motivation for view types is that mutably borrowing over parts of a large struct is hard.

Some responses then made me write up this lint, since it likely is a code smell to have struct with too many fields. In nearly any case I can think of, too many fields can be made cleaner by making new structs to hold related fields.

The number of fields is configurable, like the other related lints, but it defaults to 10, which somewhat arbitrary, but also "feels right". There's the famous 7 +/- 2 magic number, but I can imagine some fields needing to exist for unrelated metadata, an ID, a kind, etc, so making it 10 seemed correct.

I otherwise tried to follow the pattern of the other lints, looking at `too_many_arguments` and `large_enum_variants` for inspiration.

changelog: [`too_many_fields`]: add new lint
