### PR TITLE
Fix `strlen_on_c_strings` incorrect suggestion logic

### DIFF
--- a/clippy_lints/src/strlen_on_c_strings.rs
+++ b/clippy_lints/src/strlen_on_c_strings.rs
@@ -76,11 +76,13 @@ impl<'tcx> LateLintPass<'tcx> for StrlenOnCStrings {
 
             let ctxt = expr.span.ctxt();
             let span = match cx.tcx.parent_hir_node(expr.hir_id) {
-                Node::Block(&Block {
-                    rules: BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided),
-                    span,
-                    ..
-                }) if span.ctxt() == ctxt && !is_expr_unsafe(cx, self_arg) => span,
+                Node::Block(
+                    block @ &Block {
+                        rules: BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided),
+                        span,
+                        ..
+                    },
+                ) if span.ctxt() == ctxt && !is_expr_unsafe(cx, self_arg) && block.stmts.is_empty() => span,
                 _ => expr.span,
             };
 

--- a/tests/ui/strlen_on_c_strings.fixed
+++ b/tests/ui/strlen_on_c_strings.fixed
@@ -18,21 +18,33 @@ fn main() {
     let _ = cstr.count_bytes();
     //~^ ERROR: using `libc::strlen` on a `CStr` value
 
+    let _ = unsafe {
+        let x = 1;
+        cstr.count_bytes()
+        //~^ ERROR: using `libc::strlen` on a `CStr` value
+    };
+
     let pcstr: *const &CStr = &cstr;
-    let _ = unsafe { (*pcstr).count_bytes() };
-    //~^ ERROR: using `libc::strlen` on a `CStr` value
+    let _ = unsafe {
+        (*pcstr).count_bytes()
+        //~^ ERROR: using `libc::strlen` on a `CStr` value
+    };
 
     unsafe fn unsafe_identity<T>(x: T) -> T {
         x
     }
-    let _ = unsafe { unsafe_identity(cstr).count_bytes() };
-    //~^ ERROR: using `libc::strlen` on a `CStr` value
+    let _ = unsafe {
+        unsafe_identity(cstr).count_bytes()
+        //~^ ERROR: using `libc::strlen` on a `CStr` value
+    };
     let _ = unsafe { unsafe_identity(cstr) }.count_bytes();
     //~^ ERROR: using `libc::strlen` on a `CStr` value
 
     let f: unsafe fn(_) -> _ = unsafe_identity;
-    let _ = unsafe { f(cstr).count_bytes() };
-    //~^ ERROR: using `libc::strlen` on a `CStr` value
+    let _ = unsafe {
+        f(cstr).count_bytes()
+        //~^ ERROR: using `libc::strlen` on a `CStr` value
+    };
 }
 
 // make sure we lint types that _adjust_ to `CStr`

--- a/tests/ui/strlen_on_c_strings.rs
+++ b/tests/ui/strlen_on_c_strings.rs
@@ -18,21 +18,33 @@ fn main() {
     let _ = unsafe { strlen(cstr.as_ptr()) };
     //~^ ERROR: using `libc::strlen` on a `CStr` value
 
+    let _ = unsafe {
+        let x = 1;
+        strlen(cstr.as_ptr())
+        //~^ ERROR: using `libc::strlen` on a `CStr` value
+    };
+
     let pcstr: *const &CStr = &cstr;
-    let _ = unsafe { strlen((*pcstr).as_ptr()) };
-    //~^ ERROR: using `libc::strlen` on a `CStr` value
+    let _ = unsafe {
+        strlen((*pcstr).as_ptr())
+        //~^ ERROR: using `libc::strlen` on a `CStr` value
+    };
 
     unsafe fn unsafe_identity<T>(x: T) -> T {
         x
     }
-    let _ = unsafe { strlen(unsafe_identity(cstr).as_ptr()) };
-    //~^ ERROR: using `libc::strlen` on a `CStr` value
+    let _ = unsafe {
+        strlen(unsafe_identity(cstr).as_ptr())
+        //~^ ERROR: using `libc::strlen` on a `CStr` value
+    };
     let _ = unsafe { strlen(unsafe { unsafe_identity(cstr) }.as_ptr()) };
     //~^ ERROR: using `libc::strlen` on a `CStr` value
 
     let f: unsafe fn(_) -> _ = unsafe_identity;
-    let _ = unsafe { strlen(f(cstr).as_ptr()) };
-    //~^ ERROR: using `libc::strlen` on a `CStr` value
+    let _ = unsafe {
+        strlen(f(cstr).as_ptr())
+        //~^ ERROR: using `libc::strlen` on a `CStr` value
+    };
 }
 
 // make sure we lint types that _adjust_ to `CStr`

