### PR TITLE
fix(docs): typo with choosing MSRV

### DIFF
--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -447,8 +447,8 @@ Sometimes a lint makes suggestions that require a certain version of Rust. For
 example, the `manual_strip` lint suggests using `str::strip_prefix` and
 `str::strip_suffix` which is only available after Rust 1.45. In such cases, you
 need to ensure that the MSRV configured for the project is >= the MSRV of the
-required Rust feature. If multiple features are required, just use the one with
-a lower MSRV.
+required Rust feature. If multiple features are used in a suggestion, choose a
+MSRV that supports them all.
 
 First, add an MSRV alias for the required feature in [`clippy_utils::msrvs`].
 This can be accessed later as `msrvs::STR_STRIP_PREFIX`, for example.


### PR DESCRIPTION
Fix a simple typo in the developer guide. If two features that have different MSRVs, choose the higher one which guarantees both features (and the lint) will work, compared to the lower one which only guarantees that feature (and therefore not the entire lint) will work.

changelog: none