### PR TITLE
Avoid overlapping out_of_bounds_indexing with unconditional_panic

### DIFF
--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -64,8 +64,8 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for out of bounds array indexing with a constant
-    /// index.
+    /// Checks for out of bounds array slicing with a constant
+    /// range.
     ///
     /// ### Why is this bad?
     /// This will always panic at runtime.
@@ -74,7 +74,6 @@ declare_clippy_lint! {
     /// ```rust,no_run
     /// let x = [1, 2, 3, 4];
     ///
-    /// x[9];
     /// &x[2..9];
     /// ```
     ///
@@ -83,8 +82,7 @@ declare_clippy_lint! {
     /// # let x = [1, 2, 3, 4];
     /// // Index within bounds
     ///
-    /// x[0];
-    /// x[3];
+    /// &x[2..3];
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub OUT_OF_BOUNDS_INDEXING,
@@ -191,26 +189,8 @@ impl<'tcx> LateLintPass<'tcx> for IndexingSlicing {
                     if let ExprKind::ConstBlock(..) = index.kind {
                         return;
                     }
-                    // Index is a constant uint.
-                    if let Some(constant) = ConstEvalCtxt::new(cx).eval(index) {
-                        // only `usize` index is legal in rust array index
-                        // leave other type to rustc
-                        if let Constant::Int(off) = constant
-                            && off <= usize::MAX as u128
-                            && let ty::Uint(utype) = cx.typeck_results().expr_ty(index).kind()
-                            && *utype == ty::UintTy::Usize
-                            && let ty::Array(_, s) = ty.kind()
-                            && let Some(size) = s.try_to_target_usize(cx.tcx)
-                        {
-                            // get constant offset and check whether it is in bounds
-                            let off = usize::try_from(off).unwrap();
-                            let size = usize::try_from(size).unwrap();
-
-                            if off >= size {
-                                span_lint(cx, OUT_OF_BOUNDS_INDEXING, expr.span, "index is out of bounds");
-                            }
-                        }
-                        // Let rustc's `const_err` lint handle constant `usize` indexing on arrays.
+                    // Let rustc's `unconditional_panic` lint handle constant `usize` indexing on arrays.
+                    if ConstEvalCtxt::new(cx).eval(index).is_some() {
                         return;
                     }
                 }

--- a/tests/ui-toml/suppress_lint_in_const/test.rs
+++ b/tests/ui-toml/suppress_lint_in_const/test.rs
@@ -3,12 +3,6 @@
     unconditional_panic,
     clippy::needless_lifetimes,
     clippy::no_effect,
-    // This lint should be enabled again after issue
-    // <https://github.com/rust-lang/rust-clippy/issues/17117> is fixed and `clippy::out_of_bounds_indexing`
-    // and `unconditional_panic` don't overlap anymore.
-    // We want to check for `clippy::out_of_bounds_indexing` because it lints similar things and
-    // we want to avoid false positives.
-    clippy::out_of_bounds_indexing,
     clippy::unnecessary_operation,
     clippy::useless_vec
 )]

--- a/tests/ui-toml/suppress_lint_in_const/test.stderr
+++ b/tests/ui-toml/suppress_lint_in_const/test.stderr
@@ -1,5 +1,5 @@
 error: indexing may panic
-  --> tests/ui-toml/suppress_lint_in_const/test.rs:29:5
+  --> tests/ui-toml/suppress_lint_in_const/test.rs:23:5
    |
 LL |     x[index];
    |     ^^^^^^^^
@@ -9,7 +9,7 @@ LL |     x[index];
    = help: to override `-D warnings` add `#[allow(clippy::indexing_slicing)]`
 
 error: indexing may panic
-  --> tests/ui-toml/suppress_lint_in_const/test.rs:45:5
+  --> tests/ui-toml/suppress_lint_in_const/test.rs:39:5
    |
 LL |     v[0];
    |     ^^^^
@@ -17,7 +17,7 @@ LL |     v[0];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> tests/ui-toml/suppress_lint_in_const/test.rs:47:5
+  --> tests/ui-toml/suppress_lint_in_const/test.rs:41:5
    |
 LL |     v[10];
    |     ^^^^^
@@ -25,7 +25,7 @@ LL |     v[10];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> tests/ui-toml/suppress_lint_in_const/test.rs:49:5
+  --> tests/ui-toml/suppress_lint_in_const/test.rs:43:5
    |
 LL |     v[1 << 3];
    |     ^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     v[1 << 3];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> tests/ui-toml/suppress_lint_in_const/test.rs:56:5
+  --> tests/ui-toml/suppress_lint_in_const/test.rs:50:5
    |
 LL |     v[N];
    |     ^^^^
@@ -41,7 +41,7 @@ LL |     v[N];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> tests/ui-toml/suppress_lint_in_const/test.rs:58:5
+  --> tests/ui-toml/suppress_lint_in_const/test.rs:52:5
    |
 LL |     v[M];
    |     ^^^^

--- a/tests/ui/indexing_slicing_index.rs
+++ b/tests/ui/indexing_slicing_index.rs
@@ -49,10 +49,8 @@ fn main() {
     //~^ ERROR: indexing may panic
     // Ok, let rustc's `unconditional_panic` lint handle `usize` indexing on arrays.
     x[4];
-    //~^ out_of_bounds_indexing
     // Ok, let rustc's `unconditional_panic` lint handle `usize` indexing on arrays.
     x[1 << 3];
-    //~^ out_of_bounds_indexing
 
     // Ok, should not produce stderr.
     x[0];
@@ -74,7 +72,6 @@ fn main() {
     y[0];
     // Ok, rustc will handle references too.
     y[4];
-    //~^ out_of_bounds_indexing
 
     let v = vec![0; 5];
     v[0];
@@ -90,7 +87,6 @@ fn main() {
     const M: usize = 3;
     // Ok, let rustc's `unconditional_panic` lint handle `usize` indexing on arrays.
     x[N];
-    //~^ out_of_bounds_indexing
     // Ok, should not produce stderr.
     x[M];
     v[N];
@@ -100,5 +96,4 @@ fn main() {
 
     let slice = &x;
     let _ = x[4];
-    //~^ out_of_bounds_indexing
 }

--- a/tests/ui/indexing_slicing_index.stderr
+++ b/tests/ui/indexing_slicing_index.stderr
@@ -17,23 +17,8 @@ LL |     x[index];
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
-error: index is out of bounds
-  --> tests/ui/indexing_slicing_index.rs:51:5
-   |
-LL |     x[4];
-   |     ^^^^
-   |
-   = note: `-D clippy::out-of-bounds-indexing` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::out_of_bounds_indexing)]`
-
-error: index is out of bounds
-  --> tests/ui/indexing_slicing_index.rs:54:5
-   |
-LL |     x[1 << 3];
-   |     ^^^^^^^^^
-
 error: indexing may panic
-  --> tests/ui/indexing_slicing_index.rs:66:14
+  --> tests/ui/indexing_slicing_index.rs:64:14
    |
 LL |     const { &ARR[idx()] };
    |              ^^^^^^^^^^
@@ -42,7 +27,7 @@ LL |     const { &ARR[idx()] };
    = note: the suggestion might not be applicable in constant blocks
 
 error: indexing may panic
-  --> tests/ui/indexing_slicing_index.rs:69:14
+  --> tests/ui/indexing_slicing_index.rs:67:14
    |
 LL |     const { &ARR[idx4()] };
    |              ^^^^^^^^^^^
@@ -50,14 +35,8 @@ LL |     const { &ARR[idx4()] };
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = note: the suggestion might not be applicable in constant blocks
 
-error: index is out of bounds
-  --> tests/ui/indexing_slicing_index.rs:76:5
-   |
-LL |     y[4];
-   |     ^^^^
-
 error: indexing may panic
-  --> tests/ui/indexing_slicing_index.rs:80:5
+  --> tests/ui/indexing_slicing_index.rs:77:5
    |
 LL |     v[0];
    |     ^^^^
@@ -65,7 +44,7 @@ LL |     v[0];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> tests/ui/indexing_slicing_index.rs:82:5
+  --> tests/ui/indexing_slicing_index.rs:79:5
    |
 LL |     v[10];
    |     ^^^^^
@@ -73,21 +52,15 @@ LL |     v[10];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> tests/ui/indexing_slicing_index.rs:84:5
+  --> tests/ui/indexing_slicing_index.rs:81:5
    |
 LL |     v[1 << 3];
    |     ^^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
-error: index is out of bounds
-  --> tests/ui/indexing_slicing_index.rs:92:5
-   |
-LL |     x[N];
-   |     ^^^^
-
 error: indexing may panic
-  --> tests/ui/indexing_slicing_index.rs:96:5
+  --> tests/ui/indexing_slicing_index.rs:92:5
    |
 LL |     v[N];
    |     ^^^^
@@ -95,18 +68,12 @@ LL |     v[N];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> tests/ui/indexing_slicing_index.rs:98:5
+  --> tests/ui/indexing_slicing_index.rs:94:5
    |
 LL |     v[M];
    |     ^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
-error: index is out of bounds
-  --> tests/ui/indexing_slicing_index.rs:102:13
-   |
-LL |     let _ = x[4];
-   |             ^^^^
-
-error: aborting due to 14 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17117.

`unconditional_panic` already reports scalar constant out-of-bounds array indexing such as `x[4]`, so `clippy::out_of_bounds_indexing` should not emit a second diagnostic for the same expression. This keeps Clippy's `out_of_bounds_indexing` coverage for out-of-bounds array ranges, where rustc does not report `unconditional_panic`, and leaves constant scalar array indexes to rustc.

The suppress-in-const regression fixture now enables `clippy::out_of_bounds_indexing` again, as requested in the issue thread.

changelog: [`out_of_bounds_indexing`]: no longer lints scalar constant array indexes already covered by rustc's `unconditional_panic` lint

## Tests

- `TESTNAME=suppress_lint_in_const cargo uitest --features internal`
- `TESTNAME=indexing_slicing_index cargo uitest --features internal`
- `cargo fmt --all --check`
- `git diff --check`