### PR TITLE
perf: match expression shape before MSRV check in cloned_ref_to_slice_refs

### DIFF
--- a/clippy_lints/src/cloned_ref_to_slice_refs.rs
+++ b/clippy_lints/src/cloned_ref_to_slice_refs.rs
@@ -64,15 +64,8 @@ impl<'a> ClonedRefToSliceRefs<'a> {
 
 impl<'tcx> LateLintPass<'tcx> for ClonedRefToSliceRefs<'_> {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
-        if self.msrv.meets(cx, {
-            if is_in_const_context(cx) {
-                msrvs::CONST_SLICE_FROM_REF
-            } else {
-                msrvs::SLICE_FROM_REF
-            }
-        })
-            // `&[foo.clone()]` expressions
-            && let ExprKind::AddrOf(_, mutability, arr) = &expr.kind
+        // `&[foo.clone()]` expressions
+        if let ExprKind::AddrOf(_, mutability, arr) = &expr.kind
             // mutable references would have a different meaning
             && mutability.is_not()
 
@@ -81,6 +74,14 @@ impl<'tcx> LateLintPass<'tcx> for ClonedRefToSliceRefs<'_> {
 
             // check for clones
             && let ExprKind::MethodCall(path, recv, _, _) = item.kind
+
+            && self.msrv.meets(cx, {
+                if is_in_const_context(cx) {
+                    msrvs::CONST_SLICE_FROM_REF
+                } else {
+                    msrvs::SLICE_FROM_REF
+                }
+            })
             && let Some(adjustment) = is_needless_clone_or_equivalent(cx, recv, path.ident.name, item.hir_id)
 
             // check for immutability or purity


### PR DESCRIPTION
| crate | instructions base | instructions new | delta |
|---|---|---|---|
| cargo-0.80.0 (lib) | 29,894,214,196 | 29,815,601,172 | -0.26% |
| cargo-0.80.0 (bin) | 1,632,000,585 | 1,628,125,546 | -0.24% |
| wasmi-0.35.0 | 16,146,480,040 | 16,118,321,503 | -0.17% |
| syn-2.0.71 | 3,398,084,482 | 3,390,218,789 | -0.23% |
| ryu-1.0.18 | 271,125,280 | 269,613,992 | -0.56% |

changelog: none
