### PR TITLE
perf: defer single_match comment extraction until the lint fires

### DIFF
--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -27,9 +27,7 @@ mod wild_in_or_pats;
 use clippy_config::Conf;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::walk_span_to_context;
-use clippy_utils::{
-    higher, is_direct_expn_of, is_in_const_context, is_span_match, span_contains_cfg, span_extract_comments, sym,
-};
+use clippy_utils::{higher, is_direct_expn_of, is_in_const_context, is_span_match, span_contains_cfg, sym};
 use rustc_hir::{Arm, Expr, ExprKind, LetStmt, MatchSource, Pat, PatKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::impl_lint_pass;
@@ -1093,25 +1091,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                     }
 
                     redundant_pattern_match::check_match(cx, expr, ex, arms);
-                    let mut match_comments = span_extract_comments(cx, expr.span);
-                    // We remove comments from inside arms block.
-                    if !match_comments.is_empty() {
-                        for arm in arms {
-                            for comment in span_extract_comments(cx, arm.body.span) {
-                                if let Some(index) = match_comments
-                                    .iter()
-                                    .enumerate()
-                                    .find(|(_, cm)| **cm == comment)
-                                    .map(|(index, _)| index)
-                                {
-                                    match_comments.remove(index);
-                                }
-                            }
-                        }
-                    }
-                    // If there are still comments, it means they are outside of the arms. Tell the lint
-                    // code about it.
-                    single_match::check(cx, ex, arms, expr, !match_comments.is_empty());
+                    single_match::check(cx, ex, arms, expr);
                     match_bool::check(cx, ex, arms, expr);
                     overlapping_arms::check(cx, ex, arms);
                     match_wild_enum::check(cx, ex, arms);

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -3,7 +3,9 @@ use clippy_utils::source::{
     SpanRangeExt, expr_block, snippet, snippet_block_with_context, snippet_with_applicability, snippet_with_context,
 };
 use clippy_utils::ty::{implements_trait, peel_and_count_ty_refs};
-use clippy_utils::{is_lint_allowed, is_unit_expr, peel_blocks, peel_hir_pat_refs, peel_n_hir_expr_refs, sym};
+use clippy_utils::{
+    is_lint_allowed, is_unit_expr, peel_blocks, peel_hir_pat_refs, peel_n_hir_expr_refs, span_extract_comments, sym,
+};
 use core::ops::ControlFlow;
 use rustc_arena::DroplessArena;
 use rustc_errors::{Applicability, Diag};
@@ -25,13 +27,24 @@ fn empty_arm_has_comment(cx: &LateContext<'_>, span: Span) -> bool {
     span.check_source_text(cx, |text| text.as_bytes().windows(2).any(|w| w == b"//" || w == b"/*"))
 }
 
-pub(crate) fn check<'tcx>(
-    cx: &LateContext<'tcx>,
-    ex: &'tcx Expr<'_>,
-    arms: &'tcx [Arm<'_>],
-    expr: &'tcx Expr<'_>,
-    contains_comments: bool,
-) {
+/// Checks if the `match` has comments outside the arm bodies that the suggestion would lose.
+fn contains_comments_outside_arm_bodies(cx: &LateContext<'_>, expr: &Expr<'_>, arms: &[Arm<'_>]) -> bool {
+    let mut match_comments = span_extract_comments(cx, expr.span);
+    // We remove comments from inside arms block.
+    if !match_comments.is_empty() {
+        for arm in arms {
+            for comment in span_extract_comments(cx, arm.body.span) {
+                if let Some(index) = match_comments.iter().position(|cm| *cm == comment) {
+                    match_comments.remove(index);
+                }
+            }
+        }
+    }
+    // If there are still comments, it means they are outside of the arms.
+    !match_comments.is_empty()
+}
+
+pub(crate) fn check<'tcx>(cx: &LateContext<'tcx>, ex: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>], expr: &'tcx Expr<'_>) {
     if let [arm1, arm2] = arms
         && !arms.iter().any(|arm| arm.guard.is_some() || arm.pat.span.from_expansion())
         && !expr.span.from_expansion()
@@ -75,6 +88,8 @@ pub(crate) fn check<'tcx>(
                 }
             }
 
+            // Extracting comments tokenizes the whole `match`, so only do it once a lint fires.
+            let contains_comments = contains_comments_outside_arm_bodies(cx, expr, arms);
             report_single_pattern(cx, ex, arm1, expr, els, contains_comments);
         }
     }


### PR DESCRIPTION
| crate | instructions base | instructions new | delta |
| --- | --- | --- | --- |
| wasmi-0.35.0 | 16,147,355,319 | 16,127,549,923 | -0.123% |
| cargo-0.80.0 (lib) | 29,894,153,929 | 29,860,999,655 | -0.111% |
| cargo-0.80.0 (bin) | 1,632,176,183 | 1,630,411,516 | -0.108% |
| ripgrep-14.1.0 | 1,969,925,181 | 1,967,592,905 | -0.118% |
| ryu-1.0.18 | 271,085,997 | 270,820,226 | -0.098% |

changelog: none