### PR TITLE
Add `with_capacity_zero` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7520,6 +7520,7 @@ Released 2018-09-13
 [`wildcard_enum_match_arm`]: https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_enum_match_arm
 [`wildcard_imports`]: https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_imports
 [`wildcard_in_or_patterns`]: https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_in_or_patterns
+[`with_capacity_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#with_capacity_zero
 [`write_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#write_literal
 [`write_with_newline`]: https://rust-lang.github.io/rust-clippy/master/index.html#write_with_newline
 [`writeln_empty_string`]: https://rust-lang.github.io/rust-clippy/master/index.html#writeln_empty_string

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -809,6 +809,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::volatile_composites::VOLATILE_COMPOSITES_INFO,
     crate::wildcard_imports::ENUM_GLOB_USE_INFO,
     crate::wildcard_imports::WILDCARD_IMPORTS_INFO,
+    crate::with_capacity_zero::WITH_CAPACITY_ZERO_INFO,
     crate::write::PRINT_LITERAL_INFO,
     crate::write::PRINT_STDERR_INFO,
     crate::write::PRINT_STDOUT_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -403,6 +403,7 @@ mod vec_init_then_push;
 mod visibility;
 mod volatile_composites;
 mod wildcard_imports;
+mod with_capacity_zero;
 mod write;
 mod zero_div_zero;
 mod zero_repeat_side_effects;
@@ -860,6 +861,7 @@ rustc_lint::late_lint_methods!(
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
+        WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/with_capacity_zero.rs
+++ b/clippy_lints/src/with_capacity_zero.rs
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.98.0"]
     pub WITH_CAPACITY_ZERO,
-    complexity,
+    pedantic,
     "calling `with_capacity(0)` which is equivalent to `new()`"
 }
 

--- a/clippy_lints/src/with_capacity_zero.rs
+++ b/clippy_lints/src/with_capacity_zero.rs
@@ -1,0 +1,83 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::res::MaybeDef;
+use clippy_utils::source::snippet;
+use clippy_utils::{fn_def_id, is_integer_const, last_path_segment, span_contains_comment, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, LangItem};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::Ty;
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for calls to `with_capacity(0)` on standard library collections and types.
+    ///
+    /// ### Why is this bad?
+    /// Calling `with_capacity(0)` does not allocate any initial capacity and behaves identically
+    /// to `new()`. Using `new()` is more idiomatic, concise, and is a `const fn` for these types.
+    ///
+    /// ### Example
+    /// ```rust
+    /// let v: Vec<i32> = Vec::with_capacity(0);
+    /// let s = String::with_capacity(0);
+    /// ```
+    ///
+    /// Use instead:
+    /// ```rust
+    /// let v: Vec<i32> = Vec::new();
+    /// let s = String::new();
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub WITH_CAPACITY_ZERO,
+    complexity,
+    "calling `with_capacity(0)` which is equivalent to `new()`"
+}
+
+declare_lint_pass!(WithCapacityZero => [WITH_CAPACITY_ZERO]);
+
+fn is_target_type(cx: &LateContext<'_>, ty: Ty<'_>) -> bool {
+    let ty = ty.peel_refs();
+    ty.is_lang_item(cx, LangItem::String)
+        || ty.is_diag_item(cx, sym::Vec)
+        || ty.is_diag_item(cx, sym::HashMap)
+        || ty.is_diag_item(cx, sym::HashSet)
+        || ty.is_diag_item(cx, sym::VecDeque)
+        || ty.is_diag_item(cx, sym::BinaryHeap)
+        || ty.is_diag_item(cx, sym::PathBuf)
+        || ty.is_diag_item(cx, sym::OsString)
+}
+
+impl<'tcx> LateLintPass<'tcx> for WithCapacityZero {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        if !expr.span.from_expansion()
+            && let ExprKind::Call(func, [arg]) = expr.kind
+            && let Some(def_id) = fn_def_id(cx, expr)
+            && cx.tcx.item_name(def_id) == sym::with_capacity
+            && is_integer_const(cx, arg, 0)
+            && let ExprKind::Path(ref qpath) = func.kind
+        {
+            let ty = cx.typeck_results().expr_ty(expr);
+            if is_target_type(cx, ty) {
+                let last_seg = last_path_segment(qpath);
+                let prefix_span = expr.span.with_hi(last_seg.ident.span.lo());
+                let app = if span_contains_comment(cx, expr.span) {
+                    Applicability::Unspecified
+                } else {
+                    Applicability::MachineApplicable
+                };
+
+                let sugg = format!("{}new()", snippet(cx, prefix_span, ".."));
+
+                span_lint_and_sugg(
+                    cx,
+                    WITH_CAPACITY_ZERO,
+                    expr.span,
+                    "calling `with_capacity(0)` is equivalent to `new()`",
+                    "use `new()` instead",
+                    sugg,
+                    app,
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/with_capacity_zero.rs
+++ b/clippy_lints/src/with_capacity_zero.rs
@@ -1,6 +1,5 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::MaybeDef;
-use clippy_utils::source::snippet;
 use clippy_utils::{fn_def_id, is_integer_const, last_path_segment, span_contains_comment, sym};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, LangItem};
@@ -38,13 +37,12 @@ declare_lint_pass!(WithCapacityZero => [WITH_CAPACITY_ZERO]);
 fn is_target_type(cx: &LateContext<'_>, ty: Ty<'_>) -> bool {
     let ty = ty.peel_refs();
     ty.is_lang_item(cx, LangItem::String)
-        || ty.is_diag_item(cx, sym::Vec)
-        || ty.is_diag_item(cx, sym::HashMap)
-        || ty.is_diag_item(cx, sym::HashSet)
-        || ty.is_diag_item(cx, sym::VecDeque)
-        || ty.is_diag_item(cx, sym::BinaryHeap)
-        || ty.is_diag_item(cx, sym::PathBuf)
-        || ty.is_diag_item(cx, sym::OsString)
+        || matches!(
+            ty.opt_diag_name(cx),
+            Some(
+                sym::Vec | sym::HashMap | sym::HashSet | sym::VecDeque | sym::BinaryHeap | sym::PathBuf | sym::OsString
+            )
+        )
 }
 
 impl<'tcx> LateLintPass<'tcx> for WithCapacityZero {
@@ -55,29 +53,26 @@ impl<'tcx> LateLintPass<'tcx> for WithCapacityZero {
             && cx.tcx.item_name(def_id) == sym::with_capacity
             && is_integer_const(cx, arg, 0)
             && let ExprKind::Path(ref qpath) = func.kind
+            && let ty = cx.typeck_results().expr_ty(expr)
+            && is_target_type(cx, ty)
         {
-            let ty = cx.typeck_results().expr_ty(expr);
-            if is_target_type(cx, ty) {
-                let last_seg = last_path_segment(qpath);
-                let prefix_span = expr.span.with_hi(last_seg.ident.span.lo());
-                let app = if span_contains_comment(cx, expr.span) {
-                    Applicability::Unspecified
-                } else {
-                    Applicability::MachineApplicable
-                };
+            let last_seg = last_path_segment(qpath);
+            let sugg_span = last_seg.ident.span.with_hi(expr.span.hi());
+            let app = if span_contains_comment(cx, expr.span) {
+                Applicability::MaybeIncorrect
+            } else {
+                Applicability::MachineApplicable
+            };
 
-                let sugg = format!("{}new()", snippet(cx, prefix_span, ".."));
-
-                span_lint_and_sugg(
-                    cx,
-                    WITH_CAPACITY_ZERO,
-                    expr.span,
-                    "calling `with_capacity(0)` is equivalent to `new()`",
-                    "use `new()` instead",
-                    sugg,
-                    app,
-                );
-            }
+            span_lint_and_then(
+                cx,
+                WITH_CAPACITY_ZERO,
+                expr.span,
+                "calling `with_capacity(0)` is equivalent to `new()`",
+                |diag| {
+                    diag.span_suggestion_verbose(sugg_span, "use `new()` instead", "new()", app);
+                },
+            );
         }
     }
 }

--- a/tests/ui/with_capacity_zero.fixed
+++ b/tests/ui/with_capacity_zero.fixed
@@ -1,0 +1,54 @@
+#![warn(clippy::with_capacity_zero)]
+#![allow(unused)]
+#![allow(clippy::eq_op)]
+
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
+use std::ffi::OsString;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+struct MyStruct;
+impl MyStruct {
+    fn with_capacity(cap: usize) -> Self {
+        MyStruct
+    }
+}
+
+fn main() {
+    // Positive cases
+    let v: Vec<i32> = Vec::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let s = String::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let v2 = std::vec::Vec::<i32>::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let map = HashMap::<i32, i32>::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let set = HashSet::<i32>::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let deque = VecDeque::<i32>::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let heap = BinaryHeap::<i32>::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let path = PathBuf::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let os_str = OsString::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+
+    // Constant folded capacity evaluates to 0
+    let v_const = Vec::<i32>::new();
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+
+    // Negative cases
+    let v_non_zero = Vec::<i32>::with_capacity(10);
+    let s_non_zero = String::with_capacity(5);
+
+    let cap = 0;
+    let v_variable = Vec::<i32>::with_capacity(cap);
+
+    // Custom struct with with_capacity method
+    let custom = MyStruct::with_capacity(0);
+
+    // Two-argument capacity call (BufReader)
+    let reader = BufReader::with_capacity(0, std::io::empty());
+}

--- a/tests/ui/with_capacity_zero.rs
+++ b/tests/ui/with_capacity_zero.rs
@@ -1,0 +1,54 @@
+#![warn(clippy::with_capacity_zero)]
+#![allow(unused)]
+#![allow(clippy::eq_op)]
+
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
+use std::ffi::OsString;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+struct MyStruct;
+impl MyStruct {
+    fn with_capacity(cap: usize) -> Self {
+        MyStruct
+    }
+}
+
+fn main() {
+    // Positive cases
+    let v: Vec<i32> = Vec::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let s = String::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let v2 = std::vec::Vec::<i32>::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let map = HashMap::<i32, i32>::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let set = HashSet::<i32>::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let deque = VecDeque::<i32>::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let heap = BinaryHeap::<i32>::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let path = PathBuf::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+    let os_str = OsString::with_capacity(0);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+
+    // Constant folded capacity evaluates to 0
+    let v_const = Vec::<i32>::with_capacity(1 - 1);
+    //~^ ERROR: calling `with_capacity(0)` is equivalent to `new()`
+
+    // Negative cases
+    let v_non_zero = Vec::<i32>::with_capacity(10);
+    let s_non_zero = String::with_capacity(5);
+
+    let cap = 0;
+    let v_variable = Vec::<i32>::with_capacity(cap);
+
+    // Custom struct with with_capacity method
+    let custom = MyStruct::with_capacity(0);
+
+    // Two-argument capacity call (BufReader)
+    let reader = BufReader::with_capacity(0, std::io::empty());
+}

--- a/tests/ui/with_capacity_zero.stderr
+++ b/tests/ui/with_capacity_zero.stderr
@@ -1,0 +1,65 @@
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:19:23
+   |
+LL |     let v: Vec<i32> = Vec::with_capacity(0);
+   |                       ^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `Vec::new()`
+   |
+   = note: `-D clippy::with-capacity-zero` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::with_capacity_zero)]`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:21:13
+   |
+LL |     let s = String::with_capacity(0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `String::new()`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:23:14
+   |
+LL |     let v2 = std::vec::Vec::<i32>::with_capacity(0);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `std::vec::Vec::<i32>::new()`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:25:15
+   |
+LL |     let map = HashMap::<i32, i32>::with_capacity(0);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `HashMap::<i32, i32>::new()`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:27:15
+   |
+LL |     let set = HashSet::<i32>::with_capacity(0);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `HashSet::<i32>::new()`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:29:17
+   |
+LL |     let deque = VecDeque::<i32>::with_capacity(0);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `VecDeque::<i32>::new()`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:31:16
+   |
+LL |     let heap = BinaryHeap::<i32>::with_capacity(0);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `BinaryHeap::<i32>::new()`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:33:16
+   |
+LL |     let path = PathBuf::with_capacity(0);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `PathBuf::new()`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:35:18
+   |
+LL |     let os_str = OsString::with_capacity(0);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `OsString::new()`
+
+error: calling `with_capacity(0)` is equivalent to `new()`
+  --> tests/ui/with_capacity_zero.rs:39:19
+   |
+LL |     let v_const = Vec::<i32>::with_capacity(1 - 1);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `Vec::<i32>::new()`
+
+error: aborting due to 10 previous errors
+

--- a/tests/ui/with_capacity_zero.stderr
+++ b/tests/ui/with_capacity_zero.stderr
@@ -2,64 +2,123 @@ error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:19:23
    |
 LL |     let v: Vec<i32> = Vec::with_capacity(0);
-   |                       ^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `Vec::new()`
+   |                       ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::with-capacity-zero` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::with_capacity_zero)]`
+help: use `new()` instead
+   |
+LL -     let v: Vec<i32> = Vec::with_capacity(0);
+LL +     let v: Vec<i32> = Vec::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:21:13
    |
 LL |     let s = String::with_capacity(0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `String::new()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let s = String::with_capacity(0);
