### PR TITLE
internal(`manual_non_exhaustive`): explain why we have hint+suggestion instead of multipart suggestion

### DIFF
--- a/clippy_lints/src/manual_non_exhaustive.rs
+++ b/clippy_lints/src/manual_non_exhaustive.rs
@@ -145,9 +145,8 @@ impl<'tcx> LateLintPass<'tcx> for ManualNonExhaustive {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        for &(enum_id, _, enum_span, variant_span) in self
-            .potential_enums
-            .iter()
+        for (enum_id, _, enum_span, variant_span) in std::mem::take(&mut self.potential_enums)
+            .into_iter()
             .filter(|(_, variant_id, _, _)| !self.constructed_enum_variants.contains(variant_id))
         {
             let hir_id = cx.tcx.local_def_id_to_hir_id(enum_id);

--- a/clippy_lints/src/manual_non_exhaustive.rs
+++ b/clippy_lints/src/manual_non_exhaustive.rs
@@ -125,6 +125,21 @@ impl<'tcx> LateLintPass<'tcx> for ManualNonExhaustive {
                                     Applicability::MaybeIncorrect,
                                 );
                             }
+                            // FIXME: Ideally this would be a suggestion, but the span for that is annoying to get.
+                            // Consider cases like:
+                            // ```
+                            // _non_exhaustive: (),
+                            //
+                            // _non_exhaustive: ()
+                            // , pub another field: u32
+                            //
+                            // _non_exhaustive: () // some random comment
+                            // , pub another field: u32
+                            //
+                            // _non_exhaustive: (), // a comment that we wouldn't want to
+                            //                      // stick to the next field after the fix
+                            // pub another field: u32
+                            // ```
                             diag.span_help(field.span, "remove this field");
                         },
                     );
@@ -164,6 +179,8 @@ impl<'tcx> LateLintPass<'tcx> for ManualNonExhaustive {
                         format!("#[non_exhaustive]\n{indent}"),
                         Applicability::MaybeIncorrect,
                     );
+                    // FIXME: Ideally this would be a suggestion, but the span for that is annoying to get.
+                    // See the comment above for examples.
                     diag.span_help(variant_span, "remove this variant");
                 },
             );

--- a/tests/ui/manual_non_exhaustive_enum.rs
+++ b/tests/ui/manual_non_exhaustive_enum.rs
@@ -1,4 +1,6 @@
 #![warn(clippy::manual_non_exhaustive)]
