### PR TITLE
Enable triagebot `merge` and `delegate` commands

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -60,6 +60,11 @@ labels = ["S-waiting-on-concerns"]
 [view-all-comments-link]
 threshold = 20
 
+# Allows `merge` and `delegate` commands for merging a PR
+# Documentation at: https://forge.rust-lang.org/triagebot/merge.html
+[merge]
+type = "merge-queue"
+
 [notify-zulip."lint-nominated"]
 zulip_stream = 577190 # #clippy/fcp
 topic = "FCP rust-clippy#{number}: {title}"


### PR DESCRIPTION
This PR enable the newly added triagebot `merge` and `delegate` commands.

They allow merging a PR with rustbot:
 - `@rustbot merge` -- enqueue the PR in the merge queue
 - `@rustbot delegate+`/`@rustbot delegate=@user` -- delegate merge rights to the author or specific user

Documentation at: https://forge.rust-lang.org/triagebot/merge.html

Requested by @samueltardieu 
r? @flip1995

changelog: none
