### PR TITLE
Don't trigger `unnecessary_box_returns` when the size depends on generics

### DIFF
--- a/clippy_lints/src/unnecessary_box_returns.rs
+++ b/clippy_lints/src/unnecessary_box_returns.rs
@@ -1,10 +1,10 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::ty::approx_ty_size;
 use rustc_errors::Applicability;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{FnDecl, FnRetTy, ImplItemKind, Item, ItemKind, Node, TraitItem, TraitItemKind};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::layout::LayoutOf;
 use rustc_session::impl_lint_pass;
 use rustc_span::Symbol;
 
@@ -81,8 +81,13 @@ impl UnnecessaryBoxReturns {
 
         // It's sometimes useful to return Box<T> if T is unsized, so don't lint those.
         // Also, don't lint if we know that T is very large, in which case returning
-        // a Box<T> may be beneficial.
-        if boxed_ty.is_sized(cx.tcx, cx.typing_env()) && approx_ty_size(cx, boxed_ty) <= self.maximum_size {
+        // a Box<T> may be beneficial. When the size depends on generic parameters
+        // (e.g. `[T; N]`) it cannot be determined here, so don't lint that either, as
+        // the `Box` may be a deliberate choice to avoid copying a large value.
+        if boxed_ty.is_sized(cx.tcx, cx.typing_env())
+            && let Ok(layout) = cx.layout_of(boxed_ty)
+            && layout.size.bytes() <= self.maximum_size
+        {
             span_lint_and_then(
                 cx,
                 UNNECESSARY_BOX_RETURNS,

--- a/tests/ui/unnecessary_box_returns.rs
+++ b/tests/ui/unnecessary_box_returns.rs
@@ -81,6 +81,13 @@ fn generic_element_array<T>(value: Box<[T; 10]>) -> Box<[T; 10]> {
     value
 }
 
+// lint: the size of `Vec<T>` is known regardless of the generic element type
+#[expect(clippy::box_collection)]
+fn generic_vec<T>(value: Box<Vec<T>>) -> Box<Vec<T>> {
+    //~^ unnecessary_box_returns
+    value
+}
+
 fn main() {
     // don't lint: this is a closure
     let a = || -> Box<usize> { Box::new(5) };

--- a/tests/ui/unnecessary_box_returns.rs
+++ b/tests/ui/unnecessary_box_returns.rs
@@ -71,6 +71,16 @@ impl HasHuge {
     }
 }
 
+// don't lint (issue #17202): the size of `[T; N]` depends on a const generic parameter
+fn const_generic_array<const N: usize, T>(value: Box<[T; N]>) -> Box<[T; N]> {
+    value
+}
+
+// don't lint (issue #17202): the size of `[T; 10]` depends on the generic element type
+fn generic_element_array<T>(value: Box<[T; 10]>) -> Box<[T; 10]> {
+    value
+}
+
 fn main() {
     // don't lint: this is a closure
     let a = || -> Box<usize> { Box::new(5) };

--- a/tests/ui/unnecessary_box_returns.stderr
+++ b/tests/ui/unnecessary_box_returns.stderr
@@ -32,5 +32,13 @@ LL | fn _bxed_foo() -> Box<Foo> {
    |
    = help: changing this also requires a change to the return expressions in this function
 
-error: aborting due to 4 previous errors
+error: boxed return of the sized type `std::vec::Vec<T>`
+  --> tests/ui/unnecessary_box_returns.rs:86:42
+   |
+LL | fn generic_vec<T>(value: Box<Vec<T>>) -> Box<Vec<T>> {
+   |                                          ^^^^^^^^^^^ help: try: `std::vec::Vec<T>`
+   |
+   = help: changing this also requires a change to the return expressions in this function
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17202.

`unnecessary_box_returns` fired on return types whose size depends on generic
parameters, e.g.:

```rust
fn strip<const N: usize, T>(value: Box<[SyncUnsafeCell<T>; N]>) -> Box<[T; N]> { /* ... */ }
//                                                                 ^^^^^^^^^^^ help: try: `[T; N]`
```

The size of `[T; N]` can't be determined here (it depends on `T` and the const
parameter `N`), but `approx_ty_size` falls back to `0` for such arrays, so the
`<= unnecessary_box_size` check always passed and the lint fired. Returning a
`Box` is often deliberate in these cases to avoid copying a potentially large
value.

The lint now queries the type's layout directly and only fires when the size can
actually be computed. Concrete types and generic types with a known layout (e.g.
`Box<Vec<T>>`) are unaffected.

changelog: [`unnecessary_box_returns`]: no longer fires when the boxed type's size depends on generic parameters (e.g. `Box<[T; N]>`)