### PR TITLE
Detect more ranges in single_range_in_vec_init

### DIFF
--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -1,15 +1,14 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::higher::VecArgs;
+use clippy_utils::higher::{Range, VecArgs};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::source::{SpanRangeExt, snippet_with_context};
 use clippy_utils::ty::implements_trait;
 use clippy_utils::{is_no_std_crate, sym};
-use rustc_ast::{LitIntType, LitKind, UintTy};
+use rustc_ast::{LitIntType, LitKind, RangeLimits, UintTy};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, StructTailExpr};
+use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
-use rustc_span::DesugaringKind;
 use std::fmt::{self, Display, Formatter};
 
 declare_clippy_lint! {
@@ -88,66 +87,99 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
             return;
         };
 
-        let ExprKind::Struct(_, [start, end], StructTailExpr::None) = inner_expr.kind else {
+        let Some(range) = Range::hir(cx, inner_expr) else {
             return;
         };
 
-        if inner_expr.span.is_desugaring(DesugaringKind::RangeExpr)
-            && let ty = cx.typeck_results().expr_ty(start.expr)
-            && let Some(snippet) = span.get_source_text(cx)
-            // `is_from_proc_macro` will skip any `vec![]`. Let's not!
-            && snippet.starts_with(suggested_type.starts_with())
-            && snippet.ends_with(suggested_type.ends_with())
-        {
-            let mut applicability = Applicability::MaybeIncorrect;
-            let (start_snippet, _) = snippet_with_context(cx, start.expr.span, span.ctxt(), "..", &mut applicability);
-            let (end_snippet, _) = snippet_with_context(cx, end.expr.span, span.ctxt(), "..", &mut applicability);
-
-            let should_emit_every_value = if let Some(step_def_id) = cx.tcx.get_diagnostic_item(sym::range_step)
-                && implements_trait(cx, ty, step_def_id, &[])
-            {
-                true
-            } else {
-                false
-            };
-            let should_emit_of_len = if let Some(copy_def_id) = cx.tcx.lang_items().copy_trait()
-                && implements_trait(cx, ty, copy_def_id, &[])
-                && let ExprKind::Lit(lit_kind) = end.expr.kind
-                && let LitKind::Int(.., suffix_type) = lit_kind.node
-                && let LitIntType::Unsigned(UintTy::Usize) | LitIntType::Unsuffixed = suffix_type
-            {
-                true
-            } else {
-                false
-            };
-
-            if should_emit_every_value || should_emit_of_len {
-                span_lint_and_then(
-                    cx,
-                    SINGLE_RANGE_IN_VEC_INIT,
-                    span,
-                    format!("{suggested_type} of `Range` that is only one element"),
-                    |diag| {
-                        if should_emit_every_value && !is_no_std_crate(cx) {
-                            diag.span_suggestion(
-                                span,
-                                "if you wanted a `Vec` that contains the entire range, try",
-                                format!("({start_snippet}..{end_snippet}).collect::<std::vec::Vec<{ty}>>()"),
-                                applicability,
-                            );
-                        }
-
-                        if should_emit_of_len {
-                            diag.span_suggestion(
-                                inner_expr.span,
-                                format!("if you wanted {suggested_type} of len {end_snippet}, try"),
-                                format!("{start_snippet}; {end_snippet}"),
-                                applicability,
-                            );
-                        }
-                    },
-                );
-            }
+        let Some(snippet) = span.get_source_text(cx) else {
+            return;
+        };
+        // `is_from_proc_macro` will skip any `vec![]`. Let's not!
+        if !snippet.starts_with(suggested_type.starts_with()) || !snippet.ends_with(suggested_type.ends_with()) {
+            return;
         }
+
+        let mut applicability = Applicability::MaybeIncorrect;
+        let suggestion = match (range.start, range.end, range.limits) {
+            (Some(start), Some(end), limits) => {
+                let ty = cx.typeck_results().expr_ty(start);
+                let (start_snippet, _) = snippet_with_context(cx, start.span, span.ctxt(), "..", &mut applicability);
+                let (end_snippet, _) = snippet_with_context(cx, end.span, span.ctxt(), "..", &mut applicability);
+
+                let should_emit_every_value = if let Some(step_def_id) = cx.tcx.get_diagnostic_item(sym::range_step)
+                    && implements_trait(cx, ty, step_def_id, &[])
+                {
+                    true
+                } else {
+                    false
+                };
+                let should_emit_of_len = if limits == RangeLimits::HalfOpen
+                    && let Some(copy_def_id) = cx.tcx.lang_items().copy_trait()
+                    && implements_trait(cx, ty, copy_def_id, &[])
+                    && let ExprKind::Lit(lit_kind) = end.kind
+                    && let LitKind::Int(.., suffix_type) = lit_kind.node
+                    && let LitIntType::Unsigned(UintTy::Usize) | LitIntType::Unsuffixed = suffix_type
+                {
+                    true
+                } else {
+                    false
+                };
+
+                if should_emit_every_value || should_emit_of_len {
+                    Some((
+                        ty,
+                        start_snippet,
+                        end_snippet,
+                        limits,
+                        should_emit_every_value,
+                        should_emit_of_len,
+                    ))
+                } else {
+                    return;
+                }
+            },
+            (None, Some(_) | None, _) | (Some(_), None, RangeLimits::HalfOpen) => None,
+            (Some(_), None, RangeLimits::Closed) => return,
+        };
+
+        span_lint_and_then(
+            cx,
+            SINGLE_RANGE_IN_VEC_INIT,
+            span,
+            format!(
+                "{suggested_type} of `{}` that is only one element",
+                cx.typeck_results()
+                    .expr_ty(inner_expr)
+                    .ty_adt_def()
+                    .map_or(sym::Range, |adt_def| cx.tcx.item_name(adt_def.did()))
+            ),
+            |diag| {
+                if let Some((ty, start_snippet, end_snippet, limits, should_emit_every_value, should_emit_of_len)) =
+                    suggestion
+                {
+                    if should_emit_every_value && !is_no_std_crate(cx) {
+                        let range_op = match limits {
+                            RangeLimits::HalfOpen => "..",
+                            RangeLimits::Closed => "..=",
+                        };
+                        diag.span_suggestion(
+                            span,
+                            "if you wanted a `Vec` that contains the entire range, try",
+                            format!("({start_snippet}{range_op}{end_snippet}).collect::<std::vec::Vec<{ty}>>()"),
+                            applicability,
+                        );
+                    }
+
+                    if should_emit_of_len {
+                        diag.span_suggestion(
+                            inner_expr.span,
+                            format!("if you wanted {suggested_type} of len {end_snippet}, try"),
+                            format!("{start_snippet}; {end_snippet}"),
+                            applicability,
+                        );
+                    }
+                }
+            },
+        );
     }
 }

