### PR TITLE
`redundant_pattern_matching`: parenthesize guarded `matches!` suggestion

### DIFF
--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -4,12 +4,12 @@ use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::sugg::{Sugg, make_unop};
 use clippy_utils::ty::needs_ordered_drop;
 use clippy_utils::visitors::{any_temporaries_need_ordered_drop, for_each_expr_without_closures};
-use clippy_utils::{higher, is_expn_of, sym};
+use clippy_utils::{get_parent_expr, higher, is_expn_of, sym};
 use rustc_ast::ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::{self, OptionNone, OptionSome, PollPending, PollReady, ResultErr, ResultOk};
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::{Arm, Expr, ExprKind, Node, Pat, PatExpr, PatExprKind, PatKind, QPath, UnOp};
+use rustc_hir::{Arm, BinOpKind, Expr, ExprKind, Node, Pat, PatExpr, PatExprKind, PatKind, QPath, UnOp};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, GenericArgKind, Ty};
 use rustc_span::{Span, Symbol, kw};
@@ -312,11 +312,28 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op
                 if let Some(guard) = maybe_guard {
                     let guard = Sugg::hir_with_context(cx, guard, ctxt, "..", &mut app);
                     let _ = write!(sugg, " && {}", guard.maybe_paren());
+                    if guard_sugg_needs_parens(cx, expr) {
+                        sugg = format!("({sugg})");
+                    }
                 }
 
                 diag.span_suggestion_verbose(expr_span, format!("consider using `{good_method}`"), sugg, app);
             },
         );
+    }
+}
+
+/// Whether the appended `&& guard` makes the suggestion bind looser than `expr`'s
+/// parent, so the whole `recv.method() && guard` must be wrapped in parentheses.
+fn guard_sugg_needs_parens(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    let Some(parent) = get_parent_expr(cx, expr) else {
+        return false;
+    };
+    match parent.kind {
+        ExprKind::Binary(op, ..) => !matches!(op.node, BinOpKind::And | BinOpKind::Or),
+        ExprKind::Unary(..) | ExprKind::AddrOf(..) | ExprKind::Cast(..) => true,
+        ExprKind::MethodCall(_, receiver, ..) => receiver.hir_id == expr.hir_id,
+        _ => false,
     }
 }
 

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -23,6 +23,29 @@ fn issue_11174_edge_cases<T>(boolean: bool, boolean2: bool, maybe_some: Option<T
     };
 }
 
+fn issue_17286(a: bool, b: bool, opt: Option<i32>) {
+    let _ = !(opt.is_none() && a);
+    //~^ redundant_pattern_matching
+    let _ = &(opt.is_none() && a);
+    //~^ redundant_pattern_matching
+    let _ = (opt.is_none() && a) as u8;
+    //~^ redundant_pattern_matching
+    let _ = (opt.is_none() && a) == b;
+    //~^ redundant_pattern_matching
+    let _ = (opt.is_none() && a).then_some(1);
+    //~^ redundant_pattern_matching
+    let _ = opt.is_none() && a;
+    //~^ redundant_pattern_matching
+    if opt.is_none() && a {}
+    //~^ redundant_pattern_matching
+    let _ = opt.is_none() && a && b;
+    //~^ redundant_pattern_matching
+    let _ = opt.is_none() && a || b;
+    //~^ redundant_pattern_matching
+    let _ = b.then_some(opt.is_none() && a);
+    //~^ redundant_pattern_matching
+}
+
 fn main() {
     if None::<()>.is_none() {}
     //~^ redundant_pattern_matching

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -23,6 +23,29 @@ fn issue_11174_edge_cases<T>(boolean: bool, boolean2: bool, maybe_some: Option<T
     };
 }
 
