### PR TITLE
Clean-up `used_underscore_*`

### DIFF
--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -1,11 +1,14 @@
 use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{SpanlessEq, fulfill_or_allowed, get_parent_expr, in_automatically_derived, last_path_segment};
+use clippy_utils::{fulfill_or_allowed, in_automatically_derived};
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
-use rustc_hir::{BinOpKind, Expr, ExprKind, QPath, Stmt, StmtKind};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::{BinOpKind, Expr, ExprKind, HirId, Node, QPath, Stmt, StmtKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
 use rustc_session::declare_lint_pass;
+use rustc_span::{Span, Symbol};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -125,122 +128,129 @@ impl<'tcx> LateLintPass<'tcx> for LintPass {
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if expr.span.in_external_macro(cx.sess().source_map())
-            || expr.span.desugaring_kind().is_some()
-            || in_automatically_derived(cx.tcx, expr.hir_id)
-        {
-            return;
+        check_used_underscore(cx, expr);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Id<'tcx> {
+    /// A local binding.
+    Binding(HirId),
+    /// A resolved local definition.
+    LocalDef(LocalDefId),
+    /// An unresolved type-relative definition.
+    TyRel,
+    /// A field of an unresolved type.
+    FieldOf(&'tcx Expr<'tcx>),
+}
+impl Id<'_> {
+    fn from_res(res: Res) -> Option<Self> {
+        match res {
+            Res::Local(id) => Some(Self::Binding(id)),
+            Res::Def(_, id) => id.as_local().map(Self::LocalDef),
+            _ => None,
         }
+    }
 
-        used_underscore_binding(cx, expr);
-        used_underscore_items(cx, expr);
+    fn get_local_def(self, cx: &LateContext<'_>, e: &Expr<'_>, name: Symbol) -> Option<(HirId, Span)> {
+        let id = match self {
+            Self::Binding(id) if let Node::Pat(p) = cx.tcx.hir_node(id) => return Some((id, p.span)),
+            Self::LocalDef(id) => id,
+            Self::TyRel => cx.typeck_results().type_dependent_def_id(e.hir_id)?.as_local()?,
+            Self::FieldOf(e)
+                if let ty::Adt(adt, _) = *cx.typeck_results().expr_ty_adjusted(e).kind()
+                    && adt.did().is_local()
+                    && let [variant] = &adt.variants().raw
+                    && let Some(f) = variant.fields.iter().find(|&f| f.name == name)
+                    && match *cx.tcx.type_of(f.did).instantiate_identity().skip_normalization().kind() {
+                        ty::Adt(adt, _) => !adt.is_phantom_data(),
+                        _ => true,
+                    }
+                    && let Some(id) = f.did.as_local() =>
+            {
+                id
+            },
+            Self::FieldOf(_) | Self::Binding(_) => return None,
+        };
+        if cx.tcx.is_foreign_item(id) {
+            None
+        } else {
+            Some((cx.tcx.local_def_id_to_hir_id(id), cx.tcx.def_span(id)))
+        }
     }
 }
 
-fn used_underscore_items<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-    let (def_id, ident) = match expr.kind {
-        ExprKind::Call(func, ..) => {
-            if let ExprKind::Path(QPath::Resolved(.., path)) = func.kind
-                && let Some(last_segment) = path.segments.last()
-                && let Res::Def(_, def_id) = last_segment.res
+fn check_used_underscore<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
+    let (ident, id) = match e.kind {
+        ExprKind::Path(path) => match path {
+            QPath::Resolved(_, path)
+                if let Some(id) = Id::from_res(path.res)
+                    && let [.., seg] = path.segments =>
             {
-                (def_id, last_segment.ident)
-            } else {
-                return;
-            }
+                (seg.ident, id)
+            },
+            QPath::Resolved(..) => return,
+            QPath::TypeRelative(_, seg) => (seg.ident, Id::TyRel),
         },
-        ExprKind::MethodCall(path, ..) => {
-            if let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
-                (def_id, path.ident)
-            } else {
-                return;
-            }
-        },
-        ExprKind::Struct(QPath::Resolved(_, path), ..) => {
-            if let Some(last_segment) = path.segments.last()
-                && let Res::Def(_, def_id) = last_segment.res
+        ExprKind::MethodCall(path, ..) => (path.ident, Id::TyRel),
+        ExprKind::Struct(path, ..) => match path {
+            QPath::Resolved(_, path)
+                if let Some(id) = Id::from_res(path.res)
+                    && let [.., seg] = path.segments =>
             {
-                (def_id, last_segment.ident)
-            } else {
-                return;
-            }
+                (seg.ident, id)
+            },
+            QPath::Resolved(..) => return,
+            QPath::TypeRelative(_, seg) => (seg.ident, Id::TyRel),
         },
+        ExprKind::Field(base, ident) => (ident, Id::FieldOf(base)),
         _ => return,
     };
 
-    let name = ident.name.as_str();
-    let definition_span = cx.tcx.def_span(def_id);
-    if name.starts_with('_')
-        && !name.starts_with("__")
-        && !definition_span.from_expansion()
-        && def_id.is_local()
-        && !cx.tcx.is_foreign_item(def_id)
+    if !e.span.from_expansion()
+        && !ident.span.from_expansion()
+        && ident
+            .name
+            .as_str()
+            .strip_prefix('_')
+            .is_some_and(|x| !x.starts_with('_'))
+        && let Some((def_hir_id, def_sp)) = id.get_local_def(cx, e, ident.name)
+        && !def_sp.from_expansion()
+        // Only lint when rustc's `unused_variables` would trigger
+        && (!matches!(id, Id::Binding(_)) || is_used(cx, e))
+        && !in_automatically_derived(cx.tcx, e.hir_id)
+        && let (lint, msg, help_msg) = match id {
+            Id::Binding(_) | Id::FieldOf(_) => (
+                USED_UNDERSCORE_BINDING,
+                "used underscore-prefixed binding",
+                "binding is defined here",
+            ),
+            Id::TyRel | Id::LocalDef(_) => (
+                USED_UNDERSCORE_ITEMS,
+                "used underscore-prefixed item",
+                "item is defined here",
+            ),
+        }
+        && !fulfill_or_allowed(cx, lint, [def_hir_id])
     {
-        span_lint_and_then(
-            cx,
-            USED_UNDERSCORE_ITEMS,
-            expr.span,
-            "used underscore-prefixed item".to_string(),
-            |diag| {
-                diag.span_note(definition_span, "item is defined here".to_string());
-            },
-        );
+        span_lint_and_then(cx, lint, e.span, msg, |diag| {
+            diag.span_note(def_sp, help_msg);
+        });
     }
 }
 
