### PR TITLE
Avoid clone_on_copy for static-only Copy impls

### DIFF
--- a/clippy_lints/src/methods/clone_on_copy.rs
+++ b/clippy_lints/src/methods/clone_on_copy.rs
@@ -4,11 +4,31 @@ use clippy_utils::ty::is_copy;
 use rustc_errors::Applicability;
 use rustc_hir::{BindingMode, ByRef, Expr, ExprKind, MatchSource, Node, PatKind};
 use rustc_lint::LateContext;
-use rustc_middle::ty;
 use rustc_middle::ty::adjustment::Adjust;
 use rustc_middle::ty::print::with_forced_trimmed_paths;
+use rustc_middle::ty::{self, GenericArgKind, Ty, TypeVisitableExt};
 
 use super::CLONE_ON_COPY;
+
+fn copy_impl_self_ty_has_static_region<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    let Some(copy_trait) = cx.tcx.lang_items().copy_trait() else {
+        return false;
+    };
+
+    cx.tcx.non_blanket_impls_for_ty(copy_trait, ty).any(|impl_id| {
+        cx.tcx
+            .impl_trait_ref(impl_id)
+            .instantiate_identity()
+            .skip_norm_wip()
+            .self_ty()
+            .walk()
+            .any(|arg| matches!(arg.kind(), GenericArgKind::Lifetime(region) if region.is_static()))
+    })
+}
+
+fn copy_suggestion_may_require_static_region<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    ty.has_erased_regions() && copy_impl_self_ty_has_static_region(cx, ty)
+}
 
 /// Checks for the `CLONE_ON_COPY` lint.
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>) {
@@ -33,7 +53,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>) 
         return; // don't report clone_on_copy
     }
 
-    if is_copy(cx, ty) {
+    if is_copy(cx, ty) && !copy_suggestion_may_require_static_region(cx, ty) {
         let parent_is_suffix_expr = match cx.tcx.parent_hir_node(expr.hir_id) {
             Node::Expr(parent) => match parent.kind {
                 // &*x is a nop, &x.clone() is not

--- a/tests/ui/clone_on_copy.fixed
+++ b/tests/ui/clone_on_copy.fixed
@@ -121,3 +121,34 @@ fn issue9277() -> Option<i32> {
     //~^^ clone_on_copy
     None
 }
+
+#[allow(clippy::non_canonical_clone_impl)]
+mod issue15610 {
+    struct Weird<'a>(&'a i32);
+
+    impl Clone for Weird<'_> {
+        fn clone(&self) -> Self {
+            Weird(self.0)
+        }
+    }
+
+    impl Copy for Weird<'static> {}
+
+    impl Weird<'_> {
+        fn foo(&self) -> Self {
+            self.clone()
+        }
+    }
+}
+
+mod lifetime_generic_copy_still_lints {
+    #[derive(Clone, Copy)]
+    struct AlwaysCopy<'a>(&'a i32);
+
+    impl AlwaysCopy<'_> {
+        fn foo(&self) -> Self {
+            *self
+            //~^ clone_on_copy
+        }
+    }
+}

--- a/tests/ui/clone_on_copy.rs
+++ b/tests/ui/clone_on_copy.rs
@@ -121,3 +121,34 @@ fn issue9277() -> Option<i32> {
     //~^^ clone_on_copy
     None
 }
+
+#[allow(clippy::non_canonical_clone_impl)]
+mod issue15610 {
+    struct Weird<'a>(&'a i32);
+
+    impl Clone for Weird<'_> {
+        fn clone(&self) -> Self {
+            Weird(self.0)
+        }
+    }
+
+    impl Copy for Weird<'static> {}
+
+    impl Weird<'_> {
+        fn foo(&self) -> Self {
+            self.clone()
+        }
+    }
+}
+
+mod lifetime_generic_copy_still_lints {
+    #[derive(Clone, Copy)]
+    struct AlwaysCopy<'a>(&'a i32);
+
+    impl AlwaysCopy<'_> {
+        fn foo(&self) -> Self {
+            self.clone()
+            //~^ clone_on_copy
+        }
+    }
+}

--- a/tests/ui/clone_on_copy.stderr
+++ b/tests/ui/clone_on_copy.stderr
@@ -61,5 +61,11 @@ error: using `clone` on type `Option<i32>` which implements the `Copy` trait
 LL |     let value = opt.clone()?; // operator precedence needed (*opt)?
    |                 ^^^^^^^^^^^ help: try dereferencing it: `(*opt)`
 
-error: aborting due to 10 previous errors
+error: using `clone` on type `AlwaysCopy<'_>` which implements the `Copy` trait
+  --> tests/ui/clone_on_copy.rs:150:13
+   |
+LL |             self.clone()
+   |             ^^^^^^^^^^^^ help: try dereferencing it: `*self`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
changelog: Fix [`clone_on_copy`] false positive for lifetime-restricted `Copy` impls

Fixes rust-lang/rust-clippy#15610.

This prevents `clone_on_copy` from suggesting `*self` when the cloned type only appears to be `Copy` after regions are erased and the concrete `Copy` impl self type requires `'static`. In that case rustfix can produce code that fails borrow checking.

The change is intentionally scoped to `clone_on_copy`. The related `non_canonical_clone_impl` issue in rust-lang/rust-clippy#15577 has the same root cause, but is left as follow-up unless reviever want this PR expanded.

Validation:
- `TESTNAME=clone_on_copy cargo uitest`
- `cargo dev fmt --check`
- `git diff --check`
- `cargo check -p clippy_lints`
- `cargo dev dogfood` was attempted locally; it hit existing Windows-local blockers unrelated to this lint.