### PR TITLE
Implement new lint `clippy::public-types-missing-drop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7233,6 +7233,7 @@ Released 2018-09-13
 [`pub_use`]: https://rust-lang.github.io/rust-clippy/master/index.html#pub_use
 [`pub_with_shorthand`]: https://rust-lang.github.io/rust-clippy/master/index.html#pub_with_shorthand
 [`pub_without_shorthand`]: https://rust-lang.github.io/rust-clippy/master/index.html#pub_without_shorthand
+[`public_types_missing_drop`]: https://rust-lang.github.io/rust-clippy/master/index.html#public_types_missing_drop
 [`question_mark`]: https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
 [`question_mark_used`]: https://rust-lang.github.io/rust-clippy/master/index.html#question_mark_used
 [`range_minus_one`]: https://rust-lang.github.io/rust-clippy/master/index.html#range_minus_one

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -651,6 +651,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::ptr::PTR_EQ_INFO,
     crate::pub_underscore_fields::PUB_UNDERSCORE_FIELDS_INFO,
     crate::pub_use::PUB_USE_INFO,
+    crate::public_types_missing_drop::PUBLIC_TYPES_MISSING_DROP_INFO,
     crate::question_mark::QUESTION_MARK_INFO,
     crate::question_mark_used::QUESTION_MARK_USED_INFO,
     crate::ranges::MANUAL_RANGE_CONTAINS_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -301,6 +301,7 @@ mod precedence;
 mod ptr;
 mod pub_underscore_fields;
 mod pub_use;
+mod public_types_missing_drop;
 mod question_mark;
 mod question_mark_used;
 mod ranges;
@@ -862,6 +863,7 @@ rustc_lint::late_lint_methods!(
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
+        PublicTypesMissingDrop: public_types_missing_drop::PublicTypesMissingDrop = public_types_missing_drop::PublicTypesMissingDrop,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/public_types_missing_drop.rs
+++ b/clippy_lints/src/public_types_missing_drop.rs
@@ -1,0 +1,74 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::ty::is_copy;
+use rustc_hir::{Item, ItemKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for exported types that have no drop glue, i.e. that neither implement `Drop`
+    /// nor contain any field that does.
+    ///
+    /// ### Why is this bad?
+    /// Adding `Drop` later is a breaking change because it alters the lifetime rules
+    /// applying to values of a type.  This also happens automatically if any
+    /// type this type contains begins to implement `Drop` (due to "drop glue"). This
+    /// makes it very challenging to keep an internal type private, or keep a type
+    /// from a dependency private.
+    ///
+    /// Note that excessive `impl Drop` comes with costs (stricter move/borrow rules,
+    /// slightly worse codegen, removal of partial moves, etc.)
+    ///
+    /// ### Known problems
+    /// - Does not work for generic types.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # struct PrivateType;
+    /// pub struct PublicType(PrivateType);
+    /// ```
+    /// This is bad because `PrivateType` might gain drop glue in the future (for example by
+    /// implementing `Drop`), which would be a breaking change on `PublicType`.  Note that if
+    /// `PublicType` *already* has drop glue, this lint will not fire.
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// # struct PrivateType;
+    /// pub struct PublicType(PrivateType);
+    ///
+    /// impl Drop for PublicType {
+    ///     fn drop(&mut self) {}
+    /// }
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub PUBLIC_TYPES_MISSING_DROP,
+    nursery,
+    "detects exported types that have no drop glue"
+}
+
+declare_lint_pass!(PublicTypesMissingDrop => [PUBLIC_TYPES_MISSING_DROP]);
+
+impl<'tcx> LateLintPass<'tcx> for PublicTypesMissingDrop {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &Item<'tcx>) {
+        if !cx.effective_visibilities.is_exported(item.owner_id.def_id) {
+            return;
+        }
+
+        let (ItemKind::Struct(..) | ItemKind::Enum(..) | ItemKind::Union(..)) = item.kind else {
+            return;
+        };
+
+        let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip();
+
+        if !ty.needs_drop(cx.tcx, cx.typing_env()) && !is_copy(cx, ty) {
+            span_lint_and_help(
+                cx,
+                PUBLIC_TYPES_MISSING_DROP,
+                item.span,
+                "this exported type has no drop glue",
+                None,
+                "add an empty `Drop` implementation so that gaining drop glue later is not a breaking change",
+            );
+        }
+    }
+}

