### PR TITLE
perf: cache the most recent MSRV attribute scan

### DIFF
--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -191,6 +191,12 @@ impl MsrvStack {
 }
 
 fn parse_attrs(sess: &Session, attrs: &[impl AttributeExt]) -> Option<RustcVersion> {
+    // The early `MsrvStack` passes call this for every node's attributes on both enter and exit, and
+    // most nodes carry none, so skip building the filter iterator in that common case.
+    if attrs.is_empty() {
+        return None;
+    }
+
     let mut msrv_attrs = attrs.iter().filter(|attr| attr.path_matches(&[sym::clippy, sym::msrv]));
 
     let msrv_attr = msrv_attrs.next()?;

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -8,6 +8,7 @@ use rustc_lint::LateContext;
 use rustc_session::Session;
 use rustc_span::Symbol;
 use serde::Deserialize;
+use std::cell::Cell;
 use std::iter::once;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -177,17 +178,45 @@ impl MsrvStack {
     }
 
     pub fn check_attributes(&mut self, sess: &Session, attrs: &[Attribute]) {
-        if let Some(version) = parse_attrs(sess, attrs) {
+        if let Some(version) = parse_attrs_memo(sess, attrs) {
             SEEN_MSRV_ATTR.store(true, Ordering::Relaxed);
             self.stack.push(version);
         }
     }
 
     pub fn check_attributes_post(&mut self, sess: &Session, attrs: &[Attribute]) {
-        if parse_attrs(sess, attrs).is_some() {
+        if parse_attrs_memo(sess, attrs).is_some() {
             self.stack.pop();
         }
     }
+}
+
+thread_local! {
+    /// Remembers the result of the most recent [`parse_attrs_memo`] call. The early `MsrvStack`
+    /// passes are registered separately, so each node's attribute slice is scanned once per pass on
+    /// both enter and exit; those calls arrive back to back with the same slice, so caching the last
+    /// one collapses them to a single scan.
+    static LAST_PARSED_ATTRS: Cell<Option<(*const Attribute, usize, Option<RustcVersion>)>> = const { Cell::new(None) };
+}
+
+/// [`parse_attrs`] wrapper used by the early `MsrvStack` passes that caches the most recent result,
+/// keyed on the attribute slice's pointer and length. Only the early AST path goes through here, so
+/// the cache never mixes `ast` and `hir` attributes.
+fn parse_attrs_memo(sess: &Session, attrs: &[Attribute]) -> Option<RustcVersion> {
+    if attrs.is_empty() {
+        return None;
+    }
+
+    let key = (attrs.as_ptr(), attrs.len());
+    if let Some((ptr, len, version)) = LAST_PARSED_ATTRS.get()
+        && (ptr, len) == key
+    {
+        return version;
+    }
+
+    let version = parse_attrs(sess, attrs);
+    LAST_PARSED_ATTRS.set(Some((key.0, key.1, version)));
+    version
 }
 
 fn parse_attrs(sess: &Session, attrs: &[impl AttributeExt]) -> Option<RustcVersion> {


### PR DESCRIPTION
## Summary

Follow-up to rust-lang/rust-clippy#17138 (skip MSRV attribute parsing for nodes without attributes). This PR is stacked on it, so the first commit is shared; if rust-lang/rust-clippy#17138 lands first, rebasing leaves only the cache commit here.

The five early `MsrvStack` passes are registered separately, so for each AST node the same attribute slice is scanned once per pass on both enter and exit. Those calls arrive back to back with the same slice. This adds a single-slot thread-local cache, keyed on the slice's pointer and length, so the repeated scans of one node collapse to a single parse. Only the early AST path goes through the cache, so it never mixes `ast` and `hir` attributes.

Lint output is unchanged.

## Measurements

callgrind Ir (sum of clippy-driver Ir over a workspace re-lint), master vs the fast path alone (rust-lang/rust-clippy#17138) vs this PR, back to back in one session:

| crate | master | rust-lang/rust-clippy#17138 only | + cache (this PR) |
| --- | --- | --- | --- |
| wasmi | 12,182,497,351 | -0.09% | -0.12% |
| syn | 2,069,987,997 | -0.25% | -0.34% |
| regex | 808,301,202 | +0.06% | -0.04% |
| serde | 3,165,571,048 | -0.25% | -0.24% |
| ripgrep | 1,273,725,148 | -0.31% | -0.28% |

On top of the fast path the cache is roughly break-even: it helps wasmi, syn and regex a little and costs serde and ripgrep about as much, all within noise. I'm opening it for completeness on top of rust-lang/rust-clippy#17138, but it may not be worth the extra complexity over the fast path alone.

Diagnostics are byte-identical against master on serde, wasmi, ripgrep, regex, syn and tokio.

> Benchmarked against master at 2b4f8f5d1; re-measure if #17132 (combine early lint passes) lands first.

changelog: none
