### PR TITLE
Do not trigger `ref_patterns` lint on automatically derived code

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -534,7 +534,6 @@ rustc_lint::early_lint_methods!(
         PartialPubFields: partial_pub_fields::PartialPubFields = partial_pub_fields::PartialPubFields,
         UnderscoreTyped: let_with_type_underscore::UnderscoreTyped = let_with_type_underscore::UnderscoreTyped,
         ExcessiveNesting: excessive_nesting::ExcessiveNesting = excessive_nesting::ExcessiveNesting::new(conf),
-        RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
         NeedlessElse: needless_else::NeedlessElse = needless_else::NeedlessElse,
         RawStrings: raw_strings::RawStrings = raw_strings::RawStrings::new(conf),
         Visibility: visibility::Visibility = visibility::Visibility,
@@ -862,6 +861,7 @@ rustc_lint::late_lint_methods!(
         ByteCharSlice: byte_char_slices::ByteCharSlice = byte_char_slices::ByteCharSlice,
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
+        RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/ref_patterns.rs
+++ b/clippy_lints/src/ref_patterns.rs
@@ -1,6 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_ast::ast::{BindingMode, Pat, PatKind};
-use rustc_lint::{EarlyContext, EarlyLintPass};
+use clippy_utils::in_automatically_derived;
+use rustc_hir::{BindingMode, Pat, PatKind};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 
 declare_clippy_lint! {
@@ -29,10 +30,11 @@ declare_clippy_lint! {
 
 declare_lint_pass!(RefPatterns => [REF_PATTERNS]);
 
-impl EarlyLintPass for RefPatterns {
-    fn check_pat(&mut self, cx: &EarlyContext<'_>, pat: &Pat) {
-        if let PatKind::Ident(BindingMode::REF, _, _) = pat.kind
+impl<'tcx> LateLintPass<'tcx> for RefPatterns {
+    fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx Pat<'tcx>) {
+        if let PatKind::Binding(BindingMode::REF, _, _, _) = pat.kind
             && !pat.span.from_expansion()
+            && !in_automatically_derived(cx.tcx, pat.hir_id)
         {
             #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
             span_lint_and_then(cx, REF_PATTERNS, pat.span, "usage of ref pattern", |diag| {

--- a/tests/ui/ref_patterns.rs
+++ b/tests/ui/ref_patterns.rs
@@ -19,4 +19,14 @@ fn use_in_binding() {
 fn use_in_parameter(ref x: i32) {}
 //~^ ref_patterns
 
+struct Foo {}
+
+// shouldn't trigger the lint
+#[automatically_derived]
+impl Foo {
+    fn foo() {
+        if let Some(ref x) = Some(1) {}
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Code marked with `#[automatically_derived]` attribute is macro generated
and its syntax is out of user's control. Since `ref_patterns` is a lint
for clarity, it should not be triggered for auto derived code.

Fixed by converting the lint into a late pass lint and checking the auto
derived attribute using `in_automatically_derived` utility.

changelog:  Fix [`ref_patterns`] false positive: shouldn't trigger on `#[automatically_derived]` annotated code

fixes rust-lang/rust-clippy#17198

--- 

Note: I converted the lint into late pass because I found an existing utility `in_automatically_derived` that operates on the HIR, but the util only checks for the impl blocks (which is a subset of the possible auto derived code, I suppose). 

```rust
/// Checks if the given HIR node is inside an `impl` block with the `automatically_derived`
/// attribute.
pub fn in_automatically_derived(tcx: TyCtxt<'_>, id: HirId) -> bool {
    tcx.hir_parent_owner_iter(id)
        .filter(|(_, node)| matches!(node, OwnerNode::Item(item) if matches!(item.kind, ItemKind::Impl(_))))
        .any(|(id, _)| find_attr!(tcx, id.def_id, AutomaticallyDerived))
}
```

So, should I create a new utility for checking all possible nodes for auto derived attribute?
Thanks!