### PR TITLE
Count length of the first paragraph by its text

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -776,7 +776,8 @@ impl<'tcx> LateLintPass<'tcx> for Documentation {
                     cx,
                     item,
                     attrs,
-                    headers.first_paragraph_len,
+                    headers.first_paragraph_text_len,
+                    headers.first_paragraph_md_len,
                     self.check_private_items,
                 );
                 match item.kind {
@@ -851,7 +852,8 @@ struct DocHeaders {
     safety: bool,
     errors: bool,
     panics: bool,
-    first_paragraph_len: usize,
+    first_paragraph_md_len: usize,
+    first_paragraph_text_len: usize,
 }
 
 /// Does some pre-processing on raw, desugared `#[doc]` attributes such as parsing them and
@@ -1227,11 +1229,13 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                 ticks_unbalanced = false;
                 paragraph_range = range;
                 if is_first_paragraph {
-                    headers.first_paragraph_len = doc[paragraph_range.clone()].chars().count();
-                    is_first_paragraph = false;
+                    headers.first_paragraph_md_len = doc[paragraph_range.clone()].chars().count();
                 }
             },
             End(TagEnd::Heading(_) | TagEnd::Paragraph | TagEnd::Item) => {
+                if is_first_paragraph {
+                    is_first_paragraph = false;
+                }
                 if let End(TagEnd::Heading(_)) = event {
                     in_heading = false;
                 }
@@ -1257,8 +1261,11 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
             Start(FootnoteDefinition(..)) => in_footnote_definition = true,
             End(TagEnd::FootnoteDefinition) => in_footnote_definition = false,
             Start(_) | End(_)  // We don't care about other tags
-            | TaskListMarker(_) | Code(_) | Rule | InlineMath(..) | DisplayMath(..) => (),
+            | TaskListMarker(_) | Rule => (),
             SoftBreak | HardBreak => {
+                if is_first_paragraph {
+                    headers.first_paragraph_text_len += 1;
+                }
                 if !containers.is_empty()
                     && !in_footnote_definition
                     // Tabs aren't handled correctly vvvv
@@ -1284,7 +1291,15 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                     collected_breaks.push(span);
                 }
             },
