### PR TITLE
Respect the configured MSRV in `manual_is_variant_and`'s `map() == Some(_)` rewrite

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -957,6 +957,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`manual_hash_one`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_hash_one)
 * [`manual_is_ascii_check`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_ascii_check)
 * [`manual_is_power_of_two`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_power_of_two)
+* [`manual_is_variant_and`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_variant_and)
 * [`manual_isolate_lowest_one`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_isolate_lowest_one)
 * [`manual_let_else`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else)
 * [`manual_midpoint`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_midpoint)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -812,6 +812,7 @@ define_Conf! {
         manual_hash_one,
         manual_is_ascii_check,
         manual_is_power_of_two,
+        manual_is_variant_and,
         manual_isolate_lowest_one,
         manual_let_else,
         manual_midpoint,

--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -168,6 +168,7 @@ impl<'hir> MapFunc<'hir> {
     }
 }
 
+#[expect(clippy::too_many_arguments)]
 fn emit_lint<'tcx>(
     cx: &LateContext<'tcx>,
     span: Span,
@@ -176,7 +177,16 @@ fn emit_lint<'tcx>(
     in_some_or_ok: bool,
     map_func: MapFunc<'tcx>,
     recv: &Expr<'_>,
+    msrv: Msrv,
 ) {
+    let required_msrv = match (flavor, op) {
+        (Flavor::Option, Op::Ne) => msrvs::IS_NONE_OR,
+        _ => msrvs::OPTION_RESULT_IS_VARIANT_AND,
+    };
+    if !msrv.meets(cx, required_msrv) {
+        return;
+    }
+
     let mut app = Applicability::MachineApplicable;
     let recv = snippet_with_applicability(cx, recv.span, "_", &mut app);
 
@@ -201,7 +211,7 @@ fn emit_lint<'tcx>(
     );
 }
 
