### PR TITLE
Do not trigger `manual_option_zip` when map receiver is a lazy evaluated expression

### DIFF
--- a/clippy_lints/src/methods/manual_option_zip.rs
+++ b/clippy_lints/src/methods/manual_option_zip.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::eager_or_lazy::switch_to_eager_eval;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::peel_blocks;
 use clippy_utils::res::{MaybeDef, MaybeResPath};
@@ -29,6 +30,8 @@ pub(super) fn check<'tcx>(
         && let ExprKind::MethodCall(method_path, map_recv, [map_arg], _) = peel_blocks(outer_value).kind
         && method_path.ident.name == sym::map
         && cx.typeck_results().expr_ty(map_recv).is_diag_item(cx, sym::Option)
+        // `b` is not lazy evaluated
+        && switch_to_eager_eval(cx, map_recv)
         // `b` does not reference the outer closure parameter `a`.
         && !local_used_in(cx, outer_param_id, map_recv)
         // `|b| (a, b)`

--- a/tests/ui/manual_option_zip.fixed
+++ b/tests/ui/manual_option_zip.fixed
@@ -21,11 +21,6 @@ fn should_lint() {
     let _ = None::<i32>.zip(b);
     //~^ manual_option_zip
 
-    // with function call as map receiver
-    let a: Option<i32> = Some(1);
-    let _ = a.zip(get_option());
-    //~^ manual_option_zip
-
     // tuple order reversed: (inner, outer) instead of (outer, inner)
     let a: Option<i32> = Some(1);
     let b: Option<i32> = Some(2);
@@ -122,4 +117,27 @@ fn issue16968() {
 
     let opts = [1, 2];
     let _ = a.and_then(|a| opts.into_iter().find(|b| *b == a).map(|b| (a, b)));
+}
+
+fn issue17253() {
+    // don't trigger the lint if map receiver is a lazy evaluated expression
+    // because `a.zip(b_func())` requires eager evaluation of the argument,
+    // preventing the otherwise conditional execution of `b_func()`
+
+    use std::hint::black_box;
+    let a: Option<i32> = Some(1);
+
+    // conditional function call
+    let _ = a.and_then(|a| black_box(get_option()).map(|b| (a, b)));
+
+    let mut b = 2;
+
+    // conditional side effects
+    let _ = a.and_then(|a| {
+        {
+            b /= 2;
+            Some(b)
+        }
+        .map(|b| (a, b))
+    });
 }

--- a/tests/ui/manual_option_zip.rs
+++ b/tests/ui/manual_option_zip.rs
@@ -21,11 +21,6 @@ fn should_lint() {
     let _ = None::<i32>.and_then(|a| b.map(|b| (a, b)));
     //~^ manual_option_zip
 
-    // with function call as map receiver
-    let a: Option<i32> = Some(1);
-    let _ = a.and_then(|a| get_option().map(|b| (a, b)));
-    //~^ manual_option_zip
-
     // tuple order reversed: (inner, outer) instead of (outer, inner)
     let a: Option<i32> = Some(1);
     let b: Option<i32> = Some(2);
@@ -122,4 +117,27 @@ fn issue16968() {
 
     let opts = [1, 2];
     let _ = a.and_then(|a| opts.into_iter().find(|b| *b == a).map(|b| (a, b)));
+}
+
+fn issue17253() {
+    // don't trigger the lint if map receiver is a lazy evaluated expression
+    // because `a.zip(b_func())` requires eager evaluation of the argument,
+    // preventing the otherwise conditional execution of `b_func()`
+
+    use std::hint::black_box;
+    let a: Option<i32> = Some(1);
+
+    // conditional function call
+    let _ = a.and_then(|a| black_box(get_option()).map(|b| (a, b)));
+
+    let mut b = 2;
+
+    // conditional side effects
+    let _ = a.and_then(|a| {
+        {
+            b /= 2;
+            Some(b)
+        }
+        .map(|b| (a, b))
+    });
 }

--- a/tests/ui/manual_option_zip.stderr
+++ b/tests/ui/manual_option_zip.stderr
@@ -20,34 +20,28 @@ LL |     let _ = None::<i32>.and_then(|a| b.map(|b| (a, b)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `None::<i32>.zip(b)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:26:13
-   |
-LL |     let _ = a.and_then(|a| get_option().map(|b| (a, b)));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(get_option())`
-
-error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:32:13
+  --> tests/ui/manual_option_zip.rs:27:13
    |
 LL |     let _ = a.and_then(|a| b.map(|b| (b, a)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.zip(a)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:39:13
+  --> tests/ui/manual_option_zip.rs:34:13
    |
 LL |     let _ = a.and_then(|a| { b.map(|b| (a, b)) });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(b)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:42:13
+  --> tests/ui/manual_option_zip.rs:37:13
    |
 LL |     let _ = a.and_then(|a| b.map(|b| { (a, b) }));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(b)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:45:13
+  --> tests/ui/manual_option_zip.rs:40:13
    |
 LL |     let _ = a.and_then(|a| { b.map(|b| { (a, b) }) });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(b)`
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
`Option::zip` eagerly evaluates both the receiver and parameter expressions, always evaluating the argument and preventing its conditional execution, otherwise possible in the original `and_then` + `map` pattern. hence `manual_option_zip` shouldn't be triggered for such cases

changelog: fix [`manual_option_zip`] false positive: don't trigger when the map receiver is a lazy evaluated expression

fixes rust-lang/rust-clippy#17253 