### PR TITLE
Fix `result_large_err` and `result_unit_err` not triggering on async functions

### DIFF
--- a/clippy_lints/src/functions/result.rs
+++ b/clippy_lints/src/functions/result.rs
@@ -2,10 +2,12 @@ use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
 use rustc_errors::Diag;
 use rustc_hir as hir;
+use rustc_infer::infer::TyCtxtInferExt as _;
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::def_id::DefIdSet;
 use rustc_span::{Span, sym};
+use rustc_trait_selection::error_reporting::InferCtxtErrorExt as _;
 
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::ty::{AdtVariantInfo, approx_ty_size};
@@ -23,17 +25,31 @@ fn result_err_ty<'tcx>(
 ) -> Option<(&'tcx hir::Ty<'tcx>, Ty<'tcx>)> {
     if !item_span.in_external_macro(cx.sess().source_map())
         && let hir::FnRetTy::Return(hir_ty) = decl.output
-        && let ty = cx
-            .tcx
-            .instantiate_bound_regions_with_erased(cx.tcx.fn_sig(id).instantiate_identity().skip_norm_wip().output())
-        && ty.is_diag_item(cx, sym::Result)
-        && let ty::Adt(_, args) = ty.kind()
     {
-        let err_ty = args.type_at(1);
-        Some((hir_ty, err_ty))
-    } else {
-        None
+        let mut ty = cx
+            .tcx
+            .instantiate_bound_regions_with_erased(cx.tcx.fn_sig(id).instantiate_identity().skip_norm_wip().output());
+
+        // for async functions, peel through `impl Future<Output = T>` to get `T`
+        if cx.tcx.ty_is_opaque_future(ty)
+            && let Some(future_output_ty) = cx
+                .tcx
+                .infer_ctxt()
+                .build(cx.typing_mode())
+                .err_ctxt()
+                .get_impl_future_output_ty(ty)
+        {
+            ty = future_output_ty;
+        }
+
+        if ty.is_diag_item(cx, sym::Result)
+            && let ty::Adt(_, args) = ty.kind()
+        {
+            let err_ty = args.type_at(1);
+            return Some((hir_ty, err_ty));
+        }
     }
+    None
 }
 
 pub(super) fn check_item<'tcx>(

--- a/clippy_lints/src/functions/result.rs
+++ b/clippy_lints/src/functions/result.rs
@@ -42,8 +42,8 @@ fn result_err_ty<'tcx>(
             ty = future_output_ty;
         }
 
