### PR TITLE
`needless_bool` should handle logical and/or

### DIFF
--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -1,11 +1,11 @@
 use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg};
 use clippy_utils::source::snippet_with_context;
-use clippy_utils::sugg::Sugg;
+use clippy_utils::sugg::{Sugg, make_binop};
 use clippy_utils::{
     SpanlessEq, get_parent_expr, higher, is_block_like, is_else_clause, is_parent_stmt, is_receiver_of_method_call,
     peel_blocks, peel_blocks_with_stmt, span_contains_comment,
 };
-use rustc_ast::ast::LitKind;
+use rustc_ast::ast::{BinOpKind, LitKind};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -141,10 +141,43 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
                     applicability,
                 );
             };
-            if let Some(a) = fetch_bool_block(then)
-                && let Some(b) = fetch_bool_block(else_expr)
-            {
-                match (a, b) {
+            let reduce_mixed = |other: &Expr<'_>, negate_cond: bool, is_or: bool| {
+                let mut applicability = Applicability::MachineApplicable;
+                let cond_snip = Sugg::hir_with_context(cx, cond, e.span.ctxt(), "<predicate>", &mut applicability);
+                let cond_snip = if negate_cond { !cond_snip } else { cond_snip };
+                let other_snip =
+                    Sugg::hir_with_context(cx, other, e.span.ctxt(), "<other>", &mut applicability);
+                let mut snip = if is_or {
+                    make_binop(BinOpKind::Or, &cond_snip, &other_snip)
+                } else {
+                    make_binop(BinOpKind::And, &cond_snip, &other_snip)
+                };
+
+                if is_else_clause(cx.tcx, e) {
+                    snip = snip.blockify();
+                }
+
+                if (condition_needs_parentheses(cond) && is_parent_stmt(cx, e.hir_id))
+                    || is_receiver_of_method_call(cx, e)
+                    || is_as_argument(cx, e)
+                {
+                    snip = snip.maybe_paren();
+                }
+
+                span_lint_and_sugg(
+                    cx,
+                    NEEDLESS_BOOL,
+                    e.span,
+                    "this if-then-else expression returns a bool literal",
+                    "you can reduce it to",
+                    snip.to_string(),
+                    applicability,
+                );
+            };
+            let then_bool = fetch_bool_block(then);
+            let else_bool = fetch_bool_block(else_expr);
+            match (then_bool, else_bool) {
+                (Some(a), Some(b)) => match (a, b) {
                     (RetBool(true), RetBool(true)) | (Bool(true), Bool(true)) => {
                         span_lint(
                             cx,
@@ -166,7 +199,20 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
                     (RetBool(false), RetBool(true)) => reduce(true, true),
                     (Bool(false), Bool(true)) => reduce(false, true),
                     _ => (),
-                }
+                },
+                (Some(Bool(lit)), None) if cx.typeck_results().expr_ty(else_expr).is_bool() => {
+                    let other = peel_blocks_with_stmt(else_expr);
+                    // `if c { true }  else { e }` -> `c || e`
+                    // `if c { false } else { e }` -> `!c && e`
+                    reduce_mixed(other, !lit, lit);
+                },
+                (None, Some(Bool(lit))) if cx.typeck_results().expr_ty(then).is_bool() => {
+                    let other = peel_blocks_with_stmt(then);
+                    // `if c { e } else { true }`  -> `!c || e`
+                    // `if c { e } else { false }` -> `c && e`
+                    reduce_mixed(other, lit, lit);
+                },
+                _ => (),
             }
             if let Some((lhs_a, a)) = fetch_assign(then)
                 && let Some((lhs_b, b)) = fetch_assign(else_expr)

--- a/tests/ui/needless_bool/fixable.fixed
+++ b/tests/ui/needless_bool/fixable.fixed
@@ -59,11 +59,8 @@ fn main() {
     //~^^^^^ needless_bool
     a < b;
     //~^^^^^ needless_bool
-    if x {
-        x
-    } else {
-        false
-    }; // would also be questionable, but we don't catch this yet
+    x && x;
+    //~^^^^^ needless_bool
     bool_ret3(x);
     bool_ret4(x);
     bool_ret5(x, x);
@@ -166,6 +163,18 @@ fn issue12846() {
     // parentheses are not needed here
     let _x = a.then(|| todo!());
     //~^ needless_bool
+}
+
+fn issue17170(x: bool, y: bool) -> [bool; 4] {
+    let a = x || y;
+    //~^ needless_bool
+    let b = x && y;
+    //~^ needless_bool
+    let c = !x && y;
+    //~^ needless_bool
+    let d = !x || y;
+    //~^ needless_bool
+    [a, b, c, d]
 }
 
 fn wrongly_unmangled_macros() {

--- a/tests/ui/needless_bool/fixable.rs
+++ b/tests/ui/needless_bool/fixable.rs
@@ -99,7 +99,8 @@ fn main() {
         x
     } else {
         false
-    }; // would also be questionable, but we don't catch this yet
+    };
+    //~^^^^^ needless_bool
     bool_ret3(x);
     bool_ret4(x);
     bool_ret5(x, x);
@@ -226,6 +227,18 @@ fn issue12846() {
     // parentheses are not needed here
     let _x = if a { true } else { false }.then(|| todo!());
     //~^ needless_bool
+}
+
+fn issue17170(x: bool, y: bool) -> [bool; 4] {
+    let a = if x { true } else { y };
+    //~^ needless_bool
+    let b = if x { y } else { false };
+    //~^ needless_bool
+    let c = if x { false } else { y };
+    //~^ needless_bool
+    let d = if x { y } else { true };
+    //~^ needless_bool
+    [a, b, c, d]
 }
 
 fn wrongly_unmangled_macros() {


### PR DESCRIPTION
## Summary

**Problem:** `needless_bool` only fires when *both* arms of an `if`/`else` are bool literals. The "single-literal" forms — `if c { true } else { e }`, `if c { e } else { false }`, `if c { false } else { e }`, `if c { e } else { true }` — are silently ignored even though they reduce to short-circuit `||`/`&&` expressions. The file at `tests/ui/needless_bool/fixable.rs:98-102` explicitly acknowledged this gap.

**Root cause:** `check_expr` in `clippy_lints/src/needless_bool.rs` matched on `(fetch_bool_block(then), fetch_bool_block(else_expr))` only when both returned `Some(Bool(_))`. Mixed pairs (`Some/None`) had no handler.

**Fix:** In `clippy_lints/src/needless_bool.rs`:
- Imported `BinOpKind` from `rustc_ast::ast` and `make_binop` from `clippy_utils::sugg`.
- Added a `reduce_mixed` closure that builds a `Sugg` for the condition (optionally negated via `!`) and for the surviving non-literal branch (after `peel_blocks_with_stmt`), then combines them with `make_binop(BinOpKind::Or, …)` or `BinOpKind::And` per a truth table. It reuses the same `is_else_clause` blockify, `condition_needs_parentheses`, `is_receiver_of_method_call`, and `is_as_argument` paren-decisions as the original `reduce`.
- Replaced the two-`fetch_bool_block` `if let` with a `match` on the pair of `Option<Expression>` — the original `(Some, Some)` arms are preserved verbatim; two new arms handle `(Some(Bool(lit)), None)` and `(None, Some(Bool(lit)))`, guarded by `cx.typeck_results().expr_ty(other).is_bool()` so non-bool branches (e.g. `panic!()`) aren't rewritten. `RetBool` mixed cases are intentionally skipped to avoid control-flow rewrites.

The four mappings produced:
- `if c { true }  else { e }` → `c || e`
- `if c { false } else { e }` → `!c && e`
- `if c { e } else { true }`  → `!c || e`
- `if c { e } else { false }` → `c && e`

Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`lint_name`]: your change
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:

Closes rust-lang/rust-clippy#17170