### PR TITLE
perf: check is_in_test last in incompatible_msrv

### DIFF
--- a/clippy_lints/src/incompatible_msrv.rs
+++ b/clippy_lints/src/incompatible_msrv.rs
@@ -193,10 +193,11 @@ impl IncompatibleMsrv {
             }
         }
 
-        if (self.check_in_tests || !is_in_test(cx.tcx, node))
-            && let Some(current) = self.msrv.current(cx)
+        // Check `is_in_test` last as it walks the HIR parent chain.
+        if let Some(current) = self.msrv.current(cx)
             && let Availability::Since(version) = self.get_def_id_availability(cx.tcx, def_id, needs_const)
             && version > current
+            && (self.check_in_tests || !is_in_test(cx.tcx, node))
         {
             span_lint_and_then(
                 cx,


### PR DESCRIPTION

| crate | instructions base | instructions new | delta |
|---|---|---|---|
| cargo-0.80.0 (lib) | 29,893,214,650 | 29,726,591,660 | -0.56% |
| cargo-0.80.0 (bin) | 1,631,825,989 | 1,627,901,224 | -0.24% |
| serde-1.0.204 | 7,203,901,010 | 7,167,022,578 | -0.51% |
| tokio-1.38.1 | 522,611,594 | 518,512,971 | -0.78% |
| ryu-1.0.18 | 271,073,171 | 270,569,049 | -0.19% |

changelog: none