-fn used_underscore_binding<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-    let (definition_hir_id, ident) = match expr.kind {
-        ExprKind::Path(ref qpath) => {
-            if let QPath::Resolved(None, path) = qpath
-                && let Res::Local(id) = path.res
-                && is_used(cx, expr)
-            {
-                (id, last_path_segment(qpath).ident)
-            } else {
-                return;
-            }
-        },
-        ExprKind::Field(recv, ident) => {
-            if let Some(adt_def) = cx.typeck_results().expr_ty_adjusted(recv).ty_adt_def()
-                && let Some(field) = adt_def.all_fields().find(|field| field.name == ident.name)
-                && let Some(local_did) = field.did.as_local()
-                && !cx.tcx.type_of(field.did).skip_binder().is_phantom_data()
-            {
-                (cx.tcx.local_def_id_to_hir_id(local_did), ident)
-            } else {
-                return;
-            }
-        },
-        _ => return,
-    };
-
-    let name = ident.name.as_str();
-    if name.starts_with('_')
-        && !name.starts_with("__")
-        && let definition_span = cx.tcx.hir_span(definition_hir_id)
-        && !definition_span.from_expansion()
-        && !fulfill_or_allowed(cx, USED_UNDERSCORE_BINDING, [expr.hir_id, definition_hir_id])
-    {
-        span_lint_and_then(
-            cx,
-            USED_UNDERSCORE_BINDING,
-            expr.span,
-            "used underscore-prefixed binding".to_string(),
-            |diag| {
-                diag.span_note(definition_span, "binding is defined here".to_string());
-            },
-        );
-    }
-}
-
-/// Heuristic to see if an expression is used. Should be compatible with
-/// `unused_variables`'s idea
-/// of what it means for an expression to be "used".
 fn is_used(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    get_parent_expr(cx, expr).is_none_or(|parent| match parent.kind {
-        ExprKind::Assign(_, rhs, _) | ExprKind::AssignOp(_, _, rhs) => {
-            SpanlessEq::new(cx).eq_expr(parent.span.ctxt(), rhs, expr)
-        },
-        _ => is_used(cx, parent),
-    })
+    let mut child = expr.hir_id;
+    let typeck = cx.typeck_results();
+    for (id, node) in cx.tcx.hir_parent_iter(child) {
+        match node {
+            Node::Expr(e) => match e.kind {
+                ExprKind::Field(base, ..) if typeck.expr_adjustments(base).is_empty() => child = id,
+                ExprKind::Assign(lhs, ..) | ExprKind::AssignOp(_, lhs, _) if child == lhs.hir_id => return false,
+                _ => return true,
+            },
+            _ => return true,
+        }
+    }
+    true
 }

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -1,11 +1,14 @@
 use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{SpanlessEq, fulfill_or_allowed, get_parent_expr, in_automatically_derived, last_path_segment};
