### PR TITLE
needless_bool: lint the early-return guard form

### DIFF
--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -122,11 +122,7 @@ fn is_arms_disjointed(cx: &LateContext<'_>, arm1: &Arm<'_>, arm2: &Arm<'_>) -> b
         return false;
     }
 
-    if !is_enum_variant(cx, arm1.pat) || !is_enum_variant(cx, arm2.pat) {
-        return false;
-    }
-
-    true
+    is_enum_variant(cx, arm1.pat) && is_enum_variant(cx, arm2.pat)
 }
 
 /// Returns `true` if the given pattern is a variant of an enum.

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -7,7 +7,9 @@ use clippy_utils::{
 };
 use rustc_ast::ast::LitKind;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Block, Expr, ExprKind, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 use rustc_span::SyntaxContext;
@@ -16,6 +18,9 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for expressions of the form `if c { true } else {
     /// false }` (or vice versa) and suggests using the condition directly.
+    ///
+    /// This also covers the early-return guard form, where a condition returns a
+    /// tuple-like based on it.
     ///
     /// ### Why is this bad?
     /// Redundant code.
@@ -42,6 +47,23 @@ declare_clippy_lint! {
     /// # let x = true;
     /// !x
     /// # ;
+    /// ```
+    ///
+    /// Or, for the early-return guard form:
+    /// ```
+    /// # fn f(c: bool) -> Result<bool, ()> {
+    /// if c {
+    ///     return Ok(true);
+    /// }
+    /// Ok(false)
+    /// # }
+    /// ```
+    ///
+    /// Use instead:
+    /// ```
+    /// # fn f(c: bool) -> Result<bool, ()> {
+    /// Ok(c)
+    /// # }
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub NEEDLESS_BOOL,
@@ -197,6 +219,102 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
                 );
             }
         }
