### PR TITLE
Fix OOM panic for large types on uninit check

### DIFF
--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use core::ops::ControlFlow;
-use rustc_abi::VariantIdx;
+use rustc_abi::{BackendRepr, FieldsShape, VariantIdx, Variants};
 use rustc_ast::ast::Mutability;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
@@ -17,7 +17,7 @@ use rustc_middle::mir::ConstValue;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::traits::EvaluationResult;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, DerefAdjustKind};
-use rustc_middle::ty::layout::ValidityRequirement;
+use rustc_middle::ty::layout::{LayoutError, LayoutOf, TyAndLayout};
 use rustc_middle::ty::{
     self, AdtDef, AliasTy, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
     GenericArgKind, GenericArgsRef, IntTy, Region, RegionKind, TraitRef, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
@@ -505,29 +505,103 @@ pub fn same_type_modulo_regions<'tcx>(a: Ty<'tcx>, b: Ty<'tcx>) -> bool {
 
 /// Checks if a given type looks safe to be uninitialized.
 pub fn is_uninit_value_valid_for_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-    let typing_env = cx.typing_env().with_post_analysis_normalized(cx.tcx);
-    cx.tcx
-        .check_validity_requirement((ValidityRequirement::Uninit, typing_env.as_query_input(ty)))
-        .unwrap_or_else(|_| is_uninit_value_valid_for_ty_fallback(cx, ty))
+    match cx.layout_of(ty) {
+        Ok(layout) => is_uninit_value_valid_for_layout(cx, layout),
+        // The type layout is either not concrete enough yet or too large, fall back to structural check instead
+        Err(LayoutError::TooGeneric(_) | LayoutError::SizeOverflow(_)) => is_uninit_value_valid_for_ty_fallback(cx, ty),
+        Err(_) => false,
+    }
 }
 
-/// A fallback for polymorphic types, which are not supported by `check_validity_requirement`.
+fn is_uninit_value_valid_for_layout<'tcx>(cx: &LateContext<'tcx>, layout: TyAndLayout<'tcx>) -> bool {
+    // ZSTs contribute no bytes to the vector buffer
+    if layout.layout.is_zst() {
+        return true;
+    }
+
+    match layout.layout.backend_repr {
+        BackendRepr::Scalar(s) => s.is_uninit_valid(),
+        BackendRepr::ScalarPair(a, b) => a.is_uninit_valid() && b.is_uninit_valid(),
+        BackendRepr::SimdVector { element, count } => count == 0 || element.is_uninit_valid(),
+        BackendRepr::SimdScalableVector { element, .. } => element.is_uninit_valid(),
+        // Here validity is determined by the structural fields instead.
+        BackendRepr::Memory { .. } => match &layout.layout.variants {
+            Variants::Single { .. } => match &layout.layout.fields {
+                FieldsShape::Primitive => {
+                    debug_assert!(false, "Both Scalar primitives and ! should be handled above.");
+                    false
+                },
+                // Arrays are valid if empty, or if their elements are valid.
+                FieldsShape::Array { count, .. } => {
+                    if *count == 0 {
+                        true
+                    } else {
+                        is_uninit_value_valid_for_layout(cx, layout.field(cx, 0))
+                    }
+                },
+                // Structs like types are valid only if all fields are valid.
+                FieldsShape::Arbitrary { offsets, .. } => {
+                    (0..offsets.len()).all(|i| is_uninit_value_valid_for_layout(cx, layout.field(cx, i)))
+                },
+                // Unions are valid if at least one field is valid.
+                FieldsShape::Union(count) => {
+                    (0..count.get()).any(|i| is_uninit_value_valid_for_layout(cx, layout.field(cx, i)))
+                },
+            },
+            // Types with no valid variants must be uninhabited
+            Variants::Empty => true,
+            // Enum like with multiple inhabited variants have a discriminant, they cannot be uninitialized.
+            Variants::Multiple { .. } => false,
+        },
+    }
+}
+
+/// Fallback for polymorphic types where `layout_of` fails
 fn is_uninit_value_valid_for_ty_fallback<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    let typing_env = cx.typing_env().with_post_analysis_normalized(cx.tcx);
