### PR TITLE
Move `empty_enums` to the nursery

### DIFF
--- a/clippy_lints/src/empty_enums.rs
+++ b/clippy_lints/src/empty_enums.rs
@@ -51,7 +51,7 @@ declare_clippy_lint! {
     /// [visibility]: https://doc.rust-lang.org/reference/visibility-and-privacy.html
     #[clippy::version = "pre 1.29.0"]
     pub EMPTY_ENUMS,
-    pedantic,
+    nursery,
     "enum with no variants"
 }
 


### PR DESCRIPTION
This lint currently requires one to enable the `never_type` feature, but once that's stabilized this will start linting on all stable code with a recent enough MSRV. Due to rust-lang/rust-clippy#17297 this will start linting way too aggressively once that happens

cc @flip1995 since this should merged before the sync

changelog: Move `empty_enums` to the nursery