-pub(super) fn check_map(cx: &LateContext<'_>, expr: &Expr<'_>) {
+pub(super) fn check_map(cx: &LateContext<'_>, expr: &Expr<'_>, msrv: Msrv) {
     if let Some(parent_expr) = get_parent_expr(cx, expr)
         && let ExprKind::Binary(op, left, right) = parent_expr.kind
         && op.span.eq_ctxt(expr.span)
@@ -222,7 +232,7 @@ pub(super) fn check_map(cx: &LateContext<'_>, expr: &Expr<'_>) {
                 && cx.typeck_results().expr_ty(recv).is_diag_item(cx, flavor.diag_sym())
                 && let Ok(map_func) = MapFunc::try_from(map_expr)
             {
-                emit_lint(cx, parent_expr.span, op, flavor, bool_cst, map_func, recv);
+                emit_lint(cx, parent_expr.span, op, flavor, bool_cst, map_func, recv, msrv);
                 return;
             }
         }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5598,7 +5598,7 @@ impl Methods {
                     if name == sym::map {
                         map_clone::check(cx, expr, recv, m_arg, self.msrv);
                         map_with_unused_argument_over_ranges::check(cx, expr, recv, m_arg, self.msrv, span);
-                        manual_is_variant_and::check_map(cx, expr);
+                        manual_is_variant_and::check_map(cx, expr, self.msrv);
                         match method_call(recv) {
                             Some((map_name @ (sym::iter | sym::into_iter), recv2, _, _, _)) => {
                                 iter_kv_map::check(cx, map_name, expr, recv2, m_arg, self.msrv, sym::map);

--- a/tests/ui/manual_is_variant_and.fixed
+++ b/tests/ui/manual_is_variant_and.fixed
@@ -244,6 +244,19 @@ fn issue16419_msrv() {
     let _ = opt.is_some_and(then_fn) || opt.is_none();
 }
 
+#[clippy::msrv = "1.69"]
+fn check_map_msrv_is_some_and(opt: Option<i32>) {
+    let _ = opt.map(|x| x > 0) == Some(true);
+    let _ = opt.map(|x| x > 0) != Some(false);
+}
+
+#[clippy::msrv = "1.81"]
+fn check_map_msrv_is_none_or(opt: Option<i32>) {
+    let _ = opt.is_some_and(|x| x > 0);
+    //~^ manual_is_variant_and
+    let _ = opt.map(|x| x > 0) != Some(false);
+}
+
 fn issue16518(opt: Option<i32>) {
     let condition = |x: &i32| *x > 10;
 

--- a/tests/ui/manual_is_variant_and.rs
+++ b/tests/ui/manual_is_variant_and.rs
@@ -253,6 +253,19 @@ fn issue16419_msrv() {
     let _ = opt.is_some_and(then_fn) || opt.is_none();
 }
 
+#[clippy::msrv = "1.69"]
+fn check_map_msrv_is_some_and(opt: Option<i32>) {
+    let _ = opt.map(|x| x > 0) == Some(true);
+    let _ = opt.map(|x| x > 0) != Some(false);
+}
+
+#[clippy::msrv = "1.81"]
+fn check_map_msrv_is_none_or(opt: Option<i32>) {
+    let _ = opt.map(|x| x > 0) == Some(true);
+    //~^ manual_is_variant_and
+    let _ = opt.map(|x| x > 0) != Some(false);
+}
+
 fn issue16518(opt: Option<i32>) {
     let condition = |x: &i32| *x > 10;
 

--- a/tests/ui/manual_is_variant_and.stderr
+++ b/tests/ui/manual_is_variant_and.stderr
@@ -234,29 +234,35 @@ error: manual implementation of `Option::is_none_or`
 LL |     let _ = opt.is_some_and(then_fn) || opt.is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_none_or(then_fn)`
 
+error: called `.map() == Some()`
+  --> tests/ui/manual_is_variant_and.rs:264:13
+   |
+LL |     let _ = opt.map(|x| x > 0) == Some(true);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.is_some_and(|x| x > 0)`
+
 error: manual implementation of `Option::is_some_and`
-  --> tests/ui/manual_is_variant_and.rs:259:5
+  --> tests/ui/manual_is_variant_and.rs:272:5
    |
 LL |     opt.filter(|x| condition(x)).is_some();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_some_and(|x| condition(x))`
 
 error: manual implementation of `Option::is_none_or`
-  --> tests/ui/manual_is_variant_and.rs:261:5
+  --> tests/ui/manual_is_variant_and.rs:274:5
    |
 LL |     opt.filter(|x| condition(x)).is_none();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `opt.as_ref().is_none_or(|x| !condition(x))`
 
 error: called `.ok().is_some_and(..)` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:273:13
+  --> tests/ui/manual_is_variant_and.rs:286:13
    |
 LL |     let _ = res.ok().is_some_and(|x| x > 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `is_ok_and` instead: `res.is_ok_and(|x| x > 0)`
 
 error: called `.ok().is_some_and(..)` on a `Result` value
-  --> tests/ui/manual_is_variant_and.rs:276:13
+  --> tests/ui/manual_is_variant_and.rs:289:13
    |
 LL |     let _ = res.ok().is_some_and(|x| x > 0) || res.is_err();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `is_ok_and` instead: `res.is_ok_and(|x| x > 0)`
 
-error: aborting due to 37 previous errors
+error: aborting due to 38 previous errors
 


### PR DESCRIPTION
The `map(...) == Some(true)` and `map(...) != Some(false)` path of `manual_is_variant_and` suggested `is_some_and` and `is_ok_and` (stable since 1.70) and `is_none_or` (stable since 1.82) without checking the configured MSRV. The other paths of this lint already gate these methods, so this path alone could suggest a method that is newer than the project allows, and `cargo clippy --fix` would apply it.

For example, with the MSRV set to 1.81, `opt.map(|x| x > 0) != Some(false)` was rewritten to `opt.is_none_or(|x| x > 0)`, which is not available until 1.82, so the result no longer compiles.

This threads the MSRV through `check_map` into `emit_lint` and gates each suggested method behind its stabilization version, matching what `check_or` and `check_is_some_is_none` already do.

Fixes rust-lang/rust-clippy#17327

changelog: [`manual_is_variant_and`] respect the MSRV for `map() == Some(_)` comparisons
