### PR TITLE
Implement redundant idempotent calls lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7255,6 +7255,7 @@ Released 2018-09-13
 [`redundant_feature_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_feature_names
 [`redundant_field_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
 [`redundant_guards`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_guards
+[`redundant_idempotent_calls`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_idempotent_calls
 [`redundant_iter_cloned`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_iter_cloned
 [`redundant_locals`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_locals
 [`redundant_pattern`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -465,6 +465,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::READ_LINE_WITHOUT_TRIM_INFO,
     crate::methods::READONLY_WRITE_LOCK_INFO,
     crate::methods::REDUNDANT_AS_STR_INFO,
+    crate::methods::REDUNDANT_IDEMPOTENT_CALLS_INFO,
     crate::methods::REDUNDANT_ITER_CLONED_INFO,
     crate::methods::REPEAT_ONCE_INFO,
     crate::methods::RESULT_FILTER_MAP_INFO,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -103,6 +103,7 @@ mod range_zip_with_len;
 mod read_line_without_trim;
 mod readonly_write_lock;
 mod redundant_as_str;
+mod redundant_idempotent_calls;
 mod repeat_once;
 mod result_map_or_else_none;
 mod return_and_then;
@@ -3278,6 +3279,30 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for redundant calls to idempotent methods, where calling the
+    /// same method with the same arguments on a value that has already had
+    /// that method applied produces no change.
+    ///
+    /// ### Why is this bad?
+    /// Redundant method calls add uncessary computation to the code
+    /// without any effect, making it harder to read and understand.
+    ///
+    /// ### Example
+    /// ```no_run
+    ///     let _ = "Ba-dum!".to_lowercase().to_lowercase();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    ///     let _ = "Ba-dum!".to_lowercase();
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub REDUNDANT_IDEMPOTENT_CALLS,
+    nursery,
+    "default lint description"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for calls to `Iterator::cloned` where the original value could be used
     /// instead.
     ///
@@ -4971,6 +4996,7 @@ impl_lint_pass!(Methods => [
     READONLY_WRITE_LOCK,
     READ_LINE_WITHOUT_TRIM,
     REDUNDANT_AS_STR,
+    REDUNDANT_IDEMPOTENT_CALLS,
     REDUNDANT_ITER_CLONED,
     REPEAT_ONCE,
     RESULT_FILTER_MAP,
@@ -5202,6 +5228,18 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
 
             new_ret_no_self::check_trait_item(cx, item);
         }
+    }
+
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _kind: rustc_hir::intravisit::FnKind<'tcx>,
+        _decl: &'tcx rustc_hir::FnDecl<'tcx>,
+        body: &'tcx rustc_hir::Body<'tcx>,
+        _span: Span,
+        _id: rustc_span::def_id::LocalDefId,
+    ) {
+        redundant_idempotent_calls::check(cx, body);
     }
 }
 

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3298,7 +3298,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.97.0"]
     pub REDUNDANT_IDEMPOTENT_CALLS,
     nursery,
-    "default lint description"
+    "redundant call to an idempotent method"
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/methods/redundant_idempotent_calls.rs
+++ b/clippy_lints/src/methods/redundant_idempotent_calls.rs
@@ -33,7 +33,7 @@ fn walk_block<'tcx>(
             StmtKind::Semi(expr) | StmtKind::Expr(expr) => {
                 check_expr(cx, expr, map);
             },
-            _ => {},
+            StmtKind::Item(_) => {},
         }
     }
     // Covers the final expression the block evaluates to
@@ -43,7 +43,6 @@ fn walk_block<'tcx>(
     None
 }
 // Checking functions for language elements
-
 // Checks any expression
 fn check_expr<'tcx>(
     cx: &LateContext<'tcx>,
@@ -52,20 +51,21 @@ fn check_expr<'tcx>(
 ) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
     match &expr.kind {
         ExprKind::MethodCall(method, receiver, args, _) => check_method_call(cx, expr, method, receiver, args, map),
-        ExprKind::Assign(left_value, right_value, _) => check_assign(cx, left_value, right_value, map),
-        ExprKind::AssignOp(_, left_value, right_value) => check_assign(cx, left_value, right_value, map),
+        ExprKind::Assign(left_value, right_value, _) | ExprKind::AssignOp(_, left_value, right_value) => {
+            check_assign(cx, left_value, right_value, map)
+        },
         ExprKind::Loop(block, _, _, _) => check_loop(cx, block, map),
         ExprKind::Match(_, arms, _) => check_match(cx, arms, map),
         ExprKind::Call(_, args) => check_func_args(cx, args, map),
         ExprKind::Closure(closure) => check_closure(cx, closure, map),
         ExprKind::Block(block, _) => walk_block(cx, block, map),
-        ExprKind::Ret(Some(expr)) => check_expr(cx, expr, map),
-        ExprKind::Cast(expr, _) => check_expr(cx, expr, map),
+        ExprKind::Ret(Some(expr))
+        | ExprKind::Cast(expr, _)
+        | ExprKind::Unary(_, expr)
+        | ExprKind::Repeat(expr, _)
+        | ExprKind::AddrOf(_, _, expr) => check_expr(cx, expr, map),
         ExprKind::DropTemps(inner) => check_expr(cx, inner, map),
-        ExprKind::Unary(_, expr) => check_expr(cx, expr, map),
-        ExprKind::Repeat(expr, _) => check_expr(cx, expr, map),
         ExprKind::Let(let_expr) => check_expr(cx, let_expr.init, map),
-        ExprKind::AddrOf(_, _, expr) => check_expr(cx, expr, map),
         ExprKind::Index(arr, idx, _) => {
             check_expr(cx, arr, map);
             check_expr(cx, idx, map);
@@ -73,14 +73,14 @@ fn check_expr<'tcx>(
         },
         ExprKind::If(cond, then_block, else_block) => {
             check_expr(cx, cond, map);
-            check_if(cx, then_block, else_block, map)
+            check_if(cx, then_block, *else_block, map)
         },
         ExprKind::Binary(_, left, right) => {
             check_expr(cx, left, map);
             check_expr(cx, right, map);
             None
         },
-        ExprKind::Tup(exprs) => {
+        ExprKind::Tup(exprs) | ExprKind::Array(exprs) => {
             for expr in *exprs {
                 check_expr(cx, expr, map);
             }
@@ -92,12 +92,6 @@ fn check_expr<'tcx>(
             }
             if let rustc_hir::StructTailExpr::Base(base_expr) = base {
                 check_expr(cx, base_expr, map);
-            }
-            None
-        },
-        ExprKind::Array(exprs) => {
-            for expr in *exprs {
-                check_expr(cx, expr, map);
             }
             None
         },
@@ -123,17 +117,15 @@ fn check_let<'tcx>(
             if let PatKind::Binding(_, hir_id, _, _) = local.pat.kind {
                 map.insert(hir_id, (method.ident.name, args));
             }
-        } else {
-            if let PatKind::Binding(_, hir_id, _, _) = local.pat.kind {
-                // try to inherit the alias symbol otherwise we check the expr
-                if !try_inherit_alias(expr, hir_id, map) {
-                    if let Some((symbol, args)) = check_expr(cx, expr, map) {
-                        map.insert(hir_id, (symbol, args));
-                    }
-                }
-            } else {
-                check_expr(cx, expr, map);
+        } else if let PatKind::Binding(_, hir_id, _, _) = local.pat.kind {
+            // try to inherit the alias symbol otherwise we check the expr
+            if !try_inherit_alias(expr, hir_id, map)
+                && let Some((symbol, args)) = check_expr(cx, expr, map)
+            {
+                map.insert(hir_id, (symbol, args));
             }
+        } else {
+            check_expr(cx, expr, map);
         }
     }
 
