### PR TITLE
Optimize `Msrv::meets` calls

### DIFF
--- a/clippy_lints/src/casts/cast_possible_wrap.rs
+++ b/clippy_lints/src/casts/cast_possible_wrap.rs
@@ -96,8 +96,8 @@ pub(super) fn check(
                 .note("for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types");
         }
 
-        if msrv.meets(cx, msrvs::INTEGER_SIGN_CAST)
-            && let Some(cast) = utils::is_signedness_cast(cast_from, cast_to)
+        if let Some(cast) = utils::is_signedness_cast(cast_from, cast_to)
+            && msrv.meets(cx, msrvs::INTEGER_SIGN_CAST)
         {
             let method = match cast {
                 utils::CastTo::Signed => "cast_signed()",

--- a/clippy_lints/src/casts/cast_sign_loss.rs
+++ b/clippy_lints/src/casts/cast_sign_loss.rs
@@ -54,8 +54,8 @@ pub(super) fn check<'cx>(
             expr.span,
             format!("casting `{cast_from}` to `{cast_to}` may lose the sign of the value"),
             |diag| {
-                if msrv.meets(cx, msrvs::INTEGER_SIGN_CAST)
-                    && let Some(cast) = utils::is_signedness_cast(cast_from, cast_to)
+                if let Some(cast) = utils::is_signedness_cast(cast_from, cast_to)
+                    && msrv.meets(cx, msrvs::INTEGER_SIGN_CAST)
                 {
                     let method = match cast {
                         utils::CastTo::Signed => "cast_signed()",

--- a/clippy_lints/src/casts/ptr_as_ptr.rs
+++ b/clippy_lints/src/casts/ptr_as_ptr.rs
@@ -41,8 +41,8 @@ pub(super) fn check<'tcx>(
         // The `U` in `pointer::cast` have to be `Sized`
         // as explained here: https://github.com/rust-lang/rust/issues/60602.
         && to_pointee_ty.is_sized(cx.tcx, cx.typing_env())
-        && msrv.meets(cx, msrvs::POINTER_CAST)
         && !is_from_proc_macro(cx, expr)
+        && msrv.meets(cx, msrvs::POINTER_CAST)
     {
         let mut app = Applicability::MachineApplicable;
         let turbofish = match &cast_to_hir.kind {

--- a/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
+++ b/clippy_lints/src/methods/chunks_exact_to_as_chunks.rs
@@ -26,13 +26,9 @@ pub(super) fn check<'tcx>(
     }
 
     if is_const_evaluatable(cx.tcx, cx.typeck_results(), arg) {
-        if !msrv.meets(cx, msrvs::AS_CHUNKS) {
-            return;
-        }
-
         let use_ctxt = get_expr_use_site(cx.tcx, cx.typeck_results(), expr.span.ctxt(), expr);
 
-        if use_ctxt.is_ty_unified {
+        if use_ctxt.is_ty_unified || !msrv.meets(cx, msrvs::AS_CHUNKS) {
             return;
         }
 

--- a/clippy_lints/src/methods/manual_is_variant_and.rs
+++ b/clippy_lints/src/methods/manual_is_variant_and.rs
@@ -263,13 +263,13 @@ pub(super) fn check_or<'tcx>(
         return;
     };
 
-    if !msrv.meets(cx, msrvs::IS_NONE_OR) {
-        return;
-    }
-
     let Ok(map_func) = MapFunc::try_from(some_arg) else {
         return;
     };
+
+    if !msrv.meets(cx, msrvs::IS_NONE_OR) {
+        return;
+    }
 
     span_lint_and_then(
         cx,

--- a/clippy_lints/src/methods/ptr_offset_by_literal.rs
+++ b/clippy_lints/src/methods/ptr_offset_by_literal.rs
@@ -12,12 +12,6 @@ use std::fmt;
 use super::PTR_OFFSET_BY_LITERAL;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Msrv) {
-    // `pointer::add` and `pointer::wrapping_add` are only stable since 1.26.0. These functions
-    // became const-stable in 1.61.0, the same version that `pointer::offset` became const-stable.
-    if !msrv.meets(cx, msrvs::POINTER_ADD_SUB_METHODS) {
-        return;
-    }
-
     let ExprKind::MethodCall(method_name, recv, [arg_expr], _) = expr.kind else {
         return;
     };
@@ -27,6 +21,12 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Ms
         sym::wrapping_offset => Method::WrappingOffset,
         _ => return,
     };
+
+    // `pointer::add` and `pointer::wrapping_add` are only stable since 1.26.0. These functions
+    // became const-stable in 1.61.0, the same version that `pointer::offset` became const-stable.
+    if !msrv.meets(cx, msrvs::POINTER_ADD_SUB_METHODS) {
+        return;
+    }
 
     if !cx.typeck_results().expr_ty_adjusted(recv).is_raw_ptr() {
         return;

--- a/clippy_lints/src/methods/ptr_offset_with_cast.rs
+++ b/clippy_lints/src/methods/ptr_offset_with_cast.rs
@@ -17,17 +17,17 @@ pub(super) fn check(
     arg: &Expr<'_>,
     msrv: Msrv,
 ) {
-    // `pointer::add` and `pointer::wrapping_add` are only stable since 1.26.0. These functions
-    // became const-stable in 1.61.0, the same version that `pointer::offset` became const-stable.
-    if !msrv.meets(cx, msrvs::POINTER_ADD_SUB_METHODS) {
-        return;
-    }
-
     let method = match method {
         sym::offset => Method::Offset,
         sym::wrapping_offset => Method::WrappingOffset,
         _ => return,
     };
+
+    // `pointer::add` and `pointer::wrapping_add` are only stable since 1.26.0. These functions
+    // became const-stable in 1.61.0, the same version that `pointer::offset` became const-stable.
+    if !msrv.meets(cx, msrvs::POINTER_ADD_SUB_METHODS) {
+        return;
+    }
 
     if !cx.typeck_results().expr_ty_adjusted(recv).is_raw_ptr() {
         return;


### PR DESCRIPTION
Calls to `Msrv::meets` are expensive, so I defer various calls to this function across the codebase to later in control flow. I do not have a sense for performance, so I only picked obvious/trivial applications of this optimization.

changelog: none
