### PR TITLE
Add `missing_builder_fields` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ document.
 
 [df995e...master](https://github.com/rust-lang/rust-clippy/compare/df995e...master)
 
+### New Lints
+
+* Added [`missing_builder_fields`] to `correctness`
+  [#XXXXX](https://github.com/rust-lang/rust-clippy/pull/XXXXX)
+
 ## Rust 1.95
 
 Current stable, released 2026-04-16
@@ -6979,6 +6984,7 @@ Released 2018-09-13
 [`misrefactored_assign_op`]: https://rust-lang.github.io/rust-clippy/master/index.html#misrefactored_assign_op
 [`missing_assert_message`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_assert_message
 [`missing_asserts_for_indexing`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_asserts_for_indexing
+[`missing_builder_fields`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_builder_fields
 [`missing_const_for_fn`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn
 [`missing_const_for_thread_local`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_thread_local
 [`missing_docs_in_private_items`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_docs_in_private_items

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -533,6 +533,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::mismatching_type_param_order::MISMATCHING_TYPE_PARAM_ORDER_INFO,
     crate::missing_assert_message::MISSING_ASSERT_MESSAGE_INFO,
     crate::missing_asserts_for_indexing::MISSING_ASSERTS_FOR_INDEXING_INFO,
+    crate::missing_builder_fields::MISSING_BUILDER_FIELDS_INFO,
     crate::missing_const_for_fn::MISSING_CONST_FOR_FN_INFO,
     crate::missing_const_for_thread_local::MISSING_CONST_FOR_THREAD_LOCAL_INFO,
     crate::missing_doc::MISSING_DOCS_IN_PRIVATE_ITEMS_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -234,6 +234,7 @@ mod misc_early;
 mod mismatching_type_param_order;
 mod missing_assert_message;
 mod missing_asserts_for_indexing;
+mod missing_builder_fields;
 mod missing_const_for_fn;
 mod missing_const_for_thread_local;
 mod missing_doc;
@@ -815,6 +816,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
         Box::new(|_| Box::<reserve_after_initialization::ReserveAfterInitialization>::default()),
         Box::new(|_| Box::new(implied_bounds_in_impls::ImpliedBoundsInImpls)),
         Box::new(|_| Box::new(missing_asserts_for_indexing::MissingAssertsForIndexing)),
+        Box::new(|_| Box::new(missing_builder_fields::MissingBuilderFields)),
         Box::new(|_| Box::new(unnecessary_map_on_constructor::UnnecessaryMapOnConstructor)),
         Box::new(move |_| {
             Box::new(needless_borrows_for_generic_args::NeedlessBorrowsForGenericArgs::new(

--- a/clippy_lints/src/missing_builder_fields.rs
+++ b/clippy_lints/src/missing_builder_fields.rs
@@ -1,0 +1,185 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::path_to_local_with_projections;
+use clippy_utils::visitors::for_each_expr_without_closures;
+use rustc_hir::{self as hir, PatExprKind, PatKind, QPath};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
+use rustc_session::declare_lint_pass;
+use rustc_span::{Symbol, sym};
+use std::ops::ControlFlow;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Warns when calling `.build()` on a `derive_builder`-generated builder without
+    /// setting all required fields (those without `#[builder(default)]`).
+    ///
+    /// ### Why is this bad?
+    /// Missing required fields cause a runtime panic or error from `.build()`,
+    /// which the compiler cannot catch.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// // Bad: `timeout` is required but never set
+    /// let _ = FooBuilder::default().build();
+    ///
+    /// // Good
+    /// let _ = FooBuilder::default().timeout(30).build();
+    /// ```
+    #[clippy::version = "1.87.0"]
+    pub MISSING_BUILDER_FIELDS,
+    correctness,
+    "calling `.build()` on a builder with missing required fields"
+}
+
+declare_lint_pass!(MissingBuilderFields => [MISSING_BUILDER_FIELDS]);
+
+impl<'tcx> LateLintPass<'tcx> for MissingBuilderFields {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        let hir::ExprKind::MethodCall(method_segment, receiver, args, _) = expr.kind else {
+            return;
+        };
+
+        if method_segment.ident.name.as_str() != "build" || !args.is_empty() {
+            return;
+        }
+
+        // Get the receiver type — should be FooBuilder (peel &mut T since setters return &mut Self)
+        let receiver_ty = cx.typeck_results().expr_ty(receiver).peel_refs();
+        let ty::Adt(builder_adt, _) = receiver_ty.kind() else {
+            return;
+        };
+
+        // Get the return type of .build() — may be Result<Foo, E> or Foo directly
+        let return_ty = cx.typeck_results().expr_ty(expr);
+        let target_ty = if let ty::Adt(adt, args) = return_ty.kind()
+            && cx.tcx.is_diagnostic_item(sym::Result, adt.did())
+        {
+            args.type_at(0)
+        } else {
+            return_ty
+        };
+
+        let ty::Adt(target_adt, _) = target_ty.kind() else {
+            return;
+        };
+
+        // Heuristic: FooBuilder builds Foo — confirm the names match
+        let builder_name = cx.tcx.def_path_str(builder_adt.did());
+        let target_name = cx.tcx.def_path_str(target_adt.did());
+        if !builder_name.ends_with("Builder") || builder_name[..builder_name.len() - "Builder".len()] != target_name {
+            return;
+        }
+
+        // Get the body of the build() method to determine required fields.
+        // Both #[derive(Builder)] and #[builder(default)] are stripped before the HIR,
+        // so we analyze the generated build() body instead.
+        let Some(method_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) else {
+            return;
+        };
+        let Some(local_def_id) = method_def_id.as_local() else {
+            return;
+        };
+        let Some(body) = cx.tcx.hir_maybe_body_owned_by(local_def_id) else {
+            return;
+        };
+
+        // Walk the build() body looking for patterns that indicate a required field:
+        //   match self.FIELD { ..., None => return ..., ... }
+        //   self.FIELD.ok_or(...)
+        let required_fields = collect_required_fields(body.value);
+
+        if required_fields.is_empty() {
+            return;
+        }
+
+        // Walk the caller's method chain to see which setters were called.
+        // Returns None when the chain root is a local variable (we can't know its history).
+        let Some(called) = collect_method_chain(receiver) else {
+            return;
+        };
+
+        let missing: Vec<&str> = required_fields
+            .iter()
+            .filter(|&&name| !called.contains(&name))
+            .map(Symbol::as_str)
+            .collect();
+
+        if missing.is_empty() {
+            return;
+        }
+
+        span_lint_and_help(
+            cx,
+            MISSING_BUILDER_FIELDS,
+            expr.span,
+            format!(
+                "builder is missing required field{}: {}",
+                if missing.len() == 1 { "" } else { "s" },
+                missing.join(", ")
+            ),
+            None,
+            "call the setter for each required field before `.build()`",
+        );
+    }
+}
+
+/// Walk a method call chain and collect all method names, from outermost to root.
+/// Returns `None` when the chain root is a local variable — in that case we cannot
+/// know which setters were called before this expression, so we skip to avoid false positives.
+fn collect_method_chain(mut expr: &hir::Expr<'_>) -> Option<Vec<Symbol>> {
+    let mut methods = Vec::new();
+    loop {
+        if let hir::ExprKind::MethodCall(seg, recv, _, _) = expr.kind {
+            methods.push(seg.ident.name);
+            expr = recv;
+        } else {
+            // If the chain root is a local variable we can't track its prior setters.
+            if path_to_local_with_projections(expr).is_some() {
+                return None;
+            }
+            return Some(methods);
+        }
+    }
+}
+
+/// Walk a `build()` method body and collect names of required fields.
+/// Required fields are identified by two patterns `derive_builder` generates:
+///   1. `match self.FIELD { ..., None => return ..., ... }`
+///   2. `self.FIELD.ok_or(...)` / `self.FIELD.ok_or_else(...)`
+fn collect_required_fields(body: &hir::Expr<'_>) -> Vec<Symbol> {
+    let mut fields = Vec::new();
+    for_each_expr_without_closures(body, |expr| -> ControlFlow<(), ()> {
+        // Pattern 1: match self.FIELD { ..., None => return ..., ... }
+        if let hir::ExprKind::Match(scrutinee, arms, _) = expr.kind
+            && let hir::ExprKind::Field(_, field_ident) = scrutinee.kind
+            && arms.iter().any(|arm| is_none_pat(arm.pat) && is_return(arm.body))
+        {
+            fields.push(field_ident.name);
+            return ControlFlow::Continue(());
+        }
+        // Pattern 2: self.FIELD.ok_or(...) / self.FIELD.ok_or_else(...)
+        if let hir::ExprKind::MethodCall(seg, recv, _, _) = expr.kind
+            && matches!(seg.ident.name.as_str(), "ok_or" | "ok_or_else")
+            && let hir::ExprKind::Field(_, field_ident) = recv.kind
+        {
+            fields.push(field_ident.name);
+            return ControlFlow::Continue(());
+        }
+        ControlFlow::Continue(())
+    });
+    fields
+}
+
+fn is_none_pat(pat: &hir::Pat<'_>) -> bool {
+    if let PatKind::Expr(pat_expr) = pat.kind
+        && let PatExprKind::Path(QPath::Resolved(_, path)) = pat_expr.kind
+    {
+        path.segments.last().is_some_and(|seg| seg.ident.name == sym::None)
+    } else {
+        false
+    }
+}
+
+fn is_return(expr: &hir::Expr<'_>) -> bool {
+    matches!(expr.kind, hir::ExprKind::Ret(_))
+}

--- a/clippy_test_deps/Cargo.lock
+++ b/clippy_test_deps/Cargo.lock
@@ -69,6 +69,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 name = "clippy_test_deps"
 version = "0.1.0"
 dependencies = [
+ "derive_builder",
  "futures",
  "itertools",
  "libc",
@@ -81,10 +82,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -180,6 +253,12 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "io-uring"
@@ -386,6 +465,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/clippy_test_deps/Cargo.toml
+++ b/clippy_test_deps/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3"
 parking_lot = "0.12"
 tokio = { version = "1", features = ["io-util"] }
 itertools = "0.12"
+derive_builder = "0.20"
 
 # Make sure we are not part of the rustc workspace.
 [workspace]

--- a/tests/ui/missing_builder_fields.rs
+++ b/tests/ui/missing_builder_fields.rs
@@ -1,0 +1,33 @@
+#![warn(clippy::missing_builder_fields)]
+
+use derive_builder::Builder;
+
+#[derive(Builder)]
+struct Foo {
+    required_a: u32,
+    required_b: u32,
+    #[builder(default)]
+    optional: u32,
+}
+
+fn main() {
+    // Bad: both required fields missing
+    let _ = FooBuilder::default().build();
+    //~^ ERROR: builder is missing required fields: required_a, required_b
+
+    // Bad: `required_b` missing
+    let _ = FooBuilder::default().required_a(1).build();
+    //~^ ERROR: builder is missing required field: required_b
+
+    // Good: both required fields set, optional omitted
+    let _ = FooBuilder::default().required_a(1).required_b(2).build();
+
+    // Good: all fields set
+    let _ = FooBuilder::default().required_a(1).required_b(2).optional(99).build();
+
+    // Good: mutable builder — we can't track setters through a variable, so we don't lint
+    let mut builder = FooBuilder::default();
+    builder.required_a(1);
+    builder.required_b(2);
+    let _ = builder.build();
+}

--- a/tests/ui/missing_builder_fields.stderr
+++ b/tests/ui/missing_builder_fields.stderr
@@ -1,0 +1,20 @@
+error: builder is missing required fields: required_a, required_b
+  --> tests/ui/missing_builder_fields.rs:15:13
+   |
+LL |     let _ = FooBuilder::default().build();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: call the setter for each required field before `.build()`
+   = note: `-D clippy::missing-builder-fields` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_builder_fields)]`
+
+error: builder is missing required field: required_b
+  --> tests/ui/missing_builder_fields.rs:19:13
+   |
+LL |     let _ = FooBuilder::default().required_a(1).build();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: call the setter for each required field before `.build()`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Adds a new lint in the `correctness` category that warns when `.build()` is called on a `derive_builder`-generated builder without setting all required fields (those without `#[builder(default)]`).

Missing required fields cause a runtime error that the compiler cannot catch. The lint inspects the generated `build()` body to find required fields, then checks the fluent method-call chain to see which setters were called.

Fluent chain example (linted):
```rust
// bad: `required_b` is never set
let _ = FooBuilder::default().required_a(1).build();

// good
let _ = FooBuilder::default().required_a(1).required_b(2).build();
```

Mutable builder pattern is intentionally not linted to avoid false positives when setters are called through a variable.

changelog: [`missing_builder_fields`]: new lint

Testing
Verified with UI tests covering: all fields missing, some fields missing, all fields set, optional field omitted, and mutable builder pattern (no false positive). Also manually tested against a standalone Rust project using cargo dev lint. Ran cargo dev fmt.

cargo test has one pre-existing failure on Windows: E0463: can't find crate for tikv_jemalloc_sys in src/driver.rs. This is caused by the dogfood test running --all-features, which enables the jemalloc feature — a crate that isn't available in the Windows sysroot. It is unrelated to this change.

changelog: [missing_builder_fields]: new lint
