### PR TITLE
Lint for unbounded iterations checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7312,6 +7312,7 @@ Released 2018-09-13
 [`type_complexity`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
 [`type_id_on_box`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_id_on_box
 [`type_repetition_in_bounds`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_repetition_in_bounds
+[`unbounded_iter`]: https://rust-lang.github.io/rust-clippy/master/index.html#unbounded_iter
 [`unbuffered_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#unbuffered_bytes
 [`unchecked_duration_subtraction`]: https://rust-lang.github.io/rust-clippy/master/index.html#unchecked_duration_subtraction
 [`unchecked_time_subtraction`]: https://rust-lang.github.io/rust-clippy/master/index.html#unchecked_time_subtraction

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -227,6 +227,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::infallible_try_from::INFALLIBLE_TRY_FROM_INFO,
     crate::infinite_iter::INFINITE_ITER_INFO,
     crate::infinite_iter::MAYBE_INFINITE_ITER_INFO,
+    crate::infinite_iter::UNBOUNDED_ITER_INFO,
     crate::inherent_impl::MULTIPLE_INHERENT_IMPL_INFO,
     crate::inherent_to_string::INHERENT_TO_STRING_INFO,
     crate::inherent_to_string::INHERENT_TO_STRING_SHADOW_DISPLAY_INFO,

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -50,18 +50,48 @@ declare_clippy_lint! {
     "possible infinite iteration"
 }
 
-declare_lint_pass!(InfiniteIter => [INFINITE_ITER, MAYBE_INFINITE_ITER]);
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// ### Why restrict this?
+    ///
+    /// ### Example
+    /// ```no_run
+    /// // example code where clippy issues a warning
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// // example code which does not raise clippy warning
+    /// ```
+    #[clippy::version = "1.97.0"]
+    pub UNBOUNDED_ITER,
+    restriction,
+    "default lint description"
+}
+
+declare_lint_pass!(InfiniteIter => [
+    INFINITE_ITER,
+    MAYBE_INFINITE_ITER,
+    UNBOUNDED_ITER,
+]);
 
 impl<'tcx> LateLintPass<'tcx> for InfiniteIter {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        let (lint, msg) = match complete_infinite_iter(cx, expr) {
-            Infinite => (INFINITE_ITER, "infinite iteration detected"),
-            MaybeInfinite => (MAYBE_INFINITE_ITER, "possible infinite iteration detected"),
-            Finite => {
-                return;
-            },
+        let lint_msg = match complete_infinite_iter(cx, expr) {
+            Infinite => Some((INFINITE_ITER, "infinite iteration detected")),
+            MaybeInfinite => Some((MAYBE_INFINITE_ITER, "possible infinite iteration detected")),
+            Finite => None,
         };
-        span_lint(cx, lint, expr.span, msg);
+        if let Some((lint, msg)) = lint_msg {
+            span_lint(cx, lint, expr.span, msg);
+        }
+        let lint_msg = match is_unbounded(cx, expr) {
+            Unbounded => Some((UNBOUNDED_ITER, "unbounded iteration detected")),
+            Bounded => None,
+        };
+        if let Some((lint, msg)) = lint_msg {
+            span_lint(cx, lint, expr.span, msg);
+        }
     }
 }
 
@@ -258,4 +288,55 @@ fn complete_infinite_iter(cx: &LateContext<'_>, expr: &Expr<'_>) -> Finiteness {
         _ => (),
     }
     Finite
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Boundedness {
+    Unbounded,
+    Bounded,
+}
+
+use self::Boundedness::{Bounded, Unbounded};
+
+impl From<bool> for Boundedness {
+    fn from(b: bool) -> Self {
+        if b { Bounded } else { Unbounded }
+    }
+}
+
+impl Boundedness {
+    #[must_use]
+    fn and(self, b: Self) -> Boundedness {
+        match (self, b) {
+            (Unbounded, Unbounded) => Unbounded,
+            (_, _) => Bounded,
+        }
+    }
+
+    #[must_use]
+    fn or(self, b: Self) -> Boundedness {
+        match (self, b) {
+            (Unbounded, _) => Unbounded,
+            (_, Unbounded) => Unbounded,
+            (_, _) => Bounded,
+        }
+    }
+}
+
+fn is_unbounded(cx: &LateContext<'_>, expr: &Expr<'_>) -> Boundedness {
+    match expr.kind {
+        ExprKind::MethodCall(method, receiver, args, _) => {
+            if method.ident.name == sym::zip {
+                is_unbounded(cx, receiver).and(is_unbounded(cx, &args[0]))
+            } else if method.ident.name == sym::chain {
+                is_unbounded(cx, receiver).or(is_unbounded(cx, &args[0]))
+            } else {
+                is_unbounded(cx, receiver)
+            }
+        },
+        ExprKind::Block(block, _) => block.expr.as_ref().map_or(Bounded, |e| is_unbounded(cx, e)),
+        ExprKind::AddrOf(BorrowKind::Ref, _, e) => is_unbounded(cx, e),
+        ExprKind::Struct(..) => higher::Range::hir(cx, expr).is_some_and(|r| r.end.is_some()).into(),
+        _ => Bounded,
+    }
 }

--- a/tests/ui/unbounded_iter.rs
+++ b/tests/ui/unbounded_iter.rs
@@ -1,0 +1,6 @@
+#![warn(clippy::unbounded_iter)]
+
+fn main() {
+    (0..).all(|x| x > 0);
+    //~^ unbounded_iter
+}


### PR DESCRIPTION
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`unbounded_iter`]: <still need to write>
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[x] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

@llogiq last month at RustWeek 2026 was walking me through the "how" of writing a Clippy lint.

Life got a little busy, but he suggested that I open this as a WIP for now so that I can get a little feedback and then keep chipping away at it =]

changelog:
