### PR TITLE
fix(chunks_exact_to_as_chunks): Don't report expressions with const parameters

### DIFF
--- a/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
+++ b/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
@@ -3,7 +3,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::{MaybeDef, MaybeTypeckRes};
 use clippy_utils::source::snippet_with_context;
-use clippy_utils::visitors::is_const_evaluatable;
+use clippy_utils::visitors::is_const_param_evaluatable;
 use clippy_utils::{get_expr_use_site, sym};
 use rustc_errors::Applicability;
 use rustc_hir::{BlockCheckMode, Expr, ExprKind, Node, PatKind, QPath};
@@ -25,7 +25,7 @@ pub(super) fn check<'tcx>(
         return;
     }
 
-    if is_const_evaluatable(cx.tcx, cx.typeck_results(), arg) {
+    if is_const_param_evaluatable(cx.tcx, cx.typeck_results(), arg) {
         let use_ctxt = get_expr_use_site(cx.tcx, cx.typeck_results(), expr.span.ctxt(), expr);
 
         if use_ctxt.is_ty_unified || !msrv.meets(cx, msrvs::AS_CHUNKS) {

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -6,10 +6,10 @@ use crate::ty::needs_ordered_drop;
 use core::ops::ControlFlow;
 use rustc_ast::visit::{VisitorResult, try_visit};
 use rustc_hir::def::{CtorKind, DefKind, Res};
-use rustc_hir::intravisit::{self, Visitor, walk_block, walk_expr};
+use rustc_hir::intravisit::{self, Visitor, walk_block, walk_expr, walk_qpath};
 use rustc_hir::{
-    self as hir, AmbigArg, AnonConst, Arm, Block, BlockCheckMode, Body, BodyId, CRATE_HIR_ID, Expr, ExprKind, HirId,
-    ItemId, ItemKind, LetExpr, Pat, QPath, Stmt, StructTailExpr, UnOp, UnsafeSource,
+    self as hir, AmbigArg, AnonConst, Arm, Block, BlockCheckMode, Body, BodyId, CRATE_HIR_ID, ConstBlock, Expr,
+    ExprKind, HirId, ItemId, ItemKind, LetExpr, Pat, QPath, Stmt, StructTailExpr, UnOp, UnsafeSource,
 };
 use rustc_lint::LateContext;
 use rustc_middle::hir::nested_filter;
@@ -322,69 +322,170 @@ pub fn is_local_used<'tcx>(cx: &LateContext<'tcx>, visitable: impl Visitable<'tc
     .is_some()
 }
 
+/// Returns whether the given expression can be evaluated as a constant assuming that all its sub
+/// expressions can be evaluated as constants.
+fn is_const_evaluatable_helper<'tcx>(tcx: TyCtxt<'tcx>, typeck: &'tcx TypeckResults<'tcx>, e: &'tcx Expr<'_>) -> bool {
+    match e.kind {
+        ExprKind::Call(
+            &Expr {
+                kind: ExprKind::Path(ref p),
+                hir_id,
+                ..
+            },
+            _,
+        ) if typeck
+            .qpath_res(p, hir_id)
+            .opt_def_id()
+            .is_some_and(|id| is_stable_const_fn_at(tcx, CRATE_HIR_ID, id, Msrv::default())) =>
+        {
+            true
+        },
+        ExprKind::MethodCall(..)
+            if typeck
+                .type_dependent_def_id(e.hir_id)
+                .is_some_and(|id| is_stable_const_fn_at(tcx, CRATE_HIR_ID, id, Msrv::default())) =>
+        {
+            true
+        },
+        ExprKind::Binary(_, lhs, rhs)
+            if typeck.expr_ty(lhs).peel_refs().is_primitive_ty()
+                && typeck.expr_ty(rhs).peel_refs().is_primitive_ty() =>
+        {
+            true
+        },
+        ExprKind::Unary(UnOp::Deref, e) if typeck.expr_ty(e).is_raw_ptr() => true,
+        ExprKind::Unary(_, e) if typeck.expr_ty(e).peel_refs().is_primitive_ty() => true,
+        ExprKind::Index(base, _, _)
+            if matches!(typeck.expr_ty(base).peel_refs().kind(), ty::Slice(_) | ty::Array(..)) =>
+        {
+            true
+        },
+        ExprKind::Path(ref p)
+            if matches!(
+                typeck.qpath_res(p, e.hir_id),
+                Res::Def(
+                    DefKind::Const { .. }
+                        | DefKind::AssocConst { .. }
+                        | DefKind::AnonConst
+                        | DefKind::ConstParam
+                        | DefKind::Ctor(..)
+                        | DefKind::Fn
+                        | DefKind::AssocFn,
+                    _
+                ) | Res::SelfCtor(_)
+            ) =>
+        {
+            true
+        },
+
+        ExprKind::AddrOf(..)
+        | ExprKind::Array(_)
+        | ExprKind::Block(..)
+        | ExprKind::Cast(..)
+        | ExprKind::ConstBlock(_)
+        | ExprKind::DropTemps(_)
+        | ExprKind::Field(..)
+        | ExprKind::If(..)
+        | ExprKind::Let(..)
+        | ExprKind::Lit(_)
+        | ExprKind::Match(..)
+        | ExprKind::Repeat(..)
+        | ExprKind::Struct(..)
+        | ExprKind::Tup(_)
+        | ExprKind::Type(..)
+        | ExprKind::UnsafeBinderCast(..) => true,
+
+        _ => false,
+    }
+}
+
 /// Checks if the given expression can be evaluated as a constant at the specified node
 pub fn is_const_evaluatable<'tcx>(tcx: TyCtxt<'tcx>, typeck: &'tcx TypeckResults<'tcx>, e: &'tcx Expr<'_>) -> bool {
     for_each_expr(tcx, e, move |e| {
-        match e.kind {
-            ExprKind::ConstBlock(_) => return ControlFlow::Continue(Descend::No),
-            ExprKind::Call(
-                &Expr {
-                    kind: ExprKind::Path(ref p),
-                    hir_id,
-                    ..
-                },
-                _,
-            ) if typeck
-                .qpath_res(p, hir_id)
-                .opt_def_id()
-                .is_some_and(|id| is_stable_const_fn_at(tcx, CRATE_HIR_ID, id, Msrv::default())) => {},
-            ExprKind::MethodCall(..)
-                if typeck
-                    .type_dependent_def_id(e.hir_id)
-                    .is_some_and(|id| is_stable_const_fn_at(tcx, CRATE_HIR_ID, id, Msrv::default())) => {},
-            ExprKind::Binary(_, lhs, rhs)
-                if typeck.expr_ty(lhs).peel_refs().is_primitive_ty()
-                    && typeck.expr_ty(rhs).peel_refs().is_primitive_ty() => {},
-            ExprKind::Unary(UnOp::Deref, e) if typeck.expr_ty(e).is_raw_ptr() => (),
-            ExprKind::Unary(_, e) if typeck.expr_ty(e).peel_refs().is_primitive_ty() => (),
-            ExprKind::Index(base, _, _)
-                if matches!(typeck.expr_ty(base).peel_refs().kind(), ty::Slice(_) | ty::Array(..)) => {},
-            ExprKind::Path(ref p)
-                if matches!(
-                    typeck.qpath_res(p, e.hir_id),
-                    Res::Def(
-                        DefKind::Const { .. }
-                            | DefKind::AssocConst { .. }
-                            | DefKind::AnonConst
-                            | DefKind::ConstParam
-                            | DefKind::Ctor(..)
-                            | DefKind::Fn
-                            | DefKind::AssocFn,
-                        _
-                    ) | Res::SelfCtor(_)
-                ) => {},
-
-            ExprKind::AddrOf(..)
-            | ExprKind::Array(_)
-            | ExprKind::Block(..)
-            | ExprKind::Cast(..)
-            | ExprKind::DropTemps(_)
-            | ExprKind::Field(..)
-            | ExprKind::If(..)
-            | ExprKind::Let(..)
-            | ExprKind::Lit(_)
-            | ExprKind::Match(..)
-            | ExprKind::Repeat(..)
-            | ExprKind::Struct(..)
-            | ExprKind::Tup(_)
-            | ExprKind::Type(..)
-            | ExprKind::UnsafeBinderCast(..) => {},
-
-            _ => return ControlFlow::Break(()),
+        if !is_const_evaluatable_helper(tcx, typeck, e) {
+            ControlFlow::Break(())
+        } else if matches!(e.kind, ExprKind::ConstBlock(_)) {
+            ControlFlow::Continue(Descend::No)
+        } else {
+            ControlFlow::Continue(Descend::Yes)
         }
-        ControlFlow::Continue(Descend::Yes)
     })
     .is_none()
+}
+
+/// Checks if the given expression can be used as a const parameter.
+///
+/// This is more strict than `is_const_evaluatable` as it requires that the expression does not
+/// contain any operations on const parameters.
+pub fn is_const_param_evaluatable<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    typeck: &'tcx TypeckResults<'tcx>,
+    e: &'tcx Expr<'_>,
+) -> bool {
+    fn is_const_param(e: &QPath<'_>) -> bool {
+        if let QPath::Resolved(None, path) = e {
+            matches!(path.res, Res::Def(DefKind::ConstParam, _))
+        } else {
+            false
+        }
+    }
+
+    struct V1<'tcx> {
+        tcx: TyCtxt<'tcx>,
+        typeck: &'tcx TypeckResults<'tcx>,
+    }
+    impl<'tcx> Visitor<'tcx> for V1<'tcx> {
+        type NestedFilter = nested_filter::OnlyBodies;
+        type Result = ControlFlow<()>;
+        fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+            self.tcx
+        }
+        fn visit_expr(&mut self, e: &'tcx Expr<'tcx>) -> Self::Result {
+            if !is_const_evaluatable_helper(self.tcx, self.typeck, e) {
+                return ControlFlow::Break(());
+            }
+            walk_expr(self, e)
+        }
+        fn visit_inline_const(&mut self, c: &'tcx ConstBlock) -> Self::Result {
+            V2(self.tcx).visit_inline_const(c)
+        }
+        fn visit_anon_const(&mut self, c: &'tcx AnonConst) -> Self::Result {
+            V2(self.tcx).visit_anon_const(c)
+        }
+        fn visit_qpath(&mut self, qpath: &'tcx QPath<'tcx>, id: HirId, _span: Span) -> Self::Result {
+            if is_const_param(qpath) {
+                return ControlFlow::Break(());
+            }
+            walk_qpath(self, qpath, id)
+        }
+    }
+
+    struct V2<'tcx>(TyCtxt<'tcx>);
+    impl<'tcx> Visitor<'tcx> for V2<'tcx> {
+        type NestedFilter = nested_filter::OnlyBodies;
+        type Result = ControlFlow<()>;
+        fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+            self.0
+        }
+        fn visit_qpath(&mut self, qpath: &'tcx QPath<'tcx>, id: HirId, _span: Span) -> Self::Result {
+            if is_const_param(qpath) {
+                return ControlFlow::Break(());
+            }
+            walk_qpath(self, qpath, id)
+        }
+    }
+
+    // We have to work around limitations of `#![feature(generic_const_exprs)]` being unstable.
+    // A const parameter (e.g. `N` in `fn foo<const N: usize>()`) can be used as is, but any
+    // expression involving a const parameter (e.g. `N * 2`) will be a compiler error.
+
+    if let ExprKind::Path(ref qpath) = e.kind
+        && is_const_param(qpath)
+    {
+        return true;
+    }
+
+    V1 { tcx, typeck }.visit_expr(e).is_continue()
 }
 
 /// Checks if the given expression performs an unsafe operation outside of an unsafe block.

