### PR TITLE
Add `blanket_allow_warnings` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6652,6 +6652,7 @@ Released 2018-09-13
 [`big_endian_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#big_endian_bytes
 [`bind_instead_of_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#bind_instead_of_map
 [`blacklisted_name`]: https://rust-lang.github.io/rust-clippy/master/index.html#blacklisted_name
+[`blanket_allow_warnings`]: https://rust-lang.github.io/rust-clippy/master/index.html#blanket_allow_warnings
 [`blanket_clippy_restriction_lints`]: https://rust-lang.github.io/rust-clippy/master/index.html#blanket_clippy_restriction_lints
 [`block_in_if_condition_expr`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_in_if_condition_expr
 [`block_in_if_condition_stmt`]: https://rust-lang.github.io/rust-clippy/master/index.html#block_in_if_condition_stmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6766,6 +6766,7 @@ Released 2018-09-13
 [`big_endian_bytes`]: https://rust-lang.github.io/rust-clippy/main/index.html#big_endian_bytes
 [`bind_instead_of_map`]: https://rust-lang.github.io/rust-clippy/main/index.html#bind_instead_of_map
 [`blacklisted_name`]: https://rust-lang.github.io/rust-clippy/main/index.html#blacklisted_name
+[`blanket_allow_warnings`]: https://rust-lang.github.io/rust-clippy/main/index.html#blanket_allow_warnings
 [`blanket_clippy_restriction_lints`]: https://rust-lang.github.io/rust-clippy/main/index.html#blanket_clippy_restriction_lints
 [`block_in_if_condition_expr`]: https://rust-lang.github.io/rust-clippy/main/index.html#block_in_if_condition_expr
 [`block_in_if_condition_stmt`]: https://rust-lang.github.io/rust-clippy/main/index.html#block_in_if_condition_stmt

--- a/clippy_lints/src/attrs/blanket_allow_warnings.rs
+++ b/clippy_lints/src/attrs/blanket_allow_warnings.rs
@@ -1,0 +1,31 @@
+use super::{Attribute, BLANKET_ALLOW_WARNINGS};
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::is_from_proc_macro;
+use rustc_ast::MetaItemInner;
+use rustc_lint::{EarlyContext, LintContext};
+use rustc_span::symbol::Symbol;
+
+pub(super) fn check<'cx>(cx: &EarlyContext<'cx>, name: Symbol, items: &[MetaItemInner], attr: &'cx Attribute) {
+    for lint in items {
+        // Check if the attribute is in an external macro and therefore out of the developer's control
+        // TODO?: (taken from `allow_attributes_without_reason`; should this be an `attrs` util? )
+        if attr.span.in_external_macro(cx.sess().source_map()) || is_from_proc_macro(cx, attr) {
+            return;
+        }
+
+        if let Some(item) = lint.meta_item()
+            && let Some(group) = item.name()
+            && group == Symbol::intern("warnings")
+        {
+            span_lint_and_help(
+                cx,
+                BLANKET_ALLOW_WARNINGS,
+                lint.span(),
+                format!("`warnings` group in `{name}` attribute"),
+                None,
+                format!("`{name}` lints individually or in smaller groups"),
+            );
+        }
+    }
+}

--- a/clippy_lints/src/attrs/blanket_allow_warnings.rs
+++ b/clippy_lints/src/attrs/blanket_allow_warnings.rs
@@ -1,7 +1,7 @@
 use super::{Attribute, BLANKET_ALLOW_WARNINGS};
 
 use clippy_utils::diagnostics::span_lint_and_help;
-use clippy_utils::is_from_proc_macro;
+use clippy_utils::{is_from_proc_macro, sym};
 use rustc_ast::MetaItemInner;
 use rustc_lint::{EarlyContext, LintContext};
 use rustc_span::symbol::Symbol;
@@ -16,7 +16,7 @@ pub(super) fn check<'cx>(cx: &EarlyContext<'cx>, name: Symbol, items: &[MetaItem
 
         if let Some(item) = lint.meta_item()
             && let Some(group) = item.name()
-            && group == Symbol::intern("warnings")
+            && group == sym::warnings
         {
             span_lint_and_help(
                 cx,

--- a/clippy_lints/src/attrs/blanket_allow_warnings.rs
+++ b/clippy_lints/src/attrs/blanket_allow_warnings.rs
@@ -3,7 +3,7 @@ use super::{Attribute, BLANKET_ALLOW_WARNINGS};
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::{is_from_proc_macro, sym};
 use rustc_ast::MetaItemInner;
-use rustc_lint::{EarlyContext, LintContext};
+use rustc_lint::{EarlyContext, LintContext as _};
 use rustc_span::symbol::Symbol;
 
 pub(super) fn check<'cx>(cx: &EarlyContext<'cx>, name: Symbol, items: &[MetaItemInner], attr: &'cx Attribute) {

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -1,5 +1,6 @@
 mod allow_attributes;
 mod allow_attributes_without_reason;
+mod blanket_allow_warnings;
 mod blanket_clippy_restriction_lints;
 mod deprecated_cfg_attr;
 mod deprecated_semver;
@@ -80,6 +81,28 @@ declare_clippy_lint! {
     pub ALLOW_ATTRIBUTES_WITHOUT_REASON,
     restriction,
     "ensures that all `allow` and `expect` attributes have a reason"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `allow`/`expect` attributes targeting the `warnings` group.
+    ///
+    /// ### Why is this bad?
+    /// The `warnings` group includes all current and future warnings.
+    /// This is usually too broad of a category to ignore.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #![allow(warnings)]
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// #![allow(non_snake_case)]
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub BLANKET_ALLOW_WARNINGS,
+    nursery,
+    "`#[allow]` or `#[expect]` with the entire `warnings` groups"
 }
 
 declare_clippy_lint! {
@@ -491,6 +514,7 @@ impl_lint_pass!(EarlyAttributes => [
 impl_lint_pass!(PostExpansionEarlyAttributes => [
     ALLOW_ATTRIBUTES,
     ALLOW_ATTRIBUTES_WITHOUT_REASON,
+    BLANKET_ALLOW_WARNINGS,
     BLANKET_CLIPPY_RESTRICTION_LINTS,
     DEPRECATED_SEMVER,
     DUPLICATED_ATTRIBUTES,
@@ -592,6 +616,7 @@ impl EarlyLintPass for PostExpansionEarlyAttributes {
             }
             if matches!(name, sym::allow | sym::expect) && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
                 allow_attributes_without_reason::check(cx, name, items, attr);
+                blanket_allow_warnings::check(cx, name, items, attr);
             }
             if is_lint_level(name) {
                 blanket_clippy_restriction_lints::check(cx, name, items);

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -614,8 +614,10 @@ impl EarlyLintPass for PostExpansionEarlyAttributes {
             if matches!(name, sym::allow) && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
                 allow_attributes::check(cx, attr);
             }
-            if matches!(name, sym::allow | sym::expect) && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
-                allow_attributes_without_reason::check(cx, name, items, attr);
+            if matches!(name, sym::allow | sym::expect) {
+                if self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
+                    allow_attributes_without_reason::check(cx, name, items, attr);
+                }
                 blanket_allow_warnings::check(cx, name, items, attr);
             }
             if is_lint_level(name) {

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -610,8 +610,10 @@ impl EarlyLintPass for PostExpansionEarlyAttributes {
             if matches!(name, sym::allow) && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
                 allow_attributes::check(cx, attr);
             }
-            if matches!(name, sym::allow | sym::expect) && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
-                allow_attributes_without_reason::check(cx, name, items, attr);
+            if matches!(name, sym::allow | sym::expect) {
+                if self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
+                    allow_attributes_without_reason::check(cx, name, items, attr);
+                }
                 blanket_allow_warnings::check(cx, name, items, attr);
             }
             if is_lint_level(name) {

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -1,5 +1,6 @@
 mod allow_attributes;
 mod allow_attributes_without_reason;
+mod blanket_allow_warnings;
 mod blanket_clippy_restriction_lints;
 mod deprecated_cfg_attr;
 mod deprecated_semver;
@@ -80,6 +81,28 @@ declare_clippy_lint! {
     pub ALLOW_ATTRIBUTES_WITHOUT_REASON,
     restriction,
     "ensures that all `allow` and `expect` attributes have a reason"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `allow`/`expect` attributes targeting the `warnings` group.
+    ///
+    /// ### Why is this bad?
+    /// The `warnings` group includes all current and future warnings.
+    /// This is usually too broad of a category to ignore.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #![allow(warnings)]
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// #![allow(non_snake_case)]
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub BLANKET_ALLOW_WARNINGS,
+    nursery,
+    "`#[allow]` or `#[expect]` with the entire `warnings` groups"
 }
 
 declare_clippy_lint! {
@@ -491,6 +514,7 @@ impl_lint_pass!(EarlyAttributes => [
 impl_lint_pass!(PostExpansionEarlyAttributes => [
     ALLOW_ATTRIBUTES,
     ALLOW_ATTRIBUTES_WITHOUT_REASON,
+    BLANKET_ALLOW_WARNINGS,
     BLANKET_CLIPPY_RESTRICTION_LINTS,
     DEPRECATED_SEMVER,
     DUPLICATED_ATTRIBUTES,
@@ -588,6 +612,7 @@ impl EarlyLintPass for PostExpansionEarlyAttributes {
             }
             if matches!(name, sym::allow | sym::expect) && self.msrv.meets(msrvs::LINT_REASONS_STABILIZATION) {
                 allow_attributes_without_reason::check(cx, name, items, attr);
+                blanket_allow_warnings::check(cx, name, items, attr);
             }
             if is_lint_level(name) {
                 blanket_clippy_restriction_lints::check(cx, name, items);

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -17,6 +17,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::async_yields_async::ASYNC_YIELDS_ASYNC_INFO,
     crate::attrs::ALLOW_ATTRIBUTES_INFO,
     crate::attrs::ALLOW_ATTRIBUTES_WITHOUT_REASON_INFO,
+    crate::attrs::BLANKET_ALLOW_WARNINGS_INFO,
     crate::attrs::BLANKET_CLIPPY_RESTRICTION_LINTS_INFO,
     crate::attrs::DEPRECATED_CFG_ATTR_INFO,
     crate::attrs::DEPRECATED_CLIPPY_CFG_ATTR_INFO,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -18,6 +18,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::async_yields_async::ASYNC_YIELDS_ASYNC_INFO,
     crate::attrs::ALLOW_ATTRIBUTES_INFO,
     crate::attrs::ALLOW_ATTRIBUTES_WITHOUT_REASON_INFO,
+    crate::attrs::BLANKET_ALLOW_WARNINGS_INFO,
     crate::attrs::BLANKET_CLIPPY_RESTRICTION_LINTS_INFO,
     crate::attrs::DEPRECATED_CFG_ATTR_INFO,
     crate::attrs::DEPRECATED_CLIPPY_CFG_ATTR_INFO,

--- a/tests/lint-attributes-organization.rs
+++ b/tests/lint-attributes-organization.rs
@@ -22,8 +22,9 @@ use walkdir::{DirEntry, WalkDir};
 
 mod test_utils;
 
-const SKIPPED_FILES: [&str; 7] = [
+const SKIPPED_FILES: [&str; 8] = [
     "./tests/lint-attributes-organization.rs", // this file, for the sanity checks
+    "./tests/ui/blanket_allow_warnings.rs",    // separate lines are better
     "./tests/ui/blanket_clippy_restriction_lints.rs", // separate lines are better
     "./tests/ui/deprecated.rs",                // generated
     "./tests/ui/duplicated_attributes.rs",     // obviously

--- a/tests/ui/blanket_allow_warnings.rs
+++ b/tests/ui/blanket_allow_warnings.rs
@@ -1,0 +1,41 @@
+// HACK?: `deny` instead of `warn`
+#![deny(clippy::blanket_allow_warnings)]
+#![allow(warnings)]
+//~^ blanket_allow_warnings
+#![expect(warnings)]
+//~^ blanket_allow_warnings
+#![allow(
+    innocuous,
+    warnings,
+//~^ blanket_allow_warnings
+    alright
+)]
+#![expect(
+    acceptable,
+    reasonable,
+    warnings
+//~^ blanket_allow_warnings
+)]
+#![allow(warnings, reason = "shrug")]
+//~^ blanket_allow_warnings
+#![expect(warnings, reason = "shrug")]
+//~^ blanket_allow_warnings
+
+#[allow(warnings)]
+//~^ blanket_allow_warnings
+fn on_item(x: u32) {}
+
+fn ok() {
+    #![deny(warnings)]
+    #![forbid(warnings)]
+}
+
+fn specific() {
+    #[allow(unused)]
+    let x = 43;
+}
+
+#[recursion_limit = "4"]
+fn other_attr() {}
+
+fn main() {}

--- a/tests/ui/blanket_allow_warnings.stderr
+++ b/tests/ui/blanket_allow_warnings.stderr
@@ -1,0 +1,63 @@
+error: `warnings` group in `allow` attribute
+  --> tests/ui/blanket_allow_warnings.rs:3:10
+   |
+LL | #![allow(warnings)]
+   |          ^^^^^^^^
+   |
+   = help: `allow` lints individually or in smaller groups
+note: the lint level is defined here
+  --> tests/ui/blanket_allow_warnings.rs:2:9
+   |
+LL | #![deny(clippy::blanket_allow_warnings)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `warnings` group in `expect` attribute
+  --> tests/ui/blanket_allow_warnings.rs:5:11
+   |
+LL | #![expect(warnings)]
+   |           ^^^^^^^^
+   |
+   = help: `expect` lints individually or in smaller groups
+
+error: `warnings` group in `allow` attribute
+  --> tests/ui/blanket_allow_warnings.rs:9:5
+   |
+LL |     warnings,
+   |     ^^^^^^^^
+   |
+   = help: `allow` lints individually or in smaller groups
+
+error: `warnings` group in `expect` attribute
+  --> tests/ui/blanket_allow_warnings.rs:16:5
+   |
+LL |     warnings
+   |     ^^^^^^^^
+   |
+   = help: `expect` lints individually or in smaller groups
+
+error: `warnings` group in `allow` attribute
+  --> tests/ui/blanket_allow_warnings.rs:19:10
+   |
+LL | #![allow(warnings, reason = "shrug")]
+   |          ^^^^^^^^
+   |
+   = help: `allow` lints individually or in smaller groups
+
+error: `warnings` group in `expect` attribute
+  --> tests/ui/blanket_allow_warnings.rs:21:11
+   |
+LL | #![expect(warnings, reason = "shrug")]
+   |           ^^^^^^^^
+   |
+   = help: `expect` lints individually or in smaller groups
+
+error: `warnings` group in `allow` attribute
+  --> tests/ui/blanket_allow_warnings.rs:24:9
+   |
+LL | #[allow(warnings)]
+   |         ^^^^^^^^
+   |
+   = help: `allow` lints individually or in smaller groups
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
Based on rust-lang/rust-clippy#1648, this lint checks for `allow` or `expect` attributes with the `warnings` group; for example, `#![allow(warnings)]` instead of `#![allow(non_snake_case)]`.
This is generally suspicious (though perhaps not the literal category), especially if you're using clippy. The use of "blanket" comes from [`blanket_clippy_restriction_lints`](https://rust-lang.github.io/rust-clippy/master/?search=blanket#blanket_clippy_restriction_lints).

Some questions about this lint that I don't know the answers to:
- Is this even something we want?
- What's the right name for this?
- What category is this?
- Should this be extended to check for `#[allow(clippy)]`?
- Would a customizable `allow`/`except` denylist be better?
- How do we issue an "unsilenceable" warning instead of an error?

Also the error messages, documentation, and testing could be better.

---

changelog: [`blanket_allow_warnings`]: new lint