+
     match *ty.kind() {
         // The array length may be polymorphic, let's try the inner type.
-        ty::Array(component, _) => is_uninit_value_valid_for_ty(cx, component),
+        ty::Array(component, len) => {
+            // Zero-length arrays are always valid
+            if len.try_to_target_usize(cx.tcx) == Some(0) {
+                return true;
+            }
+            is_uninit_value_valid_for_ty(cx, component)
+        },
         // Peek through tuples and try their fallbacks.
         ty::Tuple(types) => types.iter().all(|ty| is_uninit_value_valid_for_ty(cx, ty)),
-        // Unions are always fine right now.
-        // This includes MaybeUninit, the main way people use uninitialized memory.
-        ty::Adt(adt, _) if adt.is_union() => true,
+        // For Unions, check if any field is uninit
+        ty::Adt(adt, args) if adt.is_union() => adt.all_fields().any(|field| {
+            let unnormalized_field_ty = field.ty(cx.tcx, args);
+            let Ok(field_ty) = cx.tcx.try_normalize_erasing_regions(typing_env, unnormalized_field_ty) else {
+                debug_assert!(
+                    false,
+                    "failed to normalize field type `{unnormalized_field_ty:?}`, ParamEnv is likely set incorrectly."
+                );
+                return false;
+            };
+            is_uninit_value_valid_for_ty(cx, field_ty)
+        }),
         // Types (e.g. `UnsafeCell<MaybeUninit<T>>`) that recursively contain only types that can be uninit
         // can themselves be uninit too.
-        // This purposefully ignores enums as they may have a discriminant that can't be uninit.
-        ty::Adt(adt, args) if adt.is_struct() => adt
-            .all_fields()
-            .all(|field| is_uninit_value_valid_for_ty(cx, field.ty(cx.tcx, args).skip_norm_wip())),
-        // For the rest, conservatively assume that they cannot be uninit.
+        // This also applies for single variant enums, whose validity is determined by their fields.
+        ty::Adt(adt, args) if adt.is_struct() || adt.variants().len() == 1 => adt.all_fields().all(|field| {
+            let unnormalized_field_ty = field.ty(cx.tcx, args);
+            let Ok(field_ty) = cx.tcx.try_normalize_erasing_regions(typing_env, unnormalized_field_ty) else {
+                debug_assert!(
+                    false,
+                    "failed to normalize field type `{unnormalized_field_ty:?}`, ParamEnv is likely set incorrectly."
+                );
+                return false;
+            };
+
+            is_uninit_value_valid_for_ty(cx, field_ty)
+        }),
+        // Without a usable whole type layout,
+        // conservatively reject remaining enum cases
+        ty::Adt(adt, _) if adt.is_enum() => false,
+        // Conservatively reject remaining types
         _ => false,
     }
 }

--- a/tests/ui/uninit_vec.rs
+++ b/tests/ui/uninit_vec.rs
@@ -205,3 +205,125 @@ fn main() {
         }
     }
 }
