### PR TITLE
perf: skip the inline_always relevance walk for items without the attribute

### DIFF
--- a/clippy_lints/src/attrs/inline_always.rs
+++ b/clippy_lints/src/attrs/inline_always.rs
@@ -1,17 +1,20 @@
 use super::INLINE_ALWAYS;
+use super::utils::is_relevant_expr;
 use clippy_utils::diagnostics::span_lint;
 use rustc_hir::attrs::InlineAttr;
-use rustc_hir::{Attribute, find_attr};
+use rustc_hir::{Attribute, BodyId, find_attr};
 use rustc_lint::LateContext;
 use rustc_span::Span;
 use rustc_span::symbol::Symbol;
 
-pub(super) fn check(cx: &LateContext<'_>, span: Span, name: Symbol, attrs: &[Attribute]) {
+pub(super) fn check(cx: &LateContext<'_>, span: Span, name: Symbol, attrs: &[Attribute], body: Option<BodyId>) {
     if span.from_expansion() {
         return;
     }
 
-    if let Some(span) = find_attr!(attrs, Inline(InlineAttr::Always, span) => *span) {
+    if let Some(span) = find_attr!(attrs, Inline(InlineAttr::Always, span) => *span)
+        && body.is_none_or(|body| is_relevant_expr(cx, cx.tcx.hir_body(body).value))
+    {
         span_lint(
             cx,
             INLINE_ALWAYS,

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -17,11 +17,11 @@ use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::msrvs::{self, Msrv, MsrvStack};
 use rustc_ast::{self as ast, AttrArgs, AttrItemKind, AttrKind, Attribute, MetaItemInner, MetaItemKind};
-use rustc_hir::{ImplItem, Item, ItemKind, TraitItem};
+use rustc_hir::{ImplItem, ImplItemKind, Item, ItemKind, TraitFn, TraitItem, TraitItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
 use rustc_span::sym;
-use utils::{is_lint_level, is_relevant_impl, is_relevant_item, is_relevant_trait};
+use utils::is_lint_level;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -512,23 +512,31 @@ impl Attributes {
 impl<'tcx> LateLintPass<'tcx> for Attributes {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'_>) {
         let attrs = cx.tcx.hir_attrs(item.hir_id());
-        if let ItemKind::Fn { ident, .. } = item.kind
-            && is_relevant_item(cx, item)
-        {
-            inline_always::check(cx, item.span, ident.name, attrs);
+        if let ItemKind::Fn { ident, body, .. } = item.kind {
+            inline_always::check(cx, item.span, ident.name, attrs, Some(body));
         }
         repr_attributes::check(cx, item.span, attrs, self.msrv);
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx ImplItem<'_>) {
-        if is_relevant_impl(cx, item) {
-            inline_always::check(cx, item.span, item.ident.name, cx.tcx.hir_attrs(item.hir_id()));
+        if let ImplItemKind::Fn(_, body) = item.kind {
+            inline_always::check(
+                cx,
+                item.span,
+                item.ident.name,
+                cx.tcx.hir_attrs(item.hir_id()),
+                Some(body),
+            );
         }
     }
 
     fn check_trait_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx TraitItem<'_>) {
-        if is_relevant_trait(cx, item) {
-            inline_always::check(cx, item.span, item.ident.name, cx.tcx.hir_attrs(item.hir_id()));
+        if let TraitItemKind::Fn(_, kind) = item.kind {
+            let body = match kind {
+                TraitFn::Required(_) => None,
+                TraitFn::Provided(body) => Some(body),
+            };
+            inline_always::check(cx, item.span, item.ident.name, cx.tcx.hir_attrs(item.hir_id()), body);
         }
     }
 }

--- a/clippy_lints/src/attrs/utils.rs
+++ b/clippy_lints/src/attrs/utils.rs
@@ -1,10 +1,7 @@
 use clippy_utils::macros::{is_panic, macro_backtrace};
 use rustc_ast::MetaItemInner;
-use rustc_hir::{
-    Block, Expr, ExprKind, ImplItem, ImplItemKind, Item, ItemKind, StmtKind, TraitFn, TraitItem, TraitItemKind,
-};
+use rustc_hir::{Block, Expr, ExprKind, StmtKind};
 use rustc_lint::{LateContext, Level};
-use rustc_middle::ty;
 use rustc_span::sym;
 use rustc_span::symbol::Symbol;
 
@@ -20,56 +17,26 @@ pub(super) fn is_lint_level(symbol: Symbol) -> bool {
     Level::from_symbol(symbol).is_some()
 }
 
-pub(super) fn is_relevant_item(cx: &LateContext<'_>, item: &Item<'_>) -> bool {
-    if let ItemKind::Fn { body: eid, .. } = item.kind {
-        is_relevant_expr(cx, cx.tcx.typeck_body(eid), cx.tcx.hir_body(eid).value)
-    } else {
-        false
-    }
-}
-
-pub(super) fn is_relevant_impl(cx: &LateContext<'_>, item: &ImplItem<'_>) -> bool {
-    match item.kind {
-        ImplItemKind::Fn(_, eid) => is_relevant_expr(cx, cx.tcx.typeck_body(eid), cx.tcx.hir_body(eid).value),
-        _ => false,
-    }
-}
-
-pub(super) fn is_relevant_trait(cx: &LateContext<'_>, item: &TraitItem<'_>) -> bool {
-    match item.kind {
-        TraitItemKind::Fn(_, TraitFn::Required(_)) => true,
-        TraitItemKind::Fn(_, TraitFn::Provided(eid)) => {
-            is_relevant_expr(cx, cx.tcx.typeck_body(eid), cx.tcx.hir_body(eid).value)
-        },
-        _ => false,
-    }
-}
-
-fn is_relevant_block(cx: &LateContext<'_>, typeck_results: &ty::TypeckResults<'_>, block: &Block<'_>) -> bool {
+fn is_relevant_block(cx: &LateContext<'_>, block: &Block<'_>) -> bool {
     block.stmts.first().map_or_else(
-        || {
-            block
-                .expr
-                .as_ref()
-                .is_some_and(|e| is_relevant_expr(cx, typeck_results, e))
-        },
+        || block.expr.as_ref().is_some_and(|e| is_relevant_expr(cx, e)),
         |stmt| match &stmt.kind {
             StmtKind::Let(_) => true,
-            StmtKind::Expr(expr) | StmtKind::Semi(expr) => is_relevant_expr(cx, typeck_results, expr),
+            StmtKind::Expr(expr) | StmtKind::Semi(expr) => is_relevant_expr(cx, expr),
             StmtKind::Item(_) => false,
         },
     )
 }
 
-fn is_relevant_expr(cx: &LateContext<'_>, typeck_results: &ty::TypeckResults<'_>, expr: &Expr<'_>) -> bool {
+pub(super) fn is_relevant_expr(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     if macro_backtrace(expr.span).last().is_some_and(|macro_call| {
         is_panic(cx, macro_call.def_id) || cx.tcx.item_name(macro_call.def_id) == sym::unreachable
     }) {
         return false;
     }
     match &expr.kind {
-        ExprKind::Block(block, _) => is_relevant_block(cx, typeck_results, block),
-        ExprKind::Ret(Some(e)) => is_relevant_expr(cx, typeck_results, e),
+        ExprKind::Block(block, _) => is_relevant_block(cx, block),
+        ExprKind::Ret(Some(e)) => is_relevant_expr(cx, e),
         ExprKind::Ret(None) | ExprKind::Break(_, None) => false,
         _ => true,
     }


### PR DESCRIPTION
The `Attributes` lint pass ran `is_relevant_item`/`is_relevant_impl`/`is_relevant_trait` for every function, impl method and trait method. Each of those walks the macro backtrace of the body (which clones expansion data) and forced `typeck_body`. The result is only used to decide whether to run the `inline_always` lint, which fires only when the item carries `#[inline(always)]`.

This moves the relevance check behind the attribute lookup in `inline_always::check`, so it runs only for the few items that actually have `#[inline(always)]`. It also drops the `typeck_results` parameter that was threaded through `is_relevant_expr`/`is_relevant_block` without ever being read, and the `typeck_body` call that produced it.

Instruction counts via `valgrind --tool=callgrind` (sum of clippy-driver Ir over a workspace re-lint), master vs this change, measured back to back in one session:

| crate | master | this PR | change |
| --- | --- | --- | --- |
| wasmi | 12,472,185,447 | 12,305,205,229 | -1.34% |
| syn | 2,115,685,230 | 2,114,074,495 | -0.08% |
| serde | 3,361,594,598 | 3,358,936,201 | -0.08% |
| ripgrep | 1,319,902,448 | 1,319,555,835 | -0.03% |
| regex | 816,515,573 | 817,127,610 | +0.07% |

The gain is concentrated on macro-heavy code: wasmi has many functions sitting in nested macro expansions, where the per-item macro backtrace walk was the dominant cost.

changelog: none