### PR TITLE
Misc fixes to `expr_eagerness`

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -573,6 +573,15 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
         self.expr(e)
     }
 
+    /// Attempts to evaluate the expression and optionally dereference the result.
+    pub fn eval_deref(&self, e: &Expr<'_>, deref: bool) -> Option<Constant> {
+        match (self.eval(e), deref) {
+            (Some(c), false) => Some(c),
+            (Some(Constant::Ref(c)), true) => Some(*c),
+            _ => None,
+        }
+    }
+
     /// Attempts to evaluate the expression without accessing other items.
     ///
     /// The context argument is the context used to view the evaluated expression. e.g. when

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -412,6 +412,13 @@ impl Constant {
             _ => false,
         }
     }
+
+    pub fn to_int(&self, tcx: TyCtxt<'_>, ty: IntTy) -> Option<i128> {
+        match *self {
+            Self::Int(x) => Some(sext(tcx, x, ty)),
+            _ => None,
+        }
+    }
 }
 
 /// Parses a `LitKind` to a `Constant`.

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -13,7 +13,7 @@ use crate::consts::ConstEvalCtxt;
 use crate::sym;
 use crate::ty::all_predicates_of;
 use crate::visitors::is_const_evaluatable;
-use core::ops::ControlFlow::{self, Break};
+use core::ops::ControlFlow::{self, Break, Continue};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{Visitor, walk_expr};
@@ -215,8 +215,13 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     let ty = self.ecx.typeck.expr_ty(e).kind();
                     match op {
                         UnOp::Neg => match *ty {
-                            ty::Int(_) if self.ecx.eval(e).is_none() => self.eagerness |= NoChange,
-                            ty::Int(_) | ty::Float(_) => {},
+                            ty::Int(_) => {
+                                if self.ecx.eval(e).is_some() {
+                                    return Continue(());
+                                }
+                                self.eagerness |= NoChange;
+                            },
+                            ty::Float(_) => {},
                             _ => self.eagerness = Lazy,
                         },
                         UnOp::Deref => match *ty {
@@ -239,32 +244,55 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     let same_ty = lhs_ty == rhs_ty;
                     match op.node {
                         BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
-                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) if self.ecx.eval(rhs).is_none() => {
+                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {
+                                if self.ecx.eval(rhs).is_some() {
+                                    return self.visit_expr(lhs);
+                                }
+                                // Possible over shift or negative shift.
                                 self.eagerness |= NoChange;
                             },
-                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {},
                             _ => self.eagerness = Lazy,
                         },
                         BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
-                            ty::Uint(_) if same_ty && self.ecx.eval(rhs).is_none() => self.eagerness |= NoChange,
-                            ty::Int(ty)
-                                if same_ty
-                                    && self.ecx.eval(rhs).is_none_or(|rhs| {
-                                        rhs.to_int(self.ecx.tcx, ty) == Some(-1) && self.ecx.eval(lhs).is_none()
-                                    }) =>
-                            {
+                            ty::Uint(_) if same_ty => {
+                                if self.ecx.eval(rhs).is_some() {
+                                    return self.visit_expr(lhs);
+                                }
+                                // Possible division-by-zero.
                                 self.eagerness |= NoChange;
                             },
-                            ty::Uint(_) | ty::Int(_) | ty::Float(_) if same_ty => {},
+                            ty::Int(ty) if same_ty => {
+                                if let Some(rhs) = self.ecx.eval(rhs) {
+                                    if rhs.to_int(self.ecx.tcx, ty) == Some(-1) {
+                                        if self.ecx.eval(lhs).is_some() {
+                                            return Continue(());
+                                        }
+                                        // Possible overflow.
+                                        self.eagerness |= NoChange;
+                                    }
+                                    return self.visit_expr(lhs);
+                                }
+                                // Possible division-by-zero.
+                                self.eagerness |= NoChange;
+                            },
+                            ty::Float(_) if same_ty => {},
                             _ => self.eagerness = Lazy,
                         },
                         BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
-                            ty::Int(_) | ty::Uint(_)
-                                if same_ty && (self.ecx.eval(lhs).is_none() || self.ecx.eval(rhs).is_none()) =>
-                            {
+                            ty::Int(_) | ty::Uint(_) if same_ty => {
+                                if self.ecx.eval(lhs).is_some() {
+                                    return if self.ecx.eval(rhs).is_some() {
+                                        Continue(())
+                                    } else {
+                                        // Possible overflow.
+                                        self.eagerness |= NoChange;
+                                        self.visit_expr(rhs)
+                                    };
+                                }
+                                // Possible overflow.
                                 self.eagerness |= NoChange;
                             },
-                            ty::Int(_) | ty::Uint(_) | ty::Float(_) if same_ty => {},
+                            ty::Float(_) if same_ty => {},
                             _ => self.eagerness = Lazy,
                         },
                         BinOpKind::BitAnd

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -213,10 +213,20 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 // caught by rustc's `arithmetic_overflow` or `unconditional_panic` lints.
                 ExprKind::Unary(op, e) => {
                     let ty = self.ecx.typeck.expr_ty(e).kind();
+                    let (deref_ty, deref) = match ty {
+                        &ty::Ref(_, ty, _) => {
+                            // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
+                            if op != UnOp::Deref {
+                                self.eagerness |= NoChange;
+                            }
+                            (ty.kind(), true)
+                        },
+                        ty => (ty, false),
+                    };
                     match op {
-                        UnOp::Neg => match *ty {
+                        UnOp::Neg => match *deref_ty {
                             ty::Int(_) => {
-                                if self.ecx.eval(e).is_some() {
+                                if self.ecx.eval_deref(e, deref).is_some() {
                                     return Continue(());
                                 }
                                 self.eagerness |= NoChange;
@@ -232,7 +242,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                             // cheap, but we don't know for sure.
                             _ => self.eagerness |= NoChange,
                         },
-                        UnOp::Not => match *ty {
+                        UnOp::Not => match *deref_ty {
                             ty::Int(_) | ty::Uint(_) | ty::Bool => {},
                             _ => self.eagerness |= NoChange,
                         },
@@ -240,12 +250,28 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 },
                 ExprKind::Binary(op, lhs, rhs) => {
                     let lhs_ty = self.ecx.typeck.expr_ty(lhs);
+                    let (lhs_ty, lhs_deref) = match *lhs_ty.kind() {
+                        ty::Ref(_, lhs_ty, _) => {
+                            // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
+                            self.eagerness |= NoChange;
+                            (lhs_ty, true)
+                        },
+                        _ => (lhs_ty, false),
+                    };
                     let rhs_ty = self.ecx.typeck.expr_ty(rhs);
+                    let (rhs_ty, rhs_deref) = match *rhs_ty.kind() {
+                        ty::Ref(_, rhs_ty, _) => {
+                            // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
+                            self.eagerness |= NoChange;
+                            (rhs_ty, true)
+                        },
+                        _ => (rhs_ty, false),
+                    };
                     let same_ty = lhs_ty == rhs_ty;
                     match op.node {
                         BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
                             (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {
-                                if self.ecx.eval(rhs).is_some() {
+                                if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
                                     return self.visit_expr(lhs);
                                 }
                                 // Possible over shift or negative shift.
@@ -255,16 +281,16 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                         },
                         BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
                             ty::Uint(_) if same_ty => {
-                                if self.ecx.eval(rhs).is_some() {
+                                if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
                                     return self.visit_expr(lhs);
                                 }
                                 // Possible division-by-zero.
                                 self.eagerness |= NoChange;
                             },
                             ty::Int(ty) if same_ty => {
-                                if let Some(rhs) = self.ecx.eval(rhs) {
+                                if let Some(rhs) = self.ecx.eval_deref(rhs, rhs_deref) {
                                     if rhs.to_int(self.ecx.tcx, ty) == Some(-1) {
-                                        if self.ecx.eval(lhs).is_some() {
+                                        if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
                                             return Continue(());
                                         }
                                         // Possible overflow.
@@ -280,8 +306,8 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                         },
                         BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
                             ty::Int(_) | ty::Uint(_) if same_ty => {
-                                if self.ecx.eval(lhs).is_some() {
-                                    return if self.ecx.eval(rhs).is_some() {
+                                if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
+                                    return if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
                                         Continue(())
                                     } else {
                                         // Possible overflow.
@@ -295,20 +321,36 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                             ty::Float(_) if same_ty => {},
                             _ => self.eagerness = Lazy,
                         },
-                        BinOpKind::BitAnd
-                        | BinOpKind::BitOr
-                        | BinOpKind::BitXor
-                        | BinOpKind::Eq
+                        BinOpKind::Or | BinOpKind::And | BinOpKind::BitAnd | BinOpKind::BitOr | BinOpKind::BitXor => {
+                            match *lhs_ty.kind() {
+                                ty::Bool | ty::Int(_) | ty::Uint(_) if same_ty => {},
+                                _ => self.eagerness = Lazy,
+                            }
+                        },
+                        BinOpKind::Eq
                         | BinOpKind::Ne
                         | BinOpKind::Lt
                         | BinOpKind::Le
                         | BinOpKind::Gt
-                        | BinOpKind::Ge
-                        | BinOpKind::Or
-                        | BinOpKind::And => match *lhs_ty.kind() {
-                            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) if same_ty => {},
-                            ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
-                            _ => self.eagerness = Lazy,
+                        | BinOpKind::Ge => {
+                            if lhs_deref == rhs_deref {
+                                let mut lhs_ty = lhs_ty;
+                                let mut rhs_ty = rhs_ty;
+                                while let ty::Ref(_, lhs, _) = *lhs_ty.kind()
+                                    && let ty::Ref(_, rhs, _) = *rhs_ty.kind()
+                                {
+                                    lhs_ty = lhs;
+                                    rhs_ty = rhs;
+                                }
+                                match *lhs_ty.kind() {
+                                    ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_)
+                                        if lhs_ty == rhs_ty => {},
+                                    ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
+                                    _ => self.eagerness = Lazy,
+                                }
+                            } else {
+                                self.eagerness = Lazy;
+                            }
                         },
                     }
                 },

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -13,6 +13,7 @@ use crate::consts::ConstEvalCtxt;
 use crate::sym;
 use crate::ty::all_predicates_of;
 use crate::visitors::is_const_evaluatable;
+use core::ops::ControlFlow::{self, Break};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{Visitor, walk_expr};
@@ -121,11 +122,9 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
     }
 
     impl<'tcx> Visitor<'tcx> for V<'tcx> {
-        fn visit_expr(&mut self, e: &'tcx Expr<'_>) {
+        type Result = ControlFlow<()>;
+        fn visit_expr(&mut self, e: &'tcx Expr<'_>) -> Self::Result {
             use EagernessSuggestion::{ForceNoChange, Lazy, NoChange};
-            if self.eagerness == ForceNoChange {
-                return;
-            }
 
             // Autoderef through a user-defined `Deref` impl can have side-effects,
             // so don't suggest changing it.
@@ -151,14 +150,14 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     res @ (Res::Def(DefKind::Ctor(..) | DefKind::Variant, _) | Res::SelfCtor(_)) => {
                         if res_has_significant_drop(res, &self.ecx, e) {
                             self.eagerness = ForceNoChange;
-                            return;
+                            return Break(());
                         }
                     },
                     Res::Def(_, id) if self.ecx.tcx.is_promotable_const_fn(id) => (),
                     // No need to walk the arguments here, `is_const_evaluatable` already did
                     Res::Def(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
                         self.eagerness |= NoChange;
-                        return;
+                        return Break(());
                     },
                     Res::Def(_, id) => match path {
                         QPath::Resolved(_, p) => {
@@ -178,19 +177,19 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 // No need to walk the arguments here, `is_const_evaluatable` already did
                 ExprKind::MethodCall(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
                     self.eagerness |= NoChange;
-                    return;
+                    return Break(());
                 },
                 #[expect(clippy::match_same_arms)] // arm pattern can't be merged due to `ref`, see rust#105778
                 ExprKind::Struct(path, ..) => {
                     if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
                         self.eagerness = ForceNoChange;
-                        return;
+                        return Break(());
                     }
                 },
                 ExprKind::Path(ref path) => {
                     if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
                         self.eagerness = ForceNoChange;
-                        return;
+                        return Break(());
                     }
                 },
                 ExprKind::MethodCall(name, ..) => {
@@ -295,7 +294,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 | ExprKind::Yield(..)
                 | ExprKind::Err(_) => {
                     self.eagerness = ForceNoChange;
-                    return;
+                    return Break(());
                 },
 
                 ExprKind::Loop(..) | ExprKind::Call(..) => {
@@ -326,7 +325,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 // TODO: Actually check if either of these are true here.
                 ExprKind::Assign(..) | ExprKind::AssignOp(..) | ExprKind::Block(..) => self.eagerness |= NoChange,
             }
-            walk_expr(self, e);
+            walk_expr(self, e)
         }
     }
 
@@ -334,7 +333,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
         ecx: ConstEvalCtxt::new(cx),
         eagerness: EagernessSuggestion::Eager,
     };
-    v.visit_expr(e);
+    let _ = v.visit_expr(e);
     v.eagerness
 }
 

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -9,7 +9,7 @@
 //!  - or-fun-call
 //!  - option-if-let-else
 
-use crate::consts::{ConstEvalCtxt, FullInt};
+use crate::consts::ConstEvalCtxt;
 use crate::sym;
 use crate::ty::all_predicates_of;
 use crate::visitors::is_const_evaluatable;
@@ -210,62 +210,82 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     }
                 },
 
-                // `-i32::MIN` panics with overflow checks
-                ExprKind::Unary(UnOp::Neg, right) if self.ecx.eval(right).is_none() => {
-                    self.eagerness |= NoChange;
+                // Both binary and unary operations have cases which panic for integer types.
+                // For such cases we will only suggest eager evaluation if the overflow would be
+                // caught by rustc's `arithmetic_overflow` or `unconditional_panic` lints.
+                ExprKind::Unary(op, e) => {
+                    let ty = self.ecx.typeck.expr_ty(e).kind();
+                    match op {
+                        UnOp::Neg => match *ty {
+                            ty::Int(_) if self.ecx.eval(e).is_none() => self.eagerness |= NoChange,
+                            ty::Int(_) | ty::Float(_) => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                        UnOp::Deref => match *ty {
+                            ty::Adt(def, _) if def.is_box() => {},
+                            ty::Ref(..) => {},
+                            // Raw pointer dereferences have validity invariants which may not be
+                            // met if moved earlier. Everything else is a custom deref which should be
+                            // cheap, but we don't know for sure.
+                            _ => self.eagerness |= NoChange,
+                        },
+                        UnOp::Not => match *ty {
+                            ty::Int(_) | ty::Uint(_) | ty::Bool => {},
+                            _ => self.eagerness |= NoChange,
+                        },
+                    }
                 },
-
-                // Custom `Deref` impl might have side effects
-                ExprKind::Unary(UnOp::Deref, e) if self.ecx.typeck.expr_ty(e).builtin_deref(true).is_none() => {
-                    self.eagerness |= NoChange;
+                ExprKind::Binary(op, lhs, rhs) => {
+                    let lhs_ty = self.ecx.typeck.expr_ty(lhs);
+                    let rhs_ty = self.ecx.typeck.expr_ty(rhs);
+                    let same_ty = lhs_ty == rhs_ty;
+                    match op.node {
+                        BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
+                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) if self.ecx.eval(rhs).is_none() => {
+                                self.eagerness |= NoChange;
+                            },
+                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                        BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
+                            ty::Uint(_) if same_ty && self.ecx.eval(rhs).is_none() => self.eagerness |= NoChange,
+                            ty::Int(ty)
+                                if same_ty
+                                    && self.ecx.eval(rhs).is_none_or(|rhs| {
+                                        rhs.to_int(self.ecx.tcx, ty) == Some(-1) && self.ecx.eval(lhs).is_none()
+                                    }) =>
+                            {
+                                self.eagerness |= NoChange;
+                            },
+                            ty::Uint(_) | ty::Int(_) | ty::Float(_) if same_ty => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                        BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
+                            ty::Int(_) | ty::Uint(_)
+                                if same_ty && (self.ecx.eval(lhs).is_none() || self.ecx.eval(rhs).is_none()) =>
+                            {
+                                self.eagerness |= NoChange;
+                            },
+                            ty::Int(_) | ty::Uint(_) | ty::Float(_) if same_ty => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                        BinOpKind::BitAnd
+                        | BinOpKind::BitOr
+                        | BinOpKind::BitXor
+                        | BinOpKind::Eq
+                        | BinOpKind::Ne
+                        | BinOpKind::Lt
+                        | BinOpKind::Le
+                        | BinOpKind::Gt
+                        | BinOpKind::Ge
+                        | BinOpKind::Or
+                        | BinOpKind::And => match *lhs_ty.kind() {
+                            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) if same_ty => {},
+                            ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                    }
                 },
-                // Dereferences should be cheap, but dereferencing a raw pointer earlier may not be safe.
-                ExprKind::Unary(UnOp::Deref, e) if !self.ecx.typeck.expr_ty(e).is_raw_ptr() => (),
-                ExprKind::Unary(UnOp::Deref, _) => self.eagerness |= NoChange,
-                ExprKind::Unary(_, e)
-                    if matches!(self.ecx.typeck.expr_ty(e).kind(), ty::Bool | ty::Int(_) | ty::Uint(_),) => {},
-
-                // `>>` and `<<` panic when the right-hand side is greater than or equal to the number of bits in the
-                // type of the left-hand side, or is negative.
-                // We intentionally only check if the right-hand isn't a constant, because even if the suggestion would
-                // overflow with constants, the compiler emits an error for it and the programmer will have to fix it.
-                // Thus, we would realistically only delay the lint.
-                ExprKind::Binary(op, _, right)
-                    if matches!(op.node, BinOpKind::Shl | BinOpKind::Shr) && self.ecx.eval(right).is_none() =>
-                {
-                    self.eagerness |= NoChange;
-                },
-
-                ExprKind::Binary(op, left, right)
-                    if matches!(op.node, BinOpKind::Div | BinOpKind::Rem)
-                        && let right_ty = self.ecx.typeck.expr_ty(right)
-                        && let left = self.ecx.eval(left)
-                        && let right = self.ecx.eval(right).and_then(|c| c.int_value(self.ecx.tcx, right_ty))
-                        && matches!(
-                            (left, right),
-                            // `1 / x`: x might be zero
-                            (_, None)
-                            // `x / -1`: x might be T::MIN
-                            | (None, Some(FullInt::S(-1)))
-                        ) =>
-                {
-                    self.eagerness |= NoChange;
-                },
-
-                // Similar to `>>` and `<<`, we only want to avoid linting entirely if either side is unknown and the
-                // compiler can't emit an error for an overflowing expression.
-                // Suggesting eagerness for `true.then(|| i32::MAX + 1)` is okay because the compiler will emit an
-                // error and it's good to have the eagerness warning up front when the user fixes the logic error.
-                ExprKind::Binary(op, left, right)
-                    if matches!(op.node, BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul)
-                        && !self.ecx.typeck.expr_ty(e).is_floating_point()
-                        && (self.ecx.eval(left).is_none() || self.ecx.eval(right).is_none()) =>
-                {
-                    self.eagerness |= NoChange;
-                },
-
-                ExprKind::Binary(_, lhs, rhs)
-                    if self.ecx.typeck.expr_ty(lhs).is_primitive() && self.ecx.typeck.expr_ty(rhs).is_primitive() => {},
 
                 // Can't be moved into a closure
                 ExprKind::Break(..)
@@ -279,8 +299,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     return;
                 },
 
-                // Memory allocation, custom operator, loop, or call to an unknown function
-                ExprKind::Unary(..) | ExprKind::Binary(..) | ExprKind::Loop(..) | ExprKind::Call(..) => {
+                ExprKind::Loop(..) | ExprKind::Call(..) => {
                     self.eagerness = Lazy;
                 },
 

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -137,7 +137,6 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 .any(|adj| matches!(adj.kind, Adjust::Deref(DerefAdjustKind::Overloaded(_))))
             {
                 self.eagerness |= NoChange;
-                return;
             }
 
             match e.kind {

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -114,292 +114,286 @@ fn res_has_significant_drop(res: Res, ecx: &ConstEvalCtxt<'_>, e: &Expr<'_>) -> 
     }
 }
 
-#[expect(clippy::too_many_lines)]
-fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessSuggestion {
-    struct V<'tcx> {
-        ecx: ConstEvalCtxt<'tcx>,
-        eagerness: EagernessSuggestion,
-    }
+struct ExprEagernessVisitor<'tcx> {
+    ecx: ConstEvalCtxt<'tcx>,
+    eagerness: EagernessSuggestion,
+}
+impl<'tcx> Visitor<'tcx> for ExprEagernessVisitor<'tcx> {
+    type Result = ControlFlow<()>;
 
-    impl<'tcx> Visitor<'tcx> for V<'tcx> {
-        type Result = ControlFlow<()>;
-        fn visit_expr(&mut self, e: &'tcx Expr<'_>) -> Self::Result {
-            use EagernessSuggestion::{ForceNoChange, Lazy, NoChange};
+    #[expect(clippy::too_many_lines)]
+    fn visit_expr(&mut self, e: &'tcx Expr<'_>) -> Self::Result {
+        use EagernessSuggestion::{ForceNoChange, Lazy, NoChange};
 
-            // Autoderef through a user-defined `Deref` impl can have side-effects,
-            // so don't suggest changing it.
-            if self
-                .ecx
-                .typeck
-                .expr_adjustments(e)
-                .iter()
-                .any(|adj| matches!(adj.kind, Adjust::Deref(DerefAdjustKind::Overloaded(_))))
-            {
-                self.eagerness |= NoChange;
-            }
+        // Autoderef through a user-defined `Deref` impl can have side-effects,
+        // so don't suggest changing it.
+        if self
+            .ecx
+            .typeck
+            .expr_adjustments(e)
+            .iter()
+            .any(|adj| matches!(adj.kind, Adjust::Deref(DerefAdjustKind::Overloaded(_))))
+        {
+            self.eagerness |= NoChange;
+        }
 
-            match e.kind {
-                ExprKind::Call(
-                    &Expr {
-                        kind: ExprKind::Path(ref path),
-                        hir_id,
-                        ..
-                    },
-                    args,
-                ) => match self.ecx.typeck.qpath_res(path, hir_id) {
-                    res @ (Res::Def(DefKind::Ctor(..) | DefKind::Variant, _) | Res::SelfCtor(_)) => {
-                        if res_has_significant_drop(res, &self.ecx, e) {
-                            self.eagerness = ForceNoChange;
-                            return Break(());
-                        }
-                    },
-                    Res::Def(_, id) if self.ecx.tcx.is_promotable_const_fn(id) => (),
-                    // No need to walk the arguments here, `is_const_evaluatable` already did
-                    Res::Def(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
-                        self.eagerness |= NoChange;
-                        return Break(());
-                    },
-                    Res::Def(_, id) => match path {
-                        QPath::Resolved(_, p) => {
-                            self.eagerness |= fn_eagerness(
-                                self.ecx.tcx,
-                                id,
-                                p.segments.last().unwrap().ident.name,
-                                !args.is_empty(),
-                            );
-                        },
-                        QPath::TypeRelative(_, name) => {
-                            self.eagerness |= fn_eagerness(self.ecx.tcx, id, name.ident.name, !args.is_empty());
-                        },
-                    },
-                    _ => self.eagerness = Lazy,
+        match e.kind {
+            ExprKind::Call(
+                &Expr {
+                    kind: ExprKind::Path(ref path),
+                    hir_id,
+                    ..
                 },
+                args,
+            ) => match self.ecx.typeck.qpath_res(path, hir_id) {
+                res @ (Res::Def(DefKind::Ctor(..) | DefKind::Variant, _) | Res::SelfCtor(_)) => {
+                    if res_has_significant_drop(res, &self.ecx, e) {
+                        self.eagerness = ForceNoChange;
+                        return Break(());
+                    }
+                },
+                Res::Def(_, id) if self.ecx.tcx.is_promotable_const_fn(id) => (),
                 // No need to walk the arguments here, `is_const_evaluatable` already did
-                ExprKind::MethodCall(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
+                Res::Def(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
                     self.eagerness |= NoChange;
                     return Break(());
                 },
-                #[expect(clippy::match_same_arms)] // arm pattern can't be merged due to `ref`, see rust#105778
-                ExprKind::Struct(path, ..) => {
-                    if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
-                        self.eagerness = ForceNoChange;
-                        return Break(());
-                    }
+                Res::Def(_, id) => match path {
+                    QPath::Resolved(_, p) => {
+                        self.eagerness |= fn_eagerness(
+                            self.ecx.tcx,
+                            id,
+                            p.segments.last().unwrap().ident.name,
+                            !args.is_empty(),
+                        );
+                    },
+                    QPath::TypeRelative(_, name) => {
+                        self.eagerness |= fn_eagerness(self.ecx.tcx, id, name.ident.name, !args.is_empty());
+                    },
                 },
-                ExprKind::Path(ref path) => {
-                    if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
-                        self.eagerness = ForceNoChange;
-                        return Break(());
-                    }
-                },
-                ExprKind::MethodCall(name, ..) => {
-                    self.eagerness |= self
-                        .ecx
-                        .typeck
-                        .type_dependent_def_id(e.hir_id)
-                        .map_or(Lazy, |id| fn_eagerness(self.ecx.tcx, id, name.ident.name, true));
-                },
-                ExprKind::Index(_, e, _) => {
-                    let ty = self.ecx.typeck.expr_ty_adjusted(e);
-                    if self.ecx.tcx.type_is_copy_modulo_regions(self.ecx.typing_env, ty) && !ty.is_ref() {
-                        self.eagerness |= NoChange;
-                    } else {
-                        self.eagerness = Lazy;
-                    }
-                },
-
-                // Both binary and unary operations have cases which panic for integer types.
-                // For such cases we will only suggest eager evaluation if the overflow would be
-                // caught by rustc's `arithmetic_overflow` or `unconditional_panic` lints.
-                ExprKind::Unary(op, e) => {
-                    let ty = self.ecx.typeck.expr_ty(e).kind();
-                    let (deref_ty, deref) = match ty {
-                        &ty::Ref(_, ty, _) => {
-                            // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
-                            if op != UnOp::Deref {
-                                self.eagerness |= NoChange;
-                            }
-                            (ty.kind(), true)
-                        },
-                        ty => (ty, false),
-                    };
-                    match op {
-                        UnOp::Neg => match *deref_ty {
-                            ty::Int(_) => {
-                                if self.ecx.eval_deref(e, deref).is_some() {
-                                    return Continue(());
-                                }
-                                self.eagerness |= NoChange;
-                            },
-                            ty::Float(_) => {},
-                            _ => self.eagerness = Lazy,
-                        },
-                        UnOp::Deref => match *ty {
-                            ty::Adt(def, _) if def.is_box() => {},
-                            ty::Ref(..) => {},
-                            // Raw pointer dereferences have validity invariants which may not be
-                            // met if moved earlier. Everything else is a custom deref which should be
-                            // cheap, but we don't know for sure.
-                            _ => self.eagerness |= NoChange,
-                        },
-                        UnOp::Not => match *deref_ty {
-                            ty::Int(_) | ty::Uint(_) | ty::Bool => {},
-                            _ => self.eagerness |= NoChange,
-                        },
-                    }
-                },
-                ExprKind::Binary(op, lhs, rhs) => {
-                    let lhs_ty = self.ecx.typeck.expr_ty(lhs);
-                    let (lhs_ty, lhs_deref) = match *lhs_ty.kind() {
-                        ty::Ref(_, lhs_ty, _) => {
-                            // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
-                            self.eagerness |= NoChange;
-                            (lhs_ty, true)
-                        },
-                        _ => (lhs_ty, false),
-                    };
-                    let rhs_ty = self.ecx.typeck.expr_ty(rhs);
-                    let (rhs_ty, rhs_deref) = match *rhs_ty.kind() {
-                        ty::Ref(_, rhs_ty, _) => {
-                            // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
-                            self.eagerness |= NoChange;
-                            (rhs_ty, true)
-                        },
-                        _ => (rhs_ty, false),
-                    };
-                    let same_ty = lhs_ty == rhs_ty;
-                    match op.node {
-                        BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
-                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {
-                                if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                                    return self.visit_expr(lhs);
-                                }
-                                // Possible over shift or negative shift.
-                                self.eagerness |= NoChange;
-                            },
-                            _ => self.eagerness = Lazy,
-                        },
-                        BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
-                            ty::Uint(_) if same_ty => {
-                                if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                                    return self.visit_expr(lhs);
-                                }
-                                // Possible division-by-zero.
-                                self.eagerness |= NoChange;
-                            },
-                            ty::Int(ty) if same_ty => {
-                                if let Some(rhs) = self.ecx.eval_deref(rhs, rhs_deref) {
-                                    if rhs.to_int(self.ecx.tcx, ty) == Some(-1) {
-                                        if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
-                                            return Continue(());
-                                        }
-                                        // Possible overflow.
-                                        self.eagerness |= NoChange;
-                                    }
-                                    return self.visit_expr(lhs);
-                                }
-                                // Possible division-by-zero.
-                                self.eagerness |= NoChange;
-                            },
-                            ty::Float(_) if same_ty => {},
-                            _ => self.eagerness = Lazy,
-                        },
-                        BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
-                            ty::Int(_) | ty::Uint(_) if same_ty => {
-                                if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
-                                    return if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                                        Continue(())
-                                    } else {
-                                        // Possible overflow.
-                                        self.eagerness |= NoChange;
-                                        self.visit_expr(rhs)
-                                    };
-                                }
-                                // Possible overflow.
-                                self.eagerness |= NoChange;
-                            },
-                            ty::Float(_) if same_ty => {},
-                            _ => self.eagerness = Lazy,
-                        },
-                        BinOpKind::Or | BinOpKind::And | BinOpKind::BitAnd | BinOpKind::BitOr | BinOpKind::BitXor => {
-                            match *lhs_ty.kind() {
-                                ty::Bool | ty::Int(_) | ty::Uint(_) if same_ty => {},
-                                _ => self.eagerness = Lazy,
-                            }
-                        },
-                        BinOpKind::Eq
-                        | BinOpKind::Ne
-                        | BinOpKind::Lt
-                        | BinOpKind::Le
-                        | BinOpKind::Gt
-                        | BinOpKind::Ge => {
-                            if lhs_deref == rhs_deref {
-                                let mut lhs_ty = lhs_ty;
-                                let mut rhs_ty = rhs_ty;
-                                while let ty::Ref(_, lhs, _) = *lhs_ty.kind()
-                                    && let ty::Ref(_, rhs, _) = *rhs_ty.kind()
-                                {
-                                    lhs_ty = lhs;
-                                    rhs_ty = rhs;
-                                }
-                                match *lhs_ty.kind() {
-                                    ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_)
-                                        if lhs_ty == rhs_ty => {},
-                                    ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
-                                    _ => self.eagerness = Lazy,
-                                }
-                            } else {
-                                self.eagerness = Lazy;
-                            }
-                        },
-                    }
-                },
-
-                // Can't be moved into a closure
-                ExprKind::Break(..)
-                | ExprKind::Continue(_)
-                | ExprKind::Ret(_)
-                | ExprKind::Become(_)
-                | ExprKind::InlineAsm(_)
-                | ExprKind::Yield(..)
-                | ExprKind::Err(_) => {
+                _ => self.eagerness = Lazy,
+            },
+            // No need to walk the arguments here, `is_const_evaluatable` already did
+            ExprKind::MethodCall(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
+                self.eagerness |= NoChange;
+                return Break(());
+            },
+            #[expect(clippy::match_same_arms)] // arm pattern can't be merged due to `ref`, see rust#105778
+            ExprKind::Struct(path, ..) => {
+                if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
                     self.eagerness = ForceNoChange;
                     return Break(());
-                },
-
-                ExprKind::Loop(..) | ExprKind::Call(..) => {
+                }
+            },
+            ExprKind::Path(ref path) => {
+                if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
+                    self.eagerness = ForceNoChange;
+                    return Break(());
+                }
+            },
+            ExprKind::MethodCall(name, ..) => {
+                self.eagerness |= self
+                    .ecx
+                    .typeck
+                    .type_dependent_def_id(e.hir_id)
+                    .map_or(Lazy, |id| fn_eagerness(self.ecx.tcx, id, name.ident.name, true));
+            },
+            ExprKind::Index(_, e, _) => {
+                let ty = self.ecx.typeck.expr_ty_adjusted(e);
+                if self.ecx.tcx.type_is_copy_modulo_regions(self.ecx.typing_env, ty) && !ty.is_ref() {
+                    self.eagerness |= NoChange;
+                } else {
                     self.eagerness = Lazy;
-                },
+                }
+            },
 
-                ExprKind::ConstBlock(_)
-                | ExprKind::Array(_)
-                | ExprKind::Tup(_)
-                | ExprKind::Use(..)
-                | ExprKind::Lit(_)
-                | ExprKind::Cast(..)
-                | ExprKind::Type(..)
-                | ExprKind::DropTemps(_)
-                | ExprKind::Let(..)
-                | ExprKind::If(..)
-                | ExprKind::Match(..)
-                | ExprKind::Closure { .. }
-                | ExprKind::Field(..)
-                | ExprKind::AddrOf(..)
-                | ExprKind::Repeat(..)
-                | ExprKind::Block(Block { stmts: [], .. }, _)
-                | ExprKind::OffsetOf(..)
-                | ExprKind::UnsafeBinderCast(..) => (),
+            // Both binary and unary operations have cases which panic for integer types.
+            // For such cases we will only suggest eager evaluation if the overflow would be
+            // caught by rustc's `arithmetic_overflow` or `unconditional_panic` lints.
+            ExprKind::Unary(op, e) => {
+                let ty = self.ecx.typeck.expr_ty(e).kind();
+                let (deref_ty, deref) = match ty {
+                    &ty::Ref(_, ty, _) => {
+                        // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
+                        if op != UnOp::Deref {
+                            self.eagerness |= NoChange;
+                        }
+                        (ty.kind(), true)
+                    },
+                    ty => (ty, false),
+                };
+                match op {
+                    UnOp::Neg => match *deref_ty {
+                        ty::Int(_) => {
+                            if self.ecx.eval_deref(e, deref).is_some() {
+                                return Continue(());
+                            }
+                            self.eagerness |= NoChange;
+                        },
+                        ty::Float(_) => {},
+                        _ => self.eagerness = Lazy,
+                    },
+                    UnOp::Deref => match *ty {
+                        ty::Adt(def, _) if def.is_box() => {},
+                        ty::Ref(..) => {},
+                        // Raw pointer dereferences have validity invariants which may not be
+                        // met if moved earlier. Everything else is a custom deref which should be
+                        // cheap, but we don't know for sure.
+                        _ => self.eagerness |= NoChange,
+                    },
+                    UnOp::Not => match *deref_ty {
+                        ty::Int(_) | ty::Uint(_) | ty::Bool => {},
+                        _ => self.eagerness |= NoChange,
+                    },
+                }
+            },
+            ExprKind::Binary(op, lhs, rhs) => {
+                let lhs_ty = self.ecx.typeck.expr_ty(lhs);
+                let (lhs_ty, lhs_deref) = match *lhs_ty.kind() {
+                    ty::Ref(_, lhs_ty, _) => {
+                        // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
+                        self.eagerness |= NoChange;
+                        (lhs_ty, true)
+                    },
+                    _ => (lhs_ty, false),
+                };
+                let rhs_ty = self.ecx.typeck.expr_ty(rhs);
+                let (rhs_ty, rhs_deref) = match *rhs_ty.kind() {
+                    ty::Ref(_, rhs_ty, _) => {
+                        // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
+                        self.eagerness |= NoChange;
+                        (rhs_ty, true)
+                    },
+                    _ => (rhs_ty, false),
+                };
+                let same_ty = lhs_ty == rhs_ty;
+                match op.node {
+                    BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
+                        (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {
+                            if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
+                                return self.visit_expr(lhs);
+                            }
+                            // Possible over shift or negative shift.
+                            self.eagerness |= NoChange;
+                        },
+                        _ => self.eagerness = Lazy,
+                    },
+                    BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
+                        ty::Uint(_) if same_ty => {
+                            if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
+                                return self.visit_expr(lhs);
+                            }
+                            // Possible division-by-zero.
+                            self.eagerness |= NoChange;
+                        },
+                        ty::Int(ty) if same_ty => {
+                            if let Some(rhs) = self.ecx.eval_deref(rhs, rhs_deref) {
+                                if rhs.to_int(self.ecx.tcx, ty) == Some(-1) {
+                                    if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
+                                        return Continue(());
+                                    }
+                                    // Possible overflow.
+                                    self.eagerness |= NoChange;
+                                }
+                                return self.visit_expr(lhs);
+                            }
+                            // Possible division-by-zero.
+                            self.eagerness |= NoChange;
+                        },
+                        ty::Float(_) if same_ty => {},
+                        _ => self.eagerness = Lazy,
+                    },
+                    BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
+                        ty::Int(_) | ty::Uint(_) if same_ty => {
+                            if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
+                                return if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
+                                    Continue(())
+                                } else {
+                                    // Possible overflow.
+                                    self.eagerness |= NoChange;
+                                    self.visit_expr(rhs)
+                                };
+                            }
+                            // Possible overflow.
+                            self.eagerness |= NoChange;
+                        },
+                        ty::Float(_) if same_ty => {},
+                        _ => self.eagerness = Lazy,
+                    },
+                    BinOpKind::Or | BinOpKind::And | BinOpKind::BitAnd | BinOpKind::BitOr | BinOpKind::BitXor => {
+                        match *lhs_ty.kind() {
+                            ty::Bool | ty::Int(_) | ty::Uint(_) if same_ty => {},
+                            _ => self.eagerness = Lazy,
+                        }
+                    },
+                    BinOpKind::Eq | BinOpKind::Ne | BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge => {
+                        if lhs_deref == rhs_deref {
+                            let mut lhs_ty = lhs_ty;
+                            let mut rhs_ty = rhs_ty;
+                            while let ty::Ref(_, lhs, _) = *lhs_ty.kind()
+                                && let ty::Ref(_, rhs, _) = *rhs_ty.kind()
+                            {
+                                lhs_ty = lhs;
+                                rhs_ty = rhs;
+                            }
+                            match *lhs_ty.kind() {
+                                ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) if lhs_ty == rhs_ty => {},
+                                ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
+                                _ => self.eagerness = Lazy,
+                            }
+                        } else {
+                            self.eagerness = Lazy;
+                        }
+                    },
+                }
+            },
 
