### PR TITLE
unnecessary_operation: avoid bad `!` suggestions

### DIFF
--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -274,14 +274,6 @@ fn check_unnecessary_operation(cx: &LateContext<'_>, stmt: &Stmt<'_>) {
         && expr.range_span().unwrap_or(expr.span).ctxt() == ctxt
         && let Some(reduced) = reduce_expression(cx, expr)
         && reduced.iter().all(|e| e.span.ctxt() == ctxt)
-        // ignore operations that evaluate to `!`, because
-        // a statement expression of type `!` will make the
-        // containing block also have type `!`
-        && let ty = cx.typeck_results().expr_ty(expr)
-        && (!ty.is_never() || reduced.last().is_some_and(|e| {
-            let ty = cx.typeck_results().expr_ty(e);
-            ty.is_never()
-        }))
     {
         if let ExprKind::Index(..) = &expr.kind {
             if !is_inside_always_const_context(cx.tcx, expr.hir_id)
@@ -349,10 +341,15 @@ fn reduce_expression<'a>(cx: &LateContext<'_>, expr: &'a Expr<'a>) -> Option<Vec
         | ExprKind::Type(inner, _)
         | ExprKind::Unary(_, inner)
         | ExprKind::Field(inner, _)
-        | ExprKind::AddrOf(_, _, inner) => reduce_expression(cx, inner).or_else(|| Some(vec![inner])),
+        | ExprKind::AddrOf(_, _, inner)
+        // accessing a field of type `!` makes the statement unreachable in
+        // the eye of the type checker, so don't remove it
+        if !cx.typeck_results().expr_ty(expr).is_never() => {
+            reduce_expression(cx, inner).or_else(|| Some(vec![inner]))
+        }
         ExprKind::Cast(inner, _) if expr_type_is_certain(cx, inner) => {
             reduce_expression(cx, inner).or_else(|| Some(vec![inner]))
-        },
+        }
         ExprKind::Struct(_, fields, ref base) => {
             if has_drop(cx, cx.typeck_results().expr_ty(expr)) {
                 None

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -274,6 +274,14 @@ fn check_unnecessary_operation(cx: &LateContext<'_>, stmt: &Stmt<'_>) {
         && expr.range_span().unwrap_or(expr.span).ctxt() == ctxt
         && let Some(reduced) = reduce_expression(cx, expr)
         && reduced.iter().all(|e| e.span.ctxt() == ctxt)
+        // ignore operations that evaluate to `!`, because
+        // a statement expression of type `!` will make the
+        // containing block also have type `!`
+        && let ty = cx.typeck_results().expr_ty(expr)
+        && (!ty.is_never() || reduced.last().is_some_and(|e| {
+            let ty = cx.typeck_results().expr_ty(e);
+            ty.is_never()
+        }))
     {
         if let ExprKind::Index(..) = &expr.kind {
             if !is_inside_always_const_context(cx.tcx, expr.hir_id)

--- a/tests/ui/unnecessary_operation.fixed
+++ b/tests/ui/unnecessary_operation.fixed
@@ -157,3 +157,22 @@ fn issue15173_original<MsU>(handler: impl FnOnce() -> MsU + Clone + 'static) {
         None
     }) as Box<dyn Fn(i32) -> Option<i32>>;
 }
+
+mod issue12898 {
+    use futures::future;
+    async fn forever() -> ! {
+        // pretend there is an infinite loop here...
+        future::pending().await
+    }
+    pub async fn definitely_forever() -> ! {
+        future::join(forever(), forever()).await.0;
+    }
+
+    pub async fn no_false_negative() -> ! {
+        fn never() -> ! {
+            unimplemented!()
+        }
+        never();
+        //~^^^ unnecessary_operation
+    }
+}

--- a/tests/ui/unnecessary_operation.rs
+++ b/tests/ui/unnecessary_operation.rs
@@ -163,3 +163,24 @@ fn issue15173_original<MsU>(handler: impl FnOnce() -> MsU + Clone + 'static) {
         None
     }) as Box<dyn Fn(i32) -> Option<i32>>;
 }
+
+mod issue12898 {
+    use futures::future;
+    async fn forever() -> ! {
+        // pretend there is an infinite loop here...
+        future::pending().await
+    }
+    pub async fn definitely_forever() -> ! {
+        future::join(forever(), forever()).await.0;
+    }
+
+    pub async fn no_false_negative() -> ! {
+        fn never() -> ! {
+            unimplemented!()
+        }
+        {
+            never()
+        };
+        //~^^^ unnecessary_operation
+    }
+}

--- a/tests/ui/unnecessary_operation.stderr
+++ b/tests/ui/unnecessary_operation.stderr
@@ -127,5 +127,13 @@ error: unnecessary operation
 LL |     [42, 55][get_usize()];
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
 
-error: aborting due to 20 previous errors
+error: unnecessary operation
+  --> tests/ui/unnecessary_operation.rs:181:9
+   |
+LL | /         {
+LL | |             never()
+LL | |         };
+   | |__________^ help: statement can be reduced to: `never();`
+
+error: aborting due to 21 previous errors
 


### PR DESCRIPTION
If an operation evaluates to `!`, but its last expression doesn't, don't try to simplify by removing the operation. You might need the operation, since the containing block's type is changed by it.

changelog: [`unnecessary_operation`]: avoid bad `!` suggestions

Fixes https://github.com/rust-lang/rust-clippy/issues/12898