### PR TITLE
perf: skip tokenizing in span_contains_cfg when no '#' is present

### DIFF
--- a/clippy_utils/src/attrs.rs
+++ b/clippy_utils/src/attrs.rs
@@ -108,6 +108,11 @@ pub fn has_non_exhaustive_attr(tcx: TyCtxt<'_>, adt: AdtDef<'_>) -> bool {
 /// Checks whether the given span contains a `#[cfg(..)]` attribute
 pub fn span_contains_cfg(cx: &LateContext<'_>, s: Span) -> bool {
     s.check_text(cx, |src| {
+        // PERF: A `#[cfg]` needs a literal `#`, so skip the lexer when the source has none.
+        if !src.contains('#') {
+            return false;
+        }
+
         let mut iter = tokenize_with_text(src);
 
         // Search for the token sequence [`#`, `[`, `cfg`]


### PR DESCRIPTION
| crate | instructions base | instructions new | delta |
|---|---|---|---|
| ryu 1.0.18 | 271,084,569 | 270,129,389 | -0.35% |
| syn 2.0.71 | 3,398,285,199 | 3,397,800,261 | -0.01% |
| wasmi 0.35.0 | 16,147,971,341 | 16,146,973,772 | -0.01% |
| cargo 0.80.0 (bin) | 1,632,220,846 | 1,632,092,730 | -0.01% |

changelog: none