-                // Assignment might be to a local defined earlier, so don't eagerly evaluate.
-                // Blocks with multiple statements might be expensive, so don't eagerly evaluate.
-                // TODO: Actually check if either of these are true here.
-                ExprKind::Assign(..) | ExprKind::AssignOp(..) | ExprKind::Block(..) => self.eagerness |= NoChange,
-            }
-            walk_expr(self, e)
+            // Can't be moved into a closure
+            ExprKind::Break(..)
+            | ExprKind::Continue(_)
+            | ExprKind::Ret(_)
+            | ExprKind::Become(_)
+            | ExprKind::InlineAsm(_)
+            | ExprKind::Yield(..)
+            | ExprKind::Err(_) => {
+                self.eagerness = ForceNoChange;
+                return Break(());
+            },
+
+            ExprKind::Loop(..) | ExprKind::Call(..) => {
+                self.eagerness = Lazy;
+            },
+
+            ExprKind::ConstBlock(_)
+            | ExprKind::Array(_)
+            | ExprKind::Tup(_)
+            | ExprKind::Use(..)
+            | ExprKind::Lit(_)
+            | ExprKind::Cast(..)
+            | ExprKind::Type(..)
+            | ExprKind::DropTemps(_)
+            | ExprKind::Let(..)
+            | ExprKind::If(..)
+            | ExprKind::Match(..)
+            | ExprKind::Closure { .. }
+            | ExprKind::Field(..)
+            | ExprKind::AddrOf(..)
+            | ExprKind::Repeat(..)
+            | ExprKind::Block(Block { stmts: [], .. }, _)
+            | ExprKind::OffsetOf(..)
+            | ExprKind::UnsafeBinderCast(..) => (),
+
+            // Assignment might be to a local defined earlier, so don't eagerly evaluate.
+            // Blocks with multiple statements might be expensive, so don't eagerly evaluate.
+            // TODO: Actually check if either of these are true here.
+            ExprKind::Assign(..) | ExprKind::AssignOp(..) | ExprKind::Block(..) => self.eagerness |= NoChange,
         }
