### PR TITLE
Rewrite `redundant_else` as a late pass.

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -509,7 +509,6 @@ rustc_lint::early_lint_methods!(
         MiscEarlyLints: misc_early::MiscEarlyLints = misc_early::MiscEarlyLints,
         UnusedUnit: unused_unit::UnusedUnit = unused_unit::UnusedUnit,
         Precedence: precedence::Precedence = precedence::Precedence,
-        RedundantElse: redundant_else::RedundantElse = redundant_else::RedundantElse,
         NeedlessArbitrarySelfType: needless_arbitrary_self_type::NeedlessArbitrarySelfType = needless_arbitrary_self_type::NeedlessArbitrarySelfType,
         LiteralDigitGrouping: literal_representation::LiteralDigitGrouping = literal_representation::LiteralDigitGrouping::new(conf),
         DecimalLiteralRepresentation: literal_representation::DecimalLiteralRepresentation = literal_representation::DecimalLiteralRepresentation::new(conf),
@@ -862,6 +861,7 @@ rustc_lint::late_lint_methods!(
         ManualAssertEq: manual_assert_eq::ManualAssertEq = manual_assert_eq::ManualAssertEq,
         WithCapacityZero: with_capacity_zero::WithCapacityZero = with_capacity_zero::WithCapacityZero,
         RefPatterns: ref_patterns::RefPatterns = ref_patterns::RefPatterns,
+        RedundantElse: redundant_else::RedundantElse = redundant_else::RedundantElse,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/needless_borrows_for_generic_args.rs
+++ b/clippy_lints/src/needless_borrows_for_generic_args.rs
@@ -356,9 +356,8 @@ fn is_mixed_projection_predicate<'tcx>(
                 },
             }
         }
-    } else {
-        false
     }
+    false
 }
 
 fn referent_used_exactly_once<'tcx>(

--- a/clippy_lints/src/redundant_else.rs
+++ b/clippy_lints/src/redundant_else.rs
@@ -1,9 +1,9 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::{indent_of, reindent_multiline, snippet};
-use rustc_ast::ast::{Block, Expr, ExprKind, Stmt, StmtKind};
-use rustc_ast::visit::{Visitor, walk_expr};
 use rustc_errors::Applicability;
