### PR TITLE
perf: skip doc_markdown text collection and word scan when the lint is allowed

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -1124,6 +1124,9 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
 
     let mut containers = Vec::new();
 
+    // Skip collecting text and the per-word scan when `DOC_MARKDOWN` (pedantic) is allowed.
+    let check_doc_markdown = !clippy_utils::is_lint_allowed(cx, DOC_MARKDOWN, cx.last_node_with_lint_attrs);
+
     let mut events = events.peekable();
 
     while let Some((event, range)) = events.next() {
@@ -1238,19 +1241,29 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                 if let End(TagEnd::Item) = event {
                     containers.pop();
                 }
-                if ticks_unbalanced && let Some(span) = fragments.span(cx, paragraph_range.clone()) {
-                    span_lint_and_help(
-                        cx,
-                        DOC_MARKDOWN,
-                        span,
-                        "backticks are unbalanced",
-                        None,
-                        "a backtick may be missing a pair",
-                    );
-                    text_to_check.clear();
-                } else {
-                    for (text, range, assoc_code_level) in text_to_check.drain(..) {
-                        markdown::check(cx, valid_idents, &text, &fragments, range, assoc_code_level, blockquote_level);
+                if check_doc_markdown {
+                    if ticks_unbalanced && let Some(span) = fragments.span(cx, paragraph_range.clone()) {
+                        span_lint_and_help(
+                            cx,
+                            DOC_MARKDOWN,
+                            span,
+                            "backticks are unbalanced",
+                            None,
+                            "a backtick may be missing a pair",
+                        );
+                        text_to_check.clear();
+                    } else {
+                        for (text, range, assoc_code_level) in text_to_check.drain(..) {
+                            markdown::check(
+                                cx,
+                                valid_idents,
+                                &text,
+                                &fragments,
+                                range,
+                                assoc_code_level,
+                                blockquote_level,
+                            );
+                        }
                     }
                 }
             },
@@ -1331,7 +1344,9 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                         // Don't check the text associated with external URLs
                         continue;
                     }
-                    text_to_check.push((text, range.clone(), code_level));
+                    if check_doc_markdown {
+                        text_to_check.push((text, range.clone(), code_level));
+                    }
                     doc_suspicious_footnotes::check(cx, doc, range, &fragments, attrs);
                 }
             }


### PR DESCRIPTION
Instruction counts (perf stat instructions:u):

| crate | instructions base | instructions new | delta |
|---|---|---|---|
| regex-1.10.5 | 1,010,565,235 | 968,595,926 | -4.15% |
| bumpalo-3.16.0 | 320,518,375 | 313,577,464 | -2.17% |
| tokio-1.38.1 | 522,405,496 | 510,949,744 | -2.19% |
| mdbook-0.4.40 (bin) | 3,475,263,547 | 3,466,707,439 | -0.25% |
| ripgrep-14.1.0 | 1,969,387,093 | 1,957,903,931 | -0.58% |

changelog: none
