### PR TITLE
unnecessary_lazy_evaluations: handle closure `->`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5238,7 +5238,7 @@ impl Methods {
                     let biom_option_linted = bind_instead_of_map::check_and_then_some(cx, expr, recv, arg);
                     let biom_result_linted = bind_instead_of_map::check_and_then_ok(cx, expr, recv, arg);
                     if !biom_option_linted && !biom_result_linted {
-                        let ule_and_linted = unnecessary_lazy_eval::check(cx, expr, recv, arg, "and");
+                        let ule_and_linted = unnecessary_lazy_eval::check(cx, expr, recv, arg, "and", true);
                         if !ule_and_linted {
                             return_and_then::check(cx, expr, recv, arg);
                         }
@@ -5474,7 +5474,7 @@ impl Methods {
                     get_last_with_len::check(cx, expr, recv, arg);
                 },
                 (sym::get_or_insert_with, [arg]) => {
-                    unnecessary_lazy_eval::check(cx, expr, recv, arg, "get_or_insert");
+                    unnecessary_lazy_eval::check(cx, expr, recv, arg, "get_or_insert", false);
                 },
                 (sym::hash, [arg]) => {
                     unit_hash::check(cx, expr, recv, arg);
@@ -5629,14 +5629,14 @@ impl Methods {
                     ptr_offset_by_literal::check(cx, expr, self.msrv);
                 },
                 (sym::ok_or_else, [arg]) => {
-                    unnecessary_lazy_eval::check(cx, expr, recv, arg, "ok_or");
+                    unnecessary_lazy_eval::check(cx, expr, recv, arg, "ok_or", true);
                 },
                 (sym::open, [_]) => {
                     open_options::check(cx, expr, recv);
                 },
                 (sym::or_else, [arg]) => {
                     if !bind_instead_of_map::check_or_else_err(cx, expr, recv, arg) {
-                        unnecessary_lazy_eval::check(cx, expr, recv, arg, "or");
+                        unnecessary_lazy_eval::check(cx, expr, recv, arg, "or", false);
                     }
                 },
                 (sym::peek, []) => {
@@ -5737,7 +5737,7 @@ impl Methods {
                     if !self.msrv.meets(cx, msrvs::BOOL_THEN_SOME) {
                         return;
                     }
-                    unnecessary_lazy_eval::check(cx, expr, recv, arg, "then_some");
+                    unnecessary_lazy_eval::check(cx, expr, recv, arg, "then_some", true);
                 },
                 (sym::try_into, []) if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::TryInto) => {
                     unnecessary_fallible_conversions::check_method(cx, expr);
@@ -5827,7 +5827,7 @@ impl Methods {
                             );
                         },
                         _ => {
-                            unnecessary_lazy_eval::check(cx, expr, recv, u_arg, "unwrap_or");
+                            unnecessary_lazy_eval::check(cx, expr, recv, u_arg, "unwrap_or", false);
                         },
                     }
                     unnecessary_literal_unwrap::check(cx, expr, recv, name, args);

--- a/clippy_lints/src/methods/unnecessary_lazy_eval.rs
+++ b/clippy_lints/src/methods/unnecessary_lazy_eval.rs
@@ -47,38 +47,43 @@ pub(super) fn check<'tcx>(
             } else {
                 "unnecessary closure used with `bool::then`"
             };
+
             let mut applicability = Applicability::MachineApplicable;
-            let (ascription, turbofish) = if body
+            if body
                 .params
                 .iter()
                 // bindings are checked to be unused above
-                .all(|param| matches!(param.pat.kind, hir::PatKind::Binding(..) | hir::PatKind::Wild))
+                .any(|param| !matches!(param.pat.kind, hir::PatKind::Binding(..) | hir::PatKind::Wild))
             {
-                match fn_decl.output {
-                    FnRetTy::DefaultReturn(_)
-                    | FnRetTy::Return(hir::Ty {
-                        kind: hir::TyKind::Infer(()),
-                        ..
-                    }) => {
-                        // type ascription is definitely not needed here
-                        (String::new(), String::new())
-                    },
-                    FnRetTy::Return(ty) => {
-                        // explicit type was given on the closure
-                        // try to use turbofish for this, since it's less dangerous,
-                        // but, failing that, use `as`
-                        let ty = snippet_with_applicability(cx, ty.span, "_", &mut applicability);
-                        if use_turbofish {
-                            (String::new(), format!("::<{ty}>"))
-                        } else {
-                            (format!(" as {ty}"), String::new())
-                        }
-                    },
-                }
-            } else {
-                // can't infer the actual type
+                // If the closure parameters have a pattern,
+                // it might be required for type inferrence.
                 applicability = Applicability::MaybeIncorrect;
-                (String::new(), String::new())
+            }
+            let (ascription, turbofish) = match fn_decl.output {
+                FnRetTy::DefaultReturn(_)
+                | FnRetTy::Return(hir::Ty {
+                    kind: hir::TyKind::Infer(()),
+                    ..
+                }) => {
+                    // if the closure has no explicit return type,
+                    // then there's nothing to preserve
+                    (String::new(), String::new())
+                },
+                FnRetTy::Return(ty) => {
+                    // explicit return type was given on the closure
+                    //
+                    // we can preserve this information using `as`, but `as` is
+                    // a somewhat dangerous feature, because it can be used to
+                    // truncate integers
+                    //
+                    // if possible, use turbofish to preserve the type information
+                    let ty = snippet_with_applicability(cx, ty.span, "_", &mut applicability);
+                    if use_turbofish {
+                        (String::new(), format!("::<{ty}>"))
+                    } else {
+                        (format!(" as {ty}"), String::new())
+                    }
+                },
             };
 
             // This is a duplicate of what's happening in clippy_lints::methods::method_call,

--- a/clippy_lints/src/methods/unnecessary_lazy_eval.rs
+++ b/clippy_lints/src/methods/unnecessary_lazy_eval.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::MaybeDef;
-use clippy_utils::source::snippet;
+use clippy_utils::source::{snippet, snippet_with_applicability};
 use clippy_utils::{eager_or_lazy, is_from_proc_macro, usage};
 use hir::FnRetTy;
 use rustc_errors::Applicability;
@@ -18,6 +18,7 @@ pub(super) fn check<'tcx>(
     recv: &'tcx hir::Expr<'_>,
     arg: &'tcx hir::Expr<'_>,
     simplify_using: &str,
+    use_turbofish: bool,
 ) -> bool {
     let is_option = cx.typeck_results().expr_ty(recv).is_diag_item(cx, sym::Option);
     let is_result = cx.typeck_results().expr_ty(recv).is_diag_item(cx, sym::Result);
@@ -46,23 +47,38 @@ pub(super) fn check<'tcx>(
             } else {
                 "unnecessary closure used with `bool::then`"
             };
