### PR TITLE
Don't trigger `let_underscore_future` when the type is specified

### DIFF
--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -162,7 +162,8 @@ impl<'tcx> LateLintPass<'tcx> for LetUnderscore {
                         );
                     },
                 );
-            } else if let Some(future_trait_def_id) = cx.tcx.lang_items().future_trait()
+            } else if local.ty.is_none()
+                && let Some(future_trait_def_id) = cx.tcx.lang_items().future_trait()
                 && implements_trait(cx, cx.typeck_results().expr_ty(init), future_trait_def_id, &[])
             {
                 #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]

--- a/tests/ui/let_underscore_future.rs
+++ b/tests/ui/let_underscore_future.rs
@@ -21,4 +21,8 @@ fn main() {
     do_something_to_future(&mut future);
     let _ = future;
     //~^ let_underscore_future
+
+    // An explicitly typed `let _: T` shows intent, so the lint should not fire.
+    // See https://github.com/rust-lang/rust-clippy/issues/16991
+    let _: std::pin::Pin<Box<dyn Future<Output = ()>>> = Box::pin(some_async_fn());
 }


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16991.

`let_underscore_future` fired even when the discarded value had an explicit type
annotation:

```rust
let _: Pin<Box<dyn Future<Output = ()>>> = Box::pin(some_async_fn());
```

Writing the type already shows intent, and the `mem::drop` suggestion is noisier
here. This makes `let_underscore_future` a strict subset of `let_underscore_untyped`
by only firing when no type is given (matching how `let_underscore_untyped` itself
is gated on `local.ty.is_none()`).

changelog: [`let_underscore_future`]: no longer fires when the `let _` binding has an explicit type annotation