### PR TITLE
Fix unused_async_trait_impl suggestions with return statements

### DIFF
--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -154,6 +154,27 @@ impl<'tcx> Visitor<'tcx> for AsyncFnVisitor<'_, 'tcx> {
     }
 }
 
+/// Find all return value expressions (in order to replace them).
+struct ReturnValueVisitor<'tcx> {
+    exprs: Vec<&'tcx Expr<'tcx>>,
+}
+
+impl<'tcx> Visitor<'tcx> for ReturnValueVisitor<'tcx> {
+    fn visit_expr(&mut self, ex: &'tcx Expr<'tcx>) -> Self::Result {
+        match ex.kind {
+            ExprKind::Ret(expr) => {
+                if let Some(expr) = expr {
+                    self.exprs.push(expr);
+
+                    // Unlikely, but someone could potentially hide another return statement in this expression.
+                    walk_expr(self, expr);
+                }
+            },
+            _ => walk_expr(self, ex),
+        }
+    }
+}
+
 impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
     fn check_fn(
         &mut self,
@@ -287,11 +308,23 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
                             let signature_snippet = snippet_with_applicability(cx, signature_span, "_", &mut app);
                             let tail_snippet = snippet_with_applicability(cx, tail_span, "_", &mut app).to_string();
 
-                            let sugg = vec![
+                            let mut sugg = vec![
                                 (async_span, String::new()),
                                 (signature_span, format!("impl Future<Output = {signature_snippet}>")),
                                 (tail_span, format!("{builtin_crate}::future::ready({tail_snippet})")),
                             ];
+
+                            let mut visitor = ReturnValueVisitor { exprs: vec![] };
+                            visitor.visit_block(block);
+
+                            sugg.extend(visitor.exprs.into_iter().filter_map(|expr| {
+                                walk_span_to_context(expr.span, ctxt).map(|expr_span| {
+                                    let expr_snippet =
+                                        snippet_with_applicability(cx, expr_span, "_", &mut app).to_string();
+
+                                    (expr_span, format!("{builtin_crate}::future::ready({expr_snippet})"))
+                                })
+                            }));
 
                             diag.multipart_suggestion(
                                 format!(

--- a/tests/ui/unused_async_trait_impl.fixed
+++ b/tests/ui/unused_async_trait_impl.fixed
@@ -107,3 +107,36 @@ mod macros {
         }
     }
 }
+
+mod issue17179 {
+    struct Test;
+
+    impl crate::HasAsyncMethod for Test {
+        fn do_something() -> impl Future<Output = u32> {
+            //~^ unused_async_trait_impl
+
+            // Test that local functions are not touched by the suggestion.
+            fn local_func() -> u32 {
+                if 5 == 2 {
+                    return 1;
+                }
+                2
+            }
+
+            // Test that we do not change the tail expr or return in a (unrelated) closure.
+            let f = || {
+                if 5 == 2 {
+                    return 1;
+                }
+                2
+            };
+
+            // However the following return statement and tail expression should be changed.
+            if f() == 5 {
+                return std::future::ready(3);
+            }
+
+            std::future::ready(5)
+        }
+    }
+}

--- a/tests/ui/unused_async_trait_impl.rs
+++ b/tests/ui/unused_async_trait_impl.rs
@@ -107,3 +107,36 @@ mod macros {
         }
     }
 }
+
+mod issue17179 {
+    struct Test;
+
+    impl crate::HasAsyncMethod for Test {
+        async fn do_something() -> u32 {
+            //~^ unused_async_trait_impl
+
+            // Test that local functions are not touched by the suggestion.
+            fn local_func() -> u32 {
+                if 5 == 2 {
+                    return 1;
+                }
+                2
+            }
+
+            // Test that we do not change the tail expr or return in a (unrelated) closure.
+            let f = || {
+                if 5 == 2 {
+                    return 1;
+                }
+                2
+            };
+
+            // However the following return statement and tail expression should be changed.
+            if f() == 5 {
+                return 3;
+            }
+
+            5
+        }
+    }
+}

--- a/tests/ui/unused_async_trait_impl.stderr
+++ b/tests/ui/unused_async_trait_impl.stderr
@@ -90,5 +90,27 @@ LL |
 LL ~             std::future::ready(vec![])
    |
 
-error: aborting due to 5 previous errors
+error: unused `async` for async trait impl function with no `.await` statements
+  --> tests/ui/unused_async_trait_impl.rs:115:9
+   |
+LL | /         async fn do_something() -> u32 {
+...  |
+LL | |             5
+LL | |         }
+   | |_________^
+   |
+   = note: `std::future::ready` creates a `Future` which returns the value immediately when `poll`ed
+help: consider removing the `async` from this function and returning `impl Future<Output = u32>` instead
+   |
+LL ~         fn do_something() -> impl Future<Output = u32> {
+LL |
+...
+LL |             if f() == 5 {
+LL ~                 return std::future::ready(3);
+LL |             }
+LL |
+LL ~             std::future::ready(5)
+   |
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
changelog: [`unused_async_trait_impl`]: fix suggestions for statements containing `return`

Fixes rust-lang/rust-clippy#17179.