+fn issue_17286(a: bool, b: bool, opt: Option<i32>) {
+    let _ = !matches!(opt, None if a);
+    //~^ redundant_pattern_matching
+    let _ = &matches!(opt, None if a);
+    //~^ redundant_pattern_matching
+    let _ = matches!(opt, None if a) as u8;
+    //~^ redundant_pattern_matching
+    let _ = matches!(opt, None if a) == b;
+    //~^ redundant_pattern_matching
+    let _ = matches!(opt, None if a).then_some(1);
+    //~^ redundant_pattern_matching
+    let _ = matches!(opt, None if a);
+    //~^ redundant_pattern_matching
+    if matches!(opt, None if a) {}
+    //~^ redundant_pattern_matching
+    let _ = matches!(opt, None if a) && b;
+    //~^ redundant_pattern_matching
+    let _ = matches!(opt, None if a) || b;
+    //~^ redundant_pattern_matching
+    let _ = b.then_some(matches!(opt, None if a));
+    //~^ redundant_pattern_matching
+}
+
 fn main() {
     if let None = None::<()> {}
     //~^ redundant_pattern_matching

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -25,7 +25,127 @@ LL +     let _ = maybe_some.is_none() && (boolean || boolean2); // guard needs p
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:27:12
+  --> tests/ui/redundant_pattern_matching_option.rs:27:14
+   |
+LL |     let _ = !matches!(opt, None if a);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = !matches!(opt, None if a);
+LL +     let _ = !(opt.is_none() && a);
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:29:14
+   |
+LL |     let _ = &matches!(opt, None if a);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = &matches!(opt, None if a);
+LL +     let _ = &(opt.is_none() && a);
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:31:13
+   |
+LL |     let _ = matches!(opt, None if a) as u8;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = matches!(opt, None if a) as u8;
+LL +     let _ = (opt.is_none() && a) as u8;
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:33:13
+   |
+LL |     let _ = matches!(opt, None if a) == b;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = matches!(opt, None if a) == b;
+LL +     let _ = (opt.is_none() && a) == b;
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:35:13
+   |
+LL |     let _ = matches!(opt, None if a).then_some(1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = matches!(opt, None if a).then_some(1);
+LL +     let _ = (opt.is_none() && a).then_some(1);
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:37:13
+   |
+LL |     let _ = matches!(opt, None if a);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = matches!(opt, None if a);
+LL +     let _ = opt.is_none() && a;
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:39:8
+   |
+LL |     if matches!(opt, None if a) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     if matches!(opt, None if a) {}
+LL +     if opt.is_none() && a {}
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:41:13
+   |
+LL |     let _ = matches!(opt, None if a) && b;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = matches!(opt, None if a) && b;
+LL +     let _ = opt.is_none() && a && b;
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:43:13
+   |
+LL |     let _ = matches!(opt, None if a) || b;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = matches!(opt, None if a) || b;
+LL +     let _ = opt.is_none() && a || b;
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:45:25
+   |
+LL |     let _ = b.then_some(matches!(opt, None if a));
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `is_none()`
+   |
+LL -     let _ = b.then_some(matches!(opt, None if a));
+LL +     let _ = b.then_some(opt.is_none() && a);
+   |
+
+error: redundant pattern matching
+  --> tests/ui/redundant_pattern_matching_option.rs:50:12
    |
 LL |     if let None = None::<()> {}
    |            ^^^^
@@ -37,7 +157,7 @@ LL +     if None::<()>.is_none() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:30:12
+  --> tests/ui/redundant_pattern_matching_option.rs:53:12
    |
 LL |     if let Some(_) = Some(42) {}
    |            ^^^^^^^
@@ -49,7 +169,7 @@ LL +     if Some(42).is_some() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:33:12
+  --> tests/ui/redundant_pattern_matching_option.rs:56:12
    |
 LL |     if let Some(_) = Some(42) {
    |            ^^^^^^^
@@ -61,7 +181,7 @@ LL +     if Some(42).is_some() {
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:40:15
+  --> tests/ui/redundant_pattern_matching_option.rs:63:15
    |
 LL |     while let Some(_) = Some(42) {}
    |               ^^^^^^^
@@ -73,7 +193,7 @@ LL +     while Some(42).is_some() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:43:15
+  --> tests/ui/redundant_pattern_matching_option.rs:66:15
    |
 LL |     while let None = Some(42) {}
    |               ^^^^
@@ -85,7 +205,7 @@ LL +     while Some(42).is_none() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:46:15
+  --> tests/ui/redundant_pattern_matching_option.rs:69:15
    |
 LL |     while let None = None::<()> {}
    |               ^^^^
@@ -97,7 +217,7 @@ LL +     while None::<()>.is_none() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:50:15
+  --> tests/ui/redundant_pattern_matching_option.rs:73:15
    |
 LL |     while let Some(_) = v.pop() {
    |               ^^^^^^^
@@ -109,7 +229,7 @@ LL +     while v.pop().is_some() {
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:59:5
+  --> tests/ui/redundant_pattern_matching_option.rs:82:5
    |
 LL | /     match Some(42) {
 LL | |
@@ -129,7 +249,7 @@ LL +     Some(42).is_some();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:65:5
+  --> tests/ui/redundant_pattern_matching_option.rs:88:5
    |
 LL | /     match None::<()> {
 LL | |
@@ -149,7 +269,7 @@ LL +     None::<()>.is_none();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:71:13
+  --> tests/ui/redundant_pattern_matching_option.rs:94:13
    |
 LL |       let _ = match None::<()> {
    |  _____________^
@@ -170,7 +290,7 @@ LL +     let _ = None::<()>.is_none();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:78:20
+  --> tests/ui/redundant_pattern_matching_option.rs:101:20
    |
 LL |     let _ = if let Some(_) = opt { true } else { false };
    |                    ^^^^^^^
@@ -182,7 +302,7 @@ LL +     let _ = if opt.is_some() { true } else { false };
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:85:20
+  --> tests/ui/redundant_pattern_matching_option.rs:108:20
    |
 LL |     let _ = if let Some(_) = gen_opt() {
    |                    ^^^^^^^
@@ -194,7 +314,7 @@ LL +     let _ = if gen_opt().is_some() {
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:88:19
+  --> tests/ui/redundant_pattern_matching_option.rs:111:19
    |
 LL |     } else if let None = gen_opt() {
    |                   ^^^^
@@ -206,7 +326,7 @@ LL +     } else if gen_opt().is_none() {
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:95:12
+  --> tests/ui/redundant_pattern_matching_option.rs:118:12
    |
 LL |     if let Some(..) = gen_opt() {}
    |            ^^^^^^^^
@@ -218,7 +338,7 @@ LL +     if gen_opt().is_some() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:111:12
+  --> tests/ui/redundant_pattern_matching_option.rs:134:12
    |
 LL |     if let Some(_) = Some(42) {}
    |            ^^^^^^^
@@ -230,7 +350,7 @@ LL +     if Some(42).is_some() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:114:12
+  --> tests/ui/redundant_pattern_matching_option.rs:137:12
    |
 LL |     if let None = None::<()> {}
    |            ^^^^
@@ -242,7 +362,7 @@ LL +     if None::<()>.is_none() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:117:15
+  --> tests/ui/redundant_pattern_matching_option.rs:140:15
    |
 LL |     while let Some(_) = Some(42) {}
    |               ^^^^^^^
@@ -254,7 +374,7 @@ LL +     while Some(42).is_some() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:120:15
+  --> tests/ui/redundant_pattern_matching_option.rs:143:15
    |
 LL |     while let None = None::<()> {}
    |               ^^^^
@@ -266,7 +386,7 @@ LL +     while None::<()>.is_none() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:123:5
+  --> tests/ui/redundant_pattern_matching_option.rs:146:5
    |
 LL | /     match Some(42) {
 LL | |
@@ -286,7 +406,7 @@ LL +     Some(42).is_some();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:129:5
+  --> tests/ui/redundant_pattern_matching_option.rs:152:5
    |
 LL | /     match None::<()> {
 LL | |
@@ -306,7 +426,7 @@ LL +     None::<()>.is_none();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:138:12
+  --> tests/ui/redundant_pattern_matching_option.rs:161:12
    |
 LL |     if let None = *(&None::<()>) {}
    |            ^^^^
@@ -318,7 +438,7 @@ LL +     if (&None::<()>).is_none() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:140:12
+  --> tests/ui/redundant_pattern_matching_option.rs:163:12
    |
 LL |     if let None = *&None::<()> {}
    |            ^^^^
@@ -330,7 +450,7 @@ LL +     if (&None::<()>).is_none() {}
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:147:5
+  --> tests/ui/redundant_pattern_matching_option.rs:170:5
    |
 LL | /     match x {
 LL | |
@@ -350,7 +470,7 @@ LL +     x.is_some();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:153:5
+  --> tests/ui/redundant_pattern_matching_option.rs:176:5
    |
 LL | /     match x {
 LL | |
@@ -370,7 +490,7 @@ LL +     x.is_none();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:159:5
+  --> tests/ui/redundant_pattern_matching_option.rs:182:5
    |
 LL | /     match x {
 LL | |
@@ -390,7 +510,7 @@ LL +     x.is_none();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:165:5
+  --> tests/ui/redundant_pattern_matching_option.rs:188:5
    |
 LL | /     match x {
 LL | |
@@ -410,7 +530,7 @@ LL +     x.is_some();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:181:13
+  --> tests/ui/redundant_pattern_matching_option.rs:204:13
    |
 LL |     let _ = matches!(x, Some(_));
    |             ^^^^^^^^^^^^^^^^^^^^
@@ -422,7 +542,7 @@ LL +     let _ = x.is_some();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:184:13
+  --> tests/ui/redundant_pattern_matching_option.rs:207:13
    |
 LL |     let _ = matches!(x, None);
    |             ^^^^^^^^^^^^^^^^^
@@ -434,7 +554,7 @@ LL +     let _ = x.is_none();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:195:17
+  --> tests/ui/redundant_pattern_matching_option.rs:218:17
    |
 LL |         let _ = matches!(*p, None);
    |                 ^^^^^^^^^^^^^^^^^^
@@ -446,7 +566,7 @@ LL +         let _ = (*p).is_none();
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:203:16
+  --> tests/ui/redundant_pattern_matching_option.rs:226:16
    |
 LL |         if let Some(_) = x? {
    |                ^^^^^^^
@@ -458,7 +578,7 @@ LL +         if x?.is_some() {
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:223:16
+  --> tests/ui/redundant_pattern_matching_option.rs:246:16
    |
 LL |         if let Some(_) = x.await {
    |                ^^^^^^^
@@ -470,7 +590,7 @@ LL +         if x.await.is_some() {
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:236:12
+  --> tests/ui/redundant_pattern_matching_option.rs:259:12
    |
 LL |     if let Some(_) = (x! {}) {};
    |            ^^^^^^^
@@ -482,7 +602,7 @@ LL +     if x! {}.is_some() {};
    |
 
 error: redundant pattern matching
-  --> tests/ui/redundant_pattern_matching_option.rs:238:15
+  --> tests/ui/redundant_pattern_matching_option.rs:261:15
    |
 LL |     while let Some(_) = (x! {}) {}
    |               ^^^^^^^
@@ -493,5 +613,5 @@ LL -     while let Some(_) = (x! {}) {}
 LL +     while x! {}.is_some() {}
    |
 
-error: aborting due to 35 previous errors
+error: aborting due to 45 previous errors
 


### PR DESCRIPTION
The suggestion for a guarded `matches!(x, Pat if guard)` was built as `x.is_some() && guard` but never wrapped in parentheses, so applying it where the `matches!(...)` binds tighter than `&&` (`!matches!(...)`, `matches!(...) == false`, a method receiver, an `as` cast, ...) changed operator precedence. That either silently changed the program's behavior or broke compilation.

The fix wraps the whole `is_xxx() && guard` suggestion in parentheses when the parent expression binds tighter than `&&`, and leaves it untouched otherwise (statements, `if`/`while` conditions, arguments, `&&`/`||` operands).

Fixes rust-lang/rust-clippy#17286

changelog: [`redundant_pattern_matching`]: parenthesize the suggestion for a guarded `matches!` so the autofix keeps the original operator precedence