### PR TITLE
wildcard_imports: ignore generated imports

### DIFF
--- a/clippy_lints/src/wildcard_imports.rs
+++ b/clippy_lints/src/wildcard_imports.rs
@@ -1,7 +1,7 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::is_in_test;
 use clippy_utils::source::{snippet, snippet_with_applicability};
+use clippy_utils::{in_automatically_derived, is_from_proc_macro, is_in_test};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
@@ -118,7 +118,18 @@ impl WildcardImports {
 
 impl LateLintPass<'_> for WildcardImports {
     fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
-        if cx.sess().is_test_crate() || item.span.in_external_macro(cx.sess().source_map()) {
+        let ItemKind::Use(use_path, UseKind::Glob) = &item.kind else {
+            return;
+        };
+
+        if cx.sess().is_test_crate()
+            || item.span.in_external_macro(cx.sess().source_map())
+            || use_path
+                .segments
+                .first()
+                .is_some_and(|segment| is_from_proc_macro(cx, &segment.ident))
+            || in_automatically_derived(cx.tcx, item.hir_id())
+        {
             return;
         }
 
@@ -128,8 +139,7 @@ impl LateLintPass<'_> for WildcardImports {
         {
             return;
         }
-        if let ItemKind::Use(use_path, UseKind::Glob) = &item.kind
-            && (self.warn_on_all || !self.check_exceptions(cx, item, use_path.segments))
+        if (self.warn_on_all || !self.check_exceptions(cx, item, use_path.segments))
             && let Some(used_imports) = cx.tcx.resolutions(()).glob_map.get(&item.owner_id.def_id)
             && !used_imports.is_empty() // Already handled by `unused_imports`
             && !used_imports.contains(&kw::Underscore)

--- a/tests/ui/auxiliary/wildcard_imports_proc_macro.rs
+++ b/tests/ui/auxiliary/wildcard_imports_proc_macro.rs
@@ -1,0 +1,43 @@
+extern crate proc_macro;
+
+use proc_macro::{Group, TokenStream, TokenTree};
+
+#[proc_macro_derive(WildcardImport)]
+pub fn derive_wildcard_import(input: TokenStream) -> TokenStream {
+    let span = input.into_iter().next().unwrap().span();
+    let generated = r#"
+        fn generated_by_proc_macro() {
+            use crate::fn_mod::*;
+            foo();
+        }
+    "#
+    .parse()
+    .unwrap();
+
+    respan(generated, span)
+}
+
+fn respan(stream: TokenStream, span: proc_macro::Span) -> TokenStream {
+    stream
+        .into_iter()
+        .map(|token| match token {
+            TokenTree::Group(group) => {
+                let mut respanned = Group::new(group.delimiter(), respan(group.stream(), span));
+                respanned.set_span(span);
+                TokenTree::Group(respanned)
+            },
+            TokenTree::Ident(mut ident) => {
+                ident.set_span(span);
+                TokenTree::Ident(ident)
+            },
+            TokenTree::Punct(mut punct) => {
+                punct.set_span(span);
+                TokenTree::Punct(punct)
+            },
+            TokenTree::Literal(mut literal) => {
+                literal.set_span(span);
+                TokenTree::Literal(literal)
+            },
+        })
+        .collect()
+}

--- a/tests/ui/wildcard_imports_generated.rs
+++ b/tests/ui/wildcard_imports_generated.rs
@@ -1,0 +1,26 @@
+//@aux-build:wildcard_imports_proc_macro.rs
+//@check-pass
+
+#![warn(clippy::wildcard_imports)]
+#![allow(dead_code)]
+
+extern crate wildcard_imports_proc_macro;
+
+mod fn_mod {
+    pub fn foo() {}
+}
+
+#[derive(wildcard_imports_proc_macro::WildcardImport)]
+struct ProcMacroGenerated;
+
+struct AutomaticallyDerived;
+
+#[automatically_derived]
+impl AutomaticallyDerived {
+    fn import() {
+        use crate::fn_mod::*;
+        foo();
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
changelog: [`wildcard_imports`]: avoid false positives in generated code

## Summary
- skip wildcard imports whose path tokens were respanned by a procedural macro
- skip wildcard imports inside `#[automatically_derived]` implementations
- add UI coverage for both generated-code cases

Fixes rust-lang/rust-clippy#17200

## Validation
- PASS: `TESTNAME=wildcard_imports cargo uitest` (8 UI tests and 4 config tests)
- PASS: `cargo dev fmt --check`
- PASS: `cargo test --manifest-path clippy_lints/Cargo.toml --lib` (15 tests)
- PASS: `cargo test --features internal --test compile-test` (1794 UI tests passed, 7 ignored; 190 UI-TOML, 46 UI-Cargo, and 22 UI-internal tests passed)
- PASS: `git diff --check`
- PARTIAL: `cargo test --manifest-path clippy_lints/Cargo.toml` passed 1300 doctests but failed 3 Windows-dependent doctests (`HOME` unavailable at compile time and two missing Unix child commands)
- PARTIAL: `cargo test --features internal` passed the compile-test suites, then failed in `dogfood` on Windows because `tikv_jemalloc_sys` was unavailable

## Notes
- no configuration or compatibility changes
- the procedural-macro check runs only after confirming the item is a glob import