### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ regex = "1.5.5"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.122"
 walkdir = "2.3"
-filetime = "0.2.9"
 itertools = "0.15"
 pulldown-cmark = { version = "0.11", default-features = false, features = ["html"] }
 askama = { version = "0.16.0", default-features = false, features = ["alloc", "config", "derive"] }

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -30,9 +30,6 @@ default-features = false
 # preserve_order keeps diagnostic output in file order
 features = ["parse", "preserve_order"]
 
-[dev-dependencies]
-walkdir = "2.3"
-
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(bootstrap)']

--- a/clippy_lints_internal/Cargo.toml
+++ b/clippy_lints_internal/Cargo.toml
@@ -8,7 +8,6 @@ clippy_config = { path = "../clippy_config" }
 clippy_utils = { path = "../clippy_utils" }
 itertools = "0.15"
 regex = { version = "1.5" }
-rustc-semver = "1.1"
 
 [package.metadata.rust-analyzer]
 # This crate uses #[feature(rustc_private)]


### PR DESCRIPTION
changelog: Removed unused dependencies

Cleans up the following unused dependencies:

| Crate | Removed from |
|---|---|
| `filetime = "0.2.9"` | `Cargo.toml` (workspace) |
| `walkdir = "2.3"` | `clippy_lints/Cargo.toml` (dev-dependency) |
| `rustc-semver = "1.1"` | `clippy_lints_internal/Cargo.toml` |

All tests pass on my computer but just make sure to test them again.
