### PR TITLE
`infallible_destructuring_match`: clean-up, split off the suggestion from the main message

### DIFF
--- a/clippy_lints/src/matches/infallible_destructuring_match.rs
+++ b/clippy_lints/src/matches/infallible_destructuring_match.rs
@@ -11,13 +11,11 @@ use super::INFALLIBLE_DESTRUCTURING_MATCH;
 pub(crate) fn check(cx: &LateContext<'_>, local: &LetStmt<'_>) -> bool {
     if !local.span.from_expansion()
         && let Some(expr) = local.init
-        && let ExprKind::Match(target, arms, MatchSource::Normal) = expr.kind
-        && arms.len() == 1
-        && arms[0].guard.is_none()
-        && let PatKind::TupleStruct(QPath::Resolved(None, variant_name), args, _) = arms[0].pat.kind
-        && args.len() == 1
-        && let PatKind::Binding(binding, arg, ..) = strip_pat_refs(&args[0]).kind
-        && let body = peel_blocks(arms[0].body)
+        && let ExprKind::Match(target, [arm], MatchSource::Normal) = expr.kind
+        && arm.guard.is_none()
+        && let PatKind::TupleStruct(QPath::Resolved(None, variant_name), [arg], _) = arm.pat.kind
+        && let PatKind::Binding(binding, arg, ..) = strip_pat_refs(arg).kind
+        && let body = peel_blocks(arm.body)
         && body.res_local_id() == Some(arg)
     {
         let mut applicability = Applicability::MachineApplicable;

--- a/clippy_lints/src/matches/infallible_destructuring_match.rs
+++ b/clippy_lints/src/matches/infallible_destructuring_match.rs
@@ -9,14 +9,23 @@ use rustc_lint::LateContext;
 use super::INFALLIBLE_DESTRUCTURING_MATCH;
 
 pub(crate) fn check(cx: &LateContext<'_>, local: &LetStmt<'_>) -> bool {
+    // turn this:
+    //
+    // let local = match target {
+    //     Variant(binding arg) => { arg }
+    // };
+    //
+    // into this:
+    //
+    // let Variant(binding local) = target;
     if !local.span.from_expansion()
         && let Some(expr) = local.init
         && let ExprKind::Match(target, [arm], MatchSource::Normal) = expr.kind
         && arm.guard.is_none()
-        && let PatKind::TupleStruct(QPath::Resolved(None, variant_name), [arg], _) = arm.pat.kind
-        && let PatKind::Binding(binding, arg, ..) = strip_pat_refs(arg).kind
-        && let body = peel_blocks(arm.body)
-        && body.res_local_id() == Some(arg)
+        && let PatKind::TupleStruct(QPath::Resolved(None, variant_name), [arg_lhs], _) = arm.pat.kind
+        && let PatKind::Binding(binding, arg_lhs, ..) = strip_pat_refs(arg_lhs).kind
+        && let arg_rhs = peel_blocks(arm.body)
+        && Some(arg_lhs) == arg_rhs.res_local_id()
     {
         let mut applicability = Applicability::MachineApplicable;
         span_lint_and_sugg(

--- a/clippy_lints/src/matches/infallible_destructuring_match.rs
+++ b/clippy_lints/src/matches/infallible_destructuring_match.rs
@@ -32,9 +32,8 @@ pub(crate) fn check(cx: &LateContext<'_>, local: &LetStmt<'_>) -> bool {
             cx,
             INFALLIBLE_DESTRUCTURING_MATCH,
             local.span,
-            "you seem to be trying to use `match` to destructure a single infallible pattern. \
-            Consider using `let`",
-            "try",
+            "you seem to be trying to use `match` to destructure a single infallible pattern",
+            "consider using `let`",
             format!(
                 "let {}({}{}) = {};",
                 snippet_with_applicability(cx, variant_name.span, "..", &mut applicability),

--- a/tests/ui/infallible_destructuring_match.stderr
+++ b/tests/ui/infallible_destructuring_match.stderr
@@ -1,41 +1,41 @@
-error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
+error: you seem to be trying to use `match` to destructure a single infallible pattern
   --> tests/ui/infallible_destructuring_match.rs:27:5
    |
 LL | /     let data = match wrapper {
 LL | |
 LL | |         SingleVariantEnum::Variant(i) => i,
 LL | |     };
-   | |______^ help: try: `let SingleVariantEnum::Variant(data) = wrapper;`
+   | |______^ help: consider using `let`: `let SingleVariantEnum::Variant(data) = wrapper;`
    |
    = note: `-D clippy::infallible-destructuring-match` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::infallible_destructuring_match)]`
 
-error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
+error: you seem to be trying to use `match` to destructure a single infallible pattern
   --> tests/ui/infallible_destructuring_match.rs:60:5
    |
 LL | /     let data = match wrapper {
 LL | |
 LL | |         TupleStruct(i) => i,
 LL | |     };
-   | |______^ help: try: `let TupleStruct(data) = wrapper;`
+   | |______^ help: consider using `let`: `let TupleStruct(data) = wrapper;`
 
-error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
+error: you seem to be trying to use `match` to destructure a single infallible pattern
   --> tests/ui/infallible_destructuring_match.rs:85:5
    |
 LL | /     let data = match wrapper {
 LL | |
 LL | |         TupleStructWithNonCopy(ref n) => n,
 LL | |     };
-   | |______^ help: try: `let TupleStructWithNonCopy(ref data) = wrapper;`
+   | |______^ help: consider using `let`: `let TupleStructWithNonCopy(ref data) = wrapper;`
 
-error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
+error: you seem to be trying to use `match` to destructure a single infallible pattern
   --> tests/ui/infallible_destructuring_match.rs:105:5
    |
 LL | /     let data = match wrapper {
 LL | |
 LL | |         Ok(i) => i,
 LL | |     };
-   | |______^ help: try: `let Ok(data) = wrapper;`
+   | |______^ help: consider using `let`: `let Ok(data) = wrapper;`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
changelog: none