### PR TITLE
Add assert_is_empty lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ document.
 
 [88f787...master](https://github.com/rust-lang/rust-clippy/compare/88f787...master)
 
+### New Lints
+
+* Added [`assert_is_empty`] to `pedantic`
+  [#17114](https://github.com/rust-lang/rust-clippy/issues/17114)
+
 ## Rust 1.96
 
 Current stable, released 2026-05-28
@@ -6639,6 +6644,7 @@ Released 2018-09-13
 [`as_pointer_underscore`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_pointer_underscore
 [`as_ptr_cast_mut`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_ptr_cast_mut
 [`as_underscore`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_underscore
+[`assert_is_empty`]: https://rust-lang.github.io/rust-clippy/master/index.html#assert_is_empty
 [`assertions_on_constants`]: https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
 [`assertions_on_result_states`]: https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_result_states
 [`assign_op_pattern`]: https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

--- a/clippy_lints/src/assert_is_empty.rs
+++ b/clippy_lints/src/assert_is_empty.rs
@@ -1,0 +1,310 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::macros::{find_assert_args, root_macro_call_first_node};
+use clippy_utils::res::MaybeDef as _;
+use clippy_utils::source::walk_span_to_context;
+use clippy_utils::sugg::Sugg;
+use clippy_utils::sym;
+use clippy_utils::ty::implements_trait;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, LangItem, UnOp};
+use rustc_lint::{LateContext, LateLintPass, LintContext as _};
+use rustc_middle::ty::{self, Ty};
+use rustc_session::declare_lint_pass;
+use rustc_span::Span;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks assertions that only test whether a supported value is empty.
+    ///
+    /// The lint handles `assert!` and `debug_assert!` calls on strings, slices, arrays, and `Vec`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A boolean assertion only reports that the emptiness check failed. It does not show what the
+    /// asserted value contained.
+    ///
+    /// In CI or another remote test service, the failure output tells you that the value was
+    /// unexpectedly empty or non-empty, but not which values were present. The next step is often
+    /// to reproduce the failure locally, add temporary logging, or change the test so it exposes
+    /// the value. That extra investigation can be much slower than fixing the problem from the
+    /// original CI failure.
+    ///
+    /// The emptiness check also commonly appears before a deeper contents assertion:
+    ///
+    /// ```no_run
+    /// # let items = vec!["baz"];
+    /// assert!(!items.is_empty());
+    /// assert_eq!(items[0], "bar");
+    /// ```
+    ///
+    /// If the first assertion fails, the second assertion never runs, so the failure can hide the
+    /// check that would have shown more useful context.
+    ///
+    /// Instead, compare the value with an empty value using `assert_eq!`, `assert_ne!`,
+    /// `debug_assert_eq!`, or `debug_assert_ne!`. These macros print the asserted value on failure.
+    ///
+    /// ### Known problems
+    ///
+    /// Printing the asserted value can be undesirable outside tests, especially when the value may
+    /// be very large or contain sensitive information. If the assertion failure should not reveal
+    /// the value, keep the boolean assertion and allow this lint at that assertion.
+    ///
+    /// ### Example
+    ///
+    /// ```no_run
+    /// # let items = vec![1, 2, 3];
+    /// assert!(items.is_empty());
+    /// assert!(!items.is_empty());
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```no_run
+    /// # let items = vec![1, 2, 3];
+    /// assert_eq!(items, [] as [i32; 0]);
+    /// assert_ne!(items, [] as [i32; 0]);
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub ASSERT_IS_EMPTY,
+    pedantic,
+    "asserting on emptiness without showing the asserted value on failure"
+}
+
+declare_lint_pass!(AssertIsEmpty => [ASSERT_IS_EMPTY]);
+
+impl<'tcx> LateLintPass<'tcx> for AssertIsEmpty {
+    /// Finds assertion conditions that only test emptiness.
+    ///
+    /// Matching assertions without a custom message are rewritten as equality or inequality
+    /// assertions against an empty value.
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        // `assert!` and `debug_assert!` expand to `if`; skip other expressions before walking the
+        // macro backtrace.
+        if !matches!(expr.kind, ExprKind::If(..)) {
+            return;
+        }
+
+        let Some((macro_name, condition, assert_span)) = assert_call(cx, expr) else {
+            return;
+        };
+        let Some((assertion_kind, receiver)) = emptiness_assertion(condition) else {
+            return;
+        };
+        let Some((receiver_suffix, empty_value)) = assertion_suggestion(cx, receiver) else {
+            return;
+        };
+
+        emit_assertion_suggestion(
+            cx,
+            macro_name,
+            assert_span,
+            condition,
+            assertion_kind,
+            receiver,
+            (receiver_suffix, &empty_value),
+        );
+    }
+}
+
+/// Extracts the source-level condition from `assert!` and `debug_assert!`.
+///
+/// The returned macro name omits the trailing `!` so the diagnostic can build `assert_eq`,
+/// `assert_ne`, `debug_assert_eq`, or `debug_assert_ne` from the original macro. Returns `None`
+/// for other macros, assertions with a custom message parameter, and conditions from macro
+/// expansions, where rewriting the condition span would produce confusing or invalid suggestions.
+fn assert_call<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) -> Option<(&'static str, &'tcx Expr<'tcx>, Span)> {
+    let macro_call = root_macro_call_first_node(cx, expr)?;
+    let macro_name = match cx.tcx.get_diagnostic_name(macro_call.def_id) {
+        Some(sym::assert_macro) => "assert",
+        Some(sym::debug_assert_macro) => "debug_assert",
+        _ => return None,
+    };
+    let (condition, panic_expn) = find_assert_args(cx, expr, macro_call.expn)?;
+    if !panic_expn.is_default_message() {
+        return None;
+    }
+
+    if condition.span.from_expansion() {
+        return None;
+    }
+
+    Some((macro_name, condition, macro_call.span))
+}
+
+/// Returns the assertion kind and receiver for an emptiness predicate.
+///
+/// `value.is_empty()` maps to an equality assertion against an empty value. `!value.is_empty()`
+/// maps to an inequality assertion. Returns `None` when the condition is neither form.
+fn emptiness_assertion<'tcx>(condition: &'tcx Expr<'tcx>) -> Option<(AssertionKind, &'tcx Expr<'tcx>)> {
+    if let Some(receiver) = is_empty_receiver(condition) {
+        return Some((AssertionKind::Eq, receiver));
+    }
+
+    let ExprKind::Unary(UnOp::Not, inner) = condition.kind else {
+        return None;
+    };
+
+    is_empty_receiver(inner).map(|receiver| (AssertionKind::Ne, receiver))
+}
+
+/// Returns the receiver when `expr` is a direct `value.is_empty()` call.
+///
+/// Returns `None` for other method calls, negated expressions, and non-method expressions.
+fn is_empty_receiver<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    let ExprKind::MethodCall(method, receiver, [], _) = expr.kind else {
+        return None;
+    };
+    (method.ident.name == sym::is_empty).then_some(receiver)
+}
+
+/// Assertion macro polarity for the replacement assertion.
+///
+/// The variants are named after the comparison macro suffixes rather than the original predicate
+/// shape because suggestions are the only consumer.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AssertionKind {
+    /// Use an equality assertion against an empty value.
+    Eq,
+
+    /// Use an inequality assertion against an empty value.
+    Ne,
+}
+
+impl AssertionKind {
+    /// Returns the assertion macro suffix for this emptiness predicate.
+    ///
+    /// Empty checks become equality assertions. Non-empty checks become inequality assertions.
+    fn suffix(self) -> &'static str {
+        match self {
+            Self::Eq => "_eq",
+            Self::Ne => "_ne",
+        }
+    }
+
+    /// Returns the expected state named in the diagnostic.
+    fn expected_state(self) -> &'static str {
+        match self {
+            Self::Eq => "empty",
+            Self::Ne => "not empty",
+        }
+    }
+}
+
+/// Builds replacement operands when the resulting assertion is useful.
+///
+/// The replacement assertion must compile, compare the same value, and print useful failure
+/// output. Returns `None` for unsupported collection types and for element types that cannot be
+/// printed and compared by the replacement assertion.
+fn assertion_suggestion<'tcx>(cx: &LateContext<'tcx>, receiver: &'tcx Expr<'tcx>) -> Option<(&'static str, String)> {
+    let receiver_ty = cx.typeck_results().expr_ty(receiver);
+    let suggestion = suggestion_for_type(cx, receiver_ty)?;
+    if type_is_printable_and_comparable(cx, receiver_ty.peel_refs()) {
+        Some(suggestion)
+    } else {
+        None
+    }
+}
+
+/// Returns the receiver suffix and empty value for this receiver type.
+///
+/// Arrays and borrowed vectors are compared through slices because direct comparison with `[]` does
+/// not compile for those receiver types. Returns `None` when the receiver has no compact
+/// empty-literal comparison.
+fn suggestion_for_type<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<(&'static str, String)> {
+    match ty.kind() {
+        ty::Array(..) => Some((".as_slice()", "[]".to_string())),
+        ty::Ref(_, inner, _) if matches!(inner.kind(), ty::Array(..)) => Some((".as_slice()", "[]".to_string())),
+        ty::Ref(_, inner, _) if inner.is_diag_item(cx, sym::Vec) => Some((".as_slice()", "[]".to_string())),
+        _ => suggestion_for_peeled_type(cx, ty.peel_refs()),
+    }
+}
+
+/// Returns the empty value for receivers that compare directly after peeling references.
+///
+/// `String` and `str` compare against `""`. Slices compare against `[]`. `Vec<T>` compares
+/// against `[] as [T; 0]` so the empty value carries the element type. Returns `None` for other
+/// receiver types.
+fn suggestion_for_peeled_type<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<(&'static str, String)> {
+    if ty.is_str() || ty.is_lang_item(cx, LangItem::String) {
+        Some(("", "\"\"".to_string()))
+    } else if matches!(ty.kind(), ty::Slice(..)) {
+        Some(("", "[]".to_string()))
+    } else if ty.is_diag_item(cx, sym::Vec) {
+        Some(("", format!("[] as [{}; 0]", element_type(cx, ty)?)))
+    } else {
+        None
+    }
+}
+
+/// Returns whether the replacement assertion has useful failure output.
+///
+/// Suggestions are limited to cases where the replacement assertion can both compare the value and
+/// print it on failure. Strings satisfy this directly; sequence-like values require printable,
+/// self-comparable elements. Returns `false` when either trait bound is missing.
+fn type_is_printable_and_comparable<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    if ty.is_str() || ty.is_lang_item(cx, LangItem::String) {
+        return true;
+    }
+
+    if let Some(element_ty) = element_type(cx, ty)
+        && let Some(debug_trait) = cx.tcx.get_diagnostic_item(sym::Debug)
+        && let Some(partial_eq_trait) = cx.tcx.get_diagnostic_item(sym::PartialEq)
+    {
+        implements_trait(cx, element_ty, debug_trait, &[])
+            && implements_trait(cx, element_ty, partial_eq_trait, &[element_ty.into()])
+    } else {
+        false
+    }
+}
+
+/// Extracts the element type from supported sequence-like values.
+///
+/// The element type is used both for trait checks and for the typed empty-array suggestion required
+/// by `Vec<T>` suggestions. Returns `None` for non-sequence receiver types.
+fn element_type<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+    match ty.kind() {
+        ty::Array(ty, _) | ty::Slice(ty) => Some(*ty),
+        ty::Adt(_, args) if ty.is_diag_item(cx, sym::Vec) => args.types().next(),
+        _ => None,
+    }
+}
+
+/// Emits the rewrite from a boolean assertion to a comparison assertion.
+fn emit_assertion_suggestion(
+    cx: &LateContext<'_>,
+    macro_name: &str,
+    assert_span: Span,
+    condition: &Expr<'_>,
+    assertion_kind: AssertionKind,
+    receiver: &Expr<'_>,
+    suggestion: (&str, &str),
+) {
+    let mut applicability = Applicability::MachineApplicable;
+    let receiver_snip =
+        Sugg::hir_with_context(cx, receiver, assert_span.ctxt(), "..", &mut applicability).maybe_paren();
+    let (receiver_suffix, empty_value) = suggestion;
+    let receiver_snip = format!("{receiver_snip}{receiver_suffix}");
+    let assertion_suffix = assertion_kind.suffix();
+    let expected_state = assertion_kind.expected_state();
+
+    span_lint_and_then(
+        cx,
+        ASSERT_IS_EMPTY,
+        assert_span,
+        format!("used `{macro_name}!` to check that a value is {expected_state}"),
+        |diag| {
+            let macro_name_span = cx.sess().source_map().span_until_char(assert_span, '!');
+            let condition_span = walk_span_to_context(condition.span, assert_span.ctxt()).unwrap_or(condition.span);
+
+            diag.multipart_suggestion(
+                format!("use `{macro_name}{assertion_suffix}!` to show the value on failure"),
+                vec![
+                    (macro_name_span.shrink_to_hi(), assertion_suffix.to_string()),
+                    (condition_span, format!("{receiver_snip}, {empty_value}")),
+                ],
+                applicability,
+            );
+        },
+    );
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -11,6 +11,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::as_conversions::AS_CONVERSIONS_INFO,
     crate::asm_syntax::INLINE_ASM_X86_ATT_SYNTAX_INFO,
     crate::asm_syntax::INLINE_ASM_X86_INTEL_SYNTAX_INFO,
+    crate::assert_is_empty::ASSERT_IS_EMPTY_INFO,
     crate::assertions_on_constants::ASSERTIONS_ON_CONSTANTS_INFO,
     crate::assertions_on_result_states::ASSERTIONS_ON_RESULT_STATES_INFO,
     crate::assigning_clones::ASSIGNING_CLONES_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -69,6 +69,7 @@ mod arbitrary_source_item_ordering;
 mod arc_with_non_send_sync;
 mod as_conversions;
 mod asm_syntax;
+mod assert_is_empty;
 mod assertions_on_constants;
 mod assertions_on_result_states;
 mod assigning_clones;
@@ -571,6 +572,7 @@ rustc_lint::late_lint_methods!(
         UnnecessaryMutPassed: unnecessary_mut_passed::UnnecessaryMutPassed = unnecessary_mut_passed::UnnecessaryMutPassed,
         SignificantDropTightening: significant_drop_tightening::SignificantDropTightening<'tcx> = <significant_drop_tightening::SignificantDropTightening<'_>>::default(),
         LenZero: len_zero::LenZero = len_zero::LenZero::new(conf),
+        AssertIsEmpty: assert_is_empty::AssertIsEmpty = assert_is_empty::AssertIsEmpty,
         LenWithoutIsEmpty: len_without_is_empty::LenWithoutIsEmpty = len_without_is_empty::LenWithoutIsEmpty,
         Attributes: attrs::Attributes = attrs::Attributes::new(conf),
         BlocksInConditions: blocks_in_conditions::BlocksInConditions = blocks_in_conditions::BlocksInConditions,

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -82,8 +82,9 @@ fn internal_extern_flags() -> Vec<String> {
         .copied()
         .filter(|n| !crates.contains_key(n))
         .collect();
-    assert!(
-        not_found.is_empty(),
+    assert_eq!(
+        not_found,
+        [] as [&str; 0],
         "dependencies not found in depinfo: {not_found:?}\n\
         help: Make sure the `-Z binary-dep-depinfo` rust flag is enabled\n\
         help: Try adding to dev-dependencies in Cargo.toml\n\

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -50,8 +50,9 @@ fn dogfood() {
         }
     }
 
-    assert!(
-        failed_packages.is_empty(),
+    assert_eq!(
+        failed_packages,
+        [] as [&str; 0],
         "Dogfood failed for packages `{}`",
         failed_packages.iter().join(", "),
     );

--- a/tests/ui/assert_is_empty.fixed
+++ b/tests/ui/assert_is_empty.fixed
@@ -1,0 +1,112 @@
+#![warn(clippy::assert_is_empty)]
+#![allow(clippy::useless_vec)]
+#![allow(clippy::const_is_empty, clippy::needless_ifs)]
+
+fn main() {
+    let vec = vec![1, 2, 3];
+    assert_eq!(vec, [] as [i32; 0]);
+    //~^ assert_is_empty
+    assert_ne!(vec, [] as [i32; 0]);
+    //~^ assert_is_empty
+    debug_assert_eq!(vec, [] as [i32; 0]);
+    //~^ assert_is_empty
+    debug_assert_ne!(vec, [] as [i32; 0]);
+    //~^ assert_is_empty
+
+    let vec_ref = &vec;
+    assert_eq!(vec_ref.as_slice(), []);
+    //~^ assert_is_empty
+    assert_ne!(vec_ref.as_slice(), []);
+    //~^ assert_is_empty
+
+    let vec_mut_ref = &mut vec![1, 2, 3];
+    assert_eq!(vec_mut_ref.as_slice(), []);
+    //~^ assert_is_empty
+
+    let slice: &[i32] = &[1, 2, 3];
+    assert_eq!(slice, []);
+    //~^ assert_is_empty
+    assert_ne!(slice, []);
+    //~^ assert_is_empty
+
+    let array = [1, 2, 3];
+    assert_eq!(array.as_slice(), []);
+    //~^ assert_is_empty
+    assert_ne!(array.as_slice(), []);
+    //~^ assert_is_empty
+
+    let array_ref = &array;
+    assert_eq!(array_ref.as_slice(), []);
+    //~^ assert_is_empty
+
+    let string = String::from("foo");
+    assert_eq!(string, "");
+    //~^ assert_is_empty
+    assert_ne!(string, "");
+    //~^ assert_is_empty
+
+    let str_ref = "foo";
+    assert_eq!(str_ref, "");
+    //~^ assert_is_empty
+    assert_ne!(str_ref, "");
+    //~^ assert_is_empty
+
+    // Don't lint: has assert message.
+    assert!(vec.is_empty(), "items should be empty");
+    assert!(!vec.is_empty(), "items should not be empty");
+    assert!(vec.is_empty(), "unexpected values: {vec:?}");
+    assert!(!vec.is_empty(), "unexpected values: {vec:?}");
+
+    // Common chained assertion shape. The first assertion can hide the value
+    // that the second assertion would otherwise help diagnose.
+    let items = vec!["baz"];
+    assert_ne!(items, [] as [&str; 0]);
+    //~^ assert_is_empty
+    assert_eq!(items[0], "bar");
+
+    // Don't lint: the outer `assert!` is written here, but the condition comes
+    // from a macro expansion. Rewriting the expanded condition span would make
+    // the suggestion point at generated code rather than source code.
+    macro_rules! is_empty {
+        ($value:expr) => {
+            $value.is_empty()
+        };
+    }
+    assert!(is_empty!(vec));
+
+    // Don't lint: the `assert!` itself comes from a macro expansion. The lint
+    // only rewrites assert calls that are present at the call site.
+    macro_rules! assert_empty {
+        ($value:expr) => {
+            assert!($value.is_empty())
+        };
+    }
+    assert_empty!(vec);
+
+    // Don't lint: not an assert macro.
+    if vec.is_empty() {}
+    if !vec.is_empty() {}
+
+    // Don't lint: maps do not have a compact empty literal suggestion. This is
+    // a conservative call; comparing against `HashMap::new()` may be worth
+    // revisiting if the type inference cost and constructor path are acceptable
+    // for aliases, custom hashers, and similar map types.
+    let map = std::collections::HashMap::<i32, i32>::new();
+    assert!(map.is_empty());
+    assert!(!map.is_empty());
+
+    // Don't lint: assert_eq! would require Debug and PartialEq for the element type.
+    struct NotDebugOrPartialEq;
+    let not_debug_or_partial_eq = vec![NotDebugOrPartialEq];
+    assert!(not_debug_or_partial_eq.is_empty());
+
+    #[derive(Debug)]
+    struct NotPartialEq;
+    let not_partial_eq = vec![NotPartialEq];
+    assert!(not_partial_eq.is_empty());
+
+    #[derive(PartialEq)]
+    struct NotDebug;
+    let not_debug = vec![NotDebug];
+    assert!(not_debug.is_empty());
+}

--- a/tests/ui/assert_is_empty.rs
+++ b/tests/ui/assert_is_empty.rs
@@ -1,0 +1,112 @@
+#![warn(clippy::assert_is_empty)]
+#![allow(clippy::useless_vec)]
+#![allow(clippy::const_is_empty, clippy::needless_ifs)]
+
+fn main() {
+    let vec = vec![1, 2, 3];
+    assert!(vec.is_empty());
+    //~^ assert_is_empty
+    assert!(!vec.is_empty());
+    //~^ assert_is_empty
+    debug_assert!(vec.is_empty());
+    //~^ assert_is_empty
+    debug_assert!(!vec.is_empty());
+    //~^ assert_is_empty
+
+    let vec_ref = &vec;
+    assert!(vec_ref.is_empty());
+    //~^ assert_is_empty
+    assert!(!vec_ref.is_empty());
+    //~^ assert_is_empty
+
+    let vec_mut_ref = &mut vec![1, 2, 3];
+    assert!(vec_mut_ref.is_empty());
+    //~^ assert_is_empty
+
+    let slice: &[i32] = &[1, 2, 3];
+    assert!(slice.is_empty());
+    //~^ assert_is_empty
+    assert!(!slice.is_empty());
+    //~^ assert_is_empty
+
+    let array = [1, 2, 3];
+    assert!(array.is_empty());
+    //~^ assert_is_empty
+    assert!(!array.is_empty());
+    //~^ assert_is_empty
+
+    let array_ref = &array;
+    assert!(array_ref.is_empty());
+    //~^ assert_is_empty
+
+    let string = String::from("foo");
+    assert!(string.is_empty());
+    //~^ assert_is_empty
+    assert!(!string.is_empty());
+    //~^ assert_is_empty
+
+    let str_ref = "foo";
+    assert!(str_ref.is_empty());
+    //~^ assert_is_empty
+    assert!(!str_ref.is_empty());
+    //~^ assert_is_empty
+
+    // Don't lint: has assert message.
+    assert!(vec.is_empty(), "items should be empty");
+    assert!(!vec.is_empty(), "items should not be empty");
+    assert!(vec.is_empty(), "unexpected values: {vec:?}");
+    assert!(!vec.is_empty(), "unexpected values: {vec:?}");
+
+    // Common chained assertion shape. The first assertion can hide the value
+    // that the second assertion would otherwise help diagnose.
+    let items = vec!["baz"];
+    assert!(!items.is_empty());
+    //~^ assert_is_empty
+    assert_eq!(items[0], "bar");
+
+    // Don't lint: the outer `assert!` is written here, but the condition comes
+    // from a macro expansion. Rewriting the expanded condition span would make
+    // the suggestion point at generated code rather than source code.
+    macro_rules! is_empty {
+        ($value:expr) => {
+            $value.is_empty()
+        };
+    }
+    assert!(is_empty!(vec));
+
+    // Don't lint: the `assert!` itself comes from a macro expansion. The lint
+    // only rewrites assert calls that are present at the call site.
+    macro_rules! assert_empty {
+        ($value:expr) => {
+            assert!($value.is_empty())
+        };
+    }
+    assert_empty!(vec);
+
+    // Don't lint: not an assert macro.
+    if vec.is_empty() {}
+    if !vec.is_empty() {}
+
+    // Don't lint: maps do not have a compact empty literal suggestion. This is
+    // a conservative call; comparing against `HashMap::new()` may be worth
+    // revisiting if the type inference cost and constructor path are acceptable
+    // for aliases, custom hashers, and similar map types.
+    let map = std::collections::HashMap::<i32, i32>::new();
+    assert!(map.is_empty());
+    assert!(!map.is_empty());
+
+    // Don't lint: assert_eq! would require Debug and PartialEq for the element type.
+    struct NotDebugOrPartialEq;
+    let not_debug_or_partial_eq = vec![NotDebugOrPartialEq];
+    assert!(not_debug_or_partial_eq.is_empty());
+
+    #[derive(Debug)]
+    struct NotPartialEq;
+    let not_partial_eq = vec![NotPartialEq];
+    assert!(not_partial_eq.is_empty());
+
+    #[derive(PartialEq)]
+    struct NotDebug;
+    let not_debug = vec![NotDebug];
+    assert!(not_debug.is_empty());
+}

--- a/tests/ui/assert_is_empty.stderr
+++ b/tests/ui/assert_is_empty.stderr
@@ -1,0 +1,208 @@
+error: used `assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:7:5
+   |
+LL |     assert!(vec.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::assert-is-empty` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::assert_is_empty)]`
+help: use `assert_eq!` to show the value on failure
+   |
+LL -     assert!(vec.is_empty());
+LL +     assert_eq!(vec, [] as [i32; 0]);
+   |
+
+error: used `assert!` to check that a value is not empty
+  --> tests/ui/assert_is_empty.rs:9:5
+   |
+LL |     assert!(!vec.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_ne!` to show the value on failure
+   |
+LL -     assert!(!vec.is_empty());
+LL +     assert_ne!(vec, [] as [i32; 0]);
+   |
+
+error: used `debug_assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:11:5
+   |
+LL |     debug_assert!(vec.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `debug_assert_eq!` to show the value on failure
+   |
+LL -     debug_assert!(vec.is_empty());
+LL +     debug_assert_eq!(vec, [] as [i32; 0]);
+   |
+
+error: used `debug_assert!` to check that a value is not empty
+  --> tests/ui/assert_is_empty.rs:13:5
+   |
+LL |     debug_assert!(!vec.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `debug_assert_ne!` to show the value on failure
+   |
+LL -     debug_assert!(!vec.is_empty());
+LL +     debug_assert_ne!(vec, [] as [i32; 0]);
+   |
+
+error: used `assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:17:5
+   |
+LL |     assert!(vec_ref.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_eq!` to show the value on failure
+   |
+LL -     assert!(vec_ref.is_empty());
+LL +     assert_eq!(vec_ref.as_slice(), []);
+   |
+
+error: used `assert!` to check that a value is not empty
+  --> tests/ui/assert_is_empty.rs:19:5
+   |
+LL |     assert!(!vec_ref.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_ne!` to show the value on failure
+   |
+LL -     assert!(!vec_ref.is_empty());
+LL +     assert_ne!(vec_ref.as_slice(), []);
+   |
+
+error: used `assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:23:5
+   |
+LL |     assert!(vec_mut_ref.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_eq!` to show the value on failure
+   |
+LL -     assert!(vec_mut_ref.is_empty());
+LL +     assert_eq!(vec_mut_ref.as_slice(), []);
+   |
+
+error: used `assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:27:5
+   |
+LL |     assert!(slice.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_eq!` to show the value on failure
+   |
+LL -     assert!(slice.is_empty());
+LL +     assert_eq!(slice, []);
+   |
+
+error: used `assert!` to check that a value is not empty
+  --> tests/ui/assert_is_empty.rs:29:5
+   |
+LL |     assert!(!slice.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_ne!` to show the value on failure
+   |
+LL -     assert!(!slice.is_empty());
+LL +     assert_ne!(slice, []);
+   |
+
+error: used `assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:33:5
+   |
+LL |     assert!(array.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_eq!` to show the value on failure
+   |
+LL -     assert!(array.is_empty());
+LL +     assert_eq!(array.as_slice(), []);
+   |
+
+error: used `assert!` to check that a value is not empty
+  --> tests/ui/assert_is_empty.rs:35:5
+   |
+LL |     assert!(!array.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_ne!` to show the value on failure
+   |
+LL -     assert!(!array.is_empty());
+LL +     assert_ne!(array.as_slice(), []);
+   |
+
+error: used `assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:39:5
+   |
+LL |     assert!(array_ref.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_eq!` to show the value on failure
+   |
+LL -     assert!(array_ref.is_empty());
+LL +     assert_eq!(array_ref.as_slice(), []);
+   |
+
+error: used `assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:43:5
+   |
+LL |     assert!(string.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_eq!` to show the value on failure
+   |
+LL -     assert!(string.is_empty());
+LL +     assert_eq!(string, "");
+   |
+
+error: used `assert!` to check that a value is not empty
+  --> tests/ui/assert_is_empty.rs:45:5
+   |
+LL |     assert!(!string.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_ne!` to show the value on failure
+   |
+LL -     assert!(!string.is_empty());
+LL +     assert_ne!(string, "");
+   |
+
+error: used `assert!` to check that a value is empty
+  --> tests/ui/assert_is_empty.rs:49:5
+   |
+LL |     assert!(str_ref.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_eq!` to show the value on failure
+   |
+LL -     assert!(str_ref.is_empty());
+LL +     assert_eq!(str_ref, "");
+   |
+
+error: used `assert!` to check that a value is not empty
+  --> tests/ui/assert_is_empty.rs:51:5
+   |
+LL |     assert!(!str_ref.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_ne!` to show the value on failure
+   |
+LL -     assert!(!str_ref.is_empty());
+LL +     assert_ne!(str_ref, "");
+   |
+
+error: used `assert!` to check that a value is not empty
+  --> tests/ui/assert_is_empty.rs:63:5
+   |
+LL |     assert!(!items.is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `assert_ne!` to show the value on failure
+   |
+LL -     assert!(!items.is_empty());
+LL +     assert_ne!(items, [] as [&str; 0]);
+   |
+
+error: aborting due to 17 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17149)*

changelog: new lint: [`assert_is_empty`]

fixes rust-lang/rust-clippy#17114

Adds a pedantic lint for `assert!` and `debug_assert!` calls without custom messages that only check whether a supported value is empty. The lint suggests `assert_eq!`, `assert_ne!`, `debug_assert_eq!`, or `debug_assert_ne!` forms so failures print the unexpected value.

Rationale:

Boolean emptiness assertions only report that the predicate failed. In test failures, especially CI failures, that often leaves the developer without the collection contents needed to diagnose the problem. Comparing against an empty value gives the assertion machinery a value to print, and it also avoids hiding later content checks such as `assert_eq!(items[0], "bar")` behind a preceding `assert!(!items.is_empty())` failure.

Supported suggestions currently cover strings, slices, arrays, and `Vec`. Other collection types are skipped when there is no compact empty-literal comparison or when the replacement assertion would not provide useful failure output.

Implementation notes:

- Assertions with custom messages are skipped, following the `manual_assert_eq` precedent that a custom message is a signal that the author chose the diagnostic output.
- `Vec<T>` suggestions use `[] as [T; 0]` so the empty operand carries enough type information for both `assert_eq!` and `assert_ne!`.
- Arrays and borrowed vectors are compared through `.as_slice()` because direct comparison with `[]` does not compile for those receiver types.
- Suggestions are only emitted when the replacement assertion can compare and print the value. Sequence element types must implement `Debug` and `PartialEq`.
- Macro-expanded assertion conditions are skipped because rewriting generated spans can produce confusing or invalid suggestions.
- Map-like collections are intentionally not covered yet. Comparing against `HashMap::new()` may be worth revisiting, but this PR keeps the first version to compact empty-literal comparisons.
- The lint docs call out that printing the asserted value can be the wrong tradeoff for very large values or values containing sensitive information. In those cases, keep the boolean assertion and allow the lint at that assertion.

New-lint checklist:

- [x] Followed lint naming conventions
- [x] Added passing UI tests, including committed `.stderr` and `.fixed` files
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo dev fmt`

Validation run locally:

- `cargo dev update_lints`
- `cargo dev fmt`
- `TESTNAME=assert_is_empty cargo uitest`
- `cargo test --test dogfood`
- `cargo test`
