### PR TITLE
Replace `is_range_full` with `is_full_collection_range`

### DIFF
--- a/clippy_lints/src/methods/clear_with_drain.rs
+++ b/clippy_lints/src/methods/clear_with_drain.rs
@@ -1,8 +1,8 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::res::MaybeDef;
-use clippy_utils::{is_range_full, sym};
+use clippy_utils::res::{MaybeDef, MaybeResPath};
+use clippy_utils::{is_full_collection_range, sym};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, LangItem, QPath};
+use rustc_hir::{Expr, LangItem};
 use rustc_lint::LateContext;
 use rustc_span::Span;
 
@@ -16,8 +16,7 @@ const ACCEPTABLE_TYPES_WITHOUT_ARG: [rustc_span::Symbol; 3] = [sym::BinaryHeap, 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, span: Span, arg: Option<&Expr<'_>>) {
     if let Some(arg) = arg {
         if match_acceptable_type(cx, recv, &ACCEPTABLE_TYPES_WITH_ARG)
-            && let ExprKind::Path(QPath::Resolved(None, container_path)) = recv.kind
-            && is_range_full(cx, arg, Some(container_path))
+            && is_full_collection_range(cx, recv.res_local_id(), arg)
         {
             suggest(cx, expr, recv, span);
         }

--- a/clippy_lints/src/methods/drain_collect.rs
+++ b/clippy_lints/src/methods/drain_collect.rs
@@ -4,64 +4,34 @@ use clippy_utils::res::MaybeDef;
 use clippy_utils::source::snippet;
 use clippy_utils::{is_range_full, std_or_core, sym};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, LangItem, Path, QPath};
+use rustc_hir::{Expr, ExprKind, QPath};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
-use rustc_middle::ty::Ty;
-use rustc_span::Symbol;
 
-/// Checks if both types match the given diagnostic item, e.g.:
-///
-/// `vec![1,2].drain(..).collect::<Vec<_>>()`
-///  ^^^^^^^^^                     ^^^^^^   true
-/// `vec![1,2].drain(..).collect::<HashSet<_>>()`
-///  ^^^^^^^^^                     ^^^^^^^^^^  false
-fn types_match_diagnostic_item(cx: &LateContext<'_>, expr: Ty<'_>, recv: Ty<'_>, sym: Symbol) -> bool {
-    if let Some(expr_adt) = expr.ty_adt_def()
-        && let Some(recv_adt) = recv.ty_adt_def()
-    {
-        cx.tcx.is_diagnostic_item(sym, expr_adt.did()) && cx.tcx.is_diagnostic_item(sym, recv_adt.did())
-    } else {
-        false
-    }
-}
-
-/// Checks `std::{vec::Vec, collections::VecDeque}`.
-fn check_vec(cx: &LateContext<'_>, args: &[Expr<'_>], expr: Ty<'_>, recv: Ty<'_>, recv_path: &Path<'_>) -> bool {
-    (types_match_diagnostic_item(cx, expr, recv, sym::Vec)
-        || types_match_diagnostic_item(cx, expr, recv, sym::VecDeque))
-        && matches!(args, [arg] if is_range_full(cx, arg, Some(recv_path)))
-}
-
-/// Checks `std::string::String`
-fn check_string(cx: &LateContext<'_>, args: &[Expr<'_>], expr: Ty<'_>, recv: Ty<'_>, recv_path: &Path<'_>) -> bool {
-    expr.is_lang_item(cx, LangItem::String)
-        && recv.is_lang_item(cx, LangItem::String)
-        && matches!(args, [arg] if is_range_full(cx, arg, Some(recv_path)))
-}
-
-/// Checks `std::collections::{HashSet, HashMap, BinaryHeap}`.
-fn check_collections(cx: &LateContext<'_>, expr: Ty<'_>, recv: Ty<'_>) -> Option<&'static str> {
-    types_match_diagnostic_item(cx, expr, recv, sym::HashSet)
-        .then_some("HashSet")
-        .or_else(|| types_match_diagnostic_item(cx, expr, recv, sym::HashMap).then_some("HashMap"))
-        .or_else(|| types_match_diagnostic_item(cx, expr, recv, sym::BinaryHeap).then_some("BinaryHeap"))
-}
-
-pub(super) fn check(cx: &LateContext<'_>, args: &[Expr<'_>], expr: &Expr<'_>, recv: &Expr<'_>) {
-    let expr_ty = cx.typeck_results().expr_ty(expr);
-    let recv_ty = cx.typeck_results().expr_ty(recv);
-    let recv_ty_no_refs = recv_ty.peel_refs();
-
-    if let ExprKind::Path(QPath::Resolved(_, recv_path)) = recv.kind
-        && let Some(typename) = check_vec(cx, args, expr_ty, recv_ty_no_refs, recv_path)
-            .then_some("Vec")
-            .or_else(|| check_string(cx, args, expr_ty, recv_ty_no_refs, recv_path).then_some("String"))
-            .or_else(|| check_collections(cx, expr_ty, recv_ty_no_refs))
+pub(super) fn check(cx: &LateContext<'_>, arg: Option<&Expr<'_>>, expr: &Expr<'_>, recv: &Expr<'_>) {
+    let ty = cx.typeck_results().expr_ty(recv);
+    let (is_ref, ty) = match *ty.kind() {
+        ty::Ref(_, ty, _) => (true, ty),
+        _ => (false, ty),
+    };
+    if cx.typeck_results().expr_ty(expr) == ty
+        && let Some(did) = ty.opt_def_id()
+        && (cx.tcx.lang_items().string() == Some(did)
+            || matches!(
+                ty.opt_diag_name(cx),
+                Some(sym::HashMap | sym::HashSet | sym::BinaryHeap | sym::Vec | sym::VecDeque)
+            ))
+        && arg.is_none_or(|arg| {
+            if let ExprKind::Path(QPath::Resolved(None, path)) = recv.kind {
+                is_range_full(cx, arg, Some(path))
+            } else {
+                false
+            }
+        })
         && let Some(exec_context) = std_or_core(cx)
     {
         let recv = snippet(cx, recv.span, "<expr>");
-        let sugg = if let ty::Ref(..) = recv_ty.kind() {
+        let sugg = if is_ref {
             format!("{exec_context}::mem::take({recv})")
         } else {
             format!("{exec_context}::mem::take(&mut {recv})")
@@ -71,8 +41,8 @@ pub(super) fn check(cx: &LateContext<'_>, args: &[Expr<'_>], expr: &Expr<'_>, re
             cx,
             DRAIN_COLLECT,
             expr.span,
-            format!("you seem to be trying to move all elements into a new `{typename}`"),
-            "consider using `mem::take`",
+            "draining all elements of a collection into a new collection of the same type",
+            "use `mem::take` to avoid creating a new allocation",
             sugg,
             Applicability::MachineApplicable,
         );

--- a/clippy_lints/src/methods/drain_collect.rs
+++ b/clippy_lints/src/methods/drain_collect.rs
@@ -1,10 +1,10 @@
 use crate::methods::DRAIN_COLLECT;
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::res::MaybeDef;
+use clippy_utils::res::{MaybeDef, MaybeResPath};
 use clippy_utils::source::snippet;
-use clippy_utils::{is_range_full, std_or_core, sym};
+use clippy_utils::{is_full_collection_range, std_or_core, sym};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, QPath};
+use rustc_hir::Expr;
 use rustc_lint::LateContext;
 use rustc_middle::ty;
 
@@ -21,13 +21,7 @@ pub(super) fn check(cx: &LateContext<'_>, arg: Option<&Expr<'_>>, expr: &Expr<'_
                 ty.opt_diag_name(cx),
                 Some(sym::HashMap | sym::HashSet | sym::BinaryHeap | sym::Vec | sym::VecDeque)
             ))
-        && arg.is_none_or(|arg| {
-            if let ExprKind::Path(QPath::Resolved(None, path)) = recv.kind {
-                is_range_full(cx, arg, Some(path))
-            } else {
-                false
-            }
-        })
+        && arg.is_none_or(|arg| is_full_collection_range(cx, recv.res_local_id(), arg))
         && let Some(exec_context) = std_or_core(cx)
     {
         let recv = snippet(cx, recv.span, "<expr>");

--- a/clippy_lints/src/methods/iter_with_drain.rs
+++ b/clippy_lints/src/methods/iter_with_drain.rs
@@ -1,7 +1,8 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::{is_range_full, sym};
+use clippy_utils::res::MaybeResPath;
+use clippy_utils::{is_full_collection_range, sym};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, QPath};
+use rustc_hir::{Expr, ExprKind};
 use rustc_lint::LateContext;
 use rustc_span::Span;
 
@@ -12,8 +13,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, span
         && let Some(adt) = cx.typeck_results().expr_ty(recv).ty_adt_def()
         && let Some(ty_name) = cx.tcx.get_diagnostic_name(adt.did())
         && matches!(ty_name, sym::Vec | sym::VecDeque)
-        && let ExprKind::Path(QPath::Resolved(None, container_path)) = recv.kind
-        && is_range_full(cx, arg, Some(container_path))
+        && is_full_collection_range(cx, recv.res_local_id(), arg)
     {
         span_lint_and_sugg(
             cx,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5277,8 +5277,10 @@ impl Methods {
                                 manual_str_repeat::check(cx, expr, recv, take_self_arg, take_arg);
                             }
                         },
-                        Some((sym::drain, recv, args, ..)) => {
-                            drain_collect::check(cx, args, expr, recv);
+                        Some((sym::drain, recv, args, ..)) => match args {
+                            [arg] => drain_collect::check(cx, Some(arg), expr, recv),
+                            [] => drain_collect::check(cx, None, expr, recv),
+                            _ => {},
                         },
                         _ => {},
                     }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -120,7 +120,6 @@ use source::{SpanRangeExt, walk_span_to_context};
 use visitors::{Visitable, for_each_unconsumed_temporary};
 
 use crate::ast_utils::unordered_over;
-use crate::consts::ConstEvalCtxt;
 use crate::higher::Range;
 use crate::msrvs::Msrv;
 use crate::res::{MaybeDef, MaybeQPath, MaybeResPath};
@@ -1329,59 +1328,23 @@ pub fn is_else_clause_in_let_else(tcx: TyCtxt<'_>, expr: &Expr<'_>) -> bool {
     })
 }
 
-/// Checks whether the given `Expr` is a range equivalent to a `RangeFull`.
-///
-/// For the lower bound, this means that:
-/// - either there is none
-/// - or it is the smallest value that can be represented by the range's integer type
-///
-/// For the upper bound, this means that:
-/// - either there is none
-/// - or it is the largest value that can be represented by the range's integer type and is
-///   inclusive
-/// - or it is a call to some container's `len` method and is exclusive, and the range is passed to
-///   a method call on that same container (e.g. `v.drain(..v.len())`)
-///
-/// If the given `Expr` is not some kind of range, the function returns `false`.
-pub fn is_range_full(cx: &LateContext<'_>, expr: &Expr<'_>, container_path: Option<&Path<'_>>) -> bool {
-    let ty = cx.typeck_results().expr_ty(expr);
+/// Checks whether the given `Expr` is a range over the entire container.
+pub fn is_full_collection_range(cx: &LateContext<'_>, container: Option<HirId>, expr: &Expr<'_>) -> bool {
     if let Some(Range { start, end, limits, .. }) = Range::hir(cx, expr) {
-        let start_is_none_or_min = start.is_none_or(|start| {
-            if let rustc_ty::Adt(_, subst) = ty.kind()
-                && let bnd_ty = subst.type_at(0)
-                && let Some(start_const) = ConstEvalCtxt::new(cx).eval(start)
-            {
-                start_const.is_numeric_min(cx.tcx, bnd_ty)
-            } else {
-                false
-            }
-        });
-        let end_is_none_or_max = end.is_none_or(|end| match limits {
-            RangeLimits::Closed => {
-                if let rustc_ty::Adt(_, subst) = ty.kind()
-                    && let bnd_ty = subst.type_at(0)
-                    && let Some(end_const) = ConstEvalCtxt::new(cx).eval(end)
+        start.is_none_or(|start| is_integer_literal(start, 0))
+            && end.is_none_or(|end| {
+                if limits == RangeLimits::HalfOpen
+                    && let Some(container) = container
+                    && let ExprKind::MethodCall(seg, recv, [], _) = end.kind
                 {
-                    end_const.is_numeric_max(cx.tcx, bnd_ty)
+                    seg.ident.name == sym::len && recv.res_local_id() == Some(container)
                 } else {
                     false
                 }
-            },
-            RangeLimits::HalfOpen => {
-                if let Some(container_path) = container_path
-                    && let ExprKind::MethodCall(name, self_arg, [], _) = end.kind
-                    && name.ident.name == sym::len
-                    && let ExprKind::Path(QPath::Resolved(None, path)) = self_arg.kind
-                {
-                    container_path.res == path.res
-                } else {
-                    false
-                }
-            },
-        });
-        return start_is_none_or_min && end_is_none_or_max;
+            })
+    } else {
+        false
     }
-    false
 }
 
 /// Checks whether the given expression is a constant literal of the given value.

--- a/tests/ui/clear_with_drain.fixed
+++ b/tests/ui/clear_with_drain.fixed
@@ -20,11 +20,6 @@ fn vec_range() {
     let mut v = vec![1, 2, 3];
     v.clear();
     //~^ clear_with_drain
-
-    // Do lint
-    let mut v = vec![1, 2, 3];
-    v.clear();
-    //~^ clear_with_drain
 }
 
 fn vec_range_from() {
@@ -40,11 +35,6 @@ fn vec_range_from() {
     // Do not lint because iterator is used
     let mut v = vec![1, 2, 3];
     let next = v.drain(usize::MIN..).next();
-
-    // Do lint
-    let mut v = vec![1, 2, 3];
-    v.clear();
-    //~^ clear_with_drain
 
     // Do lint
     let mut v = vec![1, 2, 3];
@@ -124,11 +114,6 @@ fn vec_deque_range() {
     let mut deque = VecDeque::from([1, 2, 3]);
     deque.clear();
     //~^ clear_with_drain
-
-    // Do lint
-    let mut deque = VecDeque::from([1, 2, 3]);
-    deque.clear();
-    //~^ clear_with_drain
 }
 
 fn vec_deque_range_from() {
@@ -144,11 +129,6 @@ fn vec_deque_range_from() {
     // Do not lint because iterator is used
     let mut deque = VecDeque::from([1, 2, 3]);
     let next = deque.drain(usize::MIN..).next();
-
-    // Do lint
-    let mut deque = VecDeque::from([1, 2, 3]);
-    deque.clear();
-    //~^ clear_with_drain
 
     // Do lint
     let mut deque = VecDeque::from([1, 2, 3]);
@@ -228,11 +208,6 @@ fn string_range() {
     let mut s = String::from("Hello, world!");
     s.clear();
     //~^ clear_with_drain
-
-    // Do lint
-    let mut s = String::from("Hello, world!");
-    s.clear();
-    //~^ clear_with_drain
 }
 
 fn string_range_from() {
@@ -248,11 +223,6 @@ fn string_range_from() {
     // Do not lint because iterator is used
     let mut s = String::from("Hello, world!");
     let next = s.drain(usize::MIN..).next();
-
-    // Do lint
-    let mut s = String::from("Hello, world!");
-    s.clear();
-    //~^ clear_with_drain
 
     // Do lint
     let mut s = String::from("Hello, world!");

--- a/tests/ui/clear_with_drain.rs
+++ b/tests/ui/clear_with_drain.rs
@@ -20,11 +20,6 @@ fn vec_range() {
     let mut v = vec![1, 2, 3];
     v.drain(0..v.len());
     //~^ clear_with_drain
-
-    // Do lint
-    let mut v = vec![1, 2, 3];
-    v.drain(usize::MIN..v.len());
-    //~^ clear_with_drain
 }
 
 fn vec_range_from() {
@@ -44,11 +39,6 @@ fn vec_range_from() {
     // Do lint
     let mut v = vec![1, 2, 3];
     v.drain(0..);
-    //~^ clear_with_drain
-
-    // Do lint
-    let mut v = vec![1, 2, 3];
-    v.drain(usize::MIN..);
     //~^ clear_with_drain
 }
 
@@ -124,11 +114,6 @@ fn vec_deque_range() {
     let mut deque = VecDeque::from([1, 2, 3]);
     deque.drain(0..deque.len());
     //~^ clear_with_drain
-
-    // Do lint
-    let mut deque = VecDeque::from([1, 2, 3]);
-    deque.drain(usize::MIN..deque.len());
-    //~^ clear_with_drain
 }
 
 fn vec_deque_range_from() {
@@ -148,11 +133,6 @@ fn vec_deque_range_from() {
     // Do lint
     let mut deque = VecDeque::from([1, 2, 3]);
     deque.drain(0..);
-    //~^ clear_with_drain
-
-    // Do lint
-    let mut deque = VecDeque::from([1, 2, 3]);
-    deque.drain(usize::MIN..);
     //~^ clear_with_drain
 }
 
@@ -228,11 +208,6 @@ fn string_range() {
     let mut s = String::from("Hello, world!");
     s.drain(0..s.len());
     //~^ clear_with_drain
-
-    // Do lint
-    let mut s = String::from("Hello, world!");
-    s.drain(usize::MIN..s.len());
-    //~^ clear_with_drain
 }
 
 fn string_range_from() {
@@ -252,11 +227,6 @@ fn string_range_from() {
     // Do lint
     let mut s = String::from("Hello, world!");
     s.drain(0..);
-    //~^ clear_with_drain
-
-    // Do lint
-    let mut s = String::from("Hello, world!");
-    s.drain(usize::MIN..);
     //~^ clear_with_drain
 }
 

--- a/tests/ui/clear_with_drain.stderr
+++ b/tests/ui/clear_with_drain.stderr
@@ -8,124 +8,88 @@ LL |     v.drain(0..v.len());
    = help: to override `-D warnings` add `#[allow(clippy::clear_with_drain)]`
 
 error: `drain` used to clear a `Vec`
-  --> tests/ui/clear_with_drain.rs:26:7
-   |
-LL |     v.drain(usize::MIN..v.len());
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `clear()`
-
-error: `drain` used to clear a `Vec`
-  --> tests/ui/clear_with_drain.rs:46:7
+  --> tests/ui/clear_with_drain.rs:41:7
    |
 LL |     v.drain(0..);
    |       ^^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `Vec`
-  --> tests/ui/clear_with_drain.rs:51:7
-   |
-LL |     v.drain(usize::MIN..);
-   |       ^^^^^^^^^^^^^^^^^^^ help: try: `clear()`
-
-error: `drain` used to clear a `Vec`
-  --> tests/ui/clear_with_drain.rs:68:7
+  --> tests/ui/clear_with_drain.rs:58:7
    |
 LL |     v.drain(..);
    |       ^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `Vec`
-  --> tests/ui/clear_with_drain.rs:86:7
+  --> tests/ui/clear_with_drain.rs:76:7
    |
 LL |     v.drain(..v.len());
    |       ^^^^^^^^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `VecDeque`
-  --> tests/ui/clear_with_drain.rs:125:11
+  --> tests/ui/clear_with_drain.rs:115:11
    |
 LL |     deque.drain(0..deque.len());
    |           ^^^^^^^^^^^^^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `VecDeque`
-  --> tests/ui/clear_with_drain.rs:130:11
-   |
-LL |     deque.drain(usize::MIN..deque.len());
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `clear()`
-
-error: `drain` used to clear a `VecDeque`
-  --> tests/ui/clear_with_drain.rs:150:11
+  --> tests/ui/clear_with_drain.rs:135:11
    |
 LL |     deque.drain(0..);
    |           ^^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `VecDeque`
-  --> tests/ui/clear_with_drain.rs:155:11
-   |
-LL |     deque.drain(usize::MIN..);
-   |           ^^^^^^^^^^^^^^^^^^^ help: try: `clear()`
-
-error: `drain` used to clear a `VecDeque`
-  --> tests/ui/clear_with_drain.rs:172:11
+  --> tests/ui/clear_with_drain.rs:152:11
    |
 LL |     deque.drain(..);
    |           ^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `VecDeque`
-  --> tests/ui/clear_with_drain.rs:190:11
+  --> tests/ui/clear_with_drain.rs:170:11
    |
 LL |     deque.drain(..deque.len());
    |           ^^^^^^^^^^^^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `String`
-  --> tests/ui/clear_with_drain.rs:229:7
+  --> tests/ui/clear_with_drain.rs:209:7
    |
 LL |     s.drain(0..s.len());
    |       ^^^^^^^^^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `String`
-  --> tests/ui/clear_with_drain.rs:234:7
-   |
-LL |     s.drain(usize::MIN..s.len());
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `clear()`
-
-error: `drain` used to clear a `String`
-  --> tests/ui/clear_with_drain.rs:254:7
+  --> tests/ui/clear_with_drain.rs:229:7
    |
 LL |     s.drain(0..);
    |       ^^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `String`
-  --> tests/ui/clear_with_drain.rs:259:7
-   |
-LL |     s.drain(usize::MIN..);
-   |       ^^^^^^^^^^^^^^^^^^^ help: try: `clear()`
-
-error: `drain` used to clear a `String`
-  --> tests/ui/clear_with_drain.rs:276:7
+  --> tests/ui/clear_with_drain.rs:246:7
    |
 LL |     s.drain(..);
    |       ^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `String`
-  --> tests/ui/clear_with_drain.rs:294:7
+  --> tests/ui/clear_with_drain.rs:264:7
    |
 LL |     s.drain(..s.len());
    |       ^^^^^^^^^^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `HashSet`
-  --> tests/ui/clear_with_drain.rs:333:9
+  --> tests/ui/clear_with_drain.rs:303:9
    |
 LL |     set.drain();
    |         ^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `HashMap`
-  --> tests/ui/clear_with_drain.rs:353:9
+  --> tests/ui/clear_with_drain.rs:323:9
    |
 LL |     map.drain();
    |         ^^^^^^^ help: try: `clear()`
 
 error: `drain` used to clear a `BinaryHeap`
-  --> tests/ui/clear_with_drain.rs:373:10
+  --> tests/ui/clear_with_drain.rs:343:10
    |
 LL |     heap.drain();
    |          ^^^^^^^ help: try: `clear()`
 
-error: aborting due to 21 previous errors
+error: aborting due to 15 previous errors
 

--- a/tests/ui/drain_collect.stderr
+++ b/tests/ui/drain_collect.stderr
@@ -1,8 +1,8 @@
-error: you seem to be trying to move all elements into a new `BinaryHeap`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:6:5
    |
 LL |     b.drain().collect()
-   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
    |
 note: the lint level is defined here
   --> tests/ui/drain_collect.rs:1:9
@@ -10,59 +10,59 @@ note: the lint level is defined here
 LL | #![deny(clippy::drain_collect)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 
-error: you seem to be trying to move all elements into a new `HashMap`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:15:5
    |
 LL |     b.drain().collect()
-   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
 
-error: you seem to be trying to move all elements into a new `HashSet`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:24:5
    |
 LL |     b.drain().collect()
-   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
 
-error: you seem to be trying to move all elements into a new `Vec`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:33:5
    |
 LL |     b.drain(..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
 
-error: you seem to be trying to move all elements into a new `Vec`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:42:5
    |
 LL |     b.drain(..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
 
-error: you seem to be trying to move all elements into a new `Vec`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:47:5
    |
 LL |     b.drain(0..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
 
-error: you seem to be trying to move all elements into a new `Vec`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:52:5
    |
 LL |     b.drain(..b.len()).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
 
-error: you seem to be trying to move all elements into a new `Vec`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:57:5
    |
 LL |     b.drain(0..b.len()).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
 
-error: you seem to be trying to move all elements into a new `Vec`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:63:5
    |
 LL |     b.drain(..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(&mut b)`
 
-error: you seem to be trying to move all elements into a new `String`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect.rs:72:5
    |
 LL |     b.drain(..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(b)`
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/drain_collect_nostd.stderr
+++ b/tests/ui/drain_collect_nostd.stderr
@@ -1,8 +1,8 @@
-error: you seem to be trying to move all elements into a new `Vec`
+error: draining all elements of a collection into a new collection of the same type
   --> tests/ui/drain_collect_nostd.rs:7:5
    |
 LL |     v.drain(..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `core::mem::take(v)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `core::mem::take(v)`
    |
    = note: `-D clippy::drain-collect` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::drain_collect)]`


### PR DESCRIPTION
Based on rust-lang/rust-clippy#17212

This was only ever used for collections and the extra work it did was incorrect for that use case. This will no longer const eval the start, but we shouldn't doing that on style lints anyways.

changelog: none
