### PR TITLE
Unused import prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7477,6 +7477,7 @@ Released 2018-09-13
 [`unused_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_collect
 [`unused_enumerate_index`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_enumerate_index
 [`unused_format_specs`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_format_specs
+[`unused_import_prefixes`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_import_prefixes
 [`unused_io_amount`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount
 [`unused_label`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_label
 [`unused_peekable`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_peekable

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -787,6 +787,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME_INFO,
     crate::unused_async::UNUSED_ASYNC_INFO,
     crate::unused_async::UNUSED_ASYNC_TRAIT_IMPL_INFO,
+    crate::unused_import_prefixes::UNUSED_IMPORT_PREFIXES_INFO,
     crate::unused_io_amount::UNUSED_IO_AMOUNT_INFO,
     crate::unused_peekable::UNUSED_PEEKABLE_INFO,
     crate::unused_result_ok::UNUSED_RESULT_OK_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -385,6 +385,7 @@ mod unneeded_struct_pattern;
 mod unnested_or_patterns;
 mod unsafe_removed_from_name;
 mod unused_async;
+mod unused_import_prefixes;
 mod unused_io_amount;
 mod unused_peekable;
 mod unused_result_ok;
@@ -862,6 +863,7 @@ rustc_lint::late_lint_methods!(
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
+        UnusedImportPrefixes: unused_import_prefixes::UnusedImportPrefixes = unused_import_prefixes::UnusedImportPrefixes::default(),
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/unused_import_prefixes.rs
+++ b/clippy_lints/src/unused_import_prefixes.rs
@@ -18,21 +18,25 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```no_run
-    /// // src/foo.rs
     /// pub mod bar {
-    ///     pub struct Baz;
-    /// }
+    ///     mod baz {
+    ///         pub struct Baz;
+    ///     }
     ///
-    /// use crate::foo::bar::Baz;
+    ///     use crate::bar::baz::Baz;
+    /// }
+    /// # fn main() {}
     /// ```
     /// Use instead:
     /// ```no_run
-    /// // src/foo.rs
     /// pub mod bar {
-    ///     pub struct Baz;
-    /// }
+    ///     mod baz {
+    ///         pub struct Baz;
+    ///     }
     ///
-    /// use self::bar::Baz;
+    ///     use self::baz::Baz;
+    /// }
+    /// # fn main() {}
     /// ```
     #[clippy::version = "1.98.0"]
     pub UNUSED_IMPORT_PREFIXES,

--- a/clippy_lints/src/unused_import_prefixes.rs
+++ b/clippy_lints/src/unused_import_prefixes.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// ### Example
     /// ```no_run
     /// // src/foo.rs
-    /// pub mod bar {}
+    /// pub mod bar {
     ///     pub struct Baz;
     /// }
     ///
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     /// Use instead:
     /// ```no_run
     /// // src/foo.rs
-    /// pub mod bar {}
+    /// pub mod bar {
     ///     pub struct Baz;
     /// }
     ///

--- a/clippy_lints/src/unused_import_prefixes.rs
+++ b/clippy_lints/src/unused_import_prefixes.rs
@@ -66,6 +66,11 @@ impl LateLintPass<'_> for UnusedImportPrefixes {
             return;
         }
 