+use clippy_utils::{fulfill_or_allowed, in_automatically_derived};
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
-use rustc_hir::{BinOpKind, Expr, ExprKind, QPath, Stmt, StmtKind};
-use rustc_lint::{LateContext, LateLintPass, LintContext as _};
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::{BinOpKind, Expr, ExprKind, HirId, Node, QPath, Stmt, StmtKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
 use rustc_session::declare_lint_pass;
+use rustc_span::{Span, Symbol};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -125,122 +128,137 @@ impl<'tcx> LateLintPass<'tcx> for LintPass {
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if expr.span.in_external_macro(cx.sess().source_map())
-            || expr.span.desugaring_kind().is_some()
-            || in_automatically_derived(cx.tcx, expr.hir_id)
-        {
-            return;
+        check_used_underscore(cx, expr);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Id<'tcx> {
+    /// A local binding.
+    Binding(HirId),
+    /// A resolved local definition.
+    LocalDef(LocalDefId),
+    /// An unresolved type-relative definition.
+    TyRel,
+    /// A field of an unresolved type.
+    FieldOf(&'tcx Expr<'tcx>),
+}
+impl Id<'_> {
+    fn from_res(res: Res) -> Option<Self> {
+        match res {
+            Res::Local(id) => Some(Self::Binding(id)),
+            Res::Def(_, id) => id.as_local().map(Self::LocalDef),
+            _ => None,
         }
+    }
 
-        used_underscore_binding(cx, expr);
-        used_underscore_items(cx, expr);
+    fn get_local_def(self, cx: &LateContext<'_>, e: &Expr<'_>, name: Symbol) -> Option<(HirId, Span)> {
+        let id = match self {
+            Self::Binding(id) if let Node::Pat(p) = cx.tcx.hir_node(id) => return Some((id, p.span)),
+            Self::LocalDef(id) => id,
+            Self::TyRel => cx.typeck_results().type_dependent_def_id(e.hir_id)?.as_local()?,
+            Self::FieldOf(e)
+                if let ty::Adt(adt, _) = *cx.typeck_results().expr_ty_adjusted(e).kind()
+                    && adt.did().is_local()
+                    && let [variant] = &adt.variants().raw
+                    && let Some(f) = variant.fields.iter().find(|&f| f.name == name)
+                    && match *cx.tcx.type_of(f.did).instantiate_identity().skip_normalization().kind() {
+                        ty::Adt(adt, _) => !adt.is_phantom_data(),
+                        _ => true,
+                    }
+                    && let Some(id) = f.did.as_local() =>
+            {
+                id
+            },
+            Self::FieldOf(_) | Self::Binding(_) => return None,
+        };
+        if cx.tcx.is_foreign_item(id) {
+            None
+        } else {
+            Some((cx.tcx.local_def_id_to_hir_id(id), cx.tcx.def_span(id)))
+        }
     }
 }
 
-fn used_underscore_items<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-    let (def_id, ident) = match expr.kind {
-        ExprKind::Call(func, ..) => {
-            if let ExprKind::Path(QPath::Resolved(.., path)) = func.kind
-                && let Some(last_segment) = path.segments.last()
-                && let Res::Def(_, def_id) = last_segment.res
+fn check_used_underscore<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
+    let (ident, id) = match e.kind {
+        ExprKind::Path(path) => match path {
+            QPath::Resolved(_, path)
+                if let Some(id) = Id::from_res(path.res)
+                    && let [.., seg] = path.segments =>
             {
-                (def_id, last_segment.ident)
-            } else {
-                return;
-            }
+                (seg.ident, id)
+            },
+            QPath::Resolved(..) => return,
+            QPath::TypeRelative(_, seg) => (seg.ident, Id::TyRel),
         },
-        ExprKind::MethodCall(path, ..) => {
-            if let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
-                (def_id, path.ident)
-            } else {
-                return;
-            }
-        },
-        ExprKind::Struct(QPath::Resolved(_, path), ..) => {
-            if let Some(last_segment) = path.segments.last()
-                && let Res::Def(_, def_id) = last_segment.res
+        ExprKind::MethodCall(path, ..) => (path.ident, Id::TyRel),
+        ExprKind::Struct(path, ..) => match path {
+            QPath::Resolved(_, path)
+                if let Some(id) = Id::from_res(path.res)
+                    && let [.., seg] = path.segments =>
             {
-                (def_id, last_segment.ident)
-            } else {
-                return;
-            }
+                (seg.ident, id)
+            },
+            QPath::Resolved(..) => return,
+            QPath::TypeRelative(_, seg) => (seg.ident, Id::TyRel),
         },
+        ExprKind::Field(base, ident) => (ident, Id::FieldOf(base)),
         _ => return,
     };
 
-    let name = ident.name.as_str();
-    let definition_span = cx.tcx.def_span(def_id);
-    if name.starts_with('_')
-        && !name.starts_with("__")
-        && !definition_span.from_expansion()
-        && def_id.is_local()
-        && !cx.tcx.is_foreign_item(def_id)
+    if !e.span.from_expansion()
+        && !ident.span.from_expansion()
+        && ident
+            .name
+            .as_str()
+            .strip_prefix('_')
+            .is_some_and(|x| !x.starts_with('_'))
+        && let Some((def_hir_id, def_sp)) = id.get_local_def(cx, e, ident.name)
+        && !def_sp.from_expansion()
+        // Only lint when rustc's `unused_variables` would trigger
+        && (!matches!(id, Id::Binding(_)) || is_used(cx, e))
+        && !in_automatically_derived(cx.tcx, e.hir_id)
+        && let (lint, msg, help_msg) = match id {
+            Id::Binding(_) | Id::FieldOf(_) => (
+                USED_UNDERSCORE_BINDING,
+                "used underscore-prefixed binding",
+                "binding is defined here",
+            ),
+            Id::TyRel | Id::LocalDef(_) => (
+                USED_UNDERSCORE_ITEMS,
+                "used underscore-prefixed item",
+                "item is defined here",
+            ),
+        }
+        && !fulfill_or_allowed(cx, lint, [def_hir_id])
     {
-        span_lint_and_then(
-            cx,
-            USED_UNDERSCORE_ITEMS,
-            expr.span,
-            "used underscore-prefixed item".to_string(),
-            |diag| {
-                diag.span_note(definition_span, "item is defined here".to_string());
-            },
-        );
+        span_lint_and_then(cx, lint, e.span, msg, |diag| {
+            diag.span_note(def_sp, help_msg);
+        });
     }
 }
 
