### PR TITLE
Do not check for unused lifetimes in expanded code

### DIFF
--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -161,7 +161,9 @@ impl<'tcx> LateLintPass<'tcx> for Lifetimes {
     }
 
     fn check_poly_trait_ref(&mut self, cx: &LateContext<'tcx>, poly_trait_ref: &'tcx PolyTraitRef<'tcx>) {
-        report_extra_trait_object_lifetimes(cx, poly_trait_ref.bound_generic_params, &poly_trait_ref.trait_ref);
+        if !poly_trait_ref.span.from_expansion() {
+            report_extra_trait_object_lifetimes(cx, poly_trait_ref.bound_generic_params, &poly_trait_ref.trait_ref);
+        }
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx ImplItem<'_>) {

--- a/tests/ui/extra_unused_lifetimes.rs
+++ b/tests/ui/extra_unused_lifetimes.rs
@@ -211,4 +211,18 @@ mod proc_macro_generated {
     }
 }
 
+mod issue17255 {
+
+    trait AnotherSimpleTrait<'a> {}
+
+    macro_rules! mac {
+        ($lt:lifetime, $t:ident, $tr:path) => {
+            impl<$t: for<'lt> $tr> AnotherSimpleTrait<'_> for $t {}
+        };
+    }
+
+    // Do not lint code expanded from macros
+    mac!('a, T, super::SimplerTrait);
+}
+
 fn main() {}


### PR DESCRIPTION
changelog: [`extra_unused_lifetimes`]: do not lint the expanded code

Fixes rust-lang/rust-clippy#17255 