### PR TITLE
fix(chunks_exact_to_as_chunks): Use correct method name in message

### DIFF
--- a/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
+++ b/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
@@ -62,7 +62,7 @@ pub(super) fn check<'tcx>(
                         {
                             diag.span_suggestion(
                                 call_span,
-                                "consider using `as_chunks` instead",
+                                format!("consider using `{suggestion_method}` instead"),
                                 format!("{as_chunks}.0"),
                                 applicability,
                             );
@@ -77,7 +77,7 @@ pub(super) fn check<'tcx>(
                         {
                             diag.span_suggestion(
                                 call_span,
-                                "consider using `as_chunks` instead",
+                                format!("consider using `{suggestion_method}` instead"),
                                 format!("{as_chunks}.0.{iter_method}()"),
                                 applicability,
                             );

--- a/tests/ui/chunks_exact_to_as_chunks_fixable.stderr
+++ b/tests/ui/chunks_exact_to_as_chunks_fixable.stderr
@@ -11,13 +11,13 @@ error: using `chunks_exact_mut` with a constant chunk size
   --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:9:18
    |
 LL |     for _ in arr.chunks_exact_mut(4) {}
-   |                  ^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks_mut::<4>().0`
+   |                  ^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks_mut` instead: `as_chunks_mut::<4>().0`
 
 error: using `chunks_exact_mut` with a constant chunk size
   --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:11:22
    |
 LL |     for chunk in arr.chunks_exact_mut(4).take(2) {
-   |                      ^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks_mut::<4>().0.iter_mut()`
+   |                      ^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks_mut` instead: `as_chunks_mut::<4>().0.iter_mut()`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Use `as_chunks` and `as_chunks_mut` in the message depending on what is actually suggested.

Existing UI tests cover both branches, so I just updated the output.

---

changelog: [`chunks_exact_to_as_chunks`]: Use correct method name in message
