### PR TITLE
Add funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: rustfoundation
+custom: [ "rust-lang.org/funding" ]


### PR DESCRIPTION
This will add a "Sponsor" button to the Clippy repo, same as we have on the [compiler repo](https://github.com/rust-lang/rust):
<img width="970" height="112" alt="image" src="https://github.com/user-attachments/assets/10b812ce-87db-4df7-aa6c-e906ba97dfb1" />

Which will point both to the RFMF [Sponsors page](https://github.com/sponsors/rustfoundation) and to the Rust [Funding page](https://rust-lang.org/funding/), which is a bit more general.

changelog: none