+// One half of the fix is emitted as a suggestion, but the other is only a help message -- see the
+// lint file for the reasons. Since the fix is therefore incomplete, rustfix will end up complaining
 //@no-rustfix
 pub enum E {
     //~^ manual_non_exhaustive

--- a/tests/ui/manual_non_exhaustive_enum.stderr
+++ b/tests/ui/manual_non_exhaustive_enum.stderr
@@ -1,5 +1,5 @@
 error: this seems like a manual implementation of the non-exhaustive pattern
-  --> tests/ui/manual_non_exhaustive_enum.rs:3:1
+  --> tests/ui/manual_non_exhaustive_enum.rs:5:1
    |
 LL | / pub enum E {
 LL | |
@@ -11,7 +11,7 @@ LL | | }
    | |_^
    |
 help: remove this variant
-  --> tests/ui/manual_non_exhaustive_enum.rs:8:5
+  --> tests/ui/manual_non_exhaustive_enum.rs:10:5
    |
 LL |     _C,
    |     ^^
@@ -24,7 +24,7 @@ LL | pub enum E {
    |
 
 error: this seems like a manual implementation of the non-exhaustive pattern
-  --> tests/ui/manual_non_exhaustive_enum.rs:28:1
+  --> tests/ui/manual_non_exhaustive_enum.rs:30:1
    |
 LL | / pub enum NoUnderscore {
 LL | |
@@ -36,7 +36,7 @@ LL | | }
    | |_^
    |
 help: remove this variant
-  --> tests/ui/manual_non_exhaustive_enum.rs:33:5
+  --> tests/ui/manual_non_exhaustive_enum.rs:35:5
    |
 LL |     C,
    |     ^

--- a/tests/ui/manual_non_exhaustive_struct.rs
+++ b/tests/ui/manual_non_exhaustive_struct.rs
@@ -1,4 +1,6 @@
 #![warn(clippy::manual_non_exhaustive)]
+// One half of the fix is emitted as a suggestion, but the other is only a help message -- see the
+// lint file for the reasons. Since the fix is therefore incomplete, rustfix will end up complaining
 //@no-rustfix
 pub mod structs {
     pub struct S {

--- a/tests/ui/manual_non_exhaustive_struct.stderr
+++ b/tests/ui/manual_non_exhaustive_struct.stderr
@@ -1,5 +1,5 @@
 error: this seems like a manual implementation of the non-exhaustive pattern
-  --> tests/ui/manual_non_exhaustive_struct.rs:4:5
+  --> tests/ui/manual_non_exhaustive_struct.rs:6:5
    |
 LL | /     pub struct S {
 LL | |
@@ -10,7 +10,7 @@ LL | |     }
    | |_____^
    |
 help: remove this field
-  --> tests/ui/manual_non_exhaustive_struct.rs:8:9
+  --> tests/ui/manual_non_exhaustive_struct.rs:10:9
    |
 LL |         _c: (),
    |         ^^^^^^
@@ -23,7 +23,7 @@ LL ~     pub struct S {
    |
 
 error: this seems like a manual implementation of the non-exhaustive pattern
-  --> tests/ui/manual_non_exhaustive_struct.rs:13:5
+  --> tests/ui/manual_non_exhaustive_struct.rs:15:5
    |
 LL | /     pub struct Sp {
 LL | |
@@ -34,18 +34,18 @@ LL | |     }
    | |_____^
    |
 note: the struct is already non-exhaustive
-  --> tests/ui/manual_non_exhaustive_struct.rs:12:5
+  --> tests/ui/manual_non_exhaustive_struct.rs:14:5
    |
 LL |     #[non_exhaustive]
    |     ^^^^^^^^^^^^^^^^^
 help: remove this field
-  --> tests/ui/manual_non_exhaustive_struct.rs:17:9
+  --> tests/ui/manual_non_exhaustive_struct.rs:19:9
    |
 LL |         _c: (),
    |         ^^^^^^
 
 error: this seems like a manual implementation of the non-exhaustive pattern
-  --> tests/ui/manual_non_exhaustive_struct.rs:27:5
+  --> tests/ui/manual_non_exhaustive_struct.rs:29:5
    |
 LL | /     pub struct NoUnderscore {
 LL | |
@@ -56,7 +56,7 @@ LL | |     }
    | |_____^
    |
 help: remove this field
-  --> tests/ui/manual_non_exhaustive_struct.rs:31:9
+  --> tests/ui/manual_non_exhaustive_struct.rs:33:9
    |
 LL |         c: (),
    |         ^^^^^
@@ -67,13 +67,13 @@ LL ~     pub struct NoUnderscore {
    |
 
 error: this seems like a manual implementation of the non-exhaustive pattern
-  --> tests/ui/manual_non_exhaustive_struct.rs:55:5
+  --> tests/ui/manual_non_exhaustive_struct.rs:57:5
    |
 LL |     pub struct T(pub i32, pub i32, ());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove this field
-  --> tests/ui/manual_non_exhaustive_struct.rs:55:36
+  --> tests/ui/manual_non_exhaustive_struct.rs:57:36
    |
 LL |     pub struct T(pub i32, pub i32, ());
    |                                    ^^
@@ -84,18 +84,18 @@ LL ~     pub struct T(pub i32, pub i32, ());
    |
 
 error: this seems like a manual implementation of the non-exhaustive pattern
-  --> tests/ui/manual_non_exhaustive_struct.rs:60:5
+  --> tests/ui/manual_non_exhaustive_struct.rs:62:5
    |
 LL |     pub struct Tp(pub i32, pub i32, ());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the struct is already non-exhaustive
-  --> tests/ui/manual_non_exhaustive_struct.rs:59:5
+  --> tests/ui/manual_non_exhaustive_struct.rs:61:5
    |
 LL |     #[non_exhaustive]
    |     ^^^^^^^^^^^^^^^^^
 help: remove this field
-  --> tests/ui/manual_non_exhaustive_struct.rs:60:37
+  --> tests/ui/manual_non_exhaustive_struct.rs:62:37
    |
 LL |     pub struct Tp(pub i32, pub i32, ());
    |                                     ^^


### PR DESCRIPTION
Will hopefully save a fool like me some time trying to turn this into a multipart suggestion.

changelog: none