### PR TITLE
`non_ascii_literal`, `invisible_characters`: don't suggest a fix on raw strings

### DIFF
--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -108,6 +108,8 @@ fn check_str(cx: &LateContext<'_>, span: Span, id: HirId) {
     }
 
     let string = snippet(cx, span, "");
+    let is_raw = string.starts_with('r');
+
     if string.chars().any(|c| ['\u{200B}', '\u{ad}', '\u{2060}'].contains(&c)) {
         #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
         span_lint_and_then(cx, INVISIBLE_CHARACTERS, span, "invisible character detected", |diag| {
@@ -124,23 +126,26 @@ fn check_str(cx: &LateContext<'_>, span: Span, id: HirId) {
     }
 
     if string.chars().any(|c| c as u32 > 0x7F) {
-        #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
         span_lint_and_then(
             cx,
             NON_ASCII_LITERAL,
             span,
             "literal non-ASCII character detected",
             |diag| {
-                diag.span_suggestion(
-                    span,
-                    "consider replacing the string with",
-                    if is_lint_allowed(cx, UNICODE_NOT_NFC, id) {
-                        escape(string.chars())
-                    } else {
-                        escape(string.nfc())
-                    },
-                    Applicability::MachineApplicable,
-                );
+                if is_raw {
+                    diag.help("use a normal string literal instead of a raw one to escape the character");
+                } else {
+                    diag.span_suggestion(
+                        span,
+                        "consider replacing the string with",
+                        if is_lint_allowed(cx, UNICODE_NOT_NFC, id) {
+                            escape(string.chars())
+                        } else {
+                            escape(string.nfc())
+                        },
+                        Applicability::MachineApplicable,
+                    );
+                }
             },
         );
     }

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -111,17 +111,20 @@ fn check_str(cx: &LateContext<'_>, span: Span, id: HirId) {
     let is_raw = string.starts_with('r');
 
     if string.chars().any(|c| ['\u{200B}', '\u{ad}', '\u{2060}'].contains(&c)) {
-        #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
         span_lint_and_then(cx, INVISIBLE_CHARACTERS, span, "invisible character detected", |diag| {
-            diag.span_suggestion(
-                span,
-                "consider replacing the string with",
-                string
-                    .replace('\u{200B}', "\\u{200B}")
-                    .replace('\u{ad}', "\\u{AD}")
-                    .replace('\u{2060}', "\\u{2060}"),
-                Applicability::MachineApplicable,
-            );
+            if is_raw {
+                diag.help("use a normal string literal instead of a raw one to escape the character");
+            } else {
+                diag.span_suggestion(
+                    span,
+                    "consider replacing the string with",
+                    string
+                        .replace('\u{200B}', "\\u{200B}")
+                        .replace('\u{ad}', "\\u{AD}")
+                        .replace('\u{2060}', "\\u{2060}"),
+                    Applicability::MachineApplicable,
+                );
+            }
         });
     }
 

--- a/tests/ui/invisible_characters_unfixable.rs
+++ b/tests/ui/invisible_characters_unfixable.rs
@@ -1,0 +1,16 @@
+//@no-rustfix
+#![warn(clippy::invisible_characters)]
+#![allow(dead_code)]
+
+fn invisible() {
+    print!(r"a ZWS >​< here");
+    //~^ invisible_characters
+    print!(r"a SHY >­< here");
+    //~^ invisible_characters
+    print!(r"a WJ >⁠< here");
+    //~^ invisible_characters
+    print!(r#"a ZWS >​< between hashes"#);
+    //~^ invisible_characters
+}
+
+fn main() {}

--- a/tests/ui/invisible_characters_unfixable.stderr
+++ b/tests/ui/invisible_characters_unfixable.stderr
@@ -1,0 +1,36 @@
+error: invisible character detected
+  --> tests/ui/invisible_characters_unfixable.rs:6:12
+   |
+LL |     print!(r"a ZWS >​< here");
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = help: use a normal string literal instead of a raw one to escape the character
+   = note: `-D clippy::invisible-characters` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::invisible_characters)]`
+
+error: invisible character detected
+  --> tests/ui/invisible_characters_unfixable.rs:8:12
+   |
+LL |     print!(r"a SHY >­< here");
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = help: use a normal string literal instead of a raw one to escape the character
+
+error: invisible character detected
+  --> tests/ui/invisible_characters_unfixable.rs:10:12
+   |
+LL |     print!(r"a WJ >⁠< here");
+   |            ^^^^^^^^^^^^^^^
+   |
+   = help: use a normal string literal instead of a raw one to escape the character
+
+error: invisible character detected
+  --> tests/ui/invisible_characters_unfixable.rs:12:12
+   |
+LL |     print!(r#"a ZWS >​< between hashes"#);
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use a normal string literal instead of a raw one to escape the character
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/non_ascii_literal_unfixable.rs
+++ b/tests/ui/non_ascii_literal_unfixable.rs
@@ -1,0 +1,16 @@
+//@no-rustfix
+#![warn(clippy::non_ascii_literal)]
+#![allow(dead_code)]
+
+fn non_ascii() {
+    print!(r"€");
+    //~^ non_ascii_literal
+    print!(r"Üben!");
+    //~^ non_ascii_literal
+    print!(r"an en dash –");
+    //~^ non_ascii_literal
+    print!(r#"€ between hashes"#);
+    //~^ non_ascii_literal
+}
+
+fn main() {}

--- a/tests/ui/non_ascii_literal_unfixable.stderr
+++ b/tests/ui/non_ascii_literal_unfixable.stderr
@@ -1,0 +1,36 @@
+error: literal non-ASCII character detected
+  --> tests/ui/non_ascii_literal_unfixable.rs:6:12
+   |
+LL |     print!(r"€");
+   |            ^^^^
+   |
+   = help: use a normal string literal instead of a raw one to escape the character
+   = note: `-D clippy::non-ascii-literal` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::non_ascii_literal)]`
+
+error: literal non-ASCII character detected
+  --> tests/ui/non_ascii_literal_unfixable.rs:8:12
+   |
+LL |     print!(r"Üben!");
+   |            ^^^^^^^^
+   |
+   = help: use a normal string literal instead of a raw one to escape the character
+
+error: literal non-ASCII character detected
+  --> tests/ui/non_ascii_literal_unfixable.rs:10:12
+   |
+LL |     print!(r"an en dash –");
+   |            ^^^^^^^^^^^^^^^
+   |
+   = help: use a normal string literal instead of a raw one to escape the character
+
+error: literal non-ASCII character detected
+  --> tests/ui/non_ascii_literal_unfixable.rs:12:12
+   |
+LL |     print!(r#"€ between hashes"#);
+   |            ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use a normal string literal instead of a raw one to escape the character
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Both `non_ascii_literal` and `invisible_characters` build their suggestion from the source snippet and inject `\u{...}` escapes into it. Those escapes are inert inside a raw string literal, so `cargo clippy --fix` corrupts raw strings: the real character is dropped.

For a raw string literal the lints now keep the warning but only emit a help to use a normal string literal, instead of a machine-applicable suggestion that would corrupt the code. Cooked strings, char literals and `unicode_not_nfc` are left unchanged.

Fixes rust-lang/rust-clippy#9805

changelog: [`non_ascii_literal`]: warn without a suggestion on raw strings instead of suggesting a fix that corrupts them
changelog: [`invisible_characters`]: warn without a suggestion on raw strings instead of suggesting a fix that corrupts them