### PR TITLE
perf: check the method name first in or_fun_call

### DIFF
--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -30,6 +30,23 @@ pub(super) fn check<'tcx>(
     args: &'tcx [hir::Expr<'_>],
     msrv: Msrv,
 ) {
+    // Bail out early unless the method is one that `check_unwrap_or_default` or
+    // `check_or_fn_call` can lint, to avoid walking the argument of every method call.
+    if !matches!(
+        name,
+        sym::unwrap_or
+            | sym::unwrap_or_else
+            | sym::or_insert
+            | sym::or_insert_with
+            | sym::get_or_insert
+            | sym::map_or
+            | sym::ok_or
+            | sym::or
+            | sym::and
+    ) {
+        return;
+    }
+
     if let [arg] = args {
         let inner_arg = peel_blocks(arg);
         for_each_expr(cx, inner_arg, |ex| {
@@ -112,6 +129,12 @@ fn check_unwrap_or_default(
     method_span: Span,
     msrv: Msrv,
 ) -> bool {
+    let sugg = match (name, call_expr.is_some()) {
+        (sym::unwrap_or, true) | (sym::unwrap_or_else, false) => sym::unwrap_or_default,
+        (sym::or_insert, true) | (sym::or_insert_with, false) => sym::or_default,
+        _ => return false,
+    };
+
     let receiver_ty = cx.typeck_results().expr_ty_adjusted(receiver).peel_refs();
 
     // Check MSRV, but only for `Result::unwrap_or_default`
@@ -148,12 +171,6 @@ fn check_unwrap_or_default(
         } else {
             false
         }
-    };
-
-    let sugg = match (name, call_expr.is_some()) {
-        (sym::unwrap_or, true) | (sym::unwrap_or_else, false) => sym::unwrap_or_default,
-        (sym::or_insert, true) | (sym::or_insert_with, false) => sym::or_default,
-        _ => return false,
     };
 
     let Some(suggested_method_def_id) = receiver_ty.ty_adt_def().and_then(|adt_def| {


### PR DESCRIPTION
`or_fun_call` check runs for every method call in the crate, and before this change it walked the entire argument expression (including closure bodies) with for_each_expr, and ran type queries in check_unwrap_or_default, before comparing the method name

| crate | instructions base | instructions new | delta |
|---|---|---|---|
| cargo-0.80.0 (lib) | 29,891,979,058 | 29,833,065,792 | -0.20% |
| cargo-0.80.0 (bin) | 1,631,502,396 | 1,623,055,610 | -0.52% |
| syn-2.0.71 | 3,397,389,176 | 3,392,929,964 | -0.13% |
| tokio-1.38.1 | 522,363,523 | 521,964,144 | -0.08% |
| ryu-1.0.18 | 271,052,786 | 270,867,046 | -0.07% |

changelog: none