+        // Do not lint public exports
+        if cx.tcx.visibility(item.owner_id.def_id).is_public() {
+            return;
+        }
+
         // Only check imports starting with the `crate` keyword
         if use_path.segments.is_empty() || use_path.segments[0].ident.name != kw::Crate {
             return;

--- a/clippy_lints/src/unused_import_prefixes.rs
+++ b/clippy_lints/src/unused_import_prefixes.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use clippy_utils::res::MaybeDef;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
-use rustc_hir::*;
+use rustc_hir::{HirId, Item, ItemKind, Mod};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
 use rustc_span::{Span, kw};

--- a/clippy_lints/src/unused_import_prefixes.rs
+++ b/clippy_lints/src/unused_import_prefixes.rs
@@ -1,0 +1,132 @@
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
+use clippy_utils::res::MaybeDef;
+use rustc_data_structures::fx::FxHashSet;
+use rustc_errors::Applicability;
+use rustc_hir::*;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::impl_lint_pass;
+use rustc_span::{Span, kw};
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for redundant `crate::...` prefixes in imports (use statements)
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unnecessarily increases noise and complicates imports.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// // src/foo.rs
+    /// pub mod bar {}
+    ///     pub struct Baz;
+    /// }
+    ///
+    /// use crate::foo::bar::Baz;
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// // src/foo.rs
+    /// pub mod bar {}
+    ///     pub struct Baz;
+    /// }
+    ///
+    /// use self::bar::Baz;
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub UNUSED_IMPORT_PREFIXES,
+    nursery,
+    "redundant `crate::...` prefix in an use statement"
+}
+
+impl_lint_pass!(UnusedImportPrefixes => [UNUSED_IMPORT_PREFIXES]);
+
+#[derive(Default)]
+pub struct UnusedImportPrefixes {
+    processed: FxHashSet<Span>,
+}
+
+impl LateLintPass<'_> for UnusedImportPrefixes {
+    fn check_mod(&mut self, _: &LateContext<'_>, _: &Mod<'_>, _: HirId) {
+        self.processed.clear();
+    }
+
+    fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
+        let ItemKind::Use(use_path, _) = item.kind else {
+            return;
+        };
+
+        // Ignore use statements expanded from macros
+        if item.span.from_expansion() {
+            return;
+        }
+
+        // Only check imports starting with the `crate` keyword
+        if use_path.segments.is_empty() || use_path.segments[0].ident.name != kw::Crate {
+            return;
+        }
+
+        // Prevent duplicate lints for the same use statement
+        let root_span = use_path.segments[0].ident.span;
+        if !self.processed.insert(root_span) {
+            return;
+        }
+
+        let module_def_id = cx.tcx.parent_module(item.hir_id()).to_def_id();
+        let Some(target_def_id) = use_path.res.iter().find_map(|res| res.opt_def_id()) else {
+            return;
+        };
+
+        // Checks if the use statement is really redundant
+        if !cx.tcx.is_descendant_of(target_def_id, module_def_id) && target_def_id != module_def_id {
+            return;
+        }
+
+        let mut redundant_len = 0;
+        for (i, mod_sym) in cx
+            .tcx
+            .def_path(module_def_id)
+            .data
+            .iter()
+            .filter_map(|s| s.data.get_opt_name())
+            .enumerate()
+        {
+            redundant_len += 1;
+            let Some(segment) = use_path.segments.get(i + 1) else {
+                return;
+            };
+            if mod_sym != segment.ident.name {
+                return;
+            }
+        }
+
+        let prefix_span = use_path.segments[0]
+            .ident
+            .span
+            .to(use_path.segments[redundant_len].ident.span);
+
+        let snippet = clippy_utils::source::snippet_opt(cx, prefix_span).unwrap_or_default();
+
+        if snippet.contains(['{', '}']) {
+            span_lint_and_help(
+                cx,
+                UNUSED_IMPORT_PREFIXES,
+                prefix_span,
+                "redundant `crate::...` prefix in a use statement",
+                None,
+                "consider removing the redundant prefix manually",
+            );
+        } else {
+            span_lint_and_sugg(
+                cx,
+                UNUSED_IMPORT_PREFIXES,
+                prefix_span,
+                UNUSED_IMPORT_PREFIXES.desc,
+                "remove redundant use path prefix",
+                "self".to_string(),
+                Applicability::MachineApplicable,
+            );
+        }
+    }
+}

--- a/tests/ui/unused_import_prefixes.fixed
+++ b/tests/ui/unused_import_prefixes.fixed
@@ -1,0 +1,44 @@
+#![warn(clippy::unused_import_prefixes)]
+
+mod mod_one {
+    pub struct StructOne;
+}
+
+mod parent {
+    mod child {
+        use self::deep::DeepStruct;
+        //~^ unused_import_prefixes
+
+        // the `crate::` prefix is needed
+        use crate::mod_one::StructOne;
+
+        use self::deep::{ItemA, ItemB};
+        //~^ unused_import_prefixes
+
+        use self::{deep::ItemC, deep::StructTwo};
+        //~^ unused_import_prefixes
+
+        // glob imports
+        use self::deep::*;
+        //~^ unused_import_prefixes
+
+        pub mod deep {
+            pub struct DeepStruct;
+            pub struct ItemA;
+            pub struct ItemB;
+            pub struct ItemC;
+            pub struct StructTwo;
+        }
+    }
+}
+
+// do not lint imports inside macro declarations
+macro_rules! generate_import {
+    () => {
+        use crate::mod_one::StructOne;
+    };
+}
+
+fn main() {
+    generate_import!();
+}