-fn used_underscore_binding<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-    let (definition_hir_id, ident) = match expr.kind {
-        ExprKind::Path(ref qpath) => {
-            if let QPath::Resolved(None, path) = qpath
-                && let Res::Local(id) = path.res
-                && is_used(cx, expr)
-            {
-                (id, last_path_segment(qpath).ident)
-            } else {
-                return;
-            }
-        },
-        ExprKind::Field(recv, ident) => {
-            if let Some(adt_def) = cx.typeck_results().expr_ty_adjusted(recv).ty_adt_def()
-                && let Some(field) = adt_def.all_fields().find(|field| field.name == ident.name)
-                && let Some(local_did) = field.did.as_local()
-                && !cx.tcx.type_of(field.did).skip_binder().is_phantom_data()
-            {
-                (cx.tcx.local_def_id_to_hir_id(local_did), ident)
-            } else {
-                return;
-            }
-        },
-        _ => return,
-    };
-
-    let name = ident.name.as_str();
-    if name.starts_with('_')
-        && !name.starts_with("__")
-        && let definition_span = cx.tcx.hir_span(definition_hir_id)
-        && !definition_span.from_expansion()
-        && !fulfill_or_allowed(cx, USED_UNDERSCORE_BINDING, [expr.hir_id, definition_hir_id])
-    {
-        span_lint_and_then(
-            cx,
-            USED_UNDERSCORE_BINDING,
-            expr.span,
-            "used underscore-prefixed binding".to_string(),
-            |diag| {
-                diag.span_note(definition_span, "binding is defined here".to_string());
-            },
-        );
-    }
-}
-
-/// Heuristic to see if an expression is used. Should be compatible with
-/// `unused_variables`'s idea
-/// of what it means for an expression to be "used".
 fn is_used(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    get_parent_expr(cx, expr).is_none_or(|parent| match parent.kind {
-        ExprKind::Assign(_, rhs, _) | ExprKind::AssignOp(_, _, rhs) => {
-            SpanlessEq::new(cx).eq_expr(parent.span.ctxt(), rhs, expr)
-        },
-        _ => is_used(cx, parent),
-    })
+    let mut child = expr.hir_id;
+    let typeck = cx.typeck_results();
+    for (id, node) in cx.tcx.hir_parent_iter(child) {
+        match node {
+            Node::Expr(e) => match e.kind {
+                ExprKind::Field(base, ..) if typeck.expr_adjustments(base).is_empty() => child = id,
+                ExprKind::Assign(lhs, ..) if child == lhs.hir_id => return false,
+                // Only primitive types are considered unused for compound assignment.
+                // Everything else uses takes a mutable borrow of the lhs.
+                ExprKind::AssignOp(_, lhs, _)
+                    if child == lhs.hir_id
+                        && let ty::Int(_) | ty::Uint(_) | ty::Float(_) = *typeck.node_type(child).kind() =>
+                {
+                    return false;
+                },
+                _ => return true,
+            },
+            _ => return true,
+        }
+    }
+    true
 }

--- a/tests/ui/used_underscore_binding.rs
+++ b/tests/ui/used_underscore_binding.rs
@@ -1,153 +1,150 @@
-//@aux-build:proc_macro_derive.rs
-#![feature(rustc_private)]
+//@aux-build:proc_macros.rs
+
 #![warn(clippy::used_underscore_binding)]
-#![expect(clippy::disallowed_names, clippy::eq_op, clippy::uninlined_format_args)]
+#![expect(clippy::explicit_auto_deref, clippy::no_effect)]
 
-#[macro_use]
-extern crate proc_macro_derive;
+extern crate proc_macros;
 
-// This should not trigger the lint. There's underscore binding inside the external derive that
-// would trigger the `used_underscore_binding` lint.
-#[derive(DeriveSomething)]
-struct Baz;
+use core::marker::PhantomData;
+use proc_macros::{external, inline_macros};
 
