### PR TITLE
manual_is_variant_and: lint `result.ok().is_some_and(f)`

### DIFF
--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::res::MaybeDef;
+use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{SpanlessEq, get_parent_expr, sym};
@@ -327,6 +327,36 @@ pub(super) fn check_is_some_is_none<'tcx>(
                     app,
                 );
             },
+        );
+    }
+}
+
+/// Lint `result.ok().is_some_and(f)`, which is `result.is_ok_and(f)`.
+pub(super) fn check_ok_is_some_and<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    is_some_and_recv: &'tcx Expr<'tcx>,
+    arg: &'tcx Expr<'tcx>,
+) {
+    // `is_some_and` and `is_ok_and` were both stabilized in the same release, so if the receiver
+    // already calls `is_some_and` then `is_ok_and` is necessarily available too: no MSRV check.
+    if !expr.span.from_expansion()
+        && let ExprKind::MethodCall(_, result_recv, [], _) = is_some_and_recv.kind
+        && cx
+            .ty_based_def(is_some_and_recv)
+            .is_diag_item(cx, sym::result_ok_method)
+    {
+        let mut app = Applicability::MachineApplicable;
+        let recv_snip = snippet_with_context(cx, result_recv.span, expr.span.ctxt(), "_", &mut app).0;
+        let arg_snip = snippet_with_context(cx, arg.span, expr.span.ctxt(), "_", &mut app).0;
+        span_lint_and_sugg(
+            cx,
+            MANUAL_IS_VARIANT_AND,
+            expr.span,
+            "called `.ok().is_some_and(..)` on a `Result` value",
+            "use `is_ok_and` instead",
+            format!("{recv_snip}.is_ok_and({arg_snip})"),
+            app,
         );
     }
 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1903,7 +1903,8 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for usage of `option.map(f).unwrap_or_default()` and `result.map(f).unwrap_or_default()` where `f` is a function or closure that returns the `bool` type.
     ///
-    /// Also checks for equality comparisons like `option.map(f) == Some(true)` and `result.map(f) == Ok(true)`.
+    /// Also checks for equality comparisons like `option.map(f) == Some(true)` and `result.map(f) == Ok(true)`,
+    /// as well as `result.ok().is_some_and(f)`.
     ///
     /// ### Why is this bad?
     /// Readability. These can be written more concisely as `option.is_some_and(f)` and `result.is_ok_and(f)`.
@@ -1919,6 +1920,8 @@ declare_clippy_lint! {
     /// result.map(|a| a > 10) == Ok(true);
     /// option.map(|a| a > 10) != Some(true);
     /// result.map(|a| a > 10) != Ok(true);
+    ///
+    /// result.ok().is_some_and(|a| a > 10);
     /// ```
     /// Use instead:
     /// ```no_run
@@ -1931,6 +1934,8 @@ declare_clippy_lint! {
     /// result.is_ok_and(|a| a > 10);
     /// option.is_none_or(|a| a > 10);
     /// !result.is_ok_and(|a| a > 10);
+    ///
+    /// result.is_ok_and(|a| a > 10);
     /// ```
     #[clippy::version = "1.77.0"]
     pub MANUAL_IS_VARIANT_AND,
@@ -5499,6 +5504,7 @@ impl Methods {
                 (sym::is_digit, [radix]) => is_digit_ascii_radix::check(cx, expr, recv, radix, self.msrv),
                 (sym::is_none, []) => check_is_some_is_none(cx, expr, recv, call_span, false, self.msrv),
                 (sym::is_some, []) => check_is_some_is_none(cx, expr, recv, call_span, true, self.msrv),
+                (sym::is_some_and, [arg]) => manual_is_variant_and::check_ok_is_some_and(cx, expr, recv, arg),
                 (sym::iter | sym::iter_mut | sym::into_iter, []) => {
                     iter_on_single_or_empty_collections::check(cx, expr, name, recv);
                 },

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -259,3 +259,45 @@ fn issue16518_msrv(opt: Option<i32>) {
 
     opt.filter(|x| condition(x)).is_none();
 }
+
+fn ok_is_some_and(res: Result<i32, ()>) {
+    let _ = res.is_ok_and(|x| x > 0);
+    //~^ manual_is_variant_and
+
+    let _ = res.is_ok_and(|x| x > 0) || res.is_err();
+    //~^ manual_is_variant_and
+
+    // Already an `Option`: must not be rewritten to `is_ok_and`.
+    let opt: Option<i32> = Some(1);
+    let _ = opt.is_some_and(|x| x > 0);
+
+    // Bare `is_some_and` (no `.ok()` receiver): don't touch.
+    let it = [1, 2, 3].iter();
+    let _ = it.peekable().peek().is_some_and(|&&x| x > 0);
+
+    // A custom `.ok()` returning an `Option` on a non-`Result` type: don't touch.
+    struct NotResult;
+    impl NotResult {
+        fn ok(self) -> Option<i32> {
+            Some(0)
+        }
+    }
+    let _ = NotResult.ok().is_some_and(|x| x > 0);
+}
+
+trait CustomOk {
+    fn ok(&self) -> Option<i32>;
+}
+
+impl CustomOk for Result<i32, ()> {
+    fn ok(&self) -> Option<i32> {
+        Some(0)
+    }
+}
+
+fn ok_trait_method_via_ref(res: &Result<i32, ()>) {
+    // `res` is a reference, so `.ok()` resolves to the `CustomOk` trait method, not the
+    // by-value `Result::ok`. The receiver type is still `Result`, so a type-based check would
+    // wrongly fire; resolving the called method's `DefId` keeps this correct. Don't touch.
+    let _ = res.ok().is_some_and(|x| x > 0);
+}

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -268,3 +268,45 @@ fn issue16518_msrv(opt: Option<i32>) {
 
     opt.filter(|x| condition(x)).is_none();
 }
+
+fn ok_is_some_and(res: Result<i32, ()>) {
+    let _ = res.ok().is_some_and(|x| x > 0);
+    //~^ manual_is_variant_and
+
+    let _ = res.ok().is_some_and(|x| x > 0) || res.is_err();
+    //~^ manual_is_variant_and
+
+    // Already an `Option`: must not be rewritten to `is_ok_and`.
+    let opt: Option<i32> = Some(1);
+    let _ = opt.is_some_and(|x| x > 0);
+
+    // Bare `is_some_and` (no `.ok()` receiver): don't touch.
+    let it = [1, 2, 3].iter();
+    let _ = it.peekable().peek().is_some_and(|&&x| x > 0);
+
+    // A custom `.ok()` returning an `Option` on a non-`Result` type: don't touch.
+    struct NotResult;
+    impl NotResult {
+        fn ok(self) -> Option<i32> {
+            Some(0)
+        }
+    }
+    let _ = NotResult.ok().is_some_and(|x| x > 0);
+}
+
+trait CustomOk {
+    fn ok(&self) -> Option<i32>;
+}
+
+impl CustomOk for Result<i32, ()> {
+    fn ok(&self) -> Option<i32> {
+        Some(0)
+    }
+}
+
+fn ok_trait_method_via_ref(res: &Result<i32, ()>) {
+    // `res` is a reference, so `.ok()` resolves to the `CustomOk` trait method, not the
+    // by-value `Result::ok`. The receiver type is still `Result`, so a type-based check would
+    // wrongly fire; resolving the called method's `DefId` keeps this correct. Don't touch.
+    let _ = res.ok().is_some_and(|x| x > 0);
+}

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -246,5 +246,17 @@ error: manual implementation of `Option::is_none_or`
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`
 
-error: aborting due to 35 previous errors
+error: called `.ok().is_some_and(..)` on a `Result` value
+  --> tests/ui/manual_is_variant_and.rs:273:13
+   |
+LL |     let _ = res.ok().is_some_and(|x| x > 0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `is_ok_and` instead: `res.is_ok_and(|x| x > 0)`
+
+error: called `.ok().is_some_and(..)` on a `Result` value
+  --> tests/ui/manual_is_variant_and.rs:276:13
+   |
+LL |     let _ = res.ok().is_some_and(|x| x > 0) || res.is_err();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `is_ok_and` instead: `res.is_ok_and(|x| x > 0)`
+
+error: aborting due to 37 previous errors
 


### PR DESCRIPTION
Reduce `result.ok().is_some_and(f)` to `result.is_ok_and(f)`, dropping the needless `Result` -> `Option` conversion. Only fires when the `.ok()` receiver is a `Result` (an existing `Option` is left alone). `is_ok_and` and `is_some_and` were stabilized together, so no MSRV gate is needed.

changelog: [`manual_is_variant_and`]: lint `result.ok().is_some_and(f)`