+        walk_expr(self, e)
     }
+}
 
-    let mut v = V {
+fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessSuggestion {
+    let mut v = ExprEagernessVisitor {
         ecx: ConstEvalCtxt::new(cx),
         eagerness: EagernessSuggestion::Eager,
     };

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -137,6 +137,7 @@ impl<'tcx> ExprEagernessVisitor<'tcx> {
             UnOp::Neg => match *deref_ty {
                 ty::Int(_) => {
                     if self.ecx.eval_deref(e, deref).is_some() {
+                        // rustc's `arithmetic_overflow` lint will catch this case.
                         return Continue(());
                     }
                     // Possible overflow.
@@ -182,85 +183,73 @@ impl<'tcx> ExprEagernessVisitor<'tcx> {
             },
             _ => (rhs_ty, false),
         };
-        let same_ty = lhs_ty == rhs_ty;
-        match op {
-            BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
-                (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {
-                    if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                        return self.visit_expr(lhs);
-                    }
-                    // Possible over shift or negative shift.
-                    self.eagerness |= NoChange;
-                },
-                _ => self.eagerness = Lazy,
-            },
-            BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
-                ty::Uint(_) if same_ty => {
-                    if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                        return self.visit_expr(lhs);
-                    }
-                    // Possible division-by-zero.
-                    self.eagerness |= NoChange;
-                },
-                ty::Int(ty) if same_ty => {
-                    if let Some(rhs) = self.ecx.eval_deref(rhs, rhs_deref) {
-                        if rhs.to_int(self.ecx.tcx, ty) == Some(-1) {
-                            if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
-                                return Continue(());
-                            }
-                            // Possible overflow.
-                            self.eagerness |= NoChange;
-                        }
-                        return self.visit_expr(lhs);
-                    }
-                    // Possible division-by-zero.
-                    self.eagerness |= NoChange;
-                },
-                ty::Float(_) if same_ty => {},
-                _ => self.eagerness = Lazy,
-            },
-            BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
-                ty::Int(_) | ty::Uint(_) if same_ty => {
-                    if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
-                        return if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                            Continue(())
-                        } else {
-                            // Possible overflow.
-                            self.eagerness |= NoChange;
-                            self.visit_expr(rhs)
-                        };
-                    }
-                    // Possible overflow.
-                    self.eagerness |= NoChange;
-                },
-                ty::Float(_) if same_ty => {},
-                _ => self.eagerness = Lazy,
-            },
-            BinOpKind::Or | BinOpKind::And | BinOpKind::BitAnd | BinOpKind::BitOr | BinOpKind::BitXor => {
+
+        if let BinOpKind::Eq | BinOpKind::Ne | BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge = op {
+            if lhs_deref == rhs_deref {
+                let mut lhs_ty = lhs_ty;
+                let mut rhs_ty = rhs_ty;
+                while let ty::Ref(_, lhs, _) = *lhs_ty.kind()
+                    && let ty::Ref(_, rhs, _) = *rhs_ty.kind()
+                {
+                    lhs_ty = lhs;
+                    rhs_ty = rhs;
+                }
                 match *lhs_ty.kind() {
-                    ty::Bool | ty::Int(_) | ty::Uint(_) if same_ty => {},
+                    ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) if lhs_ty == rhs_ty => {},
+                    ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
                     _ => self.eagerness = Lazy,
                 }
+            } else {
+                self.eagerness = Lazy;
+            }
+        } else if let Some((is_signed, ty)) = match (lhs_ty.kind(), rhs_ty.kind()) {
+            // If both sides are an integer type then we can assume either the types are
+            // the same, or we have a shift operator. Since we don't care about the types
+            // in that case just take the lhs's type.
+            (&ty::Int(ty), ty::Int(_) | ty::Uint(_)) => Some((true, ty)),
+            (&ty::Uint(ty), ty::Int(_) | ty::Uint(_)) => Some((false, ty.to_signed())),
+            (ty::Float(_), ty::Float(_)) | (ty::Bool, ty::Bool) => None,
+            _ => {
+                self.eagerness = Lazy;
+                None
             },
-            BinOpKind::Eq | BinOpKind::Ne | BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge => {
-                if lhs_deref == rhs_deref {
-                    let mut lhs_ty = lhs_ty;
-                    let mut rhs_ty = rhs_ty;
-                    while let ty::Ref(_, lhs, _) = *lhs_ty.kind()
-                        && let ty::Ref(_, rhs, _) = *rhs_ty.kind()
-                    {
-                        lhs_ty = lhs;
-                        rhs_ty = rhs;
+        } {
+            // For operators which can panic we will only suggest eager evaluation if the
+            // expression would be caught by rustc's `arithmetic_overflow` or
+            // `unconditional_panic` lints.
+            match (op, is_signed) {
+                (BinOpKind::Div | BinOpKind::Rem, true) if let Some(rhs_val) = self.ecx.eval_deref(rhs, rhs_deref) => {
+                    if rhs_val.to_int(self.ecx.tcx, ty) == Some(-1) {
+                        if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
+                            return Continue(());
+                        }
+                        // Possible overflow.
+                        self.eagerness |= NoChange;
                     }
-                    match *lhs_ty.kind() {
-                        ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) if lhs_ty == rhs_ty => {},
-                        ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
-                        _ => self.eagerness = Lazy,
-                    }
-                } else {
-                    self.eagerness = Lazy;
-                }
-            },
+                    return self.visit_expr(rhs);
+                },
+                (BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul, _)
+                    if self.ecx.eval_deref(rhs, rhs_deref).is_some() =>
+                {
+                    return if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
+                        Continue(())
+                    } else {
+                        // Possible overflow.
+                        self.eagerness |= NoChange;
+                        self.visit_expr(lhs)
+                    };
+                },
+                (BinOpKind::Div | BinOpKind::Rem, false) | (BinOpKind::Shl | BinOpKind::Shr, _)
+                    if self.ecx.eval_deref(rhs, rhs_deref).is_some() =>
+                {
+                    return self.visit_expr(lhs);
+                },
+                (BinOpKind::Or | BinOpKind::And | BinOpKind::BitAnd | BinOpKind::BitOr | BinOpKind::BitXor, _) => {},
+                _ => {
+                    // Possible division-by-zero, overflow, or over/negative shift.
+                    self.eagerness |= NoChange;
+                },
+            }
         }
         (lhs, rhs).visit(self)
     }
