### PR TITLE
perf: skip MSRV attribute parsing for nodes without attributes

### DIFF
--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -191,6 +191,12 @@ impl MsrvStack {
 }
 
 fn parse_attrs(sess: &Session, attrs: &[impl AttributeExt]) -> Option<RustcVersion> {
+    // The early `MsrvStack` passes call this for every node's attributes on both enter and exit, and
+    // most nodes carry none, so skip building the filter iterator in that common case.
+    if attrs.is_empty() {
+        return None;
+    }
+
     let mut msrv_attrs = attrs.iter().filter(|attr| attr.path_matches(&[sym::clippy, sym::msrv]));
 
     let msrv_attr = msrv_attrs.next()?;


### PR DESCRIPTION
The early `MsrvStack` lint passes scan every AST node's attributes for `#[clippy::msrv]` on both enter (`check_attributes`) and exit (`check_attributes_post`). `parse_attrs` built a `filter` iterator over the attribute slice unconditionally, but most nodes carry no attributes, and six early passes do this, so the same empty slice is walked many times per node.

This returns early from `parse_attrs` when the attribute slice is empty. As the surrounding code already notes, `#[clippy::msrv]` is rare outside Clippy's own test suite, so the no-attributes case is overwhelmingly common.

Diagnostics are byte-identical against master on serde, wasmi, ripgrep, regex, syn and tokio.

Instruction counts via `valgrind --tool=callgrind` (sum of clippy-driver Ir over a workspace re-lint), master vs this change, measured back to back in one session:

| crate | master | this PR | change |
| --- | --- | --- | --- |
| syn | 1,967,439,254 | 1,961,901,861 | -0.28% |
| serde | 2,963,167,041 | 2,956,273,845 | -0.23% |
| ripgrep | 1,216,978,500 | 1,214,609,682 | -0.19% |
| wasmi | 11,816,380,553 | 11,799,594,846 | -0.14% |
| regex | 772,035,129 | 771,499,303 | -0.07% |


Benchmarked against master at 9ca5050a4, which already includes rust-lang/rust-clippy#17132 (combine early lint passes). The early passes are now dispatched through one statically combined pass, and the early return still skips the per-node attribute walk in each of them.

changelog: none