### PR TITLE
Be less assertive about the gains obtained through `mul_add`

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic/mul_add.rs
+++ b/clippy_lints/src/floating_point_arithmetic/mul_add.rs
@@ -91,7 +91,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
         cx,
         SUBOPTIMAL_FLOPS,
         expr.span,
-        "multiply and add expressions can be calculated more efficiently and accurately",
+        "multiply and add expressions may be calculated more efficiently and accurately",
         |diag| {
             let maybe_neg_sugg = |expr, app: &mut _| {
                 let sugg = Sugg::hir_with_applicability(cx, expr, "_", app);
@@ -120,6 +120,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
                 },
                 app,
             );
+            diag.note_once("the performance gain from `mul_add` may vary depending on the target architecture");
         },
     );
 }

--- a/tests/ui/floating_point_mul_add.stderr
+++ b/tests/ui/floating_point_mul_add.stderr
@@ -1,121 +1,122 @@
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:19:13
    |
 LL |     let _ = a * b + c;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
    |
+   = note: the performance gain from `mul_add` may vary depending on the target architecture
    = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::suboptimal_flops)]`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:21:13
    |
 LL |     let _ = a * b - c;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(b, -c)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:23:13
    |
 LL |     let _ = c + a * b;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:25:13
    |
 LL |     let _ = c - a * b;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(-b, c)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:27:13
    |
 LL |     let _ = a + 2.0 * 4.0;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4.0, a)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:29:13
    |
 LL |     let _ = a + 2. * 4.;
    |             ^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4., a)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:32:13
    |
 LL |     let _ = (a * b) + c;
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:34:13
    |
 LL |     let _ = c + (a * b);
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:36:13
    |
 LL |     let _ = a * b * c + d;
    |             ^^^^^^^^^^^^^ help: consider using: `(a * b).mul_add(c, d)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:39:13
    |
 LL |     let _ = a.mul_add(b, c) * a.mul_add(b, c) + a.mul_add(b, c) + c;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `a.mul_add(b, c).mul_add(a.mul_add(b, c), a.mul_add(b, c))`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:41:13
    |
 LL |     let _ = 1234.567_f64 * 45.67834_f64 + 0.0004_f64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1234.567_f64.mul_add(45.67834_f64, 0.0004_f64)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:44:13
    |
 LL |     let _ = (a * a + b).sqrt();
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(a, b)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:48:13
    |
 LL |     let _ = a - (b * u as f64);
    |             ^^^^^^^^^^^^^^^^^^ help: consider using: `b.mul_add(-(u as f64), a)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:102:13
    |
 LL |     let _ = 0.5 + 2.0 * x;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(x, 0.5)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:104:13
    |
 LL |     let _ = 2.0 * x + 0.5;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(x, 0.5)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:107:13
    |
 LL |     let _ = x + 2.0 * 4.0;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4.0, x)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:111:13
    |
 LL |     let _ = y * 2.0 + 0.5;
    |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(2.0, 0.5)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:113:13
    |
 LL |     let _ = 1.0 * 2.0 + 0.5;
    |             ^^^^^^^^^^^^^^^ help: consider using: `1.0f64.mul_add(2.0, 0.5)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:122:5
    |
 LL |     a += b * c;
    |     ^^^^^^^^^^ help: consider using: `a = b.mul_add(c, a)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
+error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:125:5
    |
 LL |     a -= b * c;


### PR DESCRIPTION
changelog: [`suboptimal_flops`]: be less assertive about the gains obtained through `mul_add`

Fixes rust-lang/rust-clippy#17214 