### PR TITLE
dummy: update to term-1 which has fewer deps

### DIFF
--- a/clippy_dummy/Cargo.toml
+++ b/clippy_dummy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy_dummy" # rename to clippy before publishing
-version = "0.0.303"
+version = "0.0.304"
 edition = "2024"
 readme = "crates-readme.md"
 description = "A bunch of helpful lints to avoid common pitfalls in Rust."
@@ -13,4 +13,4 @@ keywords = ["clippy", "lint", "plugin"]
 categories = ["development-tools", "development-tools::cargo-plugins"]
 
 [build-dependencies]
-term = "0.7"
+term = "1"


### PR DESCRIPTION
This update reduces the transitive deps of clippy_dummy, because term dropped dirs-next for home and home for std. This makes the build.rs error appear more quickly.

changelog:none