--- a/tests/ui/single_range_in_vec_init.1.fixed
+++ b/tests/ui/single_range_in_vec_init.1.fixed
@@ -82,3 +82,10 @@ fn issue16044() {
     let input = (0..as_i32!(10)).collect::<std::vec::Vec<i32>>();
     //~^ single_range_in_vec_init
 }
+
+fn issue16508() {
+    (0..=10).collect::<std::vec::Vec<i32>>();
+    //~^ single_range_in_vec_init
+    (0..=10).collect::<std::vec::Vec<i32>>();
+    //~^ single_range_in_vec_init
+}

--- a/tests/ui/single_range_in_vec_init.2.fixed
+++ b/tests/ui/single_range_in_vec_init.2.fixed
@@ -82,3 +82,10 @@ fn issue16044() {
     let input = (0..as_i32!(10)).collect::<std::vec::Vec<i32>>();
     //~^ single_range_in_vec_init
 }
+
+fn issue16508() {
+    (0..=10).collect::<std::vec::Vec<i32>>();
+    //~^ single_range_in_vec_init
+    (0..=10).collect::<std::vec::Vec<i32>>();
+    //~^ single_range_in_vec_init
+}

--- a/tests/ui/single_range_in_vec_init.rs
+++ b/tests/ui/single_range_in_vec_init.rs
@@ -82,3 +82,10 @@ fn issue16044() {
     let input = vec![0..as_i32!(10)];
     //~^ single_range_in_vec_init
 }
+
+fn issue16508() {
+    [0..=10];
+    //~^ single_range_in_vec_init
+    vec![0..=10];
+    //~^ single_range_in_vec_init
+}

