### PR TITLE
needless_borrow: same-name methods false positive

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -2,7 +2,9 @@ use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_hir_and_then};
 use clippy_utils::res::MaybeResPath;
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use clippy_utils::sugg::has_enclosing_paren;
-use clippy_utils::ty::{adjust_derefs_manually_drop, implements_trait, is_manually_drop, peel_and_count_ty_refs};
+use clippy_utils::ty::{
+    adjust_derefs_manually_drop, get_adt_inherent_method, implements_trait, is_manually_drop, peel_and_count_ty_refs,
+};
 use clippy_utils::{
     DefinedTy, ExprUseNode, get_expr_use_site, get_parent_expr, is_block_like, is_from_proc_macro, is_lint_allowed, sym,
 };
@@ -17,7 +19,7 @@ use rustc_hir::{
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, AutoBorrowMutability};
-use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt, TypeckResults, Unnormalized};
+use rustc_middle::ty::{self, AssocTag, Ty, TyCtxt, TypeVisitableExt, TypeckResults, Unnormalized};
 use rustc_session::impl_lint_pass;
 use rustc_span::{Span, Symbol, SyntaxContext};
 use std::borrow::Cow;
@@ -368,12 +370,13 @@ impl<'tcx> LateLintPass<'tcx> for Dereferencing<'tcx> {
                             },
                             ExprUseNode::Callee | ExprUseNode::FieldAccess(_) if !use_site.moved_before_use => true,
                             ExprUseNode::MethodArg(hir_id, _, 0) if !use_site.moved_before_use => {
-                                // Check for calls to trait methods where the trait is implemented
-                                // on a reference.
-                                // Two cases need to be handled:
+                                // Check for calls to trait methods where auto-borrow will not resolve.
+                                // Three cases need to be handled:
                                 // * `self` methods on `&T` will never have auto-borrow
                                 // * `&self` methods on `&T` can have auto-borrow, but `&self` methods on `T` will take
                                 //   priority.
+                                // * `&self` methods on `T` can have auto-borrow, but if there's another method with the
+                                //   same name, it may take priority.
                                 if let Some(fn_id) = typeck.type_dependent_def_id(hir_id)
                                     && let Some(trait_id) = cx.tcx.trait_of_assoc(fn_id)
                                     && let arg_ty = cx.tcx.erase_and_anonymize_regions(adjusted_ty)
@@ -395,12 +398,42 @@ impl<'tcx> LateLintPass<'tcx> for Dereferencing<'tcx> {
                                         // Trait methods taking `self`
                                         arg_ty
                                     }