-macro_rules! test_macro {
-    () => {{
-        let _foo = 42;
-        _foo + 1
-    }};
-}
-
-/// Tests that we lint if we use a binding with a single leading underscore
-fn prefix_underscore(_foo: u32) -> u32 {
-    _foo + 1
-    //~^ used_underscore_binding
-}
-
-/// Tests that we lint if we use a `_`-variable defined outside within a macro expansion
-fn in_macro_or_desugar(_foo: u32) {
-    println!("{}", _foo);
-    //~^ used_underscore_binding
-    assert_eq!(_foo, _foo);
-    //~^ used_underscore_binding
-    //~| used_underscore_binding
-
-    test_macro!() + 1;
-}
-
-// Struct for testing use of fields prefixed with an underscore
-struct StructFieldTest {
-    _underscore_field: u32,
-}
-
-/// Tests that we lint the use of a struct field which is prefixed with an underscore
-fn in_struct_field() {
-    let mut s = StructFieldTest { _underscore_field: 0 };
-    s._underscore_field += 1;
-    //~^ used_underscore_binding
-}
-
-/// Tests that we do not lint if the struct field is used in code created with derive.
-#[derive(Clone, Debug)]
-pub struct UnderscoreInStruct {
-    _foo: u32,
-}
-
-/// Tests that we do not lint if the underscore is not a prefix
-fn non_prefix_underscore(some_foo: u32) -> u32 {
-    some_foo + 1
-}
-
-/// Tests that we do not lint if we do not use the binding (simple case)
-fn unused_underscore_simple(_foo: u32) -> u32 {
-    1
-}
-
-/// Tests that we do not lint if we do not use the binding (complex case). This checks for
-/// compatibility with the built-in `unused_variables` lint.
-fn unused_underscore_complex(mut _foo: u32) -> u32 {
-    _foo += 1;
-    _foo = 2;
-    1
-}
-
-/// Test that we do not lint for multiple underscores
-fn multiple_underscores(__foo: u32) -> u32 {
-    __foo + 1
-}
-
-// Non-variable bindings with preceding underscore
-fn _fn_test() {}
-struct _StructTest;
-enum _EnumTest {
-    _Empty,
-    _Value(_StructTest),
-}
-
-/// Tests that we do not lint for non-variable bindings
-fn non_variables() {
-    _fn_test();
-    let _s = _StructTest;
-    let _e = match _EnumTest::_Value(_StructTest) {
-        _EnumTest::_Empty => 0,
-        _EnumTest::_Value(_st) => 1,
-    };
-    let f = _fn_test;
-    f();
-}
-
-// Tests that we do not lint if the binding comes from await desugaring,
-// but we do lint the awaited expression. See issue 5360.
-async fn await_desugaring() {
-    async fn foo() {}
-    fn uses_i(_i: i32) {}
-
-    foo().await;
-    ({
-        let _i = 5;
-        uses_i(_i);
-        //~^ used_underscore_binding
-        foo()
-    })
-    .await
-}
-
-struct PhantomField<T> {
-    _marker: std::marker::PhantomData<T>,
-}
-
-impl<T> std::fmt::Debug for PhantomField<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct("PhantomField").field("_marker", &self._marker).finish()
-    }
-}
-
-struct AllowedField {
-    #[allow(clippy::used_underscore_binding)]
-    _allowed: usize,
-}
-
-struct ExpectedField {
-    #[expect(clippy::used_underscore_binding)]
-    _expected: usize,
-}
-
-fn lint_levels(allowed: AllowedField, expected: ExpectedField) {
-    let _ = allowed._allowed;
-    let _ = expected._expected;
-}
-
+#[inline_macros]
 fn main() {
-    let foo = 0u32;
-    // tests of unused_underscore lint
-    let _ = prefix_underscore(foo);
-    in_macro_or_desugar(foo);
-    in_struct_field();
-    // possible false positives
-    let _ = non_prefix_underscore(foo);
-    let _ = unused_underscore_simple(foo);
-    let _ = unused_underscore_complex(foo);
-    let _ = multiple_underscores(foo);
-    non_variables();
-    await_desugaring();
+    // Declaration only.
+    {
+        let _a = 0;
+    }
+    // Check various reads.
+    {
+        let _a = 0;
+        let _b = &0;
+        let _c = (0, &0);
+        let _d = String::new();
+
+        _a; //~ used_underscore_binding
+        *_b; //~ used_underscore_binding
+        _c.0; //~ used_underscore_binding
+        *_c.1; //~ used_underscore_binding
+        _d.is_empty(); //~ used_underscore_binding
+    }
+    // Check that we match rustc on what a use is.
+    {
+        let mut _a = 0;
+        let mut _b = (0, 0);
+        let mut c = 0;
+        let mut _c = &mut c;
+        let mut d = (0, 0);
+        let _d = &mut d;
+
+        _a = 0;
+        _b.0 = 0;
+        _c = &mut c;
+        *_c = 0; //~ used_underscore_binding
+        _d.0 = 0; //~ used_underscore_binding
+        (*_d).0 = 0; //~ used_underscore_binding
+    }
+    // Check field access.
+    {
+        struct X<'a> {
+            _x: &'a mut (u32, u32),
+        };
+
+        let mut a = (0, 0);
+        let mut b = (0, 0);
+        let mut c = X { _x: &mut a };
+
+        c._x; //~ used_underscore_binding
+        c._x = &mut b; //~ used_underscore_binding
+        *c._x; //~ used_underscore_binding
+        *c._x = (0, 0); //~ used_underscore_binding
+        (*c._x).0 = 0; //~ used_underscore_binding
+        c._x.0 = 0; //~ used_underscore_binding
+    }
+    // Await desugaring contains a used underscore binding.
+    {
+        async fn f1() {}
+        async fn f2() {
+            f1().await;
+            {
+                let _a = 0;
+                _a; //~ used_underscore_binding
+                f1()
+            }
+            .await;
+        }
+    }
+    // Ignore phantom fields
+    {
+        struct X {
+            _marker: PhantomData<u32>,
+        }
+        let a = X { _marker: PhantomData };
+        a._marker;
+    }
+    // Ignore multiple underscores
+    {
+        struct X {
+            __x: u32,
+        }
+        let __a = 0;
+        let b = X { __x: 0 };
+        __a;
+        b.__x;
+    }
+    // Check compound assignment
+    {
+        let mut _a = 0;
+        let mut _b = (0, 0);
+        let mut _c = 0.0;
+        let mut _d = String::new();
+
+        _a += 0;
+        _b.0 -= 0;
+        _b.1 |= 0;
+        _c *= 1.0;
+        _d += ""; //~ used_underscore_binding
+    }
+    // Expect on the binding
+    {
+        struct X {
+            #[expect(clippy::used_underscore_binding)]
+            _x: u32,
+        }
+        #[expect(clippy::used_underscore_binding)]
+        let _a = 0;
+        let b = X { _x: 0 };
+
+        _a;
+        b._x;
+    }
+    // Check macros
+    {
+        struct X {
+            _x: u32,
+        };
+
+        let _a = 0;
+        let _b = (0, 0);
+        let mut _c = 0;
+        let mut _d = (0, 0);
+        let e = X { _x: 0 };
+        let mut f = X { _x: 0 };
+
+        inline!({
+            $(@expr _a); //~ used_underscore_binding
+            $(@expr _b.0); //~ used_underscore_binding
+            $(@expr _c) = 0;
+            $(@expr _d.0) = 0;
+            $(@expr e._x); //~ used_underscore_binding
+            $(@expr f._x) = 0; //~ used_underscore_binding
+        });
+        external!({
+            $_a; //~ used_underscore_binding
+            $(_b.0); //~ used_underscore_binding
+            $_c = 0;
+            $(_d.0) = 0;
+            $(e._x); //~ used_underscore_binding
+            $(f._x) = 0; //~ used_underscore_binding
+        });
+    }
 }

--- a/tests/ui/used_underscore_binding.stderr
+++ b/tests/ui/used_underscore_binding.stderr
@@ -1,76 +1,292 @@
 error: used underscore-prefixed binding
-  --> tests/ui/used_underscore_binding.rs:23:5
+  --> tests/ui/used_underscore_binding.rs:24:9
    |
-LL |     _foo + 1
-   |     ^^^^
+LL |         _a;
+   |         ^^
    |
 note: binding is defined here
-  --> tests/ui/used_underscore_binding.rs:22:22
+  --> tests/ui/used_underscore_binding.rs:19:13
    |
