### PR TITLE
Detect new range types in `higher::Range`.

### DIFF
--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -245,7 +245,7 @@ fn to_const_range(cx: &LateContext<'_>, range: higher::Range<'_>, array_size: u1
     let e = range.end.map(|expr| ecx.eval(expr));
     let end = match e {
         Some(Some(Constant::Int(x))) => {
-            if range.limits == RangeLimits::Closed {
+            if range.ty.limits() == RangeLimits::Closed {
                 Some(x + 1)
             } else {
                 Some(x)

--- a/clippy_lints/src/loops/explicit_counter_loop.rs
+++ b/clippy_lints/src/loops/explicit_counter_loop.rs
@@ -87,7 +87,7 @@ pub(super) fn check<'tcx>(
                 // If the loop variable is unused and the range is `0..n`, suggest `(init..).take(n)`.
                 if pat_snippet == "_"
                     && let Some(range) = Range::hir(cx, arg)
-                    && range.limits == RangeLimits::HalfOpen
+                    && range.ty.limits() == RangeLimits::HalfOpen
                     && range.start.is_some_and(|start| is_integer_literal(start, 0))
                     && let Some(end) = range.end
                 {

--- a/clippy_lints/src/loops/manual_memcpy.rs
+++ b/clippy_lints/src/loops/manual_memcpy.rs
@@ -28,6 +28,7 @@ pub(super) fn check<'tcx>(
         start: Some(start),
         end: Some(end),
         limits,
+        iterable: _,
         span: _,
     }) = higher::Range::hir(cx, arg)
         // the var must be a single name

--- a/clippy_lints/src/loops/manual_memcpy.rs
+++ b/clippy_lints/src/loops/manual_memcpy.rs
@@ -27,8 +27,7 @@ pub(super) fn check<'tcx>(
     if let Some(higher::Range {
         start: Some(start),
         end: Some(end),
-        limits,
-        iterable: _,
+        ty: range_ty,
         span: _,
     }) = higher::Range::hir(cx, arg)
         // the var must be a single name
@@ -90,7 +89,11 @@ pub(super) fn check<'tcx>(
                     }
                 })
             })
-            .map(|o| o.map(|(ty, dst, src)| build_manual_memcpy_suggestion(cx, start, end, limits, ty, &dst, &src)))
+            .map(|o| {
+                o.map(|(ty, dst, src)| {
+                    build_manual_memcpy_suggestion(cx, start, end, range_ty.limits(), ty, &dst, &src)
+                })
+            })
             .collect::<Option<Vec<_>>>()
             .filter(|v| !v.is_empty())
             .map(|v| v.join("\n    "));

--- a/clippy_lints/src/loops/manual_slice_fill.rs
+++ b/clippy_lints/src/loops/manual_slice_fill.rs
@@ -30,10 +30,10 @@ pub(super) fn check<'tcx>(
     if let Some(higher::Range {
         start: Some(start),
         end: Some(end),
-        limits: RangeLimits::HalfOpen,
-        iterable: _,
+        ty: range_ty,
         span: _,
     }) = higher::Range::hir(cx, arg)
+        && let RangeLimits::HalfOpen = range_ty.limits()
         && let ExprKind::Lit(Spanned {
             node: LitKind::Int(Pu128(0), _),
             ..

--- a/clippy_lints/src/loops/manual_slice_fill.rs
+++ b/clippy_lints/src/loops/manual_slice_fill.rs
@@ -31,6 +31,7 @@ pub(super) fn check<'tcx>(
         start: Some(start),
         end: Some(end),
         limits: RangeLimits::HalfOpen,
+        iterable: _,
         span: _,
     }) = higher::Range::hir(cx, arg)
         && let ExprKind::Lit(Spanned {

--- a/clippy_lints/src/loops/needless_range_loop.rs
+++ b/clippy_lints/src/loops/needless_range_loop.rs
@@ -30,6 +30,7 @@ pub(super) fn check<'tcx>(
         start: Some(start),
         ref end,
         limits,
+        iterable: _,
         span,
     }) = higher::Range::hir(cx, arg)
         // the var must be a single name

--- a/clippy_lints/src/loops/needless_range_loop.rs
+++ b/clippy_lints/src/loops/needless_range_loop.rs
@@ -29,8 +29,7 @@ pub(super) fn check<'tcx>(
     if let Some(higher::Range {
         start: Some(start),
         ref end,
-        limits,
-        iterable: _,
+        ty: range_ty,
         span,
     }) = higher::Range::hir(cx, arg)
         // the var must be a single name
@@ -115,12 +114,12 @@ pub(super) fn check<'tcx>(
                     end_is_start_plus_val = start_equal_left | start_equal_right;
                 }
 