+LL +     let s = String::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:23:14
    |
 LL |     let v2 = std::vec::Vec::<i32>::with_capacity(0);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `std::vec::Vec::<i32>::new()`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let v2 = std::vec::Vec::<i32>::with_capacity(0);
+LL +     let v2 = std::vec::Vec::<i32>::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:25:15
    |
 LL |     let map = HashMap::<i32, i32>::with_capacity(0);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `HashMap::<i32, i32>::new()`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let map = HashMap::<i32, i32>::with_capacity(0);
+LL +     let map = HashMap::<i32, i32>::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:27:15
    |
 LL |     let set = HashSet::<i32>::with_capacity(0);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `HashSet::<i32>::new()`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let set = HashSet::<i32>::with_capacity(0);
+LL +     let set = HashSet::<i32>::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:29:17
    |
 LL |     let deque = VecDeque::<i32>::with_capacity(0);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `VecDeque::<i32>::new()`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let deque = VecDeque::<i32>::with_capacity(0);
+LL +     let deque = VecDeque::<i32>::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:31:16
    |
 LL |     let heap = BinaryHeap::<i32>::with_capacity(0);
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `BinaryHeap::<i32>::new()`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let heap = BinaryHeap::<i32>::with_capacity(0);
+LL +     let heap = BinaryHeap::<i32>::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:33:16
    |
 LL |     let path = PathBuf::with_capacity(0);
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `PathBuf::new()`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let path = PathBuf::with_capacity(0);
+LL +     let path = PathBuf::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:35:18
    |
 LL |     let os_str = OsString::with_capacity(0);
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `OsString::new()`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let os_str = OsString::with_capacity(0);
+LL +     let os_str = OsString::new();
+   |
 
 error: calling `with_capacity(0)` is equivalent to `new()`
   --> tests/ui/with_capacity_zero.rs:39:19
    |
 LL |     let v_const = Vec::<i32>::with_capacity(1 - 1);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `new()` instead: `Vec::<i32>::new()`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `new()` instead