@@ -354,9 +343,6 @@ impl<'tcx> Visitor<'tcx> for ExprEagernessVisitor<'tcx> {
                 }
             },
 
-            // Both binary and unary operations have cases which panic for integer types.
-            // For such cases we will only suggest eager evaluation if the overflow would be
-            // caught by rustc's `arithmetic_overflow` or `unconditional_panic` lints.
             ExprKind::Unary(op, e) => return self.visit_unary(op, e),
             ExprKind::Binary(op, lhs, rhs) => return self.visit_binary(op.node, lhs, rhs),
 

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -12,7 +12,7 @@
 use crate::consts::ConstEvalCtxt;
 use crate::sym;
 use crate::ty::all_clauses_of;
-use crate::visitors::is_const_evaluatable;
+use crate::visitors::{Visitable as _, is_const_evaluatable};
 use core::ops::ControlFlow::{self, Break, Continue};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
@@ -118,6 +118,153 @@ struct ExprEagernessVisitor<'tcx> {
     ecx: ConstEvalCtxt<'tcx>,
     eagerness: EagernessSuggestion,
 }
+impl<'tcx> ExprEagernessVisitor<'tcx> {
+    fn visit_unary(&mut self, op: UnOp, e: &'tcx Expr<'tcx>) -> ControlFlow<()> {
+        use EagernessSuggestion::{Lazy, NoChange};
+
+        let ty = self.ecx.typeck.expr_ty(e).kind();
+        let (deref_ty, deref) = match ty {
+            &ty::Ref(_, ty, _) => {
+                // TODO(@Jarcho): Allow eager evaluation starting with 1.102.
+                if op != UnOp::Deref {
+                    self.eagerness |= NoChange;
+                }
+                (ty.kind(), true)
+            },
+            ty => (ty, false),
+        };
+        match op {
+            UnOp::Neg => match *deref_ty {
+                ty::Int(_) => {
+                    if self.ecx.eval_deref(e, deref).is_some() {
+                        return Continue(());
+                    }
+                    // Possible overflow.
+                    self.eagerness |= NoChange;
+                },
+                ty::Float(_) => {},
+                _ => self.eagerness = Lazy,
+            },
+            UnOp::Deref => match *ty {
+                ty::Adt(def, _) if def.is_box() => {},
+                ty::Ref(..) => {},
+                // Raw pointer dereferences have validity invariants which may not be
+                // met if moved earlier. Everything else is a custom deref which should be
+                // cheap, but we don't know for sure.
+                _ => self.eagerness |= NoChange,
+            },
+            UnOp::Not => match *deref_ty {
+                ty::Int(_) | ty::Uint(_) | ty::Bool => {},
+                _ => self.eagerness |= NoChange,
+            },
+        }
+        self.visit_expr(e)
+    }
+
+    fn visit_binary(&mut self, op: BinOpKind, lhs: &'tcx Expr<'tcx>, rhs: &'tcx Expr<'tcx>) -> ControlFlow<()> {
+        use EagernessSuggestion::{Lazy, NoChange};
+
+        let lhs_ty = self.ecx.typeck.expr_ty(lhs);
+        let (lhs_ty, lhs_deref) = match *lhs_ty.kind() {
+            ty::Ref(_, lhs_ty, _) => {
+                // TODO(@Jarcho): Allow eager evaluation starting with 1.102.
+                self.eagerness |= NoChange;
+                (lhs_ty, true)
+            },
+            _ => (lhs_ty, false),
+        };
+        let rhs_ty = self.ecx.typeck.expr_ty(rhs);
+        let (rhs_ty, rhs_deref) = match *rhs_ty.kind() {
+            ty::Ref(_, rhs_ty, _) => {
+                // TODO(@Jarcho): Allow eager evaluation starting with 1.102.
+                self.eagerness |= NoChange;
+                (rhs_ty, true)
+            },
+            _ => (rhs_ty, false),
+        };
+        let same_ty = lhs_ty == rhs_ty;
+        match op {
+            BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
+                (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {
+                    if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
+                        return self.visit_expr(lhs);
+                    }
+                    // Possible over shift or negative shift.
+                    self.eagerness |= NoChange;
+                },
+                _ => self.eagerness = Lazy,
+            },
+            BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
+                ty::Uint(_) if same_ty => {
+                    if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
+                        return self.visit_expr(lhs);
+                    }
+                    // Possible division-by-zero.
+                    self.eagerness |= NoChange;
+                },
+                ty::Int(ty) if same_ty => {
+                    if let Some(rhs) = self.ecx.eval_deref(rhs, rhs_deref) {
+                        if rhs.to_int(self.ecx.tcx, ty) == Some(-1) {
+                            if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
+                                return Continue(());
+                            }
+                            // Possible overflow.
+                            self.eagerness |= NoChange;
+                        }
+                        return self.visit_expr(lhs);
+                    }
+                    // Possible division-by-zero.
+                    self.eagerness |= NoChange;
+                },
+                ty::Float(_) if same_ty => {},
+                _ => self.eagerness = Lazy,
+            },
+            BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
+                ty::Int(_) | ty::Uint(_) if same_ty => {
+                    if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
+                        return if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
+                            Continue(())
+                        } else {
+                            // Possible overflow.
+                            self.eagerness |= NoChange;
+                            self.visit_expr(rhs)
+                        };
+                    }
+                    // Possible overflow.
+                    self.eagerness |= NoChange;
+                },
+                ty::Float(_) if same_ty => {},
+                _ => self.eagerness = Lazy,
+            },
+            BinOpKind::Or | BinOpKind::And | BinOpKind::BitAnd | BinOpKind::BitOr | BinOpKind::BitXor => {
+                match *lhs_ty.kind() {
+                    ty::Bool | ty::Int(_) | ty::Uint(_) if same_ty => {},
+                    _ => self.eagerness = Lazy,
+                }
+            },
+            BinOpKind::Eq | BinOpKind::Ne | BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge => {
+                if lhs_deref == rhs_deref {
+                    let mut lhs_ty = lhs_ty;
+                    let mut rhs_ty = rhs_ty;
+                    while let ty::Ref(_, lhs, _) = *lhs_ty.kind()
+                        && let ty::Ref(_, rhs, _) = *rhs_ty.kind()
+                    {
+                        lhs_ty = lhs;
+                        rhs_ty = rhs;
+                    }
+                    match *lhs_ty.kind() {
+                        ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) if lhs_ty == rhs_ty => {},
+                        ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
+                        _ => self.eagerness = Lazy,
+                    }
+                } else {
+                    self.eagerness = Lazy;
+                }
+            },
+        }
+        (lhs, rhs).visit(self)
+    }
+}
 impl<'tcx> Visitor<'tcx> for ExprEagernessVisitor<'tcx> {
     type Result = ControlFlow<()>;
 