-                if is_len_call(end, indexed) || is_end_eq_array_len(cx, end, limits, indexed_ty) {
+                if is_len_call(end, indexed) || is_end_eq_array_len(cx, end, range_ty, indexed_ty) {
                     String::new()
                 } else if visitor.indexed_mut.contains(&indexed) && contains_name(indexed, take_expr, cx) {
                     return;
                 } else {
-                    match limits {
+                    match range_ty.limits() {
                         ast::RangeLimits::Closed => {
                             let take_expr = sugg::Sugg::hir(cx, take_expr, "<count>");
                             format!(".take({})", take_expr + sugg::ONE)
@@ -206,7 +205,7 @@ fn is_len_call(expr: &Expr<'_>, var: Symbol) -> bool {
 fn is_end_eq_array_len<'tcx>(
     cx: &LateContext<'tcx>,
     end: &Expr<'_>,
-    limits: ast::RangeLimits,
+    range_ty: higher::RangeTy,
     indexed_ty: Ty<'tcx>,
 ) -> bool {
     if let ExprKind::Lit(lit) = end.kind
@@ -214,7 +213,7 @@ fn is_end_eq_array_len<'tcx>(
         && let ty::Array(_, arr_len_const) = indexed_ty.kind()
         && let Some(arr_len) = arr_len_const.try_to_target_usize(cx.tcx)
     {
-        return match limits {
+        return match range_ty.limits() {
             ast::RangeLimits::Closed => end_int.get() + 1 >= arr_len.into(),
             ast::RangeLimits::HalfOpen => end_int.get() >= arr_len.into(),
         };

--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -118,6 +118,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualIsAsciiCheck {
                 start: Some(start),
                 end: Some(end),
                 limits: RangeLimits::Closed,
+                iterable: _,
                 span: _,
             }) = higher::Range::hir(cx, receiver)
             && !matches!(cx.typeck_results().expr_ty(arg).peel_refs().kind(), ty::Param(_))

--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -117,10 +117,10 @@ impl<'tcx> LateLintPass<'tcx> for ManualIsAsciiCheck {
             && let Some(higher::Range {
                 start: Some(start),
                 end: Some(end),
-                limits: RangeLimits::Closed,
-                iterable: _,
+                ty: range_ty,
                 span: _,
             }) = higher::Range::hir(cx, receiver)
+            && let RangeLimits::Closed = range_ty.limits()
             && !matches!(cx.typeck_results().expr_ty(arg).peel_refs().kind(), ty::Param(_))
         {
             let arg = peel_ref_operators(cx, arg);

--- a/clippy_lints/src/methods/iter_next_slice.rs
+++ b/clippy_lints/src/methods/iter_next_slice.rs
@@ -39,6 +39,7 @@ pub(super) fn check<'tcx>(
                 start: Some(start_expr),
                 end: None,
                 limits: ast::RangeLimits::HalfOpen,
+                iterable: _,
                 span: _,
             }) = higher::Range::hir(cx, index_expr)
             && let hir::ExprKind::Lit(start_lit) = &start_expr.kind

--- a/clippy_lints/src/methods/iter_next_slice.rs
+++ b/clippy_lints/src/methods/iter_next_slice.rs
@@ -38,10 +38,10 @@ pub(super) fn check<'tcx>(
             && let Some(higher::Range {
                 start: Some(start_expr),
                 end: None,
-                limits: ast::RangeLimits::HalfOpen,
-                iterable: _,
+                ty: range_ty,
                 span: _,
             }) = higher::Range::hir(cx, index_expr)
+            && let ast::RangeLimits::HalfOpen = range_ty.limits()
             && let hir::ExprKind::Lit(start_lit) = &start_expr.kind
             && let ast::LitKind::Int(start_idx, _) = start_lit.node
         {

--- a/clippy_lints/src/methods/map_with_unused_argument_over_ranges.rs
+++ b/clippy_lints/src/methods/map_with_unused_argument_over_ranges.rs
@@ -32,7 +32,7 @@ fn extract_count_with_applicability(
         {
             // Here we can explicitly calculate the number of iterations
             let count = if upper_bound >= lower_bound {
-                match range.limits {
+                match range.ty.limits() {
                     RangeLimits::HalfOpen => upper_bound - lower_bound,
                     RangeLimits::Closed => (upper_bound - lower_bound).checked_add(1)?,
                 }
@@ -45,12 +45,12 @@ fn extract_count_with_applicability(
             .maybe_paren()
             .into_string();
         if lower_bound == 0 {
-            if range.limits == RangeLimits::Closed {
+            if range.ty.limits() == RangeLimits::Closed {
                 return Some(format!("{end_snippet} + 1"));
             }
             return Some(end_snippet);
         }
-        if range.limits == RangeLimits::Closed {
+        if range.ty.limits() == RangeLimits::Closed {
             return Some(format!("{end_snippet} - {}", lower_bound - 1));
         }
         return Some(format!("{end_snippet} - {lower_bound}"));

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -221,13 +221,11 @@ fn upper_index_expr(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<usize> {
         && let LitKind::Int(Pu128(index), _) = lit.node
     {
         Some(index as usize)
-    } else if let Some(Range {
-        end: Some(end), limits, ..
-    }) = Range::hir(cx, expr)
+    } else if let Some(Range { end: Some(end), ty, .. }) = Range::hir(cx, expr)
         && let ExprKind::Lit(lit) = &end.kind
         && let LitKind::Int(Pu128(index @ 1..), _) = lit.node
     {
-        match limits {
+        match ty.limits() {
             RangeLimits::HalfOpen => Some(index as usize - 1),
             RangeLimits::Closed => Some(index as usize),
         }

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -523,12 +523,11 @@ fn check_range_switch<'tcx>(
     if let higher::Range {
         start,
         end: Some(end),
-        limits,
-        iterable: _,
+        ty,
         span,
     } = *range
         && span.can_be_used_for_suggestions()
-        && limits == kind
+        && ty.limits() == kind
         && let Some(y) = predicate(end)
         && can_switch_ranges(cx, span.ctxt(), expr, kind, cx.typeck_results().expr_ty(y))
     {
@@ -591,8 +590,7 @@ fn check_reversed_empty_range(cx: &LateContext<'_>, expr: &Expr<'_>, range: &hig
     if let higher::Range {
         start: Some(start),
         end: Some(end),
-        limits,
-        iterable: _,
+        ty: range_ty,
         span,
     } = *range
         && let ty = cx.typeck_results().expr_ty(start)
@@ -601,7 +599,7 @@ fn check_reversed_empty_range(cx: &LateContext<'_>, expr: &Expr<'_>, range: &hig
         && let Some(start_idx) = ecx.eval(start)
         && let Some(end_idx) = ecx.eval(end)
         && let Some(ordering) = Constant::partial_cmp(cx.tcx, ty, &start_idx, &end_idx)
-        && is_empty_range(limits, ordering)
+        && is_empty_range(range_ty.limits(), ordering)
     {
         if inside_indexing_expr(cx, expr) {
             // Avoid linting `N..N` as it has proven to be useful, see #5689 and #5628 ...
@@ -624,7 +622,7 @@ fn check_reversed_empty_range(cx: &LateContext<'_>, expr: &Expr<'_>, range: &hig
                     if ordering != Ordering::Equal {
                         let start_snippet = snippet(cx, start.span, "_");
                         let end_snippet = snippet(cx, end.span, "_");
-                        let dots = match limits {
+                        let dots = match range_ty.limits() {
                             RangeLimits::HalfOpen => "..",
                             RangeLimits::Closed => "..=",
                         };

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -524,6 +524,7 @@ fn check_range_switch<'tcx>(
         start,
         end: Some(end),
         limits,
+        iterable: _,
         span,
     } = *range
         && span.can_be_used_for_suggestions()
@@ -591,6 +592,7 @@ fn check_reversed_empty_range(cx: &LateContext<'_>, expr: &Expr<'_>, range: &hig
         start: Some(start),
         end: Some(end),
         limits,
+        iterable: _,
         span,
     } = *range
         && let ty = cx.typeck_results().expr_ty(start)

--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -69,6 +69,7 @@ impl Display for SuggestedType {
 }
 
 impl LateLintPass<'_> for SingleRangeInVecInit {
+    #[expect(clippy::too_many_lines)]
     fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
         // inner_expr: `vec![0..200]` or `[0..200]`
         //                   ^^^^^^       ^^^^^^^
@@ -102,12 +103,12 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
         let mut applicability = Applicability::MaybeIncorrect;
         let suggestion = match (range.start, range.end, range.limits) {
             (Some(start), Some(end), limits) => {
-                let ty = cx.typeck_results().expr_ty(start);
+                let element_ty = cx.typeck_results().expr_ty(start);
                 let (start_snippet, _) = snippet_with_context(cx, start.span, span.ctxt(), "..", &mut applicability);
                 let (end_snippet, _) = snippet_with_context(cx, end.span, span.ctxt(), "..", &mut applicability);
 
                 let should_emit_every_value = if let Some(step_def_id) = cx.tcx.get_diagnostic_item(sym::range_step)
-                    && implements_trait(cx, ty, step_def_id, &[])
+                    && implements_trait(cx, element_ty, step_def_id, &[])
                 {
                     true
                 } else {
@@ -115,7 +116,7 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
                 };
                 let should_emit_of_len = if limits == RangeLimits::HalfOpen
                     && let Some(copy_def_id) = cx.tcx.lang_items().copy_trait()
-                    && implements_trait(cx, ty, copy_def_id, &[])
+                    && implements_trait(cx, element_ty, copy_def_id, &[])
                     && let ExprKind::Lit(lit_kind) = end.kind
                     && let LitKind::Int(.., suffix_type) = lit_kind.node
                     && let LitIntType::Unsigned(UintTy::Usize) | LitIntType::Unsuffixed = suffix_type
@@ -127,7 +128,7 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
 
                 if should_emit_every_value || should_emit_of_len {
                     Some((
-                        ty,
+                        element_ty,
                         start_snippet,
                         end_snippet,
                         limits,
@@ -162,10 +163,29 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
                             RangeLimits::HalfOpen => "..",
                             RangeLimits::Closed => "..=",
                         };
+
+                        // Old range types implement Iterator (and IntoIterator).
+                        // New range types implement IntoIterator only.
+                        // These have different optimal suggestions.
+                        let range_ty = cx.typeck_results().expr_ty(inner_expr);
+                        let range_implements_iterator = cx
+                            .tcx
+                            .get_diagnostic_item(sym::Iterator)
+                            .is_some_and(|id| implements_trait(cx, range_ty, id, &[]));
+
+                        let collect_code = if range_implements_iterator {
+                            format!("({start_snippet}{range_op}{end_snippet}).collect::<std::vec::Vec<{ty}>>()")
+                        } else {
+                            // If the range type does not implement `Iterator` then we cannot just call `.collect()`.
+                            // In that case, we use `from_iter()` rather than `.into_iter().collect::<...>()` because
+                            // it is more concise.
+                            format!("std::vec::Vec::<{ty}>::from_iter({start_snippet}{range_op}{end_snippet})")
+                        };
+
                         diag.span_suggestion(
                             span,
                             "if you wanted a `Vec` that contains the entire range, try",
-                            format!("({start_snippet}{range_op}{end_snippet}).collect::<std::vec::Vec<{ty}>>()"),
+                            collect_code,
                             applicability,
                         );
                     }

--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::higher::{Range, RangeIterability, VecArgs};
+use clippy_utils::higher::{Range, VecArgs};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::source::{SpanExt, snippet_with_context};
 use clippy_utils::ty::implements_trait;
@@ -101,7 +101,7 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
         }
 
         let mut applicability = Applicability::MaybeIncorrect;
-        let suggestion = match (range.start, range.end, range.limits) {
+        let suggestion = match (range.start, range.end, range.ty.limits()) {
             (Some(start), Some(end), limits) => {
                 let element_ty = cx.typeck_results().expr_ty(start);
                 let (start_snippet, _) = snippet_with_context(cx, start.span, span.ctxt(), "..", &mut applicability);
@@ -109,11 +109,9 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
 
                 let should_emit_every_value = if let Some(step_def_id) = cx.tcx.get_diagnostic_item(sym::range_step)
                     && implements_trait(cx, element_ty, step_def_id, &[])
-                    && matches!(
-                        range.iterable,
-                        RangeIterability::IntoIterator | RangeIterability::Iterator
-                    ) {
-                    Some(range.iterable)
+                    && range.ty.implements_into_iterator()
+                {
+                    Some(range.ty)
                 } else {
                     None
                 };
@@ -134,7 +132,6 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
                         element_ty,
                         start_snippet,
                         end_snippet,
-                        limits,
                         should_emit_every_value,
                         should_emit_of_len,
                     ))
@@ -158,33 +155,23 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
                     .map_or(sym::Range, |adt_def| cx.tcx.item_name(adt_def.did()))
             ),
             |diag| {
-                if let Some((ty, start_snippet, end_snippet, limits, should_emit_every_value, should_emit_of_len)) =
-                    suggestion
+                if let Some((ty, start_snippet, end_snippet, should_emit_every_value, should_emit_of_len)) = suggestion
                 {
-                    if let Some(iterability) = should_emit_every_value
+                    if let Some(range_ty) = should_emit_every_value
                         && !is_no_std_crate(cx)
                     {
-                        let range_op = match limits {
+                        let range_op = match range_ty.limits() {
                             RangeLimits::HalfOpen => "..",
                             RangeLimits::Closed => "..=",
                         };
 
-                        // Old range types implement Iterator (and IntoIterator).
-                        // New range types implement IntoIterator only.
-                        // These have different optimal suggestions.
-                        let collect_code = match iterability {
-                            RangeIterability::Iterator => {
-                                format!("({start_snippet}{range_op}{end_snippet}).collect::<std::vec::Vec<{ty}>>()")
-                            },
-                            RangeIterability::IntoIterator => {
-                                // If the range type does not implement `Iterator` then we cannot just call
-                                // `.collect()`. In that case, we use `from_iter()` rather than
-                                // `.into_iter().collect::<...>()` because it is more concise.
-                                format!("std::vec::Vec::<{ty}>::from_iter({start_snippet}{range_op}{end_snippet})")
-                            },
-                            RangeIterability::None => {
-                                unreachable!("should not be trying to suggest collecting a non-iterable range")
-                            },
+                        let collect_code = if range_ty.implements_iterator() {
+                            format!("({start_snippet}{range_op}{end_snippet}).collect::<std::vec::Vec<{ty}>>()")
+                        } else {
+                            // If the range type does not implement `Iterator` then we cannot just call
+                            // `.collect()`. In that case, we use `from_iter()` rather than
+                            // `.into_iter().collect::<...>()` because it is more concise.
+                            format!("std::vec::Vec::<{ty}>::from_iter({start_snippet}{range_op}{end_snippet})")
                         };
 
                         diag.span_suggestion(

--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::higher::{Range, VecArgs};
+use clippy_utils::higher::{Range, RangeIterability, VecArgs};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::source::{SpanExt, snippet_with_context};
 use clippy_utils::ty::implements_trait;
@@ -109,10 +109,13 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
 
                 let should_emit_every_value = if let Some(step_def_id) = cx.tcx.get_diagnostic_item(sym::range_step)
                     && implements_trait(cx, element_ty, step_def_id, &[])
-                {
-                    true
+                    && matches!(
+                        range.iterable,
+                        RangeIterability::IntoIterator | RangeIterability::Iterator
+                    ) {
+                    Some(range.iterable)
                 } else {
-                    false
+                    None
                 };
                 let should_emit_of_len = if limits == RangeLimits::HalfOpen
                     && let Some(copy_def_id) = cx.tcx.lang_items().copy_trait()
@@ -126,7 +129,7 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
                     false
                 };
 
-                if should_emit_every_value || should_emit_of_len {
+                if should_emit_every_value.is_some() || should_emit_of_len {
                     Some((
                         element_ty,
                         start_snippet,
@@ -158,7 +161,9 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
                 if let Some((ty, start_snippet, end_snippet, limits, should_emit_every_value, should_emit_of_len)) =
                     suggestion
                 {
-                    if should_emit_every_value && !is_no_std_crate(cx) {
+                    if let Some(iterability) = should_emit_every_value
+                        && !is_no_std_crate(cx)
+                    {
                         let range_op = match limits {
                             RangeLimits::HalfOpen => "..",
                             RangeLimits::Closed => "..=",
@@ -167,19 +172,19 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
                         // Old range types implement Iterator (and IntoIterator).
                         // New range types implement IntoIterator only.
                         // These have different optimal suggestions.
-                        let range_ty = cx.typeck_results().expr_ty(inner_expr);
-                        let range_implements_iterator = cx
-                            .tcx
-                            .get_diagnostic_item(sym::Iterator)
-                            .is_some_and(|id| implements_trait(cx, range_ty, id, &[]));
-
-                        let collect_code = if range_implements_iterator {
-                            format!("({start_snippet}{range_op}{end_snippet}).collect::<std::vec::Vec<{ty}>>()")
-                        } else {
-                            // If the range type does not implement `Iterator` then we cannot just call `.collect()`.
-                            // In that case, we use `from_iter()` rather than `.into_iter().collect::<...>()` because
-                            // it is more concise.
-                            format!("std::vec::Vec::<{ty}>::from_iter({start_snippet}{range_op}{end_snippet})")
+                        let collect_code = match iterability {
+                            RangeIterability::Iterator => {
+                                format!("({start_snippet}{range_op}{end_snippet}).collect::<std::vec::Vec<{ty}>>()")
+                            },
+                            RangeIterability::IntoIterator => {
+                                // If the range type does not implement `Iterator` then we cannot just call
+                                // `.collect()`. In that case, we use `from_iter()` rather than
+                                // `.into_iter().collect::<...>()` because it is more concise.
+                                format!("std::vec::Vec::<{ty}>::from_iter({start_snippet}{range_op}{end_snippet})")
+                            },
+                            RangeIterability::None => {
+                                unreachable!("should not be trying to suggest collecting a non-iterable range")
+                            },
                         };
 
                         diag.span_suggestion(

--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -236,13 +236,17 @@ impl<'a> Range<'a> {
                     limits: ast::RangeLimits::HalfOpen,
                     span,
                 }),
-                (hir::LangItem::RangeFrom, [field]) if field.ident.name == sym::start => Some(Range {
-                    start: Some(field.expr),
-                    end: None,
-                    limits: ast::RangeLimits::HalfOpen,
-                    span,
-                }),
-                (hir::LangItem::Range, [field1, field2]) => {
+                (hir::LangItem::RangeFrom | hir::LangItem::RangeFromCopy, [field])
+                    if field.ident.name == sym::start =>
+                {
+                    Some(Range {
+                        start: Some(field.expr),
+                        end: None,
+                        limits: ast::RangeLimits::HalfOpen,
+                        span,
+                    })
+                },
+                (hir::LangItem::Range | hir::LangItem::RangeCopy, [field1, field2]) => {
                     let (start, end) = match (field1.ident.name, field2.ident.name) {
                         (sym::start, sym::end) => (field1.expr, field2.expr),
                         (sym::end, sym::start) => (field2.expr, field1.expr),
@@ -255,12 +259,29 @@ impl<'a> Range<'a> {
                         span,
                     })
                 },
-                (hir::LangItem::RangeToInclusive, [field]) if field.ident.name == sym::end => Some(Range {
-                    start: None,
-                    end: Some(field.expr),
-                    limits: ast::RangeLimits::Closed,
-                    span,
-                }),
+                (hir::LangItem::RangeInclusiveCopy, [field1, field2]) => {
+                    let (start, last) = match (field1.ident.name, field2.ident.name) {
+                        (sym::start, sym::last) => (field1.expr, field2.expr),
+                        (sym::last, sym::start) => (field2.expr, field1.expr),
+                        _ => return None,
+                    };
+                    Some(Range {
+                        start: Some(start),
+                        end: Some(last),
+                        limits: ast::RangeLimits::Closed,
+                        span,
+                    })
+                },
+                (hir::LangItem::RangeToInclusive | hir::LangItem::RangeToInclusiveCopy, [field])
+                    if field.ident.name == sym::end =>
+                {
+                    Some(Range {
+                        start: None,
+                        end: Some(field.expr),
+                        limits: ast::RangeLimits::Closed,
+                        span,
+                    })
+                },
                 (hir::LangItem::RangeTo, [field]) if field.ident.name == sym::end => Some(Range {
                     start: None,
                     end: Some(field.expr),

--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -209,12 +209,25 @@ pub struct Range<'a> {
     pub end: Option<&'a Expr<'a>>,
     /// Whether the interval is open or closed.
     pub limits: ast::RangeLimits,
+    pub iterable: RangeIterability,
     pub span: Span,
+}
+
+/// Whether a range type is iterable (presuming that its element type implements the `Step` trait).
+///
+/// This is a component of [`Range`].
+#[derive(Debug, Copy, Clone)]
+pub enum RangeIterability {
+    /// Not iterable.
+    None,
+    /// Implements the [`Iterator`] trait (and [`IntoIterator`] by blanket impl).
+    Iterator,
+    /// Implements the [`IntoIterator`] trait, but not [`Iterator`].
+    IntoIterator,
 }
 
 impl<'a> Range<'a> {
     /// Higher a `hir` range to something similar to `ast::ExprKind::Range`.
-    #[expect(clippy::similar_names)]
     pub fn hir(cx: &LateContext<'_>, expr: &'a Expr<'_>) -> Option<Range<'a>> {
         let span = expr.range_span()?;
         match expr.kind {
@@ -226,6 +239,7 @@ impl<'a> Range<'a> {
                     start: Some(arg1),
                     end: Some(arg2),
                     limits: ast::RangeLimits::Closed,
+                    iterable: RangeIterability::Iterator,
                     span,
                 })
             },
@@ -234,58 +248,72 @@ impl<'a> Range<'a> {
                     start: None,
                     end: None,
                     limits: ast::RangeLimits::HalfOpen,
+                    iterable: RangeIterability::None,
                     span,
                 }),
-                (hir::LangItem::RangeFrom | hir::LangItem::RangeFromCopy, [field])
-                    if field.ident.name == sym::start =>
+                (hir::LangItem::RangeFrom, [start]) if start.ident.name == sym::start => Some(Range {
+                    start: Some(start.expr),
+                    end: None,
+                    limits: ast::RangeLimits::HalfOpen,
+                    iterable: RangeIterability::Iterator,
+                    span,
+                }),
+                (hir::LangItem::RangeFromCopy, [start]) if start.ident.name == sym::start => Some(Range {
+                    start: Some(start.expr),
+                    end: None,
+                    limits: ast::RangeLimits::HalfOpen,
+                    iterable: RangeIterability::IntoIterator,
+                    span,
+                }),
+                (hir::LangItem::Range, [start, end] | [end, start])
+                    if start.ident.name == sym::start && end.ident.name == sym::end =>
                 {
                     Some(Range {
-                        start: Some(field.expr),
-                        end: None,
+                        start: Some(start.expr),
+                        end: Some(end.expr),
                         limits: ast::RangeLimits::HalfOpen,
+                        iterable: RangeIterability::Iterator,
                         span,
                     })
                 },
-                (hir::LangItem::Range | hir::LangItem::RangeCopy, [field1, field2]) => {
-                    let (start, end) = match (field1.ident.name, field2.ident.name) {
-                        (sym::start, sym::end) => (field1.expr, field2.expr),
-                        (sym::end, sym::start) => (field2.expr, field1.expr),
-                        _ => return None,
-                    };
+                (hir::LangItem::RangeCopy, [start, end] | [end, start])
+                    if start.ident.name == sym::start && end.ident.name == sym::end =>
+                {
                     Some(Range {
-                        start: Some(start),
-                        end: Some(end),
+                        start: Some(start.expr),
+                        end: Some(end.expr),
                         limits: ast::RangeLimits::HalfOpen,
+                        iterable: RangeIterability::IntoIterator,
                         span,
                     })
                 },
-                (hir::LangItem::RangeInclusiveCopy, [field1, field2]) => {
-                    let (start, last) = match (field1.ident.name, field2.ident.name) {
-                        (sym::start, sym::last) => (field1.expr, field2.expr),
-                        (sym::last, sym::start) => (field2.expr, field1.expr),
-                        _ => return None,
-                    };
+                (hir::LangItem::RangeInclusiveCopy, [start, last] | [last, start])
+                    if start.ident.name == sym::start && last.ident.name == sym::last =>
+                {
                     Some(Range {
-                        start: Some(start),
-                        end: Some(last),
+                        start: Some(start.expr),
+                        end: Some(last.expr),
                         limits: ast::RangeLimits::Closed,
+                        iterable: RangeIterability::IntoIterator,
                         span,
                     })
                 },
-                (hir::LangItem::RangeToInclusive | hir::LangItem::RangeToInclusiveCopy, [field])
-                    if field.ident.name == sym::end =>
+                (hir::LangItem::RangeToInclusive | hir::LangItem::RangeToInclusiveCopy, [end])
+                    if end.ident.name == sym::end =>
                 {
                     Some(Range {
                         start: None,
-                        end: Some(field.expr),
+                        end: Some(end.expr),
                         limits: ast::RangeLimits::Closed,
+                        iterable: RangeIterability::None,
                         span,
                     })
                 },
-                (hir::LangItem::RangeTo, [field]) if field.ident.name == sym::end => Some(Range {
+                (hir::LangItem::RangeTo, [end]) if end.ident.name == sym::end => Some(Range {
                     start: None,
-                    end: Some(field.expr),
+                    end: Some(end.expr),
                     limits: ast::RangeLimits::HalfOpen,
+                    iterable: RangeIterability::None,
                     span,
                 }),
                 _ => None,

--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -203,122 +203,152 @@ impl<'hir> IfOrIfLet<'hir> {
 /// Represent a range akin to `ast::ExprKind::Range`.
 #[derive(Debug, Copy, Clone)]
 pub struct Range<'a> {
+    /// Type of the range, as an enum of only range types.
+    pub ty: RangeTy,
     /// The lower bound of the range, or `None` for ranges such as `..X`.
     pub start: Option<&'a Expr<'a>>,
     /// The upper bound of the range, or `None` for ranges such as `X..`.
     pub end: Option<&'a Expr<'a>>,
-    /// Whether the interval is open or closed.
-    pub limits: ast::RangeLimits,
-    pub iterable: RangeIterability,
     pub span: Span,
-}
-
-/// Whether a range type is iterable (presuming that its element type implements the `Step` trait).
-///
-/// This is a component of [`Range`].
-#[derive(Debug, Copy, Clone)]
-pub enum RangeIterability {
-    /// Not iterable.
-    None,
-    /// Implements the [`Iterator`] trait (and [`IntoIterator`] by blanket impl).
-    Iterator,
-    /// Implements the [`IntoIterator`] trait, but not [`Iterator`].
-    IntoIterator,
 }
 
 impl<'a> Range<'a> {
     /// Higher a `hir` range to something similar to `ast::ExprKind::Range`.
     pub fn hir(cx: &LateContext<'_>, expr: &'a Expr<'_>) -> Option<Range<'a>> {
         let span = expr.range_span()?;
-        match expr.kind {
+        let (ty, start, end) = match expr.kind {
             ExprKind::Call(path, [arg1, arg2])
                 if let ExprKind::Path(qpath) = path.kind
                     && cx.tcx.qpath_is_lang_item(qpath, hir::LangItem::RangeInclusiveNew) =>
             {
-                Some(Range {
-                    start: Some(arg1),
-                    end: Some(arg2),
-                    limits: ast::RangeLimits::Closed,
-                    iterable: RangeIterability::Iterator,
-                    span,
-                })
+                (RangeTy::OpsInclusive, Some(arg1), Some(arg2))
             },
             ExprKind::Struct(&qpath, fields, StructTailExpr::None) => match (cx.tcx.qpath_lang_item(qpath)?, fields) {
-                (hir::LangItem::RangeFull, []) => Some(Range {
-                    start: None,
-                    end: None,
-                    limits: ast::RangeLimits::HalfOpen,
-                    iterable: RangeIterability::None,
-                    span,
-                }),
-                (hir::LangItem::RangeFrom, [start]) if start.ident.name == sym::start => Some(Range {
-                    start: Some(start.expr),
-                    end: None,
-                    limits: ast::RangeLimits::HalfOpen,
-                    iterable: RangeIterability::Iterator,
-                    span,
-                }),
-                (hir::LangItem::RangeFromCopy, [start]) if start.ident.name == sym::start => Some(Range {
-                    start: Some(start.expr),
-                    end: None,
-                    limits: ast::RangeLimits::HalfOpen,
-                    iterable: RangeIterability::IntoIterator,
-                    span,
-                }),
+                (hir::LangItem::RangeFull, []) => (RangeTy::OpsFull, None, None),
+                (hir::LangItem::RangeFrom, [start]) if start.ident.name == sym::start => {
+                    (RangeTy::OpsFrom, Some(start.expr), None)
+                },
+                (hir::LangItem::RangeFromCopy, [start]) if start.ident.name == sym::start => {
+                    (RangeTy::RangeFrom, Some(start.expr), None)
+                },
                 (hir::LangItem::Range, [start, end] | [end, start])
                     if start.ident.name == sym::start && end.ident.name == sym::end =>
                 {
-                    Some(Range {
-                        start: Some(start.expr),
-                        end: Some(end.expr),
-                        limits: ast::RangeLimits::HalfOpen,
-                        iterable: RangeIterability::Iterator,
-                        span,
-                    })
+                    (RangeTy::OpsRange, Some(start.expr), Some(end.expr))
                 },
                 (hir::LangItem::RangeCopy, [start, end] | [end, start])
                     if start.ident.name == sym::start && end.ident.name == sym::end =>
                 {
-                    Some(Range {
-                        start: Some(start.expr),
-                        end: Some(end.expr),
-                        limits: ast::RangeLimits::HalfOpen,
-                        iterable: RangeIterability::IntoIterator,
-                        span,
-                    })
+                    (RangeTy::RangeRange, Some(start.expr), Some(end.expr))
                 },
                 (hir::LangItem::RangeInclusiveCopy, [start, last] | [last, start])
                     if start.ident.name == sym::start && last.ident.name == sym::last =>
                 {
-                    Some(Range {
-                        start: Some(start.expr),
-                        end: Some(last.expr),
-                        limits: ast::RangeLimits::Closed,
-                        iterable: RangeIterability::IntoIterator,
-                        span,
-                    })
+                    (RangeTy::RangeInclusive, Some(start.expr), Some(last.expr))
                 },
-                (hir::LangItem::RangeToInclusive | hir::LangItem::RangeToInclusiveCopy, [end])
-                    if end.ident.name == sym::end =>
-                {
-                    Some(Range {
-                        start: None,
-                        end: Some(end.expr),
-                        limits: ast::RangeLimits::Closed,
-                        iterable: RangeIterability::None,
-                        span,
-                    })
+                (hir::LangItem::RangeToInclusive, [end]) if end.ident.name == sym::end => {
+                    (RangeTy::OpsToInclusive, None, Some(end.expr))
                 },
-                (hir::LangItem::RangeTo, [end]) if end.ident.name == sym::end => Some(Range {
-                    start: None,
-                    end: Some(end.expr),
-                    limits: ast::RangeLimits::HalfOpen,
-                    iterable: RangeIterability::None,
-                    span,
-                }),
-                _ => None,
+                (hir::LangItem::RangeToInclusiveCopy, [last]) if last.ident.name == sym::last => {
+                    (RangeTy::RangeToInclusive, None, Some(last.expr))
+                },
+                (hir::LangItem::RangeTo, [end]) if end.ident.name == sym::end => (RangeTy::OpsTo, None, Some(end.expr)),
+                _ => return None,
             },
-            _ => None,
+            _ => return None,
+        };
+
+        Some(Range { ty, start, end, span })
+    }
+}
+
+/// A type that can appear as the type of a range expression.
+///
+/// This is a component of [`Range`].
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RangeTy {
+    /// [`core::ops::RangeFrom`]
+    OpsFrom,
+    /// [`core::range::RangeFrom`]
+    RangeFrom,
+
+    /// [`core::ops::RangeFull`]
+    OpsFull,
+
+    /// [`core::ops::Range`]
+    OpsRange,
+    /// [`core::range::Range`]
+    RangeRange,
+
+    /// [`core::ops::RangeInclusive`]
+    OpsInclusive,
+    /// [`core::range::RangeInclusive`]
+    RangeInclusive,
+
+    /// [`core::ops::RangeTo`]
+    OpsTo,
+
+    /// [`core::ops::RangeToInclusive`]
+    OpsToInclusive,
+    /// [`core::range::RangeToInclusive`]
+    RangeToInclusive,
+}
+
+#[expect(clippy::match_same_arms, reason = "regularity over density")]
+impl RangeTy {
+    /// Returns whether this type implements [`IntoIterator`] — that is, whether it is iterable —
+    /// presuming that its element type implements the `Step` trait.
+    pub fn implements_into_iterator(self) -> bool {
+        match self {
+            RangeTy::OpsFrom => true,
+            RangeTy::RangeFrom => true,
+            RangeTy::OpsRange => true,
+            RangeTy::RangeRange => true,
+            RangeTy::OpsInclusive => true,
+            RangeTy::RangeInclusive => true,
+
+            RangeTy::OpsFull => false,
+            RangeTy::OpsTo => false,
+            RangeTy::OpsToInclusive => false,
+            RangeTy::RangeToInclusive => false,
+        }
+    }
+
+    /// Returns whether this type implements [`Iterator`] directly, and [`IntoIterator`] via blanket
+    /// impl, presuming that its element type implements the `Step` trait.
+    pub fn implements_iterator(self) -> bool {
+        match self {
+            RangeTy::OpsFrom => true,
+            RangeTy::OpsRange => true,
+            RangeTy::OpsInclusive => true,
+
+            // New range types don’t implement Iterator, only IntoIterator
+            RangeTy::RangeFrom => false,
+            RangeTy::RangeRange => false,
+            RangeTy::RangeInclusive => false,
+
+            // Non-iterables
+            RangeTy::OpsFull => false,
+            RangeTy::OpsTo => false,
+            RangeTy::OpsToInclusive => false,
+            RangeTy::RangeToInclusive => false,
+        }
+    }
+
+    pub fn limits(self) -> ast::RangeLimits {
+        match self {
+            RangeTy::RangeFrom => ast::RangeLimits::HalfOpen,
+            RangeTy::OpsRange => ast::RangeLimits::HalfOpen,
+            RangeTy::RangeRange => ast::RangeLimits::HalfOpen,
+
+            RangeTy::OpsFrom => ast::RangeLimits::HalfOpen,
+            RangeTy::OpsTo => ast::RangeLimits::HalfOpen,
+            RangeTy::OpsFull => ast::RangeLimits::HalfOpen,
+
+            RangeTy::OpsInclusive => ast::RangeLimits::Closed,
+            RangeTy::RangeInclusive => ast::RangeLimits::Closed,
+            RangeTy::OpsToInclusive => ast::RangeLimits::Closed,
+            RangeTy::RangeToInclusive => ast::RangeLimits::Closed,
         }
     }
 }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1331,10 +1331,10 @@ pub fn is_else_clause_in_let_else(tcx: TyCtxt<'_>, expr: &Expr<'_>) -> bool {
 
 /// Checks whether the given `Expr` is a range over the entire container.
 pub fn is_full_collection_range(cx: &LateContext<'_>, container: Option<HirId>, expr: &Expr<'_>) -> bool {
-    if let Some(Range { start, end, limits, .. }) = Range::hir(cx, expr) {
+    if let Some(Range { start, end, ty, .. }) = Range::hir(cx, expr) {
         start.is_none_or(|start| is_integer_literal(start, 0))
             && end.is_none_or(|end| {
-                if limits == RangeLimits::HalfOpen
+                if ty.limits() == RangeLimits::HalfOpen
                     && let Some(container) = container
                     && let ExprKind::MethodCall(seg, recv, [], _) = end.kind
                 {

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -133,7 +133,7 @@ impl<'a> Sugg<'a> {
         mut get_snippet: impl FnMut(Span) -> Cow<'a, str>,
     ) -> Self {
         if let Some(range) = higher::Range::hir(cx, expr) {
-            let op = AssocOp::Range(range.limits);
+            let op = AssocOp::Range(range.ty.limits());
             let start = range.start.map_or("".into(), |expr| get_snippet(expr.span));
             let end = range.end.map_or("".into(), |expr| get_snippet(expr.span));
 

--- a/tests/ui/single_range_in_vec_init.new_range.1.fixed
+++ b/tests/ui/single_range_in_vec_init.new_range.1.fixed
@@ -1,4 +1,10 @@
 //@aux-build:proc_macros.rs
+//@revisions: old_range new_range
+//@[new_range] compile-flags: --cfg=new_range
+
+// When feature(new_range) stabilizes, this should be converted to testing
+// old and new editions instead.
+#![cfg_attr(new_range, feature(new_range))]
 #![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::useless_vec, unused)]
 #![warn(clippy::single_range_in_vec_init)]
 
@@ -21,26 +27,26 @@ fn awa_vec<T: PartialOrd>(start: T, end: T) {
 
 fn main() {
     // Lint
-    [0; 200];
+    std::vec::Vec::<i32>::from_iter(0..200);
     //~^ single_range_in_vec_init
-    vec![0; 200];
+    std::vec::Vec::<i32>::from_iter(0..200);
     //~^ single_range_in_vec_init
-    [0u8; 200];
+    std::vec::Vec::<u8>::from_iter(0u8..200);
     //~^ single_range_in_vec_init
-    [0usize; 200];
+    std::vec::Vec::<usize>::from_iter(0usize..200);
     //~^ single_range_in_vec_init
-    [0; 200usize];
+    std::vec::Vec::<usize>::from_iter(0..200usize);
     //~^ single_range_in_vec_init
-    vec![0u8; 200];
+    std::vec::Vec::<u8>::from_iter(0u8..200);
     //~^ single_range_in_vec_init
-    vec![0usize; 200];
+    std::vec::Vec::<usize>::from_iter(0usize..200);
     //~^ single_range_in_vec_init
-    vec![0; 200usize];
+    std::vec::Vec::<usize>::from_iter(0..200usize);
     //~^ single_range_in_vec_init
     // Only suggest collect
-    (0..200isize).collect::<std::vec::Vec<isize>>();
+    std::vec::Vec::<isize>::from_iter(0..200isize);
     //~^ single_range_in_vec_init
-    (0..200isize).collect::<std::vec::Vec<isize>>();
+    std::vec::Vec::<isize>::from_iter(0..200isize);
     //~^ single_range_in_vec_init
     // Do not lint
     [0..200, 0..100];
@@ -79,13 +85,13 @@ fn issue16044() {
         };
     }
 
-    let input = (0..as_i32!(10)).collect::<std::vec::Vec<i32>>();
+    let input = std::vec::Vec::<i32>::from_iter(0..as_i32!(10));
     //~^ single_range_in_vec_init
 }
 
 fn issue16508() {
-    (0..=10).collect::<std::vec::Vec<i32>>();
+    std::vec::Vec::<i32>::from_iter(0..=10);
     //~^ single_range_in_vec_init
-    (0..=10).collect::<std::vec::Vec<i32>>();
+    std::vec::Vec::<i32>::from_iter(0..=10);
     //~^ single_range_in_vec_init
 }

--- a/tests/ui/single_range_in_vec_init.new_range.2.fixed
+++ b/tests/ui/single_range_in_vec_init.new_range.2.fixed
@@ -27,26 +27,26 @@ fn awa_vec<T: PartialOrd>(start: T, end: T) {
 
 fn main() {
     // Lint
-    [0..200];
+    [0; 200];
     //~^ single_range_in_vec_init
-    vec![0..200];
+    vec![0; 200];
     //~^ single_range_in_vec_init
-    [0u8..200];
+    [0u8; 200];
     //~^ single_range_in_vec_init
-    [0usize..200];
+    [0usize; 200];
     //~^ single_range_in_vec_init
-    [0..200usize];
+    [0; 200usize];
     //~^ single_range_in_vec_init
-    vec![0u8..200];
+    vec![0u8; 200];
     //~^ single_range_in_vec_init
-    vec![0usize..200];
+    vec![0usize; 200];
     //~^ single_range_in_vec_init
-    vec![0..200usize];
+    vec![0; 200usize];
     //~^ single_range_in_vec_init
     // Only suggest collect
-    [0..200isize];
+    std::vec::Vec::<isize>::from_iter(0..200isize);
     //~^ single_range_in_vec_init
-    vec![0..200isize];
+    std::vec::Vec::<isize>::from_iter(0..200isize);
     //~^ single_range_in_vec_init
     // Do not lint
     [0..200, 0..100];
@@ -85,13 +85,13 @@ fn issue16044() {
         };
     }
 
-    let input = vec![0..as_i32!(10)];
+    let input = std::vec::Vec::<i32>::from_iter(0..as_i32!(10));
     //~^ single_range_in_vec_init
 }
 
 fn issue16508() {
-    [0..=10];
+    std::vec::Vec::<i32>::from_iter(0..=10);
     //~^ single_range_in_vec_init
-    vec![0..=10];
+    std::vec::Vec::<i32>::from_iter(0..=10);
     //~^ single_range_in_vec_init
 }

--- a/tests/ui/single_range_in_vec_init.new_range.stderr
+++ b/tests/ui/single_range_in_vec_init.new_range.stderr
@@ -1,0 +1,200 @@
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:30:5
+   |
+LL |     [0..200];
+   |     ^^^^^^^^
+   |
+   = note: `-D clippy::single-range-in-vec-init` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::single_range_in_vec_init)]`
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0..200];
+LL +     std::vec::Vec::<i32>::from_iter(0..200);
+   |
+help: if you wanted an array of len 200, try
+   |
+LL -     [0..200];
+LL +     [0; 200];
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:32:5
+   |
+LL |     vec![0..200];
+   |     ^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0..200];
+LL +     std::vec::Vec::<i32>::from_iter(0..200);
+   |
+help: if you wanted a `Vec` of len 200, try
+   |
+LL -     vec![0..200];
+LL +     vec![0; 200];
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:34:5
+   |
+LL |     [0u8..200];
+   |     ^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0u8..200];
+LL +     std::vec::Vec::<u8>::from_iter(0u8..200);
+   |
+help: if you wanted an array of len 200, try
+   |
+LL -     [0u8..200];
+LL +     [0u8; 200];
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:36:5
+   |
+LL |     [0usize..200];
+   |     ^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0usize..200];
+LL +     std::vec::Vec::<usize>::from_iter(0usize..200);
+   |
+help: if you wanted an array of len 200, try
+   |
+LL -     [0usize..200];
+LL +     [0usize; 200];
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:38:5
+   |
+LL |     [0..200usize];
+   |     ^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0..200usize];
+LL +     std::vec::Vec::<usize>::from_iter(0..200usize);
+   |
+help: if you wanted an array of len 200usize, try
+   |
+LL -     [0..200usize];
+LL +     [0; 200usize];
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:40:5
+   |
+LL |     vec![0u8..200];
+   |     ^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0u8..200];
+LL +     std::vec::Vec::<u8>::from_iter(0u8..200);
+   |
+help: if you wanted a `Vec` of len 200, try
+   |
+LL -     vec![0u8..200];
+LL +     vec![0u8; 200];
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:42:5
+   |
+LL |     vec![0usize..200];
+   |     ^^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0usize..200];
+LL +     std::vec::Vec::<usize>::from_iter(0usize..200);
+   |
+help: if you wanted a `Vec` of len 200, try
+   |
+LL -     vec![0usize..200];
+LL +     vec![0usize; 200];
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:44:5
+   |
+LL |     vec![0..200usize];
+   |     ^^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0..200usize];
+LL +     std::vec::Vec::<usize>::from_iter(0..200usize);
+   |
+help: if you wanted a `Vec` of len 200usize, try
+   |
+LL -     vec![0..200usize];
+LL +     vec![0; 200usize];
+   |
+
+error: an array of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:47:5
+   |
+LL |     [0..200isize];
+   |     ^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0..200isize];
+LL +     std::vec::Vec::<isize>::from_iter(0..200isize);
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:49:5
+   |
+LL |     vec![0..200isize];
+   |     ^^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0..200isize];
+LL +     std::vec::Vec::<isize>::from_iter(0..200isize);
+   |
+
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:88:17
+   |
+LL |     let input = vec![0..as_i32!(10)];
+   |                 ^^^^^^^^^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     let input = vec![0..as_i32!(10)];
+LL +     let input = std::vec::Vec::<i32>::from_iter(0..as_i32!(10));
+   |
+
+error: an array of `RangeInclusive` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:93:5
+   |
+LL |     [0..=10];
+   |     ^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     [0..=10];
+LL +     std::vec::Vec::<i32>::from_iter(0..=10);
+   |
+
+error: a `Vec` of `RangeInclusive` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:95:5
+   |
+LL |     vec![0..=10];
+   |     ^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL -     vec![0..=10];
+LL +     std::vec::Vec::<i32>::from_iter(0..=10);
+   |
+
+error: aborting due to 13 previous errors
+

--- a/tests/ui/single_range_in_vec_init.old_range.1.fixed
+++ b/tests/ui/single_range_in_vec_init.old_range.1.fixed
@@ -1,4 +1,10 @@
 //@aux-build:proc_macros.rs
+//@revisions: old_range new_range
+//@[new_range] compile-flags: --cfg=new_range
+
+// When feature(new_range) stabilizes, this should be converted to testing
+// old and new editions instead.
+#![cfg_attr(new_range, feature(new_range))]
 #![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::useless_vec, unused)]
 #![warn(clippy::single_range_in_vec_init)]
 

--- a/tests/ui/single_range_in_vec_init.old_range.2.fixed
+++ b/tests/ui/single_range_in_vec_init.old_range.2.fixed
@@ -27,26 +27,26 @@ fn awa_vec<T: PartialOrd>(start: T, end: T) {
 
 fn main() {
     // Lint
-    [0..200];
+    [0; 200];
     //~^ single_range_in_vec_init
-    vec![0..200];
+    vec![0; 200];
     //~^ single_range_in_vec_init
-    [0u8..200];
+    [0u8; 200];
     //~^ single_range_in_vec_init
-    [0usize..200];
+    [0usize; 200];
     //~^ single_range_in_vec_init
-    [0..200usize];
+    [0; 200usize];
     //~^ single_range_in_vec_init
-    vec![0u8..200];
+    vec![0u8; 200];
     //~^ single_range_in_vec_init
-    vec![0usize..200];
+    vec![0usize; 200];
     //~^ single_range_in_vec_init
-    vec![0..200usize];
+    vec![0; 200usize];
     //~^ single_range_in_vec_init
     // Only suggest collect
-    [0..200isize];
+    (0..200isize).collect::<std::vec::Vec<isize>>();
     //~^ single_range_in_vec_init
-    vec![0..200isize];
+    (0..200isize).collect::<std::vec::Vec<isize>>();
     //~^ single_range_in_vec_init
     // Do not lint
     [0..200, 0..100];
@@ -85,13 +85,13 @@ fn issue16044() {
         };
     }
 
-    let input = vec![0..as_i32!(10)];
+    let input = (0..as_i32!(10)).collect::<std::vec::Vec<i32>>();
     //~^ single_range_in_vec_init
 }
 
 fn issue16508() {
-    [0..=10];
+    (0..=10).collect::<std::vec::Vec<i32>>();
     //~^ single_range_in_vec_init
-    vec![0..=10];
+    (0..=10).collect::<std::vec::Vec<i32>>();
     //~^ single_range_in_vec_init
 }

--- a/tests/ui/single_range_in_vec_init.old_range.stderr
+++ b/tests/ui/single_range_in_vec_init.old_range.stderr
@@ -1,5 +1,5 @@
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:24:5
+  --> tests/ui/single_range_in_vec_init.rs:30:5
    |
 LL |     [0..200];
    |     ^^^^^^^^
@@ -18,7 +18,7 @@ LL +     [0; 200];
    |
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:26:5
+  --> tests/ui/single_range_in_vec_init.rs:32:5
    |
 LL |     vec![0..200];
    |     ^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL +     vec![0; 200];
    |
 
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:28:5
+  --> tests/ui/single_range_in_vec_init.rs:34:5
    |
 LL |     [0u8..200];
    |     ^^^^^^^^^^
@@ -52,7 +52,7 @@ LL +     [0u8; 200];
    |
 
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:30:5
+  --> tests/ui/single_range_in_vec_init.rs:36:5
    |
 LL |     [0usize..200];
    |     ^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL +     [0usize; 200];
    |
 
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:32:5
+  --> tests/ui/single_range_in_vec_init.rs:38:5
    |
 LL |     [0..200usize];
    |     ^^^^^^^^^^^^^
@@ -86,7 +86,7 @@ LL +     [0; 200usize];
    |
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:34:5
+  --> tests/ui/single_range_in_vec_init.rs:40:5
    |
 LL |     vec![0u8..200];
    |     ^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL +     vec![0u8; 200];
    |
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:36:5
+  --> tests/ui/single_range_in_vec_init.rs:42:5
    |
 LL |     vec![0usize..200];
    |     ^^^^^^^^^^^^^^^^^
@@ -120,7 +120,7 @@ LL +     vec![0usize; 200];
    |
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:38:5
+  --> tests/ui/single_range_in_vec_init.rs:44:5
    |
 LL |     vec![0..200usize];
    |     ^^^^^^^^^^^^^^^^^
@@ -137,7 +137,7 @@ LL +     vec![0; 200usize];
    |
 
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:41:5
+  --> tests/ui/single_range_in_vec_init.rs:47:5
    |
 LL |     [0..200isize];
    |     ^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL +     (0..200isize).collect::<std::vec::Vec<isize>>();
    |
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:43:5
+  --> tests/ui/single_range_in_vec_init.rs:49:5
    |
 LL |     vec![0..200isize];
    |     ^^^^^^^^^^^^^^^^^
@@ -161,7 +161,7 @@ LL +     (0..200isize).collect::<std::vec::Vec<isize>>();
    |
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:82:17
+  --> tests/ui/single_range_in_vec_init.rs:88:17
    |
 LL |     let input = vec![0..as_i32!(10)];
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +173,7 @@ LL +     let input = (0..as_i32!(10)).collect::<std::vec::Vec<i32>>();
    |
 
 error: an array of `RangeInclusive` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:87:5
+  --> tests/ui/single_range_in_vec_init.rs:93:5
    |
 LL |     [0..=10];
    |     ^^^^^^^^
@@ -185,7 +185,7 @@ LL +     (0..=10).collect::<std::vec::Vec<i32>>();
    |
 
 error: a `Vec` of `RangeInclusive` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:89:5
+  --> tests/ui/single_range_in_vec_init.rs:95:5
    |
 LL |     vec![0..=10];
    |     ^^^^^^^^^^^^


### PR DESCRIPTION
Without this change, `single_range_in_vec_init`, and all lints depending on `higher::Range`, will not lint range expressions that use the new `Copy + !Iterator` range types, which occur when `feature(new_range)` is enabled and will occur when using the future edition where that type change is the default, stable behavior.

Prior to <https://github.com/rust-lang/rust-clippy/pull/17146>, `single_range_in_vec_init` did detect such ranges (because it looked for the desugaring and not what lang item was involved); therefore, this is also fixing a regression.

Note that because the new range types do not implement `Iterator`, the `collect()` suggestion must change. I chose `Vec::from_iter(range)` over `(range).into_iter().collect()` because I believe it is the more elegant (and intended) solution.

This PR does not add new tests for the effect on lints other than `single_range_in_vec_init`, but I skimmed them and I don’t think any others need changes to their suggestions.

changelog: [`single_range_in_vec_init`]: support unstable `feature(new_range)` range expressions
