### PR TITLE
feat: add tuple_let_chain lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7406,6 +7406,7 @@ Released 2018-09-13
 [`trivially_copy_pass_by_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref
 [`try_err`]: https://rust-lang.github.io/rust-clippy/master/index.html#try_err
 [`tuple_array_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#tuple_array_conversions
+[`tuple_let_chain`]: https://rust-lang.github.io/rust-clippy/master/index.html#tuple_let_chain
 [`type_complexity`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
 [`type_id_on_box`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_id_on_box
 [`type_repetition_in_bounds`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_repetition_in_bounds

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -751,6 +751,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::transmute::USELESS_TRANSMUTE_INFO,
     crate::transmute::WRONG_TRANSMUTE_INFO,
     crate::tuple_array_conversions::TUPLE_ARRAY_CONVERSIONS_INFO,
+    crate::tuple_let_chain::TUPLE_LET_CHAIN_INFO,
     crate::types::BORROWED_BOX_INFO,
     crate::types::BOX_COLLECTION_INFO,
     crate::types::LINKEDLIST_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -364,6 +364,7 @@ mod trailing_empty_array;
 mod trait_bounds;
 mod transmute;
 mod tuple_array_conversions;
+mod tuple_let_chain;
 mod types;
 mod unconditional_recursion;
 mod undocumented_unsafe_blocks;
@@ -860,6 +861,7 @@ rustc_lint::late_lint_methods!(
         ManualNoopWaker: manual_noop_waker::ManualNoopWaker = manual_noop_waker::ManualNoopWaker::new(conf),
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
+        TupleLetChain: tuple_let_chain::TupleLetChain = tuple_let_chain::TupleLetChain,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/tuple_let_chain.rs
+++ b/clippy_lints/src/tuple_let_chain.rs
@@ -1,0 +1,90 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, PatKind, QPath};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for tuples or arrays constructed and immediately destructured.
+    ///
+    /// ### Why is this bad?
+    /// It creates unnecessary intermediate objects and can be more cleanly expressed
+    /// using a `let` chain.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// if let (Some(x), Ok(y)) = (x, y) {
+    /// 
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// if let Some(x) = x && let Ok(y) = y {
+    ///
+    /// }
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub TUPLE_LET_CHAIN,
+    complexity,
+    "tuple or array constructed and immediately destructured"
+}
+
+declare_lint_pass!(TupleLetChain => [TUPLE_LET_CHAIN]);
+
+impl<'tcx> LateLintPass<'tcx> for TupleLetChain {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        let ExprKind::Let(let_expr) = expr.kind else { return };
+
+        let (pat_elements, expr_elements) = match (&let_expr.pat.kind, &let_expr.init.kind) {
+            (PatKind::Tuple(p_els, _), ExprKind::Tup(e_els)) => (p_els, e_els),
+            (PatKind::Slice(p_els, None, _), ExprKind::Array(e_els)) => (p_els, e_els),
+            _ => return,
+        };
+
+        if pat_elements.len() != expr_elements.len() {
+            return;
+        }
+
+        // Check if any binding in the pattern is used in subsequent init expressions.
+        // This prevents incorrect refactoring where a later init depends on a binding from the pattern.
+        let mut is_shadowed = false;
+        for (i, pat) in pat_elements.iter().enumerate() {
+            pat.each_binding(|_, _, _, bound_ident| {
+                for expr in &expr_elements[i + 1..] {
+                    if let ExprKind::Path(QPath::Resolved(_, path)) = expr.kind {
+                        if path.segments.last().unwrap().ident.name == bound_ident.name {
+                            is_shadowed = true;
+                        }
+                    }
+                }
+            });
+        }
+
+        if !is_shadowed {
+            let mut sugg = String::new();
+            for (i, (pat, init)) in pat_elements.iter().zip(expr_elements.iter()).enumerate() {
+                let pat_snip = snippet(cx, pat.span, "..");
+                let init_snip = snippet(cx, init.span, "..");
+                
+                if i > 0 {
+                    sugg.push_str(" && let ");
+                } else {
+                    sugg.push_str("let ");
+                }
+                sugg.push_str(&format!("{pat_snip} = {init_snip}"));
+            }
+
+            span_lint_and_sugg(
+                cx,
+                TUPLE_LET_CHAIN,
+                expr.span,
+                "this tuple or array is constructed and immediately destructured",
+                "consider using a `let` chain instead",
+                sugg,
+                Applicability::MachineApplicable,
+            );
+        }
+    }
+}

--- a/clippy_lints/src/tuple_let_chain.rs
+++ b/clippy_lints/src/tuple_let_chain.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, PatKind, QPath};
+use rustc_hir::{Expr, ExprKind, Node, PatKind, QPath};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 
@@ -16,13 +16,13 @@ declare_clippy_lint! {
     /// ### Example
     /// ```no_run
     /// if let (Some(x), Ok(y)) = (x, y) {
-    /// 
+    ///     // ...
     /// }
     /// ```
     /// Use instead:
     /// ```no_run
     /// if let Some(x) = x && let Ok(y) = y {
-    ///
+    ///     // ...
     /// }
     /// ```
     #[clippy::version = "1.98.0"]
@@ -35,6 +35,27 @@ declare_lint_pass!(TupleLetChain => [TUPLE_LET_CHAIN]);
 
 impl<'tcx> LateLintPass<'tcx> for TupleLetChain {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        if expr.span.from_expansion() {
+            return;
+        }
+
+        let mut parent = cx.tcx.parent_hir_node(expr.hir_id);
+        let mut in_if_cond = false;
+
+        while let Node::Expr(parent_expr) = parent {
+            if let ExprKind::If(cond, ..) = parent_expr.kind {
+                if cond.hir_id == expr.hir_id {
+                    in_if_cond = true;
+                    break;
+                }
+            }
+            parent = cx.tcx.parent_hir_node(parent_expr.hir_id);
+        }
+
+        if !in_if_cond {
+            return;
+        }
+
         let ExprKind::Let(let_expr) = expr.kind else { return };
 
         let (pat_elements, expr_elements) = match (&let_expr.pat.kind, &let_expr.init.kind) {
@@ -47,8 +68,6 @@ impl<'tcx> LateLintPass<'tcx> for TupleLetChain {
             return;
         }
 
-        // Check if any binding in the pattern is used in subsequent init expressions.
-        // This prevents incorrect refactoring where a later init depends on a binding from the pattern.
         let mut is_shadowed = false;
         for (i, pat) in pat_elements.iter().enumerate() {
             pat.each_binding(|_, _, _, bound_ident| {
@@ -67,7 +86,7 @@ impl<'tcx> LateLintPass<'tcx> for TupleLetChain {
             for (i, (pat, init)) in pat_elements.iter().zip(expr_elements.iter()).enumerate() {
                 let pat_snip = snippet(cx, pat.span, "..");
                 let init_snip = snippet(cx, init.span, "..");
-                
+
                 if i > 0 {
                     sugg.push_str(" && let ");
                 } else {

--- a/tests/ui/tuple_let_chain.rs
+++ b/tests/ui/tuple_let_chain.rs
@@ -1,0 +1,25 @@
+#![warn(clippy::tuple_let_chain)]
+#![allow(clippy::redundant_pattern_matching)]
+
+fn main() {
+    let x = Some(1);
+    let y = Ok::<i32, i32>(2);
+    let a = Some(3);
+    let b = None::<i32>;
+
+    // Should fail
+    if let (Some(x), Ok(y)) = (x, y) {}
+    if let [Some(_), None] = [a, b] {}
+    if let (Some(x), Ok(y)) = (x, y) && let [Some(_), None] = [a, b] {}
+
+    // Should NOT fail
+    let c = Some(1);
+    let d = Some(2);
+    let e = Some(3);
+
+    // Swapped variables
+    if let (Some(c), Some(d)) = (d, c) {}
+
+    // Different variables
+    if let (Some(c), Some(d)) = (c, e) {}
+}

--- a/tests/ui/tuple_let_chain.rs
+++ b/tests/ui/tuple_let_chain.rs
@@ -10,7 +10,9 @@ fn main() {
     // Should fail
     if let (Some(x), Ok(y)) = (x, y) {}
     if let [Some(_), None] = [a, b] {}
-    if let (Some(x), Ok(y)) = (x, y) && let [Some(_), None] = [a, b] {}
+    if let (Some(x), Ok(y)) = (x, y)
+        && let [Some(_), None] = [a, b]
+    {}
 
     // Should NOT fail
     let c = Some(1);

--- a/tests/ui/tuple_let_chain.stderr
+++ b/tests/ui/tuple_let_chain.stderr
@@ -1,0 +1,35 @@
+error: this tuple or array is constructed and immediately destructured
+  --> tests/ui/tuple_let_chain.rs:11:8
+   |
+LL |     if let (Some(x), Ok(y)) = (x, y) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a `let` chain instead: `let Some(x) = x && let Ok(y) = y`
+   |
+   = note: `-D clippy::tuple-let-chain` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::tuple_let_chain)]`
+
+error: this tuple or array is constructed and immediately destructured
+  --> tests/ui/tuple_let_chain.rs:12:8
+   |
+LL |     if let [Some(_), None] = [a, b] {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a `let` chain instead: `let Some(_) = a && let None = b`
+
+error: this tuple or array is constructed and immediately destructured
+  --> tests/ui/tuple_let_chain.rs:13:8
+   |
+LL |     if let (Some(x), Ok(y)) = (x, y) && let [Some(_), None] = [a, b] {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a `let` chain instead: `let Some(x) = x && let Ok(y) = y`
+
+error: this tuple or array is constructed and immediately destructured
+  --> tests/ui/tuple_let_chain.rs:13:41
+   |
+LL |     if let (Some(x), Ok(y)) = (x, y) && let [Some(_), None] = [a, b] {}
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a `let` chain instead: `let Some(_) = a && let None = b`
+
+error: this tuple or array is constructed and immediately destructured
+  --> tests/ui/tuple_let_chain.rs:24:8
+   |
+LL |     if let (Some(c), Some(d)) = (c, e) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a `let` chain instead: `let Some(c) = c && let Some(d) = e`
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
This PR adds a new `complexity` lint called `tuple_let_chain`.

It detects instances where a tuple or array is constructed and immediately destructured in a `let` statement. These patterns are often unnecessarily verbose and can be simplified using `let` chains.

Example:
```rust
// Before
if let (Some(x), Ok(y)) = (x, y) { ... }

// After (Suggested)
if let Some(x) = x && let Ok(y) = y { ... }

```

Checklist:

* [x] Followed [lint naming conventions](https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints)
* [x] Added passing UI tests (including committed `.stderr` file)
* [x] `cargo test` passes locally
* [x] Executed `cargo dev update_lints`
* [x] Added lint documentation
* [x] Run `cargo dev fmt`

changelog: [`tuple_let_chain`]: add new lint

fixes rust-lang/rust-clippy#17169
