### PR TITLE
`iter_cloned_collect`: split off the suggestion from the main message

### DIFF
--- a/clippy_lints/src/methods/iter_cloned_collect.rs
+++ b/clippy_lints/src/methods/iter_cloned_collect.rs
@@ -12,10 +12,10 @@ use super::ITER_CLONED_COLLECT;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, method_name: Symbol, expr: &Expr<'_>, recv: &'tcx Expr<'_>) {
     let expr_ty = cx.typeck_results().expr_ty(expr);
-    if expr_ty.is_diag_item(cx, sym::Vec)
+    if let ty::Adt(def, args) = expr_ty.kind()
+        && def.is_diag_item(cx, sym::Vec)
         && let recv_ty = cx.typeck_results().expr_ty(recv)
         && let Some(slice) = derefs_to_slice(cx, recv, recv_ty)
-        && let ty::Adt(_, args) = expr_ty.kind()
         && let Some(iter_item_ty) = get_iterator_item_ty(cx, recv_ty)
         && let ty::Ref(_, iter_item_ty, _) = iter_item_ty.kind()
         && *iter_item_ty == args.type_at(0)

--- a/clippy_lints/src/methods/iter_cloned_collect.rs
+++ b/clippy_lints/src/methods/iter_cloned_collect.rs
@@ -1,5 +1,5 @@
 use crate::methods::utils::derefs_to_slice;
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::MaybeDef;
 use clippy_utils::ty::get_iterator_item_ty;
 use rustc_errors::Applicability;
@@ -21,17 +21,19 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, method_name: Symbol, expr: &Ex
         && *iter_item_ty == args.type_at(0)
         && let Some(to_replace) = expr.span.trim_start(slice.span.source_callsite())
     {
-        span_lint_and_sugg(
+        span_lint_and_then(
             cx,
             ITER_CLONED_COLLECT,
             to_replace,
-            format!(
-                "called `iter().{method_name}().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and \
-            more readable"
-            ),
-            "try",
-            ".to_vec()".to_string(),
-            Applicability::MachineApplicable,
+            format!("called `.iter().{method_name}().collect()` on a slice to create a `Vec`"),
+            |diag| {
+                diag.span_suggestion_verbose(
+                    to_replace,
+                    "calling `.to_vec()` is both faster and more readable",
+                    ".to_vec()",
+                    Applicability::MachineApplicable,
+                );
+            },
         );
     }
 }

--- a/clippy_lints/src/methods/iter_cloned_collect.rs
+++ b/clippy_lints/src/methods/iter_cloned_collect.rs
@@ -3,24 +3,20 @@ use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::res::MaybeDef;
 use clippy_utils::ty::get_iterator_item_ty;
 use rustc_errors::Applicability;
-use rustc_hir as hir;
+use rustc_hir::Expr;
 use rustc_lint::LateContext;
 use rustc_middle::ty;
 use rustc_span::{Symbol, sym};
 
 use super::ITER_CLONED_COLLECT;
 
-pub(super) fn check<'tcx>(
-    cx: &LateContext<'tcx>,
-    method_name: Symbol,
-    expr: &hir::Expr<'_>,
-    recv: &'tcx hir::Expr<'_>,
-) {
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, method_name: Symbol, expr: &Expr<'_>, recv: &'tcx Expr<'_>) {
     let expr_ty = cx.typeck_results().expr_ty(expr);
     if expr_ty.is_diag_item(cx, sym::Vec)
-        && let Some(slice) = derefs_to_slice(cx, recv, cx.typeck_results().expr_ty(recv))
+        && let recv_ty = cx.typeck_results().expr_ty(recv)
+        && let Some(slice) = derefs_to_slice(cx, recv, recv_ty)
         && let ty::Adt(_, args) = expr_ty.kind()
-        && let Some(iter_item_ty) = get_iterator_item_ty(cx, cx.typeck_results().expr_ty(recv))
+        && let Some(iter_item_ty) = get_iterator_item_ty(cx, recv_ty)
         && let ty::Ref(_, iter_item_ty, _) = iter_item_ty.kind()
         && *iter_item_ty == args.type_at(0)
         && let Some(to_replace) = expr.span.trim_start(slice.span.source_callsite())

--- a/tests/ui/iter_cloned_collect.stderr
+++ b/tests/ui/iter_cloned_collect.stderr
@@ -1,19 +1,30 @@
-error: called `iter().cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+error: called `.iter().cloned().collect()` on a slice to create a `Vec`
   --> tests/ui/iter_cloned_collect.rs:8:27
    |
 LL |     let v2: Vec<isize> = v.iter().cloned().collect();
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::iter-cloned-collect` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::iter_cloned_collect)]`
+help: calling `.to_vec()` is both faster and more readable
+   |
+LL -     let v2: Vec<isize> = v.iter().cloned().collect();
+LL +     let v2: Vec<isize> = v.to_vec();
+   |
 
-error: called `iter().cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+error: called `.iter().cloned().collect()` on a slice to create a `Vec`
   --> tests/ui/iter_cloned_collect.rs:14:38
    |
 LL |     let _: Vec<isize> = vec![1, 2, 3].iter().cloned().collect();
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: calling `.to_vec()` is both faster and more readable
+   |
+LL -     let _: Vec<isize> = vec![1, 2, 3].iter().cloned().collect();
+LL +     let _: Vec<isize> = vec![1, 2, 3].to_vec();
+   |
 
-error: called `iter().cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+error: called `.iter().cloned().collect()` on a slice to create a `Vec`
   --> tests/ui/iter_cloned_collect.rs:20:24
    |
 LL |               .to_bytes()
@@ -22,25 +33,53 @@ LL | |
 LL | |             .iter()
 LL | |             .cloned()
 LL | |             .collect();
-   | |______________________^ help: try: `.to_vec()`
+   | |______________________^
+   |
+help: calling `.to_vec()` is both faster and more readable
+   |
+LL -             .to_bytes()
+LL -
+LL -             .iter()
+LL -             .cloned()
+LL -             .collect();
+LL +             .to_bytes().to_vec();
+   |
 
-error: called `iter().cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+error: called `.iter().cloned().collect()` on a slice to create a `Vec`
   --> tests/ui/iter_cloned_collect.rs:29:24
    |
 LL |     let _: Vec<_> = arr.iter().cloned().collect();
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: calling `.to_vec()` is both faster and more readable
+   |
+LL -     let _: Vec<_> = arr.iter().cloned().collect();
+LL +     let _: Vec<_> = arr.to_vec();
+   |
 
-error: called `iter().copied().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+error: called `.iter().copied().collect()` on a slice to create a `Vec`
   --> tests/ui/iter_cloned_collect.rs:33:26
    |
 LL |     let _: Vec<isize> = v.iter().copied().collect();
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: calling `.to_vec()` is both faster and more readable
+   |
+LL -     let _: Vec<isize> = v.iter().copied().collect();
+LL +     let _: Vec<isize> = v.to_vec();
+   |
 
-error: called `iter().cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+error: called `.iter().cloned().collect()` on a slice to create a `Vec`
   --> tests/ui/iter_cloned_collect.rs:59:33
    |
 LL |         let v: Vec<&&String> = a.iter().cloned().collect();
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: calling `.to_vec()` is both faster and more readable
+   |
+LL -         let v: Vec<&&String> = a.iter().cloned().collect();
+LL +         let v: Vec<&&String> = a.to_vec();
+   |
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Also use verbose suggestion, because just suggesting `: .to_vec()` isn't very clear

changelog: none