### PR TITLE
perf: skip single_component_path_imports module walk when nothing to lint

### DIFF
--- a/clippy_lints/src/single_component_path_imports.rs
+++ b/clippy_lints/src/single_component_path_imports.rs
@@ -146,16 +146,24 @@ impl SingleComponentPathImports {
         // ```
         let mut macros = Vec::new();
 
-        let mut import_usage_visitor = ImportUsageVisitor::default();
         for item in items {
             self.track_uses(item, &mut imports_reused_with_self, &mut single_use_usages, &mut macros);
+        }
+
+        // Only walk the module's AST in search of `self::xxx` paths when there are single
+        // component imports left to lint, as the visitor recurses into every nested item.
+        single_use_usages.retain(|usage| !imports_reused_with_self.contains(&usage.name));
+        if single_use_usages.is_empty() {
+            return;
+        }
+
+        let mut import_usage_visitor = ImportUsageVisitor::default();
+        for item in items {
             import_usage_visitor.visit_item(item);
         }
 
         for usage in single_use_usages {
-            if !imports_reused_with_self.contains(&usage.name)
-                && !import_usage_visitor.imports_referenced_with_self.contains(&usage.name)
-            {
+            if !import_usage_visitor.imports_referenced_with_self.contains(&usage.name) {
                 self.found.entry(usage.item_id).or_default().push(usage);
             }
         }


### PR DESCRIPTION
| crate | instructions base | instructions new | delta |
|---|---|---|---|
| cargo-0.80.0 (lib) | 29,895,121,178 | 29,874,691,083 | -0.068% |
| cargo-0.80.0 (bin) | 1,632,148,485 | 1,630,985,360 | -0.071% |
| wasmi-0.35.0 | 16,147,142,661 | 16,124,491,362 | -0.140% |
| serde-1.0.204 | 7,203,885,789 | 7,198,196,376 | -0.079% |
| ryu-1.0.18 | 271,121,817 | 270,416,802 | -0.260% |

changelog: none
