### PR TITLE
fix suspicious_operation_groupings duplications

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -500,7 +500,7 @@ rustc_lint::early_lint_methods!(
         UnnestedOrPatterns: unnested_or_patterns::UnnestedOrPatterns = unnested_or_patterns::UnnestedOrPatterns::new(conf),
         EarlyFunctions: functions::EarlyFunctions = functions::EarlyFunctions,
         Documentation: doc::Documentation = doc::Documentation::new(conf),
-        SuspiciousOperationGroupings: suspicious_operation_groupings::SuspiciousOperationGroupings = suspicious_operation_groupings::SuspiciousOperationGroupings,
+        SuspiciousOperationGroupings: suspicious_operation_groupings::SuspiciousOperationGroupings = <suspicious_operation_groupings::SuspiciousOperationGroupings>::default(),
         DoubleParens: double_parens::DoubleParens = double_parens::DoubleParens,
         UnsafeNameRemoval: unsafe_removed_from_name::UnsafeNameRemoval = unsafe_removed_from_name::UnsafeNameRemoval,
         ElseIfWithoutElse: else_if_without_else::ElseIfWithoutElse = else_if_without_else::ElseIfWithoutElse,

--- a/clippy_lints/src/suspicious_operation_groupings.rs
+++ b/clippy_lints/src/suspicious_operation_groupings.rs
@@ -6,7 +6,7 @@ use rustc_ast::ast::{BinOpKind, Expr, ExprKind, StmtKind};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
-use rustc_session::declare_lint_pass;
+use rustc_session::impl_lint_pass;
 use rustc_span::symbol::Ident;
 use rustc_span::{Span, Spanned};
 
@@ -63,9 +63,13 @@ declare_clippy_lint! {
     "groupings of binary operations that look suspiciously like typos"
 }
 
-declare_lint_pass!(SuspiciousOperationGroupings => [
-    SUSPICIOUS_OPERATION_GROUPINGS,
-]);
+impl_lint_pass!(SuspiciousOperationGroupings => [SUSPICIOUS_OPERATION_GROUPINGS]);
+
+#[derive(Default)]
+pub struct SuspiciousOperationGroupings {
+    // Spans already linted.
+    linted_spans: FxHashSet<Span>,
+}
 
 impl EarlyLintPass for SuspiciousOperationGroupings {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
@@ -74,7 +78,7 @@ impl EarlyLintPass for SuspiciousOperationGroupings {
         }
 
         if let Some(binops) = extract_related_binops(&expr.kind) {
-            check_binops(cx, &binops.iter().collect::<Vec<_>>());
+            check_binops(cx, &binops.iter().collect::<Vec<_>>(), &mut self.linted_spans);
 
             let mut op_types = Vec::with_capacity(binops.len());
             // We could use a hashmap, etc. to avoid being O(n*m) here, but
@@ -90,13 +94,13 @@ impl EarlyLintPass for SuspiciousOperationGroupings {
             for op_type in op_types {
                 let ops: Vec<_> = binops.iter().filter(|b| b.op == op_type).collect();
 
-                check_binops(cx, &ops);
+                check_binops(cx, &ops, &mut self.linted_spans);
             }
         }
     }
 }
 
-fn check_binops(cx: &EarlyContext<'_>, binops: &[&BinaryOp<'_>]) {
+fn check_binops(cx: &EarlyContext<'_>, binops: &[&BinaryOp<'_>], linted_spans: &mut FxHashSet<Span>) {
     let binop_count = binops.len();
     if binop_count < 2 {
         // Single binary operation expressions would likely be false
@@ -153,7 +157,7 @@ fn check_binops(cx: &EarlyContext<'_>, binops: &[&BinaryOp<'_>]) {
 
     if let Some(expected_loc) = expected_ident_loc {
         match (no_difference_info, double_difference_info) {
-            (Some(i), None) => attempt_to_emit_no_difference_lint(cx, binops, i, expected_loc),
+            (Some(i), None) => attempt_to_emit_no_difference_lint(cx, binops, i, expected_loc, linted_spans),
             (None, Some((double_difference_index, ident_loc1, ident_loc2))) => {
                 if one_ident_difference_count == binop_count - 1
                     && let Some(binop) = binops.get(double_difference_index)
@@ -170,7 +174,7 @@ fn check_binops(cx: &EarlyContext<'_>, binops: &[&BinaryOp<'_>]) {
 
                     if let Some(sugg) = ident_swap_sugg(cx, &paired_identifiers, binop, changed_loc, &mut applicability)
                     {
-                        emit_suggestion(cx, binop.span, sugg, applicability);
+                        emit_suggestion(cx, binop.span, sugg, applicability, linted_spans);
                     }
                 }
             },
@@ -184,6 +188,7 @@ fn attempt_to_emit_no_difference_lint(
     binops: &[&BinaryOp<'_>],
     i: usize,
     expected_loc: IdentLocation,
+    linted_spans: &mut FxHashSet<Span>,
 ) {
     if let Some(binop) = binops.get(i).copied() {
         // We need to try and figure out which identifier we should
@@ -210,6 +215,7 @@ fn attempt_to_emit_no_difference_lint(
                     binop.span,
                     replace_left_sugg(cx, binop, &sugg, &mut applicability),
                     applicability,
+                    linted_spans,
                 );
                 return;
             }
@@ -224,6 +230,7 @@ fn attempt_to_emit_no_difference_lint(
                     binop.span,
                     replace_right_sugg(cx, binop, &sugg, &mut applicability),
                     applicability,
+                    linted_spans,
                 );
                 return;
             }
@@ -231,7 +238,17 @@ fn attempt_to_emit_no_difference_lint(
     }
 }
 
-fn emit_suggestion(cx: &EarlyContext<'_>, span: Span, sugg: String, applicability: Applicability) {
+fn emit_suggestion(
+    cx: &EarlyContext<'_>,
+    span: Span,
+    sugg: String,
+    applicability: Applicability,
+    linted_spans: &mut FxHashSet<Span>,
+) {
+    // Avoid cases already linted.
+    if !linted_spans.insert(span) {
+        return;
+    }
     span_lint_and_sugg(
         cx,
         SUSPICIOUS_OPERATION_GROUPINGS,

--- a/tests/ui/suspicious_operation_groupings.fixed
+++ b/tests/ui/suspicious_operation_groupings.fixed
@@ -1,5 +1,3 @@
-//@compile-flags: -Zdeduplicate-diagnostics=yes
-
 #![warn(clippy::suspicious_operation_groupings)]
 #![allow(dead_code, unused_parens, clippy::eq_op, clippy::manual_midpoint)]
 
@@ -85,7 +83,6 @@ fn odd_number_of_pairs(s1: &S, s2: &S) -> i32 {
     // There's no `s2.b`
     s1.a * s2.a + s1.b * s2.b + s1.c * s2.c
     //~^ suspicious_operation_groupings
-    //~| suspicious_operation_groupings
 }
 
 fn not_caught_by_eq_op_middle_change_left(s1: &S, s2: &S) -> i32 {
@@ -148,7 +145,6 @@ fn all_parens_balanced_tree(s1: &S, s2: &S) -> i32 {
     // There's no `s2.c`
     (((s1.a * s2.a) + (s1.b * s2.b)) + ((s1.c * s2.c) + (s1.d * s2.d)))
     //~^ suspicious_operation_groupings
-    //~| suspicious_operation_groupings
 }
 
 fn all_parens_left_tree(s1: &S, s2: &S) -> i32 {

--- a/tests/ui/suspicious_operation_groupings.rs
+++ b/tests/ui/suspicious_operation_groupings.rs
@@ -1,5 +1,3 @@
-//@compile-flags: -Zdeduplicate-diagnostics=yes
-
 #![warn(clippy::suspicious_operation_groupings)]
 #![allow(dead_code, unused_parens, clippy::eq_op, clippy::manual_midpoint)]
 
@@ -85,7 +83,6 @@ fn odd_number_of_pairs(s1: &S, s2: &S) -> i32 {
     // There's no `s2.b`
     s1.a * s2.a + s1.b * s2.c + s1.c * s2.c
     //~^ suspicious_operation_groupings
-    //~| suspicious_operation_groupings
 }
 
 fn not_caught_by_eq_op_middle_change_left(s1: &S, s2: &S) -> i32 {
@@ -148,7 +145,6 @@ fn all_parens_balanced_tree(s1: &S, s2: &S) -> i32 {
     // There's no `s2.c`
     (((s1.a * s2.a) + (s1.b * s2.b)) + ((s1.c * s2.b) + (s1.d * s2.d)))
     //~^ suspicious_operation_groupings
-    //~| suspicious_operation_groupings
 }
 
 fn all_parens_left_tree(s1: &S, s2: &S) -> i32 {

--- a/tests/ui/suspicious_operation_groupings.stderr
+++ b/tests/ui/suspicious_operation_groupings.stderr
@@ -1,5 +1,5 @@
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:17:9
+  --> tests/ui/suspicious_operation_groupings.rs:15:9
    |
 LL |         self.x == other.y && self.y == other.y && self.z == other.z
    |         ^^^^^^^^^^^^^^^^^ help: did you mean: `self.x == other.x`
@@ -8,154 +8,142 @@ LL |         self.x == other.y && self.y == other.y && self.z == other.z
    = help: to override `-D warnings` add `#[allow(clippy::suspicious_operation_groupings)]`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:31:20
+  --> tests/ui/suspicious_operation_groupings.rs:29:20
    |
 LL |     s1.a < s2.a && s1.a < s2.b
    |                    ^^^^^^^^^^^ help: did you mean: `s1.b < s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:80:33
+  --> tests/ui/suspicious_operation_groupings.rs:78:33
    |
 LL |     s1.a * s2.a + s1.b * s2.b + s1.c * s2.b + s1.d * s2.d
    |                                 ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:86:19
+  --> tests/ui/suspicious_operation_groupings.rs:84:19
    |
 LL |     s1.a * s2.a + s1.b * s2.c + s1.c * s2.c
    |                   ^^^^^^^^^^^ help: did you mean: `s1.b * s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:86:19
-   |
-LL |     s1.a * s2.a + s1.b * s2.c + s1.c * s2.c
-   |                   ^^^^^^^^^^^ help: did you mean: `s1.b * s2.b`
-
-error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:93:19
+  --> tests/ui/suspicious_operation_groupings.rs:90:19
    |
 LL |     s1.a * s2.a + s2.b * s2.b + s1.c * s2.c
    |                   ^^^^^^^^^^^ help: did you mean: `s1.b * s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:99:19
+  --> tests/ui/suspicious_operation_groupings.rs:96:19
    |
 LL |     s1.a * s2.a + s1.b * s1.b + s1.c * s2.c
    |                   ^^^^^^^^^^^ help: did you mean: `s1.b * s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:105:5
+  --> tests/ui/suspicious_operation_groupings.rs:102:5
    |
 LL |     s1.a * s1.a + s1.b * s2.b + s1.c * s2.c
    |     ^^^^^^^^^^^ help: did you mean: `s1.a * s2.a`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:111:33
+  --> tests/ui/suspicious_operation_groupings.rs:108:33
    |
 LL |     s1.a * s2.a + s1.b * s2.b + s1.c * s1.c
    |                                 ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:125:20
+  --> tests/ui/suspicious_operation_groupings.rs:122:20
    |
 LL |     (s1.a * s2.a + s1.b * s1.b)
    |                    ^^^^^^^^^^^ help: did you mean: `s1.b * s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:131:34
+  --> tests/ui/suspicious_operation_groupings.rs:128:34
    |
 LL |     (s1.a * s2.a + s1.b * s2.b + s1.c * s2.b + s1.d * s2.d)
    |                                  ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:137:38
+  --> tests/ui/suspicious_operation_groupings.rs:134:38
    |
 LL |     (s1.a * s2.a) + (s1.b * s2.b) + (s1.c * s2.b) + (s1.d * s2.d)
    |                                      ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:143:39
+  --> tests/ui/suspicious_operation_groupings.rs:140:39
    |
 LL |     ((s1.a * s2.a) + (s1.b * s2.b) + (s1.c * s2.b) + (s1.d * s2.d))
    |                                       ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:149:42
+  --> tests/ui/suspicious_operation_groupings.rs:146:42
    |
 LL |     (((s1.a * s2.a) + (s1.b * s2.b)) + ((s1.c * s2.b) + (s1.d * s2.d)))
    |                                          ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:149:42
-   |
-LL |     (((s1.a * s2.a) + (s1.b * s2.b)) + ((s1.c * s2.b) + (s1.d * s2.d)))
-   |                                          ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
-
-error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:156:40
+  --> tests/ui/suspicious_operation_groupings.rs:152:40
    |
 LL |     (((s1.a * s2.a) + (s1.b * s2.b) + (s1.c * s2.b)) + (s1.d * s2.d))
    |                                        ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:162:40
+  --> tests/ui/suspicious_operation_groupings.rs:158:40
    |
 LL |     ((s1.a * s2.a) + ((s1.b * s2.b) + (s1.c * s2.b) + (s1.d * s2.d)))
    |                                        ^^^^^^^^^^^ help: did you mean: `s1.c * s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:168:20
+  --> tests/ui/suspicious_operation_groupings.rs:164:20
    |
 LL |     (s1.a * s2.a + s2.b * s2.b) / 2
    |                    ^^^^^^^^^^^ help: did you mean: `s1.b * s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:174:35
+  --> tests/ui/suspicious_operation_groupings.rs:170:35
    |
 LL |     i32::swap_bytes(s1.a * s2.a + s2.b * s2.b)
    |                                   ^^^^^^^^^^^ help: did you mean: `s1.b * s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:180:29
+  --> tests/ui/suspicious_operation_groupings.rs:176:29
    |
 LL |     s1.a > 0 && s1.b > 0 && s1.d == s2.c && s1.d == s2.d
    |                             ^^^^^^^^^^^^ help: did you mean: `s1.c == s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:186:17
+  --> tests/ui/suspicious_operation_groupings.rs:182:17
    |
 LL |     s1.a > 0 && s1.d == s2.c && s1.b > 0 && s1.d == s2.d
    |                 ^^^^^^^^^^^^ help: did you mean: `s1.c == s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:196:77
+  --> tests/ui/suspicious_operation_groupings.rs:192:77
    |
 LL |     (n1.inner.0).0 == (n2.inner.0).0 && (n1.inner.1).0 == (n2.inner.1).0 && (n1.inner.2).0 == (n2.inner.1).0
    |                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `(n1.inner.2).0 == (n2.inner.2).0`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:211:25
+  --> tests/ui/suspicious_operation_groupings.rs:207:25
    |
 LL |         s1.a <= s2.a && s1.a <= s2.b
    |                         ^^^^^^^^^^^^ help: did you mean: `s1.b <= s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:218:23
+  --> tests/ui/suspicious_operation_groupings.rs:214:23
    |
 LL |     if s1.a < s2.a && s1.a < s2.b {
    |                       ^^^^^^^^^^^ help: did you mean: `s1.b < s2.b`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:226:48
+  --> tests/ui/suspicious_operation_groupings.rs:222:48
    |
 LL |     -(-(-s1.a * -s2.a) + (-(-s1.b * -s2.b) + -(-s1.c * -s2.b) + -(-s1.d * -s2.d)))
    |                                                ^^^^^^^^^^^^^ help: did you mean: `-s1.c * -s2.c`
 
 error: this sequence of operators looks suspiciously like a bug
-  --> tests/ui/suspicious_operation_groupings.rs:232:27
+  --> tests/ui/suspicious_operation_groupings.rs:228:27
    |
 LL |     -(if -s1.a < -s2.a && -s1.a < -s2.b { s1.c } else { s2.a })
    |                           ^^^^^^^^^^^^^ help: did you mean: `-s1.b < -s2.b`
 
-error: aborting due to 26 previous errors
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
part of rust-lang/rust-clippy#12379

changelog: [`suspicious_operation_groupings`]: fix lint duplications.