@@ -210,143 +357,8 @@ impl<'tcx> Visitor<'tcx> for ExprEagernessVisitor<'tcx> {
             // Both binary and unary operations have cases which panic for integer types.
             // For such cases we will only suggest eager evaluation if the overflow would be
             // caught by rustc's `arithmetic_overflow` or `unconditional_panic` lints.
-            ExprKind::Unary(op, e) => {
-                let ty = self.ecx.typeck.expr_ty(e).kind();
-                let (deref_ty, deref) = match ty {
-                    &ty::Ref(_, ty, _) => {
-                        // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
-                        if op != UnOp::Deref {
-                            self.eagerness |= NoChange;
-                        }
-                        (ty.kind(), true)
-                    },
-                    ty => (ty, false),
-                };
-                match op {
-                    UnOp::Neg => match *deref_ty {
-                        ty::Int(_) => {
-                            if self.ecx.eval_deref(e, deref).is_some() {
-                                return Continue(());
-                            }
-                            self.eagerness |= NoChange;
-                        },
-                        ty::Float(_) => {},
-                        _ => self.eagerness = Lazy,
-                    },
-                    UnOp::Deref => match *ty {
-                        ty::Adt(def, _) if def.is_box() => {},
-                        ty::Ref(..) => {},
-                        // Raw pointer dereferences have validity invariants which may not be
-                        // met if moved earlier. Everything else is a custom deref which should be
-                        // cheap, but we don't know for sure.
-                        _ => self.eagerness |= NoChange,
-                    },
-                    UnOp::Not => match *deref_ty {
-                        ty::Int(_) | ty::Uint(_) | ty::Bool => {},
-                        _ => self.eagerness |= NoChange,
-                    },
-                }
-            },
-            ExprKind::Binary(op, lhs, rhs) => {
-                let lhs_ty = self.ecx.typeck.expr_ty(lhs);
-                let (lhs_ty, lhs_deref) = match *lhs_ty.kind() {
-                    ty::Ref(_, lhs_ty, _) => {
-                        // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
-                        self.eagerness |= NoChange;
-                        (lhs_ty, true)
-                    },
-                    _ => (lhs_ty, false),
-                };
-                let rhs_ty = self.ecx.typeck.expr_ty(rhs);
-                let (rhs_ty, rhs_deref) = match *rhs_ty.kind() {
-                    ty::Ref(_, rhs_ty, _) => {
-                        // TODO(@Jarcho): Allow eager evaluation starting with 1.99.
-                        self.eagerness |= NoChange;
-                        (rhs_ty, true)
-                    },
-                    _ => (rhs_ty, false),
-                };
-                let same_ty = lhs_ty == rhs_ty;
-                match op.node {
-                    BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
-                        (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {
-                            if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                                return self.visit_expr(lhs);
-                            }
-                            // Possible over shift or negative shift.
-                            self.eagerness |= NoChange;
-                        },
-                        _ => self.eagerness = Lazy,
-                    },
-                    BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
-                        ty::Uint(_) if same_ty => {
-                            if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                                return self.visit_expr(lhs);
-                            }
-                            // Possible division-by-zero.
-                            self.eagerness |= NoChange;
-                        },
-                        ty::Int(ty) if same_ty => {
-                            if let Some(rhs) = self.ecx.eval_deref(rhs, rhs_deref) {
-                                if rhs.to_int(self.ecx.tcx, ty) == Some(-1) {
-                                    if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
-                                        return Continue(());
-                                    }
-                                    // Possible overflow.
-                                    self.eagerness |= NoChange;
-                                }
-                                return self.visit_expr(lhs);
-                            }
-                            // Possible division-by-zero.
-                            self.eagerness |= NoChange;
-                        },
-                        ty::Float(_) if same_ty => {},
-                        _ => self.eagerness = Lazy,
-                    },
-                    BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
-                        ty::Int(_) | ty::Uint(_) if same_ty => {
-                            if self.ecx.eval_deref(lhs, lhs_deref).is_some() {
-                                return if self.ecx.eval_deref(rhs, rhs_deref).is_some() {
-                                    Continue(())
-                                } else {
-                                    // Possible overflow.
-                                    self.eagerness |= NoChange;
-                                    self.visit_expr(rhs)
-                                };
-                            }
-                            // Possible overflow.
-                            self.eagerness |= NoChange;
-                        },
-                        ty::Float(_) if same_ty => {},
-                        _ => self.eagerness = Lazy,
-                    },
-                    BinOpKind::Or | BinOpKind::And | BinOpKind::BitAnd | BinOpKind::BitOr | BinOpKind::BitXor => {
-                        match *lhs_ty.kind() {
-                            ty::Bool | ty::Int(_) | ty::Uint(_) if same_ty => {},
-                            _ => self.eagerness = Lazy,
-                        }
-                    },
-                    BinOpKind::Eq | BinOpKind::Ne | BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge => {
-                        if lhs_deref == rhs_deref {
-                            let mut lhs_ty = lhs_ty;
-                            let mut rhs_ty = rhs_ty;
-                            while let ty::Ref(_, lhs, _) = *lhs_ty.kind()
-                                && let ty::Ref(_, rhs, _) = *rhs_ty.kind()
-                            {
-                                lhs_ty = lhs;
-                                rhs_ty = rhs;
-                            }
-                            match *lhs_ty.kind() {
-                                ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) if lhs_ty == rhs_ty => {},
-                                ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
-                                _ => self.eagerness = Lazy,
-                            }
-                        } else {
-                            self.eagerness = Lazy;
-                        }
-                    },
-                }
-            },
+            ExprKind::Unary(op, e) => return self.visit_unary(op, e),
+            ExprKind::Binary(op, lhs, rhs) => return self.visit_binary(op.node, lhs, rhs),
 
             // Can't be moved into a closure
             ExprKind::Break(..)

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -13,7 +13,7 @@ use crate::consts::ConstEvalCtxt;
 use crate::sym;
 use crate::ty::all_clauses_of;
 use crate::visitors::is_const_evaluatable;