-use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
+use rustc_hir::{Block, Expr, ExprKind, Stmt, StmtKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TypeckResults;
 use rustc_session::declare_lint_pass;
 use rustc_span::Span;
 
@@ -46,111 +46,94 @@ declare_clippy_lint! {
 
 declare_lint_pass!(RedundantElse => [REDUNDANT_ELSE]);
 
-impl EarlyLintPass for RedundantElse {
-    fn check_stmt(&mut self, cx: &EarlyContext<'_>, stmt: &Stmt) {
-        if stmt.span.in_external_macro(cx.sess().source_map()) {
+impl<'tcx> LateLintPass<'tcx> for RedundantElse {
+    fn check_block_post(&mut self, cx: &LateContext<'tcx>, b: &Block<'_>) {
+        if let Some(e) = b.expr {
+            check(cx, e);
+        }
+    }
+
+    fn check_stmt(&mut self, cx: &LateContext<'tcx>, s: &Stmt<'_>) {
+        if let StmtKind::Expr(e) | StmtKind::Semi(e) = s.kind {
+            check(cx, e);
+        }
+    }
+}
+
+fn check(cx: &LateContext<'_>, e: &Expr<'_>) {
+    if e.span.in_external_macro(cx.tcx.sess.source_map()) {
+        return;
+    }
+    // if else
+    let (mut then, mut els) = match e.kind {
+        ExprKind::If(_, then, Some(els)) => (then, els),
+        _ => return,
+    };
+    loop {
+        if !is_never(cx.typeck_results(), then) {
+            // then block does not always break
             return;
         }
-        // Only look at expressions that are a whole statement
-        let expr: &Expr = match &stmt.kind {
-            StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr,
-            _ => return,
-        };
-        // if else
-        let (mut then, mut els): (&Block, &Expr) = match &expr.kind {
-            ExprKind::If(_, then, Some(els)) => (then, els),
-            _ => return,
-        };
-        loop {
-            if !BreakVisitor::default().check_block(then) {
-                // then block does not always break
-                return;
-            }
-            match &els.kind {
-                // else if else
-                ExprKind::If(_, next_then, Some(next_els)) => {
-                    then = next_then;
-                    els = next_els;
-                },
-                // else if without else
-                ExprKind::If(..) => return,
-                // done
-                _ => break,
+        match &els.kind {
+            // else if else
+            ExprKind::If(_, next_then, Some(next_els)) => {
+                then = next_then;
+                els = next_els;
+            },
+            // else if without else
+            ExprKind::If(..) => return,
+            // done
+            _ => break,
+        }
+    }
+
+    let mut app = Applicability::MachineApplicable;
+    if let ExprKind::Block(block, _) = &els.kind {
+        for stmt in block.stmts {
+            // If the `else` block contains a local binding, Clippy shouldn't auto-fix it
+            if matches!(&stmt.kind, StmtKind::Let(_)) {
+                app = Applicability::Unspecified;
+                break;
             }
         }
+    }
 
-        let mut app = Applicability::MachineApplicable;
-        if let ExprKind::Block(block, _) = &els.kind {
-            for stmt in &block.stmts {
-                // If the `else` block contains a local binding or a macro invocation, Clippy shouldn't auto-fix it
-                if matches!(&stmt.kind, StmtKind::Let(_) | StmtKind::MacCall(_)) {
-                    app = Applicability::Unspecified;
-                    break;
-                }
-            }
-        }
-
-        // FIXME: The indentation of the suggestion would be the same as the one of the macro invocation in this implementation, see https://github.com/rust-lang/rust-clippy/pull/13936#issuecomment-2569548202
-        span_lint_and_sugg(
-            cx,
-            REDUNDANT_ELSE,
-            els.span.with_lo(then.span.hi()),
-            "redundant else block",
+    // FIXME: The indentation of the suggestion would be the same as the one of the macro invocation in this implementation, see https://github.com/rust-lang/rust-clippy/pull/13936#issuecomment-2569548202
+    let sp = els.span.with_lo(then.span.hi());
+    span_lint_hir_and_then(cx, REDUNDANT_ELSE, e.hir_id, sp, "redundant else block", |diag| {
+        diag.span_suggestion(
+            sp,
             "remove the `else` block and move the contents out",
-            make_sugg(cx, els.span, "..", Some(expr.span)),
+            make_sugg(cx, els.span, "..", Some(e.span)),
             app,
         );
-    }
+    });
 }
 
-/// Call `check` functions to check if an expression always breaks control flow
-#[derive(Default)]
-struct BreakVisitor {
-    is_break: bool,
-}
-
-impl<'ast> Visitor<'ast> for BreakVisitor {
-    fn visit_block(&mut self, block: &'ast Block) {
-        self.is_break = match block.stmts.as_slice() {
-            [.., last] => self.check_stmt(last),
-            _ => false,
-        };
-    }
-
-    fn visit_expr(&mut self, expr: &'ast Expr) {
-        self.is_break = match expr.kind {
-            ExprKind::Break(..) | ExprKind::Continue(..) | ExprKind::Ret(..) => true,
-            ExprKind::Match(_, ref arms, _) => arms.iter().all(|arm|
-                arm.body.is_none() || arm.body.as_deref().is_some_and(|body| self.check_expr(body))
-            ),
-            ExprKind::If(_, ref then, Some(ref els)) => self.check_block(then) && self.check_expr(els),
-            ExprKind::If(_, _, None)
-            // ignore loops for simplicity
-            | ExprKind::While(..) | ExprKind::ForLoop { .. } | ExprKind::Loop(..) => false,
-            _ => {
-                walk_expr(self, expr);
-                return;
-            },
-        };
-    }
-}
-
-impl BreakVisitor {
-    fn check<T>(&mut self, item: T, visit: fn(&mut Self, T)) -> bool {
-        visit(self, item);
-        std::mem::replace(&mut self.is_break, false)
-    }
-
-    fn check_block(&mut self, block: &Block) -> bool {
-        self.check(block, Self::visit_block)
-    }
-
-    fn check_expr(&mut self, expr: &Expr) -> bool {
-        self.check(expr, Self::visit_expr)
-    }
-
-    fn check_stmt(&mut self, stmt: &Stmt) -> bool {
-        self.check(stmt, Self::visit_stmt)
+fn is_never(typeck: &TypeckResults<'_>, e: &Expr<'_>) -> bool {
+    match e.kind {
+        ExprKind::Break(..) | ExprKind::Continue(_) | ExprKind::Ret(_) | ExprKind::Become(..) => return true,
+        ExprKind::DropTemps(e) => is_never(typeck, e),
+        ExprKind::Block(b, _)
+            if !b.targeted_by_break
+                && let Some(e) = match (b.expr, b.stmts) {
+                    (Some(e), _) => Some(e),
+                    (None, [.., s]) if let StmtKind::Expr(e) | StmtKind::Semi(e) = s.kind => Some(e),
+                    _ => None,
+                } =>
+        {
+            is_never(typeck, e)
+        },
+        ExprKind::Match(_, arms, _) => arms.iter().all(|a| is_never(typeck, a.body)),
+        ExprKind::If(_, then, Some(else_)) => is_never(typeck, then) && is_never(typeck, else_),
+        ExprKind::Call(..)
+        | ExprKind::MethodCall(..)
+        | ExprKind::Binary(..)
+        | ExprKind::Unary(..)
+        | ExprKind::Block(..)
+        | ExprKind::Loop(..)
+        | ExprKind::Path(_) => typeck.expr_ty(e).is_never(),
+        _ => false,
     }
 }
 
@@ -162,7 +145,7 @@ fn extract_else_block(mut block: &str) -> String {
     block.trim_end().to_string()
 }
 
-fn make_sugg(cx: &EarlyContext<'_>, els_span: Span, default: &str, indent_relative_to: Option<Span>) -> String {
+fn make_sugg(cx: &LateContext<'_>, els_span: Span, default: &str, indent_relative_to: Option<Span>) -> String {
     let extracted = extract_else_block(&snippet(cx, els_span, default));
     let indent = indent_relative_to.and_then(|s| indent_of(cx, s));
 

--- a/clippy_lints/src/redundant_else.rs
+++ b/clippy_lints/src/redundant_else.rs
@@ -2,11 +2,11 @@ use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::is_from_proc_macro;
 use clippy_utils::source::{SpanExt, indent_of, reindent_multiline};
 use rustc_errors::Applicability;
-use rustc_hir::{Block, Expr, ExprKind, Stmt, StmtKind};
+use rustc_hir::{Block, Expr, ExprKind, MatchSource, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TypeckResults;
 use rustc_session::declare_lint_pass;
-use rustc_span::SyntaxContext;
+use rustc_span::{ExpnKind, SyntaxContext};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -50,18 +50,18 @@ declare_lint_pass!(RedundantElse => [REDUNDANT_ELSE]);
 impl<'tcx> LateLintPass<'tcx> for RedundantElse {
     fn check_block_post(&mut self, cx: &LateContext<'tcx>, b: &'tcx Block<'_>) {
         if let Some(e) = b.expr {
-            check(cx, b.span.ctxt(), e);
+            check(cx, b.span.ctxt(), false, e);
         }
     }
 
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, s: &'tcx Stmt<'_>) {
         if let StmtKind::Expr(e) | StmtKind::Semi(e) = s.kind {
-            check(cx, s.span.ctxt(), e);
+            check(cx, s.span.ctxt(), matches!(s.kind, StmtKind::Expr(_)), e);
         }
     }
 }
 
-fn check<'tcx>(cx: &LateContext<'tcx>, ctxt: SyntaxContext, e: &'tcx Expr<'_>) {
+fn check<'tcx>(cx: &LateContext<'tcx>, ctxt: SyntaxContext, needs_semi: bool, e: &'tcx Expr<'_>) {
     // Find the final `else` block in an `if` chain.
     let mut prev_then = None;
     let mut next = e;
@@ -92,10 +92,14 @@ fn check<'tcx>(cx: &LateContext<'tcx>, ctxt: SyntaxContext, e: &'tcx Expr<'_>) {
     {
         let sp = else_.span.with_lo(then.span.hi());
         span_lint_hir_and_then(cx, REDUNDANT_ELSE, e.hir_id, sp, "redundant else block", |diag| {
+            let mut sugg = reindent_multiline(src.trim_end(), false, Some(indent));
+            if needs_semi && else_.expr.is_some_and(|e| expr_needs_semi(ctxt, e)) {
+                sugg.push(';');
+            }
             diag.span_suggestion(
                 sp,
                 "remove the `else` block and move the contents out",
-                reindent_multiline(src.trim_end(), false, Some(indent)),
+                sugg,
                 if ctxt.is_root() && else_.stmts.iter().all(|s| !matches!(s.kind, StmtKind::Let(_))) {
                     Applicability::MachineApplicable
                 } else {
@@ -103,6 +107,22 @@ fn check<'tcx>(cx: &LateContext<'tcx>, ctxt: SyntaxContext, e: &'tcx Expr<'_>) {
                 },
             );
         });
+    }
+}
+
+/// Checks if an expression, viewed from the specified context, needs a trailing semicolon
+/// to be parsed as a statement.
+fn expr_needs_semi(ctxt: SyntaxContext, e: &Expr<'_>) -> bool {
+    match e.kind {
+        ExprKind::Block(..) | ExprKind::Loop(..) | ExprKind::Match(..) | ExprKind::If(..) if ctxt == e.span.ctxt() => {
+            false
+        },
+        ExprKind::Loop(..) => {
+            let expn = e.span.ctxt().outer_expn_data();
+            ctxt != expn.call_site.ctxt() || !matches!(expn.kind, ExpnKind::Desugaring(_))
+        },
+        ExprKind::Match(_, _, MatchSource::ForLoopDesugar) => ctxt != e.span.ctxt().outer_expn_data().call_site.ctxt(),
+        _ => true,
     }
 }
 

--- a/clippy_lints/src/redundant_else.rs
+++ b/clippy_lints/src/redundant_else.rs
@@ -5,7 +5,7 @@ use rustc_hir::{Block, Expr, ExprKind, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TypeckResults;
 use rustc_session::declare_lint_pass;
-use rustc_span::Span;
+use rustc_span::{Span, SyntaxContext};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -49,19 +49,19 @@ declare_lint_pass!(RedundantElse => [REDUNDANT_ELSE]);
 impl<'tcx> LateLintPass<'tcx> for RedundantElse {
     fn check_block_post(&mut self, cx: &LateContext<'tcx>, b: &Block<'_>) {
         if let Some(e) = b.expr {
-            check(cx, e);
+            check(cx, b.span.ctxt(), e);
         }
     }
 
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, s: &Stmt<'_>) {
         if let StmtKind::Expr(e) | StmtKind::Semi(e) = s.kind {
-            check(cx, e);
+            check(cx, s.span.ctxt(), e);
         }
     }
 }
 
-fn check(cx: &LateContext<'_>, e: &Expr<'_>) {
-    if e.span.in_external_macro(cx.tcx.sess.source_map()) {
+fn check(cx: &LateContext<'_>, ctxt: SyntaxContext, e: &Expr<'_>) {
+    if e.span.ctxt() != ctxt || ctxt.in_external_macro(cx.tcx.sess.source_map()) {
         return;
     }
     // if else
@@ -70,7 +70,7 @@ fn check(cx: &LateContext<'_>, e: &Expr<'_>) {
         _ => return,
     };
     loop {
-        if !is_never(cx.typeck_results(), then) {
+        if then.span.ctxt() != ctxt || els.span.ctxt() != ctxt || !is_never(cx.typeck_results(), ctxt, then) {
             // then block does not always break
             return;
         }
@@ -110,22 +110,26 @@ fn check(cx: &LateContext<'_>, e: &Expr<'_>) {
     });
 }
 
-fn is_never(typeck: &TypeckResults<'_>, e: &Expr<'_>) -> bool {
+fn is_never(typeck: &TypeckResults<'_>, ctxt: SyntaxContext, e: &Expr<'_>) -> bool {
+    if ctxt.is_root() {
+        is_never_root(typeck, e)
+    } else {
+        is_never_mac(ctxt, e)
+    }
+}
+
+fn is_never_root(typeck: &TypeckResults<'_>, e: &Expr<'_>) -> bool {
     match e.kind {
-        ExprKind::Break(..) | ExprKind::Continue(_) | ExprKind::Ret(_) | ExprKind::Become(..) => return true,
-        ExprKind::DropTemps(e) => is_never(typeck, e),
+        ExprKind::Break(..) | ExprKind::Continue(_) | ExprKind::Ret(_) | ExprKind::Become(..) => true,
+        ExprKind::DropTemps(e) => is_never_root(typeck, e),
         ExprKind::Block(b, _)
-            if !b.targeted_by_break
-                && let Some(e) = match (b.expr, b.stmts) {
-                    (Some(e), _) => Some(e),
-                    (None, [.., s]) if let StmtKind::Expr(e) | StmtKind::Semi(e) = s.kind => Some(e),
-                    _ => None,
-                } =>
+            if let Some(e) = b.expr
+                && !b.targeted_by_break =>
         {
-            is_never(typeck, e)
+            is_never_root(typeck, e)
         },
-        ExprKind::Match(_, arms, _) => arms.iter().all(|a| is_never(typeck, a.body)),
-        ExprKind::If(_, then, Some(else_)) => is_never(typeck, then) && is_never(typeck, else_),
+        ExprKind::Match(_, arms, _) => arms.iter().all(|a| is_never_root(typeck, a.body)),
+        ExprKind::If(_, then, Some(else_)) => is_never_root(typeck, then) && is_never_root(typeck, else_),
         ExprKind::Call(..)
         | ExprKind::MethodCall(..)
         | ExprKind::Binary(..)
@@ -134,6 +138,41 @@ fn is_never(typeck: &TypeckResults<'_>, e: &Expr<'_>) -> bool {
         | ExprKind::Loop(..)
         | ExprKind::Path(_) => typeck.expr_ty(e).is_never(),
         _ => false,
+    }
+}
+
+fn is_never_mac(ctxt: SyntaxContext, mut e: &Expr<'_>) -> bool {
+    loop {
+        let next = match e.kind {
+            ExprKind::Break(..) | ExprKind::Continue(_) | ExprKind::Ret(_) | ExprKind::Become(..) => return true,
+            ExprKind::DropTemps(e) => e,
+            ExprKind::Block(b, _)
+                if !b.targeted_by_break
+                    && let Some(e) = match (b.expr, b.stmts) {
+                        (Some(e), _) => Some(e),
+                        (None, [.., s]) if let StmtKind::Expr(e) | StmtKind::Semi(e) = s.kind => Some(e),
+                        _ => None,
+                    }
+                    && ctxt == b.span.ctxt() =>
+            {
+                e
+            },
+            ExprKind::Match(_, arms, _) => {
+                return arms
+                    .iter()
+                    .all(|a| ctxt == a.span.ctxt() && ctxt == a.body.span.ctxt() && is_never_mac(ctxt, a.body));
+            },
+            ExprKind::If(_, then, Some(else_))
+                if ctxt == then.span.ctxt() && ctxt == else_.span.ctxt() && is_never_mac(ctxt, then) =>
+            {
+                else_
+            },
+            _ => return false,
+        };
+        if ctxt != next.span.ctxt() {
+            return false;
+        }
+        e = next;
     }
 }
 

--- a/clippy_lints/src/redundant_else.rs
+++ b/clippy_lints/src/redundant_else.rs
@@ -1,11 +1,12 @@
 use clippy_utils::diagnostics::span_lint_hir_and_then;
-use clippy_utils::source::{indent_of, reindent_multiline, snippet};
+use clippy_utils::is_from_proc_macro;
+use clippy_utils::source::{SpanExt, indent_of, reindent_multiline};
 use rustc_errors::Applicability;
 use rustc_hir::{Block, Expr, ExprKind, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TypeckResults;
 use rustc_session::declare_lint_pass;
-use rustc_span::{Span, SyntaxContext};
+use rustc_span::SyntaxContext;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -47,67 +48,62 @@ declare_clippy_lint! {
 declare_lint_pass!(RedundantElse => [REDUNDANT_ELSE]);
 
 impl<'tcx> LateLintPass<'tcx> for RedundantElse {
-    fn check_block_post(&mut self, cx: &LateContext<'tcx>, b: &Block<'_>) {
+    fn check_block_post(&mut self, cx: &LateContext<'tcx>, b: &'tcx Block<'_>) {
         if let Some(e) = b.expr {
             check(cx, b.span.ctxt(), e);
         }
     }
 
-    fn check_stmt(&mut self, cx: &LateContext<'tcx>, s: &Stmt<'_>) {
+    fn check_stmt(&mut self, cx: &LateContext<'tcx>, s: &'tcx Stmt<'_>) {
         if let StmtKind::Expr(e) | StmtKind::Semi(e) = s.kind {
             check(cx, s.span.ctxt(), e);
         }
     }
 }
 
-fn check(cx: &LateContext<'_>, ctxt: SyntaxContext, e: &Expr<'_>) {
-    if e.span.ctxt() != ctxt || ctxt.in_external_macro(cx.tcx.sess.source_map()) {
-        return;
-    }
-    // if else
-    let (mut then, mut els) = match e.kind {
-        ExprKind::If(_, then, Some(els)) => (then, els),
-        _ => return,
-    };
-    loop {
-        if then.span.ctxt() != ctxt || els.span.ctxt() != ctxt || !is_never(cx.typeck_results(), ctxt, then) {
-            // then block does not always break
-            return;
-        }
-        match &els.kind {
-            // else if else
-            ExprKind::If(_, next_then, Some(next_els)) => {
-                then = next_then;
-                els = next_els;
+fn check<'tcx>(cx: &LateContext<'tcx>, ctxt: SyntaxContext, e: &'tcx Expr<'_>) {
+    // Find the final `else` block in an `if` chain.
+    let mut prev_then = None;
+    let mut next = e;
+    let (then, else_) = loop {
+        match next.kind {
+            ExprKind::If(_, then, Some(else_))
+                if is_never(cx.typeck_results(), ctxt, then)
+                    && then.span.ctxt() == ctxt
+                    && else_.span.ctxt() == ctxt =>
+            {
+                prev_then = Some(then);
+                next = else_;
             },
-            // else if without else
-            ExprKind::If(..) => return,
-            // done
-            _ => break,
+            ExprKind::Block(b, _) if let Some(then) = prev_then => break (then, b),
+            _ => return,
         }
-    }
+    };
 
-    let mut app = Applicability::MachineApplicable;
-    if let ExprKind::Block(block, _) = &els.kind {
-        for stmt in block.stmts {
-            // If the `else` block contains a local binding, Clippy shouldn't auto-fix it
-            if matches!(&stmt.kind, StmtKind::Let(_)) {
-                app = Applicability::Unspecified;
-                break;
-            }
-        }
+    if e.span.ctxt() == ctxt
+        && !ctxt.in_external_macro(cx.tcx.sess.source_map())
+        && !is_from_proc_macro(cx, e)
+        && let Some(src) = else_.span.get_text(cx)
+        && let Some(src) = src.strip_prefix('{')
+        && let Some(src) = src.strip_suffix('}')
+        // FIXME(@Jarcho): `indent_of` walks to the root context before getting the indent
+        // which gives the wrong result here.
+        && let Some(indent) = indent_of(cx, e.span)
+    {
+        let sp = else_.span.with_lo(then.span.hi());
+        span_lint_hir_and_then(cx, REDUNDANT_ELSE, e.hir_id, sp, "redundant else block", |diag| {
+            diag.span_suggestion(
+                sp,
+                "remove the `else` block and move the contents out",
+                reindent_multiline(src.trim_end(), false, Some(indent)),
+                if ctxt.is_root() && else_.stmts.iter().all(|s| !matches!(s.kind, StmtKind::Let(_))) {
+                    Applicability::MachineApplicable
+                } else {
+                    Applicability::MaybeIncorrect
+                },
+            );
+        });
     }
-
-    // FIXME: The indentation of the suggestion would be the same as the one of the macro invocation in this implementation, see https://github.com/rust-lang/rust-clippy/pull/13936#issuecomment-2569548202
-    let sp = els.span.with_lo(then.span.hi());
-    span_lint_hir_and_then(cx, REDUNDANT_ELSE, e.hir_id, sp, "redundant else block", |diag| {
-        diag.span_suggestion(
-            sp,
-            "remove the `else` block and move the contents out",
-            make_sugg(cx, els.span, "..", Some(e.span)),
-            app,
-        );
-    });
 }
 
 fn is_never(typeck: &TypeckResults<'_>, ctxt: SyntaxContext, e: &Expr<'_>) -> bool {
@@ -174,19 +170,4 @@ fn is_never_mac(ctxt: SyntaxContext, mut e: &Expr<'_>) -> bool {
         }
         e = next;
     }
-}
-
-// Extract the inner contents of an `else` block str
-// e.g. `{ foo(); bar(); }` -> `foo(); bar();`
-fn extract_else_block(mut block: &str) -> String {
-    block = block.strip_prefix("{").unwrap_or(block);
-    block = block.strip_suffix("}").unwrap_or(block);
-    block.trim_end().to_string()
-}
-
-fn make_sugg(cx: &LateContext<'_>, els_span: Span, default: &str, indent_relative_to: Option<Span>) -> String {
-    let extracted = extract_else_block(&snippet(cx, els_span, default));
-    let indent = indent_relative_to.and_then(|s| indent_of(cx, s));
-
-    reindent_multiline(&extracted, false, indent)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,8 @@ pub fn main() {
             process::exit(clippy_lints::explain(
                 &lint.strip_prefix("clippy::").unwrap_or(&lint).replace('-', "_"),
             ));
-        } else {
-            show_help();
         }
+        show_help();
         return;
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -102,12 +102,12 @@ fn integration_test() {
         panic!("incompatible crate versions");
     } else if stderr.contains("failed to run `rustc` to learn about target-specific information") {
         panic!("couldn't find librustc_driver, consider setting `LD_LIBRARY_PATH`");
-    } else {
-        assert!(
-            !stderr.contains("toolchain") || !stderr.contains("is not installed"),
-            "missing required toolchain"
-        );
     }
+
+    assert!(
+        !stderr.contains("toolchain") || !stderr.contains("is not installed"),
+        "missing required toolchain"
+    );
 
     match output.status.code() {
         Some(0) => println!("Compilation successful"),

--- a/tests/ui/redundant_else.fixed
+++ b/tests/ui/redundant_else.fixed
@@ -1,161 +1,455 @@
+//@aux-build:proc_macros.rs
+
+#![feature(never_type)]
 #![warn(clippy::redundant_else)]
-#![allow(clippy::needless_return, clippy::if_same_then_else, clippy::needless_late_init)]
+#![expect(clippy::unnecessary_operation)]
 
+extern crate proc_macros;
+use proc_macros::{external, inline_macros, with_span};
+
+use core::hint::black_box;
+use core::ops::{Add, Deref, Not};
+
+#[inline_macros]
 fn main() {
-    loop {
-        // break
-        if foo() {
-            println!("Love your neighbor;");
-            break;
+    // then syntactic diverge final expr.
+    {
+        if black_box(false) {
+            return;
         }
         //~^ redundant_else
+        black_box(0);
 
-        println!("yet don't pull down your hedge.");
-        // continue
-        if foo() {
-            println!("He that lies down with Dogs,");
-            continue;
+        loop {
+            if black_box(false) {
+                break;
+            }
+            //~^ redundant_else
+            black_box(0);
+        }
+
+        loop {
+            if black_box(false) {
+                continue;
+            }
+            //~^ redundant_else
+            black_box(0);
+        }
+    }
+
+    // then syntactic diverge final stmt.
+    {
+        if black_box(false) {
+            return;
         }
         //~^ redundant_else
+        black_box(0);
 
-        println!("shall rise up with fleas.");
-        // match block
-        if foo() {
-            match foo() {
-                1 => break,
-                _ => return,
+        loop {
+            if black_box(false) {
+                break;
+            }
+            //~^ redundant_else
+            black_box(0);
+            if black_box(false) {
+                continue;
+            }
+            //~^ redundant_else
+            black_box(0);
+        }
+    }
+
+    // then panic
+    {
+        if black_box(false) {
+            panic!();
+        }
+        //~^ redundant_else
+        black_box(());
+
+        if black_box(false) {
+            panic!("msg");
+        }
+        //~^ redundant_else
+        black_box(0);
+
+        if black_box(false) {
+            panic!("{}", 0);
+        }
+        //~^ redundant_else
+        black_box(0i32);
+    };
+
+    // no semi on if
+    {
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        black_box(0);
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        let _ = 0;
+        black_box(());
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        { black_box(()) }
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        if black_box(true) {
+            black_box(0);
+        }
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        if black_box(true) {
+            // empty
+        } else {
+            black_box(())
+        }
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        match black_box(0) {
+            0 => {},
+            1 => {
+                let _ = 0;
+            },
+            _ => black_box(()),
+        }
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        loop {
+            if black_box(true) {
+                break black_box(());
+            }
+        }
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        while black_box(true) {
+            if black_box(true) {
+                break;
+            }
+        }
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        for _ in black_box(0..0) {
+            if black_box(true) {
+                break;
+            }
+        };
+
+        if black_box(false) {
+            return;
+        }
+        //~^ redundant_else
+        black_box(1)
+    };
+
+    // then nested block diverge
+    {
+        if black_box(false) {
+            {
+                let _ = black_box(0);
+                panic!()
             }
         }
         //~^ redundant_else
+        black_box(0);
 
-        println!("You may delay, but time will not.");
+        if black_box(false) {
+            {
+                let _ = black_box(0);
+                return;
+            }
+        }
+        //~^ redundant_else
+        black_box(0);
     }
-    // else if
-    if foo() {
-        return;
-    } else if foo() {
-        return;
-    }
-    //~^ redundant_else
 
-    println!("A fat kitchen makes a lean will.");
-    // let binding outside of block
-    let _ = {
-        if foo() {
+    // then nested branch diverge
+    {
+        loop {
+            if black_box(false) {
+                match black_box(0) {
+                    0 => return,
+                    1 => panic!(),
+                    2 => break,
+                    _ => continue,
+                }
+            }
+            //~^ redundant_else
+            black_box(0);
+        }
+
+        if black_box(false) {
+            if black_box(true) {
+                panic!();
+            }
+            //~^ redundant_else
             return;
         }
         //~^ redundant_else
+        black_box(0);
+    }
 
-        1
-    };
-    // else if with let binding outside of block
-    let _ = {
-        if foo() {
+    // if chain diverge
+    {
+        if black_box(false) {
+            panic!()
+        } else if black_box(true) {
             return;
-        } else if foo() {
-            return;
+        } else if black_box(true) {
+            let x = 0;
+            black_box(x + 2 * 55);
+            panic!();
         }
         //~^ redundant_else
+        black_box(0);
+    }
 
-        2
-    };
-    // inside if let
-    let _ = if let Some(1) = foo() {
-        let _ = 1;
-        if foo() {
-            return;
+    // then misc fn diverge
+    {
+        struct S;
+        impl Deref for S {
+            type Target = !;
+            fn deref(&self) -> &! {
+                panic!()
+            }
+        };
+        impl Not for S {
+            type Output = !;
+            fn not(self) -> ! {
+                panic!()
+            }
+        }
+        impl Add for S {
+            type Output = !;
+            fn add(self, other: Self) -> ! {
+                panic!()
+            }
+        }
+
+        if black_box(true) {
+            *S
+        } else if black_box(true) {
+            !S
+        } else if black_box(true) {
+            S + S
+        } else if black_box(true) {
+            S.not()
+        } else if black_box(true) {
+            S::add(S, S)
         }
         //~^ redundant_else
+        black_box(0);
 
-        1
-    } else {
-        1
-    };
-
-    //
-    // non-lint cases
-    //
-
-    // sanity check
-    if foo() {
-        let _ = 1;
-    } else {
-        println!("Who is wise? He that learns from every one.");
+        if black_box(true) {
+            *S;
+        } else if black_box(true) {
+            !S;
+        } else if black_box(true) {
+            S + S;
+        } else if black_box(true) {
+            S.not();
+        } else if black_box(true) {
+            S::add(S, S);
+        }
+        //~^ redundant_else
+        black_box(0);
     }
-    // else if without else
-    if foo() {
-        return;
-    } else if foo() {
-        foo()
-    };
-    // nested if return
-    if foo() {
-        if foo() {
+
+    // then no diverge
+    {
+        if black_box(true) {
+            black_box(1)
+        } else {
+            black_box(0)
+        };
+
+        if black_box(true) {
+            if black_box(true) { black_box(0) } else { return }
+        } else {
+            black_box(0)
+        };
+
+        if black_box(true) {
+            if black_box(true) { return }            black_box(0)
+            //~^ redundant_else
+        } else {
+            black_box(0)
+        };
+
+        loop {
+            if black_box(true) {
+                match black_box(1) {
+                    0 => panic!(),
+                    1 => return,
+                    2 => break,
+                    _ => {
+                        if black_box(true) {
+                            break;
+                        } else if black_box(true) {
+                            panic!()
+                        } else if black_box(true) {
+                            black_box(0)
+                        } else {
+                            return;
+                        }
+                    },
+                }
+            } else {
+                black_box(0)
+            };
+        }
+    }
+
+    // nested in various weird positions
+    {
+        black_box(if black_box(true) {
             return;
-        }
-    } else {
-        foo()
-    };
-    // match with non-breaking branch
-    if foo() {
-        match foo() {
-            1 => foo(),
-            _ => return,
-        }
-    } else {
-        println!("Three may keep a secret, if two of them are dead.");
-    }
-    // let binding
-    let _ = if foo() {
-        return;
-    } else {
-        1
-    };
-    // assign
-    let mut a;
-    a = if foo() {
-        return;
-    } else {
-        1
-    };
-    // assign-op
-    a += if foo() {
-        return;
-    } else {
-        1
-    };
-    // if return else if else
-    if foo() {
-        return;
-    } else if foo() {
-        1
-    } else {
-        2
-    };
-    // if else if return else
-    if foo() {
-        1
-    } else if foo() {
-        return;
-    } else {
-        2
-    };
-    // else if with let binding
-    let _ = if foo() {
-        return;
-    } else if foo() {
-        return;
-    } else {
-        2
-    };
-    // inside function call
-    Box::new(if foo() {
-        return;
-    } else {
-        1
-    });
-}
+        } else {
+            black_box(0)
+        });
 
-fn foo<T>() -> T {
-    unimplemented!("I'm not Santa Claus")
+        let _ = if black_box(true) {
+            return;
+        } else {
+            black_box(0)
+        };
+
+        let _ = black_box([0, 1, 2].as_slice())[if black_box(true) {
+            return;
+        } else {
+            black_box(0)
+        }];
+
+        (if black_box(true) {
+            return;
+        } else {
+            black_box(0i32)
+        })
+        .ilog2();
+
+        return if black_box(true) {
+            return;
+        } else {
+            black_box(())
+        };
+
+        1 + if black_box(true) {
+            return;
+        } else {
+            black_box(0)
+        };
+    }
+
+    // external macros
+    {
+        external! {{
+            if black_box(true) {
+                return
+            } else {
+                black_box(0)
+            };
+        }}
+        with_span! {
+            span
+            {
+                if black_box(true) {
+                    return
+                } else {
+                    black_box(0)
+                };
+            }
+        }
+    }
+
+    // internal macros
+    {
+        fn diverge() -> ! {
+            panic!()
+        }
+
+        inline! {{
+            if black_box(true) {
+                return
+            }
+        //~^ redundant_else
+        black_box(0);
+
+            if black_box(true) {
+                return;
+            }
+        //~^ redundant_else
+        black_box(0);
+
+            if black_box(true) {
+                if black_box(true) {
+                    return;
+                }
+        //~^ redundant_else
+        let _ = ();
+        return
+            }
+        //~^ redundant_else
+        black_box(0);
+
+            if black_box(true) {
+                #[expect(clippy::redundant_else)]
+                if black_box(true) {
+                    return;
+                } else {
+                    let _ = ();
+                    return;
+                };
+            }
+        //~^ redundant_else
+        black_box(0);
+
+            if black_box(true) {
+                diverge();
+            } else {
+                black_box(0);
+            }
+
+            // Needs a semicolon in the suggestion due to the macro call
+            if black_box(true) {
+                return
+            }
+        //~^ redundant_else
+        inline!({ black_box(()); });
+
+            // Needs a semicolon in the suggestion due to the context switch
+            if black_box(true) {
+                return
+            }
+        //~^ redundant_else
+        $({ black_box(()) });
+
+            let _ = 0;
+        }};
+    }
 }

--- a/tests/ui/redundant_else.rs
+++ b/tests/ui/redundant_else.rs
@@ -1,168 +1,489 @@
+//@aux-build:proc_macros.rs
+
+#![feature(never_type)]
 #![warn(clippy::redundant_else)]
-#![allow(clippy::needless_return, clippy::if_same_then_else, clippy::needless_late_init)]
+#![expect(clippy::unnecessary_operation)]
 
+extern crate proc_macros;
+use proc_macros::{external, inline_macros, with_span};
+
+use core::hint::black_box;
+use core::ops::{Add, Deref, Not};
+
+#[inline_macros]
 fn main() {
-    loop {
-        // break
-        if foo() {
-            println!("Love your neighbor;");
-            break;
+    // then syntactic diverge final expr.
+    {
+        if black_box(false) {
+            return;
         } else {
             //~^ redundant_else
+            black_box(0)
+        };
 
-            println!("yet don't pull down your hedge.");
+        loop {
+            if black_box(false) {
+                break;
+            } else {
+                //~^ redundant_else
+                black_box(0)
+            };
         }
-        // continue
-        if foo() {
-            println!("He that lies down with Dogs,");
-            continue;
+
+        loop {
+            if black_box(false) {
+                continue;
+            } else {
+                //~^ redundant_else
+                black_box(0)
+            };
+        }
+    }
+
+    // then syntactic diverge final stmt.
+    {
+        if black_box(false) {
+            return;
         } else {
             //~^ redundant_else
+            black_box(0)
+        };
 
-            println!("shall rise up with fleas.");
+        loop {
+            if black_box(false) {
+                break;
+            } else {
+                //~^ redundant_else
+                black_box(0)
+            };
+            if black_box(false) {
+                continue;
+            } else {
+                //~^ redundant_else
+                black_box(0)
+            };
         }
-        // match block
-        if foo() {
-            match foo() {
-                1 => break,
-                _ => return,
+    }
+
+    // then panic
+    {
+        if black_box(false) {
+            panic!();
+        } else {
+            //~^ redundant_else
+            black_box(())
+        };
+
+        if black_box(false) {
+            panic!("msg");
+        } else {
+            //~^ redundant_else
+            black_box(0)
+        };
+
+        if black_box(false) {
+            panic!("{}", 0);
+        } else {
+            //~^ redundant_else
+            black_box(0i32)
+        };
+    };
+
+    // no semi on if
+    {
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            black_box(0);
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            let _ = 0;
+            black_box(())
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            { black_box(()) }
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            if black_box(true) {
+                black_box(0);
+            }
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            if black_box(true) {
+                // empty
+            } else {
+                black_box(())
+            }
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            match black_box(0) {
+                0 => {},
+                1 => {
+                    let _ = 0;
+                },
+                _ => black_box(()),
+            }
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            loop {
+                if black_box(true) {
+                    break black_box(());
+                }
+            }
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            while black_box(true) {
+                if black_box(true) {
+                    break;
+                }
+            }
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            for _ in black_box(0..0) {
+                if black_box(true) {
+                    break;
+                }
+            }
+        }
+
+        if black_box(false) {
+            return;
+        } else {
+            //~^ redundant_else
+            black_box(1)
+        }
+    };
+
+    // then nested block diverge
+    {
+        if black_box(false) {
+            {
+                let _ = black_box(0);
+                panic!()
             }
         } else {
             //~^ redundant_else
+            black_box(0)
+        };
 
-            println!("You may delay, but time will not.");
-        }
-    }
-    // else if
-    if foo() {
-        return;
-    } else if foo() {
-        return;
-    } else {
-        //~^ redundant_else
-
-        println!("A fat kitchen makes a lean will.");
-    }
-    // let binding outside of block
-    let _ = {
-        if foo() {
-            return;
+        if black_box(false) {
+            {
+                let _ = black_box(0);
+                return;
+            }
         } else {
             //~^ redundant_else
+            black_box(0)
+        };
+    }
 
-            1
+    // then nested branch diverge
+    {
+        loop {
+            if black_box(false) {
+                match black_box(0) {
+                    0 => return,
+                    1 => panic!(),
+                    2 => break,
+                    _ => continue,
+                }
+            } else {
+                //~^ redundant_else
+                black_box(0)
+            };
         }
-    };
-    // else if with let binding outside of block
-    let _ = {
-        if foo() {
-            return;
-        } else if foo() {
-            return;
+
+        if black_box(false) {
+            if black_box(true) {
+                panic!();
+            } else {
+                //~^ redundant_else
+                return;
+            }
         } else {
             //~^ redundant_else
+            black_box(0)
+        };
+    }
 
-            2
-        }
-    };
-    // inside if let
-    let _ = if let Some(1) = foo() {
-        let _ = 1;
-        if foo() {
+    // if chain diverge
+    {
+        if black_box(false) {
+            panic!()
+        } else if black_box(true) {
             return;
+        } else if black_box(true) {
+            let x = 0;
+            black_box(x + 2 * 55);
+            panic!();
         } else {
             //~^ redundant_else
-
-            1
-        }
-    } else {
-        1
-    };
-
-    //
-    // non-lint cases
-    //
-
-    // sanity check
-    if foo() {
-        let _ = 1;
-    } else {
-        println!("Who is wise? He that learns from every one.");
+            black_box(0)
+        };
     }
-    // else if without else
-    if foo() {
-        return;
-    } else if foo() {
-        foo()
-    };
-    // nested if return
-    if foo() {
-        if foo() {
+
+    // then misc fn diverge
+    {
+        struct S;
+        impl Deref for S {
+            type Target = !;
+            fn deref(&self) -> &! {
+                panic!()
+            }
+        };
+        impl Not for S {
+            type Output = !;
+            fn not(self) -> ! {
+                panic!()
+            }
+        }
+        impl Add for S {
+            type Output = !;
+            fn add(self, other: Self) -> ! {
+                panic!()
+            }
+        }
+
+        if black_box(true) {
+            *S
+        } else if black_box(true) {
+            !S
+        } else if black_box(true) {
+            S + S
+        } else if black_box(true) {
+            S.not()
+        } else if black_box(true) {
+            S::add(S, S)
+        } else {
+            //~^ redundant_else
+            black_box(0)
+        };
+
+        if black_box(true) {
+            *S;
+        } else if black_box(true) {
+            !S;
+        } else if black_box(true) {
+            S + S;
+        } else if black_box(true) {
+            S.not();
+        } else if black_box(true) {
+            S::add(S, S);
+        } else {
+            //~^ redundant_else
+            black_box(0)
+        };
+    }
+
+    // then no diverge
+    {
+        if black_box(true) {
+            black_box(1)
+        } else {
+            black_box(0)
+        };
+
+        if black_box(true) {
+            if black_box(true) { black_box(0) } else { return }
+        } else {
+            black_box(0)
+        };
+
+        if black_box(true) {
+            if black_box(true) { return } else { black_box(0) }
+            //~^ redundant_else
+        } else {
+            black_box(0)
+        };
+
+        loop {
+            if black_box(true) {
+                match black_box(1) {
+                    0 => panic!(),
+                    1 => return,
+                    2 => break,
+                    _ => {
+                        if black_box(true) {
+                            break;
+                        } else if black_box(true) {
+                            panic!()
+                        } else if black_box(true) {
+                            black_box(0)
+                        } else {
+                            return;
+                        }
+                    },
+                }
+            } else {
+                black_box(0)
+            };
+        }
+    }
+
+    // nested in various weird positions
+    {
+        black_box(if black_box(true) {
             return;
-        }
-    } else {
-        foo()
-    };
-    // match with non-breaking branch
-    if foo() {
-        match foo() {
-            1 => foo(),
-            _ => return,
-        }
-    } else {
-        println!("Three may keep a secret, if two of them are dead.");
-    }
-    // let binding
-    let _ = if foo() {
-        return;
-    } else {
-        1
-    };
-    // assign
-    let mut a;
-    a = if foo() {
-        return;
-    } else {
-        1
-    };
-    // assign-op
-    a += if foo() {
-        return;
-    } else {
-        1
-    };
-    // if return else if else
-    if foo() {
-        return;
-    } else if foo() {
-        1
-    } else {
-        2
-    };
-    // if else if return else
-    if foo() {
-        1
-    } else if foo() {
-        return;
-    } else {
-        2
-    };
-    // else if with let binding
-    let _ = if foo() {
-        return;
-    } else if foo() {
-        return;
-    } else {
-        2
-    };
-    // inside function call
-    Box::new(if foo() {
-        return;
-    } else {
-        1
-    });
-}
+        } else {
+            black_box(0)
+        });
 
-fn foo<T>() -> T {
-    unimplemented!("I'm not Santa Claus")
+        let _ = if black_box(true) {
+            return;
+        } else {
+            black_box(0)
+        };
+
+        let _ = black_box([0, 1, 2].as_slice())[if black_box(true) {
+            return;
+        } else {
+            black_box(0)
+        }];
+
+        (if black_box(true) {
+            return;
+        } else {
+            black_box(0i32)
+        })
+        .ilog2();
+
+        return if black_box(true) {
+            return;
+        } else {
+            black_box(())
+        };
+
+        1 + if black_box(true) {
+            return;
+        } else {
+            black_box(0)
+        };
+    }
+
+    // external macros
+    {
+        external! {{
+            if black_box(true) {
+                return
+            } else {
+                black_box(0)
+            };
+        }}
+        with_span! {
+            span
+            {
+                if black_box(true) {
+                    return
+                } else {
+                    black_box(0)
+                };
+            }
+        }
+    }
+
+    // internal macros
+    {
+        fn diverge() -> ! {
+            panic!()
+        }
+
+        inline! {{
+            if black_box(true) {
+                return
+            } else {
+                //~^ redundant_else
+                black_box(0);
+            }
+
+            if black_box(true) {
+                return;
+            } else {
+                //~^ redundant_else
+                black_box(0);
+            }
+
+            if black_box(true) {
+                if black_box(true) {
+                    return;
+                } else {
+                    //~^ redundant_else
+                    let _ = ();
+                    return
+                }
+            } else {
+                //~^ redundant_else
+                black_box(0);
+            }
+
+            if black_box(true) {
+                #[expect(clippy::redundant_else)]
+                if black_box(true) {
+                    return;
+                } else {
+                    let _ = ();
+                    return;
+                };
+            } else {
+                //~^ redundant_else
+                black_box(0);
+            }
+
+            if black_box(true) {
+                diverge();
+            } else {
+                black_box(0);
+            }
+
+            // Needs a semicolon in the suggestion due to the macro call
+            if black_box(true) {
+                return
+            } else {
+                //~^ redundant_else
+                inline!({ black_box(()); })
+            }
+
+            // Needs a semicolon in the suggestion due to the context switch
+            if black_box(true) {
+                return
+            } else {
+                //~^ redundant_else
+                $({ black_box(()) })
+            }
+
+            let _ = 0;
+        }};
+    }
 }

--- a/tests/ui/redundant_else.stderr
+++ b/tests/ui/redundant_else.stderr
@@ -1,12 +1,11 @@
 error: redundant else block
-  --> tests/ui/redundant_else.rs:10:10
+  --> tests/ui/redundant_else.rs:19:10
    |
 LL |           } else {
    |  __________^
 LL | |
-LL | |
-LL | |             println!("yet don't pull down your hedge.");
-LL | |         }
+LL | |             black_box(0)
+LL | |         };
    | |_________^
    |
    = note: `-D clippy::redundant-else` implied by `-D warnings`
@@ -15,18 +14,152 @@ help: remove the `else` block and move the contents out
    |
 LL ~         }
 LL +
-LL + 
-LL +         println!("yet don't pull down your hedge.");
+LL ~         black_box(0);
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:19:10
+  --> tests/ui/redundant_else.rs:27:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 black_box(0)
+LL | |             };
+   | |_____________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL ~             black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:36:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 black_box(0)
+LL | |             };
+   | |_____________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL ~             black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:47:10
    |
 LL |           } else {
    |  __________^
 LL | |
+LL | |             black_box(0)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:55:14
+   |
+LL |               } else {
+   |  ______________^
 LL | |
-LL | |             println!("shall rise up with fleas.");
+LL | |                 black_box(0)
+LL | |             };
+   | |_____________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL ~             black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:61:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 black_box(0)
+LL | |             };
+   | |_____________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL ~             black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:72:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(())
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(());
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:79:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:86:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0i32)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0i32);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:96:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0);
 LL | |         }
    | |_________^
    |
@@ -34,18 +167,17 @@ help: remove the `else` block and move the contents out
    |
 LL ~         }
 LL +
-LL + 
-LL +         println!("shall rise up with fleas.");
+LL +         black_box(0);
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:30:10
+  --> tests/ui/redundant_else.rs:103:10
    |
 LL |           } else {
    |  __________^
 LL | |
-LL | |
-LL | |             println!("You may delay, but time will not.");
+LL | |             let _ = 0;
+LL | |             black_box(())
 LL | |         }
    | |_________^
    |
@@ -53,37 +185,17 @@ help: remove the `else` block and move the contents out
    |
 LL ~         }
 LL +
-LL + 
-LL +         println!("You may delay, but time will not.");
+LL +         let _ = 0;
+LL +         black_box(());
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:41:6
-   |
-LL |       } else {
-   |  ______^
-LL | |
-LL | |
-LL | |         println!("A fat kitchen makes a lean will.");
-LL | |     }
-   | |_____^
-   |
-help: remove the `else` block and move the contents out
-   |
-LL ~     }
-LL +
-LL + 
-LL +     println!("A fat kitchen makes a lean will.");
-   |
-
-error: redundant else block
-  --> tests/ui/redundant_else.rs:50:10
+  --> tests/ui/redundant_else.rs:111:10
    |
 LL |           } else {
    |  __________^
 LL | |
-LL | |
-LL | |             1
+LL | |             { black_box(()) }
 LL | |         }
    | |_________^
    |
@@ -91,18 +203,18 @@ help: remove the `else` block and move the contents out
    |
 LL ~         }
 LL +
-LL + 
-LL +         1
+LL +         { black_box(()) }
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:62:10
+  --> tests/ui/redundant_else.rs:118:10
    |
 LL |           } else {
    |  __________^
 LL | |
-LL | |
-LL | |             2
+LL | |             if black_box(true) {
+LL | |                 black_box(0);
+LL | |             }
 LL | |         }
    | |_________^
    |
@@ -110,18 +222,19 @@ help: remove the `else` block and move the contents out
    |
 LL ~         }
 LL +
-LL + 
-LL +         2
+LL +         if black_box(true) {
+LL +             black_box(0);
+LL +         }
    |
 
 error: redundant else block
-  --> tests/ui/redundant_else.rs:73:10
+  --> tests/ui/redundant_else.rs:127:10
    |
 LL |           } else {
    |  __________^
 LL | |
-LL | |
-LL | |             1
+LL | |             if black_box(true) {
+...  |
 LL | |         }
    | |_________^
    |
@@ -129,9 +242,393 @@ help: remove the `else` block and move the contents out
    |
 LL ~         }
 LL +
-LL + 
-LL +         1
+LL +         if black_box(true) {
+LL +             // empty
+LL +         } else {
+LL +             black_box(())
+LL +         }
    |
 
-error: aborting due to 7 previous errors
+error: redundant else block
+  --> tests/ui/redundant_else.rs:138:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             match black_box(0) {
+LL | |                 0 => {},
+...  |
+LL | |         }
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL +         match black_box(0) {
+LL +             0 => {},
+LL +             1 => {
+LL +                 let _ = 0;
+LL +             },
+LL +             _ => black_box(()),
+LL +         }
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:151:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             loop {
+LL | |                 if black_box(true) {
+...  |
+LL | |         }
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL +         loop {
+LL +             if black_box(true) {
+LL +                 break black_box(());
+LL +             }
+LL +         }
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:162:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             while black_box(true) {
+LL | |                 if black_box(true) {
+...  |
+LL | |         }
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL +         while black_box(true) {
+LL +             if black_box(true) {
+LL +                 break;
+LL +             }
+LL +         }
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:173:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             for _ in black_box(0..0) {
+LL | |                 if black_box(true) {
+...  |
+LL | |         }
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL +         for _ in black_box(0..0) {
+LL +             if black_box(true) {
+LL +                 break;
+LL +             }
+LL +         };
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:184:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(1)
+LL | |         }
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL +         black_box(1)
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:197:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:207:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:223:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 black_box(0)
+LL | |             };
+   | |_____________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL ~             black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:236:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:232:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 return;
+LL | |             }
+   | |_____________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL +             return;
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:252:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:290:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:305:10
+   |
+LL |           } else {
+   |  __________^
+LL | |
+LL | |             black_box(0)
+LL | |         };
+   | |_________^
+   |
+help: remove the `else` block and move the contents out
+   |
+LL ~         }
+LL +
+LL ~         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:326:42
+   |
+LL |             if black_box(true) { return } else { black_box(0) }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^ help: remove the `else` block and move the contents out: `black_box(0)`
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:426:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 black_box(0);
+LL | |             }
+   | |_____________^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL +         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:433:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 black_box(0);
+LL | |             }
+   | |_____________^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL +         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:446:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 black_box(0);
+LL | |             }
+   | |_____________^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL +         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:441:18
+   |
+LL |                   } else {
+   |  __________________^
+LL | |
+LL | |                     let _ = ();
+LL | |                     return
+LL | |                 }
+   | |_________________^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `else` block and move the contents out
+   |
+LL ~                 }
+LL +
+LL +         let _ = ();
+LL +         return
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:459:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 black_box(0);
+LL | |             }
+   | |_____________^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL +         black_box(0);
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:473:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 inline!({ black_box(()); })
+LL | |             }
+   | |_____________^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL +         inline!({ black_box(()); });
+   |
+
+error: redundant else block
+  --> tests/ui/redundant_else.rs:481:14
+   |
+LL |               } else {
+   |  ______________^
+LL | |
+LL | |                 $({ black_box(()) })
+LL | |             }
+   | |_____________^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `else` block and move the contents out
+   |
+LL ~             }
+LL +
+LL +         $({ black_box(()) });
+   |
+
+error: aborting due to 35 previous errors
 


### PR DESCRIPTION
The main behaviour changes are:
* Lint on blocks returning `!`. This greatly increases the number of cases this lints on.
* Don't lint inside a macro when the divergence comes from a different macro.
* Suggest adding a semicolon when syntactically needed.

The old test file was a bit of a mess so it was rewritten. This was done as the final commit and the new code passes both the old and the new tests.

changelog: [`redundant_else`]: Take into account divergent function calls.
