### PR TITLE
perf: bail out of unicode lint scans when the snippet is pure ASCII

### DIFF
--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -108,6 +108,12 @@ fn check_str(cx: &LateContext<'_>, span: Span, id: HirId) {
     }
 
     let string = snippet(cx, span, "");
+    // All three lints here can only fire when the snippet contains a non-ASCII character. Note
+    // that the snippet can contain non-ASCII characters even when the literal's value does not,
+    // e.g. the literal produced by `file!()` inside a macro spans the whole macro invocation.
+    if string.is_ascii() {
+        return;
+    }
     let is_raw = string.starts_with('r');
 
     if string.chars().any(|c| ['\u{200B}', '\u{ad}', '\u{2060}'].contains(&c)) {

--- a/tests/ui/unicode.fixed
+++ b/tests/ui/unicode.fixed
@@ -60,4 +60,39 @@ mod non_ascii_literal {
     }
 }
 
+mod ascii_macro_with_non_ascii_value {
+    // The source is pure ASCII, but the value contains non-ASCII, invisible, and
+    // non-NFC characters. The lints check the source snippet, not the value, so
+    // none of them may fire here.
+    #![deny(clippy::invisible_characters, clippy::non_ascii_literal, clippy::unicode_not_nfc)]
+
+    macro_rules! non_ascii_value {
+        () => {
+            "\u{00E9}\u{200B}a\u{0300}"
+        };
+    }
+
+    fn no_lint() {
+        let _ = non_ascii_value!();
+    }
+}
+
+mod ascii_value_from_non_ascii_snippet {
+    // The reverse: `file!()` produces an ASCII value (the file path), but the
+    // literal's span covers the whole macro invocation, so the snippet is
+    // non-ASCII and the lint must fire. Checking the value would miss it.
+    #![deny(clippy::non_ascii_literal)]
+
+    macro_rules! with_location {
+        ($($arg:tt)*) => {
+            let _ = file!();
+        };
+    }
+
+    fn lint() {
+        with_location!("h\u{e9}llo");
+        //~^ non_ascii_literal
+    }
+}
+
 fn main() {}

--- a/tests/ui/unicode.rs
+++ b/tests/ui/unicode.rs
@@ -60,4 +60,39 @@ mod non_ascii_literal {
     }
 }
 
+mod ascii_macro_with_non_ascii_value {
+    // The source is pure ASCII, but the value contains non-ASCII, invisible, and
+    // non-NFC characters. The lints check the source snippet, not the value, so
+    // none of them may fire here.
+    #![deny(clippy::invisible_characters, clippy::non_ascii_literal, clippy::unicode_not_nfc)]
+
+    macro_rules! non_ascii_value {
+        () => {
+            "\u{00E9}\u{200B}a\u{0300}"
+        };
+    }
+
+    fn no_lint() {
+        let _ = non_ascii_value!();
+    }
+}
+
+mod ascii_value_from_non_ascii_snippet {
+    // The reverse: `file!()` produces an ASCII value (the file path), but the
+    // literal's span covers the whole macro invocation, so the snippet is
+    // non-ASCII and the lint must fire. Checking the value would miss it.
+    #![deny(clippy::non_ascii_literal)]
+
+    macro_rules! with_location {
+        ($($arg:tt)*) => {
+            let _ = file!();
+        };
+    }
+
+    fn lint() {
+        with_location!("héllo");
+        //~^ non_ascii_literal
+    }
+}
+
 fn main() {}

--- a/tests/ui/unicode.stderr
+++ b/tests/ui/unicode.stderr
@@ -64,5 +64,17 @@ note: the lint level is defined here
 LL |         #![deny(clippy::non_ascii_literal)]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: literal non-ASCII character detected
+  --> tests/ui/unicode.rs:93:9
+   |
+LL |         with_location!("héllo");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ help: consider replacing the string with: `with_location!("h\u{e9}llo")`
+   |
+note: the lint level is defined here
+  --> tests/ui/unicode.rs:84:13
+   |
+LL |     #![deny(clippy::non_ascii_literal)]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
The Unicode pass ran three per-character scans and two NFC normalizations for every string and char literal. All three lints can only fire when the source snippet contains a non-ASCII character, so bail out early with a vectorized `is_ascii` check on the snippet.

| crate | instructions base | instructions new | delta |
|---|---|---|---|
| ripgrep-14.1.0 | 1,906,999,867 | 1,887,953,975 | -1.00% |
| regex-1.10.5 | 955,616,270 | 955,487,288 | -0.01% |
| serde-1.0.204 | 7,034,722,908 | 7,033,028,960 | -0.02% |
| ryu-1.0.18 | 260,641,521 | 260,533,447 | -0.04% |

changelog: none