-use core::ops::ControlFlow::{self, Break};
+use core::ops::ControlFlow::{self, Break, Continue};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{Visitor, walk_expr};
@@ -215,8 +215,13 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     let ty = self.ecx.typeck.expr_ty(e).kind();
                     match op {
                         UnOp::Neg => match *ty {
-                            ty::Int(_) if self.ecx.eval(e).is_none() => self.eagerness |= NoChange,
-                            ty::Int(_) | ty::Float(_) => {},
+                            ty::Int(_) => {
+                                if self.ecx.eval(e).is_some() {
+                                    return Continue(());
+                                }
+                                self.eagerness |= NoChange;
+                            },
+                            ty::Float(_) => {},
                             _ => self.eagerness = Lazy,
                         },
                         UnOp::Deref => match *ty {
@@ -239,32 +244,55 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     let same_ty = lhs_ty == rhs_ty;
                     match op.node {
                         BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
-                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) if self.ecx.eval(rhs).is_none() => {
+                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {
+                                if self.ecx.eval(rhs).is_some() {
+                                    return self.visit_expr(lhs);
+                                }
+                                // Possible over shift or negative shift.
                                 self.eagerness |= NoChange;
                             },
-                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {},
                             _ => self.eagerness = Lazy,
                         },
                         BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
-                            ty::Uint(_) if same_ty && self.ecx.eval(rhs).is_none() => self.eagerness |= NoChange,
-                            ty::Int(ty)
-                                if same_ty
-                                    && self.ecx.eval(rhs).is_none_or(|rhs| {
-                                        rhs.to_int(self.ecx.tcx, ty) == Some(-1) && self.ecx.eval(lhs).is_none()
-                                    }) =>
-                            {
+                            ty::Uint(_) if same_ty => {
+                                if self.ecx.eval(rhs).is_some() {
+                                    return self.visit_expr(lhs);
+                                }
+                                // Possible division-by-zero.
                                 self.eagerness |= NoChange;
                             },
-                            ty::Uint(_) | ty::Int(_) | ty::Float(_) if same_ty => {},
+                            ty::Int(ty) if same_ty => {
+                                if let Some(rhs) = self.ecx.eval(rhs) {
+                                    if rhs.to_int(self.ecx.tcx, ty) == Some(-1) {
+                                        if self.ecx.eval(lhs).is_some() {
+                                            return Continue(());
+                                        }
+                                        // Possible overflow.
+                                        self.eagerness |= NoChange;
+                                    }
+                                    return self.visit_expr(lhs);
+                                }
+                                // Possible division-by-zero.
+                                self.eagerness |= NoChange;
+                            },
+                            ty::Float(_) if same_ty => {},
                             _ => self.eagerness = Lazy,
                         },
                         BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
-                            ty::Int(_) | ty::Uint(_)
-                                if same_ty && (self.ecx.eval(lhs).is_none() || self.ecx.eval(rhs).is_none()) =>
-                            {
+                            ty::Int(_) | ty::Uint(_) if same_ty => {
+                                if self.ecx.eval(lhs).is_some() {
+                                    return if self.ecx.eval(rhs).is_some() {
+                                        Continue(())
+                                    } else {
+                                        // Possible overflow.
+                                        self.eagerness |= NoChange;
+                                        self.visit_expr(rhs)
+                                    };
+                                }
+                                // Possible overflow.
                                 self.eagerness |= NoChange;
                             },
-                            ty::Int(_) | ty::Uint(_) | ty::Float(_) if same_ty => {},
+                            ty::Float(_) if same_ty => {},
                             _ => self.eagerness = Lazy,
                         },
                         BinOpKind::BitAnd

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -9,7 +9,7 @@
 //!  - or-fun-call
 //!  - option-if-let-else
 
-use crate::consts::{ConstEvalCtxt, FullInt};
+use crate::consts::ConstEvalCtxt;
 use crate::sym;
 use crate::ty::all_clauses_of;
 use crate::visitors::is_const_evaluatable;
@@ -210,62 +210,82 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     }
                 },
 
