### PR TITLE
fixes issue 17162 false positive for never type impls

### DIFF
--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -285,6 +285,20 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
                 && let ExprKind::Block(block, _) = inner.kind
                 && let Some(tail_expr) = block.expr
             {
+                // check the impl method self type/item
+                if let Ok(args) = cx.tcx.try_normalize_erasing_regions(
+                    cx.typing_env(),
+                    cx.tcx
+                        .fn_sig(impl_item.owner_id.def_id)
+                        .instantiate_identity()
+                        .map(|x| cx.tcx.instantiate_bound_regions_with_erased(x.inputs_and_output())),
+                ) && args[..args.len() - 1].iter().any(|&x| {
+                    !x.peel_refs()
+                        .is_inhabited_from(cx.tcx, impl_item.owner_id.def_id.to_def_id(), cx.typing_env())
+                }) {
+                    return;
+                }
+
                 span_lint_and_then(
                     cx,
                     UNUSED_ASYNC_TRAIT_IMPL,

--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -285,6 +285,23 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
                 && let ExprKind::Block(block, _) = inner.kind
                 && let Some(tail_expr) = block.expr
             {
+                // check the impl method self type/item
+                if let Ok(args) = cx.tcx.try_normalize_erasing_regions(
+                    cx.typing_env(),
+                    cx.tcx
+                        .fn_sig(impl_item.owner_id.def_id)
+                        .instantiate_identity()
+                        .map(|x| cx.tcx.instantiate_bound_regions_with_erased(x.inputs_and_output())),
+                ) && args[..args.len() - 1].iter().any(|&x| {
+                    !x.peel_refs().is_inhabited_from(
+                        cx.tcx,
+                        cx.tcx.parent_module_from_def_id(impl_item.owner_id.def_id),
+                        cx.typing_env(),
+                    )
+                }) {
+                    return;
+                }
+
                 span_lint_and_then(
                     cx,
                     UNUSED_ASYNC_TRAIT_IMPL,

--- a/tests/ui/unused_async_trait_impl.fixed
+++ b/tests/ui/unused_async_trait_impl.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::unused_async_trait_impl)]
+#![feature(never_type)]
 
 trait HasAsyncMethod {
     async fn do_something() -> u32;
@@ -115,7 +116,6 @@ mod issue17179 {
         fn do_something() -> impl Future<Output = u32> {
             //~^ unused_async_trait_impl
 
-            // Test that local functions are not touched by the suggestion.
             fn local_func() -> u32 {
                 if 5 == 2 {
                     return 1;
@@ -123,7 +123,6 @@ mod issue17179 {
                 2
             }
 
-            // Test that we do not change the tail expr or return in a (unrelated) closure.
             let f = || {
                 if 5 == 2 {
                     return 1;
@@ -131,12 +130,32 @@ mod issue17179 {
                 2
             };
 
-            // However the following return statement and tail expression should be changed.
             if f() == 5 {
                 return std::future::ready(3);
             }
 
             std::future::ready(5)
+        }
+    }
+}
+
+mod issue17162 {
+    trait AsyncTraitWithSelf {
+        async fn do_something(&self) -> u32;
+    }
+
+    impl AsyncTraitWithSelf for ! {
+        async fn do_something(&self) -> u32 {
+            unreachable!()
+        }
+    }
+
+    // so this should lint, cause no self parameter, can be called via <! as
+    // HasAsyncMethod>::do_something()
+    impl crate::HasAsyncMethod for ! {
+        fn do_something() -> impl Future<Output = u32> {
+            //~^ unused_async_trait_impl
+            std::future::ready(1)
         }
     }
 }

--- a/tests/ui/unused_async_trait_impl.rs
+++ b/tests/ui/unused_async_trait_impl.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::unused_async_trait_impl)]
+#![feature(never_type)]
 
 trait HasAsyncMethod {
     async fn do_something() -> u32;
@@ -115,7 +116,6 @@ mod issue17179 {
         async fn do_something() -> u32 {
             //~^ unused_async_trait_impl
 
-            // Test that local functions are not touched by the suggestion.
             fn local_func() -> u32 {
                 if 5 == 2 {
                     return 1;
@@ -123,7 +123,6 @@ mod issue17179 {
                 2
             }
 
-            // Test that we do not change the tail expr or return in a (unrelated) closure.
             let f = || {
                 if 5 == 2 {
                     return 1;
@@ -131,12 +130,32 @@ mod issue17179 {
                 2
             };
 
-            // However the following return statement and tail expression should be changed.
             if f() == 5 {
                 return 3;
             }
 
             5
+        }
+    }
+}
+
+mod issue17162 {
+    trait AsyncTraitWithSelf {
+        async fn do_something(&self) -> u32;
+    }
+
+    impl AsyncTraitWithSelf for ! {
+        async fn do_something(&self) -> u32 {
+            unreachable!()
+        }
+    }
+
+    // so this should lint, cause no self parameter, can be called via <! as
+    // HasAsyncMethod>::do_something()
+    impl crate::HasAsyncMethod for ! {
+        async fn do_something() -> u32 {
+            //~^ unused_async_trait_impl
+            1
         }
     }
 }

--- a/tests/ui/unused_async_trait_impl.stderr
+++ b/tests/ui/unused_async_trait_impl.stderr
@@ -1,5 +1,5 @@
 error: unused `async` for async trait impl function with no `.await` statements
-  --> tests/ui/unused_async_trait_impl.rs:16:9
+  --> tests/ui/unused_async_trait_impl.rs:17:9
    |
 LL | /         async fn do_something() -> u32 {
 LL | |
@@ -18,7 +18,7 @@ LL ~             std::future::ready(1)
    |
 
 error: unused `async` for async trait impl function with no `.await` statements
-  --> tests/ui/unused_async_trait_impl.rs:40:9
+  --> tests/ui/unused_async_trait_impl.rs:41:9
    |
 LL | /         async fn do_something() -> u32 {
 LL | |
@@ -40,7 +40,7 @@ LL ~             std::future::ready(x)
    |
 
 error: unused `async` for async trait impl function with no `.await` statements
-  --> tests/ui/unused_async_trait_impl.rs:63:9
+  --> tests/ui/unused_async_trait_impl.rs:64:9
    |
 LL | /         async fn do_something() -> u32 {
 LL | |
@@ -57,7 +57,7 @@ LL ~             std::future::ready(5)
    |
 
 error: unused `async` for async trait impl function with no `.await` statements
-  --> tests/ui/unused_async_trait_impl.rs:97:9
+  --> tests/ui/unused_async_trait_impl.rs:98:9
    |
 LL | /         async fn do_something() -> vec_ty!(u32) {
 LL | |
@@ -74,7 +74,7 @@ LL ~             std::future::ready(Vec::new())
    |
 
 error: unused `async` for async trait impl function with no `.await` statements
-  --> tests/ui/unused_async_trait_impl.rs:104:9
+  --> tests/ui/unused_async_trait_impl.rs:105:9
    |
 LL | /         async fn do_something() -> Vec<u32> {
 LL | |
@@ -91,9 +91,12 @@ LL ~             std::future::ready(vec![])
    |
 
 error: unused `async` for async trait impl function with no `.await` statements
-  --> tests/ui/unused_async_trait_impl.rs:115:9
+  --> tests/ui/unused_async_trait_impl.rs:116:9
    |
 LL | /         async fn do_something() -> u32 {
+LL | |
+LL | |
+LL | |             fn local_func() -> u32 {
 ...  |
 LL | |             5
 LL | |         }
@@ -112,5 +115,22 @@ LL |
 LL ~             std::future::ready(5)
    |
 
-error: aborting due to 6 previous errors
+error: unused `async` for async trait impl function with no `.await` statements
+  --> tests/ui/unused_async_trait_impl.rs:156:9
+   |
+LL | /         async fn do_something() -> u32 {
+LL | |
+LL | |             1
+LL | |         }
+   | |_________^
+   |
+   = note: `std::future::ready` creates a `Future` which returns the value immediately when `poll`ed
+help: consider removing the `async` from this function and returning `impl Future<Output = u32>` instead
+   |
+LL ~         fn do_something() -> impl Future<Output = u32> {
+LL |
+LL ~             std::future::ready(1)
+   |
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17163)*

Do not lint `unused_async_trait_impl` for `impl Trait for !` blocks.

The never type `!` can never be instantiated, so any method implemented
for it can never be called. Flagging these as having an "unused async"
is a false positive since the async keyword has no practical impact.

fixes rust-lang/rust-clippy#17162

changelog: [`unused_async_trait_impl`]: do not lint when the trait is implemented for the never type `!`

I ran the tests locally and pass, also did uibless and formatted the code