+
+mod issue_11715 {
+    use std::mem::MaybeUninit;
+    #[cfg(target_pointer_width = "64")]
+    const HUGE: usize = 4_294_967_296;
+    #[cfg(target_pointer_width = "32")]
+    const HUGE: usize = 268_435_455;
+
+    fn large_maybeuninit_vec_ice() {
+        let mut v: Vec<[MaybeUninit<u64>; HUGE]> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+
+    fn large_u8_vec_ice() {
+        let mut v: Vec<[u8; HUGE]> = Vec::with_capacity(1);
+        //~^ uninit_vec
+        unsafe { v.set_len(1) };
+    }
+
+    fn large_nested_maybeuninit_vec_ice() {
+        let mut v: Vec<[[MaybeUninit<u64>; HUGE]; 2]> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+
+    struct HeavyWrapperSafe([MaybeUninit<u64>; HUGE]);
+    fn large_struct_maybeuninit_vec_ice() {
+        let mut v: Vec<HeavyWrapperSafe> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+
+    struct HeavyWrapperUnsafe([u8; HUGE]);
+    fn large_struct_u8_vec_ice() {
+        let mut v: Vec<HeavyWrapperUnsafe> = Vec::with_capacity(1);
+        //~^ uninit_vec
+        unsafe { v.set_len(1) };
+    }
+
+    #[allow(clippy::large_enum_variant)]
+    enum HeavyEnum {
+        A([MaybeUninit<u64>; HUGE]),
+        B,
+    }
+    fn large_enum_vec_ice() {
+        let mut v: Vec<HeavyEnum> = Vec::with_capacity(1);
+        //~^ uninit_vec
+        unsafe { v.set_len(1) };
+    }
+
+    enum Uninhabited {}
+    fn uninhabited_enum() {
+        let mut v: Vec<Uninhabited> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+
+    enum SingleVariant {
+        OnlyOne,
+    }
+    fn single_variant_enum() {
+        let mut v: Vec<SingleVariant> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+
+    enum OneVariantU8 {
+        ThisOne([u8; HUGE]),
+    }
+    fn one_variant_u8() {
+        let mut v: Vec<OneVariantU8> = Vec::with_capacity(1);
+        //~^ uninit_vec
+        unsafe { v.set_len(1) };
+    }
+
+    enum OneVariantMaybeUninit {
+        ThisOne([MaybeUninit<u8>; HUGE]),
+    }
+    fn one_variant_maybe_uninit() {
+        let mut v: Vec<OneVariantMaybeUninit> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+
+    fn generic_vec_lints<T>() {
+        let mut v: Vec<T> = Vec::with_capacity(1);
+        //~^ uninit_vec
+        unsafe { v.set_len(1) };
+    }
+
+    fn generic_vec_maybeuninit<T>() {
+        let mut v: Vec<MaybeUninit<T>> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+
+    trait Assoc {
+        type Item;
+    }
+    fn projection_vec_lints<T: Assoc>() {
+        let mut v: Vec<<T as Assoc>::Item> = Vec::with_capacity(1);
+        //~^ uninit_vec
+        unsafe { v.set_len(1) };
+    }
+
+    struct Concrete;
+    impl Assoc for Concrete {
+        type Item = MaybeUninit<u8>;
+    }
+    fn normalized_projection_vec_ok() {
+        let mut v: Vec<<Concrete as Assoc>::Item> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+
+    enum E<T, U> {
+        Foo(MaybeUninit<T>),
+        Bar(U),
+    }
+    fn enum_uninhabited_zst() {
+        let mut v: Vec<E<u8, core::convert::Infallible>> = Vec::with_capacity(1);
+        unsafe { v.set_len(1) };
+    }
+    fn enum_uninhabited_non_zst() {
+        let mut v: Vec<E<u8, (u8, core::convert::Infallible)>> = Vec::with_capacity(1);
+        //~^ uninit_vec
+        unsafe { v.set_len(1) };
+    }
+}

--- a/tests/ui/uninit_vec.stderr
+++ b/tests/ui/uninit_vec.stderr
@@ -159,5 +159,82 @@ LL |             vec.set_len(1);
    |
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
-error: aborting due to 15 previous errors
+error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+  --> tests/ui/uninit_vec.rs:222:9
+   |
+LL |         let mut v: Vec<[u8; HUGE]> = Vec::with_capacity(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         unsafe { v.set_len(1) };
+   |                  ^^^^^^^^^^^^
+   |
+   = help: initialize the buffer or wrap the content in `MaybeUninit`
+
+error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+  --> tests/ui/uninit_vec.rs:240:9
+   |
+LL |         let mut v: Vec<HeavyWrapperUnsafe> = Vec::with_capacity(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         unsafe { v.set_len(1) };
+   |                  ^^^^^^^^^^^^
+   |
+   = help: initialize the buffer or wrap the content in `MaybeUninit`
+
+error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+  --> tests/ui/uninit_vec.rs:251:9
+   |
+LL |         let mut v: Vec<HeavyEnum> = Vec::with_capacity(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         unsafe { v.set_len(1) };
+   |                  ^^^^^^^^^^^^
+   |
+   = help: initialize the buffer or wrap the content in `MaybeUninit`
+
+error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+  --> tests/ui/uninit_vec.rs:274:9
+   |
+LL |         let mut v: Vec<OneVariantU8> = Vec::with_capacity(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         unsafe { v.set_len(1) };
+   |                  ^^^^^^^^^^^^
+   |
+   = help: initialize the buffer or wrap the content in `MaybeUninit`
+
+error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+  --> tests/ui/uninit_vec.rs:288:9
+   |
+LL |         let mut v: Vec<T> = Vec::with_capacity(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         unsafe { v.set_len(1) };
+   |                  ^^^^^^^^^^^^
+   |
+   = help: initialize the buffer or wrap the content in `MaybeUninit`
+
+error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+  --> tests/ui/uninit_vec.rs:302:9
+   |
+LL |         let mut v: Vec<<T as Assoc>::Item> = Vec::with_capacity(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         unsafe { v.set_len(1) };
+   |                  ^^^^^^^^^^^^
+   |
+   = help: initialize the buffer or wrap the content in `MaybeUninit`
+
+error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
+  --> tests/ui/uninit_vec.rs:325:9
+   |
+LL |         let mut v: Vec<E<u8, (u8, core::convert::Infallible)>> = Vec::with_capacity(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         unsafe { v.set_len(1) };
+   |                  ^^^^^^^^^^^^
+   |
+   = help: initialize the buffer or wrap the content in `MaybeUninit`
+
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17205)*

fixes rust-lang/rust-clippy#11715 

previously clippy called `check_validity_requirement` which would take the strict path and will try to allocate memory to check the validity of the type, which can trigger OOM on large types.

instead of delegating aggregate types to rustc first, check their validity on clippy's side and let rustc handle other types.

changelog: [`uninit_vec`]: fix OOM panic on large types.