### PR TITLE
ui_test: bump to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ anstream = "0.6.18"
 
 [dev-dependencies]
 cargo_metadata = "0.23"
-ui_test = "0.30.5"
+ui_test = "0.30.7"
 regex = "1.5.5"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.122"


### PR DESCRIPTION
Mostly to pick up some cargo* updates transitively, as there was a CVE that may annoy some downstream consumers if not updated.

changelog: none