+    }
+
+    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        // Detect the early-return form:
+        //     if c {
+        //         return Ok(true);
+        //     }
+        //     Ok(false)
+        // and reduce it to `Ok(c)`. The optional `Ok(..)` wrapper can be any tuple-like
+        // constructor (or absent), as long as the guard and the trailing expression use the
+        // same one. Constructors are pure, so folding the condition in keeps the behavior.
+        if let Some(tail) = block.expr
+            && !tail.span.from_expansion()
+            && let [.., last_stmt] = block.stmts
+            && let StmtKind::Semi(if_expr) | StmtKind::Expr(if_expr) = last_stmt.kind
+            && !if_expr.span.from_expansion()
+            && let Some(higher::If {
+                cond,
+                then,
+                r#else: None,
+            }) = higher::If::hir(if_expr)
+            && let ExprKind::Ret(Some(ret)) = peel_blocks_with_stmt(then).kind
+            && let Some((then_func, then_val)) = fetch_bool_and_wrapper(ret)
+            && let Some((tail_func, tail_val)) = fetch_bool_and_wrapper(tail)
+            // `if c { return Ok(true) } Ok(true)` is always the same value; the condition might
+            // have side effects, so don't touch it. Comparing the values here is cheap, so do it
+            // before the constructor resolution in `wrapper_ctors_match`, which needs `qpath_res`.
+            && then_val != tail_val
+            && wrapper_ctors_match(cx, then_func, tail_func)
+        {
+            let span = if_expr.span.to(tail.span);
+            if span_contains_comment(cx, span) {
+                return;
+            }
+
+            let mut applicability = Applicability::MachineApplicable;
+            let mut snip = Sugg::hir_with_context(cx, cond, span.ctxt(), "..", &mut applicability);
+            // `then_val` is the value returned when the condition holds, so a `false` there means
+            // the result is the negation of the condition.
+            if !then_val {
+                snip = !snip;
+            }
+            let sugg = match tail_func {
+                Some(func) => {
+                    let func_snip = snippet_with_context(cx, func.span, span.ctxt(), "..", &mut applicability).0;
+                    format!("{func_snip}({snip})")
+                },
+                None => snip.to_string(),
+            };
+
+            span_lint_and_sugg(
+                cx,
+                NEEDLESS_BOOL,
+                span,
+                "this `if` guard returns a bool literal and is followed by another",
+                "you can reduce it to",
+                sugg,
+                applicability,
+            );
+        }
+    }
+}
+
+/// Returns the optional constructor call wrapping a bool literal (e.g. the `Ok` in `Ok(true)`)
+/// along with the bool value. The constructor is returned as the unresolved callee expression;
+/// resolving it to a `DefId` (via [`wrapper_ctors_match`]) needs `qpath_res`, which is
+/// comparatively expensive, so callers should only do that once the cheap bool-value comparison
+/// has passed. A bare bool literal yields `None`.
+fn fetch_bool_and_wrapper<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<(Option<&'tcx Expr<'tcx>>, bool)> {
+    let expr = peel_blocks(expr);
+    if let Some(value) = fetch_bool_expr(expr) {
+        return Some((None, value));
+    }
+    if let ExprKind::Call(func, [arg]) = expr.kind
+        && let Some(value) = fetch_bool_expr(arg)
+    {
+        return Some((Some(func), value));
+    }
+    None
+}
+
+/// Checks whether two optional wrapper-constructor call expressions (as returned by
+/// [`fetch_bool_and_wrapper`]) are absent on both sides, or call the same tuple-like constructor.
+fn wrapper_ctors_match(cx: &LateContext<'_>, a: Option<&Expr<'_>>, b: Option<&Expr<'_>>) -> bool {
+    fn resolve_ctor(cx: &LateContext<'_>, func: &Expr<'_>) -> Option<DefId> {
+        if let ExprKind::Path(qpath) = &func.kind
+            && let Res::Def(DefKind::Ctor(..), did) = cx.qpath_res(qpath, func.hir_id)
+        {
+            return Some(did);
+        }
+        None
+    }
+    match (a, b) {
+        (None, None) => true,
+        (Some(a), Some(b)) => resolve_ctor(cx, a).is_some_and(|a| Some(a) == resolve_ctor(cx, b)),
+        _ => false,
     }
 }
 

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -19,11 +19,8 @@ declare_clippy_lint! {
     /// Checks for expressions of the form `if c { true } else {
     /// false }` (or vice versa) and suggests using the condition directly.
     ///
-    /// This also covers the early-return guard form, where a condition returns
-    /// one bool literal and the trailing expression is the other, optionally
-    /// with both wrapped in the same tuple-like constructor (`Ok`/`Some`/a
-    /// user-defined enum or tuple-struct constructor), e.g.
-    /// `if c { return Ok(true); } Ok(false)`.
+    /// This also covers the early-return guard form, where a condition returns a
+    /// tuple-like based on it.
     ///
     /// ### Why is this bad?
     /// Redundant code.
@@ -53,7 +50,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Or, for the early-return guard form:
-    /// ```no_run
+    /// ```
     /// # fn f(c: bool) -> Result<bool, ()> {
     /// if c {
     ///     return Ok(true);
@@ -63,7 +60,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```no_run
+    /// ```
     /// # fn f(c: bool) -> Result<bool, ()> {
     /// Ok(c)
     /// # }
@@ -234,22 +231,23 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
         // constructor (or absent), as long as the guard and the trailing expression use the
         // same one. Constructors are pure, so folding the condition in keeps the behavior.
         if let Some(tail) = block.expr
+            && !tail.span.from_expansion()
             && let [.., last_stmt] = block.stmts
             && let StmtKind::Semi(if_expr) | StmtKind::Expr(if_expr) = last_stmt.kind
+            && !if_expr.span.from_expansion()
             && let Some(higher::If {
                 cond,
                 then,
                 r#else: None,
             }) = higher::If::hir(if_expr)
             && let ExprKind::Ret(Some(ret)) = peel_blocks_with_stmt(then).kind
-            && !if_expr.span.from_expansion()
-            && !tail.span.from_expansion()
-            && let Some((then_ctor, then_val)) = fetch_wrapped_bool(cx, ret)
-            && let Some((tail_ctor, tail_val)) = fetch_wrapped_bool(cx, tail)
+            && let Some((then_func, then_val)) = fetch_bool_and_wrapper(ret)
+            && let Some((tail_func, tail_val)) = fetch_bool_and_wrapper(tail)
             // `if c { return Ok(true) } Ok(true)` is always the same value; the condition might
-            // have side effects, so don't touch it.
+            // have side effects, so don't touch it. Comparing the values here is cheap, so do it
+            // before the constructor resolution in `wrapper_ctors_match`, which needs `qpath_res`.
             && then_val != tail_val
-            && wrappers_match(then_ctor, tail_ctor)
+            && wrapper_ctors_match(cx, then_func, tail_func)
         {
             let span = if_expr.span.to(tail.span);
             if span_contains_comment(cx, span) {
@@ -257,14 +255,14 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
             }
 
             let mut applicability = Applicability::MachineApplicable;
-            let mut snip = Sugg::hir_with_context(cx, cond, span.ctxt(), "<predicate>", &mut applicability);
+            let mut snip = Sugg::hir_with_context(cx, cond, span.ctxt(), "..", &mut applicability);
             // `then_val` is the value returned when the condition holds, so a `false` there means
             // the result is the negation of the condition.
             if !then_val {
                 snip = !snip;
             }
-            let sugg = match tail_ctor {
-                Some((func, _)) => {
+            let sugg = match tail_func {
+                Some(func) => {
                     let func_snip = snippet_with_context(cx, func.span, span.ctxt(), "..", &mut applicability).0;
                     format!("{func_snip}({snip})")
                 },
@@ -284,31 +282,38 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
     }
 }
 
-/// Returns the optional constructor wrapping a bool literal (e.g. the `Ok` in `Ok(true)`) along
-/// with the bool value. The constructor is returned as the callee expression plus its `DefId` so
-/// callers can both compare two wrappers and rebuild the call. A bare bool literal yields `None`.
-fn fetch_wrapped_bool<'tcx>(
-    cx: &LateContext<'tcx>,
-    expr: &'tcx Expr<'tcx>,
-) -> Option<(Option<(&'tcx Expr<'tcx>, DefId)>, bool)> {
+/// Returns the optional constructor call wrapping a bool literal (e.g. the `Ok` in `Ok(true)`)
+/// along with the bool value. The constructor is returned as the unresolved callee expression;
+/// resolving it to a `DefId` (via [`wrapper_ctors_match`]) needs `qpath_res`, which is
+/// comparatively expensive, so callers should only do that once the cheap bool-value comparison
+/// has passed. A bare bool literal yields `None`.
+fn fetch_bool_and_wrapper<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<(Option<&'tcx Expr<'tcx>>, bool)> {
     let expr = peel_blocks(expr);
     if let Some(value) = fetch_bool_expr(expr) {
         return Some((None, value));
     }
     if let ExprKind::Call(func, [arg]) = expr.kind
         && let Some(value) = fetch_bool_expr(arg)
-        && let ExprKind::Path(qpath) = &func.kind
-        && let Res::Def(DefKind::Ctor(..), did) = cx.qpath_res(qpath, func.hir_id)
     {
-        return Some((Some((func, did)), value));
+        return Some((Some(func), value));
     }
     None
 }
 
-fn wrappers_match(a: Option<(&Expr<'_>, DefId)>, b: Option<(&Expr<'_>, DefId)>) -> bool {
+/// Checks whether two optional wrapper-constructor call expressions (as returned by
+/// [`fetch_bool_and_wrapper`]) are absent on both sides, or call the same tuple-like constructor.
+fn wrapper_ctors_match(cx: &LateContext<'_>, a: Option<&Expr<'_>>, b: Option<&Expr<'_>>) -> bool {
+    fn resolve_ctor(cx: &LateContext<'_>, func: &Expr<'_>) -> Option<DefId> {
+        if let ExprKind::Path(qpath) = &func.kind
+            && let Res::Def(DefKind::Ctor(..), did) = cx.qpath_res(qpath, func.hir_id)
+        {
+            return Some(did);
+        }
+        None
+    }
     match (a, b) {
         (None, None) => true,
-        (Some((_, a)), Some((_, b))) => a == b,
+        (Some(a), Some(b)) => resolve_ctor(cx, a).is_some_and(|a| Some(a) == resolve_ctor(cx, b)),
         _ => false,
     }
 }

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -7,7 +7,9 @@ use clippy_utils::{
 };
 use rustc_ast::ast::LitKind;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Block, Expr, ExprKind, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 use rustc_span::SyntaxContext;
@@ -16,6 +18,12 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for expressions of the form `if c { true } else {
     /// false }` (or vice versa) and suggests using the condition directly.
+    ///
+    /// This also covers the early-return guard form, where a condition returns
+    /// one bool literal and the trailing expression is the other, optionally
+    /// with both wrapped in the same tuple-like constructor (`Ok`/`Some`/a
+    /// user-defined enum or tuple-struct constructor), e.g.
+    /// `if c { return Ok(true); } Ok(false)`.
     ///
     /// ### Why is this bad?
     /// Redundant code.
@@ -42,6 +50,23 @@ declare_clippy_lint! {
     /// # let x = true;
     /// !x
     /// # ;
+    /// ```
+    ///
+    /// Or, for the early-return guard form:
+    /// ```no_run
+    /// # fn f(c: bool) -> Result<bool, ()> {
+    /// if c {
+    ///     return Ok(true);
+    /// }
+    /// Ok(false)
+    /// # }
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// # fn f(c: bool) -> Result<bool, ()> {
+    /// Ok(c)
+    /// # }
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub NEEDLESS_BOOL,
@@ -197,6 +222,94 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
                 );
             }
         }
+    }
+
+    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        // Detect the early-return form:
+        //     if c {
+        //         return Ok(true);
+        //     }
+        //     Ok(false)
+        // and reduce it to `Ok(c)`. The optional `Ok(..)` wrapper can be any tuple-like
+        // constructor (or absent), as long as the guard and the trailing expression use the
+        // same one. Constructors are pure, so folding the condition in keeps the behavior.
+        if let Some(tail) = block.expr
+            && let [.., last_stmt] = block.stmts
+            && let StmtKind::Semi(if_expr) | StmtKind::Expr(if_expr) = last_stmt.kind
+            && let Some(higher::If {
+                cond,
+                then,
+                r#else: None,
+            }) = higher::If::hir(if_expr)
+            && let ExprKind::Ret(Some(ret)) = peel_blocks_with_stmt(then).kind
+            && !if_expr.span.from_expansion()
+            && !tail.span.from_expansion()
+            && let Some((then_ctor, then_val)) = fetch_wrapped_bool(cx, ret)
+            && let Some((tail_ctor, tail_val)) = fetch_wrapped_bool(cx, tail)
+            // `if c { return Ok(true) } Ok(true)` is always the same value; the condition might
+            // have side effects, so don't touch it.
+            && then_val != tail_val
+            && wrappers_match(then_ctor, tail_ctor)
+        {
+            let span = if_expr.span.to(tail.span);
+            if span_contains_comment(cx, span) {
+                return;
+            }
+
+            let mut applicability = Applicability::MachineApplicable;
+            let mut snip = Sugg::hir_with_context(cx, cond, span.ctxt(), "<predicate>", &mut applicability);
+            // `then_val` is the value returned when the condition holds, so a `false` there means
+            // the result is the negation of the condition.
+            if !then_val {
+                snip = !snip;
+            }
+            let sugg = match tail_ctor {
+                Some((func, _)) => {
+                    let func_snip = snippet_with_context(cx, func.span, span.ctxt(), "..", &mut applicability).0;
+                    format!("{func_snip}({snip})")
+                },
+                None => snip.to_string(),
+            };
+
+            span_lint_and_sugg(
+                cx,
+                NEEDLESS_BOOL,
+                span,
+                "this `if` guard returns a bool literal and is followed by another",
+                "you can reduce it to",
+                sugg,
+                applicability,
+            );
+        }
+    }
+}
+
+/// Returns the optional constructor wrapping a bool literal (e.g. the `Ok` in `Ok(true)`) along
+/// with the bool value. The constructor is returned as the callee expression plus its `DefId` so
+/// callers can both compare two wrappers and rebuild the call. A bare bool literal yields `None`.
+fn fetch_wrapped_bool<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+) -> Option<(Option<(&'tcx Expr<'tcx>, DefId)>, bool)> {
+    let expr = peel_blocks(expr);
+    if let Some(value) = fetch_bool_expr(expr) {
+        return Some((None, value));
+    }
+    if let ExprKind::Call(func, [arg]) = expr.kind
+        && let Some(value) = fetch_bool_expr(arg)
+        && let ExprKind::Path(qpath) = &func.kind
+        && let Res::Def(DefKind::Ctor(..), did) = cx.qpath_res(qpath, func.hir_id)
+    {
+        return Some((Some((func, did)), value));
+    }
+    None
+}
+
+fn wrappers_match(a: Option<(&Expr<'_>, DefId)>, b: Option<(&Expr<'_>, DefId)>) -> bool {
+    match (a, b) {
+        (None, None) => true,
+        (Some((_, a)), Some((_, b))) => a == b,
+        _ => false,
     }
 }
 

