### PR TITLE
Create a single `ConstEvalCtxt` in  `expr_eagerness`

### DIFF
--- a/clippy_lints/src/assertions_on_constants.rs
+++ b/clippy_lints/src/assertions_on_constants.rs
@@ -52,7 +52,9 @@ impl<'tcx> LateLintPass<'tcx> for AssertionsOnConstants {
                 _ => return,
             }
             && let Some((condition, _)) = find_assert_args(cx, e, macro_call.expn)
-            && is_const_evaluatable(cx, condition)
+            // Check if the whole expression can be moved into a const context.
+            // Note that const eval can evaluate things which cannot be moved (e.g. `false && x`).
+            && is_const_evaluatable(cx.tcx, cx.typeck_results(), condition)
             && let Some((Constant::Bool(assert_val), const_src)) =
                 ConstEvalCtxt::new(cx).eval_with_source(condition, macro_call.span.ctxt())
             && let in_const_context = is_inside_always_const_context(cx.tcx, e.hir_id)

--- a/clippy_lints/src/casts/needless_type_cast.rs
+++ b/clippy_lints/src/casts/needless_type_cast.rs
@@ -249,7 +249,7 @@ fn can_coerce_to_target_type(expr: &Expr<'_>) -> bool {
 fn check_binding_usages<'a>(cx: &LateContext<'a>, body: &Body<'a>, hir_id: HirId, binding_info: &BindingInfo<'a>) {
     let mut usages = Vec::new();
 
-    for_each_expr(cx, body.value, |expr| {
+    for_each_expr(cx.tcx, body.value, |expr| {
         if let ExprKind::Path(ref qpath) = expr.kind
             && !expr.span.from_expansion()
             && let Res::Local(id) = cx.qpath_res(qpath, expr.hir_id)

--- a/clippy_lints/src/cloned_ref_to_slice_refs.rs
+++ b/clippy_lints/src/cloned_ref_to_slice_refs.rs
@@ -85,7 +85,7 @@ impl<'tcx> LateLintPass<'tcx> for ClonedRefToSliceRefs<'_> {
             && let Some(adjustment) = is_needless_clone_or_equivalent(cx, recv, path.ident.name, item.hir_id)
 
             // check for immutability or purity
-            && (!is_mutable(cx, recv) || is_const_evaluatable(cx, recv))
+            && (!is_mutable(cx, recv) || is_const_evaluatable(cx.tcx, cx.typeck_results(), recv))
 
             // get appropriate crate for `slice::from_ref`
             && let Some(builtin_crate) = clippy_utils::std_or_core(cx)

--- a/clippy_lints/src/collection_is_never_read.rs
+++ b/clippy_lints/src/collection_is_never_read.rs
@@ -79,7 +79,7 @@ fn has_no_read_access<'tcx, T: Visitable<'tcx>>(cx: &LateContext<'tcx>, id: HirI
     let mut has_read_access = false;
 
     // Inspect all expressions and sub-expressions in the block.
-    for_each_expr(cx, block, |expr| {
+    for_each_expr(cx.tcx, block, |expr| {
         // Ignore expressions that are not simply `id`.
         if expr.res_local_id() != Some(id) {
             return ControlFlow::Continue(());

--- a/clippy_lints/src/doc/missing_headers.rs
+++ b/clippy_lints/src/doc/missing_headers.rs
@@ -99,7 +99,7 @@ pub fn check(
 fn find_panic(cx: &LateContext<'_>, body_id: BodyId) -> Option<Span> {
     let mut panic_span = None;
     let typeck = cx.tcx.typeck_body(body_id);
-    for_each_expr(cx, cx.tcx.hir_body(body_id), |expr| {
+    for_each_expr(cx.tcx, cx.tcx.hir_body(body_id), |expr| {
         if is_inside_always_const_context(cx.tcx, expr.hir_id) {
             return ControlFlow::<!>::Continue(());
         }

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -604,7 +604,7 @@ fn is_any_expr_in_map_used<'tcx>(
     map: &'tcx Expr<'tcx>,
     expr: &'tcx Expr<'tcx>,
 ) -> bool {
-    for_each_expr(cx, map, |e| {
+    for_each_expr(cx.tcx, map, |e| {
         if spanless_eq.eq_expr(ctxt, e, expr) {
             return ControlFlow::Break(());
         }

--- a/clippy_lints/src/functions/not_unsafe_ptr_arg_deref.rs
+++ b/clippy_lints/src/functions/not_unsafe_ptr_arg_deref.rs
@@ -50,7 +50,7 @@ fn check_raw_ptr<'tcx>(
 
         if !raw_ptrs.is_empty() {
             let typeck = cx.tcx.typeck_body(body.id());
-            let _: Option<!> = for_each_expr(cx, body.value, |e| {
+            let _: Option<!> = for_each_expr(cx.tcx, body.value, |e| {
                 match e.kind {
                     hir::ExprKind::Call(f, args) if is_unsafe_fn(cx, typeck.expr_ty(f)) => {
                         for arg in args {

--- a/clippy_lints/src/loops/char_indices_as_byte_indices.rs
+++ b/clippy_lints/src/loops/char_indices_as_byte_indices.rs
@@ -48,7 +48,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, pat: &Pat<'_>, iterable: &Expr
             && let PatKind::Binding(_, binding_id, ..) = pat.kind
         {
             // Destructured iterator element `(idx, _)`, look for uses of the binding
-            for_each_expr(cx, body, |expr| {
+            for_each_expr(cx.tcx, body, |expr| {
                 if expr.res_local_id() == Some(binding_id) {
                     check_index_usage(cx, expr, pat, enumerate_span, chars_span, chars_recv);
                 }
@@ -56,7 +56,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, pat: &Pat<'_>, iterable: &Expr
             });
         } else if let PatKind::Binding(_, binding_id, ..) = pat.kind {
             // Bound as a tuple, look for `tup.0`
-            for_each_expr(cx, body, |expr| {
+            for_each_expr(cx.tcx, body, |expr| {
                 if let ExprKind::Field(e, field) = expr.kind
                     && e.res_local_id() == Some(binding_id)
                     && field.name == sym::integer(0)

--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -367,12 +367,16 @@ fn is_call_max_min_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>)
             && let Some(inner_seg) = segment(cx, inner_fn)
             && let Some(outer_seg) = segment(cx, outer_fn)
         {
-            let (input, inner_arg) = match (is_const_evaluatable(cx, first), is_const_evaluatable(cx, second)) {
+            let typeck = cx.typeck_results();
+            let (input, inner_arg) = match (
+                is_const_evaluatable(cx.tcx, typeck, first),
+                is_const_evaluatable(cx.tcx, typeck, second),
+            ) {
                 (true, false) => (second, first),
                 (false, true) => (first, second),
                 _ => return None,
             };
-            let is_float = cx.typeck_results().expr_ty_adjusted(input).is_floating_point();
+            let is_float = typeck.expr_ty_adjusted(input).is_floating_point();
             let (min, max) = match (inner_seg, outer_seg) {
                 (FunctionType::CmpMin, FunctionType::CmpMax) => (outer_arg, inner_arg),
                 (FunctionType::CmpMax, FunctionType::CmpMin) => (inner_arg, outer_arg),

--- a/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
+++ b/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
@@ -25,7 +25,7 @@ pub(super) fn check<'tcx>(
         return;
     }
 
-    if is_const_evaluatable(cx, arg) {
+    if is_const_evaluatable(cx.tcx, cx.typeck_results(), arg) {
         if !msrv.meets(cx, msrvs::AS_CHUNKS) {
             return;
         }

--- a/clippy_lints/src/methods/expect_fun_call.rs
+++ b/clippy_lints/src/methods/expect_fun_call.rs
@@ -100,7 +100,7 @@ fn get_arg_root<'a>(cx: &LateContext<'_>, arg: &'a hir::Expr<'a>) -> &'a hir::Ex
 }
 
 fn contains_call<'a>(cx: &LateContext<'a>, arg: &'a hir::Expr<'a>) -> bool {
-    for_each_expr(cx, arg, |expr| {
+    for_each_expr(cx.tcx, arg, |expr| {
         if matches!(expr.kind, hir::ExprKind::MethodCall { .. } | hir::ExprKind::Call { .. })
             && !is_inside_always_const_context(cx.tcx, expr.hir_id)
         {

--- a/clippy_lints/src/methods/manual_inspect.rs
+++ b/clippy_lints/src/methods/manual_inspect.rs
@@ -47,7 +47,7 @@ pub(crate) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, name:
         let can_lint = for_each_expr_without_closures(block.stmts, |e| {
             if let ExprKind::Closure(c) = e.kind {
                 // Nested closures don't need to treat returns specially.
-                let _: Option<!> = for_each_expr(cx, cx.tcx.hir_body(c.body).value, |e| {
+                let _: Option<!> = for_each_expr(cx.tcx, cx.tcx.hir_body(c.body).value, |e| {
                     if e.res_local_id() == Some(arg_id) {
                         let (kind, same_ctxt) = check_use(cx, ctxt, e);
                         match (kind, same_ctxt && e.span.ctxt() == ctxt) {

--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -32,7 +32,7 @@ pub(super) fn check<'tcx>(
 ) {
     if let [arg] = args {
         let inner_arg = peel_blocks(arg);
-        for_each_expr(cx, inner_arg, |ex| {
+        for_each_expr(cx.tcx, inner_arg, |ex| {
             // `or_fun_call` lint needs to take nested expr into account,
             // but `unwrap_or_default` lint doesn't, we don't want something like:
             // `opt.unwrap_or(Foo { inner: String::default(), other: 1 })` to get replaced by
@@ -72,7 +72,7 @@ pub(super) fn check<'tcx>(
     // `map_or` takes two arguments
     if let [arg, lambda] = args {
         let inner_arg = peel_blocks(arg);
-        for_each_expr(cx, inner_arg, |ex| {
+        for_each_expr(cx.tcx, inner_arg, |ex| {
             let is_top_most_expr = ex.hir_id == inner_arg.hir_id;
             match ex.kind {
                 hir::ExprKind::Call(fun, fun_args) => {

--- a/clippy_lints/src/methods/str_split.rs
+++ b/clippy_lints/src/methods/str_split.rs
@@ -22,8 +22,9 @@ pub(super) fn check<'a>(
     // basic ones: a `'\n'`, `"\n"`, and `"\r\n"`.
     if let ExprKind::MethodCall(trim_method_name, trim_recv, [], trim_span) = split_recv.kind
         && trim_method_name.ident.name == sym::trim
-        && cx.typeck_results().expr_ty_adjusted(trim_recv).peel_refs().is_str()
-        && !is_const_evaluatable(cx, trim_recv)
+        && let typeck = cx.typeck_results()
+        && typeck.expr_ty_adjusted(trim_recv).peel_refs().is_str()
+        && !is_const_evaluatable(cx.tcx, typeck, trim_recv)
         && let ExprKind::Lit(split_lit) = split_arg.kind
         && matches!(
             split_lit.node,

--- a/clippy_lints/src/methods/str_splitn.rs
+++ b/clippy_lints/src/methods/str_splitn.rs
@@ -214,7 +214,7 @@ fn indirect_usage<'tcx>(
     }) = stmt.kind
     {
         let mut path_to_binding = None;
-        let _: Option<!> = for_each_expr(cx, init_expr, |e| {
+        let _: Option<!> = for_each_expr(cx.tcx, init_expr, |e| {
             if e.res_local_id() == Some(binding) {
                 path_to_binding = Some(e);
             }

--- a/clippy_lints/src/missing_fields_in_debug.rs
+++ b/clippy_lints/src/missing_fields_in_debug.rs
@@ -109,7 +109,7 @@ fn should_lint<'tcx>(
     // Is there a call to `DebugStruct::debug_struct`? Do lint if there is.
     let mut has_debug_struct = false;
 
-    for_each_expr(cx, block, |expr| {
+    for_each_expr(cx.tcx, block, |expr| {
         if let ExprKind::MethodCall(path, recv, ..) = &expr.kind {
             let recv_ty = typeck_results.expr_ty(recv).peel_refs();
 
@@ -166,7 +166,7 @@ fn check_struct<'tcx>(
     let mut has_direct_field_access = false;
     let mut field_accesses = FxHashSet::default();
 
-    for_each_expr(cx, block, |expr| {
+    for_each_expr(cx.tcx, block, |expr| {
         if let ExprKind::Field(target, ident) = expr.kind
             && let target_ty = typeck_results.expr_ty_adjusted(target).peel_refs()
             && target_ty == self_ty

--- a/clippy_lints/src/needless_late_init.rs
+++ b/clippy_lints/src/needless_late_init.rs
@@ -64,7 +64,7 @@ declare_clippy_lint! {
 declare_lint_pass!(NeedlessLateInit => [NEEDLESS_LATE_INIT]);
 
 fn contains_assign_expr<'tcx>(cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'tcx>) -> bool {
-    for_each_expr(cx, stmt, |e| {
+    for_each_expr(cx.tcx, stmt, |e| {
         if matches!(e.kind, ExprKind::Assign(..)) {
             ControlFlow::Break(())
         } else {

--- a/clippy_lints/src/needless_pass_by_ref_mut.rs
+++ b/clippy_lints/src/needless_pass_by_ref_mut.rs
@@ -206,7 +206,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByRefMut<'tcx> {
             // We retrieve all the closures declared in the function because they will not be found
             // by `euv::Delegate`.
             let mut closures: FxIndexSet<LocalDefId> = FxIndexSet::default();
-            for_each_expr(cx, body, |expr| {
+            for_each_expr(cx.tcx, body, |expr| {
                 if let ExprKind::Closure(closure) = expr.kind {
                     closures.insert(closure.def_id);
                 }

--- a/clippy_lints/src/non_std_lazy_statics.rs
+++ b/clippy_lints/src/non_std_lazy_statics.rs
@@ -198,7 +198,7 @@ impl LazyInfo {
 
             // visit body to collect `Lazy::new` calls
             let mut new_fn_calls = FxIndexMap::default();
-            for_each_expr::<(), ()>(cx, body, |ex| {
+            for_each_expr::<(), ()>(cx.tcx, body, |ex| {
                 if let Some((fn_did, call_span)) = fn_def_id_and_span_from_body(cx, ex, body_id)
                     && paths::ONCE_CELL_SYNC_LAZY_NEW.matches(cx, fn_did)
                 {

--- a/clippy_lints/src/panic_in_result_fn.rs
+++ b/clippy_lints/src/panic_in_result_fn.rs
@@ -64,7 +64,7 @@ impl<'tcx> LateLintPass<'tcx> for PanicInResultFn {
 
 fn lint_impl_body<'tcx>(cx: &LateContext<'tcx>, impl_span: Span, body: &'tcx hir::Body<'tcx>) {
     let mut panics = Vec::new();
-    let _: Option<!> = for_each_expr(cx, body.value, |e| {
+    let _: Option<!> = for_each_expr(cx.tcx, body.value, |e| {
         let Some(macro_call) = root_macro_call_first_node(cx, e) else {
             return ControlFlow::Continue(Descend::Yes);
         };

--- a/clippy_lints/src/redundant_test_prefix.rs
+++ b/clippy_lints/src/redundant_test_prefix.rs
@@ -144,7 +144,7 @@ fn name_conflicts<'tcx>(cx: &LateContext<'tcx>, body: &'tcx Body<'_>, fn_name: S
 
     // Also check that within the body of the function there is also no function call
     // with the same name (since it will result in recursion)
-    for_each_expr(cx, body, |expr| {
+    for_each_expr(cx.tcx, body, |expr| {
         if let ExprKind::Path(qpath) = &expr.kind
             && let Some(def_id) = cx.qpath_res(qpath, expr.hir_id).opt_def_id()
             && let Some(name) = tcx.opt_item_name(def_id)

--- a/clippy_lints/src/returns/let_and_return.rs
+++ b/clippy_lints/src/returns/let_and_return.rs
@@ -67,7 +67,7 @@ pub(super) fn check_block<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'_>) 
     }
 }
 fn last_statement_borrows<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
-    for_each_expr(cx, expr, |e| {
+    for_each_expr(cx.tcx, expr, |e| {
         if let Some(def_id) = fn_def_id(cx, e)
             && cx
                 .tcx

--- a/clippy_lints/src/set_contains_or_insert.rs
+++ b/clippy_lints/src/set_contains_or_insert.rs
@@ -127,7 +127,7 @@ fn find_insert_calls<'tcx>(
     contains_expr: &OpExpr<'tcx>,
     expr: &'tcx Expr<'_>,
 ) -> Option<OpExpr<'tcx>> {
-    for_each_expr(cx, expr, |e| {
+    for_each_expr(cx.tcx, expr, |e| {
         if let Some((insert_expr, _)) = try_parse_op_call(cx, e, sym::insert)
             && SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), contains_expr.receiver, insert_expr.receiver)
             && SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), contains_expr.value, insert_expr.value)

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -199,7 +199,7 @@ pub fn is_local_used_except<'tcx>(
     id: HirId,
     except: Option<HirId>,
 ) -> bool {
-    for_each_expr(cx, visitable, |e| {
+    for_each_expr(cx.tcx, visitable, |e| {
         if except.is_some_and(|it| it == e.hir_id) {
             ControlFlow::Continue(Descend::No)
         } else if e.res_local_id() == Some(id) {

--- a/clippy_lints/src/string_patterns.rs
+++ b/clippy_lints/src/string_patterns.rs
@@ -147,7 +147,7 @@ fn check_manual_pattern_char_comparison(cx: &LateContext<'_>, method_arg: &Expr<
 
         // We want to retrieve all the comparisons done.
         // They are ordered in a nested way and so we need to traverse the AST to collect them all.
-        if for_each_expr(cx, body.value, |sub_expr| -> ControlFlow<(), Descend> {
+        if for_each_expr(cx.tcx, body.value, |sub_expr| -> ControlFlow<(), Descend> {
             match sub_expr.kind {
                 ExprKind::Binary(op, left, right) if op.node == BinOpKind::Eq => {
                     if left.res_local_id() == Some(binding)

--- a/clippy_lints/src/undocumented_unsafe_blocks.rs
+++ b/clippy_lints/src/undocumented_unsafe_blocks.rs
@@ -393,7 +393,7 @@ fn expr_has_unnecessary_safety_comment<'tcx>(
     }
 
     // this should roughly be the reverse of `block_parents_have_safety_comment`
-    if for_each_expr(cx, expr, |expr| match expr.kind {
+    if for_each_expr(cx.tcx, expr, |expr| match expr.kind {
         hir::ExprKind::Block(
             Block {
                 rules: BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided),

--- a/clippy_lints_internal/src/repeated_is_diagnostic_item.rs
+++ b/clippy_lints_internal/src/repeated_is_diagnostic_item.rs
@@ -541,7 +541,7 @@ fn extract_nested_is_diag_item<'tcx>(
     cx: &LateContext<'tcx>,
     cond: &'tcx Expr<'_>,
 ) -> Option<(Span, (&'tcx Expr<'tcx>, &'tcx Expr<'tcx>, &'tcx Expr<'tcx>))> {
-    for_each_expr(cx, cond, |cond_part| {
+    for_each_expr(cx.tcx, cond, |cond_part| {
         if let Some(res) = extract_is_diag_item(cx, cond_part) {
             ControlFlow::Break((cond_part.span, res))
         } else {
@@ -554,7 +554,7 @@ fn extract_nested_is_diagnostic_item<'tcx>(
     cx: &LateContext<'tcx>,
     cond: &'tcx Expr<'_>,
 ) -> Option<(Span, (&'tcx Expr<'tcx>, &'tcx Expr<'tcx>, &'tcx Expr<'tcx>))> {
-    for_each_expr(cx, cond, |cond_part| {
+    for_each_expr(cx.tcx, cond, |cond_part| {
         if let Some(res) = extract_is_diagnostic_item(cx, cond_part) {
             ControlFlow::Break((cond_part.span, res))
         } else {

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -522,9 +522,9 @@ pub fn eval_int(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<FullInt> {
 ///
 /// See the module level documentation for some context.
 pub struct ConstEvalCtxt<'tcx> {
-    tcx: TyCtxt<'tcx>,
-    typing_env: ty::TypingEnv<'tcx>,
-    typeck: &'tcx TypeckResults<'tcx>,
+    pub tcx: TyCtxt<'tcx>,
+    pub typing_env: ty::TypingEnv<'tcx>,
+    pub typeck: &'tcx TypeckResults<'tcx>,
     source: Cell<ConstantSource>,
     ctxt: Cell<SyntaxContext>,
 }

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -161,7 +161,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     },
                     Res::Def(_, id) if self.cx.tcx.is_promotable_const_fn(id) => (),
                     // No need to walk the arguments here, `is_const_evaluatable` already did
-                    Res::Def(..) if is_const_evaluatable(self.cx, e) => {
+                    Res::Def(..) if is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), e) => {
                         self.eagerness |= NoChange;
                         return;
                     },
@@ -177,7 +177,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     _ => self.eagerness = Lazy,
                 },
                 // No need to walk the arguments here, `is_const_evaluatable` already did
-                ExprKind::MethodCall(..) if is_const_evaluatable(self.cx, e) => {
+                ExprKind::MethodCall(..) if is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), e) => {
                     self.eagerness |= NoChange;
                     return;
                 },

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -11,15 +11,15 @@
 
 use crate::consts::{ConstEvalCtxt, FullInt};
 use crate::sym;
-use crate::ty::{all_predicates_of, is_copy};
+use crate::ty::all_predicates_of;
 use crate::visitors::is_const_evaluatable;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{Visitor, walk_expr};
 use rustc_hir::{BinOpKind, Block, Expr, ExprKind, QPath, UnOp};
 use rustc_lint::LateContext;
-use rustc_middle::ty;
 use rustc_middle::ty::adjustment::{Adjust, DerefAdjustKind};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Symbol;
 use std::{cmp, ops};
 
@@ -48,17 +48,17 @@ impl ops::BitOrAssign for EagernessSuggestion {
 }
 
 /// Determine the eagerness of the given function call.
-fn fn_eagerness(cx: &LateContext<'_>, fn_id: DefId, name: Symbol, have_one_arg: bool) -> EagernessSuggestion {
+fn fn_eagerness(tcx: TyCtxt<'_>, fn_id: DefId, name: Symbol, have_one_arg: bool) -> EagernessSuggestion {
     use EagernessSuggestion::{Eager, Lazy, NoChange};
 
-    let ty = match cx.tcx.impl_of_assoc(fn_id) {
-        Some(id) => cx.tcx.type_of(id).instantiate_identity().skip_norm_wip(),
+    let ty = match tcx.impl_of_assoc(fn_id) {
+        Some(id) => tcx.type_of(id).instantiate_identity().skip_norm_wip(),
         None => return Lazy,
     };
 
     if (matches!(name, sym::is_empty | sym::len) || name.as_str().starts_with("as_")) && have_one_arg {
         if matches!(
-            cx.tcx.crate_name(fn_id.krate),
+            tcx.crate_name(fn_id.krate),
             sym::std | sym::core | sym::alloc | sym::proc_macro
         ) {
             Eager
@@ -71,22 +71,20 @@ fn fn_eagerness(cx: &LateContext<'_>, fn_id: DefId, name: Symbol, have_one_arg: 
         // Due to the limited operations on these types functions should be fairly cheap.
         if def.variants().iter().flat_map(|v| v.fields.iter()).any(|x| {
             matches!(
-                cx.tcx
-                    .type_of(x.did)
+                tcx.type_of(x.did)
                     .instantiate_identity()
                     .skip_norm_wip()
                     .peel_refs()
                     .kind(),
                 ty::Param(_)
             )
-        }) && all_predicates_of(cx.tcx, fn_id).all(|(pred, _)| match pred.kind().skip_binder() {
-            ty::ClauseKind::Trait(pred) => cx.tcx.trait_def(pred.trait_ref.def_id).is_marker,
+        }) && all_predicates_of(tcx, fn_id).all(|(pred, _)| match pred.kind().skip_binder() {
+            ty::ClauseKind::Trait(pred) => tcx.trait_def(pred.trait_ref.def_id).is_marker,
             _ => true,
         }) && subs.types().all(|x| matches!(x.peel_refs().kind(), ty::Param(_)))
         {
             // Limit the function to either `(self) -> bool` or `(&self) -> bool`
-            match &**cx
-                .tcx
+            match &**tcx
                 .fn_sig(fn_id)
                 .instantiate_identity()
                 .skip_norm_wip()
@@ -104,14 +102,12 @@ fn fn_eagerness(cx: &LateContext<'_>, fn_id: DefId, name: Symbol, have_one_arg: 
     }
 }
 
-fn res_has_significant_drop(res: Res, cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
+fn res_has_significant_drop(res: Res, ecx: &ConstEvalCtxt<'_>, e: &Expr<'_>) -> bool {
     if let Res::Def(DefKind::Ctor(..) | DefKind::Variant | DefKind::Enum | DefKind::Struct, _)
     | Res::SelfCtor(_)
     | Res::SelfTyAlias { .. } = res
     {
-        cx.typeck_results()
-            .expr_ty(e)
-            .has_significant_drop(cx.tcx, cx.typing_env())
+        ecx.typeck.expr_ty(e).has_significant_drop(ecx.tcx, ecx.typing_env)
     } else {
         false
     }
@@ -119,12 +115,12 @@ fn res_has_significant_drop(res: Res, cx: &LateContext<'_>, e: &Expr<'_>) -> boo
 
 #[expect(clippy::too_many_lines)]
 fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessSuggestion {
-    struct V<'cx, 'tcx> {
-        cx: &'cx LateContext<'tcx>,
+    struct V<'tcx> {
+        ecx: ConstEvalCtxt<'tcx>,
         eagerness: EagernessSuggestion,
     }
 
-    impl<'tcx> Visitor<'tcx> for V<'_, 'tcx> {
+    impl<'tcx> Visitor<'tcx> for V<'tcx> {
         fn visit_expr(&mut self, e: &'tcx Expr<'_>) {
             use EagernessSuggestion::{ForceNoChange, Lazy, NoChange};
             if self.eagerness == ForceNoChange {
@@ -134,8 +130,8 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
             // Autoderef through a user-defined `Deref` impl can have side-effects,
             // so don't suggest changing it.
             if self
-                .cx
-                .typeck_results()
+                .ecx
+                .typeck
                 .expr_adjustments(e)
                 .iter()
                 .any(|adj| matches!(adj.kind, Adjust::Deref(DerefAdjustKind::Overloaded(_))))
@@ -152,58 +148,62 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                         ..
                     },
                     args,
-                ) => match self.cx.qpath_res(path, hir_id) {
+                ) => match self.ecx.typeck.qpath_res(path, hir_id) {
                     res @ (Res::Def(DefKind::Ctor(..) | DefKind::Variant, _) | Res::SelfCtor(_)) => {
-                        if res_has_significant_drop(res, self.cx, e) {
+                        if res_has_significant_drop(res, &self.ecx, e) {
                             self.eagerness = ForceNoChange;
                             return;
                         }
                     },
-                    Res::Def(_, id) if self.cx.tcx.is_promotable_const_fn(id) => (),
+                    Res::Def(_, id) if self.ecx.tcx.is_promotable_const_fn(id) => (),
                     // No need to walk the arguments here, `is_const_evaluatable` already did
-                    Res::Def(..) if is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), e) => {
+                    Res::Def(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
                         self.eagerness |= NoChange;
                         return;
                     },
                     Res::Def(_, id) => match path {
                         QPath::Resolved(_, p) => {
-                            self.eagerness |=
-                                fn_eagerness(self.cx, id, p.segments.last().unwrap().ident.name, !args.is_empty());
+                            self.eagerness |= fn_eagerness(
+                                self.ecx.tcx,
+                                id,
+                                p.segments.last().unwrap().ident.name,
+                                !args.is_empty(),
+                            );
                         },
                         QPath::TypeRelative(_, name) => {
-                            self.eagerness |= fn_eagerness(self.cx, id, name.ident.name, !args.is_empty());
+                            self.eagerness |= fn_eagerness(self.ecx.tcx, id, name.ident.name, !args.is_empty());
                         },
                     },
                     _ => self.eagerness = Lazy,
                 },
                 // No need to walk the arguments here, `is_const_evaluatable` already did
-                ExprKind::MethodCall(..) if is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), e) => {
+                ExprKind::MethodCall(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
                     self.eagerness |= NoChange;
                     return;
                 },
                 #[expect(clippy::match_same_arms)] // arm pattern can't be merged due to `ref`, see rust#105778
                 ExprKind::Struct(path, ..) => {
-                    if res_has_significant_drop(self.cx.qpath_res(path, e.hir_id), self.cx, e) {
+                    if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
                         self.eagerness = ForceNoChange;
                         return;
                     }
                 },
                 ExprKind::Path(ref path) => {
-                    if res_has_significant_drop(self.cx.qpath_res(path, e.hir_id), self.cx, e) {
+                    if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
                         self.eagerness = ForceNoChange;
                         return;
                     }
                 },
                 ExprKind::MethodCall(name, ..) => {
                     self.eagerness |= self
-                        .cx
-                        .typeck_results()
+                        .ecx
+                        .typeck
                         .type_dependent_def_id(e.hir_id)
-                        .map_or(Lazy, |id| fn_eagerness(self.cx, id, name.ident.name, true));
+                        .map_or(Lazy, |id| fn_eagerness(self.ecx.tcx, id, name.ident.name, true));
                 },
                 ExprKind::Index(_, e, _) => {
-                    let ty = self.cx.typeck_results().expr_ty_adjusted(e);
-                    if is_copy(self.cx, ty) && !ty.is_ref() {
+                    let ty = self.ecx.typeck.expr_ty_adjusted(e);
+                    if self.ecx.tcx.type_is_copy_modulo_regions(self.ecx.typing_env, ty) && !ty.is_ref() {
                         self.eagerness |= NoChange;
                     } else {
                         self.eagerness = Lazy;
@@ -211,24 +211,19 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 },
 
                 // `-i32::MIN` panics with overflow checks
-                ExprKind::Unary(UnOp::Neg, right) if ConstEvalCtxt::new(self.cx).eval(right).is_none() => {
+                ExprKind::Unary(UnOp::Neg, right) if self.ecx.eval(right).is_none() => {
                     self.eagerness |= NoChange;
                 },
 
                 // Custom `Deref` impl might have side effects
-                ExprKind::Unary(UnOp::Deref, e)
-                    if self.cx.typeck_results().expr_ty(e).builtin_deref(true).is_none() =>
-                {
+                ExprKind::Unary(UnOp::Deref, e) if self.ecx.typeck.expr_ty(e).builtin_deref(true).is_none() => {
                     self.eagerness |= NoChange;
                 },
                 // Dereferences should be cheap, but dereferencing a raw pointer earlier may not be safe.
-                ExprKind::Unary(UnOp::Deref, e) if !self.cx.typeck_results().expr_ty(e).is_raw_ptr() => (),
+                ExprKind::Unary(UnOp::Deref, e) if !self.ecx.typeck.expr_ty(e).is_raw_ptr() => (),
                 ExprKind::Unary(UnOp::Deref, _) => self.eagerness |= NoChange,
                 ExprKind::Unary(_, e)
-                    if matches!(
-                        self.cx.typeck_results().expr_ty(e).kind(),
-                        ty::Bool | ty::Int(_) | ty::Uint(_),
-                    ) => {},
+                    if matches!(self.ecx.typeck.expr_ty(e).kind(), ty::Bool | ty::Int(_) | ty::Uint(_),) => {},
 
                 // `>>` and `<<` panic when the right-hand side is greater than or equal to the number of bits in the
                 // type of the left-hand side, or is negative.
@@ -236,18 +231,16 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 // overflow with constants, the compiler emits an error for it and the programmer will have to fix it.
                 // Thus, we would realistically only delay the lint.
                 ExprKind::Binary(op, _, right)
-                    if matches!(op.node, BinOpKind::Shl | BinOpKind::Shr)
-                        && ConstEvalCtxt::new(self.cx).eval(right).is_none() =>
+                    if matches!(op.node, BinOpKind::Shl | BinOpKind::Shr) && self.ecx.eval(right).is_none() =>
                 {
                     self.eagerness |= NoChange;
                 },
 
                 ExprKind::Binary(op, left, right)
                     if matches!(op.node, BinOpKind::Div | BinOpKind::Rem)
-                        && let right_ty = self.cx.typeck_results().expr_ty(right)
-                        && let ecx = ConstEvalCtxt::new(self.cx)
-                        && let left = ecx.eval(left)
-                        && let right = ecx.eval(right).and_then(|c| c.int_value(self.cx.tcx, right_ty))
+                        && let right_ty = self.ecx.typeck.expr_ty(right)
+                        && let left = self.ecx.eval(left)
+                        && let right = self.ecx.eval(right).and_then(|c| c.int_value(self.ecx.tcx, right_ty))
                         && matches!(
                             (left, right),
                             // `1 / x`: x might be zero
@@ -265,16 +258,14 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 // error and it's good to have the eagerness warning up front when the user fixes the logic error.
                 ExprKind::Binary(op, left, right)
                     if matches!(op.node, BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul)
-                        && !self.cx.typeck_results().expr_ty(e).is_floating_point()
-                        && let ecx = ConstEvalCtxt::new(self.cx)
-                        && (ecx.eval(left).is_none() || ecx.eval(right).is_none()) =>
+                        && !self.ecx.typeck.expr_ty(e).is_floating_point()
+                        && (self.ecx.eval(left).is_none() || self.ecx.eval(right).is_none()) =>
                 {
                     self.eagerness |= NoChange;
                 },
 
                 ExprKind::Binary(_, lhs, rhs)
-                    if self.cx.typeck_results().expr_ty(lhs).is_primitive()
-                        && self.cx.typeck_results().expr_ty(rhs).is_primitive() => {},
+                    if self.ecx.typeck.expr_ty(lhs).is_primitive() && self.ecx.typeck.expr_ty(rhs).is_primitive() => {},
 
                 // Can't be moved into a closure
                 ExprKind::Break(..)
@@ -322,7 +313,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
     }
 
     let mut v = V {
-        cx,
+        ecx: ConstEvalCtxt::new(cx),
         eagerness: EagernessSuggestion::Eager,
     };
     v.visit_expr(e);

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -119,7 +119,7 @@ impl Msrv {
     /// nodes for that attribute, prefer to run this check after cheaper pattern matching operations
     pub fn current(self, cx: &LateContext<'_>) -> Option<RustcVersion> {
         if SEEN_MSRV_ATTR.load(Ordering::Relaxed) {
-            self.from_attrs(cx.tcx, cx.last_node_with_lint_attrs)
+            self.for_attrs(cx.tcx, cx.last_node_with_lint_attrs)
         } else {
             self.0
         }
@@ -131,13 +131,13 @@ impl Msrv {
     /// nodes for that attribute, prefer to run this check after cheaper pattern matching operations
     pub fn at(self, tcx: TyCtxt<'_>, node: HirId) -> Option<RustcVersion> {
         if SEEN_MSRV_ATTR.load(Ordering::Relaxed) {
-            self.from_attrs(tcx, node)
+            self.for_attrs(tcx, node)
         } else {
             self.0
         }
     }
 
-    fn from_attrs(self, tcx: TyCtxt<'_>, node: HirId) -> Option<RustcVersion> {
+    fn for_attrs(self, tcx: TyCtxt<'_>, node: HirId) -> Option<RustcVersion> {
         once(node)
             .chain(tcx.hir_parent_id_iter(node))
             .find_map(|id| parse_attrs(tcx.sess, tcx.hir_attrs(id)))

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -3,8 +3,9 @@ use rustc_ast::Attribute;
 use rustc_ast::attr::AttributeExt;
 use rustc_attr_parsing::parse_version;
 use rustc_data_structures::smallvec::SmallVec;
-use rustc_hir::RustcVersion;
+use rustc_hir::{HirId, RustcVersion};
 use rustc_lint::LateContext;
+use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::Symbol;
 use serde::Deserialize;
@@ -118,16 +119,29 @@ impl Msrv {
     /// nodes for that attribute, prefer to run this check after cheaper pattern matching operations
     pub fn current(self, cx: &LateContext<'_>) -> Option<RustcVersion> {
         if SEEN_MSRV_ATTR.load(Ordering::Relaxed) {
-            let start = cx.last_node_with_lint_attrs;
-            if let Some(msrv_attr) = once(start)
-                .chain(cx.tcx.hir_parent_id_iter(start))
-                .find_map(|id| parse_attrs(cx.tcx.sess, cx.tcx.hir_attrs(id)))
-            {
-                return Some(msrv_attr);
-            }
+            self.from_attrs(cx.tcx, cx.last_node_with_lint_attrs)
+        } else {
+            self.0
         }
+    }
 
-        self.0
+    /// Returns the MSRV at the specified node
+    ///
+    /// If the crate being linted uses an `#[clippy::msrv]` attribute this will search the parent
+    /// nodes for that attribute, prefer to run this check after cheaper pattern matching operations
+    pub fn at(self, tcx: TyCtxt<'_>, node: HirId) -> Option<RustcVersion> {
+        if SEEN_MSRV_ATTR.load(Ordering::Relaxed) {
+            self.from_attrs(tcx, node)
+        } else {
+            self.0
+        }
+    }
+
+    fn from_attrs(self, tcx: TyCtxt<'_>, node: HirId) -> Option<RustcVersion> {
+        once(node)
+            .chain(tcx.hir_parent_id_iter(node))
+            .find_map(|id| parse_attrs(tcx.sess, tcx.hir_attrs(id)))
+            .or(self.0)
     }
 
     /// Checks if a required version from [this module](self) is met at the current node
@@ -136,6 +150,14 @@ impl Msrv {
     /// nodes for that attribute, prefer to run this check after cheaper pattern matching operations
     pub fn meets(self, cx: &LateContext<'_>, required: RustcVersion) -> bool {
         self.current(cx).is_none_or(|msrv| msrv >= required)
+    }
+
+    /// Checks if a required version from [this module](self) is met at the specified node
+    ///
+    /// If the crate being linted uses an `#[clippy::msrv]` attribute this will search the parent
+    /// nodes for that attribute, prefer to run this check after cheaper pattern matching operations
+    pub fn meets_at(self, tcx: TyCtxt<'_>, node: HirId, required: RustcVersion) -> bool {
+        self.at(tcx, node).is_none_or(|msrv| msrv >= required)
     }
 
     pub fn read_cargo(&mut self, sess: &Session) {

--- a/clippy_utils/src/qualify_min_const_fn.rs
+++ b/clippy_utils/src/qualify_min_const_fn.rs
@@ -6,9 +6,8 @@
 use crate::msrvs::{self, Msrv};
 use hir::LangItem;
 use rustc_const_eval::check_consts::ConstCx;
-use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{RustcVersion, StableSince};
+use rustc_hir::{self as hir, HirId, RustcVersion, StableSince};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::Obligation;
 use rustc_lint::LateContext;
@@ -420,14 +419,17 @@ fn check_terminator<'tcx>(
 
 /// Checks if the given `def_id` is a stable const fn, in respect to the given MSRV.
 pub fn is_stable_const_fn(cx: &LateContext<'_>, def_id: DefId, msrv: Msrv) -> bool {
-    cx.tcx.is_const_fn(def_id)
-        && cx
-            .tcx
+    is_stable_const_fn_at(cx.tcx, cx.last_node_with_lint_attrs, def_id, msrv)
+}
+
+/// Checks if the given `def_id` is a stable const fn, in respect to the given MSRV.
+pub fn is_stable_const_fn_at(tcx: TyCtxt<'_>, node: HirId, def_id: DefId, msrv: Msrv) -> bool {
+    tcx.is_const_fn(def_id)
+        && tcx
             .lookup_const_stability(def_id)
             .or_else(|| {
-                cx.tcx
-                    .trait_of_assoc(def_id)
-                    .and_then(|trait_def_id| cx.tcx.lookup_const_stability(trait_def_id))
+                tcx.trait_of_assoc(def_id)
+                    .and_then(|trait_def_id| tcx.lookup_const_stability(trait_def_id))
             })
             .is_none_or(|const_stab| {
                 if let rustc_hir::StabilityLevel::Stable { since, .. } = const_stab.level {
@@ -441,10 +443,10 @@ pub fn is_stable_const_fn(cx: &LateContext<'_>, def_id: DefId, msrv: Msrv) -> bo
                         StableSince::Err(_) => return false,
                     };
 
-                    msrv.meets(cx, const_stab_rust_version)
+                    msrv.meets_at(tcx, node, const_stab_rust_version)
                 } else {
                     // Unstable const fn, check if the feature is enabled.
-                    cx.tcx.features().enabled(const_stab.feature) && msrv.current(cx).is_none()
+                    tcx.features().enabled(const_stab.feature) && msrv.at(tcx, node).is_none()
                 }
             })
 }

--- a/clippy_utils/src/usage.rs
+++ b/clippy_utils/src/usage.rs
@@ -195,7 +195,7 @@ pub fn contains_return_break_continue_macro(expression: &Expr<'_>) -> bool {
 }
 
 pub fn local_used_in<'tcx>(cx: &LateContext<'tcx>, local_id: HirId, v: impl Visitable<'tcx>) -> bool {
-    for_each_expr(cx, v, |e| {
+    for_each_expr(cx.tcx, v, |e| {
         if e.res_local_id() == Some(local_id) {
             ControlFlow::Break(())
         } else {
@@ -220,7 +220,7 @@ pub fn local_used_after_expr(cx: &LateContext<'_>, local_id: HirId, after: &Expr
     let loop_start = get_enclosing_loop_or_multi_call_closure(cx, after).map(|e| e.hir_id);
 
     let mut past_expr = false;
-    for_each_expr(cx, block, |e| {
+    for_each_expr(cx.tcx, block, |e| {
         if past_expr {
             if e.res_local_id() == Some(local_id) {
                 ControlFlow::Break(())

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -324,87 +324,67 @@ pub fn is_local_used<'tcx>(cx: &LateContext<'tcx>, visitable: impl Visitable<'tc
 
 /// Checks if the given expression can be evaluated as a constant at the specified node
 pub fn is_const_evaluatable<'tcx>(tcx: TyCtxt<'tcx>, typeck: &'tcx TypeckResults<'tcx>, e: &'tcx Expr<'_>) -> bool {
-    struct V<'tcx> {
-        tcx: TyCtxt<'tcx>,
-        typeck: &'tcx TypeckResults<'tcx>,
-    }
-
-    impl<'tcx> Visitor<'tcx> for V<'tcx> {
-        type Result = ControlFlow<()>;
-        type NestedFilter = intravisit::nested_filter::None;
-
-        fn visit_expr(&mut self, e: &'tcx Expr<'_>) -> Self::Result {
-            match e.kind {
-                ExprKind::ConstBlock(_) => return ControlFlow::Continue(()),
-                ExprKind::Call(
-                    &Expr {
-                        kind: ExprKind::Path(ref p),
-                        hir_id,
-                        ..
-                    },
-                    _,
-                ) if self
-                    .typeck
-                    .qpath_res(p, hir_id)
-                    .opt_def_id()
-                    .is_some_and(|id| is_stable_const_fn_at(self.tcx, CRATE_HIR_ID, id, Msrv::default())) => {},
-                ExprKind::MethodCall(..)
-                    if self
-                        .typeck
-                        .type_dependent_def_id(e.hir_id)
-                        .is_some_and(|id| is_stable_const_fn_at(self.tcx, CRATE_HIR_ID, id, Msrv::default())) => {},
-                ExprKind::Binary(_, lhs, rhs)
-                    if self.typeck.expr_ty(lhs).peel_refs().is_primitive_ty()
-                        && self.typeck.expr_ty(rhs).peel_refs().is_primitive_ty() => {},
-                ExprKind::Unary(UnOp::Deref, e) if self.typeck.expr_ty(e).is_raw_ptr() => (),
-                ExprKind::Unary(_, e) if self.typeck.expr_ty(e).peel_refs().is_primitive_ty() => (),
-                ExprKind::Index(base, _, _)
-                    if matches!(
-                        self.typeck.expr_ty(base).peel_refs().kind(),
-                        ty::Slice(_) | ty::Array(..)
-                    ) => {},
-                ExprKind::Path(ref p)
-                    if matches!(
-                        self.typeck.qpath_res(p, e.hir_id),
-                        Res::Def(
-                            DefKind::Const { .. }
-                                | DefKind::AssocConst { .. }
-                                | DefKind::AnonConst
-                                | DefKind::ConstParam
-                                | DefKind::Ctor(..)
-                                | DefKind::Fn
-                                | DefKind::AssocFn,
-                            _
-                        ) | Res::SelfCtor(_)
-                    ) => {},
-
-                ExprKind::AddrOf(..)
-                | ExprKind::Array(_)
-                | ExprKind::Block(..)
-                | ExprKind::Cast(..)
-                | ExprKind::DropTemps(_)
-                | ExprKind::Field(..)
-                | ExprKind::If(..)
-                | ExprKind::Let(..)
-                | ExprKind::Lit(_)
-                | ExprKind::Match(..)
-                | ExprKind::Repeat(..)
-                | ExprKind::Struct(..)
-                | ExprKind::Tup(_)
-                | ExprKind::Type(..)
-                | ExprKind::UnsafeBinderCast(..) => (),
-
-                _ => {
-                    return ControlFlow::Break(());
+    for_each_expr(tcx, e, move |e| {
+        match e.kind {
+            ExprKind::ConstBlock(_) => return ControlFlow::Continue(Descend::No),
+            ExprKind::Call(
+                &Expr {
+                    kind: ExprKind::Path(ref p),
+                    hir_id,
+                    ..
                 },
-            }
+                _,
+            ) if typeck
+                .qpath_res(p, hir_id)
+                .opt_def_id()
+                .is_some_and(|id| is_stable_const_fn_at(tcx, CRATE_HIR_ID, id, Msrv::default())) => {},
+            ExprKind::MethodCall(..)
+                if typeck
+                    .type_dependent_def_id(e.hir_id)
+                    .is_some_and(|id| is_stable_const_fn_at(tcx, CRATE_HIR_ID, id, Msrv::default())) => {},
+            ExprKind::Binary(_, lhs, rhs)
+                if typeck.expr_ty(lhs).peel_refs().is_primitive_ty()
+                    && typeck.expr_ty(rhs).peel_refs().is_primitive_ty() => {},
+            ExprKind::Unary(UnOp::Deref, e) if typeck.expr_ty(e).is_raw_ptr() => (),
+            ExprKind::Unary(_, e) if typeck.expr_ty(e).peel_refs().is_primitive_ty() => (),
+            ExprKind::Index(base, _, _)
+                if matches!(typeck.expr_ty(base).peel_refs().kind(), ty::Slice(_) | ty::Array(..)) => {},
+            ExprKind::Path(ref p)
+                if matches!(
+                    typeck.qpath_res(p, e.hir_id),
+                    Res::Def(
+                        DefKind::Const { .. }
+                            | DefKind::AssocConst { .. }
+                            | DefKind::AnonConst
+                            | DefKind::ConstParam
+                            | DefKind::Ctor(..)
+                            | DefKind::Fn
+                            | DefKind::AssocFn,
+                        _
+                    ) | Res::SelfCtor(_)
+                ) => {},
 
-            walk_expr(self, e)
+            ExprKind::AddrOf(..)
+            | ExprKind::Array(_)
+            | ExprKind::Block(..)
+            | ExprKind::Cast(..)
+            | ExprKind::DropTemps(_)
+            | ExprKind::Field(..)
+            | ExprKind::If(..)
+            | ExprKind::Let(..)
+            | ExprKind::Lit(_)
+            | ExprKind::Match(..)
+            | ExprKind::Repeat(..)
+            | ExprKind::Struct(..)
+            | ExprKind::Tup(_)
+            | ExprKind::Type(..)
+            | ExprKind::UnsafeBinderCast(..) => {},
+
+            _ => return ControlFlow::Break(()),
         }
-    }
-
-    let mut v = V { tcx, typeck };
-    v.visit_expr(e).is_continue()
+        ControlFlow::Continue(Descend::Yes)
+    })
+    .is_none()
 }
 
 /// Checks if the given expression performs an unsafe operation outside of an unsafe block.

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -145,7 +145,7 @@ pub fn for_each_expr_without_closures<'tcx, B, C: Continue>(
 /// Calls the given function once for each expression contained. This will enter bodies, but not
 /// nested items.
 pub fn for_each_expr<'tcx, B, C: Continue>(
-    cx: &LateContext<'tcx>,
+    tcx: TyCtxt<'tcx>,
     node: impl Visitable<'tcx>,
     f: impl FnMut(&'tcx Expr<'tcx>) -> ControlFlow<B, C>,
 ) -> Option<B> {
@@ -188,7 +188,7 @@ pub fn for_each_expr<'tcx, B, C: Continue>(
             ControlFlow::Continue(())
         }
     }
-    let mut v = V { tcx: cx.tcx, f };
+    let mut v = V { tcx, f };
     node.visit(&mut v).break_value()
 }
 
@@ -299,7 +299,7 @@ where
 
 /// Checks if the given resolved path is used in the given body.
 pub fn is_res_used(cx: &LateContext<'_>, res: Res, body: BodyId) -> bool {
-    for_each_expr(cx, cx.tcx.hir_body(body).value, |e| {
+    for_each_expr(cx.tcx, cx.tcx.hir_body(body).value, |e| {
         if let ExprKind::Path(p) = &e.kind
             && cx.qpath_res(p, e.hir_id) == res
         {
@@ -312,7 +312,7 @@ pub fn is_res_used(cx: &LateContext<'_>, res: Res, body: BodyId) -> bool {
 
 /// Checks if the given local is used.
 pub fn is_local_used<'tcx>(cx: &LateContext<'tcx>, visitable: impl Visitable<'tcx>, id: HirId) -> bool {
-    for_each_expr(cx, visitable, |e| {
+    for_each_expr(cx.tcx, visitable, |e| {
         if e.res_local_id() == Some(id) {
             ControlFlow::Break(())
         } else {
@@ -785,7 +785,7 @@ pub fn local_used_once<'tcx>(
 ) -> Option<&'tcx Expr<'tcx>> {
     let mut expr = None;
 
-    let cf = for_each_expr(cx, visitable, |e| {
+    let cf = for_each_expr(cx.tcx, visitable, |e| {
         if e.res_local_id() == Some(id) && expr.replace(e).is_some() {
             ControlFlow::Break(())
         } else {

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -1,6 +1,6 @@
 use crate::get_enclosing_block;
 use crate::msrvs::Msrv;
-use crate::qualify_min_const_fn::is_stable_const_fn;
+use crate::qualify_min_const_fn::is_stable_const_fn_at;
 use crate::res::MaybeResPath;
 use crate::ty::needs_ordered_drop;
 use core::ops::ControlFlow;
@@ -8,8 +8,8 @@ use rustc_ast::visit::{VisitorResult, try_visit};
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::intravisit::{self, Visitor, walk_block, walk_expr};
 use rustc_hir::{
-    self as hir, AmbigArg, AnonConst, Arm, Block, BlockCheckMode, Body, BodyId, Expr, ExprKind, HirId, ItemId,
-    ItemKind, LetExpr, Pat, QPath, Stmt, StructTailExpr, UnOp, UnsafeSource,
+    self as hir, AmbigArg, AnonConst, Arm, Block, BlockCheckMode, Body, BodyId, CRATE_HIR_ID, Expr, ExprKind, HirId,
+    ItemId, ItemKind, LetExpr, Pat, QPath, Stmt, StructTailExpr, UnOp, UnsafeSource,
 };
 use rustc_lint::LateContext;
 use rustc_middle::hir::nested_filter;
@@ -322,13 +322,14 @@ pub fn is_local_used<'tcx>(cx: &LateContext<'tcx>, visitable: impl Visitable<'tc
     .is_some()
 }
 
-/// Checks if the given expression is a constant.
-pub fn is_const_evaluatable<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> bool {
-    struct V<'a, 'tcx> {
-        cx: &'a LateContext<'tcx>,
+/// Checks if the given expression can be evaluated as a constant at the specified node
+pub fn is_const_evaluatable<'tcx>(tcx: TyCtxt<'tcx>, typeck: &'tcx TypeckResults<'tcx>, e: &'tcx Expr<'_>) -> bool {
+    struct V<'tcx> {
+        tcx: TyCtxt<'tcx>,
+        typeck: &'tcx TypeckResults<'tcx>,
     }
 
-    impl<'tcx> Visitor<'tcx> for V<'_, 'tcx> {
+    impl<'tcx> Visitor<'tcx> for V<'tcx> {
         type Result = ControlFlow<()>;
         type NestedFilter = intravisit::nested_filter::None;
 
@@ -343,29 +344,28 @@ pub fn is_const_evaluatable<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> 
                     },
                     _,
                 ) if self
-                    .cx
+                    .typeck
                     .qpath_res(p, hir_id)
                     .opt_def_id()
-                    .is_some_and(|id| is_stable_const_fn(self.cx, id, Msrv::default())) => {},
+                    .is_some_and(|id| is_stable_const_fn_at(self.tcx, CRATE_HIR_ID, id, Msrv::default())) => {},
                 ExprKind::MethodCall(..)
                     if self
-                        .cx
-                        .typeck_results()
+                        .typeck
                         .type_dependent_def_id(e.hir_id)
-                        .is_some_and(|id| is_stable_const_fn(self.cx, id, Msrv::default())) => {},
+                        .is_some_and(|id| is_stable_const_fn_at(self.tcx, CRATE_HIR_ID, id, Msrv::default())) => {},
                 ExprKind::Binary(_, lhs, rhs)
-                    if self.cx.typeck_results().expr_ty(lhs).peel_refs().is_primitive_ty()
-                        && self.cx.typeck_results().expr_ty(rhs).peel_refs().is_primitive_ty() => {},
-                ExprKind::Unary(UnOp::Deref, e) if self.cx.typeck_results().expr_ty(e).is_raw_ptr() => (),
-                ExprKind::Unary(_, e) if self.cx.typeck_results().expr_ty(e).peel_refs().is_primitive_ty() => (),
+                    if self.typeck.expr_ty(lhs).peel_refs().is_primitive_ty()
+                        && self.typeck.expr_ty(rhs).peel_refs().is_primitive_ty() => {},
+                ExprKind::Unary(UnOp::Deref, e) if self.typeck.expr_ty(e).is_raw_ptr() => (),
+                ExprKind::Unary(_, e) if self.typeck.expr_ty(e).peel_refs().is_primitive_ty() => (),
                 ExprKind::Index(base, _, _)
                     if matches!(
-                        self.cx.typeck_results().expr_ty(base).peel_refs().kind(),
+                        self.typeck.expr_ty(base).peel_refs().kind(),
                         ty::Slice(_) | ty::Array(..)
                     ) => {},
                 ExprKind::Path(ref p)
                     if matches!(
-                        self.cx.qpath_res(p, e.hir_id),
+                        self.typeck.qpath_res(p, e.hir_id),
                         Res::Def(
                             DefKind::Const { .. }
                                 | DefKind::AssocConst { .. }
@@ -403,7 +403,7 @@ pub fn is_const_evaluatable<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> 
         }
     }
 
-    let mut v = V { cx };
+    let mut v = V { tcx, typeck };
     v.visit_expr(e).is_continue()
 }
 


### PR DESCRIPTION
Most of changes here are to remove the dependence on passing `LateContext`

changelog: none
