### PR TITLE
Add clarifying note for `as_ptr` suggestion in `manual_c_str_literals

### DIFF
--- a/clippy_lints/src/methods/manual_c_str_literals.rs
+++ b/clippy_lints/src/methods/manual_c_str_literals.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::snippet;
 use clippy_utils::{get_parent_expr, sym};
@@ -34,16 +34,25 @@ pub(super) fn check_as_ptr<'tcx>(
         && let Some(sugg) = rewrite_as_cstr(cx, lit.span)
         && msrv.meets(cx, msrvs::C_STR_LITERALS)
     {
-        span_lint_and_sugg(
+        span_lint_and_then(
             cx,
             MANUAL_C_STR_LITERALS,
             receiver.span,
             "manually constructing a nul-terminated string",
-            r#"use a `c""` literal"#,
-            sugg,
-            // an additional cast may be needed, since the type of `CStr::as_ptr` and
-            // `"".as_ptr()` can differ and is platform dependent
-            Applicability::HasPlaceholders,
+            |diag| {
+                diag.span_suggestion(
+                    receiver.span,
+                    r#"use a `c""` literal"#,
+                    sugg,
+                    Applicability::HasPlaceholders,
+                );
+                if casts_removed.hir_id == expr.hir_id {
+                    diag.note(
+                        "an additional cast may be needed, since the type of `c\"\".as_ptr()` \
+                        and `b\"\".as_ptr()` can differ and is platform dependent",
+                    );
+                }
+            },
         );
     }
 }

--- a/tests/ui/manual_c_str_literals.edition2021.stderr
+++ b/tests/ui/manual_c_str_literals.edition2021.stderr
@@ -48,12 +48,16 @@ error: manually constructing a nul-terminated string
    |
 LL |     let _: *const _ = b"foo\0".as_ptr();
    |                       ^^^^^^^^ help: use a `c""` literal: `c"foo"`
+   |
+   = note: an additional cast may be needed, since the type of `c"".as_ptr()` and `b"".as_ptr()` can differ and is platform dependent
 
 error: manually constructing a nul-terminated string
   --> tests/ui/manual_c_str_literals.rs:58:23
    |
 LL |     let _: *const _ = "foo\0".as_ptr();
    |                       ^^^^^^^ help: use a `c""` literal: `c"foo"`
+   |
+   = note: an additional cast may be needed, since the type of `c"".as_ptr()` and `b"".as_ptr()` can differ and is platform dependent
 
 error: manually constructing a nul-terminated string
   --> tests/ui/manual_c_str_literals.rs:62:23
@@ -66,18 +70,24 @@ error: manually constructing a nul-terminated string
    |
 LL |     let _ = "电脑\\\0".as_ptr();
    |             ^^^^^^^^^^ help: use a `c""` literal: `c"电脑\\"`
+   |
+   = note: an additional cast may be needed, since the type of `c"".as_ptr()` and `b"".as_ptr()` can differ and is platform dependent
 
 error: manually constructing a nul-terminated string
   --> tests/ui/manual_c_str_literals.rs:68:13
    |
 LL |     let _ = "电脑\0".as_ptr();
    |             ^^^^^^^^ help: use a `c""` literal: `c"电脑"`
+   |
+   = note: an additional cast may be needed, since the type of `c"".as_ptr()` and `b"".as_ptr()` can differ and is platform dependent
 
 error: manually constructing a nul-terminated string
   --> tests/ui/manual_c_str_literals.rs:70:13
    |
 LL |     let _ = "电脑\x00".as_ptr();
    |             ^^^^^^^^^^ help: use a `c""` literal: `c"电脑"`
+   |
+   = note: an additional cast may be needed, since the type of `c"".as_ptr()` and `b"".as_ptr()` can differ and is platform dependent
 
 error: aborting due to 13 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#15936 

changelog: [`manual_c_str_literals`]: add a clarifying note for `as_ptr` suggestion.