### PR TITLE
perf: run structural checks before const context queries in question_mark, manual_clamp and ranges

### DIFF
--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -140,7 +140,13 @@ struct InputMinMax<'tcx> {
 
 impl<'tcx> LateLintPass<'tcx> for ManualClamp {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        if !expr.span.from_expansion() && !is_in_const_context(cx) {
+        // Cheap kind check before the costlier const context query.
+        if matches!(
+            expr.kind,
+            ExprKind::If(..) | ExprKind::Match(..) | ExprKind::MethodCall(..) | ExprKind::Call(..)
+        ) && !expr.span.from_expansion()
+            && !is_in_const_context(cx)
+        {
             let suggestion = is_if_elseif_else_pattern(cx, expr)
                 .or_else(|| is_max_min_pattern(cx, expr))
                 .or_else(|| is_call_max_min_pattern(cx, expr))
@@ -155,6 +161,15 @@ impl<'tcx> LateLintPass<'tcx> for ManualClamp {
     }
 
     fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        // Cheap `if`-statement check before the costlier const context query.
+        if !block
+            .stmts
+            .iter()
+            .any(|stmt| matches!(stmt.kind, StmtKind::Expr(e) if matches!(e.kind, ExprKind::If(..))))
+        {
+            return;
+        }
+
         if is_in_const_context(cx) || !self.msrv.meets(cx, msrvs::CLAMP) {
             return;
         }
@@ -293,18 +308,19 @@ fn is_if_elseif_else_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx
 /// ```
 fn is_max_min_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> Option<ClampSuggestion<'tcx>> {
     if let ExprKind::MethodCall(seg_second, receiver, [arg_second], _) = expr.kind
+        && let ExprKind::MethodCall(seg_first, input, [arg_first], _) = &receiver.kind
+        // Match method names before the costlier type queries.
+        && let Some((min, max)) = match (seg_first.ident.name, seg_second.ident.name) {
+            (sym::min, sym::max) => Some((arg_second, arg_first)),
+            (sym::max, sym::min) => Some((arg_first, arg_second)),
+            _ => None,
+        }
         && (cx.typeck_results().expr_ty_adjusted(receiver).is_floating_point()
             || cx.ty_based_def(expr).assoc_fn_parent(cx).is_diag_item(cx, sym::Ord))
-        && let ExprKind::MethodCall(seg_first, input, [arg_first], _) = &receiver.kind
         && (cx.typeck_results().expr_ty_adjusted(input).is_floating_point()
             || cx.ty_based_def(receiver).assoc_fn_parent(cx).is_diag_item(cx, sym::Ord))
     {
         let is_float = cx.typeck_results().expr_ty_adjusted(input).is_floating_point();
-        let (min, max) = match (seg_first.ident.name, seg_second.ident.name) {
-            (sym::min, sym::max) => (arg_second, arg_first),
-            (sym::max, sym::min) => (arg_first, arg_second),
-            _ => return None,
-        };
         Some(ClampSuggestion {
             params: InputMinMax {
                 input,

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -629,6 +629,11 @@ fn is_inferred_ret_closure(expr: &Expr<'_>) -> bool {
 
 impl<'tcx> LateLintPass<'tcx> for QuestionMark {
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
+        // Cheap `let` check before the costlier lint level and const context queries.
+        if !matches!(stmt.kind, StmtKind::Let(..)) {
+            return;
+        }
+
         if !is_lint_allowed(cx, QUESTION_MARK_USED, stmt.hir_id) || !self.msrv.meets(cx, msrvs::QUESTION_MARK_OPERATOR)
         {
             return;
@@ -646,7 +651,9 @@ impl<'tcx> LateLintPass<'tcx> for QuestionMark {
             return;
         }
 
-        if !self.inside_try_block()
+        // Cheap `if`/`match` check before the costlier lint level and const context queries.
+        if matches!(expr.kind, ExprKind::If(..) | ExprKind::Match(..))
+            && !self.inside_try_block()
             && !is_in_const_context(cx)
             && is_lint_allowed(cx, QUESTION_MARK_USED, expr.hir_id)
             && self.msrv.meets(cx, msrvs::QUESTION_MARK_OPERATOR)

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -191,14 +191,21 @@ impl Ranges {
 impl<'tcx> LateLintPass<'tcx> for Ranges {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if let ExprKind::Binary(ref op, l, r) = expr.kind
+            && matches!(
+                op.node,
+                BinOpKind::And | BinOpKind::BitAnd | BinOpKind::Or | BinOpKind::BitOr
+            )
             && self.msrv.meets(cx, msrvs::RANGE_CONTAINS)
+            && !is_in_const_context(cx)
         {
             check_possible_range_contains(cx, op.node, l, r, expr, expr.span);
         }
 
-        check_exclusive_range_plus_one(cx, expr);
-        check_inclusive_range_minus_one(cx, expr);
-        check_reversed_empty_range(cx, expr);
+        if let Some(range) = higher::Range::hir(cx, expr) {
+            check_exclusive_range_plus_one(cx, expr, &range);
+            check_inclusive_range_minus_one(cx, expr, &range);
+            check_reversed_empty_range(cx, expr, &range);
+        }
     }
 }
 
@@ -210,10 +217,6 @@ fn check_possible_range_contains(
     expr: &Expr<'_>,
     span: Span,
 ) {
-    if is_in_const_context(cx) {
-        return;
-    }
-
     let combine_and = match op {
         BinOpKind::And | BinOpKind::BitAnd => true,
         BinOpKind::Or | BinOpKind::BitOr => false,
@@ -481,54 +484,58 @@ fn can_switch_ranges<'tcx>(
 }
 
 // exclusive range plus one: `x..(y+1)`
-fn check_exclusive_range_plus_one<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+fn check_exclusive_range_plus_one<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, range: &higher::Range<'tcx>) {
     check_range_switch(
         cx,
         expr,
+        range,
         RangeLimits::HalfOpen,
         y_plus_one,
         RANGE_PLUS_ONE,
         "an inclusive range would be more readable",
-        "..=",
     );
 }
 
 // inclusive range minus one: `x..=(y-1)`
-fn check_inclusive_range_minus_one<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+fn check_inclusive_range_minus_one<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, range: &higher::Range<'tcx>) {
     check_range_switch(
         cx,
         expr,
+        range,
         RangeLimits::Closed,
         y_minus_one,
         RANGE_MINUS_ONE,
         "an exclusive range would be more readable",
-        "..",
     );
 }
 
 /// Check for a `kind` of range in `expr`, check for `predicate` on the end,
-/// and emit the `lint` with `msg` and the `operator`.
+/// and emit the `lint` with `msg`, suggesting the opposite range limits.
 fn check_range_switch<'tcx>(
     cx: &LateContext<'tcx>,
     expr: &'tcx Expr<'_>,
+    range: &higher::Range<'tcx>,
     kind: RangeLimits,
     predicate: impl for<'hir> FnOnce(&Expr<'hir>) -> Option<&'hir Expr<'hir>>,
     lint: &'static Lint,
     msg: &'static str,
-    operator: &str,
 ) {
-    if let Some(range) = higher::Range::hir(cx, expr)
-        && let higher::Range {
-            start,
-            end: Some(end),
-            limits,
-            span,
-        } = range
+    if let higher::Range {
+        start,
+        end: Some(end),
+        limits,
+        span,
+    } = *range
         && span.can_be_used_for_suggestions()
         && limits == kind
         && let Some(y) = predicate(end)
         && can_switch_ranges(cx, span.ctxt(), expr, kind, cx.typeck_results().expr_ty(y))
     {
+        // Suggest the opposite range limits to the ones being checked.
+        let operator = match kind {
+            RangeLimits::HalfOpen => "..=",
+            RangeLimits::Closed => "..",
+        };
         span_lint_and_then(cx, lint, span, msg, |diag| {
             let mut app = Applicability::MachineApplicable;
             let start = start.map_or(String::new(), |x| {
@@ -550,7 +557,7 @@ fn check_range_switch<'tcx>(
     }
 }
 
-fn check_reversed_empty_range(cx: &LateContext<'_>, expr: &Expr<'_>) {
+fn check_reversed_empty_range(cx: &LateContext<'_>, expr: &Expr<'_>, range: &higher::Range<'_>) {
     fn inside_indexing_expr(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
         matches!(
             get_parent_expr(cx, expr),
@@ -580,12 +587,12 @@ fn check_reversed_empty_range(cx: &LateContext<'_>, expr: &Expr<'_>) {
         }
     }
 
-    if let Some(higher::Range {
+    if let higher::Range {
         start: Some(start),
         end: Some(end),
         limits,
         span,
-    }) = higher::Range::hir(cx, expr)
+    } = *range
         && let ty = cx.typeck_results().expr_ty(start)
         && let ty::Int(_) | ty::Uint(_) = ty.kind()
         && let ecx = ConstEvalCtxt::new(cx)


### PR DESCRIPTION
Gate the const context, lint level and MSRV queries in the `question_mark`, `manual_clamp` and `ranges` passes behind a cheap expression/statement kind check, match method names before the type queries in `is_max_min_pattern`, and parse each range expression once instead of up to three times.

| crate | instructions base | instructions new | delta |
|---|---|---|---|
| serde-1.0.204 | 7,203,361,007 | 7,134,072,760 | -0.96% |
| syn-2.0.71 | 3,397,540,719 | 3,354,632,677 | -1.26% |
| cargo-0.80.0 (lib) | 29,891,566,078 | 29,339,576,071 | -1.85% |
| ryu-1.0.18 | 271,040,916 | 265,667,969 | -1.98% |

changelog: none