-LL | fn prefix_underscore(_foo: u32) -> u32 {
-   |                      ^^^^
+LL |         let _a = 0;
+   |             ^^
    = note: `-D clippy::used-underscore-binding` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::used_underscore_binding)]`
 
 error: used underscore-prefixed binding
-  --> tests/ui/used_underscore_binding.rs:29:20
+  --> tests/ui/used_underscore_binding.rs:25:10
    |
-LL |     println!("{}", _foo);
-   |                    ^^^^
-   |
-note: binding is defined here
-  --> tests/ui/used_underscore_binding.rs:28:24
-   |
-LL | fn in_macro_or_desugar(_foo: u32) {
-   |                        ^^^^
-
-error: used underscore-prefixed binding
-  --> tests/ui/used_underscore_binding.rs:31:16
-   |
-LL |     assert_eq!(_foo, _foo);
-   |                ^^^^
+LL |         *_b;
+   |          ^^
    |
 note: binding is defined here
-  --> tests/ui/used_underscore_binding.rs:28:24
+  --> tests/ui/used_underscore_binding.rs:20:13
    |
-LL | fn in_macro_or_desugar(_foo: u32) {
-   |                        ^^^^
-
-error: used underscore-prefixed binding
-  --> tests/ui/used_underscore_binding.rs:31:22
-   |
-LL |     assert_eq!(_foo, _foo);
-   |                      ^^^^
-   |
-note: binding is defined here
-  --> tests/ui/used_underscore_binding.rs:28:24
-   |
-LL | fn in_macro_or_desugar(_foo: u32) {
-   |                        ^^^^
-
-error: used underscore-prefixed binding
-  --> tests/ui/used_underscore_binding.rs:46:5
-   |
-LL |     s._underscore_field += 1;
-   |     ^^^^^^^^^^^^^^^^^^^
-   |
-note: binding is defined here
-  --> tests/ui/used_underscore_binding.rs:40:5
-   |
-LL |     _underscore_field: u32,
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
-error: used underscore-prefixed binding
-  --> tests/ui/used_underscore_binding.rs:108:16
-   |
-LL |         uses_i(_i);
-   |                ^^
-   |
-note: binding is defined here
-  --> tests/ui/used_underscore_binding.rs:107:13
-   |
-LL |         let _i = 5;
+LL |         let _b = &0;
    |             ^^
 
-error: aborting due to 6 previous errors
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:26:9
+   |
+LL |         _c.0;
+   |         ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:21:13
+   |
+LL |         let _c = (0, &0);
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:27:10
+   |
+LL |         *_c.1;
+   |          ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:21:13
+   |
+LL |         let _c = (0, &0);
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:28:9
+   |
+LL |         _d.is_empty();
+   |         ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:22:13
+   |
+LL |         let _d = String::new();
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:42:10
+   |
+LL |         *_c = 0;
+   |          ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:35:13
+   |
+LL |         let mut _c = &mut c;
+   |             ^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:43:9
+   |
+LL |         _d.0 = 0;
+   |         ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:37:13
+   |
+LL |         let _d = &mut d;
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:44:11
+   |
+LL |         (*_d).0 = 0;
+   |           ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:37:13
+   |
+LL |         let _d = &mut d;
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:56:9
+   |
+LL |         c._x;
+   |         ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:49:13
+   |
+LL |             _x: &'a mut (u32, u32),
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:57:9
+   |
+LL |         c._x = &mut b;
+   |         ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:49:13
+   |
+LL |             _x: &'a mut (u32, u32),
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:58:10
+   |
+LL |         *c._x;
+   |          ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:49:13
+   |
+LL |             _x: &'a mut (u32, u32),
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:59:10
+   |
+LL |         *c._x = (0, 0);
+   |          ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:49:13
+   |
+LL |             _x: &'a mut (u32, u32),
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:60:11
+   |
+LL |         (*c._x).0 = 0;
+   |           ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:49:13
+   |
+LL |             _x: &'a mut (u32, u32),
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:61:9
+   |
+LL |         c._x.0 = 0;
+   |         ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:49:13
+   |
+LL |             _x: &'a mut (u32, u32),
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:70:17
+   |
+LL |                 _a;
+   |                 ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:69:21
+   |
+LL |                 let _a = 0;
+   |                     ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:105:9
+   |
+LL |         _d += "";
+   |         ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:99:13
+   |
+LL |         let mut _d = String::new();
+   |             ^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:134:21
+   |
+LL |             $(@expr _a);
+   |                     ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:126:13
+   |
+LL |         let _a = 0;
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:135:21
+   |
+LL |             $(@expr _b.0);
+   |                     ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:127:13
+   |
+LL |         let _b = (0, 0);
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:138:21
+   |
+LL |             $(@expr e._x);
+   |                     ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:123:13
+   |
+LL |             _x: u32,
+   |             ^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:139:21
+   |
+LL |             $(@expr f._x) = 0;
+   |                     ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:123:13
+   |
+LL |             _x: u32,
+   |             ^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:142:14
+   |
+LL |             $_a;
+   |              ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:126:13
+   |
+LL |         let _a = 0;
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:143:15
+   |
+LL |             $(_b.0);
+   |               ^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:127:13
+   |
+LL |         let _b = (0, 0);
+   |             ^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:146:15
+   |
+LL |             $(e._x);
+   |               ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:123:13
+   |
+LL |             _x: u32,
+   |             ^^^^^^^
+
+error: used underscore-prefixed binding
+  --> tests/ui/used_underscore_binding.rs:147:15
+   |
+LL |             $(f._x) = 0;
+   |               ^^^^
+   |
+note: binding is defined here
+  --> tests/ui/used_underscore_binding.rs:123:13
+   |
+LL |             _x: u32,
+   |             ^^^^^^^
+
+error: aborting due to 24 previous errors
 

--- a/tests/ui/used_underscore_items.rs
+++ b/tests/ui/used_underscore_items.rs
@@ -1,81 +1,149 @@
 //@aux-build:external_item.rs
+//@aux-build:proc_macros.rs
+
 #![warn(clippy::used_underscore_items)]
+#![allow(clippy::no_effect)]
 
 extern crate external_item;
+extern crate proc_macros;
 
-// should not lint macro
-macro_rules! macro_wrap_func {
-    () => {
-        fn _marco_foo() {}
-    };
-}
+use proc_macros::{external, inline_macros};
 
-macro_wrap_func!();
+#[inline_macros]
+fn main() {
+    {
+        fn _f() {}
+        const _C: u32 = 0;
+        static _S: u32 = 0;
+        struct _X;
+        enum Z {
+            _A,
+        }
 
-struct _FooStruct {}
+        struct X;
+        impl X {
+            fn _m(self) {}
+        }
 
-impl _FooStruct {
-    fn _method_call(self) {}
-}
+        _f; //~ used_underscore_items
+        _f(); //~ used_underscore_items
+        _C; //~ used_underscore_items
+        _S; //~ used_underscore_items
+        _X; //~ used_underscore_items
+        _X {}; //~ used_underscore_items
+        Z::_A; //~ used_underscore_items
+        X::_m; //~ used_underscore_items
+        X._m(); //~ used_underscore_items
+    }
+    // Non-underscore names.
+    {
+        fn f1() {}
+        const C1: u32 = 0;
+        static S1: u32 = 0;
+        struct X1;
+        enum Z1 {
+            A1,
+        }
 
-fn _foo1() {}
+        struct X;
+        impl X {
+            fn m1(self) {}
+        }
 
-fn _foo2() -> i32 {
-    0
-}
+        f1;
+        f1();
+        C1;
+        S1;
+        X1;
+        X1 {};
+        Z1::A1;
+        X::m1;
+        X.m1();
+    }
+    // Don't lint external items. The names may not be changeable.
+    {
+        let x = external_item::_ExternalStruct {};
+        x._foo();
+        external_item::_external_foo();
+    }
+    // Don't lint foreign functions. The names may not be changeable.
+    {
+        unsafe extern "C" {
+            pub fn _exit(code: i32) -> !;
+        }
+        unsafe { _exit(1) }
+    }
+    // Don't lint in macros.
+    {
+        fn _f() {}
+        const _C: u32 = 0;
+        static _S: u32 = 0;
+        struct _X;
+        enum Z {
+            _A,
+        }
 
-mod a {
-    pub mod b {
-        pub mod c {
-            pub fn _foo3() {}
+        inline! {
+            _f();
+            _C;
+            _S;
+            _X;
+            _X;
+            Z::_A;
+        }
+    }
+    // Make sure expect works on the item.
+    {
+        #[expect(clippy::used_underscore_items)]
+        fn _f() {}
+        #[expect(clippy::used_underscore_items)]
+        const _C: u32 = 0;
+        #[expect(clippy::used_underscore_items)]
+        static _S: u32 = 0;
+        #[expect(clippy::used_underscore_items)]
+        struct _X;
+        enum Z {
+            #[expect(clippy::used_underscore_items)]
+            _A,
+        }
 
-            pub struct _FooStruct2 {}
+        struct X;
+        impl X {
+            #[expect(clippy::used_underscore_items)]
+            fn _m(self) {}
+        }
 
-            impl _FooStruct2 {
-                pub fn _method_call(self) {}
+        _f;
+        _f();
+        _C;
+        _S;
+        _X;
+        _X {};
+        Z::_A;
+        X::_m;
+        X._m();
+    }
+    // Ignore anything automatically derived.
+    {
+        struct S;
+        #[automatically_derived]
+        impl S {
+            fn f() {
+                fn _f() {}
+                const _C: u32 = 0;
+                static _S: u32 = 0;
+                struct _X;
+                enum Z {
+                    _A,
+                }
+
+                _f();
+                _C;
+                _S;
+                _X;
+                _X {};
+                Z::_A;
             }
         }
     }
-}
-
-fn main() {
-    _foo1();
-    //~^ used_underscore_items
-    let _ = _foo2();
-    //~^ used_underscore_items
-    a::b::c::_foo3();
-    //~^ used_underscore_items
-    let _ = &_FooStruct {};
-    //~^ used_underscore_items
-    let _ = _FooStruct {};
-    //~^ used_underscore_items
-
-    let foo_struct = _FooStruct {};
-    //~^ used_underscore_items
-    foo_struct._method_call();
-    //~^ used_underscore_items
-
-    let foo_struct2 = a::b::c::_FooStruct2 {};
-    //~^ used_underscore_items
-    foo_struct2._method_call();
-    //~^ used_underscore_items
-}
-
-// should not lint external crate.
-// user cannot control how others name their items
-fn external_item_call() {
-    let foo_struct3 = external_item::_ExternalStruct {};
-    foo_struct3._foo();
-
-    external_item::_external_foo();
-}
-
-// should not lint foreign functions.
-// issue #14156
-unsafe extern "C" {
-    pub fn _exit(code: i32) -> !;
-}
-
-fn _f() {
-    unsafe { _exit(1) }
 }

--- a/tests/ui/used_underscore_items.stderr
+++ b/tests/ui/used_underscore_items.stderr
@@ -2,7 +2,7 @@ error: used underscore-prefixed item
   --> tests/ui/used_underscore_items.rs:43:5
    |
 LL |     _foo1();
-   |     ^^^^^^^
+   |     ^^^^^
    |
 note: item is defined here
   --> tests/ui/used_underscore_items.rs:22:1
@@ -16,7 +16,7 @@ error: used underscore-prefixed item
   --> tests/ui/used_underscore_items.rs:45:13
    |
 LL |     let _ = _foo2();
-   |             ^^^^^^^
+   |             ^^^^^
    |
 note: item is defined here
   --> tests/ui/used_underscore_items.rs:24:1
@@ -28,7 +28,7 @@ error: used underscore-prefixed item
   --> tests/ui/used_underscore_items.rs:47:5
    |
 LL |     a::b::c::_foo3();
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
 note: item is defined here
   --> tests/ui/used_underscore_items.rs:31:13

--- a/tests/ui/used_underscore_items.stderr
+++ b/tests/ui/used_underscore_items.stderr
@@ -2,7 +2,7 @@ error: used underscore-prefixed item
   --> tests/ui/used_underscore_items.rs:42:5
    |
 LL |     _foo1();
-   |     ^^^^^^^
+   |     ^^^^^
    |
 note: item is defined here
   --> tests/ui/used_underscore_items.rs:21:1
@@ -16,7 +16,7 @@ error: used underscore-prefixed item
   --> tests/ui/used_underscore_items.rs:44:13
    |
 LL |     let _ = _foo2();
-   |             ^^^^^^^
+   |             ^^^^^
    |
 note: item is defined here
   --> tests/ui/used_underscore_items.rs:23:1
@@ -28,7 +28,7 @@ error: used underscore-prefixed item
   --> tests/ui/used_underscore_items.rs:46:5
    |
 LL |     a::b::c::_foo3();
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
 note: item is defined here
   --> tests/ui/used_underscore_items.rs:30:13

--- a/tests/ui/used_underscore_items.stderr
+++ b/tests/ui/used_underscore_items.stderr
@@ -1,112 +1,112 @@
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:42:5
+  --> tests/ui/used_underscore_items.rs:28:9
    |
-LL |     _foo1();
-   |     ^^^^^
+LL |         _f;
+   |         ^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:21:1
+  --> tests/ui/used_underscore_items.rs:15:9
    |
-LL | fn _foo1() {}
-   | ^^^^^^^^^^
+LL |         fn _f() {}
+   |         ^^^^^^^
    = note: `-D clippy::used-underscore-items` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::used_underscore_items)]`
 
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:44:13
+  --> tests/ui/used_underscore_items.rs:29:9
    |