@@ -165,11 +157,10 @@ fn check_method_call<'tcx>(
     // if the receiver is borrowed with a "&mut self"
     if let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
         let fn_sig = cx.tcx.fn_sig(def_id).skip_binder();
-        if let Some(first_ty) = fn_sig.inputs().skip_binder().get(0) {
-            // to get the self
-            if let rustc_middle::ty::Ref(_, _, Mutability::Mut) = first_ty.kind() {
-                invalidate_left_value(peeled_receiver, map);
-            }
+        if let Some(first_ty) = fn_sig.inputs().skip_binder().first()
+            && let rustc_middle::ty::Ref(_, _, Mutability::Mut) = first_ty.kind()
+        {
+            invalidate_left_value(peeled_receiver, map);
         }
     }
 
@@ -212,7 +203,7 @@ fn check_method_call<'tcx>(
 fn check_if<'tcx>(
     cx: &LateContext<'tcx>,
     then_block: &'tcx rustc_hir::Expr<'tcx>,
-    else_block: &Option<&'tcx rustc_hir::Expr<'tcx>>,
+    else_block: Option<&'tcx rustc_hir::Expr<'tcx>>,
     map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
 ) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
     // each branch gets its own clone to avoid cross contamination

--- a/clippy_lints/src/methods/redundant_idempotent_calls.rs
+++ b/clippy_lints/src/methods/redundant_idempotent_calls.rs
@@ -1,0 +1,508 @@
+use clippy_utils::consts::ConstEvalCtxt;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::sym;
+use rustc_data_structures::fx::FxIndexMap;
+use rustc_errors::Applicability;
+use rustc_hir::def::Res;
+use rustc_hir::{Body, ExprKind, HirId, Mutability, PatKind, QPath, StmtKind};
+use rustc_lint::LateContext;
+use rustc_span::Symbol;
+
+use super::REDUNDANT_IDEMPOTENT_CALLS;
+
+// Checks all function code
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, body: &'tcx Body<'tcx>) {
+    // If the body of the function is a block
+    if let ExprKind::Block(block, _) = &body.value.kind {
+        // tracks which local variables have already had an idempotent method applied
+        // and the arguments used with them
+        let mut map = FxIndexMap::default();
+        walk_block(cx, block, &mut map);
+    }
+}
+// Checks blocks of code (ifs, loops, match arms, etc...)
+fn walk_block<'tcx>(
+    cx: &LateContext<'tcx>,
+    block: &'tcx rustc_hir::Block<'tcx>,
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    for stmt in block.stmts {
+        match &stmt.kind {
+            StmtKind::Let(local) => check_let(cx, local, map),
+            StmtKind::Semi(expr) | StmtKind::Expr(expr) => {
+                check_expr(cx, expr, map);
+            },
+            _ => {},
+        }
+    }
+    // Covers the final expression the block evaluates to
+    if let Some(expr) = block.expr {
+        return check_expr(cx, expr, map);
+    }
+    None
+}
+// Checking functions for language elements
+
+// Checks any expression
+fn check_expr<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx rustc_hir::Expr<'tcx>,
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    match &expr.kind {
+        ExprKind::MethodCall(method, receiver, args, _) => check_method_call(cx, expr, method, receiver, args, map),
+        ExprKind::Assign(left_value, right_value, _) => check_assign(cx, left_value, right_value, map),
+        ExprKind::AssignOp(_, left_value, right_value) => check_assign(cx, left_value, right_value, map),
+        ExprKind::Loop(block, _, _, _) => check_loop(cx, block, map),
+        ExprKind::Match(_, arms, _) => check_match(cx, arms, map),
+        ExprKind::Call(_, args) => check_func_args(cx, args, map),
+        ExprKind::Closure(closure) => check_closure(cx, closure, map),
+        ExprKind::Block(block, _) => walk_block(cx, block, map),
+        ExprKind::Ret(Some(expr)) => check_expr(cx, expr, map),
+        ExprKind::Cast(expr, _) => check_expr(cx, expr, map),
+        ExprKind::DropTemps(inner) => check_expr(cx, inner, map),
+        ExprKind::Unary(_, expr) => check_expr(cx, expr, map),
+        ExprKind::Repeat(expr, _) => check_expr(cx, expr, map),
+        ExprKind::Let(let_expr) => check_expr(cx, let_expr.init, map),
+        ExprKind::AddrOf(_, _, expr) => check_expr(cx, expr, map),
+        ExprKind::Index(arr, idx, _) => {
+            check_expr(cx, arr, map);
+            check_expr(cx, idx, map);
+            None
+        },
+        ExprKind::If(cond, then_block, else_block) => {
+            check_expr(cx, cond, map);
+            check_if(cx, then_block, else_block, map)
+        },
+        ExprKind::Binary(_, left, right) => {
+            check_expr(cx, left, map);
+            check_expr(cx, right, map);
+            None
+        },
+        ExprKind::Tup(exprs) => {
+            for expr in *exprs {
+                check_expr(cx, expr, map);
+            }
+            None
+        },
+        ExprKind::Struct(_, fields, base) => {
+            for field in *fields {
+                check_expr(cx, field.expr, map);
+            }
+            if let rustc_hir::StructTailExpr::Base(base_expr) = base {
+                check_expr(cx, base_expr, map);
+            }
+            None
+        },
+        ExprKind::Array(exprs) => {
+            for expr in *exprs {
+                check_expr(cx, expr, map);
+            }
+            None
+        },
+        _ => None,
+    }
+}
+
+// Checks a let expression
+fn check_let<'tcx>(
+    cx: &LateContext<'tcx>,
+    local: &'tcx rustc_hir::LetStmt<'tcx>,
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) {
+    if let Some(init) = local.init {
+        // inrelevant and inserted by the compiler
+        let expr = strip_parens_and_temps(init);
+
+        if let ExprKind::MethodCall(method, receiver, args, _) = &expr.kind
+            && is_idempotent(cx, expr, method.ident.name)
+        {
+            check_method_call(cx, expr, method, receiver, args, map);
+            // record the new binding if it is a simple identifier
+            if let PatKind::Binding(_, hir_id, _, _) = local.pat.kind {
+                map.insert(hir_id, (method.ident.name, args));
+            }
+        } else {
+            if let PatKind::Binding(_, hir_id, _, _) = local.pat.kind {
+                // try to inherit the alias symbol otherwise we check the expr
+                if !try_inherit_alias(expr, hir_id, map) {
+                    if let Some((symbol, args)) = check_expr(cx, expr, map) {
+                        map.insert(hir_id, (symbol, args));
+                    }
+                }
+            } else {
+                check_expr(cx, expr, map);
+            }
+        }
+    }
+
+    if let Some(els) = local.els {
+        walk_block(cx, els, map);
+    }
+}
+
+// Checks for method calls
+fn check_method_call<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx rustc_hir::Expr<'tcx>,
+    method: &rustc_hir::PathSegment<'tcx>,
+    receiver: &'tcx rustc_hir::Expr<'tcx>,
+    args: &'tcx [rustc_hir::Expr<'tcx>],
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    let mut applicability = Applicability::MachineApplicable;
+    let peeled_receiver = strip_parens_and_temps(receiver);
+    let method_name = method.ident.name;
+    let is_idemp = is_idempotent(cx, expr, method_name);
+
+    // recurse to catch inner redundancies
+    check_expr(cx, receiver, map);
+
+    // invalidate args mutable
+    check_func_args(cx, args, map);
+
+    // if the receiver is borrowed with a "&mut self"
+    if let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
+        let fn_sig = cx.tcx.fn_sig(def_id).skip_binder();
+        if let Some(first_ty) = fn_sig.inputs().skip_binder().get(0) {
+            // to get the self
+            if let rustc_middle::ty::Ref(_, _, Mutability::Mut) = first_ty.kind() {
+                invalidate_left_value(peeled_receiver, map);
+            }
+        }
+    }
+
+    if is_idemp
+        && let Some(hir_id) = path_to_local(peeled_receiver)
+        && let Some((recorded_method, recorded_args)) = map.get(&hir_id)
+    {
+        if *recorded_method == method_name && are_args_equal(cx, recorded_args, args) {
+            span_lint_and_sugg(
+                cx,
+                REDUNDANT_IDEMPOTENT_CALLS,
+                expr.span,
+                "redundant call to idempotent method, the result is already the same",
+                "replace with",
+                snippet_with_applicability(cx, peeled_receiver.span, "..", &mut applicability).to_string(),
+                applicability,
+            );
+        } else {
+            map.insert(hir_id, (method_name, args));
+            return Some((method_name, args));
+        }
+    } else if is_idemp && let ExprKind::MethodCall(recursive_method, _, recv_args, _) = peeled_receiver.kind {
+        if method_name == recursive_method.ident.name && are_args_equal(cx, recv_args, args) {
+            span_lint_and_sugg(
+                cx,
+                REDUNDANT_IDEMPOTENT_CALLS,
+                expr.span,
+                "redundant call to idempotent method, the result is already the same",
+                "replace with",
+                snippet_with_applicability(cx, peeled_receiver.span, "..", &mut applicability).to_string(),
+                applicability,
+            );
+        }
+    } else if is_idemp {
+        return Some((method_name, args));
+    }
+    None
+}
+
+fn check_if<'tcx>(
+    cx: &LateContext<'tcx>,
+    then_block: &'tcx rustc_hir::Expr<'tcx>,
+    else_block: &Option<&'tcx rustc_hir::Expr<'tcx>>,
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    // each branch gets its own clone to avoid cross contamination
+    let mut then_map = map.clone();
+    if let ExprKind::Block(block, _) = &then_block.kind {
+        walk_block(cx, block, &mut then_map);
+    }
+
+    if let Some(else_expr) = else_block {
+        if let ExprKind::Block(block, _) = &else_expr.kind {
+            let mut else_map = map.clone();
+            walk_block(cx, block, &mut else_map);
+            // conservative merge
+            map.retain(|hir_id, (method, args)| {
+                if let Some((obtained_method, obtained_args)) = then_map.get(hir_id)
+                    && let Some((obtained_method2, obtained_args2)) = else_map.get(hir_id)
+                {
+                    return obtained_method == method
+                        && are_args_equal(cx, args, obtained_args)
+                        && obtained_method2 == method
+                        && are_args_equal(cx, args, obtained_args2);
+                }
+                false
+            });
+        } else {
+            //"else if" or other node diff than block,
+            // clear everything that the then branch might have changed
+            map.retain(|hir_id, (method, args)| {
+                if let Some((obtained_method, obtained_args)) = then_map.get(hir_id) {
+                    return obtained_method == method && are_args_equal(cx, args, obtained_args);
+                }
+                false
+            });
+            check_expr(cx, else_expr, map);
+        }
+    } else {
+        // no "else" branch
+        map.retain(|hir_id, (method, args)| {
+            if let Some((obtained_method, obtained_args)) = then_map.get(hir_id) {
+                return obtained_method == method && are_args_equal(cx, args, obtained_args);
+            }
+            false
+        });
+    }
+    None
+}
+
+// Checks assignments
+fn check_assign<'tcx>(
+    cx: &LateContext<'tcx>,
+    left_value: &'tcx rustc_hir::Expr<'tcx>,
+    right_value: &'tcx rustc_hir::Expr<'tcx>,
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    if let Some(dst_hir_id) = path_to_local(left_value) {
+        if !try_inherit_alias(right_value, dst_hir_id, map) {
+            if let Some((symbol, args)) = check_expr(cx, right_value, map) {
+                map.insert(dst_hir_id, (symbol, args));
+            } else {
+                invalidate_left_value(left_value, map);
+            }
+        }
+    } else {
+        check_expr(cx, right_value, map);
+    }
+    None
+}
+
+// Checks loops
+fn check_loop<'tcx>(
+    cx: &LateContext<'tcx>,
+    block: &'tcx rustc_hir::Block<'tcx>,
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    let mut loop_map = map.clone();
+    walk_block(cx, block, &mut loop_map);
+
+    // A state survives only if it existed before the loop and if it was left completely identical
+    // inside the loop body.
+    map.retain(|hir_id, (method, args)| {
+        if let Some((obtained_method, obtained_args)) = loop_map.get(hir_id) {
+            return obtained_method == method && are_args_equal(cx, args, obtained_args);
+        }
+        false
+    });
+    None
+}
+
+// Checks matches
+fn check_match<'tcx>(
+    cx: &LateContext<'tcx>,
+    arms: &'tcx [rustc_hir::Arm<'tcx>],
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    if arms.is_empty() {
+        return None;
+    }
+
+    let mut arm_maps = Vec::new();
+    for arm in arms {
+        let mut arm_map = map.clone();
+
+        if let Some(guard) = arm.guard {
+            check_expr(cx, guard, &mut arm_map);
+        }
+
+        check_expr(cx, arm.body, &mut arm_map);
+        arm_maps.push(arm_map);
+    }
+    // A variable keeps its tracking state if it is present and identical across all match arms.
+    map.retain(|hir_id, (method, args)| {
+        arm_maps.iter().all(|arm_map| {
+            if let Some((obtained_method, obtained_args)) = arm_map.get(hir_id) {
+                return obtained_method == method && are_args_equal(cx, args, obtained_args);
+            }
+            false
+        })
+    });
+
+    None
+}
+
+// Checks closures
+fn check_closure<'tcx>(
+    cx: &LateContext<'tcx>,
+    closure: &'tcx rustc_hir::Closure<'tcx>,
+    map: &mut FxIndexMap<HirId, (Symbol, &[rustc_hir::Expr<'_>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    // invalidate any variables captured mutably
+    for capture in cx.typeck_results().closure_min_captures_flattened(closure.def_id) {
+        if capture.mutability == Mutability::Mut {
+            map.shift_remove(&capture.get_root_variable());
+        }
+    }
+    None
+}
+
+// Auxiliary functions
+
+// Removes a value from the tracked list
+fn invalidate_left_value<'tcx>(
+    expr: &'tcx rustc_hir::Expr<'tcx>,
+    map: &mut FxIndexMap<HirId, (Symbol, &[rustc_hir::Expr<'_>])>,
+) {
+    if let Some(hir_id) = path_to_local(expr) {
+        map.shift_remove(&hir_id);
+
+        // if any entry that its args reference the variable
+        map.retain(|_, (_, args)| !args.iter().any(|arg| path_to_local(arg) == Some(hir_id)));
+    }
+}
+
+// This is a known list of idempotent functions, that can either be expanded or replaced by some
+// primitive static analysis.
+fn is_idempotent<'tcx>(cx: &LateContext<'tcx>, expr: &rustc_hir::Expr<'tcx>, name: Symbol) -> bool {
+    if !matches!(
+        name,
+        sym::trim
+            | sym::trim_start
+            | sym::trim_end
+            | sym::to_lowercase
+            | sym::to_uppercase
+            | sym::to_ascii_lowercase
+            | sym::to_ascii_uppercase
+            | sym::abs
+            | sym::floor
+            | sym::ceil
+            | sym::round
+            | sym::signum
+            | sym::max
+            | sym::min
+            | sym::clamp
+            | sym::to_vec
+            | sym::and
+            | sym::or
+    ) {
+        return false;
+    }
+    // check if the method comes from the stdlib
+    if let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
+        let crate_name = cx.tcx.crate_name(def_id.krate);
+        crate_name == sym::std || crate_name == sym::alloc || crate_name == sym::core
+    } else {
+        false
+    }
+}
+
+// Resolves an expression into its respective HirId
+fn path_to_local(expr: &rustc_hir::Expr<'_>) -> Option<HirId> {
+    if let ExprKind::Path(QPath::Resolved(None, path)) = &expr.kind
+        && let Res::Local(hir_id) = path.res
+    {
+        Some(hir_id)
+    } else {
+        None
+    }
+}
+
+// Checks if any mutable references are passed down a function and if so, remove
+// those variables from the tracking Map
+fn check_func_args<'tcx>(
+    cx: &LateContext<'tcx>,
+    args: &'tcx [rustc_hir::Expr<'tcx>],
+    map: &mut FxIndexMap<HirId, (Symbol, &'tcx [rustc_hir::Expr<'tcx>])>,
+) -> Option<(Symbol, &'tcx [rustc_hir::Expr<'tcx>])> {
+    for arg in args {
+        if let ExprKind::AddrOf(_, Mutability::Mut, inner) = &arg.kind
+            && let Some(hir_id) = path_to_local(inner)
+        {
+            map.shift_remove(&hir_id);
+        } else {
+            check_expr(cx, arg, map);
+        }
+    }
+    None
+}
+
+fn is_expr_safe_to_compare(expr: &rustc_hir::Expr<'_>) -> bool {
+    match &expr.kind {
+        ExprKind::Lit(_) | ExprKind::Path(_) => true,
+        ExprKind::Unary(_, inner) => is_expr_safe_to_compare(inner),
+        // to cover constructors just like Some(1), Ok(2), None (but only literals)
+        ExprKind::Call(func, args) => {
+            matches!(func.kind, ExprKind::Path(_)) && args.iter().all(is_expr_safe_to_compare)
+        },
+        _ => false,
+    }
+}
+
+// In the case of some functions, they are idempotent as long as their arguments
+// are used in the same manner
+fn are_args_equal<'tcx>(
+    cx: &LateContext<'tcx>,
+    args1: &'tcx [rustc_hir::Expr<'tcx>],
+    args2: &'tcx [rustc_hir::Expr<'tcx>],
+) -> bool {
+    for (arg1, arg2) in args1.iter().zip(args2.iter()) {
+        let const_context = ConstEvalCtxt::new(cx);
+        if let Some(const_1) = const_context.eval(arg1)
+            && let Some(const_2) = const_context.eval(arg2)
+        {
+            if const_1 != const_2 {
+                return false;
+            }
+        } else if let Some(id1) = path_to_local(arg1)
+            && let Some(id2) = path_to_local(arg2)
+        {
+            if id1 != id2 {
+                return false;
+            }
+        } else if is_expr_safe_to_compare(arg1) && is_expr_safe_to_compare(arg2) {
+            if !clippy_utils::SpanlessEq::new(cx).eq_expr(arg1.span.ctxt(), arg1, arg2) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+fn try_inherit_alias<'a>(
+    expr: &rustc_hir::Expr<'_>,
+    pat_hir_id: HirId,
+    map: &mut FxIndexMap<HirId, (Symbol, &'a [rustc_hir::Expr<'a>])>,
+) -> bool {
+    if let Some(src_hir_id) = path_to_local(expr)
+        && let Some(&(symbol, args)) = map.get(&src_hir_id)
+    {
+        map.insert(pat_hir_id, (symbol, args));
+        true
+    } else {
+        false
+    }
+}
+
+fn strip_parens_and_temps<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>) -> &'tcx rustc_hir::Expr<'tcx> {
+    let mut e = expr;
+    loop {
+        match &e.kind {
+            ExprKind::DropTemps(inner) => e = inner,
+            ExprKind::Block(block, _) if block.stmts.is_empty() => {
+                if let Some(tail) = block.expr {
+                    e = tail;
+                } else {
+                    break;
+                }
+            },
+            _ => break,
+        }
+    }
+    e
+}