--- a/clippy_lints/src/non_send_fields_in_send_ty.rs
+++ b/clippy_lints/src/non_send_fields_in_send_ty.rs
@@ -186,11 +186,7 @@ fn ty_allowed_without_raw_pointer_heuristic<'tcx>(cx: &LateContext<'tcx>, ty: Ty
         return true;
     }
 
-    if is_copy(cx, ty) && !contains_pointer_like(cx, ty) {
-        return true;
-    }
-
-    false
+    is_copy(cx, ty) && !contains_pointer_like(cx, ty)
 }
 
 /// Heuristic to allow cases like `Vec<*const u8>`

--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -156,10 +156,7 @@ fn non_consuming_ok_arm<'a>(cx: &LateContext<'a>, arm: &hir::Arm<'a>) -> bool {
         return false;
     }
 
-    if is_ok_wild_or_dotdot_pattern(cx, arm.pat) {
-        return true;
-    }
-    false
+    is_ok_wild_or_dotdot_pattern(cx, arm.pat)
 }
 
 fn check_expr<'a>(cx: &LateContext<'a>, expr: &'a hir::Expr<'a>) {

--- a/tests/ui/needless_bool/early_return.fixed
+++ b/tests/ui/needless_bool/early_return.fixed
@@ -1,0 +1,67 @@
+#![warn(clippy::needless_bool)]
+#![allow(unused, dead_code, clippy::needless_return)]
+
+// The motivating case from uutils/coreutils#12689: a guard returning a wrapped bool
+// followed by a trailing wrapped bool literal.
+fn is_sparse(blocks: u64, size: u64) -> Result<bool, ()> {
+    Ok(blocks < size / 512)
+    //~^^^^ needless_bool
+}
+
+fn bare(x: bool) -> bool {
+    x
+    //~^^^^ needless_bool
+}
+
+fn bare_negated(x: bool) -> bool {
+    !x
+    //~^^^^ needless_bool
+}
+
+fn option_wrapped(x: bool) -> Option<bool> {
+    Some(!x)
+    //~^^^^ needless_bool
+}
+
+fn complex_condition(a: i32, b: i32) -> Result<bool, ()> {
+    Ok(!(a < b && b > 0))
+    //~^^^^ needless_bool
+}
+
+// Do NOT lint: the two values are equal, and the condition might have side effects.
+fn same_value(x: bool) -> Result<bool, ()> {
+    if x {
+        return Ok(true);
+    }
+    Ok(true)
+}
+
+// Do NOT lint: mismatched wrappers.
+fn mismatched_wrappers(x: bool) -> Result<bool, ()> {
+    if x {
+        return Err(());
+    }
+    Ok(false)
+}
+
+// Do NOT lint: the guard body has a side effect besides the return.
+fn side_effect(x: bool) -> Result<bool, ()> {
+    if x {
+        println!("hi");
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+// Do NOT lint: not a constructor, just a function call (could have side effects).
+fn make(b: bool) -> bool {
+    b
+}
+fn not_a_ctor(x: bool) -> bool {
+    if x {
+        return make(true);
+    }
+    make(false)
+}
+
+fn main() {}

--- a/tests/ui/needless_bool/early_return.fixed
+++ b/tests/ui/needless_bool/early_return.fixed
@@ -1,0 +1,67 @@
+#![warn(clippy::needless_bool)]
+#![allow(dead_code, unused, clippy::needless_return)]
+
+// The motivating case from uutils/coreutils#12689: a guard returning a wrapped bool
+// followed by a trailing wrapped bool literal.
+fn is_sparse(blocks: u64, size: u64) -> Result<bool, ()> {
+    Ok(blocks < size / 512)
+    //~^^^^ needless_bool
+}
+
+fn bare(x: bool) -> bool {
+    x
+    //~^^^^ needless_bool
+}
+
+fn bare_negated(x: bool) -> bool {
+    !x
+    //~^^^^ needless_bool
+}
+
+fn option_wrapped(x: bool) -> Option<bool> {
+    Some(!x)
+    //~^^^^ needless_bool
+}
+
+fn complex_condition(a: i32, b: i32) -> Result<bool, ()> {
+    Ok(!(a < b && b > 0))
+    //~^^^^ needless_bool
+}
+
+// Do NOT lint: the two values are equal, and the condition might have side effects.
+fn same_value(x: bool) -> Result<bool, ()> {
+    if x {
+        return Ok(true);
+    }
+    Ok(true)
+}
+
+// Do NOT lint: mismatched wrappers.
+fn mismatched_wrappers(x: bool) -> Result<bool, ()> {
+    if x {
+        return Err(());
+    }
+    Ok(false)
+}
+
+// Do NOT lint: the guard body has a side effect besides the return.
+fn side_effect(x: bool) -> Result<bool, ()> {
+    if x {
+        println!("hi");
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+// Do NOT lint: not a constructor, just a function call (could have side effects).
+fn make(b: bool) -> bool {
+    b
+}
+fn not_a_ctor(x: bool) -> bool {
+    if x {
+        return make(true);
+    }
+    make(false)
+}
+
+fn main() {}

--- a/tests/ui/needless_bool/early_return.rs
+++ b/tests/ui/needless_bool/early_return.rs
@@ -1,0 +1,82 @@
+#![warn(clippy::needless_bool)]
+#![allow(unused, dead_code, clippy::needless_return)]
+
+// The motivating case from uutils/coreutils#12689: a guard returning a wrapped bool
+// followed by a trailing wrapped bool literal.
+fn is_sparse(blocks: u64, size: u64) -> Result<bool, ()> {
+    if blocks < size / 512 {
+        return Ok(true);
+    }
+    Ok(false)
+    //~^^^^ needless_bool
+}
+
+fn bare(x: bool) -> bool {
+    if x {
+        return true;
+    }
+    false
+    //~^^^^ needless_bool
+}
+
+fn bare_negated(x: bool) -> bool {
+    if x {
+        return false;
+    }
+    true
+    //~^^^^ needless_bool
+}
+
+fn option_wrapped(x: bool) -> Option<bool> {
+    if x {
+        return Some(false);
+    }
+    Some(true)
+    //~^^^^ needless_bool
+}
+
+fn complex_condition(a: i32, b: i32) -> Result<bool, ()> {
+    if a < b && b > 0 {
+        return Ok(false);
+    }
+    Ok(true)
+    //~^^^^ needless_bool
+}
+
+// Do NOT lint: the two values are equal, and the condition might have side effects.
+fn same_value(x: bool) -> Result<bool, ()> {
+    if x {
+        return Ok(true);
+    }
+    Ok(true)
+}
+
+// Do NOT lint: mismatched wrappers.
+fn mismatched_wrappers(x: bool) -> Result<bool, ()> {
+    if x {
+        return Err(());
+    }
+    Ok(false)
+}
+
+// Do NOT lint: the guard body has a side effect besides the return.
+fn side_effect(x: bool) -> Result<bool, ()> {
+    if x {
+        println!("hi");
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+// Do NOT lint: not a constructor, just a function call (could have side effects).
+fn make(b: bool) -> bool {
+    b
+}
+fn not_a_ctor(x: bool) -> bool {
+    if x {
+        return make(true);
+    }
+    make(false)
+}
+
+fn main() {}

--- a/tests/ui/needless_bool/early_return.rs
+++ b/tests/ui/needless_bool/early_return.rs
@@ -1,0 +1,82 @@
+#![warn(clippy::needless_bool)]
+#![allow(dead_code, unused, clippy::needless_return)]
+
+// The motivating case from uutils/coreutils#12689: a guard returning a wrapped bool
+// followed by a trailing wrapped bool literal.
+fn is_sparse(blocks: u64, size: u64) -> Result<bool, ()> {
+    if blocks < size / 512 {
+        return Ok(true);
+    }
+    Ok(false)
+    //~^^^^ needless_bool
+}
+
+fn bare(x: bool) -> bool {
+    if x {
+        return true;
+    }
+    false
+    //~^^^^ needless_bool
+}
+
+fn bare_negated(x: bool) -> bool {
+    if x {
+        return false;
+    }
+    true
+    //~^^^^ needless_bool
+}
+
+fn option_wrapped(x: bool) -> Option<bool> {
+    if x {
+        return Some(false);
+    }
+    Some(true)
+    //~^^^^ needless_bool
+}
+
+fn complex_condition(a: i32, b: i32) -> Result<bool, ()> {
+    if a < b && b > 0 {
+        return Ok(false);
+    }
+    Ok(true)
+    //~^^^^ needless_bool
+}
+
+// Do NOT lint: the two values are equal, and the condition might have side effects.
+fn same_value(x: bool) -> Result<bool, ()> {
+    if x {
+        return Ok(true);
+    }
+    Ok(true)
+}
+
+// Do NOT lint: mismatched wrappers.
+fn mismatched_wrappers(x: bool) -> Result<bool, ()> {
+    if x {
+        return Err(());
+    }
+    Ok(false)
+}
+
+// Do NOT lint: the guard body has a side effect besides the return.
+fn side_effect(x: bool) -> Result<bool, ()> {
+    if x {
+        println!("hi");
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+// Do NOT lint: not a constructor, just a function call (could have side effects).
+fn make(b: bool) -> bool {
+    b
+}
+fn not_a_ctor(x: bool) -> bool {
+    if x {
+        return make(true);
+    }
+    make(false)
+}
+
+fn main() {}

--- a/tests/ui/needless_bool/early_return.stderr
+++ b/tests/ui/needless_bool/early_return.stderr
@@ -1,0 +1,50 @@
+error: this `if` guard returns a bool literal and is followed by another
+  --> tests/ui/needless_bool/early_return.rs:7:5
+   |
+LL | /     if blocks < size / 512 {
+LL | |         return Ok(true);
+LL | |     }
+LL | |     Ok(false)
+   | |_____________^ help: you can reduce it to: `Ok(blocks < size / 512)`
+   |
+   = note: `-D clippy::needless-bool` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::needless_bool)]`
+
+error: this `if` guard returns a bool literal and is followed by another
+  --> tests/ui/needless_bool/early_return.rs:15:5
+   |
+LL | /     if x {
+LL | |         return true;
+LL | |     }
+LL | |     false
+   | |_________^ help: you can reduce it to: `x`
+
+error: this `if` guard returns a bool literal and is followed by another
+  --> tests/ui/needless_bool/early_return.rs:23:5
+   |
+LL | /     if x {
+LL | |         return false;
+LL | |     }
+LL | |     true
+   | |________^ help: you can reduce it to: `!x`
+
+error: this `if` guard returns a bool literal and is followed by another
+  --> tests/ui/needless_bool/early_return.rs:31:5
+   |
+LL | /     if x {
+LL | |         return Some(false);
+LL | |     }
+LL | |     Some(true)
+   | |______________^ help: you can reduce it to: `Some(!x)`
+
+error: this `if` guard returns a bool literal and is followed by another
+  --> tests/ui/needless_bool/early_return.rs:39:5
+   |
+LL | /     if a < b && b > 0 {
+LL | |         return Ok(false);
+LL | |     }
+LL | |     Ok(true)
+   | |____________^ help: you can reduce it to: `Ok(!(a < b && b > 0))`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/nonminimal_bool.rs
+++ b/tests/ui/nonminimal_bool.rs
@@ -66,6 +66,7 @@ fn issue3847(a: u32, b: u32) -> bool {
         return false;
     }
     true
+    //~^^^^ needless_bool
 }
 
 fn issue4548() {

--- a/tests/ui/nonminimal_bool.stderr
+++ b/tests/ui/nonminimal_bool.stderr
@@ -159,8 +159,20 @@ LL -     let _ = a != b && !(a != b && c == d);
 LL +     let _ = a != b && c != d;
    |
 
+error: this `if` guard returns a bool literal and is followed by another
+  --> tests/ui/nonminimal_bool.rs:65:5
+   |
+LL | /     if a < THRESHOLD && b >= THRESHOLD || a >= THRESHOLD && b < THRESHOLD {
+LL | |         return false;
+LL | |     }
+LL | |     true
+   | |________^ help: you can reduce it to: `!(a < THRESHOLD && b >= THRESHOLD || a >= THRESHOLD && b < THRESHOLD)`
+   |
+   = note: `-D clippy::needless-bool` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::needless_bool)]`
+
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:89:8
+  --> tests/ui/nonminimal_bool.rs:90:8
    |
 LL |     if matches!(true, true) && true {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,37 +184,37 @@ LL +     if matches!(true, true) {
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:170:8
+  --> tests/ui/nonminimal_bool.rs:171:8
    |
 LL |     if !(12 == a) {}
    |        ^^^^^^^^^^ help: try: `(12 != a)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:172:8
+  --> tests/ui/nonminimal_bool.rs:173:8
    |
 LL |     if !(a == 12) {}
    |        ^^^^^^^^^^ help: try: `(a != 12)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:174:8
+  --> tests/ui/nonminimal_bool.rs:175:8
    |
 LL |     if !(12 != a) {}
    |        ^^^^^^^^^^ help: try: `(12 == a)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:176:8
+  --> tests/ui/nonminimal_bool.rs:177:8
    |
 LL |     if !(a != 12) {}
    |        ^^^^^^^^^^ help: try: `(a == 12)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:181:8
+  --> tests/ui/nonminimal_bool.rs:182:8
    |
 LL |     if !b == true {}
    |        ^^^^^^^^^^ help: try: `b != true`
 
 error: equality checks against true are unnecessary
-  --> tests/ui/nonminimal_bool.rs:181:8
+  --> tests/ui/nonminimal_bool.rs:182:8
    |
 LL |     if !b == true {}
    |        ^^^^^^^^^^ help: try: `!b`
@@ -211,55 +223,55 @@ LL |     if !b == true {}
    = help: to override `-D warnings` add `#[allow(clippy::bool_comparison)]`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:184:8
+  --> tests/ui/nonminimal_bool.rs:185:8
    |
 LL |     if !b != true {}
    |        ^^^^^^^^^^ help: try: `b == true`
 
 error: inequality checks against true can be replaced by a negation
-  --> tests/ui/nonminimal_bool.rs:184:8
+  --> tests/ui/nonminimal_bool.rs:185:8
    |
 LL |     if !b != true {}
    |        ^^^^^^^^^^ help: try: `b`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:187:8
+  --> tests/ui/nonminimal_bool.rs:188:8
    |
 LL |     if true == !b {}
    |        ^^^^^^^^^^ help: try: `true != b`
 
 error: equality checks against true are unnecessary
-  --> tests/ui/nonminimal_bool.rs:187:8
+  --> tests/ui/nonminimal_bool.rs:188:8
    |
 LL |     if true == !b {}
    |        ^^^^^^^^^^ help: try: `!b`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:190:8
+  --> tests/ui/nonminimal_bool.rs:191:8
    |
 LL |     if true != !b {}
    |        ^^^^^^^^^^ help: try: `true == b`
 
 error: inequality checks against true can be replaced by a negation
-  --> tests/ui/nonminimal_bool.rs:190:8
+  --> tests/ui/nonminimal_bool.rs:191:8
    |
 LL |     if true != !b {}
    |        ^^^^^^^^^^ help: try: `b`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:193:8
+  --> tests/ui/nonminimal_bool.rs:194:8
    |
 LL |     if !b == !c {}
    |        ^^^^^^^^ help: try: `b == c`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:195:8
+  --> tests/ui/nonminimal_bool.rs:196:8
    |
 LL |     if !b != !c {}
    |        ^^^^^^^^ help: try: `b != c`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:211:8
+  --> tests/ui/nonminimal_bool.rs:212:8
    |
 LL |     if !(a < 2.0 && !b) {
    |        ^^^^^^^^^^^^^^^^
@@ -271,7 +283,7 @@ LL +     if a >= 2.0 || b {
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:230:12
+  --> tests/ui/nonminimal_bool.rs:231:12
    |
 LL |         if !(matches!(ty, TyKind::Ref(_, _, _)) && !is_mutable(&expr)) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -283,16 +295,16 @@ LL +         if !matches!(ty, TyKind::Ref(_, _, _)) || is_mutable(&expr) {
    |
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool.rs:250:8
+  --> tests/ui/nonminimal_bool.rs:251:8
    |
 LL |     if !S != true {}
    |        ^^^^^^^^^^ help: try: `S == true`
 
 error: inequality checks against true can be replaced by a negation
-  --> tests/ui/nonminimal_bool.rs:250:8
+  --> tests/ui/nonminimal_bool.rs:251:8
    |
 LL |     if !S != true {}
    |        ^^^^^^^^^^ help: try: `!!S`
 
-error: aborting due to 31 previous errors
+error: aborting due to 32 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17185)*

Extend the lint to catch

    if c {
        return W(true);
    }
    W(false)

and reduce it to `W(c)` (or `W(!c)`), where `W` is an optional tuple-like
constructor (`Ok`/`Some`/user enum & tuple-struct ctors) shared by both the
guard and the trailing expression, or absent.

Constructors are pure, so folding the condition into them preserves behavior.
The values must differ (equal values are skipped, since the condition could
have side effects), the guard body must be only the `return`, and the same
constructor must wrap both bools.

---

See example in the wild: https://github.com/uutils/coreutils/pull/12689

changelog: needless_bool: lint the early-return guard form