+            Code(code) | InlineMath(code) | DisplayMath(code) => {
+                if is_first_paragraph {
+                    headers.first_paragraph_text_len += code.chars().count();
+                }
+            }
             Text(text) => {
+                if is_first_paragraph {
+                    headers.first_paragraph_text_len += text.chars().count();
+                }
                 paragraph_range.end = range.end;
                 let range_ = range.clone();
                 ticks_unbalanced |= text.contains('`')

--- a/clippy_lints/src/doc/too_long_first_doc_paragraph.rs
+++ b/clippy_lints/src/doc/too_long_first_doc_paragraph.rs
@@ -13,13 +13,14 @@ pub(super) fn check(
     cx: &LateContext<'_>,
     item: &Item<'_>,
     attrs: &[Attribute],
-    mut first_paragraph_len: usize,
+    first_paragraph_text_len: usize,
+    mut first_paragraph_md_len: usize,
     check_private_items: bool,
 ) {
     if !check_private_items && !cx.effective_visibilities.is_exported(item.owner_id.def_id) {
         return;
     }
-    if first_paragraph_len <= 200
+    if first_paragraph_text_len <= 200
         || !matches!(
             item.kind,
             // This is the list of items which can be documented AND are displayed on the module
@@ -58,10 +59,10 @@ pub(super) fn check(
             }
 
             let len = doc.chars().count();
-            if len >= first_paragraph_len {
+            if len >= first_paragraph_md_len {
                 break;
             }
-            first_paragraph_len -= len;
+            first_paragraph_md_len -= len;
         }
     }
 

--- a/tests/ui/too_long_first_doc_paragraph-fix.fixed
+++ b/tests/ui/too_long_first_doc_paragraph-fix.fixed
@@ -9,3 +9,13 @@
 /// and probably spanning a many rows. Blablabla, it needs to be over
 /// 200 characters so I needed to write something longeeeeeeer.
 pub struct Foo;
+
+/// [A](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [very](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [short](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [summary](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com).
+//~^ too_long_first_doc_paragraph
+///
+//~^ too_long_first_doc_paragraph
+/// A much longer explanation that goes into a lot more detail about
+/// how the thing works, possibly with doclinks and so one,
+/// and probably spanning a many rows. Blablabla, it needs to be over
+/// 200 characters so I needed to write something longeeeeeeer.
+pub struct Bar;

--- a/tests/ui/too_long_first_doc_paragraph-fix.rs
+++ b/tests/ui/too_long_first_doc_paragraph-fix.rs
@@ -7,3 +7,11 @@
 /// and probably spanning a many rows. Blablabla, it needs to be over
 /// 200 characters so I needed to write something longeeeeeeer.
 pub struct Foo;
+
+/// [A](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [very](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [short](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [summary](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com).
+//~^ too_long_first_doc_paragraph
+/// A much longer explanation that goes into a lot more detail about
+/// how the thing works, possibly with doclinks and so one,
+/// and probably spanning a many rows. Blablabla, it needs to be over
+/// 200 characters so I needed to write something longeeeeeeer.
+pub struct Bar;

--- a/tests/ui/too_long_first_doc_paragraph-fix.stderr
+++ b/tests/ui/too_long_first_doc_paragraph-fix.stderr
@@ -19,5 +19,24 @@ LL + ///
 LL +
    |
 
-error: aborting due to 1 previous error
+error: first doc comment paragraph is too long
+  --> tests/ui/too_long_first_doc_paragraph-fix.rs:11:1
+   |
+LL | / /// [A](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [very](https://foooooooooooooooooooooooooo...
+LL | |
+LL | | /// A much longer explanation that goes into a lot more detail about
+LL | | /// how the thing works, possibly with doclinks and so one,
+LL | | /// and probably spanning a many rows. Blablabla, it needs to be over
+LL | | /// 200 characters so I needed to write something longeeeeeeer.
+   | |_^
+   |
+help: add an empty line
+   |
+LL | /// [A](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [very](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [short](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com) [summary](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com).
+LL |
+LL + ///
+LL +
+   |
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/too_long_first_doc_paragraph.rs
+++ b/tests/ui/too_long_first_doc_paragraph.rs
@@ -68,6 +68,18 @@ fn f() {}
 /// Here's a second paragraph. It would be preferable to put the details here.
 pub fn issue_14274() {}
 
+#[rustfmt::skip]
+/// This doc comment contains two references: [this](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com)
+/// and [this](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com)
+pub fn issue_13315() {}
+
+#[rustfmt::skip]
+/// Some function. This doc-string paragraph is too long. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of [Lorem Ipsum](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com).
+//~^ too_long_first_doc_paragraph
+///
+/// Here's a second paragraph. It would be preferable to put the details here.
+pub fn issue_1331_warn() {}
+
 fn main() {
     // test code goes here
 }

--- a/tests/ui/too_long_first_doc_paragraph.stderr
+++ b/tests/ui/too_long_first_doc_paragraph.stderr
@@ -48,5 +48,14 @@ LL | | ///
 LL | | /// Here's a second paragraph. It would be preferable to put the details here.
    | |_^
 
-error: aborting due to 4 previous errors
+error: first doc comment paragraph is too long
+  --> tests/ui/too_long_first_doc_paragraph.rs:77:1
+   |
+LL | / /// Some function. This doc-string paragraph is too long. Lorem Ipsum is simply dummy text of the printing and typesetting industr...
+LL | |
+LL | | ///
+LL | | /// Here's a second paragraph. It would be preferable to put the details here.
+   | |_^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Because of the way this lint implements text splitting, I need to track markdown and text lengths separately. This is fairly easy, since we can exhaustively check every markdown event and count the characters inside.

Fixes https://github.com/rust-lang/rust-clippy/issues/13315

changelog: [`too_long_first_doc_paragraph`]: count length of the first paragraph by its text