-LL |     let _ = _foo2();
-   |             ^^^^^
+LL |         _f();
+   |         ^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:23:1
+  --> tests/ui/used_underscore_items.rs:15:9
    |
-LL | fn _foo2() -> i32 {
-   | ^^^^^^^^^^^^^^^^^
+LL |         fn _f() {}
+   |         ^^^^^^^
 
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:46:5
+  --> tests/ui/used_underscore_items.rs:30:9
    |
-LL |     a::b::c::_foo3();
-   |     ^^^^^^^^^^^^^^
+LL |         _C;
+   |         ^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:30:13
+  --> tests/ui/used_underscore_items.rs:16:9
    |
-LL |             pub fn _foo3() {}
-   |             ^^^^^^^^^^^^^^
+LL |         const _C: u32 = 0;
+   |         ^^^^^^^^^^^^^
 
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:48:14
+  --> tests/ui/used_underscore_items.rs:31:9
    |
-LL |     let _ = &_FooStruct {};
-   |              ^^^^^^^^^^^^^
+LL |         _S;
+   |         ^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:15:1
+  --> tests/ui/used_underscore_items.rs:17:9
    |
-LL | struct _FooStruct {}
-   | ^^^^^^^^^^^^^^^^^
+LL |         static _S: u32 = 0;
+   |         ^^^^^^^^^^^^^^
 
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:50:13
+  --> tests/ui/used_underscore_items.rs:32:9
    |
-LL |     let _ = _FooStruct {};
-   |             ^^^^^^^^^^^^^
+LL |         _X;
+   |         ^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:15:1
+  --> tests/ui/used_underscore_items.rs:18:9
    |
-LL | struct _FooStruct {}
-   | ^^^^^^^^^^^^^^^^^
+LL |         struct _X;
+   |         ^^^^^^^^^
 
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:53:22
+  --> tests/ui/used_underscore_items.rs:33:9
    |
-LL |     let foo_struct = _FooStruct {};
-   |                      ^^^^^^^^^^^^^
+LL |         _X {};
+   |         ^^^^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:15:1
+  --> tests/ui/used_underscore_items.rs:18:9
    |
-LL | struct _FooStruct {}
-   | ^^^^^^^^^^^^^^^^^
+LL |         struct _X;
+   |         ^^^^^^^^^
 
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:55:5
+  --> tests/ui/used_underscore_items.rs:34:9
    |
-LL |     foo_struct._method_call();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         Z::_A;
+   |         ^^^^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:18:5
+  --> tests/ui/used_underscore_items.rs:20:13
    |
-LL |     fn _method_call(self) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
+LL |             _A,
+   |             ^^
 
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:58:23
+  --> tests/ui/used_underscore_items.rs:35:9
    |
-LL |     let foo_struct2 = a::b::c::_FooStruct2 {};
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^
+LL |         X::_m;
+   |         ^^^^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:32:13
+  --> tests/ui/used_underscore_items.rs:25:13
    |
-LL |             pub struct _FooStruct2 {}
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+LL |             fn _m(self) {}
+   |             ^^^^^^^^^^^
 
 error: used underscore-prefixed item
-  --> tests/ui/used_underscore_items.rs:60:5
+  --> tests/ui/used_underscore_items.rs:36:9
    |
-LL |     foo_struct2._method_call();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         X._m();
+   |         ^^^^^^
    |
 note: item is defined here
-  --> tests/ui/used_underscore_items.rs:35:17
+  --> tests/ui/used_underscore_items.rs:25:13
    |
-LL |                 pub fn _method_call(self) {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             fn _m(self) {}
+   |             ^^^^^^^^^^^
 
 error: aborting due to 9 previous errors
 


### PR DESCRIPTION
This primarily reorders things to do cheaper checks before more expensive checks, but there are also some smaller changes:
* No macros are linted instead of only skipping external macros.
* `expect` and `allow` on the item in `used_underscore_items` now work. `used_undercore_bindings` already did this.
* `is_used` now more closely matches what `unused_variables` does. It takes very little for a variable to count as used.
* `consts`/`statics` and all type relative paths are checked
* Functions are linted if they're named, not just if they're called.

changelog: [`used_underscore_bindings`]: lint more cases where the binding is used
changelog: [`used_underscore_items`]: additionally check for `allow` end `expect` attributes on the item definition.