-            let applicability = if body
+            let mut applicability = Applicability::MachineApplicable;
+            let (ascription, turbofish) = if body
                 .params
                 .iter()
                 // bindings are checked to be unused above
                 .all(|param| matches!(param.pat.kind, hir::PatKind::Binding(..) | hir::PatKind::Wild))
-                && matches!(
-                    fn_decl.output,
+            {
+                match fn_decl.output {
                     FnRetTy::DefaultReturn(_)
-                        | FnRetTy::Return(hir::Ty {
-                            kind: hir::TyKind::Infer(()),
-                            ..
-                        })
-                ) {
-                Applicability::MachineApplicable
+                    | FnRetTy::Return(hir::Ty {
+                        kind: hir::TyKind::Infer(()),
+                        ..
+                    }) => {
+                        // type ascription is definitely not needed here
+                        (String::new(), String::new())
+                    },
+                    FnRetTy::Return(ty) => {
+                        // explicit type was given on the closure
+                        // try to use turbofish for this, since it's less dangerous,
+                        // but, failing that, use `as`
+                        let ty = snippet_with_applicability(cx, ty.span, "_", &mut applicability);
+                        if use_turbofish {
+                            (String::new(), format!("::<{ty}>"))
+                        } else {
+                            (format!(" as {ty}"), String::new())
+                        }
+                    },
+                }
             } else {
-                // replacing the lambda may break type inference
-                Applicability::MaybeIncorrect
+                // can't infer the actual type
+                applicability = Applicability::MaybeIncorrect;
+                (String::new(), String::new())
             };
 
             // This is a duplicate of what's happening in clippy_lints::methods::method_call,
@@ -73,7 +89,10 @@ pub(super) fn check<'tcx>(
                     diag.span_suggestion_verbose(
                         span,
                         format!("use `{simplify_using}` instead"),
-                        format!("{simplify_using}({})", snippet(cx, body_expr.span, "..")),
+                        format!(
+                            "{simplify_using}{turbofish}({}{ascription})",
+                            snippet(cx, body_expr.span, "..")
+                        ),
                         applicability,
                     );
                 });