-                                    && impl_ty.is_ref()
-                                    && implements_trait(
-                                        cx,
-                                        impl_ty,
-                                        trait_id,
-                                        &args[..cx.tcx.generics_of(trait_id).own_params.len() - 1],
+                                    && let method_name = cx.tcx.item_name(fn_id)
+                                    && (
+                                        // If this trait impl is implemented on `&T`, then auto-borrowing won't work
+                                        (impl_ty.is_ref()
+                                        && implements_trait(
+                                            cx,
+                                            impl_ty,
+                                            trait_id,
+                                            &args[..cx.tcx.generics_of(trait_id).own_params.len() - 1],
+                                        ))
+                                        // If there's an inherent method, or a method from another trait,
+                                        // with the same name that's also implemented on this same type,
+                                        // then removing the borrow might cause that method to be chosen
+                                        // instead of the current one.
+                                        || get_adt_inherent_method(cx, impl_ty, method_name).is_some()
+                                        || cx.tcx.in_scope_traits(hir_id).is_some_and(|traits| {
+                                            traits
+                                                .iter()
+                                                .filter(|trait_| {
+                                                    cx.tcx
+                                                        .non_blanket_impls_for_ty(trait_.def_id, impl_ty)
+                                                        .next()
+                                                        .is_some()
+                                                        || !cx
+                                                            .tcx
+                                                            .trait_impls_of(trait_.def_id)
+                                                            .blanket_impls()
+                                                            .is_empty()
+                                                })
+                                                .any(|trait_| {
+                                                    cx.tcx
+                                                        .associated_items(trait_.def_id)
+                                                        .filter_by_name_unhygienic(method_name)
+                                                        .any(|item| item.tag() == AssocTag::Fn && item.def_id != fn_id)
+                                                })
+                                        })
                                     )
                                 {
                                     false

--- a/tests/ui/needless_borrow_false_positive_16200.fixed
+++ b/tests/ui/needless_borrow_false_positive_16200.fixed
@@ -1,0 +1,38 @@
+trait Trait {
+    fn run(&self);
+}
+
+struct Test;
+impl Test {
+    fn run(self, x: f32) {}
+}
+impl Trait for Test {
+    fn run(&self) {}
+}
+
+struct Test2;
+trait Trait2: Sized {
+    fn run(self, _x: f32) {}
+}
+impl Trait2 for Test2 {
+    fn run(self, _x: f32) {}
+}
+impl Trait for Test2 {
+    fn run(&self) {}
+}
+
+struct Test3;
+impl Trait for Test3 {
+    fn run(&self) {}
+}
+
+fn main() {
+    (&Test).run();
+    (&Test).run(); //~ needless_borrow
+
+    (&Test2).run();
+    (&Test2).run(); //~ needless_borrow
+
+    Test3.run(); //~ needless_borrow
+    Test3.run(); //~ needless_borrow
+}

--- a/tests/ui/needless_borrow_false_positive_16200.rs
+++ b/tests/ui/needless_borrow_false_positive_16200.rs
@@ -1,0 +1,38 @@
+trait Trait {
+    fn run(&self);
+}
+
+struct Test;
+impl Test {
+    fn run(self, x: f32) {}
+}
+impl Trait for Test {
+    fn run(&self) {}
+}
+
+struct Test2;
+trait Trait2: Sized {
+    fn run(self, _x: f32) {}
+}
+impl Trait2 for Test2 {
+    fn run(self, _x: f32) {}
+}
+impl Trait for Test2 {
+    fn run(&self) {}
+}
+
+struct Test3;
+impl Trait for Test3 {
+    fn run(&self) {}
+}
+
+fn main() {
+    (&Test).run();
+    (&&Test).run(); //~ needless_borrow
+
+    (&Test2).run();
+    (&&Test2).run(); //~ needless_borrow
+
+    (&Test3).run(); //~ needless_borrow
+    (&&Test3).run(); //~ needless_borrow
+}

--- a/tests/ui/needless_borrow_false_positive_16200.stderr
+++ b/tests/ui/needless_borrow_false_positive_16200.stderr
@@ -1,0 +1,29 @@
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> tests/ui/needless_borrow_false_positive_16200.rs:31:5
+   |
+LL |     (&&Test).run();
+   |     ^^^^^^^^ help: change this to: `(&Test)`
+   |
+   = note: `-D clippy::needless-borrow` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::needless_borrow)]`
+
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> tests/ui/needless_borrow_false_positive_16200.rs:34:5
+   |
+LL |     (&&Test2).run();
+   |     ^^^^^^^^^ help: change this to: `(&Test2)`
+
+error: this expression borrows a value the compiler would automatically borrow
+  --> tests/ui/needless_borrow_false_positive_16200.rs:36:5
+   |
+LL |     (&Test3).run();
+   |     ^^^^^^^^ help: change this to: `Test3`
+
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> tests/ui/needless_borrow_false_positive_16200.rs:37:5
+   |
+LL |     (&&Test3).run();
+   |     ^^^^^^^^^ help: change this to: `Test3`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This fix checks for methods that have the same name as the current one, that are also implemented on the base type. If there is any, it knows that auto-borrowing might prefer that method.

changelog: [`needless_borrow`]: same-name methods false positive

Fixes rust-lang/rust-clippy#16200