### PR TITLE
perf: skip match_same_arms work when the lint is allowed

### DIFF
--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -27,7 +27,9 @@ mod wild_in_or_pats;
 use clippy_config::Conf;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::SpanExt;
-use clippy_utils::{higher, is_direct_expn_of, is_in_const_context, is_span_match, sym, tokenize_with_text};
+use clippy_utils::{
+    higher, is_direct_expn_of, is_in_const_context, is_lint_allowed, is_span_match, sym, tokenize_with_text,
+};
 use rustc_hir::{Arm, Expr, ExprKind, LetStmt, MatchSource, Pat, PatKind};
 use rustc_lexer::{TokenKind, is_whitespace};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
@@ -1107,9 +1109,9 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                 && !has_cfg
             {
                 if source == MatchSource::Normal {
-                    if !(self.msrv.meets(cx, msrvs::MATCHES_MACRO)
-                        && match_like_matches::check_match(cx, expr, ex, arms))
-                    {
+                    let is_match_like_matches = self.msrv.meets(cx, msrvs::MATCHES_MACRO)
+                        && match_like_matches::check_match(cx, expr, ex, arms);
+                    if !(is_match_like_matches || is_lint_allowed(cx, MATCH_SAME_ARMS, expr.hir_id)) {
                         match_same_arms::check(cx, arms);
                     }
 


### PR DESCRIPTION
match_same_arms is a pedantic lint, but its quadratic pattern normalization and the SpanlessHash/SpanlessEq pass over all arm bodies ran for every match expression even when the lint is allowed, which is the default

| crate | instructions base | instructions new | delta |
|---|---|---|---|
| wasmi-0.35.0 | 16,146,242,927 | 16,083,618,068 | -0.39% |
| cargo-0.80.0 (lib) | 29,891,395,463 | 29,881,459,446 | -0.03% |
| serde-1.0.204 | 7,203,480,275 | 7,203,425,315 | -0.00% |
| ryu-1.0.18 (control) | 271,014,525 | 270,987,177 | -0.01% |

changelog: none
