### PR TITLE
fix(chunks_exact_to_as_chunks): Prevent syntactically invalid suggestions

### DIFF
--- a/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
+++ b/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
@@ -6,7 +6,7 @@ use clippy_utils::source::snippet_with_context;
 use clippy_utils::visitors::is_const_evaluatable;
 use clippy_utils::{get_expr_use_site, sym};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, Node, PatKind};
+use rustc_hir::{BlockCheckMode, Expr, ExprKind, Node, PatKind, QPath};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
 use rustc_span::{DesugaringKind, ExpnKind, Span, Symbol};
@@ -41,7 +41,10 @@ pub(super) fn check<'tcx>(
         let iter_method = if is_mut { "iter_mut" } else { "iter" };
 
         let mut applicability = Applicability::MachineApplicable;
-        let arg_str = snippet_with_context(cx, arg.span, expr.span.ctxt(), "_", &mut applicability).0;
+        let mut arg_str = snippet_with_context(cx, arg.span, expr.span.ctxt(), "_", &mut applicability).0;
+        if expr_needs_braces_for_const(arg) {
+            arg_str = std::borrow::Cow::Owned(format!("{{ {arg_str} }}"));
+        }
 
         let as_chunks = format_args!("{suggestion_method}::<{arg_str}>()");
 
@@ -98,5 +101,23 @@ pub(super) fn check<'tcx>(
                 }
             },
         );
+    }
+}
+
+/// Whether the given expression needs braces to be a syntactically valid const generics argument.
+///
+/// For more details, see: <https://doc.rust-lang.org/reference/paths.html#railroad-GenericArgsConst>
+fn expr_needs_braces_for_const(e: &Expr<'_>) -> bool {
+    match e.kind {
+        ExprKind::Lit(_) => false,
+        ExprKind::Block(block, None) => {
+            // unsafe blocks need braces
+            block.rules != BlockCheckMode::DefaultBlock
+        },
+        ExprKind::Path(QPath::Resolved(_, p)) => {
+            // path must be a single segment. E.g. Foo::BAR is not allowed
+            p.segments.len() != 1
+        },
+        _ => true,
     }
 }

--- a/tests/ui/chunks_exact_to_as_chunks_fixable.fixed
+++ b/tests/ui/chunks_exact_to_as_chunks_fixable.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::chunks_exact_to_as_chunks)]
-#![allow(unused)]
+#![allow(unused, clippy::deref_addrof)]
 
 fn main() {
     let mut arr = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -12,4 +12,23 @@ fn main() {
         //~^ chunks_exact_to_as_chunks
         chunk[0] += 1; // mutate chunks
     }
+
+    // All const expressions should produce valid Rust code
+    for _ in arr.as_chunks::<{ 1 + 1 }>().0 {}
+    //~^ chunks_exact_to_as_chunks
+    const CHUNK_SIZE: usize = 4;
+    for _ in arr.as_chunks::<{ CHUNK_SIZE + 1 }>().0 {}
+    //~^ chunks_exact_to_as_chunks
+    for _ in arr.as_chunks::<{ size_of::<u32>() }>().0 {}
+    //~^ chunks_exact_to_as_chunks
+    for _ in arr.as_chunks::<{ const { 1 } }>().0 {}
+    //~^ chunks_exact_to_as_chunks
+    for _ in arr.as_chunks::<{ unsafe { 1 } }>().0 {}
+    //~^ chunks_exact_to_as_chunks
+    struct A;
+    impl A {
+        const A: usize = 4;
+    }
+    for _ in arr.as_chunks::<{ A::A }>().0 {}
+    //~^ chunks_exact_to_as_chunks
 }

--- a/tests/ui/chunks_exact_to_as_chunks_fixable.rs
+++ b/tests/ui/chunks_exact_to_as_chunks_fixable.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::chunks_exact_to_as_chunks)]
-#![allow(unused)]
+#![allow(unused, clippy::deref_addrof)]
 
 fn main() {
     let mut arr = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -12,4 +12,23 @@ fn main() {
         //~^ chunks_exact_to_as_chunks
         chunk[0] += 1; // mutate chunks
     }
+
+    // All const expressions should produce valid Rust code
+    for _ in arr.chunks_exact(1 + 1) {}
+    //~^ chunks_exact_to_as_chunks
+    const CHUNK_SIZE: usize = 4;
+    for _ in arr.chunks_exact(CHUNK_SIZE + 1) {}
+    //~^ chunks_exact_to_as_chunks
+    for _ in arr.chunks_exact(size_of::<u32>()) {}
+    //~^ chunks_exact_to_as_chunks
+    for _ in arr.chunks_exact(const { 1 }) {}
+    //~^ chunks_exact_to_as_chunks
+    for _ in arr.chunks_exact(unsafe { 1 }) {}
+    //~^ chunks_exact_to_as_chunks
+    struct A;
+    impl A {
+        const A: usize = 4;
+    }
+    for _ in arr.chunks_exact(A::A) {}
+    //~^ chunks_exact_to_as_chunks
 }

--- a/tests/ui/chunks_exact_to_as_chunks_fixable.stderr
+++ b/tests/ui/chunks_exact_to_as_chunks_fixable.stderr
@@ -19,5 +19,41 @@ error: using `chunks_exact_mut` with a constant chunk size
 LL |     for chunk in arr.chunks_exact_mut(4).take(2) {
    |                      ^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks_mut::<4>().0.iter_mut()`
 
-error: aborting due to 3 previous errors
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:17:18
+   |
+LL |     for _ in arr.chunks_exact(1 + 1) {}
+   |                  ^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<{ 1 + 1 }>().0`
+
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:20:18
+   |
+LL |     for _ in arr.chunks_exact(CHUNK_SIZE + 1) {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<{ CHUNK_SIZE + 1 }>().0`
+
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:22:18
+   |
+LL |     for _ in arr.chunks_exact(size_of::<u32>()) {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<{ size_of::<u32>() }>().0`
+
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:24:18
+   |
+LL |     for _ in arr.chunks_exact(const { 1 }) {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<{ const { 1 } }>().0`
+
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:26:18
+   |
+LL |     for _ in arr.chunks_exact(unsafe { 1 }) {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<{ unsafe { 1 } }>().0`
+
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks_fixable.rs:32:18
+   |
+LL |     for _ in arr.chunks_exact(A::A) {}
+   |                  ^^^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<{ A::A }>().0`
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
[Const generic arguments](https://doc.rust-lang.org/reference/paths.html#railroad-GenericArgsConst) have much more restrictive syntax than regular arguments, which `chunks_exact_to_as_chunks` previously did not account for. It happily turned `chunks_exact(1 + 1)` into `as_chunks::<1 + 1>()`, creating invalid Rust code.

This PR fixes the issue by analysing the argument expression and wrapping it with braces when necessary.

I expanded the existing UI test to ensure that expressions are handled correctly. Note that existing tests (already producing valid code) were left unchanged.

---

changelog: [`chunks_exact_to_as_chunks`]: Prevent syntactically invalid suggestions
