### PR TITLE
Lint `single_element_loop` when the loop body is a trailing expression

### DIFF
--- a/clippy_lints/src/loops/single_element_loop.rs
+++ b/clippy_lints/src/loops/single_element_loop.rs
@@ -66,7 +66,8 @@ pub(super) fn check<'tcx>(
         _ => return,
     };
     if let ExprKind::Block(block, _) = body.kind
-        && !block.stmts.is_empty()
+        // The block must have a statement or a trailing expression, i.e. not be empty.
+        && !(block.stmts.is_empty() && block.expr.is_none())
         && !contains_break_or_continue(body)
     {
         let mut applicability = Applicability::MachineApplicable;
@@ -78,7 +79,12 @@ pub(super) fn check<'tcx>(
         let mut block_str = snippet_with_applicability(cx, block.span, "..", &mut applicability).into_owned();
         block_str.remove(0);
         block_str.pop();
-        let indent = " ".repeat(indent_of(cx, block.stmts[0].span).unwrap_or(0));
+        let inner_span = block
+            .stmts
+            .first()
+            .map(|stmt| stmt.span)
+            .or_else(|| block.expr.map(|expr| expr.span));
+        let indent = " ".repeat(inner_span.and_then(|span| indent_of(cx, span)).unwrap_or(0));
 
         // Reference iterator from `&(mut) []` or `[].iter(_mut)()`.
         if !prefix.is_empty()

--- a/tests/ui/single_element_loop.fixed
+++ b/tests/ui/single_element_loop.fixed
@@ -73,4 +73,21 @@ fn main() {
         //~^ single_element_loop
         let ptr: *const bool = std::ptr::null();
     }
+
+    // should lint (issue #16510): the loop body is a trailing expression, not a statement
+    {
+        let item = 42;
+        //~^ single_element_loop
+        if item > 0 {
+            dbg!(item);
+        }
+    }
+
+    // should lint (issue #16510): trailing `if` over a single range element
+    for _ in 0..5 {
+        //~^ single_element_loop
+        if std::hint::black_box(true) {
+            dbg!("once");
+        }
+    }
 }

--- a/tests/ui/single_element_loop.rs
+++ b/tests/ui/single_element_loop.rs
@@ -69,4 +69,20 @@ fn main() {
         //~^ single_element_loop
         let ptr: *const bool = std::ptr::null();
     }
+
+    // should lint (issue #16510): the loop body is a trailing expression, not a statement
+    for item in [42] {
+        //~^ single_element_loop
+        if item > 0 {
+            dbg!(item);
+        }
+    }
+
+    // should lint (issue #16510): trailing `if` over a single range element
+    for _ in [0..5] {
+        //~^ single_element_loop
+        if std::hint::black_box(true) {
+            dbg!("once");
+        }
+    }
 }

--- a/tests/ui/single_element_loop.stderr
+++ b/tests/ui/single_element_loop.stderr
@@ -106,5 +106,33 @@ LL +         let ptr: *const bool = std::ptr::null();
 LL +     }
    |
 
-error: aborting due to 8 previous errors
+error: for loop over a single element
+  --> tests/ui/single_element_loop.rs:74:5
+   |
+LL | /     for item in [42] {
+LL | |
+LL | |         if item > 0 {
+LL | |             dbg!(item);
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     {
+LL +         let item = 42;
+LL +
+LL +         if item > 0 {
+LL +             dbg!(item);
+LL +         }
+LL +     }
+   |
+
+error: this loops only once with `_` being `0..5`
+  --> tests/ui/single_element_loop.rs:82:14
+   |
+LL |     for _ in [0..5] {
+   |              ^^^^^^ help: did you mean to iterate over the range instead?: `0..5`
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16510.

`single_element_loop` did not fire when the loop body was a block whose only
content is a trailing expression, e.g. a trailing `if`:

```rust
for _ in [0..5] {
    if cond {
        println!("once");
    }
}
```

The check required `!block.stmts.is_empty()`, but here the `if` is the block's
trailing expression (`block.expr`), so `block.stmts` is empty and the lint was
skipped. The body is now considered non-empty when it has either a statement or
a trailing expression, and the suggestion indent is taken from whichever is
present (the old code indexed `block.stmts[0]`, which would have panicked on a
statement-less block).

changelog: [`single_element_loop`]: now lints when the loop body is a single trailing expression