### PR TITLE
perf: compare method names before type queries in three lint passes

### DIFF
--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -79,14 +79,15 @@ fn min_max<'a>(cx: &LateContext<'_>, expr: &'a Expr<'a>) -> Option<(MinMax, Cons
             }
         },
         ExprKind::MethodCall(path, receiver, args @ [_], _) => {
+            let m = match path.ident.name {
+                sym::max => MinMax::Max,
+                sym::min => MinMax::Min,
+                _ => return None,
+            };
             if cx.typeck_results().expr_ty(receiver).is_floating_point()
                 || cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Ord)
             {
-                match path.ident.name {
-                    sym::max => fetch_const(cx, expr.span.ctxt(), Some(receiver), args, MinMax::Max),
-                    sym::min => fetch_const(cx, expr.span.ctxt(), Some(receiver), args, MinMax::Min),
-                    _ => None,
-                }
+                fetch_const(cx, expr.span.ctxt(), Some(receiver), args, m)
             } else {
                 None
             }

--- a/clippy_lints/src/string_patterns.rs
+++ b/clippy_lints/src/string_patterns.rs
@@ -230,13 +230,13 @@ impl<'tcx> LateLintPass<'tcx> for StringPatterns {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if !expr.span.from_expansion()
             && let ExprKind::MethodCall(method, receiver, args, _) = expr.kind
-            && let ty::Ref(_, ty, _) = cx.typeck_results().expr_ty_adjusted(receiver).kind()
-            && ty.is_str()
             && let method_name = method.ident.name
             && let Some(&(_, pos)) = PATTERN_METHODS
                 .iter()
                 .find(|(array_method_name, _)| *array_method_name == method_name)
             && let Some(arg) = args.get(pos)
+            && let ty::Ref(_, ty, _) = cx.typeck_results().expr_ty_adjusted(receiver).kind()
+            && ty.is_str()
         {
             check_single_char_pattern_lint(cx, arg);
 

--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -132,8 +132,8 @@ fn into_iter_bound<'tcx>(
 /// Extracts the receiver of a `.into_iter()` method call.
 fn into_iter_call<'hir>(cx: &LateContext<'_>, expr: &'hir Expr<'hir>) -> Option<&'hir Expr<'hir>> {
     if let ExprKind::MethodCall(name, recv, [], _) = expr.kind
-        && cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::IntoIterator)
         && name.ident.name == sym::into_iter
+        && cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::IntoIterator)
     {
         Some(recv)
     } else {
@@ -208,7 +208,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
             },
 
             ExprKind::MethodCall(name, recv, [], _) => {
-                if cx.ty_based_def(e).opt_parent(cx).is_diag_item(cx, sym::Into) && name.ident.name == sym::into {
+                if name.ident.name == sym::into && cx.ty_based_def(e).opt_parent(cx).is_diag_item(cx, sym::Into) {
                     let a = cx.typeck_results().expr_ty(e);
                     let b = cx.typeck_results().expr_ty(recv);
                     if same_type_modulo_regions(a, b) {
@@ -393,8 +393,8 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                         );
                     }
                 }
-                if cx.ty_based_def(e).opt_parent(cx).is_diag_item(cx, sym::TryInto)
-                    && name.ident.name == sym::try_into
+                if name.ident.name == sym::try_into
+                    && cx.ty_based_def(e).opt_parent(cx).is_diag_item(cx, sym::TryInto)
                     && let a = cx.typeck_results().expr_ty(e)
                     && let b = cx.typeck_results().expr_ty(recv)
                     && a.is_diag_item(cx, sym::Result)


### PR DESCRIPTION
symbol comparison is much cheaper than typecheck table lookups and tcx queries

| crate | instructions base | instructions new | delta |
|---|---|---|---|
| cargo-0.80.0 | 31,525,505,650 | 31,507,313,859 | -0.058% |
| ripgrep-14.1.0 | 1,969,715,595 | 1,968,239,574 | -0.075% |
| wasmi-0.35.0 | 16,146,199,102 | 16,141,101,655 | -0.032% |
| ryu-1.0.18 | 271,047,279 | 270,775,666 | -0.100% |

changelog: none