-        if ty.is_diag_item(cx, sym::Result)
-            && let ty::Adt(_, args) = ty.kind()
+        if let ty::Adt(adt_def, args) = ty.kind()
+            && cx.tcx.is_diagnostic_item(sym::Result, adt_def.did())
         {
             let err_ty = args.type_at(1);
             return Some((hir_ty, err_ty));

--- a/tests/ui/len_without_is_empty.rs
+++ b/tests/ui/len_without_is_empty.rs
@@ -349,9 +349,9 @@ impl AsyncResultLenWithoutIsEmpty {
         true
     }
 
+    #[expect(clippy::result_unit_err)]
     pub async fn len(&self) -> Result<usize, ()> {
         //~^ len_without_is_empty
-        //~| result_unit_err
 
         Err(())
     }
@@ -364,8 +364,8 @@ impl AsyncOptionLen {
         true
     }
 
+    #[expect(clippy::result_unit_err)]
     pub async fn len(&self) -> Result<usize, ()> {
-        //~^ result_unit_err
         Err(())
     }
 

--- a/tests/ui/len_without_is_empty.rs
+++ b/tests/ui/len_without_is_empty.rs
@@ -351,6 +351,7 @@ impl AsyncResultLenWithoutIsEmpty {
 
     pub async fn len(&self) -> Result<usize, ()> {
         //~^ len_without_is_empty
+        //~| result_unit_err
 
         Err(())
     }
@@ -364,6 +365,7 @@ impl AsyncOptionLen {
     }
 
     pub async fn len(&self) -> Result<usize, ()> {
+        //~^ result_unit_err
         Err(())
     }
 

--- a/tests/ui/len_without_is_empty.stderr
+++ b/tests/ui/len_without_is_empty.stderr
@@ -143,11 +143,27 @@ error: struct `AsyncResultLenWithoutIsEmpty` has a public `len` method, but no `
 LL |     pub async fn len(&self) -> Result<usize, ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: this returns a `Result<_, ()>`
+  --> tests/ui/len_without_is_empty.rs:352:5
+   |
+LL |     pub async fn len(&self) -> Result<usize, ()> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use a custom `Error` type instead
+
+error: this returns a `Result<_, ()>`
+  --> tests/ui/len_without_is_empty.rs:367:5
+   |
+LL |     pub async fn len(&self) -> Result<usize, ()> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use a custom `Error` type instead
+
 error: type `Alias2` has a public `len` method, but no `is_empty` method
-  --> tests/ui/len_without_is_empty.rs:469:5
+  --> tests/ui/len_without_is_empty.rs:471:5
    |
 LL |     pub fn len(&self) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 16 previous errors
+error: aborting due to 18 previous errors
 

--- a/tests/ui/len_without_is_empty.stderr
+++ b/tests/ui/len_without_is_empty.stderr
@@ -138,26 +138,10 @@ LL |     pub async fn len(&self) -> Option<usize> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: struct `AsyncResultLenWithoutIsEmpty` has a public `len` method, but no `is_empty` method
-  --> tests/ui/len_without_is_empty.rs:352:5
+  --> tests/ui/len_without_is_empty.rs:353:5
    |
 LL |     pub async fn len(&self) -> Result<usize, ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: this returns a `Result<_, ()>`
-  --> tests/ui/len_without_is_empty.rs:352:5
-   |
-LL |     pub async fn len(&self) -> Result<usize, ()> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: use a custom `Error` type instead
-
-error: this returns a `Result<_, ()>`
-  --> tests/ui/len_without_is_empty.rs:367:5
-   |
-LL |     pub async fn len(&self) -> Result<usize, ()> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: use a custom `Error` type instead
 
 error: type `Alias2` has a public `len` method, but no `is_empty` method
   --> tests/ui/len_without_is_empty.rs:471:5
@@ -165,5 +149,5 @@ error: type `Alias2` has a public `len` method, but no `is_empty` method
 LL |     pub fn len(&self) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 18 previous errors
+error: aborting due to 16 previous errors
 

--- a/tests/ui/result_large_err.rs
+++ b/tests/ui/result_large_err.rs
@@ -150,3 +150,17 @@ fn issue16249() {
     let closure = || Ok::<(), Large>(());
     //~^ result_large_err
 }
+
+pub async fn async_large_err() -> Result<(), [u8; 512]> {
+    //~^ result_large_err
+    Ok(())
+}
+
+pub async fn async_small_err() -> Result<(), u128> {
+    Ok(())
+}
+
+pub async fn async_struct_error() -> Result<(), FullyDefinedLargeError> {
+    //~^ result_large_err
+    Ok(())
+}

--- a/tests/ui/result_large_err.stderr
+++ b/tests/ui/result_large_err.stderr
@@ -120,5 +120,21 @@ LL |     let closure = || Ok::<(), Large>(());
    |
    = help: try reducing the size of `[u8; 1024]`, for example by boxing large elements or replacing it with `Box<[u8; 1024]>`
 
-error: aborting due to 14 previous errors
+error: the `Err`-variant returned from this function is very large
+  --> tests/ui/result_large_err.rs:154:35
+   |
+LL | pub async fn async_large_err() -> Result<(), [u8; 512]> {
+   |                                   ^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 512 bytes
+   |
+   = help: try reducing the size of `[u8; 512]`, for example by boxing large elements or replacing it with `Box<[u8; 512]>`
+
+error: the `Err`-variant returned from this function is very large
+  --> tests/ui/result_large_err.rs:163:38
+   |
+LL | pub async fn async_struct_error() -> Result<(), FullyDefinedLargeError> {
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 240 bytes
+   |
+   = help: try reducing the size of `FullyDefinedLargeError`, for example by boxing large elements or replacing it with `Box<FullyDefinedLargeError>`
+
+error: aborting due to 16 previous errors
 

--- a/tests/ui/result_unit_error.rs
+++ b/tests/ui/result_unit_error.rs
@@ -62,4 +62,16 @@ pub mod issue_6546 {
     }
 }
 
+pub mod issue_17070 {
+    pub async fn returns_unit_error_async() -> Result<u32, ()> {
+        //~^ result_unit_err
+
+        Err(())
+    }
+
+    async fn private_unit_errors_async() -> Result<String, ()> {
+        Err(())
+    }
+}
+
 fn main() {}

--- a/tests/ui/result_unit_error.stderr
+++ b/tests/ui/result_unit_error.stderr
@@ -40,5 +40,13 @@ LL |     pub fn should_lint() -> ResInv<(), usize> {
    |
    = help: use a custom `Error` type instead
 
-error: aborting due to 5 previous errors
+error: this returns a `Result<_, ()>`
+  --> tests/ui/result_unit_error.rs:66:5
+   |
+LL |     pub async fn returns_unit_error_async() -> Result<u32, ()> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use a custom `Error` type instead
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17070

while working on the issue I also found that `result_unit_err` also had the same problem, which should also be fixed now.

changelog: fix [`result_large_err`] and [`result_unit_err`] not triggering on async functions.