### PR TITLE
Implement unnecessary bitmask on cast lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7111,6 +7111,7 @@ Released 2018-09-13
 [`naive_bytecount`]: https://rust-lang.github.io/rust-clippy/master/index.html#naive_bytecount
 [`needless_arbitrary_self_type`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_arbitrary_self_type
 [`needless_as_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_as_bytes
+[`needless_bitmask_on_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_bitmask_on_cast
 [`needless_bitwise_bool`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_bitwise_bool
 [`needless_bool`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_bool
 [`needless_bool_assign`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_bool_assign

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -19,6 +19,7 @@ mod fn_to_numeric_cast;
 mod fn_to_numeric_cast_any;
 mod fn_to_numeric_cast_with_truncation;
 mod manual_dangling_ptr;
+mod needless_bitmask_on_cast;
 mod needless_type_cast;
 mod ptr_as_ptr;
 mod ptr_cast_constness;
@@ -673,6 +674,25 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Warns against using unnecessary masks before a cast to an int
+    /// ### Why is this bad?
+    /// Creates more confusing code, with unnecessary clutter
+    /// ### Example
+    /// ```no_run
+    /// (1234_u32 & 0xFF) as u8;
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// 1234_u32 as u8;
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub NEEDLESS_BITMASK_ON_CAST,
+    nursery,
+    "unnecessary bitwise and on cast"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for bindings (constants, statics, or let bindings) that are defined
     /// with one numeric type but are consistently cast to a different type in all usages.
     ///
@@ -869,6 +889,7 @@ impl_lint_pass!(Casts => [
     FN_TO_NUMERIC_CAST_ANY,
     FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
     MANUAL_DANGLING_PTR,
+    NEEDLESS_BITMASK_ON_CAST,
     NEEDLESS_TYPE_CAST,
     PTR_AS_PTR,
     PTR_CAST_CONSTNESS,
@@ -926,6 +947,7 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
                     cast_sign_loss::check(cx, expr, cast_from_expr, cast_from, cast_to, self.msrv);
                     cast_abs_to_unsigned::check(cx, expr, cast_from_expr, cast_from, cast_to, self.msrv);
                     cast_nan_to_int::check(cx, expr, cast_from_expr, cast_from, cast_to);
+                    needless_bitmask_on_cast::check(cx, expr, cast_from_expr, cast_from, cast_to);
                 }
                 cast_lossless::check(cx, expr, cast_from_expr, cast_from, cast_to, cast_to_hir, self.msrv);
                 cast_enum_constructor::check(cx, expr, cast_from_expr, cast_from);

--- a/clippy_lints/src/casts/needless_bitmask_on_cast.rs
+++ b/clippy_lints/src/casts/needless_bitmask_on_cast.rs
@@ -1,0 +1,44 @@
+use super::NEEDLESS_BITMASK_ON_CAST;
+use clippy_utils::consts::ConstEvalCtxt;
+use clippy_utils::consts::Constant::Int;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::expr_or_init;
+use clippy_utils::source::snippet;
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Expr, ExprKind};
+use rustc_lint::LateContext;
+use rustc_middle::ty::Ty;
+
+pub(super) fn check<'a>(cx: &LateContext<'a>, expr: &Expr<'_>, cast_expr: &Expr<'_>, _from_ty: Ty<'_>, to_ty: Ty<'a>) {
+    let app = Applicability::MaybeIncorrect;
+    // Checking that the cast is to an integer type and that the operation being performed is an And
+    if to_ty.is_integral()
+        && let size = to_ty.primitive_size(cx.tcx)
+        && let ExprKind::Binary(op, left, right) = cast_expr.kind
+        && op.node == BinOpKind::BitAnd
+    {
+        // For the sake of supporting commutativity
+        let mask_and_value = [(left, right), (right, left)];
+        for (mask_op, value_op) in mask_and_value {
+            //Constant evaluation
+            let operand_init = expr_or_init(cx, mask_op);
+            let const_context = ConstEvalCtxt::new(cx);
+            if let Some(const_mask) = const_context.eval(operand_init)
+                && let Int(mask_value) = const_mask
+                && (mask_value & size.unsigned_int_max()) == size.unsigned_int_max()
+            {
+                let value_snip = snippet(cx, value_op.span, "..");
+                let suggestion = format!("{value_snip} as {to_ty}");
+                span_lint_and_sugg(
+                    cx,
+                    NEEDLESS_BITMASK_ON_CAST,
+                    expr.span,
+                    "unnecessary bitmask on cast",
+                    "the cast already truncates the input",
+                    suggestion,
+                    app,
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -70,6 +70,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::casts::FN_TO_NUMERIC_CAST_ANY_INFO,
     crate::casts::FN_TO_NUMERIC_CAST_WITH_TRUNCATION_INFO,
     crate::casts::MANUAL_DANGLING_PTR_INFO,
+    crate::casts::NEEDLESS_BITMASK_ON_CAST_INFO,
     crate::casts::NEEDLESS_TYPE_CAST_INFO,
     crate::casts::PTR_AS_PTR_INFO,
     crate::casts::PTR_CAST_CONSTNESS_INFO,

--- a/tests/ui/needless_bitmask_on_cast.fixed
+++ b/tests/ui/needless_bitmask_on_cast.fixed
@@ -1,0 +1,36 @@
+#![warn(clippy::needless_bitmask_on_cast)]
+
+const MASK_U32: u32 = 0xFF;
+
+fn i_dont_use_arch_btw(n: u16) -> (u8, u8) {
+    ((n >> 8) as u8, n as u8)
+    //~^ needless_bitmask_on_cast
+    //~| needless_bitmask_on_cast
+}
+fn should_trigger() {
+    let nixos_is_a_pain: u32 = 0x12345678;
+    let should_have_kept_mint = nixos_is_a_pain as u8;
+    //~^ needless_bitmask_on_cast
+    let debian_is_good_too = nixos_is_a_pain as u8;
+    //~^ needless_bitmask_on_cast
+    let fedora_is_great_tho = nixos_is_a_pain as u8;
+    //~^ needless_bitmask_on_cast
+    let am_i_allowed_to_meme = nixos_is_a_pain as u8;
+    //~^ needless_bitmask_on_cast
+    let x: i32 = 0x12345678;
+    let val2 = x as i8;
+    //~^ needless_bitmask_on_cast
+    let variable_mask = 0xFF;
+    let val3 = nixos_is_a_pain as u8;
+    //~^ needless_bitmask_on_cast
+    let heard_on_the_news = nixos_is_a_pain as u8;
+    //~^ needless_bitmask_on_cast
+}
+
+fn should_not_trigger() {
+    let x: u128 = 32;
+    let joe = (x & 0x7F) as u8;
+    let who_is_joe = (x & 0x7FFFFFFFFFFFFFFF) as u64;
+    let idk_man = ((x & 0xFF) + 1) as u8;
+    let then_why_did_you_say_it = (x & 0x100) as u8; // mask has effect since it is an and with last digits all the same
+}

--- a/tests/ui/needless_bitmask_on_cast.rs
+++ b/tests/ui/needless_bitmask_on_cast.rs
@@ -1,0 +1,36 @@
+#![warn(clippy::needless_bitmask_on_cast)]
+
+const MASK_U32: u32 = 0xFF;
+
+fn i_dont_use_arch_btw(n: u16) -> (u8, u8) {
+    (((n >> 8) & 0xff) as u8, (n & 0xff) as u8)
+    //~^ needless_bitmask_on_cast
+    //~| needless_bitmask_on_cast
+}
+fn should_trigger() {
+    let nixos_is_a_pain: u32 = 0x12345678;
+    let should_have_kept_mint = (nixos_is_a_pain & 0xFF) as u8;
+    //~^ needless_bitmask_on_cast
+    let debian_is_good_too = (nixos_is_a_pain & 255) as u8;
+    //~^ needless_bitmask_on_cast
+    let fedora_is_great_tho = (0xFF & nixos_is_a_pain) as u8;
+    //~^ needless_bitmask_on_cast
+    let am_i_allowed_to_meme = (nixos_is_a_pain & MASK_U32) as u8;
+    //~^ needless_bitmask_on_cast
+    let x: i32 = 0x12345678;
+    let val2 = (x & 0xFF) as i8;
+    //~^ needless_bitmask_on_cast
+    let variable_mask = 0xFF;
+    let val3 = (nixos_is_a_pain & variable_mask) as u8;
+    //~^ needless_bitmask_on_cast
+    let heard_on_the_news = (nixos_is_a_pain & (0x0F | 0xF0)) as u8;
+    //~^ needless_bitmask_on_cast
+}
+
+fn should_not_trigger() {
+    let x: u128 = 32;
+    let joe = (x & 0x7F) as u8;
+    let who_is_joe = (x & 0x7FFFFFFFFFFFFFFF) as u64;
+    let idk_man = ((x & 0xFF) + 1) as u8;
+    let then_why_did_you_say_it = (x & 0x100) as u8; // mask has effect since it is an and with last digits all the same
+}

--- a/tests/ui/needless_bitmask_on_cast.stderr
+++ b/tests/ui/needless_bitmask_on_cast.stderr
@@ -1,0 +1,59 @@
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:6:6
+   |
+LL |     (((n >> 8) & 0xff) as u8, (n & 0xff) as u8)
+   |      ^^^^^^^^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `(n >> 8) as u8`
+   |
+   = note: `-D clippy::needless-bitmask-on-cast` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::needless_bitmask_on_cast)]`
+
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:6:31
+   |
+LL |     (((n >> 8) & 0xff) as u8, (n & 0xff) as u8)
+   |                               ^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `n as u8`
+
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:12:33
+   |
+LL |     let should_have_kept_mint = (nixos_is_a_pain & 0xFF) as u8;
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `nixos_is_a_pain as u8`
+
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:14:30
+   |
+LL |     let debian_is_good_too = (nixos_is_a_pain & 255) as u8;
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `nixos_is_a_pain as u8`
+
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:16:31
+   |
+LL |     let fedora_is_great_tho = (0xFF & nixos_is_a_pain) as u8;
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `nixos_is_a_pain as u8`
+
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:18:32
+   |
+LL |     let am_i_allowed_to_meme = (nixos_is_a_pain & MASK_U32) as u8;
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `nixos_is_a_pain as u8`
+
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:21:16
+   |
+LL |     let val2 = (x & 0xFF) as i8;
+   |                ^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `x as i8`
+
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:24:16
+   |
+LL |     let val3 = (nixos_is_a_pain & variable_mask) as u8;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `nixos_is_a_pain as u8`
+
+error: unnecessary bitmask on cast
+  --> tests/ui/needless_bitmask_on_cast.rs:26:29
+   |
+LL |     let heard_on_the_news = (nixos_is_a_pain & (0x0F | 0xF0)) as u8;
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: the cast already truncates the input: `nixos_is_a_pain as u8`
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
When downcasting from a large integer type (like u_64) to a smaller type (like u_8), the rust compiler
automatically truncates the integer adequately.
Still, some people do decide to perform a bitwise
and before casting, essentially truncating
the input before it is cast.

Closes rust-lang/rust-clippy#16125


changelog: Implement needless bitmask lint