--- a/tests/ui/unused_import_prefixes.fixed
+++ b/tests/ui/unused_import_prefixes.fixed
@@ -12,6 +12,9 @@ mod parent {
         // the `crate::` prefix is needed
         use crate::mod_one::StructOne;
 
+        // don't lint public exports
+        pub use crate::parent::child::deep::ItemC;
+
         use self::deep::{ItemA, ItemB};
         //~^ unused_import_prefixes
 
@@ -23,6 +26,7 @@ mod parent {
             pub struct DeepStruct;
             pub struct ItemA;
             pub struct ItemB;
+            pub struct ItemC;
         }
     }
 }

--- a/tests/ui/unused_import_prefixes.fixed
+++ b/tests/ui/unused_import_prefixes.fixed
@@ -15,9 +15,6 @@ mod parent {
         use self::deep::{ItemA, ItemB};
         //~^ unused_import_prefixes
 
-        use self::{deep::ItemC, deep::StructTwo};
-        //~^ unused_import_prefixes
-
         // glob imports
         use self::deep::*;
         //~^ unused_import_prefixes
@@ -26,8 +23,6 @@ mod parent {
             pub struct DeepStruct;
             pub struct ItemA;
             pub struct ItemB;
-            pub struct ItemC;
-            pub struct StructTwo;
         }
     }
 }

--- a/tests/ui/unused_import_prefixes.rs
+++ b/tests/ui/unused_import_prefixes.rs
@@ -1,0 +1,44 @@
+#![warn(clippy::unused_import_prefixes)]
+
+mod mod_one {
+    pub struct StructOne;
+}
+
+mod parent {
+    mod child {
+        use crate::parent::child::deep::DeepStruct;
+        //~^ unused_import_prefixes
+
+        // the `crate::` prefix is needed
+        use crate::mod_one::StructOne;
+
+        use crate::parent::child::deep::{ItemA, ItemB};
+        //~^ unused_import_prefixes
+
+        use crate::parent::child::deep::{ItemC, StructTwo};
+        //~^ unused_import_prefixes
+
+        // glob imports
+        use crate::parent::child::deep::*;
+        //~^ unused_import_prefixes
+
+        pub mod deep {
+            pub struct DeepStruct;
+            pub struct ItemA;
+            pub struct ItemB;
+            pub struct ItemC;
+            pub struct StructTwo;
+        }
+    }
+}
+
+// do not lint imports inside macro declarations
+macro_rules! generate_import {
+    () => {
+        use crate::mod_one::StructOne;
+    };
+}
+
+fn main() {
+    generate_import!();
+}

--- a/tests/ui/unused_import_prefixes.rs
+++ b/tests/ui/unused_import_prefixes.rs
@@ -15,9 +15,6 @@ mod parent {
         use crate::parent::child::deep::{ItemA, ItemB};
         //~^ unused_import_prefixes
 
-        use crate::parent::child::deep::{ItemC, StructTwo};
-        //~^ unused_import_prefixes
-
         // glob imports
         use crate::parent::child::deep::*;
         //~^ unused_import_prefixes
@@ -26,8 +23,6 @@ mod parent {
             pub struct DeepStruct;
             pub struct ItemA;
             pub struct ItemB;
-            pub struct ItemC;
-            pub struct StructTwo;
         }
     }
 }

--- a/tests/ui/unused_import_prefixes.rs
+++ b/tests/ui/unused_import_prefixes.rs
@@ -12,6 +12,9 @@ mod parent {
         // the `crate::` prefix is needed
         use crate::mod_one::StructOne;
 
+        // don't lint public exports
+        pub use crate::parent::child::deep::ItemC;
+
         use crate::parent::child::deep::{ItemA, ItemB};
         //~^ unused_import_prefixes
 
@@ -23,6 +26,7 @@ mod parent {
             pub struct DeepStruct;
             pub struct ItemA;
             pub struct ItemB;
+            pub struct ItemC;
         }
     }
 }