--- a/tests/ui/chunks_exact_to_as_chunks.rs
+++ b/tests/ui/chunks_exact_to_as_chunks.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::chunks_exact_to_as_chunks)]
-#![allow(unused)]
+#![allow(unused, clippy::redundant_closure_call)]
 
 fn main() {
     let slice = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -40,4 +40,35 @@ fn main() {
     } else {
         slice.chunks_exact(y)
     };
+
+    fn foo<const N: usize>(slice: &[u8]) {
+        // Should trigger - passing const parameters directly is allowed
+
+        let _ = slice.chunks_exact(N);
+        //~^ chunks_exact_to_as_chunks
+        let _ = slice.chunks_exact({
+            //~^ chunks_exact_to_as_chunks
+            const fn bar<const M: usize>() -> usize {
+                M
+            }
+            bar::<5>()
+        });
+
+        // Should NOT trigger - expressions with const parameters are not allowed
+
+        let _ = slice.chunks_exact(N * 2);
+        let _ = slice.chunks_exact(size_of::<A<N>>());
+        let _ = slice.chunks_exact(A::<N>::A);
+        let _ = slice.chunks_exact((|| N)());
+        let _ = slice.chunks_exact({
+            const fn bar<const M: usize>() -> usize {
+                M
+            }
+            bar::<N>()
+        });
+    }
+    struct A<const N: usize>;
+    impl<const N: usize> A<N> {
+        const A: usize = N + 1;
+    }
 }