--- a/tests/ui/single_range_in_vec_init.stderr
+++ b/tests/ui/single_range_in_vec_init.stderr
@@ -172,5 +172,29 @@ LL -     let input = vec![0..as_i32!(10)];
 LL +     let input = (0..as_i32!(10)).collect::<std::vec::Vec<i32>>();
    |
 
-error: aborting due to 11 previous errors
+error: an array of `RangeInclusive` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:87:5
+   |
+LL |     [0..=10];
+   |     ^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0..=10];
+LL +     (0..=10).collect::<std::vec::Vec<i32>>();
+   |
+
+error: a `Vec` of `RangeInclusive` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:89:5
+   |
+LL |     vec![0..=10];
+   |     ^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0..=10];
+LL +     (0..=10).collect::<std::vec::Vec<i32>>();
+   |
+
+error: aborting due to 13 previous errors
 

--- a/tests/ui/single_range_in_vec_init_unfixable.rs
+++ b/tests/ui/single_range_in_vec_init_unfixable.rs
@@ -10,3 +10,26 @@ fn issue16306(v: &[i32]) {
     takes_range_slice(&[0..len as i64]);
     //~^ single_range_in_vec_init
 }
+
+#[allow(clippy::no_effect, clippy::useless_vec)]
+fn issue16508_open_ended() {
+    [..10];
+    //~^ single_range_in_vec_init
+    vec![..10];
+    //~^ single_range_in_vec_init
+
+    [10..];
+    //~^ single_range_in_vec_init
+    vec![10..];
+    //~^ single_range_in_vec_init
+
+    [..=10];
+    //~^ single_range_in_vec_init
+    vec![..=10];
+    //~^ single_range_in_vec_init
+
+    [..];
+    //~^ single_range_in_vec_init
+    vec![..];
+    //~^ single_range_in_vec_init
+}

--- a/tests/ui/single_range_in_vec_init_unfixable.stderr
+++ b/tests/ui/single_range_in_vec_init_unfixable.stderr
@@ -12,5 +12,53 @@ LL -     takes_range_slice(&[0..len as i64]);
 LL +     takes_range_slice(&(0..len as i64).collect::<std::vec::Vec<i64>>());
    |
 
-error: aborting due to 1 previous error
+error: an array of `RangeTo` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:16:5
+   |
+LL |     [..10];
+   |     ^^^^^^
+
+error: a `Vec` of `RangeTo` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:18:5
+   |
+LL |     vec![..10];
+   |     ^^^^^^^^^^
+
+error: an array of `RangeFrom` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:21:5
+   |
+LL |     [10..];
+   |     ^^^^^^
+
+error: a `Vec` of `RangeFrom` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:23:5
+   |
+LL |     vec![10..];
+   |     ^^^^^^^^^^
+
+error: an array of `RangeToInclusive` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:26:5
+   |
+LL |     [..=10];
+   |     ^^^^^^^
+
+error: a `Vec` of `RangeToInclusive` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:28:5
+   |
+LL |     vec![..=10];
+   |     ^^^^^^^^^^^
+
+error: an array of `RangeFull` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:31:5
+   |
+LL |     [..];
+   |     ^^^^
+
+error: a `Vec` of `RangeFull` that is only one element
+  --> tests/ui/single_range_in_vec_init_unfixable.rs:33:5
+   |
+LL |     vec![..];
+   |     ^^^^^^^^
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
changelog: enhance lint: [`single_range_in_vec_init`]

Extends `single_range_in_vec_init` to detect single range initializers beyond `start..end`, including `..end`, `start..`, `start..=end`, `..=end`, and `..`.

The implementation uses `clippy_utils::higher::Range::hir` so range syntax is handled consistently. Suggestions stay conservative: existing `start..end` fixes are preserved, inclusive ranges avoid the array-length suggestion, and open-ended/range-to/full-range forms are linted without speculative fix-its.

Note: rust-lang/rust-clippy#16598 is still open, but the prior assignee handed the issue over in rust-lang/rust-clippy#16508 and this issue is currently assigned to me.

Fixes rust-lang/rust-clippy#16508.

Validation:
- `TESTNAME=single_range_in_vec_init cargo uitest`
- `cargo dev fmt --check`
- `git diff --check`
- `cargo check -p clippy_lints`