### PR TITLE
perf: avoid per-call type and path work in unnecessary_mut_passed

### DIFF
--- a/clippy_lints/src/unnecessary_mut_passed.rs
+++ b/clippy_lints/src/unnecessary_mut_passed.rs
@@ -46,18 +46,21 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryMutPassed {
 
         match e.kind {
             ExprKind::Call(fn_expr, arguments) => {
-                if let ExprKind::Path(ref path) = fn_expr.kind {
+                if let ExprKind::Path(ref path) = fn_expr.kind
+                    && arguments.iter().any(is_mut_ref_arg)
+                {
                     check_arguments(
                         cx,
                         &mut arguments.iter(),
                         cx.typeck_results().expr_ty(fn_expr),
-                        &rustc_hir_pretty::qpath_to_string(&cx.tcx, path),
+                        &|| rustc_hir_pretty::qpath_to_string(&cx.tcx, path),
                         "function",
                     );
                 }
             },
             ExprKind::MethodCall(path, receiver, arguments, _)
-                if let Some(def_id) = cx.typeck_results().type_dependent_def_id(e.hir_id) =>
+                if iter::once(receiver).chain(arguments.iter()).any(is_mut_ref_arg)
+                    && let Some(def_id) = cx.typeck_results().type_dependent_def_id(e.hir_id) =>
             {
                 let args = cx.typeck_results().node_args(e.hir_id);
                 let method_type = cx.tcx.type_of(def_id).instantiate(cx.tcx, args).skip_norm_wip();
@@ -65,7 +68,7 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryMutPassed {
                     cx,
                     &mut iter::once(receiver).chain(arguments.iter()),
                     method_type,
-                    path.ident.as_str(),
+                    &|| path.ident.as_str().to_owned(),
                     "method",
                 );
             },
@@ -74,11 +77,16 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryMutPassed {
     }
 }
 
+/// Only `&mut ...` arguments can lint, so the type and path lookups run only after one is found.
+fn is_mut_ref_arg(argument: &Expr<'_>) -> bool {
+    matches!(argument.kind, ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, _))
+}
+
 fn check_arguments<'tcx>(
     cx: &LateContext<'tcx>,
     arguments: &mut dyn Iterator<Item = &'tcx Expr<'tcx>>,
     type_definition: Ty<'tcx>,
-    name: &str,
+    name: &dyn Fn() -> String,
     fn_kind: &str,
 ) {
     if type_definition.is_fn() {
@@ -110,7 +118,7 @@ fn check_arguments<'tcx>(
                     cx,
                     UNNECESSARY_MUT_PASSED,
                     argument.span,
-                    format!("the {fn_kind} `{name}` doesn't need a mutable reference"),
+                    format!("the {fn_kind} `{}` doesn't need a mutable reference", name()),
                     |diag| {
                         diag.span_suggestion_verbose(span_to_remove, "remove this `mut`", String::new(), applicability);
                     },


### PR DESCRIPTION
| crate | instructions base | instructions new | delta |
|---|---|---|---|
| syn-2.0.71 | 3,397,810,776 | 3,393,866,539 | -0.116% |
| cargo-0.80.0 (lib) | 29,893,756,037 | 29,871,442,600 | -0.075% |
| cargo-0.80.0 (bin) | 1,631,705,047 | 1,629,419,675 | -0.140% |
| wasmi-0.35.0 | 16,146,834,759 | 16,141,152,116 | -0.035% |
| ryu-1.0.18 | 271,096,312 | 271,119,864 | +0.009% |

changelog: none
