### PR TITLE
fix:(chunks_exact_to_as_chunks): Pick iter method depending on mut-ness

### DIFF
--- a/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
+++ b/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
@@ -36,11 +36,9 @@ pub(super) fn check<'tcx>(
             return;
         }
 
-        let suggestion_method = if method_name == sym::chunks_exact_mut {
-            "as_chunks_mut"
-        } else {
-            "as_chunks"
-        };
+        let is_mut = method_name == sym::chunks_exact_mut;
+        let suggestion_method = if is_mut { "as_chunks_mut" } else { "as_chunks" };
+        let iter_method = if is_mut { "iter_mut" } else { "iter" };
 
         let mut applicability = Applicability::MachineApplicable;
         let arg_str = snippet_with_context(cx, arg.span, expr.span.ctxt(), "_", &mut applicability).0;
@@ -80,7 +78,7 @@ pub(super) fn check<'tcx>(
                             diag.span_suggestion(
                                 call_span,
                                 "consider using `as_chunks` instead",
-                                format!("{as_chunks}.0.iter()"),
+                                format!("{as_chunks}.0.{iter_method}()"),
                                 applicability,
                             );
                             return;
@@ -95,7 +93,7 @@ pub(super) fn check<'tcx>(
                     && let PatKind::Binding(_, _, ident, _) = let_stmt.pat.kind
                 {
                     diag.note(format!(
-                        "you can access the chunks using `{ident}.0.iter()`, and the remainder using `{ident}.1`"
+                        "you can access the chunks using `{ident}.0.{iter_method}()`, and the remainder using `{ident}.1`"
                     ));
                 }
             },

--- a/tests/ui/chunks_exact_to_as_chunks.stderr
+++ b/tests/ui/chunks_exact_to_as_chunks.stderr
@@ -50,7 +50,7 @@ help: consider using `as_chunks_mut::<4>()` instead
    |
 LL |     let mut it = arr.chunks_exact_mut(4);
    |                      ^^^^^^^^^^^^^^^^^^^
-   = note: you can access the chunks using `it.0.iter()`, and the remainder using `it.1`
+   = note: you can access the chunks using `it.0.iter_mut()`, and the remainder using `it.1`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/chunks_exact_to_as_chunks_fixable.fixed
+++ b/tests/ui/chunks_exact_to_as_chunks_fixable.fixed
@@ -1,0 +1,15 @@
+#![warn(clippy::chunks_exact_to_as_chunks)]
+#![allow(unused)]
+
+fn main() {
+    let mut arr = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    for _ in arr.as_chunks::<4>().0 {}
+    //~^ chunks_exact_to_as_chunks
+    for _ in arr.as_chunks_mut::<4>().0 {}
+    //~^ chunks_exact_to_as_chunks
+    for chunk in arr.as_chunks_mut::<4>().0.iter_mut().take(2) {
+        //~^ chunks_exact_to_as_chunks
+        chunk[0] += 1; // mutate chunks
+    }
+}

--- a/tests/ui/chunks_exact_to_as_chunks_fixable.rs
+++ b/tests/ui/chunks_exact_to_as_chunks_fixable.rs
@@ -1,0 +1,15 @@
+#![warn(clippy::chunks_exact_to_as_chunks)]
+#![allow(unused)]
+
+fn main() {
+    let mut arr = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    for _ in arr.chunks_exact(4) {}
+    //~^ chunks_exact_to_as_chunks
+    for _ in arr.chunks_exact_mut(4) {}
+    //~^ chunks_exact_to_as_chunks
+    for chunk in arr.chunks_exact_mut(4).take(2) {
+        //~^ chunks_exact_to_as_chunks
+        chunk[0] += 1; // mutate chunks
+    }
+}

--- a/tests/ui/chunks_exact_to_as_chunks_fixable.stderr
+++ b/tests/ui/chunks_exact_to_as_chunks_fixable.stderr
@@ -1,0 +1,23 @@
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:7:18
+   |
+LL |     for _ in arr.chunks_exact(4) {}
+   |                  ^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<4>().0`
+   |
+   = note: `-D clippy::chunks-exact-to-as-chunks` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::chunks_exact_to_as_chunks)]`
+
+error: using `chunks_exact_mut` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:9:18
+   |
+LL |     for _ in arr.chunks_exact_mut(4) {}
+   |                  ^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks_mut::<4>().0`
+
+error: using `chunks_exact_mut` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:11:22
+   |
+LL |     for chunk in arr.chunks_exact_mut(4).take(2) {
+   |                      ^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks_mut::<4>().0.iter_mut()`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
`chunks_exact_to_as_chunks` always suggested using `.iter()` to turn a slice into an iterator even if the slice is `&mut [T]`. This loses the mut-ness of the slice, making the suggestion wrong. This PR fixes this by suggesting `.iter()` if the slice is immutable and `.iter_mut()` if it is mutable.

I added a new line to the existing UI test that the suggested snippet uses `iter_mut` (when correct).

---

changelog: [`chunks_exact_to_as_chunks`]: Suggest `iter`/`iter_mut` depending on mut-ness
