### PR TITLE
Unused empty value

### DIFF
--- a/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/clippy_lints/src/unit_types/let_unit_value.rs
@@ -28,7 +28,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, format_args: &FormatArgsStorag
         && !local.span.is_from_async_await()
         && cx.typeck_results().pat_ty(local.pat).is_unit()
     {
-        // skip `let _: () = { ... }`
+        // Annotate `let _name: () =`, should be replaced with `let () =`
         if let Some(ty) = local.ty
             && let TyKind::Tup([]) = ty.kind
         {
@@ -338,7 +338,7 @@ fn check_underscore_unit_binding(cx: &LateContext<'_>, local: &LetStmt<'_>) {
         return;
     };
 
-    if !(ident.name.as_str().starts_with('_') || ident.name.as_str() == "_") {
+    if !ident.name.as_str().starts_with('_') {
         return;
     }
 
@@ -355,6 +355,6 @@ fn check_underscore_unit_binding(cx: &LateContext<'_>, local: &LetStmt<'_>) {
         "named binding with unit type can be replaced with `()`",
         "replace with",
         "()".to_string(),
-        Applicability::MaybeIncorrect,
+        Applicability::MachineApplicable,
     );
 }

--- a/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/clippy_lints/src/unit_types/let_unit_value.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::macros::{FormatArgsStorage, find_format_arg_expr, is_format_macro, root_macro_call_first_node};
 use clippy_utils::source::{snippet_indent, walk_span_to_context};
 use clippy_utils::visitors::{for_each_local_assignment, for_each_value_source};
@@ -28,15 +28,16 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, format_args: &FormatArgsStorag
         && !local.span.is_from_async_await()
         && cx.typeck_results().pat_ty(local.pat).is_unit()
     {
-        // skip `let awa = ()`
-        if let ExprKind::Tup([]) = init.kind {
-            return;
-        }
-
         // skip `let _: () = { ... }`
         if let Some(ty) = local.ty
             && let TyKind::Tup([]) = ty.kind
         {
+            check_underscore_unit_binding(cx, local);
+            return;
+        }
+
+        // skip `let awa = ()`
+        if let ExprKind::Tup([]) = init.kind {
             return;
         }
 
@@ -330,4 +331,30 @@ fn needs_inferred_result_ty(
     } else {
         false
     }
+}
+
+fn check_underscore_unit_binding(cx: &LateContext<'_>, local: &LetStmt<'_>) {
+    let PatKind::Binding(_, _, ident, _) = local.pat.kind else {
+        return;
+    };
+
+    if !(ident.name.as_str().starts_with('_') || ident.name.as_str() == "_") {
+        return;
+    }
+
+    let lint_span = if let Some(ty) = local.ty {
+        local.pat.span.with_hi(ty.span.hi())
+    } else {
+        local.pat.span
+    };
+
+    span_lint_and_sugg(
+        cx,
+        LET_UNIT_VALUE,
+        lint_span,
+        "named binding with unit type can be replaced with `()`",
+        "replace with",
+        "()".to_string(),
+        Applicability::MaybeIncorrect,
+    );
 }

--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -19,8 +19,10 @@ fn main() {
         let () = ();
         () = returns_unit();
         () = ();
-        let _a: () = ();
-        let _a: () = returns_unit();
+        let () = ();
+        //~^ let_unit_value
+        let () = returns_unit();
+        //~^ let_unit_value
     }
 
     consume_units_with_for_loop(); // should be fine as well
@@ -175,7 +177,8 @@ fn attributes() {
 }
 
 async fn issue10433() {
-    let _pending: () = std::future::pending().await;
+    let () = std::future::pending().await;
+    //~^ let_unit_value
 }
 
 pub async fn issue11502(a: ()) {}
@@ -233,4 +236,20 @@ fn issue15789() {
     //~^ let_unit_value
 
     Foo { value: () };
+}
+
+fn issue15957() {
+    fn f() {}
+
+    // Should have the new annotation
+    let () = f();
+    //~^ let_unit_value
+    let () = f();
+    //~^ let_unit_value
+    let () = ();
+    //~^ let_unit_value
+    let () = println!();
+    //~^ let_unit_value
+    let () = { f() };
+    //~^ let_unit_value
 }

--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -252,4 +252,7 @@ fn issue15957() {
     //~^ let_unit_value
     let () = { f() };
     //~^ let_unit_value
+
+    // Should not be linted
+    let _: () = f();
 }

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -20,7 +20,9 @@ fn main() {
         () = returns_unit();
         () = ();
         let _a: () = ();
+        //~^ let_unit_value
         let _a: () = returns_unit();
+        //~^ let_unit_value
     }
 
     consume_units_with_for_loop(); // should be fine as well
@@ -176,6 +178,7 @@ fn attributes() {
 
 async fn issue10433() {
     let _pending: () = std::future::pending().await;
+    //~^ let_unit_value
 }
 
 pub async fn issue11502(a: ()) {}
@@ -231,4 +234,20 @@ fn issue15789() {
     //~^ let_unit_value
 
     Foo { value };
+}
+
+fn issue15957() {
+    fn f() {}
+
+    // Should have the new annotation
+    let _x: () = f();
+    //~^ let_unit_value
+    let _some_name: () = f();
+    //~^ let_unit_value
+    let _foo: () = ();
+    //~^ let_unit_value
+    let _a: () = println!();
+    //~^ let_unit_value
+    let _x: () = { f() };
+    //~^ let_unit_value
 }

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -250,4 +250,7 @@ fn issue15957() {
     //~^ let_unit_value
     let _x: () = { f() };
     //~^ let_unit_value
+
+    // Should not be linted
+    let _: () = f();
 }

--- a/tests/ui/let_unit.stderr
+++ b/tests/ui/let_unit.stderr
@@ -12,8 +12,20 @@ LL -     let _x = println!("x");
 LL +     println!("x");
    |
 
+error: named binding with unit type can be replaced with `()`
+  --> tests/ui/let_unit.rs:22:13
+   |
+LL |         let _a: () = ();
+   |             ^^^^^^ help: replace with: `()`
+
+error: named binding with unit type can be replaced with `()`
+  --> tests/ui/let_unit.rs:24:13
+   |
+LL |         let _a: () = returns_unit();
+   |             ^^^^^^ help: replace with: `()`
+
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:60:5
+  --> tests/ui/let_unit.rs:62:5
    |
 LL | /     let _ = v
 LL | |
@@ -31,7 +43,7 @@ LL +     v
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:110:5
+  --> tests/ui/let_unit.rs:112:5
    |
 LL | /     let x = match Some(0) {
 LL | |
@@ -48,8 +60,14 @@ LL -     let x = match Some(0) {
 LL +     match Some(0) {
    |
 
+error: named binding with unit type can be replaced with `()`
+  --> tests/ui/let_unit.rs:180:9
+   |
+LL |     let _pending: () = std::future::pending().await;
+   |         ^^^^^^^^^^^^ help: replace with: `()`
+
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:190:9
+  --> tests/ui/let_unit.rs:193:9
    |
 LL |         let res = returns_unit();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +81,7 @@ LL ~         returns_result(()).unwrap();
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:203:5
+  --> tests/ui/let_unit.rs:206:5
    |
 LL |     let res = returns_unit();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +95,7 @@ LL ~     takes_unit(());
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:211:14
+  --> tests/ui/let_unit.rs:214:14
    |
 LL |         _ => _ = returns_unit(),
    |              ^^^^^^^^^^^^^^^^^^
@@ -89,7 +107,7 @@ LL +         _ => returns_unit(),
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:215:5
+  --> tests/ui/let_unit.rs:218:5
    |
 LL |     _ = if true {}
    |     ^^^^^^^^^^^^^^
@@ -101,7 +119,7 @@ LL +     if true {}
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:220:5
+  --> tests/ui/let_unit.rs:223:5
    |
 LL |     let res = eprintln!("I return unit");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +133,7 @@ LL ~     takes_unit(());
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:230:5
+  --> tests/ui/let_unit.rs:233:5
    |
 LL |     let value = println!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -128,5 +146,35 @@ LL |
 LL ~     Foo { value: () };
    |
 
-error: aborting due to 9 previous errors
+error: named binding with unit type can be replaced with `()`
+  --> tests/ui/let_unit.rs:243:9
+   |
+LL |     let _x: () = f();
+   |         ^^^^^^ help: replace with: `()`
+
+error: named binding with unit type can be replaced with `()`
+  --> tests/ui/let_unit.rs:245:9
+   |
+LL |     let _some_name: () = f();
+   |         ^^^^^^^^^^^^^^ help: replace with: `()`
+
+error: named binding with unit type can be replaced with `()`
+  --> tests/ui/let_unit.rs:247:9
+   |
+LL |     let _foo: () = ();
+   |         ^^^^^^^^ help: replace with: `()`
+
+error: named binding with unit type can be replaced with `()`
+  --> tests/ui/let_unit.rs:249:9
+   |
+LL |     let _a: () = println!();
+   |         ^^^^^^ help: replace with: `()`
+
+error: named binding with unit type can be replaced with `()`
+  --> tests/ui/let_unit.rs:251:9
+   |
+LL |     let _x: () = { f() };
+   |         ^^^^^^ help: replace with: `()`
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
changelog: [`let_unit_value`]: lint underscore bindings with explicit unit type annotations

With these changes, the lint now suggests using `()` for underscore bindings that have an explicit unit type annotation. As previously discussed in the comments, the lint does not trigger for explicit underscore bindings.

Sorry if I misunderstood the request, I left a [comment](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/.2315957.20clarification/near/601780313) on Zulip explaining my reasoning in more detail, but it did not receive any responses. 

fixes rust-lang/rust-clippy#15957