--- a/tests/ui/chunks_exact_to_as_chunks.stderr
+++ b/tests/ui/chunks_exact_to_as_chunks.stderr
@@ -52,5 +52,49 @@ LL |     let mut it = arr.chunks_exact_mut(4);
    |                      ^^^^^^^^^^^^^^^^^^^
    = note: you can access the chunks using `it.0.iter_mut()`, and the remainder using `it.1`
 
-error: aborting due to 4 previous errors
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks.rs:47:23
+   |
+LL |         let _ = slice.chunks_exact(N);
+   |                       ^^^^^^^^^^^^^^^
+   |
+help: consider using `as_chunks::<N>()` instead
+  --> tests/ui/chunks_exact_to_as_chunks.rs:47:23
+   |
+LL |         let _ = slice.chunks_exact(N);
+   |                       ^^^^^^^^^^^^^^^
+
+error: using `chunks_exact` with a constant chunk size
+  --> tests/ui/chunks_exact_to_as_chunks.rs:49:23
+   |
+LL |           let _ = slice.chunks_exact({
+   |  _______________________^
+LL | |
+LL | |             const fn bar<const M: usize>() -> usize {
+LL | |                 M
+LL | |             }
+LL | |             bar::<5>()
+LL | |         });
+   | |__________^
+   |
+help: consider using `as_chunks::<{
+
+                  const fn bar<const M: usize>() -> usize {
+                      M
+                  }
+                  bar::<5>()
+              }>()` instead
+  --> tests/ui/chunks_exact_to_as_chunks.rs:49:23
+   |
+LL |           let _ = slice.chunks_exact({
+   |  _______________________^
+LL | |
+LL | |             const fn bar<const M: usize>() -> usize {
+LL | |                 M
+LL | |             }
+LL | |             bar::<5>()
+LL | |         });
+   | |__________^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17314

[Feature `generic_const_exprs`](https://doc.rust-lang.org/beta/unstable-book/language-features/generic-const-exprs.html) is unstable, so `chunks_exact_to_as_chunks` cannot suggest changes where it turns an expression containing a const parameter into a const parameter argument.

This PR fixes the issue by detecting when an expression contains a const parameter and not reporting anything if so. However, if the expression itself is a const parameter, then it will be reported, since that is allowed on stable without `generic_const_exprs`. Example:

```rs
fn foo<const N: usize>(slice: &[u8]) {
    let _ = slice.chunks_exact(N); // report
    let _ = slice.chunks_exact(N * 2); // no report
}
```
 
I tested this using the example above.

---

changelog: [`chunks_exact_to_as_chunks`]: Don't report expressions with const parameters to prevent invalid const expressions on stable Rust
