### PR TITLE
Do not trigger `inline_trait_bounds` on auto-derived code

### DIFF
--- a/clippy_lints/src/inline_trait_bounds.rs
+++ b/clippy_lints/src/inline_trait_bounds.rs
@@ -1,11 +1,12 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::{HasSession, snippet};
-use rustc_ast::NodeId;
+use clippy_utils::sym;
 use rustc_ast::ast::{Fn, FnRetTy, GenericParam, GenericParamKind};
 use rustc_ast::visit::{FnCtxt, FnKind};
+use rustc_ast::{HasAttrs as _, NodeId};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
-use rustc_session::declare_lint_pass;
+use rustc_session::impl_lint_pass;
 use rustc_span::Span;
 
 declare_clippy_lint! {
@@ -37,9 +38,30 @@ declare_clippy_lint! {
     "enforce that `where` bounds are used for all trait bounds"
 }
 
-declare_lint_pass!(InlineTraitBounds => [INLINE_TRAIT_BOUNDS]);
+impl_lint_pass!(InlineTraitBounds => [INLINE_TRAIT_BOUNDS]);
+
+#[derive(Default)]
+pub struct InlineTraitBounds {
+    /// The top-level item onto which `#[automatically_derived]` has been encountered
+    automatically_derived_at: Option<NodeId>,
+}
 
 impl EarlyLintPass for InlineTraitBounds {
+    fn check_item(&mut self, _: &EarlyContext<'_>, item: &rustc_ast::Item) {
+        if self.automatically_derived_at.is_none()
+            && item
+                .attrs()
+                .iter()
+                .any(|attr| attr.has_name(sym::automatically_derived))
+        {
+            self.automatically_derived_at = Some(item.id);
+        }
+    }
+
+    fn check_item_post(&mut self, _: &EarlyContext<'_>, item: &rustc_ast::Item) {
+        self.automatically_derived_at.take_if(|id| *id == item.id);
+    }
+
     fn check_fn(&mut self, cx: &EarlyContext<'_>, kind: FnKind<'_>, _: Span, _: NodeId) {
         let FnKind::Fn(ctxt, _vis, f) = kind else {
             return;
@@ -47,6 +69,11 @@ impl EarlyLintPass for InlineTraitBounds {
 
         // Skip foreign functions (extern "C" etc.)
         if !matches!(ctxt, FnCtxt::Free | FnCtxt::Assoc(..)) {
+            return;
+        }
+
+        // Skip automatically derived functions
+        if self.automatically_derived_at.is_some() {
             return;
         }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -541,7 +541,7 @@ rustc_lint::early_lint_methods!(
         FieldScopedVisibilityModifiers: field_scoped_visibility_modifiers::FieldScopedVisibilityModifiers = field_scoped_visibility_modifiers::FieldScopedVisibilityModifiers,
         CfgNotTest: cfg_not_test::CfgNotTest = cfg_not_test::CfgNotTest,
         EmptyLineAfter: empty_line_after::EmptyLineAfter = empty_line_after::EmptyLineAfter::new(),
-        InlineTraitBounds: inline_trait_bounds::InlineTraitBounds = inline_trait_bounds::InlineTraitBounds,
+        InlineTraitBounds: inline_trait_bounds::InlineTraitBounds = inline_trait_bounds::InlineTraitBounds::default(),
         // add early passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/tests/ui/inline_trait_bounds.fixed
+++ b/tests/ui/inline_trait_bounds.fixed
@@ -92,3 +92,39 @@ enum InlineEnum<T: Clone> {
 fn with_default_value<T = u32>(x: T) -> T where T: Clone {
     x
 }
+
+mod issue17110 {
+    #[automatically_derived]
+    #[allow(invalid_type_param_default)]
+    fn with_default_value<T: Clone = u32>(x: T) -> T {
+        x
+    }
+
+    struct S;
+
+    #[automatically_derived]
+    impl S {
+        #[allow(invalid_type_param_default)]
+        fn with_default_value<T: Clone = u32>(x: T) -> T {
+            x
+        }
+    }
+
+    impl S {
+        #[allow(invalid_type_param_default)]
+        //~v inline_trait_bounds
+        fn with_default_value_but_not_auto_derived<T = u32>(x: T) -> T where T: Clone {
+            x
+        }
+    }
+
+    #[automatically_derived]
+    mod inner {
+        impl super::S {
+            #[allow(invalid_type_param_default)]
+            fn with_default_value_again<T: Clone = u32>(x: T) -> T {
+                x
+            }
+        }
+    }
+}

--- a/tests/ui/inline_trait_bounds.rs
+++ b/tests/ui/inline_trait_bounds.rs
@@ -92,3 +92,39 @@ enum InlineEnum<T: Clone> {
 fn with_default_value<T: Clone = u32>(x: T) -> T {
     x
 }
+
+mod issue17110 {
+    #[automatically_derived]
+    #[allow(invalid_type_param_default)]
+    fn with_default_value<T: Clone = u32>(x: T) -> T {
+        x
+    }
+
+    struct S;
+
+    #[automatically_derived]
+    impl S {
+        #[allow(invalid_type_param_default)]
+        fn with_default_value<T: Clone = u32>(x: T) -> T {
+            x
+        }
+    }
+
+    impl S {
+        #[allow(invalid_type_param_default)]
+        //~v inline_trait_bounds
+        fn with_default_value_but_not_auto_derived<T: Clone = u32>(x: T) -> T {
+            x
+        }
+    }
+
+    #[automatically_derived]
+    mod inner {
+        impl super::S {
+            #[allow(invalid_type_param_default)]
+            fn with_default_value_again<T: Clone = u32>(x: T) -> T {
+                x
+            }
+        }
+    }
+}

--- a/tests/ui/inline_trait_bounds.stderr
+++ b/tests/ui/inline_trait_bounds.stderr
@@ -158,5 +158,17 @@ LL - fn with_default_value<T: Clone = u32>(x: T) -> T {
 LL + fn with_default_value<T = u32>(x: T) -> T where T: Clone {
    |
 
-error: aborting due to 13 previous errors
+error: inline trait bounds used
+  --> tests/ui/inline_trait_bounds.rs:116:51
+   |
+LL |         fn with_default_value_but_not_auto_derived<T: Clone = u32>(x: T) -> T {
+   |                                                   ^^^^^^^^^^^^^^^^
+   |
+help: move bounds to a `where` clause
+   |
+LL -         fn with_default_value_but_not_auto_derived<T: Clone = u32>(x: T) -> T {
+LL +         fn with_default_value_but_not_auto_derived<T = u32>(x: T) -> T where T: Clone {
+   |
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
changelog: [`inline_trait_bounds`]: do not trigger on code automatically derived from procedural macros

Fixes rust-lang/rust-clippy#17110