### PR TITLE
docs: Clarify lint configuration text.

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -98,7 +98,8 @@ To deny `clippy::enum_glob_use`, put the following in the `Cargo.toml`:
 enum_glob_use = "deny"
 ```
 
-For more details and options, refer to the Cargo documentation.
+For more details and options, refer to the [Cargo
+documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-lints-section).
 
 ### Specifying the minimum supported Rust version
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -98,8 +98,7 @@ To deny `clippy::enum_glob_use`, put the following in the `Cargo.toml`:
 enum_glob_use = "deny"
 ```
 
-For more details and options, refer to the [Cargo
-documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-lints-section).
+For more details and options, refer to the Cargo documentation.
 
 ### Specifying the minimum supported Rust version
 

--- a/book/src/lints.md
+++ b/book/src/lints.md
@@ -5,10 +5,10 @@ and idiomatic Rust code. A full list of all lints, that can be filtered by
 category, lint level or keywords, can be found in the [Clippy lint
 documentation].
 
-This chapter will give an overview of the different lint categories, which kind
-of lints they offer and recommended actions when you should see a lint out of
+This chapter provides details about the different lint categories, which kind
+of lints they offer, and recommended actions when you should see a lint out of
 that category. For examples, see the [Clippy lint documentation] and filter by
-category.
+category. For an overview of these categories, see the [introduction](..).
 
 The different lint groups were defined in the [Clippy 1.0 RFC].
 

--- a/book/src/lints.md
+++ b/book/src/lints.md
@@ -8,7 +8,8 @@ documentation].
 This chapter provides details about the different lint categories, which kind
 of lints they offer, and recommended actions when you should see a lint out of
 that category. For examples, see the [Clippy lint documentation] and filter by
-category. For an overview of these categories, see the [introduction](..).
+category. For an overview of these categories, see the
+[introduction](index.md).
 
 The different lint groups were defined in the [Clippy 1.0 RFC].
 


### PR DESCRIPTION
changelog: none

This cleans up the lint configuration docs by pointing to the summary table. It also adds a link to Cargo docs.
