### PR TITLE
feat: extract `stack-array-size-threshold` conf from `array-size-threshold`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7740,6 +7740,7 @@ Released 2018-09-13
 [`semicolon-outside-block-ignore-multiline`]: https://doc.rust-lang.org/clippy/lint_configuration.html#semicolon-outside-block-ignore-multiline
 [`single-char-binding-names-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#single-char-binding-names-threshold
 [`source-item-ordering`]: https://doc.rust-lang.org/clippy/lint_configuration.html#source-item-ordering
+[`stack-array-size-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#stack-array-size-threshold
 [`stack-size-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#stack-size-threshold
 [`standard-macro-braces`]: https://doc.rust-lang.org/clippy/lint_configuration.html#standard-macro-braces
 [`struct-field-name-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#struct-field-name-threshold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7741,6 +7741,7 @@ Released 2018-09-13
 [`semicolon-outside-block-ignore-multiline`]: https://doc.rust-lang.org/clippy/lint_configuration.html#semicolon-outside-block-ignore-multiline
 [`single-char-binding-names-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#single-char-binding-names-threshold
 [`source-item-ordering`]: https://doc.rust-lang.org/clippy/lint_configuration.html#source-item-ordering
+[`stack-array-size-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#stack-array-size-threshold
 [`stack-size-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#stack-size-threshold
 [`standard-macro-braces`]: https://doc.rust-lang.org/clippy/lint_configuration.html#standard-macro-braces
 [`struct-field-name-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#struct-field-name-threshold

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -394,7 +394,7 @@ arithmetic-side-effects-allowed-unary = ["SomeType", "AnotherType"]
 
 
 ## `array-size-threshold`
-The maximum allowed size for arrays on the stack
+The maximum allowed size for const arrays
 
 **Default Value:** `16384`
 
@@ -1089,6 +1089,16 @@ Which kind of elements should be ordered internally, possible values being `enum
 ---
 **Affected lints:**
 * [`arbitrary_source_item_ordering`](https://rust-lang.github.io/rust-clippy/main/index.html#arbitrary_source_item_ordering)
+
+
+## `stack-array-size-threshold`
+The maximum allowed size for arrays on the stack
+
+**Default Value:** `16384`
+
+---
+**Affected lints:**
+* [`large_stack_arrays`](https://rust-lang.github.io/rust-clippy/master/index.html#large_stack_arrays)
 
 
 ## `stack-size-threshold`

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -401,7 +401,6 @@ The maximum allowed size for const arrays
 ---
 **Affected lints:**
 * [`large_const_arrays`](https://rust-lang.github.io/rust-clippy/main/index.html#large_const_arrays)
-* [`large_stack_arrays`](https://rust-lang.github.io/rust-clippy/main/index.html#large_stack_arrays)
 
 
 ## `avoid-breaking-exported-api`
@@ -1098,7 +1097,7 @@ The maximum allowed size for arrays on the stack
 
 ---
 **Affected lints:**
-* [`large_stack_arrays`](https://rust-lang.github.io/rust-clippy/master/index.html#large_stack_arrays)
+* [`large_stack_arrays`](https://rust-lang.github.io/rust-clippy/main/index.html#large_stack_arrays)
 
 
 ## `stack-size-threshold`

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -394,14 +394,13 @@ arithmetic-side-effects-allowed-unary = ["SomeType", "AnotherType"]
 
 
 ## `array-size-threshold`
-The maximum allowed size for arrays on the stack
+The maximum allowed size for const arrays
 
 **Default Value:** `16384`
 
 ---
 **Affected lints:**
 * [`large_const_arrays`](https://rust-lang.github.io/rust-clippy/master/index.html#large_const_arrays)
-* [`large_stack_arrays`](https://rust-lang.github.io/rust-clippy/master/index.html#large_stack_arrays)
 
 
 ## `avoid-breaking-exported-api`
@@ -1089,6 +1088,16 @@ Which kind of elements should be ordered internally, possible values being `enum
 ---
 **Affected lints:**
 * [`arbitrary_source_item_ordering`](https://rust-lang.github.io/rust-clippy/master/index.html#arbitrary_source_item_ordering)
+
+
+## `stack-array-size-threshold`
+The maximum allowed size for arrays on the stack
+
+**Default Value:** `16384`
+
+---
+**Affected lints:**
+* [`large_stack_arrays`](https://rust-lang.github.io/rust-clippy/master/index.html#large_stack_arrays)
 
 
 ## `stack-size-threshold`

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -390,9 +390,9 @@ define_Conf! {
     /// ```
     #[lints(arithmetic_side_effects)]
     arithmetic_side_effects_allowed_unary("arithmetic-side-effects-allowed-unary"): Vec<String>,
-    /// The maximum allowed size for arrays on the stack
-    #[lints(large_const_arrays, large_stack_arrays)]
-    array_size_threshold("array-size-threshold"): u64 = 16 * 1024,
+    /// The maximum allowed size for const arrays
+    #[lints(large_const_arrays)]
+    array_size_threshold: u64 = 16 * 1024,
     /// Suppress lints whenever the suggested change would cause breakage for other crates.
     #[lints(
         box_collection,
@@ -748,6 +748,9 @@ define_Conf! {
     /// Which kind of elements should be ordered internally, possible values being `enum`, `impl`, `module`, `struct`, `trait`.
     #[lints(arbitrary_source_item_ordering)]
     source_item_ordering("source-item-ordering"): SourceItemOrdering,
+    /// The maximum allowed size for arrays on the stack
+    #[lints(large_stack_arrays)]
+    stack_array_size_threshold: u64 = 16 * 1024,
     /// The maximum allowed stack size for functions in bytes
     #[lints(large_stack_frames)]
     stack_size_threshold("stack-size-threshold"): u64 = 512_000,

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -392,7 +392,7 @@ define_Conf! {
     arithmetic_side_effects_allowed_unary("arithmetic-side-effects-allowed-unary"): Vec<String>,
     /// The maximum allowed size for const arrays
     #[lints(large_const_arrays)]
-    array_size_threshold: u64 = 16 * 1024,
+    array_size_threshold("array-size-threshold"): u64 = 16 * 1024,
     /// Suppress lints whenever the suggested change would cause breakage for other crates.
     #[lints(
         box_collection,
@@ -750,7 +750,7 @@ define_Conf! {
     source_item_ordering("source-item-ordering"): SourceItemOrdering,
     /// The maximum allowed size for arrays on the stack
     #[lints(large_stack_arrays)]
-    stack_array_size_threshold: u64 = 16 * 1024,
+    stack_array_size_threshold("stack-array-size-threshold"): u64 = 16 * 1024,
     /// The maximum allowed stack size for functions in bytes
     #[lints(large_stack_frames)]
     stack_size_threshold("stack-size-threshold"): u64 = 512_000,

--- a/clippy_lints/src/large_stack_arrays.rs
+++ b/clippy_lints/src/large_stack_arrays.rs
@@ -40,7 +40,7 @@ pub struct LargeStackArrays {
 impl LargeStackArrays {
     pub fn new(conf: &'static Conf) -> Self {
         Self {
-            maximum_allowed_size: conf.array_size_threshold,
+            maximum_allowed_size: conf.stack_array_size_threshold,
             prev_vec_macro_callsite: None,
             const_item_counter: Saturating(0),
         }

--- a/tests/ui-toml/array_size_threshold/array_size_threshold.rs
+++ b/tests/ui-toml/array_size_threshold/array_size_threshold.rs
@@ -1,11 +1,7 @@
-#![warn(clippy::large_const_arrays, clippy::large_stack_arrays)]
+#![warn(clippy::large_const_arrays)]
 //@no-rustfix
 const ABOVE: [u8; 11] = [0; 11];
 //~^ large_const_arrays
 const BELOW: [u8; 10] = [0; 10];
 
-fn main() {
-    let above = [0u8; 11];
-    //~^ large_stack_arrays
-    let below = [0u8; 10];
-}
+fn main() {}

--- a/tests/ui-toml/array_size_threshold/array_size_threshold.stderr
+++ b/tests/ui-toml/array_size_threshold/array_size_threshold.stderr
@@ -9,15 +9,5 @@ LL | const ABOVE: [u8; 11] = [0; 11];
    = note: `-D clippy::large-const-arrays` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::large_const_arrays)]`
 
-error: allocating a local array larger than 10 bytes
-  --> tests/ui-toml/array_size_threshold/array_size_threshold.rs:8:17
-   |
-LL |     let above = [0u8; 11];
-   |                 ^^^^^^^^^
-   |
-   = help: consider allocating on the heap with `vec![0u8; 11].into_boxed_slice()`
-   = note: `-D clippy::large-stack-arrays` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::large_stack_arrays)]`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui-toml/stack_array_size_threshold/clippy.toml
+++ b/tests/ui-toml/stack_array_size_threshold/clippy.toml
@@ -1,0 +1,1 @@
+stack-array-size-threshold = 10

--- a/tests/ui-toml/stack_array_size_threshold/stack_array_size_threshold.rs
+++ b/tests/ui-toml/stack_array_size_threshold/stack_array_size_threshold.rs
@@ -1,0 +1,7 @@
+#![warn(clippy::large_stack_arrays)]
+
+fn main() {
+    let above = [0u8; 11];
+    //~^ large_stack_arrays
+    let below = [0u8; 10];
+}

--- a/tests/ui-toml/stack_array_size_threshold/stack_array_size_threshold.stderr
+++ b/tests/ui-toml/stack_array_size_threshold/stack_array_size_threshold.stderr
@@ -1,0 +1,12 @@
+error: allocating a local array larger than 10 bytes
+  --> tests/ui-toml/stack_array_size_threshold/stack_array_size_threshold.rs:4:17
+   |
+LL |     let above = [0u8; 11];
+   |                 ^^^^^^^^^
+   |
+   = help: consider allocating on the heap with `vec![0u8; 11].into_boxed_slice()`
+   = note: `-D clippy::large-stack-arrays` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::large_stack_arrays)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -84,6 +84,7 @@ LL | foobar = 42
            semicolon-outside-block-ignore-multiline
            single-char-binding-names-threshold
            source-item-ordering
+           stack-array-size-threshold
            stack-size-threshold
            standard-macro-braces
            struct-field-name-threshold


### PR DESCRIPTION
Extract `stack-array-size-threshold` conf from `array-size-threshold`. It allows tuning `array-size-threshold` config value without changing `large_stack_arrays` lint behaviour.

Refers rust-lang/rust-clippy#17074

changelog: [`large_const_arrays`]: introduce `stack-array-size-threshold` configuration