--- a/tests/ui/redundant_idempotent_calls.fixed
+++ b/tests/ui/redundant_idempotent_calls.fixed
@@ -1,0 +1,314 @@
+#![warn(clippy::redundant_idempotent_calls)]
+#![allow(unused_variables, unused_mut, clippy::self_assignment)]
+
+fn direct_chain() {
+    let _ = "Ba-dum!".to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn trigger_variable_str() {
+    let s = "Tss!".to_lowercase();
+    s;
+    //~^ redundant_idempotent_calls
+}
+
+fn trigger_variable_float() {
+    let x = 1.32_f64.floor();
+    x;
+    //~^ redundant_idempotent_calls
+}
+
+fn no_false_positive_variable_leak() {
+    let c = true;
+    if c {
+        let t = "Tuntun-tuntun".to_lowercase();
+        let _ = t;
+        //~^ redundant_idempotent_calls
+    }
+    let t = "Tan-tan! ".to_lowercase();
+    let _ = t;
+    //~^ redundant_idempotent_calls
+}
+
+fn no_false_positive_invalidation() {
+    let c = true;
+    let mut s = "Tan-tan".to_lowercase();
+    let mut t = "taran-tan-tan!";
+    if c {
+        let t = s;
+    }
+    t.to_lowercase();
+}
+fn complicated_cases() {
+    let mut c = 1.32_f64.floor();
+    let mut sometime_ago = false;
+    if (sometime_ago) {
+        println!("We're no strangers to love");
+    } else {
+        println!("You know the rules and so do I");
+    }
+    while (sometime_ago) {
+        c = c;
+        //~^ redundant_idempotent_calls
+        sometime_ago = false;
+    }
+}
+fn complicated_casestoo() {
+    let c = 1.32_f64.floor();
+    let mut sometime_ago = false;
+    if (sometime_ago) {
+        println!("A full commitment's what I'm thinking of");
+    } else {
+        println!("You wouldn't get this from any other guy");
+    }
+    while (sometime_ago) {
+        sometime_ago = false;
+    }
+}
+fn simple_one() {
+    let mut c = 1.32_f64;
+    c = c.floor();
+    c = c;
+    //~^ redundant_idempotent_calls
+}
+
+fn false_positive_non_idempotent_pollutes_map() {
+    let s = "I just wanna tell you how I'm feeling".to_string();
+    let _t = s.to_lowercase();
+    s.to_lowercase();
+}
+
+fn closure_should_not_lint() {
+    let mut s = "Gotta make you understand".to_lowercase();
+    let mut f = || s = String::from("Never gonna give you up");
+    f();
+    s.to_lowercase();
+}
+
+fn for_loop_should_not_lint() {
+    let mut s = "Never gonna let you down".to_lowercase();
+    for _ in 0..10 {
+        s = String::from("Never gonna run around and desert you");
+    }
+    s.to_lowercase();
+}
+
+fn mut_self_should_not_lint() {
+    let mut s = "Never gonna make you cry".to_lowercase();
+    s.make_ascii_uppercase();
+    s.to_lowercase();
+}
+
+fn block_expr_should_lint() {
+    let x = { "Never gonna say goodbye".to_lowercase() };
+    let _ = x;
+    //~^ redundant_idempotent_calls
+}
+
+fn alias_should_lint() {
+    let x = "Never gonna tell a lie and hurt you".to_lowercase();
+    let y = x;
+    let _ = y;
+    //~^ redundant_idempotent_calls
+}
+
+fn assign_alias_should_lint() {
+    let x = "We've known each other for so long".to_lowercase();
+    let mut y = String::new();
+    y = x;
+    y;
+    //~^ redundant_idempotent_calls
+}
+
+fn condition_should_lint() {
+    let x = "Your heart's been aching, but you're too shy to say it".to_lowercase();
+    if x == "Inside, we both know what's been going on" {}
+    //~^ redundant_idempotent_calls
+}
+
+fn func_arg_should_lint() {
+    fn takes_string(_s: String) {}
+
+    let x = "We know the game, and we're gonna play it".to_lowercase();
+    takes_string(x);
+    //~^ redundant_idempotent_calls
+}
+
+fn return_should_lint() -> String {
+    let x = "And if you ask me how I'm feeling".to_lowercase();
+    if !x.is_empty() {
+        return x;
+        //~^ redundant_idempotent_calls
+    }
+    x
+}
+
+fn tuple_false_should_lint() {
+    let x = "Don't tell me you're too blind to see".to_lowercase();
+    let _ = (x, 1);
+    //~^ redundant_idempotent_calls
+}
+
+fn match_guard_should_lint() {
+    let x = "Never gonna give you up".to_lowercase();
+    match 1 {
+        _ if x == "Never gonna let you down" => {},
+        //~^ redundant_idempotent_calls
+        _ => {},
+    }
+}
+
+fn assign_index_should_lint() {
+    let x = "Never gonna run around and desert you".to_lowercase();
+    let mut arr = [String::new()];
+    arr[0] = x;
+    //~^ redundant_idempotent_calls
+}
+
+fn array_should_lint() {
+    let x = "Never gonna make you cry".to_lowercase();
+    let _ = [x, String::new()];
+    //~^ redundant_idempotent_calls
+}
+
+fn struct_should_lint() {
+    struct MyStruct {
+        field: String,
+    }
+
+    let x = "Never gonna say goodbye".to_lowercase();
+    let _ = MyStruct {
+        field: x,
+        //~^ redundant_idempotent_calls
+    };
+}
+
+fn idempotent_with_args() {
+    let mut x = 3.12_f64.max(0_f64);
+    x = x;
+    //~^ redundant_idempotent_calls
+    let mut y = 1.12_f64.max(0_f64);
+    y = y.max(2_f64);
+
+    // this is not getting detected, if you want more edges on your edge case...
+    let confusion = 2_f64;
+    let mut z = 1.12_f64.max(confusion);
+    z = z;
+    //~^ redundant_idempotent_calls
+}
+
+fn unary_should_lint() {
+    let x = 1.0_f64.abs();
+    let _ = -x;
+    //~^ redundant_idempotent_calls
+}
+
+fn let_else_should_lint() {
+    let x = "Never gonna tell a lie and hurt you".to_lowercase();
+    let Some(_) = Some(1) else {
+        x;
+        //~^ redundant_idempotent_calls
+        return;
+    };
+}
+
+fn max_different_args_should_not_lint() {
+    let _ = 1.0_f64.max(2.0).max(3.0);
+}
+
+fn cast_should_lint() {
+    let x = 1.0_f64.floor();
+    let _ = x as f32;
+    //~^ redundant_idempotent_calls
+}
+
+fn index_should_lint() {
+    let x = "Never gonna give you up".to_lowercase();
+    let arr = [1, 2, 3];
+    let _y = arr[{
+        let _ = x;
+        //~^ redundant_idempotent_calls
+        0
+    }];
+}
+
+fn repeat_should_lint() {
+    let x = 1.0_f64.floor();
+    let _ = [x; 3];
+    //~^ redundant_idempotent_calls
+}
+
+fn receiver_complex_should_lint() {
+    let x = "Never gonna let you down".to_lowercase();
+    let _ = x.to_uppercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn let_chain_should_lint() {
+    let x = "Never gonna run around and desert you".to_lowercase();
+    if let y = x
+    //~^ redundant_idempotent_calls
+        && y.is_empty()
+    {}
+}
+
+fn addr_of_should_lint() {
+    let x = "Never gonna make you cry".to_lowercase();
+    let _ = &x;
+    //~^ redundant_idempotent_calls
+}
+
+fn custom_type_should_not_lint() {
+    struct Wrapper;
+    impl Wrapper {
+        fn abs(&self) -> Wrapper {
+            Wrapper
+        }
+    }
+    let x = Wrapper.abs();
+    x.abs(); // Wrapper::abs is not the stdlib abs so it should not lint
+}
+
+fn mutable_var_should_not_lint() {
+    let mut val = Some(1_i32);
+    let x = Some(0).and(val);
+    val = Some(99);
+    x.and(val);
+}
+
+fn idempotent_methods_should_lint() {
+    let _ = Some(1).and(None::<i32>);
+    //~^ redundant_idempotent_calls
+    let _ = Some(1).and(Some(2));
+    //~^ redundant_idempotent_calls
+    let _ = None::<i32>.or(Some(2));
+    //~^ redundant_idempotent_calls
+    let _ = Some(1).or(Some(2));
+    //~^ redundant_idempotent_calls
+    let mut a = 5_i32;
+    a = a.min(10);
+    //~^ redundant_idempotent_calls
+    let _ = 1_i32.clamp(-1, 1);
+    //~^ redundant_idempotent_calls
+    let _ = b"Never gonna say goodbye".to_vec();
+    //~^ redundant_idempotent_calls
+    let _ = 1.32_f64.ceil();
+    //~^ redundant_idempotent_calls
+    let _ = 1.32_f64.signum();
+    //~^ redundant_idempotent_calls
+    let _ = "  Never gonna tell a lie and hurt you  ".trim_start();
+    //~^ redundant_idempotent_calls
+    let _ = "  Ooh (Give you up)  ".trim_end();
+    //~^ redundant_idempotent_calls
+    let x = "Ooh-ooh (Give you up)".to_ascii_lowercase();
+    let _ = x;
+    //~^ redundant_idempotent_calls
+    let y = "Ooh (Never gonna give, never gonna give)".to_ascii_uppercase();
+    let _ = y;
+    //~^ redundant_idempotent_calls
+    let x = 1.32_f64.round();
+    let _ = x;
+    //~^ redundant_idempotent_calls
+}
+
+fn main() {}

--- a/tests/ui/redundant_idempotent_calls.rs
+++ b/tests/ui/redundant_idempotent_calls.rs
@@ -1,0 +1,314 @@
+#![warn(clippy::redundant_idempotent_calls)]
+#![allow(unused_variables, unused_mut, clippy::self_assignment)]
+
+fn direct_chain() {
+    let _ = "Ba-dum!".to_lowercase().to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn trigger_variable_str() {
+    let s = "Tss!".to_lowercase();
+    s.to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn trigger_variable_float() {
+    let x = 1.32_f64.floor();
+    x.floor();
+    //~^ redundant_idempotent_calls
+}
+
+fn no_false_positive_variable_leak() {
+    let c = true;
+    if c {
+        let t = "Tuntun-tuntun".to_lowercase();
+        let _ = t.to_lowercase();
+        //~^ redundant_idempotent_calls
+    }
+    let t = "Tan-tan! ".to_lowercase();
+    let _ = t.to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn no_false_positive_invalidation() {
+    let c = true;
+    let mut s = "Tan-tan".to_lowercase();
+    let mut t = "taran-tan-tan!";
+    if c {
+        let t = s;
+    }
+    t.to_lowercase();
+}
+fn complicated_cases() {
+    let mut c = 1.32_f64.floor();
+    let mut sometime_ago = false;
+    if (sometime_ago) {
+        println!("We're no strangers to love");
+    } else {
+        println!("You know the rules and so do I");
+    }
+    while (sometime_ago) {
+        c = c.floor();
+        //~^ redundant_idempotent_calls
+        sometime_ago = false;
+    }
+}
+fn complicated_casestoo() {
+    let c = 1.32_f64.floor();
+    let mut sometime_ago = false;
+    if (sometime_ago) {
+        println!("A full commitment's what I'm thinking of");
+    } else {
+        println!("You wouldn't get this from any other guy");
+    }
+    while (sometime_ago) {
+        sometime_ago = false;
+    }
+}
+fn simple_one() {
+    let mut c = 1.32_f64;
+    c = c.floor();
+    c = c.floor();
+    //~^ redundant_idempotent_calls
+}
+
+fn false_positive_non_idempotent_pollutes_map() {
+    let s = "I just wanna tell you how I'm feeling".to_string();
+    let _t = s.to_lowercase();
+    s.to_lowercase();
+}
+
+fn closure_should_not_lint() {
+    let mut s = "Gotta make you understand".to_lowercase();
+    let mut f = || s = String::from("Never gonna give you up");
+    f();
+    s.to_lowercase();
+}
+
+fn for_loop_should_not_lint() {
+    let mut s = "Never gonna let you down".to_lowercase();
+    for _ in 0..10 {
+        s = String::from("Never gonna run around and desert you");
+    }
+    s.to_lowercase();
+}
+
+fn mut_self_should_not_lint() {
+    let mut s = "Never gonna make you cry".to_lowercase();
+    s.make_ascii_uppercase();
+    s.to_lowercase();
+}
+
+fn block_expr_should_lint() {
+    let x = { "Never gonna say goodbye".to_lowercase() };
+    let _ = x.to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn alias_should_lint() {
+    let x = "Never gonna tell a lie and hurt you".to_lowercase();
+    let y = x;
+    let _ = y.to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn assign_alias_should_lint() {
+    let x = "We've known each other for so long".to_lowercase();
+    let mut y = String::new();
+    y = x;
+    y.to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn condition_should_lint() {
+    let x = "Your heart's been aching, but you're too shy to say it".to_lowercase();
+    if x.to_lowercase() == "Inside, we both know what's been going on" {}
+    //~^ redundant_idempotent_calls
+}
+
+fn func_arg_should_lint() {
+    fn takes_string(_s: String) {}
+
+    let x = "We know the game, and we're gonna play it".to_lowercase();
+    takes_string(x.to_lowercase());
+    //~^ redundant_idempotent_calls
+}
+
+fn return_should_lint() -> String {
+    let x = "And if you ask me how I'm feeling".to_lowercase();
+    if !x.is_empty() {
+        return x.to_lowercase();
+        //~^ redundant_idempotent_calls
+    }
+    x
+}
+
+fn tuple_false_should_lint() {
+    let x = "Don't tell me you're too blind to see".to_lowercase();
+    let _ = (x.to_lowercase(), 1);
+    //~^ redundant_idempotent_calls
+}
+
+fn match_guard_should_lint() {
+    let x = "Never gonna give you up".to_lowercase();
+    match 1 {
+        _ if x.to_lowercase() == "Never gonna let you down" => {},
+        //~^ redundant_idempotent_calls
+        _ => {},
+    }
+}
+
+fn assign_index_should_lint() {
+    let x = "Never gonna run around and desert you".to_lowercase();
+    let mut arr = [String::new()];
+    arr[0] = x.to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn array_should_lint() {
+    let x = "Never gonna make you cry".to_lowercase();
+    let _ = [x.to_lowercase(), String::new()];
+    //~^ redundant_idempotent_calls
+}
+
+fn struct_should_lint() {
+    struct MyStruct {
+        field: String,
+    }
+
+    let x = "Never gonna say goodbye".to_lowercase();
+    let _ = MyStruct {
+        field: x.to_lowercase(),
+        //~^ redundant_idempotent_calls
+    };
+}
+
+fn idempotent_with_args() {
+    let mut x = 3.12_f64.max(0_f64);
+    x = x.max(0_f64);
+    //~^ redundant_idempotent_calls
+    let mut y = 1.12_f64.max(0_f64);
+    y = y.max(2_f64);
+
+    // this is not getting detected, if you want more edges on your edge case...
+    let confusion = 2_f64;
+    let mut z = 1.12_f64.max(confusion);
+    z = z.max(confusion);
+    //~^ redundant_idempotent_calls
+}
+
+fn unary_should_lint() {
+    let x = 1.0_f64.abs();
+    let _ = -(x.abs());
+    //~^ redundant_idempotent_calls
+}
+
+fn let_else_should_lint() {
+    let x = "Never gonna tell a lie and hurt you".to_lowercase();
+    let Some(_) = Some(1) else {
+        x.to_lowercase();
+        //~^ redundant_idempotent_calls
+        return;
+    };
+}
+
+fn max_different_args_should_not_lint() {
+    let _ = 1.0_f64.max(2.0).max(3.0);
+}
+
+fn cast_should_lint() {
+    let x = 1.0_f64.floor();
+    let _ = x.floor() as f32;
+    //~^ redundant_idempotent_calls
+}
+
+fn index_should_lint() {
+    let x = "Never gonna give you up".to_lowercase();
+    let arr = [1, 2, 3];
+    let _y = arr[{
+        let _ = x.to_lowercase();
+        //~^ redundant_idempotent_calls
+        0
+    }];
+}
+
+fn repeat_should_lint() {
+    let x = 1.0_f64.floor();
+    let _ = [x.floor(); 3];
+    //~^ redundant_idempotent_calls
+}
+
+fn receiver_complex_should_lint() {
+    let x = "Never gonna let you down".to_lowercase();
+    let _ = (x.to_lowercase()).to_uppercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn let_chain_should_lint() {
+    let x = "Never gonna run around and desert you".to_lowercase();
+    if let y = x.to_lowercase()
+    //~^ redundant_idempotent_calls
+        && y.is_empty()
+    {}
+}
+
+fn addr_of_should_lint() {
+    let x = "Never gonna make you cry".to_lowercase();
+    let _ = &x.to_lowercase();
+    //~^ redundant_idempotent_calls
+}
+
+fn custom_type_should_not_lint() {
+    struct Wrapper;
+    impl Wrapper {
+        fn abs(&self) -> Wrapper {
+            Wrapper
+        }
+    }
+    let x = Wrapper.abs();
+    x.abs(); // Wrapper::abs is not the stdlib abs so it should not lint
+}
+
+fn mutable_var_should_not_lint() {
+    let mut val = Some(1_i32);
+    let x = Some(0).and(val);
+    val = Some(99);
+    x.and(val);
+}
+
+fn idempotent_methods_should_lint() {
+    let _ = Some(1).and(None::<i32>).and(None::<i32>);
+    //~^ redundant_idempotent_calls
+    let _ = Some(1).and(Some(2)).and(Some(2));
+    //~^ redundant_idempotent_calls
+    let _ = None::<i32>.or(Some(2)).or(Some(2));
+    //~^ redundant_idempotent_calls
+    let _ = Some(1).or(Some(2)).or(Some(2));
+    //~^ redundant_idempotent_calls
+    let mut a = 5_i32;
+    a = a.min(10).min(10);
+    //~^ redundant_idempotent_calls
+    let _ = 1_i32.clamp(-1, 1).clamp(-1, 1);
+    //~^ redundant_idempotent_calls
+    let _ = b"Never gonna say goodbye".to_vec().to_vec();
+    //~^ redundant_idempotent_calls
+    let _ = 1.32_f64.ceil().ceil();
+    //~^ redundant_idempotent_calls
+    let _ = 1.32_f64.signum().signum();
+    //~^ redundant_idempotent_calls
+    let _ = "  Never gonna tell a lie and hurt you  ".trim_start().trim_start();
+    //~^ redundant_idempotent_calls
+    let _ = "  Ooh (Give you up)  ".trim_end().trim_end();
+    //~^ redundant_idempotent_calls
+    let x = "Ooh-ooh (Give you up)".to_ascii_lowercase();
+    let _ = x.to_ascii_lowercase();
+    //~^ redundant_idempotent_calls
+    let y = "Ooh (Never gonna give, never gonna give)".to_ascii_uppercase();
+    let _ = y.to_ascii_uppercase();
+    //~^ redundant_idempotent_calls
+    let x = 1.32_f64.round();
+    let _ = x.round();
+    //~^ redundant_idempotent_calls
+}
+
+fn main() {}

--- a/tests/ui/redundant_idempotent_calls.stderr
+++ b/tests/ui/redundant_idempotent_calls.stderr
@@ -1,0 +1,257 @@
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:5:13
+   |
+LL |     let _ = "Ba-dum!".to_lowercase().to_lowercase();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `"Ba-dum!".to_lowercase()`
+   |
+   = note: `-D clippy::redundant-idempotent-calls` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::redundant_idempotent_calls)]`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:11:5
+   |
+LL |     s.to_lowercase();
+   |     ^^^^^^^^^^^^^^^^ help: replace with: `s`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:17:5
+   |
+LL |     x.floor();
+   |     ^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:25:17
+   |
+LL |         let _ = t.to_lowercase();
+   |                 ^^^^^^^^^^^^^^^^ help: replace with: `t`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:29:13
+   |
+LL |     let _ = t.to_lowercase();
+   |             ^^^^^^^^^^^^^^^^ help: replace with: `t`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:51:13
+   |
+LL |         c = c.floor();
+   |             ^^^^^^^^^ help: replace with: `c`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:71:9
+   |
+LL |     c = c.floor();
+   |         ^^^^^^^^^ help: replace with: `c`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:104:13
+   |
+LL |     let _ = x.to_lowercase();
+   |             ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:111:13
+   |
+LL |     let _ = y.to_lowercase();
+   |             ^^^^^^^^^^^^^^^^ help: replace with: `y`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:119:5
+   |
+LL |     y.to_lowercase();
+   |     ^^^^^^^^^^^^^^^^ help: replace with: `y`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:125:8
+   |
+LL |     if x.to_lowercase() == "Inside, we both know what's been going on" {}
+   |        ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:133:18
+   |
+LL |     takes_string(x.to_lowercase());
+   |                  ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:140:16
+   |
+LL |         return x.to_lowercase();
+   |                ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:148:14
+   |
+LL |     let _ = (x.to_lowercase(), 1);
+   |              ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:155:14
+   |
+LL |         _ if x.to_lowercase() == "Never gonna let you down" => {},
+   |              ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:164:14
+   |
+LL |     arr[0] = x.to_lowercase();
+   |              ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:170:14
+   |
+LL |     let _ = [x.to_lowercase(), String::new()];
+   |              ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:181:16
+   |
+LL |         field: x.to_lowercase(),
+   |                ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:188:9
+   |
+LL |     x = x.max(0_f64);
+   |         ^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:196:9
+   |
+LL |     z = z.max(confusion);
+   |         ^^^^^^^^^^^^^^^^ help: replace with: `z`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:202:14
+   |
+LL |     let _ = -(x.abs());
+   |              ^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:209:9
+   |
+LL |         x.to_lowercase();
+   |         ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:221:13
+   |
+LL |     let _ = x.floor() as f32;
+   |             ^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:229:17
+   |
+LL |         let _ = x.to_lowercase();
+   |                 ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:237:14
+   |
+LL |     let _ = [x.floor(); 3];
+   |              ^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:243:13
+   |
+LL |     let _ = (x.to_lowercase()).to_uppercase();
+   |             ^^^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:249:16
+   |
+LL |     if let y = x.to_lowercase()
+   |                ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:257:14
+   |
+LL |     let _ = &x.to_lowercase();
+   |              ^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:280:13
+   |
+LL |     let _ = Some(1).and(None::<i32>).and(None::<i32>);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `Some(1).and(None::<i32>)`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:282:13
+   |
+LL |     let _ = Some(1).and(Some(2)).and(Some(2));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `Some(1).and(Some(2))`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:284:13
+   |
+LL |     let _ = None::<i32>.or(Some(2)).or(Some(2));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `None::<i32>.or(Some(2))`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:286:13
+   |
+LL |     let _ = Some(1).or(Some(2)).or(Some(2));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `Some(1).or(Some(2))`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:289:9
+   |
+LL |     a = a.min(10).min(10);
+   |         ^^^^^^^^^^^^^^^^^ help: replace with: `a.min(10)`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:291:13
+   |
+LL |     let _ = 1_i32.clamp(-1, 1).clamp(-1, 1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `1_i32.clamp(-1, 1)`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:293:13
+   |
+LL |     let _ = b"Never gonna say goodbye".to_vec().to_vec();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `b"Never gonna say goodbye".to_vec()`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:295:13
+   |
+LL |     let _ = 1.32_f64.ceil().ceil();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `1.32_f64.ceil()`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:297:13
+   |
+LL |     let _ = 1.32_f64.signum().signum();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `1.32_f64.signum()`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:299:13
+   |
+LL |     let _ = "  Never gonna tell a lie and hurt you  ".trim_start().trim_start();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `"  Never gonna tell a lie and hurt you  ".trim_start()`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:301:13
+   |
+LL |     let _ = "  Ooh (Give you up)  ".trim_end().trim_end();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `"  Ooh (Give you up)  ".trim_end()`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:304:13
+   |
+LL |     let _ = x.to_ascii_lowercase();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `x`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:307:13
+   |
+LL |     let _ = y.to_ascii_uppercase();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `y`
+
+error: redundant call to idempotent method, the result is already the same
+  --> tests/ui/redundant_idempotent_calls.rs:310:13
+   |
+LL |     let _ = x.round();
+   |             ^^^^^^^^^ help: replace with: `x`
+
+error: aborting due to 42 previous errors
+


### PR DESCRIPTION
When a method that is idempotent (calling it multiple times produces the same result as calling it once) is called on a value that has already had the same method applied with the same arguments, the second call is redundant and can be removed.

Examples of idempotent methods: 'to_lowercase', 'to_uppercase', 'trim', 'trim_start', 'trim_end', 'abs', 'floor', 'ceil', 'round', 'max', 'min', 'clamp', 'and', 'or', 'to_vec', 'to_ascii_lowercase', 'to_ascii_uppercase', 'signum'.

Some methods were left out as a possible follow-up, either because each call wraps the value in a new iterator adapter rather than being a true idempotent, because they have side effects, or because they are only idempotent under very specific conditions.

Closes rust-lang#16099


changelog: implement redundant idempotent call lint
