### PR TITLE
Don't lint semicolon_if_nothing_returned in #[automatically_derived] …

### DIFF
--- a/clippy_lints/src/semicolon_if_nothing_returned.rs
+++ b/clippy_lints/src/semicolon_if_nothing_returned.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::in_automatically_derived;
 use clippy_utils::source::snippet_with_context;
 use rustc_errors::Applicability;
 use rustc_hir::{Block, ExprKind};
@@ -40,6 +41,7 @@ impl<'tcx> LateLintPass<'tcx> for SemicolonIfNothingReturned {
         if !block.span.from_expansion()
             && let Some(expr) = block.expr
             && !from_attr_macro(expr.span)
+            && !in_automatically_derived(cx.tcx, expr.hir_id)
             && let t_expr = cx.typeck_results().expr_ty(expr)
             && t_expr.is_unit()
             && let mut app = Applicability::MachineApplicable

--- a/tests/ui/semicolon_if_nothing_returned.fixed
+++ b/tests/ui/semicolon_if_nothing_returned.fixed
@@ -164,3 +164,6 @@ mod issue12123 {
         async fn main() {}
     }
 }
+
+#[derive(Debug, Clone)]
+struct DerivedStruct(i32);

--- a/tests/ui/semicolon_if_nothing_returned.rs
+++ b/tests/ui/semicolon_if_nothing_returned.rs
@@ -164,3 +164,6 @@ mod issue12123 {
         async fn main() {}
     }
 }
+
+#[derive(Debug, Clone)]
+struct DerivedStruct(i32);


### PR DESCRIPTION
The `semicolon_if_nothing_returned` lint was firing inside `#[automatically_derived]` 
impl blocks generated by `#[derive(...)]`. Users do not control this generated code so the lint should not apply there

Fixed by calling `in_automatically_derived()` from `clippy_utils` before emitting the lint.

Fixes rust-lang/rust-clippy#17199

changelog: [`semicolon_if_nothing_returned`]: don't lint in code generated by `#[automatically_derived]`