### PR TITLE
Do not lint when the two differing identifiers in a suspicious grouping

### DIFF
--- a/clippy_lints/src/suspicious_operation_groupings.rs
+++ b/clippy_lints/src/suspicious_operation_groupings.rs
@@ -167,6 +167,47 @@ fn check_binops(cx: &EarlyContext<'_>, binops: &[&BinaryOp<'_>]) {
                         // looking for.
                         return;
                     };
+                    // getting the idents of the double difference binop for example f(x) and g(y) we have x and y that we wanna search for later in the full expr
+                    let left_ident = if let Some(ident) = get_ident(binop.left, ident_loc2) {
+                        ident
+                    } else {
+                        return;
+                    };
+
+                    let right_ident = if let Some(ident) = get_ident(binop.right, ident_loc2) {
+                        ident
+                    } else {
+                        return;
+                    };
+                    //create iter of all binops vec and skip the first one of the cards.
+                    for (i, b) in binops.iter().enumerate() {
+                        if i == double_difference_index {
+                            continue;
+                        }
+                        // there is probably a better way to do this, but this is what i could come up with rn.
+                        let contains_left = IdentIter::from(b.left)
+                            .chain(IdentIter::from(b.right))
+                            .any(|id| eq_id(id, left_ident));
+
+                        let contains_right = IdentIter::from(b.left)
+                            .chain(IdentIter::from(b.right))
+                            .any(|id| eq_id(id, right_ident));
+                        // check if the idents match those of the double difference binop and if the operator is a comparison if yes we dont need to lint and return
+                        if contains_left
+                            && contains_right
+                            && matches!(
+                                b.op,
+                                BinOpKind::Ne
+                                    | BinOpKind::Eq
+                                    | BinOpKind::Lt
+                                    | BinOpKind::Gt
+                                    | BinOpKind::Le
+                                    | BinOpKind::Ge
+                            )
+                        {
+                            return;
+                        }
+                    }
 
                     if let Some(sugg) = ident_swap_sugg(cx, &paired_identifiers, binop, changed_loc, &mut applicability)
                     {

--- a/tests/ui/suspicious_operation_groupings.fixed
+++ b/tests/ui/suspicious_operation_groupings.fixed
@@ -227,10 +227,20 @@ fn maximum_unary_minus_right_tree(s1: &S, s2: &S) -> i32 {
     //~^ suspicious_operation_groupings
 }
 
+fn f(_: char) -> bool { true }
+fn g(_: char) -> bool { true }
+fn h() {
+    let x = 'b';
+    let y = 'r';
+    if f(x) && g(y) && x != y {}
+}
+
 fn unary_minus_and_an_if_expression(s1: &S, s2: &S) -> i32 {
     // There's no `s1.b`
     -(if -s1.a < -s2.a && -s1.b < -s2.b { s1.c } else { s2.a })
     //~^ suspicious_operation_groupings
 }
+
+
 
 fn main() {}

--- a/tests/ui/suspicious_operation_groupings.rs
+++ b/tests/ui/suspicious_operation_groupings.rs
@@ -227,6 +227,18 @@ fn maximum_unary_minus_right_tree(s1: &S, s2: &S) -> i32 {
     //~^ suspicious_operation_groupings
 }
 
+fn f(_: char) -> bool {
+    true
+}
+fn g(_: char) -> bool {
+    true
+}
+fn h() {
+    let x = 'b';
+    let y = 'r';
+    if f(x) && g(y) && x != y {}
+}
+
 fn unary_minus_and_an_if_expression(s1: &S, s2: &S) -> i32 {
     // There's no `s1.b`
     -(if -s1.a < -s2.a && -s1.a < -s2.b { s1.c } else { s2.a })

--- a/tests/ui/suspicious_operation_groupings.stderr
+++ b/tests/ui/suspicious_operation_groupings.stderr
@@ -152,7 +152,7 @@ LL |     -(-(-s1.a * -s2.a) + (-(-s1.b * -s2.b) + -(-s1.c * -s2.b) + -(-s1.d * -
    |                                                ^^^^^^^^^^^^^ help: did you mean: `-s1.c * -s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:232:27
+  --> tests/ui/suspicious_operation_groupings.rs:240:27
    |
 LL |     -(if -s1.a < -s2.a && -s1.a < -s2.b { s1.c } else { s2.a })
    |                           ^^^^^^^^^^^^^ help: did you mean: `-s1.b < -s2.b`


### PR DESCRIPTION
When `f(x) && g(y) && x != y` is written, the presence of `x != y`
proves the programmer intentionally used different variables. The lint
was incorrectly suggesting `f(x) && g(x)` as a fix.

Before emitting the suggestion, we now scan the rest of the binary op
chain for any comparison operator (`!=`, `==`, `<`, `>`, `<=`, `>=`)
that contains both of the differing identifiers. If found, the lint is
suppressed.

fixes rust-lang/rust-clippy#17143

changelog: [`suspicious_operation_groupings`]: do not lint when the differing identifiers are explicitly compared elsewhere in the same expression

probably a better way of handling this, but i couldnt figure out how to do it better performance/idiomatic and logic wise, sorry. 