-                // `-i32::MIN` panics with overflow checks
-                ExprKind::Unary(UnOp::Neg, right) if self.ecx.eval(right).is_none() => {
-                    self.eagerness |= NoChange;
+                // Both binary and unary operations have cases which panic for integer types.
+                // For such cases we will only suggest eager evaluation if the overflow would be
+                // caught by rustc's `arithmetic_overflow` or `unconditional_panic` lints.
+                ExprKind::Unary(op, e) => {
+                    let ty = self.ecx.typeck.expr_ty(e).kind();
+                    match op {
+                        UnOp::Neg => match *ty {
+                            ty::Int(_) if self.ecx.eval(e).is_none() => self.eagerness |= NoChange,
+                            ty::Int(_) | ty::Float(_) => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                        UnOp::Deref => match *ty {
+                            ty::Adt(def, _) if def.is_box() => {},
+                            ty::Ref(..) => {},
+                            // Raw pointer dereferences have validity invariants which may not be
+                            // met if moved earlier. Everything else is a custom deref which should be
+                            // cheap, but we don't know for sure.
+                            _ => self.eagerness |= NoChange,
+                        },
+                        UnOp::Not => match *ty {
+                            ty::Int(_) | ty::Uint(_) | ty::Bool => {},
+                            _ => self.eagerness |= NoChange,
+                        },
+                    }
                 },
-
-                // Custom `Deref` impl might have side effects
-                ExprKind::Unary(UnOp::Deref, e) if self.ecx.typeck.expr_ty(e).builtin_deref(true).is_none() => {
-                    self.eagerness |= NoChange;
+                ExprKind::Binary(op, lhs, rhs) => {
+                    let lhs_ty = self.ecx.typeck.expr_ty(lhs);
+                    let rhs_ty = self.ecx.typeck.expr_ty(rhs);
+                    let same_ty = lhs_ty == rhs_ty;
+                    match op.node {
+                        BinOpKind::Shl | BinOpKind::Shr => match (lhs_ty.kind(), rhs_ty.kind()) {
+                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) if self.ecx.eval(rhs).is_none() => {
+                                self.eagerness |= NoChange;
+                            },
+                            (ty::Int(_) | ty::Uint(_), ty::Int(_) | ty::Uint(_)) => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                        BinOpKind::Div | BinOpKind::Rem => match *lhs_ty.kind() {
+                            ty::Uint(_) if same_ty && self.ecx.eval(rhs).is_none() => self.eagerness |= NoChange,
+                            ty::Int(ty)
+                                if same_ty
+                                    && self.ecx.eval(rhs).is_none_or(|rhs| {
+                                        rhs.to_int(self.ecx.tcx, ty) == Some(-1) && self.ecx.eval(lhs).is_none()
+                                    }) =>
+                            {
+                                self.eagerness |= NoChange;
+                            },
+                            ty::Uint(_) | ty::Int(_) | ty::Float(_) if same_ty => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                        BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul => match *lhs_ty.kind() {
+                            ty::Int(_) | ty::Uint(_)
+                                if same_ty && (self.ecx.eval(lhs).is_none() || self.ecx.eval(rhs).is_none()) =>
+                            {
+                                self.eagerness |= NoChange;
+                            },
+                            ty::Int(_) | ty::Uint(_) | ty::Float(_) if same_ty => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                        BinOpKind::BitAnd
+                        | BinOpKind::BitOr
+                        | BinOpKind::BitXor
+                        | BinOpKind::Eq
+                        | BinOpKind::Ne
+                        | BinOpKind::Lt
+                        | BinOpKind::Le
+                        | BinOpKind::Gt
+                        | BinOpKind::Ge
+                        | BinOpKind::Or
+                        | BinOpKind::And => match *lhs_ty.kind() {
+                            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) if same_ty => {},
+                            ty::RawPtr(..) if rhs_ty.is_raw_ptr() => {},
+                            _ => self.eagerness = Lazy,
+                        },
+                    }
                 },
-                // Dereferences should be cheap, but dereferencing a raw pointer earlier may not be safe.
-                ExprKind::Unary(UnOp::Deref, e) if !self.ecx.typeck.expr_ty(e).is_raw_ptr() => (),
-                ExprKind::Unary(UnOp::Deref, _) => self.eagerness |= NoChange,
-                ExprKind::Unary(_, e)
-                    if matches!(self.ecx.typeck.expr_ty(e).kind(), ty::Bool | ty::Int(_) | ty::Uint(_),) => {},
-
-                // `>>` and `<<` panic when the right-hand side is greater than or equal to the number of bits in the
-                // type of the left-hand side, or is negative.
-                // We intentionally only check if the right-hand isn't a constant, because even if the suggestion would
-                // overflow with constants, the compiler emits an error for it and the programmer will have to fix it.
-                // Thus, we would realistically only delay the lint.
-                ExprKind::Binary(op, _, right)
-                    if matches!(op.node, BinOpKind::Shl | BinOpKind::Shr) && self.ecx.eval(right).is_none() =>
-                {
-                    self.eagerness |= NoChange;
-                },
-
-                ExprKind::Binary(op, left, right)
-                    if matches!(op.node, BinOpKind::Div | BinOpKind::Rem)
-                        && let right_ty = self.ecx.typeck.expr_ty(right)
-                        && let left = self.ecx.eval(left)
-                        && let right = self.ecx.eval(right).and_then(|c| c.int_value(self.ecx.tcx, right_ty))
-                        && matches!(
-                            (left, right),
-                            // `1 / x`: x might be zero
-                            (_, None)
-                            // `x / -1`: x might be T::MIN
-                            | (None, Some(FullInt::S(-1)))
-                        ) =>
-                {
-                    self.eagerness |= NoChange;
-                },
-
-                // Similar to `>>` and `<<`, we only want to avoid linting entirely if either side is unknown and the
-                // compiler can't emit an error for an overflowing expression.
-                // Suggesting eagerness for `true.then(|| i32::MAX + 1)` is okay because the compiler will emit an
-                // error and it's good to have the eagerness warning up front when the user fixes the logic error.
-                ExprKind::Binary(op, left, right)
-                    if matches!(op.node, BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul)
-                        && !self.ecx.typeck.expr_ty(e).is_floating_point()
-                        && (self.ecx.eval(left).is_none() || self.ecx.eval(right).is_none()) =>
-                {
-                    self.eagerness |= NoChange;
-                },
-
-                ExprKind::Binary(_, lhs, rhs)
-                    if self.ecx.typeck.expr_ty(lhs).is_primitive() && self.ecx.typeck.expr_ty(rhs).is_primitive() => {},
 
                 // Can't be moved into a closure
                 ExprKind::Break(..)
@@ -279,8 +299,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     return;
                 },
 
-                // Memory allocation, custom operator, loop, or call to an unknown function
-                ExprKind::Unary(..) | ExprKind::Binary(..) | ExprKind::Loop(..) | ExprKind::Call(..) => {
+                ExprKind::Loop(..) | ExprKind::Call(..) => {
                     self.eagerness = Lazy;
                 },
 

--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -13,6 +13,7 @@ use crate::consts::ConstEvalCtxt;
 use crate::sym;
 use crate::ty::all_clauses_of;
 use crate::visitors::is_const_evaluatable;
+use core::ops::ControlFlow::{self, Break};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{Visitor, walk_expr};
@@ -121,11 +122,9 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
     }
 
     impl<'tcx> Visitor<'tcx> for V<'tcx> {
-        fn visit_expr(&mut self, e: &'tcx Expr<'_>) {
+        type Result = ControlFlow<()>;
+        fn visit_expr(&mut self, e: &'tcx Expr<'_>) -> Self::Result {
             use EagernessSuggestion::{ForceNoChange, Lazy, NoChange};
-            if self.eagerness == ForceNoChange {
-                return;
-            }
 
             // Autoderef through a user-defined `Deref` impl can have side-effects,
             // so don't suggest changing it.
@@ -151,14 +150,14 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                     res @ (Res::Def(DefKind::Ctor(..) | DefKind::Variant, _) | Res::SelfCtor(_)) => {
                         if res_has_significant_drop(res, &self.ecx, e) {
                             self.eagerness = ForceNoChange;
-                            return;
+                            return Break(());
                         }
                     },
                     Res::Def(_, id) if self.ecx.tcx.is_promotable_const_fn(id) => (),
                     // No need to walk the arguments here, `is_const_evaluatable` already did
                     Res::Def(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
                         self.eagerness |= NoChange;
-                        return;
+                        return Break(());
                     },
                     Res::Def(_, id) => match path {
                         QPath::Resolved(_, p) => {
@@ -178,19 +177,19 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 // No need to walk the arguments here, `is_const_evaluatable` already did
                 ExprKind::MethodCall(..) if is_const_evaluatable(self.ecx.tcx, self.ecx.typeck, e) => {
                     self.eagerness |= NoChange;
-                    return;
+                    return Break(());
                 },
                 #[expect(clippy::match_same_arms)] // arm pattern can't be merged due to `ref`, see rust#105778
                 ExprKind::Struct(path, ..) => {
                     if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
                         self.eagerness = ForceNoChange;
-                        return;
+                        return Break(());
                     }
                 },
                 ExprKind::Path(ref path) => {
                     if res_has_significant_drop(self.ecx.typeck.qpath_res(path, e.hir_id), &self.ecx, e) {
                         self.eagerness = ForceNoChange;
-                        return;
+                        return Break(());
                     }
                 },
                 ExprKind::MethodCall(name, ..) => {
@@ -295,7 +294,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 | ExprKind::Yield(..)
                 | ExprKind::Err(_) => {
                     self.eagerness = ForceNoChange;
-                    return;
+                    return Break(());
                 },
 
                 ExprKind::Loop(..) | ExprKind::Call(..) => {
@@ -326,7 +325,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 // TODO: Actually check if either of these are true here.
                 ExprKind::Assign(..) | ExprKind::AssignOp(..) | ExprKind::Block(..) => self.eagerness |= NoChange,
             }
-            walk_expr(self, e);
+            walk_expr(self, e)
         }
     }
 
@@ -334,7 +333,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
         ecx: ConstEvalCtxt::new(cx),
         eagerness: EagernessSuggestion::Eager,
     };
-    v.visit_expr(e);
+    let _ = v.visit_expr(e);
     v.eagerness
 }
 


### PR DESCRIPTION
Based on rust-lang/rust-clippy#17228

Changes:
* The handling of binary and unary operators have been separated into separate functions instead of relying on cascaded match guards. A little large, but it's much more clear how the overlapping cases are handled. 
* Returning if there were any deref adjustments was just wrong. It would miss any lazy and unchangeable expressions.
* The visitor won't descend into const-evaluated expressions. This does mean something like `cfg!(debug_assertions) || return` can be suggested for eager evaluation which is notably abnormal code. I plan to rewrite this in a way that fixes this, but I need to finish const-evaluation changes first.
* References as operator arguments are now handled. They used to return `Lazy`, but they should return `Eager`. This is changing them to `NoChange` so we don't flip the suggestion over a single release.
* The two new const-evaluation functions don't make too much sense with the current API, but they match how I'm planning to change the API.

changelog: none