### PR TITLE
fix: `borrow_as_ptr` is triggered on generated code

### DIFF
--- a/clippy_lints/src/casts/borrow_as_ptr.rs
+++ b/clippy_lints/src/casts/borrow_as_ptr.rs
@@ -58,7 +58,7 @@ pub(super) fn check<'tcx>(
 }
 
 /// Check for an implicit cast from reference to raw pointer outside an explicit `as`.
-pub(super) fn check_implicit_cast(cx: &LateContext<'_>, expr: &Expr<'_>) {
+pub(super) fn check_implicit_cast<'cx>(cx: &LateContext<'cx>, expr: &Expr<'cx>) {
     if !expr.span.from_expansion()
         && let ExprKind::AddrOf(BorrowKind::Ref, _, pointee) = expr.kind
         && !matches!(get_parent_expr(cx, expr).map(|e| e.kind), Some(ExprKind::Cast(..)))
@@ -67,6 +67,7 @@ pub(super) fn check_implicit_cast(cx: &LateContext<'_>, expr: &Expr<'_>) {
         && let Adjust::Borrow(AutoBorrow::RawPtr(mutability)) = borrow.kind
         // Do not suggest taking a raw pointer to a temporary value
         && !is_expr_temporary_value(cx, pointee)
+        && !is_from_proc_macro(cx, expr)
     {
         span_lint_and_then(cx, BORROW_AS_PTR, expr.span, "implicit borrow as raw pointer", |diag| {
             diag.span_suggestion_verbose(

--- a/tests/ui/borrow_as_ptr.fixed
+++ b/tests/ui/borrow_as_ptr.fixed
@@ -65,3 +65,9 @@ fn issue15389() {
         let _ = &var as *const u32;
     };
 }
+
+fn issue17197() {
+    let x = 0u32;
+    // implicit cast doesn't lint in proc-macros
+    proc_macros::with_span!(span let _: *const _ = &x;);
+}

--- a/tests/ui/borrow_as_ptr.rs
+++ b/tests/ui/borrow_as_ptr.rs
@@ -65,3 +65,9 @@ fn issue15389() {
         let _ = &var as *const u32;
     };
 }
+
+fn issue17197() {
+    let x = 0u32;
+    // implicit cast doesn't lint in proc-macros
+    proc_macros::with_span!(span let _: *const _ = &x;);
+}


### PR DESCRIPTION
Fixes: rust-lang/rust-clippy#17197

changelog: [`borrow_as_ptr`]: avoid linting on automatically derived code.
