### PR TITLE
feat: `large_const_arrays`: check nested large arrays

### DIFF
--- a/clippy_lints/src/large_const_arrays.rs
+++ b/clippy_lints/src/large_const_arrays.rs
@@ -3,9 +3,8 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty;
-use rustc_middle::ty::Unnormalized;
 use rustc_middle::ty::layout::LayoutOf;
+use rustc_middle::ty::{self, Ty, Unnormalized};
 use rustc_session::impl_lint_pass;
 use rustc_span::{BytePos, Pos, Span};
 
@@ -45,6 +44,31 @@ impl LargeConstArrays {
             maximum_allowed_size: conf.array_size_threshold,
         }
     }
+
+    /// Checks recursively checks whether `ty` has an array exceeding allowed size
+    fn check_impl<'a>(&self, cx: &LateContext<'a>, ty: Ty<'a>) -> bool {
+        match ty.kind() {
+            ty::Adt(adt_def, args) => adt_def
+                .all_fields()
+                .any(|f| self.check_impl(cx, f.ty(cx.tcx, args).skip_norm_wip())),
+            ty::Array(element_type, cst) => {
+                let normalized = cx
+                    .tcx
+                    .try_normalize_erasing_regions(cx.typing_env(), Unnormalized::new_wip(*cst))
+                    .unwrap_or(*cst);
+                if let Some(element_count) = normalized.try_to_target_usize(cx.tcx)
+                    && let Ok(element_size) = cx.layout_of(*element_type).map(|l| l.size.bytes())
+                    && u128::from(self.maximum_allowed_size) < u128::from(element_count) * u128::from(element_size)
+                {
+                    true
+                } else {
+                    false
+                }
+            },
+            ty::Tuple(fields) => fields.iter().any(|f| self.check_impl(cx, f)),
+            _ => false,
+        }
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for LargeConstArrays {
@@ -56,13 +80,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeConstArrays {
             && generics.params.is_empty() && !generics.has_where_clause_predicates
             && !item.span.from_expansion()
             && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip()
-            && let ty::Array(element_type, cst) = ty.kind()
-            && let Some(element_count) = cx.tcx
-                .try_normalize_erasing_regions(cx.typing_env(), Unnormalized::new_wip(*cst))
-                .unwrap_or(*cst)
-                .try_to_target_usize(cx.tcx)
-            && let Ok(element_size) = cx.layout_of(*element_type).map(|l| l.size.bytes())
-            && u128::from(self.maximum_allowed_size) < u128::from(element_count) * u128::from(element_size)
+            && self.check_impl(cx, ty)
         {
             let hi_pos = ident.span.lo() - BytePos::from_usize(1);
             let sugg_span = Span::new(

--- a/tests/ui/large_const_arrays.fixed
+++ b/tests/ui/large_const_arrays.fixed
@@ -6,6 +6,11 @@ pub struct S {
     pub data: [u64; 32],
 }
 
+#[derive(Clone, Copy)]
+pub struct Q {
+    pub data: [u32; 1_000_000],
+}
+
 // Should lint
 pub(crate) static FOO_PUB_CRATE: [u32; 1_000_000] = [0u32; 1_000_000];
 //~^ large_const_arrays
@@ -15,12 +20,21 @@ static FOO_COMPUTED: [u32; 1_000 * 100] = [0u32; 1_000 * 100];
 //~^ large_const_arrays
 static FOO: [u32; 1_000_000] = [0u32; 1_000_000];
 //~^ large_const_arrays
+pub static FOO_TUPLE: ([u32; 1_000_000],) = ([0u32; 1_000_000],);
+//~^ large_const_arrays
+pub static FOO_TUPLE_NESTED: (u8, ([u32; 1_000_000],)) = (0, ([0u32; 1_000_000],));
+//~^ large_const_arrays
+pub static FOO_STRUCT: Q = Q {
+    //~^ large_const_arrays
+    data: [0u32; 1_000_000],
+};
 
 // Good
 pub(crate) const G_FOO_PUB_CRATE: [u32; 250] = [0u32; 250];
 pub const G_FOO_PUB: [u32; 250] = [0u32; 250];
 const G_FOO_COMPUTED: [u32; 25 * 10] = [0u32; 25 * 10];
 const G_FOO: [u32; 250] = [0u32; 250];
+const G_TUPLE_SMALL: ([u32; 250],) = ([0u32; 250],);
 
 fn main() {
     // Should lint

--- a/tests/ui/large_const_arrays.rs
+++ b/tests/ui/large_const_arrays.rs
@@ -6,6 +6,11 @@ pub struct S {
     pub data: [u64; 32],
 }
 
+#[derive(Clone, Copy)]
+pub struct Q {
+    pub data: [u32; 1_000_000],
+}
+
 // Should lint
 pub(crate) const FOO_PUB_CRATE: [u32; 1_000_000] = [0u32; 1_000_000];
 //~^ large_const_arrays
@@ -15,12 +20,21 @@ const FOO_COMPUTED: [u32; 1_000 * 100] = [0u32; 1_000 * 100];
 //~^ large_const_arrays
 const FOO: [u32; 1_000_000] = [0u32; 1_000_000];
 //~^ large_const_arrays
+pub const FOO_TUPLE: ([u32; 1_000_000],) = ([0u32; 1_000_000],);
+//~^ large_const_arrays
+pub const FOO_TUPLE_NESTED: (u8, ([u32; 1_000_000],)) = (0, ([0u32; 1_000_000],));
+//~^ large_const_arrays
+pub const FOO_STRUCT: Q = Q {
+    //~^ large_const_arrays
+    data: [0u32; 1_000_000],
+};
 
 // Good
 pub(crate) const G_FOO_PUB_CRATE: [u32; 250] = [0u32; 250];
 pub const G_FOO_PUB: [u32; 250] = [0u32; 250];
 const G_FOO_COMPUTED: [u32; 25 * 10] = [0u32; 25 * 10];
 const G_FOO: [u32; 250] = [0u32; 250];
+const G_TUPLE_SMALL: ([u32; 250],) = ([0u32; 250],);
 
 fn main() {
     // Should lint

--- a/tests/ui/large_const_arrays.stderr
+++ b/tests/ui/large_const_arrays.stderr
@@ -1,5 +1,5 @@
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:10:1
+  --> tests/ui/large_const_arrays.rs:15:1
    |
 LL | pub(crate) const FOO_PUB_CRATE: [u32; 1_000_000] = [0u32; 1_000_000];
    | ^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | pub(crate) const FOO_PUB_CRATE: [u32; 1_000_000] = [0u32; 1_000_000];
    = help: to override `-D warnings` add `#[allow(clippy::large_const_arrays)]`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:12:1
+  --> tests/ui/large_const_arrays.rs:17:1
    |
 LL | pub const FOO_PUB: [u32; 1_000_000] = [0u32; 1_000_000];
    | ^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL | pub const FOO_PUB: [u32; 1_000_000] = [0u32; 1_000_000];
    |     help: make this a static item: `static`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:14:1
+  --> tests/ui/large_const_arrays.rs:19:1
    |
 LL | const FOO_COMPUTED: [u32; 1_000 * 100] = [0u32; 1_000 * 100];
    | -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL | const FOO_COMPUTED: [u32; 1_000 * 100] = [0u32; 1_000 * 100];
    | help: make this a static item: `static`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:16:1
+  --> tests/ui/large_const_arrays.rs:21:1
    |
 LL | const FOO: [u32; 1_000_000] = [0u32; 1_000_000];
    | -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +34,35 @@ LL | const FOO: [u32; 1_000_000] = [0u32; 1_000_000];
    | help: make this a static item: `static`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:27:5
+  --> tests/ui/large_const_arrays.rs:23:1
+   |
+LL | pub const FOO_TUPLE: ([u32; 1_000_000],) = ([0u32; 1_000_000],);
+   | ^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: make this a static item: `static`
+
+error: large array defined as const
+  --> tests/ui/large_const_arrays.rs:25:1
+   |
+LL | pub const FOO_TUPLE_NESTED: (u8, ([u32; 1_000_000],)) = (0, ([0u32; 1_000_000],));
+   | ^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: make this a static item: `static`
+
+error: large array defined as const
+  --> tests/ui/large_const_arrays.rs:27:1
+   |
+LL |   pub const FOO_STRUCT: Q = Q {
+   |   ^   ----- help: make this a static item: `static`
+   |  _|
+   | |
+LL | |
+LL | |     data: [0u32; 1_000_000],
+LL | | };
+   | |__^
+
+error: large array defined as const
+  --> tests/ui/large_const_arrays.rs:41:5
    |
 LL |     pub const BAR_PUB: [u32; 1_000_000] = [0u32; 1_000_000];
    |     ^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +70,7 @@ LL |     pub const BAR_PUB: [u32; 1_000_000] = [0u32; 1_000_000];
    |         help: make this a static item: `static`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:29:5
+  --> tests/ui/large_const_arrays.rs:43:5
    |
 LL |     const BAR: [u32; 1_000_000] = [0u32; 1_000_000];
    |     -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +78,7 @@ LL |     const BAR: [u32; 1_000_000] = [0u32; 1_000_000];
    |     help: make this a static item: `static`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:31:5
+  --> tests/ui/large_const_arrays.rs:45:5
    |
 LL |     pub const BAR_STRUCT_PUB: [S; 5_000] = [S { data: [0; 32] }; 5_000];
    |     ^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +86,7 @@ LL |     pub const BAR_STRUCT_PUB: [S; 5_000] = [S { data: [0; 32] }; 5_000];
    |         help: make this a static item: `static`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:33:5
+  --> tests/ui/large_const_arrays.rs:47:5
    |
 LL |     const BAR_STRUCT: [S; 5_000] = [S { data: [0; 32] }; 5_000];
    |     -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +94,7 @@ LL |     const BAR_STRUCT: [S; 5_000] = [S { data: [0; 32] }; 5_000];
    |     help: make this a static item: `static`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:35:5
+  --> tests/ui/large_const_arrays.rs:49:5
    |
 LL |     pub const BAR_S_PUB: [Option<&str>; 200_000] = [Some("str"); 200_000];
    |     ^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,12 +102,12 @@ LL |     pub const BAR_S_PUB: [Option<&str>; 200_000] = [Some("str"); 200_000];
    |         help: make this a static item: `static`
 
 error: large array defined as const
-  --> tests/ui/large_const_arrays.rs:37:5
+  --> tests/ui/large_const_arrays.rs:51:5
    |
 LL |     const BAR_S: [Option<&str>; 200_000] = [Some("str"); 200_000];
    |     -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     help: make this a static item: `static`
 
-error: aborting due to 10 previous errors
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
The `large_const_arrays` lint only checked the top-level type, while nested types (in tuples or structs) were not checked. Introduce a size check for every recursively nested type.

changelog: [`large_const_arrays`]: check nested large arrays

References rust-lang/rust-clippy#17074
