### PR TITLE
perf: Memoize first_node_in_macro for consecutive queries

### DIFF
--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::similar_names)] // `expr` and `expn`
 
+use std::cell::Cell;
 use std::sync::{Arc, OnceLock};
 
 use crate::visitors::{Descend, for_each_expr_without_closures};
@@ -179,6 +180,33 @@ pub fn first_node_macro_backtrace(cx: &LateContext<'_>, node: &impl HirNode) -> 
 /// A node may be the "first node" of multiple macro calls in a macro backtrace.
 /// The expansion of the outermost macro call site is returned in such cases.
 pub fn first_node_in_macro(cx: &LateContext<'_>, node: &impl HirNode) -> Option<ExpnId> {
+    // A node that is not from an expansion can never be the first node in a macro. This is the
+    // common case, so return before touching the cache.
+    if !node.span().from_expansion() {
+        return None;
+    }
+
+    // The macro lints each query this for the node currently being visited, and the combined late
+    // pass runs all their `check_*` callbacks on that node back to back, so the redundant queries
+    // are consecutive. A single-slot memo of the last node collapses them to one backtrace walk in
+    // O(1) memory. The result is a pure function of the `HirId` (the HIR is frozen during lint
+    // passes), so returning the stored value on a key match is always correct.
+    let hir_id = node.hir_id();
+    if let Some((cached_id, cached)) = LAST_FIRST_NODE_IN_MACRO.get()
+        && cached_id == hir_id
+    {
+        return cached;
+    }
+    let result = first_node_in_macro_uncached(cx, node);
+    LAST_FIRST_NODE_IN_MACRO.set(Some((hir_id, result)));
+    result
+}
+
+thread_local! {
+    static LAST_FIRST_NODE_IN_MACRO: Cell<Option<(HirId, Option<ExpnId>)>> = const { Cell::new(None) };
+}
+
+fn first_node_in_macro_uncached(cx: &LateContext<'_>, node: &impl HirNode) -> Option<ExpnId> {
     // get the macro expansion or return `None` if not found
     // `macro_backtrace` importantly ignores desugaring expansions
     let expn = macro_backtrace(node.span()).next()?.expn;


### PR DESCRIPTION
`first_node_in_macro` walks the macro backtrace of a node (and of its parent) to decide whether the node is the first node produced by a macro call. The macro lints (assert, format, panic, write and others) call it through `root_macro_call_first_node`, once per visited node.

The combined late pass dispatches every lint's `check_*` callback for a given node back to back before descending into that node's children, so these lints query `first_node_in_macro` for the same node consecutively. Each query repeats the same backtrace walk.

This caches the most recent result in a single-slot thread-local keyed on the node's `HirId`. Consecutive queries for the same node reuse the walk. A node that is not from an expansion returns early and never touches the cache.

The redundant queries are consecutive, so remembering only the last node captures almost all of them. A single slot keeps the cache O(1) in memory with no capacity parameter and no eviction policy to tune. It also turned out to be faster than a full `HirId -> result` map: the map pays a hash and a probe on every query, while the slot is a `Cell` load and a `HirId` comparison.

The result is a pure function of the node's `HirId` because the HIR is frozen during lint passes, so returning the stored value on a key match cannot change behaviour. Diagnostics are byte-for-byte identical to master across wasmi, serde, ripgrep, regex, syn and tokio, and the full test suite passes.

callgrind instruction reads, dependencies pre-built, only the workspace relinted:

| crate   | master Ir      | this PR Ir     | change  |
|---------|----------------|----------------|---------|
| serde   | 3,361,573,724  | 3,165,635,341  | -5.83%  |
| ripgrep | 1,320,108,814  | 1,272,160,668  | -3.63%  |
| wasmi   | 12,471,490,569 | 12,183,621,048 | -2.31%  |
| syn     | 2,115,731,764  | 2,069,176,452  | -2.20%  |
| regex   | 816,518,908    | 809,024,103    | -0.92%  |

changelog: none