+   |
+LL -     let v_const = Vec::<i32>::with_capacity(1 - 1);
+LL +     let v_const = Vec::<i32>::new();
+   |
 
 error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust-clippy#16899

This adds a new lint `with_capacity_zero` (registered as `complexity`) that checks for calls to `with_capacity(0)` on standard collections/types and suggests using `new()` instead, since it's cleaner and equivalent.

Target types:
- `Vec`, `VecDeque`, `String`, `OsString`, `PathBuf`, `HashMap`, `HashSet`, `BinaryHeap`.

The lint verifies that:
- It's a single-argument call (to avoid false-triggering on types like `BufReader` which take a second argument).
- The receiver type is one of the target std types (ignores custom types/methods).
- The capacity argument evaluates to 0 via const evaluation (so expressions like `1 - 1` are caught, but runtime variables are ignored).

changelog: new lint: [`with_capacity_zero`]

---

- [x] I have followed the instructions in the [development guide](https://github.com/rust-lang/rust-clippy/blob/master/book/src/development/basics.md).
- [x] Lints member names conform to [Clippy's naming conventions](https://github.com/rust-lang/rust-clippy/blob/master/book/src/development/lint_passes.md#naming-conventions).
- [x] I have run `cargo dev update_lints` and `cargo dev fmt`.
- [x] I have added UI tests under `tests/ui` confirming both positive and negative cases.
- [x] I have verified suggestion correctness and generated `.stderr` / `.fixed` files using `cargo uibless`.