### PR TITLE
remove dswij from rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -99,7 +99,8 @@ users_on_vacation = [
     "Alexendoo",
     "y21",
     "blyxyas",
-    "ada4a"
+    "ada4a",
+    "dswij"
 ]
 
 [assign.owners]


### PR DESCRIPTION
Will be unavailable until 22nd July.

changelog: none

r? @ghost