--- a/tests/ui/unused_import_prefixes.stderr
+++ b/tests/ui/unused_import_prefixes.stderr
@@ -14,16 +14,10 @@ LL |         use crate::parent::child::deep::{ItemA, ItemB};
    |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`
 
 error: redundant `crate::...` prefix in an use statement
-  --> tests/ui/unused_import_prefixes.rs:18:13
-   |
-LL |         use crate::parent::child::{deep::ItemC, deep::StructTwo};
-   |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`
-
-error: redundant `crate::...` prefix in an use statement
-  --> tests/ui/unused_import_prefixes.rs:22:13
+  --> tests/ui/unused_import_prefixes.rs:19:13
    |
 LL |         use crate::parent::child::deep::*;
    |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/unused_import_prefixes.stderr
+++ b/tests/ui/unused_import_prefixes.stderr
@@ -8,13 +8,13 @@ LL |         use crate::parent::child::deep::DeepStruct;
    = help: to override `-D warnings` add `#[allow(clippy::unused_import_prefixes)]`
 
 error: redundant `crate::...` prefix in an use statement
-  --> tests/ui/unused_import_prefixes.rs:15:13
+  --> tests/ui/unused_import_prefixes.rs:18:13
    |
 LL |         use crate::parent::child::deep::{ItemA, ItemB};
    |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`
 
 error: redundant `crate::...` prefix in an use statement
-  --> tests/ui/unused_import_prefixes.rs:19:13
+  --> tests/ui/unused_import_prefixes.rs:22:13
    |
 LL |         use crate::parent::child::deep::*;
    |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`

--- a/tests/ui/unused_import_prefixes.stderr
+++ b/tests/ui/unused_import_prefixes.stderr
@@ -1,0 +1,29 @@
+error: redundant `crate::...` prefix in an use statement
+  --> tests/ui/unused_import_prefixes.rs:9:13
+   |
+LL |         use crate::parent::child::deep::DeepStruct;
+   |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`
+   |
+   = note: `-D clippy::unused-import-prefixes` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_import_prefixes)]`
+
+error: redundant `crate::...` prefix in an use statement
+  --> tests/ui/unused_import_prefixes.rs:15:13
+   |
+LL |         use crate::parent::child::deep::{ItemA, ItemB};
+   |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`
+
+error: redundant `crate::...` prefix in an use statement
+  --> tests/ui/unused_import_prefixes.rs:18:13
+   |
+LL |         use crate::parent::child::{deep::ItemC, deep::StructTwo};
+   |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`
+
+error: redundant `crate::...` prefix in an use statement
+  --> tests/ui/unused_import_prefixes.rs:22:13
+   |
+LL |         use crate::parent::child::deep::*;
+   |             ^^^^^^^^^^^^^^^^^^^^ help: remove redundant use path prefix: `self`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/unused_import_prefixes_no_fix.rs
+++ b/tests/ui/unused_import_prefixes_no_fix.rs
@@ -1,0 +1,16 @@
+//@no-rustfix
+
+#![warn(clippy::unused_import_prefixes)]
+
+mod parent {
+    mod child {
+        #[rustfmt::skip]
+        use crate::parent::{child::deep::ItemA, child::deep::ItemB};
+        //~^ unused_import_prefixes
+
+        pub mod deep {
+            pub struct ItemA;
+            pub struct ItemB;
+        }
+    }
+}

--- a/tests/ui/unused_import_prefixes_no_fix.stderr
+++ b/tests/ui/unused_import_prefixes_no_fix.stderr
@@ -1,0 +1,12 @@
+error: redundant `crate::...` prefix in a use statement
+  --> tests/ui/unused_import_prefixes_no_fix.rs:8:13
+   |
+LL |         use crate::parent::{child::deep::ItemA, child::deep::ItemB};
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing the redundant prefix manually
+   = note: `-D clippy::unused-import-prefixes` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_import_prefixes)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Adds a new `nursery` lint, `unused_import_prefixes`, which detects and suggests removing redundant `crate::...` prefixes in `use` statements when importing items that are descendants of the current module.

Fixes rust-lang/rust-clippy#17084 

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

---

changelog: new lint: [`unused_import_prefixes`]