### PR TITLE
fix(vec_init_then_push): don't lint pushes from a macro expansion

### DIFF
--- a/clippy_lints/src/vec_init_then_push.rs
+++ b/clippy_lints/src/vec_init_then_push.rs
@@ -201,6 +201,7 @@ impl<'tcx> LateLintPass<'tcx> for VecInitThenPush {
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
         if let Some(searcher) = self.searcher.take() {
             if let StmtKind::Expr(expr) | StmtKind::Semi(expr) = stmt.kind
+                && !stmt.span.from_expansion()
                 && let ExprKind::MethodCall(name, self_arg, [_], _) = expr.kind
                 && self_arg.res_local_id() == Some(searcher.local_id)
                 && name.ident.name == sym::push

--- a/tests/ui/vec_init_then_push.rs
+++ b/tests/ui/vec_init_then_push.rs
@@ -126,3 +126,32 @@ fn f() {
     v.push((0i32, 0i32));
     let y = v[0].0.abs();
 }
+
+macro_rules! make_vec {
+    ($($e:expr),*) => {{
+        let mut temp = Vec::new();
+        $(temp.push($e);)*
+        temp
+    }};
+}
+
+macro_rules! push_each {
+    ($v:ident) => {
+        $v.push(1);
+        $v.push(2);
+        $v.push(3);
+        $v.push(4);
+    };
+}
+
+fn pushes_from_macro() -> Vec<i32> {
+    // no lint: the `Vec` and all the `push`es come from the macro expansion
+    make_vec![1, 2, 3, 4, 5]
+}
+
+fn local_outside_but_pushes_from_macro() -> Vec<i32> {
+    // no lint: just `push`es came from a macro expansion
+    let mut v = Vec::new();
+    push_each!(v);
+    v
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16131

changelog: [`vec_init_then_push`]: don't lint when the `push` calls come from a macro expansion