--- a/tests/ui/strlen_on_c_strings.stderr
+++ b/tests/ui/strlen_on_c_strings.stderr
@@ -20,70 +20,76 @@ LL |     let _ = unsafe { strlen(cstr.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `cstr.count_bytes()`
 
 error: using `libc::strlen` on a `CStr` value
-  --> tests/ui/strlen_on_c_strings.rs:22:22
+  --> tests/ui/strlen_on_c_strings.rs:23:9
    |
-LL |     let _ = unsafe { strlen((*pcstr).as_ptr()) };
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `(*pcstr).count_bytes()`
+LL |         strlen(cstr.as_ptr())
+   |         ^^^^^^^^^^^^^^^^^^^^^ help: use: `cstr.count_bytes()`
 
 error: using `libc::strlen` on a `CStr` value
-  --> tests/ui/strlen_on_c_strings.rs:28:22
+  --> tests/ui/strlen_on_c_strings.rs:29:9
    |
-LL |     let _ = unsafe { strlen(unsafe_identity(cstr).as_ptr()) };
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `unsafe_identity(cstr).count_bytes()`
+LL |         strlen((*pcstr).as_ptr())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `(*pcstr).count_bytes()`
 
 error: using `libc::strlen` on a `CStr` value
-  --> tests/ui/strlen_on_c_strings.rs:30:13
+  --> tests/ui/strlen_on_c_strings.rs:37:9
+   |
+LL |         strlen(unsafe_identity(cstr).as_ptr())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `unsafe_identity(cstr).count_bytes()`
+
+error: using `libc::strlen` on a `CStr` value
+  --> tests/ui/strlen_on_c_strings.rs:40:13
    |
 LL |     let _ = unsafe { strlen(unsafe { unsafe_identity(cstr) }.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `unsafe { unsafe_identity(cstr) }.count_bytes()`
 
 error: using `libc::strlen` on a `CStr` value
-  --> tests/ui/strlen_on_c_strings.rs:34:22
+  --> tests/ui/strlen_on_c_strings.rs:45:9
    |
-LL |     let _ = unsafe { strlen(f(cstr).as_ptr()) };
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `f(cstr).count_bytes()`
+LL |         strlen(f(cstr).as_ptr())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `f(cstr).count_bytes()`
 
 error: using `libc::strlen` on a type that dereferences to `CStr`
-  --> tests/ui/strlen_on_c_strings.rs:40:13
+  --> tests/ui/strlen_on_c_strings.rs:52:13
    |
 LL |     let _ = unsafe { libc::strlen(box_cstring.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `box_cstring.count_bytes()`
 
 error: using `libc::strlen` on a type that dereferences to `CStr`
-  --> tests/ui/strlen_on_c_strings.rs:42:13
+  --> tests/ui/strlen_on_c_strings.rs:54:13
    |
 LL |     let _ = unsafe { libc::strlen(box_cstr.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `box_cstr.count_bytes()`
 
 error: using `libc::strlen` on a type that dereferences to `CStr`
-  --> tests/ui/strlen_on_c_strings.rs:44:13
+  --> tests/ui/strlen_on_c_strings.rs:56:13
    |
 LL |     let _ = unsafe { libc::strlen(arc_cstring.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `arc_cstring.count_bytes()`
 
 error: using `libc::strlen` on a `CStr` value
-  --> tests/ui/strlen_on_c_strings.rs:51:13
+  --> tests/ui/strlen_on_c_strings.rs:63:13
    |
 LL |     let _ = unsafe { libc::strlen(cstr.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `cstr.to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` value
-  --> tests/ui/strlen_on_c_strings.rs:55:13
+  --> tests/ui/strlen_on_c_strings.rs:67:13
    |
 LL |     let _ = unsafe { libc::strlen(cstring.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `cstring.to_bytes().len()`
 
 error: using `libc::strlen` on a `CStr` value
-  --> tests/ui/strlen_on_c_strings.rs:62:13
+  --> tests/ui/strlen_on_c_strings.rs:74:13
    |
 LL |     let _ = unsafe { libc::strlen(cstr.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `cstr.count_bytes()`
 
 error: using `libc::strlen` on a `CString` value
-  --> tests/ui/strlen_on_c_strings.rs:66:13
+  --> tests/ui/strlen_on_c_strings.rs:78:13
    |
 LL |     let _ = unsafe { libc::strlen(cstring.as_ptr()) };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `cstring.count_bytes()`
 
-error: aborting due to 14 previous errors
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Fixes an incorrect suggestion when two expressions are inside of an unsafe block. In this case lint the original expression, and rely on `unused_unsafe` to fire.

changelog: [`strlen_on_c_strings`]: fix incorrect suggestion logic with expressions
