### PR TITLE
perf: check the token kind before extracting source in early literal lints

### DIFF
--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -207,7 +207,9 @@ pub struct LiteralDigitGrouping {
 
 impl EarlyLintPass for LiteralDigitGrouping {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        // `NumericLiteral::from_lit_kind` only accepts integer and float literals.
         if let ExprKind::Lit(lit) = expr.kind
+            && matches!(lit.kind, token::LitKind::Integer | token::LitKind::Float)
             && !expr.span.in_external_macro(cx.sess().source_map())
         {
             self.check_lit(cx, lit, expr.span);
@@ -418,7 +420,9 @@ pub struct DecimalLiteralRepresentation {
 
 impl EarlyLintPass for DecimalLiteralRepresentation {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        // Only integer tokens can produce `LitKind::Int`.
         if let ExprKind::Lit(lit) = expr.kind
+            && lit.kind == token::LitKind::Integer
             && !expr.span.in_external_macro(cx.sess().source_map())
         {
             self.check_lit(cx, lit, expr.span);
@@ -436,10 +440,10 @@ impl DecimalLiteralRepresentation {
         // Lint integral literals.
         if let Ok(lit_kind) = LitKind::from_token_lit(lit)
             && let LitKind::Int(val, _) = lit_kind
+            && val >= u128::from(self.threshold)
             && let Some(src) = span.get_source_text(cx)
             && let Some(num_lit) = NumericLiteral::from_lit_kind(&src, &lit_kind)
             && num_lit.radix == Radix::Decimal
-            && val >= u128::from(self.threshold)
         {
             let hex = format!("{val:#X}");
             let num_lit = NumericLiteral::new(&hex, num_lit.suffix, false);

--- a/clippy_lints/src/misc_early/mod.rs
+++ b/clippy_lints/src/misc_early/mod.rs
@@ -333,11 +333,15 @@ impl EarlyLintPass for MiscEarlyLints {
     }
 
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if expr.span.in_external_macro(cx.sess().source_map()) {
-            return;
-        }
-
-        if let ExprKind::Lit(lit) = expr.kind {
+        // `check_lit` only lints integer literals and suffixed float literals.
+        if let ExprKind::Lit(lit) = expr.kind
+            && match lit.kind {
+                token::LitKind::Integer => true,
+                token::LitKind::Float => lit.suffix.is_some(),
+                _ => false,
+            }
+            && !expr.span.in_external_macro(cx.sess().source_map())
+        {
             MiscEarlyLints::check_lit(cx, lit, expr.span);
         }
     }


### PR DESCRIPTION
| crate | instructions base | instructions new | delta |
|---|---|---|---|
| regex-1.10.5 | 1,010,630,738 | 1,009,916,209 | -0.07% |
| serde-1.0.204 | 7,203,816,628 | 7,192,290,548 | -0.16% |
| ripgrep-14.1.0 | 1,969,703,310 | 1,965,732,213 | -0.20% |
| ryu-1.0.18 | 271,098,517 | 270,144,240 | -0.35% |

changelog: none
