### PR TITLE
Call `in_external_macro` after running other checks in various places

### DIFF
--- a/clippy_lints/src/attrs/allow_attributes.rs
+++ b/clippy_lints/src/attrs/allow_attributes.rs
@@ -8,9 +8,9 @@ use rustc_lint::{EarlyContext, LintContext as _};
 
 // Separate each crate's features.
 pub fn check<'cx>(cx: &EarlyContext<'cx>, attr: &'cx Attribute) {
-    if !attr.span.in_external_macro(cx.sess().source_map())
-        && let AttrStyle::Outer = attr.style
+    if let AttrStyle::Outer = attr.style
         && let Some(path_span) = attr.path_span()
+        && !attr.span.in_external_macro(cx.sess().source_map())
         && !is_from_proc_macro(cx, attr)
     {
         #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]

--- a/clippy_lints/src/attrs/useless_attribute.rs
+++ b/clippy_lints/src/attrs/useless_attribute.rs
@@ -11,9 +11,6 @@ pub(super) fn check(cx: &EarlyContext<'_>, item: &Item, attrs: &[Attribute]) {
     let skip_unused_imports = attrs.iter().any(|attr| attr.has_name(sym::macro_use));
 
     for attr in attrs {
-        if attr.span.in_external_macro(cx.sess().source_map()) {
-            return;
-        }
         if let Some(lint_list) = &attr.meta_item_list()
             && attr.name().is_some_and(is_lint_level)
         {
@@ -72,9 +69,10 @@ pub(super) fn check(cx: &EarlyContext<'_>, item: &Item, attrs: &[Attribute]) {
                     _ => {},
                 }
             }
-            let line_span = first_line_of_span(cx, attr.span);
 
-            if let Some(src) = line_span.get_text(cx)
+            if !attr.span.in_external_macro(cx.sess().source_map())
+                && let line_span = first_line_of_span(cx, attr.span)
+                && let Some(src) = line_span.get_text(cx)
                 && src.contains("#[")
             {
                 #[expect(clippy::collapsible_span_lint_calls)]

--- a/clippy_lints/src/blocks_in_conditions.rs
+++ b/clippy_lints/src/blocks_in_conditions.rs
@@ -3,7 +3,7 @@ use clippy_utils::source::snippet_block_with_applicability;
 use clippy_utils::{contains_return, higher, is_from_proc_macro, leaks_droppable_temporary};
 use rustc_errors::Applicability;
 use rustc_hir::{BlockCheckMode, Expr, ExprKind, MatchSource};
-use rustc_lint::{LateContext, LateLintPass, LintContext as _};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 
 declare_clippy_lint! {
@@ -53,7 +53,7 @@ const BRACED_EXPR_MESSAGE: &str = "omit braces around single expression conditio
 
 impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if expr.span.in_external_macro(cx.sess().source_map()) {
+        if expr.span.from_expansion() {
             return;
         }
 
@@ -83,7 +83,7 @@ impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
                     if let Some(ex) = &block.expr {
                         // don't dig into the expression here, just suggest that they remove
                         // the block
-                        if expr.span.from_expansion() || ex.span.from_expansion() {
+                        if ex.span.from_expansion() {
                             return;
                         }
 
@@ -114,7 +114,7 @@ impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
                     }
                 } else {
                     let span = block.expr.as_ref().map_or_else(|| block.stmts[0].span, |e| e.span);
-                    if span.from_expansion() || expr.span.from_expansion() || is_from_proc_macro(cx, cond) {
+                    if span.from_expansion() || is_from_proc_macro(cx, cond) {
                         return;
                     }
                     // move block higher

--- a/clippy_lints/src/casts/borrow_as_ptr.rs
+++ b/clippy_lints/src/casts/borrow_as_ptr.rs
@@ -24,6 +24,7 @@ pub(super) fn check<'tcx>(
         && !is_lint_allowed(cx, BORROW_AS_PTR, expr.hir_id)
         // Fix #9884
         && !is_expr_temporary_value(cx, e)
+        && !expr.span.in_external_macro(cx.tcx.sess.source_map())
         && !is_from_proc_macro(cx, expr)
     {
         let mut app = Applicability::MachineApplicable;

--- a/clippy_lints/src/casts/cast_ptr_alignment.rs
+++ b/clippy_lints/src/casts/cast_ptr_alignment.rs
@@ -36,6 +36,7 @@ fn lint_cast_ptr_alignment<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, cast_f
         // when casting from a ZST, we don't know enough to properly lint
         && !from_layout.is_zst()
         && !is_used_as_unaligned(cx, expr)
+        && !expr.span.in_external_macro(cx.tcx.sess.source_map())
     {
         span_lint(
             cx,

--- a/clippy_lints/src/casts/cast_slice_different_sizes.rs
+++ b/clippy_lints/src/casts/cast_slice_different_sizes.rs
@@ -25,7 +25,12 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>, msrv: Msrv)
     {
         let from_size = from_layout.size.bytes();
         let to_size = to_layout.size.bytes();
-        if from_size != to_size && from_size != 0 && to_size != 0 && msrv.meets(cx, msrvs::PTR_SLICE_RAW_PARTS) {
+        if from_size != to_size
+            && from_size != 0
+            && to_size != 0
+            && msrv.meets(cx, msrvs::PTR_SLICE_RAW_PARTS)
+            && !expr.span.in_external_macro(cx.tcx.sess.source_map())
+        {
             span_lint_and_then(
                 cx,
                 CAST_SLICE_DIFFERENT_SIZES,

--- a/clippy_lints/src/casts/cast_slice_from_raw_parts.rs
+++ b/clippy_lints/src/casts/cast_slice_from_raw_parts.rs
@@ -35,6 +35,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>,
         && let ctxt = expr.span.ctxt()
         && cast_expr.span.ctxt() == ctxt
         && msrv.meets(cx, msrvs::PTR_SLICE_RAW_PARTS)
+        && !expr.span.in_external_macro(cx.tcx.sess.source_map())
     {
         let func = match rpk {
             RawPartsKind::Immutable => "from_raw_parts",

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -889,11 +889,10 @@ impl Casts {
 
 impl<'tcx> LateLintPass<'tcx> for Casts {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if expr.span.in_external_macro(cx.sess().source_map()) {
-            return;
-        }
-
         if let ExprKind::Cast(cast_from_expr, cast_to_hir) = expr.kind {
+            if expr.span.in_external_macro(cx.sess().source_map()) {
+                return;
+            }
             if is_hir_ty_cfg_dependant(cx, cast_to_hir) {
                 return;
             }

--- a/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -90,6 +90,7 @@ pub(super) fn check_null_ptr_cast_method(cx: &LateContext<'_>, expr: &Expr<'_>) 
         && let mut app = Applicability::MachineApplicable
         && let sugg = snippet_with_applicability(cx, cast_from_expr.span, "_", &mut app)
         && let Some((_, after_lt)) = sugg.split_once("::<")
+        && !expr.span.in_external_macro(cx.tcx.sess.source_map())
     {
         span_lint_and_sugg(
             cx,

--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -88,12 +88,12 @@ impl<'a, 'tcx> NumericFallbackVisitor<'a, 'tcx> {
 
     /// Check whether a passed literal has potential to cause fallback or not.
     fn check_lit(&self, lit: Lit, lit_ty: Ty<'tcx>, emit_hir_id: HirId) {
-        if !lit.span.in_external_macro(self.cx.sess().source_map())
-            && matches!(self.ty_bounds.last(), Some(ExplicitTyBound(false)))
+        if matches!(self.ty_bounds.last(), Some(ExplicitTyBound(false)))
             && matches!(
                 lit.node,
                 LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed)
             )
+            && !lit.span.in_external_macro(self.cx.sess().source_map())
         {
             let (suffix, is_float) = match lit_ty.kind() {
                 ty::Int(IntTy::I32) => ("i32", false),

--- a/clippy_lints/src/duration_suboptimal_units.rs
+++ b/clippy_lints/src/duration_suboptimal_units.rs
@@ -71,9 +71,7 @@ impl DurationSuboptimalUnits {
 
 impl LateLintPass<'_> for DurationSuboptimalUnits {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &'_ Expr<'_>) {
-        if !expr.span.in_external_macro(cx.sess().source_map())
-            // Check if a function on std::time::Duration is called
-            && let ExprKind::Call(func, [arg]) = expr.kind
+        if let ExprKind::Call(func, [arg]) = expr.kind
             && let ExprKind::Path(QPath::TypeRelative(func_ty, func_name)) = func.kind
             && cx
                 .typeck_results()
@@ -97,6 +95,7 @@ impl LateLintPass<'_> for DurationSuboptimalUnits {
             // For expressions (e.g. `10 * 60`), always lint since the expression already
             // signals intent to compute a converted value.
             && (!matches!(arg.kind, ExprKind::Lit(_)) || promoted_value > 10)
+            && !expr.span.in_external_macro(cx.sess().source_map())
         {
             span_lint_and_then(
                 cx,

--- a/clippy_lints/src/equatable_if_let.rs
+++ b/clippy_lints/src/equatable_if_let.rs
@@ -105,7 +105,7 @@ impl<'tcx> LateLintPass<'tcx> for PatternEquality {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         if let ExprKind::Let(let_expr) = expr.kind
             && is_unary_pattern(let_expr.pat)
-            && !expr.span.in_external_macro(cx.sess().source_map())
+            && !expr.span.from_expansion()
             && !let_expr.pat.span.from_expansion()
             && !let_expr.init.span.from_expansion()
         {

--- a/clippy_lints/src/functions/ref_option.rs
+++ b/clippy_lints/src/functions/ref_option.rs
@@ -12,8 +12,7 @@ use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
 fn check_ty<'a>(cx: &LateContext<'a>, param: &hir::Ty<'a>, param_ty: Ty<'a>, fixes: &mut Vec<(Span, String)>) {
-    if !param.span.in_external_macro(cx.sess().source_map())
-        && let ty::Ref(_, opt_ty, Mutability::Not) = param_ty.kind()
+    if let ty::Ref(_, opt_ty, Mutability::Not) = param_ty.kind()
         && let Some(gen_ty) = option_arg_ty(cx, *opt_ty)
         && !gen_ty.is_ref()
         // Need to gen the original spans, so first parsing mid, and hir parsing afterward
@@ -24,6 +23,7 @@ fn check_ty<'a>(cx: &LateContext<'a>, param: &hir::Ty<'a>, param_ty: Ty<'a>, fix
             args: [hir::GenericArg::Type(opt_ty)],
             ..
         }) = last.args
+        && !param.span.in_external_macro(cx.sess().source_map())
         && !is_from_proc_macro(cx, param)
     {
         let lifetime = snippet(cx, lifetime.ident.span, "..");

--- a/clippy_lints/src/functions/too_many_lines.rs
+++ b/clippy_lints/src/functions/too_many_lines.rs
@@ -18,7 +18,7 @@ pub(super) fn check_fn(
 ) {
     // Closures must be contained in a parent body, which will be checked for `too_many_lines`.
     // Don't check closures for `too_many_lines` to avoid duplicated lints.
-    if matches!(kind, FnKind::Closure) || span.in_external_macro(cx.sess().source_map()) {
+    if matches!(kind, FnKind::Closure) || (span.from_expansion() && span.in_external_macro(cx.sess().source_map())) {
         return;
     }
 

--- a/clippy_lints/src/iter_without_into_iter.rs
+++ b/clippy_lints/src/iter_without_into_iter.rs
@@ -205,13 +205,12 @@ impl {self_ty_without_ref} {{
             _ => return,
         };
 
-        if !item.span.in_external_macro(cx.sess().source_map())
-            && let ImplItemKind::Fn(sig, _) = item.kind
+        if let ImplItemKind::Fn(sig, _) = item.kind
             && let FnRetTy::Return(ret) = sig.decl.output
+            && sig.decl.inputs.len() == 1
+            && sig.decl.implicit_self() == expected_implicit_self
             && is_nameable_in_impl_trait(ret)
             && cx.tcx.generics_of(item_did).is_own_empty()
-            && sig.decl.implicit_self() == expected_implicit_self
-            && sig.decl.inputs.len() == 1
             && let Some(imp) = get_parent_as_impl(cx.tcx, item.hir_id())
             && imp.of_trait.is_none()
             && let sig = cx.tcx.liberate_late_bound_regions(
@@ -235,6 +234,7 @@ impl {self_ty_without_ref} {{
             // Only lint if the `IntoIterator` impl doesn't actually exist
             && !implements_trait(cx, ref_ty, into_iter_did, &[])
             && is_ty_exported(cx, ref_ty.peel_refs())
+            && !item.span.in_external_macro(cx.sess().source_map())
         {
             let self_ty_snippet = format!("{borrow_prefix}{}", snippet(cx, imp.self_ty.span, ".."));
 

--- a/clippy_lints/src/manual_ilog2.rs
+++ b/clippy_lints/src/manual_ilog2.rs
@@ -51,10 +51,6 @@ impl ManualIlog2 {
 
 impl LateLintPass<'_> for ManualIlog2 {
     fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
-        if expr.span.in_external_macro(cx.sess().source_map()) {
-            return;
-        }
-
         match expr.kind {
             // `BIT_WIDTH - 1 - n.leading_zeros()`
             ExprKind::Binary(op, left, right)
@@ -77,6 +73,7 @@ impl LateLintPass<'_> for ManualIlog2 {
                     }
                     && val == u128::from(bit_width) - 1
                     && self.msrv.meets(cx, msrvs::ILOG2)
+                    && !expr.span.in_external_macro(cx.sess().source_map())
                     && !is_from_proc_macro(cx, expr) =>
             {
                 emit(cx, recv, expr);
@@ -90,6 +87,7 @@ impl LateLintPass<'_> for ManualIlog2 {
                     && let LitKind::Int(Pu128(2), _) = lit.node
                     && cx.typeck_results().expr_ty_adjusted(recv).is_integral()
                     /* no need to check MSRV here, as `ilog` and `ilog2` were introduced simultaneously */
+                    && !expr.span.in_external_macro(cx.sess().source_map())
                     && !is_from_proc_macro(cx, expr) =>
             {
                 emit(cx, recv, expr);

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -32,7 +32,7 @@ use clippy_utils::{
 };
 use rustc_hir::{Arm, Expr, ExprKind, LetStmt, MatchSource, Pat, PatKind};
 use rustc_lexer::{TokenKind, is_whitespace};
-use rustc_lint::{LateContext, LateLintPass, LintContext as _};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
 use rustc_span::Span;
 
@@ -1054,9 +1054,6 @@ impl Matches {
 impl<'tcx> LateLintPass<'tcx> for Matches {
     #[expect(clippy::too_many_lines)]
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if is_direct_expn_of(expr.span, sym::matches).is_none() && expr.span.in_external_macro(cx.sess().source_map()) {
-            return;
-        }
         let from_expansion = expr.span.from_expansion();
 
         if let ExprKind::Match(ex, arms, source) = expr.kind {
@@ -1065,6 +1062,9 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
             {
                 redundant_pattern_match::check_match(cx, expr, ex, arms);
                 redundant_pattern_match::check_matches_true(cx, expr, arm, ex);
+            }
+            if expr.span.in_external_macro(cx.tcx.sess.source_map()) {
+                return;
             }
 
             if source == MatchSource::Normal && !is_span_match(cx, expr.span) {
@@ -1147,6 +1147,9 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                 match_ref_pats::check(cx, ex, arms.iter().map(|el| el.pat), expr);
             }
         } else if let Some(if_let) = higher::IfLet::hir(cx, expr) {
+            if expr.span.in_external_macro(cx.tcx.sess.source_map()) {
+                return;
+            }
             collapsible_match::check_if_let(
                 cx,
                 if_let.let_span.ctxt(),
@@ -1208,6 +1211,9 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                 needless_match::check_if_let(cx, expr, &if_let);
             }
         } else {
+            if expr.span.in_external_macro(cx.tcx.sess.source_map()) {
+                return;
+            }
             if let Some(while_let) = higher::WhileLet::hir(expr) {
                 significant_drop_in_scrutinee::check_while_let(cx, expr, while_let.let_expr, while_let.if_then);
             }

--- a/clippy_lints/src/methods/filter_map_bool_then.rs
+++ b/clippy_lints/src/methods/filter_map_bool_then.rs
@@ -14,8 +14,7 @@ use rustc_middle::ty::adjustment::Adjust;
 use rustc_span::Span;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg: &Expr<'_>, call_span: Span) {
-    if !expr.span.in_external_macro(cx.sess().source_map())
-        && cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator)
+    if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator)
         && let ExprKind::Closure(closure) = arg.kind
         && let body = cx.tcx.hir_body(closure.body)
         && let value = peel_blocks(body.value)
@@ -37,6 +36,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg: &
         && let then_body = peel_blocks(cx.tcx.hir_body(then_closure.body).value)
         && let Some(def_id) = cx.typeck_results().type_dependent_def_id(value.hir_id)
         && cx.tcx.is_diagnostic_item(sym::bool_then, def_id)
+        && !expr.span.in_external_macro(cx.sess().source_map())
         && !is_from_proc_macro(cx, expr)
         // Count the number of derefs needed to get to the bool because we need those in the suggestion
         && let needed_derefs = cx.typeck_results().expr_adjustments(recv)

--- a/clippy_lints/src/methods/is_empty.rs
+++ b/clippy_lints/src/methods/is_empty.rs
@@ -4,14 +4,15 @@ use clippy_utils::macros::{is_assert_macro, root_macro_call};
 use clippy_utils::res::MaybeResPath as _;
 use clippy_utils::{find_binding_init, get_parent_expr, is_inside_always_const_context};
 use rustc_hir::{Expr, HirId, find_attr};
-use rustc_lint::{LateContext, LintContext as _};
+use rustc_lint::LateContext;
 
 use super::CONST_IS_EMPTY;
 
 /// Expression whose initialization depend on a constant conditioned by a `#[cfg(…)]` directive will
 /// not trigger the lint.
 pub(super) fn check(cx: &LateContext<'_>, expr: &'_ Expr<'_>, receiver: &Expr<'_>) {
-    if expr.span.in_external_macro(cx.sess().source_map()) || !receiver.span.eq_ctxt(expr.span) {
+    let ctxt = expr.span.ctxt();
+    if receiver.span.ctxt() != ctxt {
         return;
     }
     if let Some(parent) = get_parent_expr(cx, expr)
@@ -23,10 +24,10 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &'_ Expr<'_>, receiver: &Expr<'_
         return;
     }
     let init_expr = expr_or_init(cx, receiver);
-    if !receiver.span.eq_ctxt(init_expr.span) {
-        return;
-    }
-    if let Some(init_is_empty) = ConstEvalCtxt::new(cx).eval_is_empty(init_expr) {
+    if init_expr.span.ctxt() == ctxt
+        && let Some(init_is_empty) = ConstEvalCtxt::new(cx).eval_is_empty(init_expr)
+        && !ctxt.in_external_macro(cx.tcx.sess.source_map())
+    {
         span_lint(
             cx,
             CONST_IS_EMPTY,

--- a/clippy_lints/src/methods/manual_try_fold.rs
+++ b/clippy_lints/src/methods/manual_try_fold.rs
@@ -20,8 +20,7 @@ pub(super) fn check<'tcx>(
     fold_span: Span,
     msrv: Msrv,
 ) {
-    if !fold_span.in_external_macro(cx.sess().source_map())
-        && cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator)
+    if cx.ty_based_def(expr).opt_parent(cx).is_diag_item(cx, sym::Iterator)
         && let init_ty = cx.typeck_results().expr_ty(init)
         && let Some(try_trait) = cx.tcx.lang_items().try_trait()
         && implements_trait(cx, init_ty, try_trait, &[])
@@ -30,6 +29,7 @@ pub(super) fn check<'tcx>(
         && let Res::Def(DefKind::Ctor(_, _), _) = cx.qpath_res(&qpath, path.hir_id)
         && let ExprKind::Closure(closure) = acc.kind
         && msrv.meets(cx, msrvs::ITERATOR_TRY_FOLD)
+        && !fold_span.in_external_macro(cx.sess().source_map())
         && !is_from_proc_macro(cx, expr)
         && let Some(args_snip) = closure.fn_arg_span.and_then(|fn_arg_span| fn_arg_span.get_text(cx))
     {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5230,11 +5230,9 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
     }
 
     fn check_trait_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx TraitItem<'_>) {
-        if item.span.in_external_macro(cx.tcx.sess.source_map()) {
-            return;
-        }
-
-        if let TraitItemKind::Fn(ref sig, _) = item.kind {
+        if let TraitItemKind::Fn(ref sig, _) = item.kind
+            && !item.span.in_external_macro(cx.tcx.sess.source_map())
+        {
             if sig.decl.implicit_self().has_implicit_self()
                 && let Some(first_arg_hir_ty) = sig.decl.inputs.first()
                 && let Some(&first_arg_ty) = cx

--- a/clippy_lints/src/misc_early/mod.rs
+++ b/clippy_lints/src/misc_early/mod.rs
@@ -322,10 +322,6 @@ impl EarlyLintPass for MiscEarlyLints {
     }
 
     fn check_pat(&mut self, cx: &EarlyContext<'_>, pat: &Pat) {
-        if pat.span.in_external_macro(cx.sess().source_map()) {
-            return;
-        }
-
         unneeded_field_pattern::check(cx, pat);
         redundant_pattern::check(cx, pat);
         redundant_at_rest_pattern::check(cx, pat);

--- a/clippy_lints/src/misc_early/redundant_at_rest_pattern.rs
+++ b/clippy_lints/src/misc_early/redundant_at_rest_pattern.rs
@@ -6,11 +6,11 @@ use rustc_lint::{EarlyContext, LintContext as _};
 use super::REDUNDANT_AT_REST_PATTERN;
 
 pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
-    if !pat.span.in_external_macro(cx.sess().source_map())
-        && let PatKind::Slice(slice) = &pat.kind
+    if let PatKind::Slice(slice) = &pat.kind
         && let [one] = &**slice
         && let PatKind::Ident(annotation, ident, Some(rest)) = &one.kind
         && let PatKind::Rest = rest.kind
+        && !pat.span.in_external_macro(cx.sess().source_map())
     {
         span_lint_and_sugg(
             cx,

--- a/clippy_lints/src/misc_early/redundant_pattern.rs
+++ b/clippy_lints/src/misc_early/redundant_pattern.rs
@@ -1,13 +1,14 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_ast::ast::{Pat, PatKind};
 use rustc_errors::Applicability;
-use rustc_lint::EarlyContext;
+use rustc_lint::{EarlyContext, LintContext as _};
 
 use super::REDUNDANT_PATTERN;
 
 pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
     if let PatKind::Ident(ann, ident, Some(ref right)) = pat.kind
         && let PatKind::Wild = right.kind
+        && !pat.span.in_external_macro(cx.sess().source_map())
     {
         span_lint_and_sugg(
             cx,

--- a/clippy_lints/src/misc_early/unneeded_field_pattern.rs
+++ b/clippy_lints/src/misc_early/unneeded_field_pattern.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::{span_lint, span_lint_and_then};
 use clippy_utils::source::SpanExt as _;
 use itertools::Itertools as _;
 use rustc_ast::ast::{Pat, PatKind};
-use rustc_lint::EarlyContext;
+use rustc_lint::{EarlyContext, LintContext as _};
 
 use super::UNNEEDED_FIELD_PATTERN;
 
@@ -22,21 +22,25 @@ pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
             }
         }
         if !pfields.is_empty() && wilds == pfields.len() {
-            #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
-            span_lint_and_then(
-                cx,
-                UNNEEDED_FIELD_PATTERN,
-                pat.span,
-                "all the struct fields are matched to a wildcard pattern, consider using `..`",
-                |diag| {
-                    diag.help(format!("try with `{type_name} {{ .. }}` instead"));
-                },
-            );
+            if !pat.span.in_external_macro(cx.sess().source_map()) {
+                #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+                span_lint_and_then(
+                    cx,
+                    UNNEEDED_FIELD_PATTERN,
+                    pat.span,
+                    "all the struct fields are matched to a wildcard pattern, consider using `..`",
+                    |diag| {
+                        diag.help(format!("try with `{type_name} {{ .. }}` instead"));
+                    },
+                );
+            }
             return;
         }
         if wilds > 0 {
             for field in pfields {
-                if let PatKind::Wild = field.pat.kind {
+                if let PatKind::Wild = field.pat.kind
+                    && !field.span.in_external_macro(cx.sess().source_map())
+                {
                     wilds -= 1;
                     if wilds > 0 {
                         span_lint(

--- a/clippy_lints/src/misc_early/unneeded_wildcard_pattern.rs
+++ b/clippy_lints/src/misc_early/unneeded_wildcard_pattern.rs
@@ -16,6 +16,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
             .take_while(|pat| matches!(pat.kind, PatKind::Wild))
             .enumerate()
             .last()
+            && !pat.span.in_external_macro(cx.sess().source_map())
         {
             span_lint(cx, left_pat.span.until(patterns[rest_index].span), left_index == 0);
         }
@@ -25,6 +26,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
             .take_while(|pat| matches!(pat.kind, PatKind::Wild))
             .enumerate()
             .last()
+            && !pat.span.in_external_macro(cx.sess().source_map())
         {
             span_lint(
                 cx,
@@ -42,6 +44,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
             .last()
         // Only run if `rest_pattern_accessible_field` is Allow, as they otherwise will contradict each other.
         && cx.get_lint_level_spec(crate::rest_when_destructuring_struct::REST_PATTERN_ACCESSIBLE_FIELD).is_allow()
+        && !pat.span.in_external_macro(cx.sess().source_map())
     {
         // Unlike the tuples above, structs have patfields rather than patterns, and separate out the
         // `..` into a separate parameter. Also, the `..` can only be at the end of the pattern.

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -99,7 +99,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
             return;
         }
 
-        if span.in_external_macro(cx.tcx.sess.source_map()) || is_entrypoint_fn(cx, def_id.to_def_id()) {
+        if is_entrypoint_fn(cx, def_id.to_def_id()) {
             return;
         }
 
@@ -151,7 +151,9 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
             return;
         }
 
-        if is_from_proc_macro(cx, &(&kind, body, hir_id, span)) {
+        if (span.from_expansion() && span.in_external_macro(cx.tcx.sess.source_map()))
+            || is_from_proc_macro(cx, &(&kind, body, hir_id, span))
+        {
             return;
         }
 

--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -51,14 +51,9 @@ impl RedundantFieldNames {
 
 impl EarlyLintPass for RedundantFieldNames {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if !self.msrv.meets(msrvs::FIELD_INIT_SHORTHAND) {
-            return;
-        }
-
-        if expr.span.in_external_macro(cx.sess().source_map()) {
-            return;
-        }
-        if let ExprKind::Struct(ref se) = expr.kind {
+        if let ExprKind::Struct(ref se) = expr.kind
+            && self.msrv.meets(msrvs::FIELD_INIT_SHORTHAND)
+        {
             for field in &se.fields {
                 if !field.is_shorthand
                     && let ExprKind::Path(None, path) = &field.expr.kind
@@ -66,6 +61,7 @@ impl EarlyLintPass for RedundantFieldNames {
                     && segment.args.is_none()
                     && segment.ident == field.ident
                     && field.span.eq_ctxt(field.ident.span)
+                    && !field.span.in_external_macro(cx.sess().source_map())
                 {
                     span_lint_and_sugg(
                         cx,

--- a/clippy_lints/src/return_self_not_must_use.rs
+++ b/clippy_lints/src/return_self_not_must_use.rs
@@ -68,9 +68,7 @@ declare_clippy_lint! {
 declare_lint_pass!(ReturnSelfNotMustUse => [RETURN_SELF_NOT_MUST_USE]);
 
 fn check_method(cx: &LateContext<'_>, decl: &FnDecl<'_>, fn_def: LocalDefId, span: Span, owner_id: OwnerId) {
-    if !span.in_external_macro(cx.sess().source_map())
-        // If it comes from an external macro, better ignore it.
-        && decl.implicit_self().has_implicit_self()
+    if decl.implicit_self().has_implicit_self()
         // We only show this warning for public exported methods.
         && cx.effective_visibilities.is_exported(fn_def)
         // We don't want to emit this lint if the `#[must_use]` attribute is already there.
@@ -88,6 +86,7 @@ fn check_method(cx: &LateContext<'_>, decl: &FnDecl<'_>, fn_def: LocalDefId, spa
         && self_arg.peel_refs() == ret_ty
         // If `Self` is already considered as `#[must_use]`, no need for the attribute here.
         && opt_must_use_path(cx, ret_ty).is_none()
+        && !span.in_external_macro(cx.sess().source_map())
     {
         span_lint_and_help(
             cx,

--- a/clippy_lints/src/returns/needless_return_with_question_mark.rs
+++ b/clippy_lints/src/returns/needless_return_with_question_mark.rs
@@ -10,8 +10,7 @@ use rustc_middle::ty::adjustment::Adjust;
 use super::NEEDLESS_RETURN_WITH_QUESTION_MARK;
 
 pub(super) fn check_stmt<'tcx>(cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
-    if !stmt.span.in_external_macro(cx.sess().source_map())
-        && let StmtKind::Semi(expr) = stmt.kind
+    if let StmtKind::Semi(expr) = stmt.kind
         && let ExprKind::Ret(Some(ret)) = expr.kind
         // return Err(...)? desugars to a match
         // over a Err(...).branch()
@@ -28,6 +27,7 @@ pub(super) fn check_stmt<'tcx>(cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
         && !is_inside_let_else(cx.tcx, expr)
         && let [.., final_stmt] = block.stmts
         && (block.expr.is_some() || final_stmt.hir_id != stmt.hir_id)
+        && !stmt.span.in_external_macro(cx.sess().source_map())
         && !is_from_proc_macro(cx, expr)
         && !stmt_needs_never_type(cx, stmt.hir_id)
     {

--- a/clippy_lints/src/single_char_lifetime_names.rs
+++ b/clippy_lints/src/single_char_lifetime_names.rs
@@ -41,13 +41,10 @@ declare_lint_pass!(SingleCharLifetimeNames => [SINGLE_CHAR_LIFETIME_NAMES]);
 
 impl EarlyLintPass for SingleCharLifetimeNames {
     fn check_generic_param(&mut self, cx: &EarlyContext<'_>, param: &GenericParam) {
-        if param.ident.span.in_external_macro(cx.sess().source_map()) {
-            return;
-        }
-
         if let GenericParamKind::Lifetime = param.kind
             && !param.is_placeholder
             && param.ident.as_str().len() <= 2
+            && !param.ident.span.in_external_macro(cx.sess().source_map())
         {
             #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
             span_lint_and_then(

--- a/clippy_lints/src/std_instead_of_core.rs
+++ b/clippy_lints/src/std_instead_of_core.rs
@@ -124,14 +124,14 @@ enum LintPoint {
 impl<'tcx> LateLintPass<'tcx> for StdReexports {
     fn check_path(&mut self, cx: &LateContext<'tcx>, path: &Path<'tcx>, _: HirId) {
         if let Res::Def(def_kind, def_id) = path.res
+            && !matches!(def_kind, DefKind::Macro(_))
             && let Some(first_segment) = get_first_segment(path)
+            && let Res::Def(DefKind::Mod, crate_def_id) = first_segment.res
+            && crate_def_id.is_crate_root()
             && is_stable(cx, def_id, self.msrv)
             && !path.span.in_external_macro(cx.sess().source_map())
             && !is_from_proc_macro(cx, &first_segment.ident)
-            && !matches!(def_kind, DefKind::Macro(_))
             && let Some(last_segment) = path.segments.last()
-            && let Res::Def(DefKind::Mod, crate_def_id) = first_segment.res
-            && crate_def_id.is_crate_root()
         {
             let (lint, used_mod, replace_with) = match first_segment.ident.name {
                 sym::std => match cx.tcx.crate_name(def_id.krate) {

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -428,11 +428,6 @@ impl<'tcx> Visitor<'tcx> for UnwrappableVariablesVisitor<'_, 'tcx> {
     type NestedFilter = nested_filter::OnlyBodies;
 
     fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
-        // Shouldn't lint when `expr` is in macro.
-        if expr.span.in_external_macro(self.cx.tcx.sess.source_map()) {
-            walk_expr(self, expr);
-            return;
-        }
         // Skip checking inside closures since they are visited through `Unwrap::check_fn()` already.
         if matches!(expr.kind, ExprKind::Closure(_)) {
             return;
@@ -455,6 +450,7 @@ impl<'tcx> Visitor<'tcx> for UnwrappableVariablesVisitor<'_, 'tcx> {
                 && let span_ctxt = expr.span.ctxt()
                 && unwrappable.branch.span.ctxt() == span_ctxt
                 && unwrappable.check.span.ctxt() == span_ctxt
+                && !expr.span.in_external_macro(self.cx.tcx.sess.source_map())
             {
                 if call_to_unwrap == unwrappable.safe_to_unwrap {
                     let unwrappable_variable_str = unwrappable.local.snippet(self.cx);

--- a/clippy_lints/src/visibility.rs
+++ b/clippy_lints/src/visibility.rs
@@ -85,8 +85,8 @@ declare_lint_pass!(Visibility => [
 
 impl EarlyLintPass for Visibility {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
-        if !item.span.in_external_macro(cx.sess().source_map())
-            && let VisibilityKind::Restricted { path, shorthand, .. } = &item.vis.kind
+        if let VisibilityKind::Restricted { path, shorthand, .. } = &item.vis.kind
+            && !item.span.in_external_macro(cx.sess().source_map())
         {
             if **path == kw::SelfLower && !is_from_proc_macro(cx, item.vis.span) {
                 span_lint_and_then(


### PR DESCRIPTION
This is the fist batch of delayed calls. Not all of the changed locations are ideal, but changing something like the `matches` pass any further would be a lot more involved.

changelog: none