--- a/tests/ui/public_types_missing_drop.rs
+++ b/tests/ui/public_types_missing_drop.rs
@@ -1,0 +1,50 @@
+#![warn(clippy::public_types_missing_drop)]
+
+struct PrivateType;
+
+// No drop glue anywhere: adding `Drop` later would be a breaking change -> lint fires.
+pub struct PublicType(PrivateType);
+//~^ public_types_missing_drop
+
+// Has drop glue via a field (`String`): a future `Drop` impl changes nothing observable
+// about its drop semantics -> no lint. This is the case `needs_drop` catches but the old
+// `has_drop` (explicit-impl-only) check would have wrongly flagged.
+pub struct HasDropGlueField(String);
+
+// Explicit `Drop` impl -> already has drop glue -> no lint.
+pub struct HasExplicitDrop(PrivateType);
+
+impl Drop for HasExplicitDrop {
+    fn drop(&mut self) {}
+}
+
+// Enums follow the same rule.
+pub enum PublicEnumNoGlue {
+    //~^ public_types_missing_drop
+    A,
+    B(u32),
+}
+
+pub enum PublicEnumWithGlue {
+    A,
+    B(String),
+}
+
+// `Copy` types cannot implement `Drop` (E0184), so the suggested fix would not compile, and
+// they can never gain drop glue -> no lint, even though they have none currently.
+#[derive(Clone, Copy)]
+pub struct CopyStruct {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Clone, Copy)]
+pub enum CopyEnum {
+    A,
+    B,
+}
+
+// Not exported -> never linted, regardless of drop glue.
+struct PrivateNoGlue(PrivateType);
+
+fn main() {}

--- a/tests/ui/public_types_missing_drop.stderr
+++ b/tests/ui/public_types_missing_drop.stderr
@@ -1,0 +1,24 @@
+error: this exported type has no drop glue
+  --> tests/ui/public_types_missing_drop.rs:6:1
+   |
+LL | pub struct PublicType(PrivateType);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add an empty `Drop` implementation so that gaining drop glue later is not a breaking change
+   = note: `-D clippy::public-types-missing-drop` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::public_types_missing_drop)]`
+
+error: this exported type has no drop glue
+  --> tests/ui/public_types_missing_drop.rs:22:1
+   |
+LL | / pub enum PublicEnumNoGlue {
+LL | |
+LL | |     A,
+LL | |     B(u32),
+LL | | }
+   | |_^
+   |
+   = help: add an empty `Drop` implementation so that gaining drop glue later is not a breaking change
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This is a new lint, for discussion, that aims to assist in making stable public APIs.

For background on the issue being addressed, see:

* https://github.com/obi1kenobi/cargo-semver-checks/issues/930
* https://github.com/rust-lang/cargo/issues/15471
* https://github.com/rustls/rustls/issues/2446 (this is my motivation, and I use this lint in rustls CI if accepted)

But, as a short motivational example, it is desirable to lint on this code in a stable public API:

```rust
pub struct PublicType(private_dependency::PrivateType);
```

This is because adding "drop glue" is a breaking change, and in this case whether your "PublicType" has drop glue depends entirely on `private_dependency::PrivateType`.  That means you can no longer insulate your stable public API against version changes in a private dependency (which adds drop glue to a type you hoped to keep private).

This is a new lint, my first contribution to clippy, so I have put this in `nursery` for now. In the fullness of time it probably belongs in `restriction`; happy to take guidance on that.

```
changelog: [`public_types_missing_drop`]: new lint
```