--- a/tests/ui/unnecessary_lazy_eval.fixed
+++ b/tests/ui/unnecessary_lazy_eval.fixed
@@ -240,6 +240,18 @@ fn main() {
     let _: Result<usize, usize> = res.or_else(|err| Ok(err));
 }
 
+fn issue11672() {
+    // needs turbofish to disambiguate
+    let _ = true.then_some::<&[u8]>({ &[] });
+    //~^ unnecessary_lazy_evaluations
+}
+
+fn issue11672_as() {
+    // Return type annotation helps type inference and removing it can break code
+    let _ = None.get_or_insert({ &[] } as &[u8]);
+    //~^ unnecessary_lazy_evaluations
+}
+
 #[allow(unused)]
 fn issue9485() {
     // should not lint, is in proc macro

--- a/tests/ui/unnecessary_lazy_eval.rs
+++ b/tests/ui/unnecessary_lazy_eval.rs
@@ -240,6 +240,18 @@ fn main() {
     let _: Result<usize, usize> = res.or_else(|err| Ok(err));
 }
 
+fn issue11672() {
+    // needs turbofish to disambiguate
+    let _ = true.then(|| -> &[u8] { &[] });
+    //~^ unnecessary_lazy_evaluations
+}
+
+fn issue11672_as() {
+    // Return type annotation helps type inference and removing it can break code
+    let _ = None.get_or_insert_with(|| -> &[u8] { &[] });
+    //~^ unnecessary_lazy_evaluations
+}
+
 #[allow(unused)]
 fn issue9485() {
     // should not lint, is in proc macro

--- a/tests/ui/unnecessary_lazy_eval.stderr
+++ b/tests/ui/unnecessary_lazy_eval.stderr
@@ -484,7 +484,31 @@ LL +     or(Ok(ext_str.some_field));
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:259:14
+  --> tests/ui/unnecessary_lazy_eval.rs:245:13
+   |
+LL |     let _ = true.then(|| -> &[u8] { &[] });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `then_some` instead
+   |
+LL -     let _ = true.then(|| -> &[u8] { &[] });
+LL +     let _ = true.then_some::<&[u8]>({ &[] });
+   |
+
+error: unnecessary closure used to substitute value for `Option::None`
+  --> tests/ui/unnecessary_lazy_eval.rs:251:13
+   |
+LL |     let _ = None.get_or_insert_with(|| -> &[u8] { &[] });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `get_or_insert` instead
+   |
+LL -     let _ = None.get_or_insert_with(|| -> &[u8] { &[] });
+LL +     let _ = None.get_or_insert({ &[] } as &[u8]);
+   |
+
+error: unnecessary closure used with `bool::then`
+  --> tests/ui/unnecessary_lazy_eval.rs:271:14
    |
 LL |     let _x = false.then(|| i32::MAX + 1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -496,7 +520,7 @@ LL +     let _x = false.then_some(i32::MAX + 1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:261:14
+  --> tests/ui/unnecessary_lazy_eval.rs:273:14
    |
 LL |     let _x = false.then(|| i32::MAX * 2);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -508,7 +532,7 @@ LL +     let _x = false.then_some(i32::MAX * 2);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:263:14
+  --> tests/ui/unnecessary_lazy_eval.rs:275:14
    |
 LL |     let _x = false.then(|| i32::MAX - 1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -520,7 +544,7 @@ LL +     let _x = false.then_some(i32::MAX - 1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:265:14
+  --> tests/ui/unnecessary_lazy_eval.rs:277:14
    |
 LL |     let _x = false.then(|| i32::MIN - 1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -532,7 +556,7 @@ LL +     let _x = false.then_some(i32::MIN - 1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:267:14
+  --> tests/ui/unnecessary_lazy_eval.rs:279:14
    |
 LL |     let _x = false.then(|| (1 + 2 * 3 - 2 / 3 + 9) << 2);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -544,7 +568,7 @@ LL +     let _x = false.then_some((1 + 2 * 3 - 2 / 3 + 9) << 2);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:269:14
+  --> tests/ui/unnecessary_lazy_eval.rs:281:14
    |
 LL |     let _x = false.then(|| 255u8 << 7);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -556,7 +580,7 @@ LL +     let _x = false.then_some(255u8 << 7);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:271:14
+  --> tests/ui/unnecessary_lazy_eval.rs:283:14
    |
 LL |     let _x = false.then(|| 255u8 << 8);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -568,7 +592,7 @@ LL +     let _x = false.then_some(255u8 << 8);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:273:14
+  --> tests/ui/unnecessary_lazy_eval.rs:285:14
    |
 LL |     let _x = false.then(|| 255u8 >> 8);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -580,7 +604,7 @@ LL +     let _x = false.then_some(255u8 >> 8);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:276:14
+  --> tests/ui/unnecessary_lazy_eval.rs:288:14
    |
 LL |     let _x = false.then(|| i32::MAX + -1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -592,7 +616,7 @@ LL +     let _x = false.then_some(i32::MAX + -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:278:14
+  --> tests/ui/unnecessary_lazy_eval.rs:290:14
    |
 LL |     let _x = false.then(|| -i32::MAX);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -604,7 +628,7 @@ LL +     let _x = false.then_some(-i32::MAX);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:280:14
+  --> tests/ui/unnecessary_lazy_eval.rs:292:14
    |
 LL |     let _x = false.then(|| -i32::MIN);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -616,7 +640,7 @@ LL +     let _x = false.then_some(-i32::MIN);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:283:14
+  --> tests/ui/unnecessary_lazy_eval.rs:295:14
    |
 LL |     let _x = false.then(|| 255 >> -7);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -628,7 +652,7 @@ LL +     let _x = false.then_some(255 >> -7);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:285:14
+  --> tests/ui/unnecessary_lazy_eval.rs:297:14
    |
 LL |     let _x = false.then(|| 255 << -1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -640,7 +664,7 @@ LL +     let _x = false.then_some(255 << -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:287:14
+  --> tests/ui/unnecessary_lazy_eval.rs:299:14
    |
 LL |     let _x = false.then(|| 1 / 0);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -652,7 +676,7 @@ LL +     let _x = false.then_some(1 / 0);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:289:14
+  --> tests/ui/unnecessary_lazy_eval.rs:301:14
    |
 LL |     let _x = false.then(|| x << -1);
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -664,7 +688,7 @@ LL +     let _x = false.then_some(x << -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:291:14
+  --> tests/ui/unnecessary_lazy_eval.rs:303:14
    |
 LL |     let _x = false.then(|| x << 2);
    |              ^^^^^^^^^^^^^^^^^^^^^
@@ -676,7 +700,7 @@ LL +     let _x = false.then_some(x << 2);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:301:14
+  --> tests/ui/unnecessary_lazy_eval.rs:313:14
    |
 LL |     let _x = false.then(|| x / 0);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -688,7 +712,7 @@ LL +     let _x = false.then_some(x / 0);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:303:14
+  --> tests/ui/unnecessary_lazy_eval.rs:315:14
    |
 LL |     let _x = false.then(|| x % 0);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -700,7 +724,7 @@ LL +     let _x = false.then_some(x % 0);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:306:14
+  --> tests/ui/unnecessary_lazy_eval.rs:318:14
    |
 LL |     let _x = false.then(|| 1 / -1);
    |              ^^^^^^^^^^^^^^^^^^^^^
@@ -712,7 +736,7 @@ LL +     let _x = false.then_some(1 / -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:308:14
+  --> tests/ui/unnecessary_lazy_eval.rs:320:14
    |
 LL |     let _x = false.then(|| i32::MIN / -1);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -724,7 +748,7 @@ LL +     let _x = false.then_some(i32::MIN / -1);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:311:14
+  --> tests/ui/unnecessary_lazy_eval.rs:323:14
    |
 LL |     let _x = false.then(|| i32::MIN / 0);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -736,7 +760,7 @@ LL +     let _x = false.then_some(i32::MIN / 0);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:313:14
+  --> tests/ui/unnecessary_lazy_eval.rs:325:14
    |
 LL |     let _x = false.then(|| 4 / 2);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -748,7 +772,7 @@ LL +     let _x = false.then_some(4 / 2);
    |
 
 error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval.rs:321:14
+  --> tests/ui/unnecessary_lazy_eval.rs:333:14
    |
 LL |     let _x = false.then(|| f1 + f2);
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -759,5 +783,5 @@ LL -     let _x = false.then(|| f1 + f2);
 LL +     let _x = false.then_some(f1 + f2);
    |
 
-error: aborting due to 63 previous errors
+error: aborting due to 65 previous errors
 

--- a/tests/ui/unnecessary_lazy_eval_unfixable.rs
+++ b/tests/ui/unnecessary_lazy_eval_unfixable.rs
@@ -12,6 +12,8 @@ fn main() {
     // fix will break type inference
     let _ = Ok(1).unwrap_or_else(|()| 2);
     //~^ unnecessary_lazy_evaluations
+    let _ = Ok(1).unwrap_or_else(|()| -> i32 { 2 });
+    //~^ unnecessary_lazy_evaluations
 
     mod e {
         pub struct E;

--- a/tests/ui/unnecessary_lazy_eval_unfixable.rs
+++ b/tests/ui/unnecessary_lazy_eval_unfixable.rs
@@ -26,9 +26,3 @@ fn main() {
     let arr = [(Some(1),)];
     Some(&0).and_then(|&i| arr[i].0);
 }
-
-fn issue11672() {
-    // Return type annotation helps type inference and removing it can break code
-    let _ = true.then(|| -> &[u8] { &[] });
-    //~^ unnecessary_lazy_evaluations
-}

--- a/tests/ui/unnecessary_lazy_eval_unfixable.stderr
+++ b/tests/ui/unnecessary_lazy_eval_unfixable.stderr
@@ -36,17 +36,5 @@ LL -     let _ = Ok(1).unwrap_or_else(|SomeStruct { .. }| 2);
 LL +     let _ = Ok(1).unwrap_or(2);
    |
 
-error: unnecessary closure used with `bool::then`
-  --> tests/ui/unnecessary_lazy_eval_unfixable.rs:32:13
-   |
-LL |     let _ = true.then(|| -> &[u8] { &[] });
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `then_some` instead
-   |
-LL -     let _ = true.then(|| -> &[u8] { &[] });
-LL +     let _ = true.then_some({ &[] });
-   |
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/unnecessary_lazy_eval_unfixable.stderr
+++ b/tests/ui/unnecessary_lazy_eval_unfixable.stderr
@@ -13,7 +13,19 @@ LL +     let _ = Ok(1).unwrap_or(2);
    |
 
 error: unnecessary closure used to substitute value for `Result::Err`
-  --> tests/ui/unnecessary_lazy_eval_unfixable.rs:19:13
+  --> tests/ui/unnecessary_lazy_eval_unfixable.rs:15:13
+   |
+LL |     let _ = Ok(1).unwrap_or_else(|()| -> i32 { 2 });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `unwrap_or` instead
+   |
+LL -     let _ = Ok(1).unwrap_or_else(|()| -> i32 { 2 });
+LL +     let _ = Ok(1).unwrap_or({ 2 } as i32);
+   |
+
+error: unnecessary closure used to substitute value for `Result::Err`
+  --> tests/ui/unnecessary_lazy_eval_unfixable.rs:21:13
    |
 LL |     let _ = Ok(1).unwrap_or_else(|e::E| 2);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +37,7 @@ LL +     let _ = Ok(1).unwrap_or(2);
    |
 
 error: unnecessary closure used to substitute value for `Result::Err`
-  --> tests/ui/unnecessary_lazy_eval_unfixable.rs:22:13
+  --> tests/ui/unnecessary_lazy_eval_unfixable.rs:24:13
    |
 LL |     let _ = Ok(1).unwrap_or_else(|SomeStruct { .. }| 2);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,5 +48,5 @@ LL -     let _ = Ok(1).unwrap_or_else(|SomeStruct { .. }| 2);
 LL +     let _ = Ok(1).unwrap_or(2);
    |
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Instead of bailing, this changes the lint to handle the return type and write out the correct result. If the function we're translating into can handle it, we use a turbofish, since that will influence type inference but not cause integer truncation. But, if that can't be done, it'll use `as` and let a future lint take care of that.

changelog: [`unnecessary_lazy_evaluations`]: avoid broken suggestion when closure has explicit return type

Fixes https://github.com/rust-lang/rust-clippy/issues/11672