### PR TITLE
arbitrary_source_item_ordering: add configurable trait impl item ordering modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7626,6 +7626,7 @@ Released 2018-09-13
 [`too-many-arguments-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-arguments-threshold
 [`too-many-lines-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-lines-threshold
 [`trait-assoc-item-kinds-order`]: https://doc.rust-lang.org/clippy/lint_configuration.html#trait-assoc-item-kinds-order
+[`trait-impl-item-order`]: https://doc.rust-lang.org/clippy/lint_configuration.html#trait-impl-item-order
 [`trivial-copy-size-limit`]: https://doc.rust-lang.org/clippy/lint_configuration.html#trivial-copy-size-limit
 [`type-complexity-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#type-complexity-threshold
 [`unnecessary-box-size`]: https://doc.rust-lang.org/clippy/lint_configuration.html#unnecessary-box-size

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -1168,6 +1168,30 @@ The order of associated items in traits.
 * [`arbitrary_source_item_ordering`](https://rust-lang.github.io/rust-clippy/master/index.html#arbitrary_source_item_ordering)
 
 
+## `trait-impl-item-order`
+The required ordering of associated items in trait impls: purely alphabetical,
+following the trait definition order, or accepting either.
+
+Note that the trait definition order may change between versions of the
+crate defining the trait without being considered a breaking change.
+
+Examples:
+When using trait definition item ordering:
+```toml
+trait-impl-item-order = "trait_item_ordering"
+```
+When using trait definition item ordering and alphabetical for fallbacks:
+```toml
+trait-impl-item-order = "alphabetical_or_trait_item_ordering"
+```
+
+**Default Value:** `"alphabetical"`
+
+---
+**Affected lints:**
+* [`arbitrary_source_item_ordering`](https://rust-lang.github.io/rust-clippy/master/index.html#arbitrary_source_item_ordering)
+
+
 ## `trivial-copy-size-limit`
 The maximum size (in bytes) to consider a `Copy` type for passing by value instead of by
 reference.

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -3,7 +3,7 @@ use crate::types::{
     DisallowedPath, DisallowedPathWithoutReplacement, InherentImplLintScope, MacroMatcher, MatchLintBehaviour,
     PubUnderscoreFieldsBehaviour, Rename, SourceItemOrdering, SourceItemOrderingCategory,
     SourceItemOrderingModuleItemGroupings, SourceItemOrderingModuleItemKind, SourceItemOrderingTraitAssocItemKind,
-    SourceItemOrderingTraitAssocItemKinds, SourceItemOrderingWithinModuleItemGroupings,
+    SourceItemOrderingTraitAssocItemKinds, SourceItemOrderingWithinModuleItemGroupings, TraitImplItemOrder,
 };
 use clippy_utils::msrvs::Msrv;
 use itertools::Itertools;
@@ -917,6 +917,23 @@ define_Conf! {
     /// The order of associated items in traits.
     #[lints(arbitrary_source_item_ordering)]
     trait_assoc_item_kinds_order: SourceItemOrderingTraitAssocItemKinds = DEFAULT_TRAIT_ASSOC_ITEM_KINDS_ORDER.into(),
+    /// The required ordering of associated items in trait impls: purely alphabetical,
+    /// following the trait definition order, or accepting either.
+    ///
+    /// Note that the trait definition order may change between versions of the
+    /// crate defining the trait without being considered a breaking change.
+    ///
+    /// Examples:
+    /// When using trait definition item ordering:
+    /// ```toml
+    /// trait-impl-item-order = "trait_item_ordering"
+    /// ```
+    /// When using trait definition item ordering and alphabetical for fallbacks:
+    /// ```toml
+    /// trait-impl-item-order = "alphabetical_or_trait_item_ordering"
+    /// ```
+    #[lints(arbitrary_source_item_ordering)]
+    trait_impl_item_order: TraitImplItemOrder = TraitImplItemOrder::Alphabetical,
     /// The maximum size (in bytes) to consider a `Copy` type for passing by value instead of by
     /// reference.
     #[default_text = "target_pointer_width"]

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -706,3 +706,12 @@ pub enum InherentImplLintScope {
     File,
     Module,
 }
+
+/// Represents the ordering requirement for associated items in trait impls.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraitImplItemOrder {
+    Alphabetical,
+    TraitItemOrdering,
+    AlphabeticalOrTraitItemOrdering,
+}

--- a/clippy_lints/src/arbitrary_source_item_ordering.rs
+++ b/clippy_lints/src/arbitrary_source_item_ordering.rs
@@ -2,7 +2,7 @@ use clippy_config::Conf;
 use clippy_config::types::{
     SourceItemOrderingCategory, SourceItemOrderingModuleItemGroupings, SourceItemOrderingModuleItemKind,
     SourceItemOrderingTraitAssocItemKind, SourceItemOrderingTraitAssocItemKinds,
-    SourceItemOrderingWithinModuleItemGroupings,
+    SourceItemOrderingWithinModuleItemGroupings, TraitImplItemOrder,
 };
 use clippy_utils::diagnostics::span_lint_and_note;
 use clippy_utils::is_cfg_test;
@@ -14,7 +14,7 @@ use rustc_hir::{
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty::AssocKind;
 use rustc_session::impl_lint_pass;
-use rustc_span::Ident;
+use rustc_span::{Ident, Symbol};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -177,6 +177,7 @@ pub struct ArbitrarySourceItemOrdering {
     enable_ordering_for_trait: bool,
     module_item_order_groupings: SourceItemOrderingModuleItemGroupings,
     module_items_ordered_within_groupings: SourceItemOrderingWithinModuleItemGroupings,
+    trait_impl_item_order: TraitImplItemOrder,
 }
 
 impl ArbitrarySourceItemOrdering {
@@ -192,6 +193,7 @@ impl ArbitrarySourceItemOrdering {
             enable_ordering_for_trait: conf.source_item_ordering.contains(&Trait),
             module_item_order_groupings: conf.module_item_order_groupings.clone(),
             module_items_ordered_within_groupings: conf.module_items_ordered_within_groupings.clone(),
+            trait_impl_item_order: conf.trait_impl_item_order,
         }
     }
 
@@ -205,6 +207,18 @@ impl ArbitrarySourceItemOrdering {
                 "incorrect ordering of impl items (defined order: {:?})",
                 self.assoc_types_order
             ),
+            Some(cx.tcx.def_span(before_item.owner_id)),
+            format!("should be placed before `{}`", cx.tcx.item_name(before_item.owner_id)),
+        );
+    }
+
+    /// Produces a linting warning for impl items that don't follow the trait definition order.
+    fn lint_trait_impl_item(cx: &LateContext<'_>, item: ImplItemId, before_item: ImplItemId) {
+        span_lint_and_note(
+            cx,
+            ARBITRARY_SOURCE_ITEM_ORDERING,
+            cx.tcx.def_span(item.owner_id),
+            "incorrect ordering of impl items (should follow the trait definition order)",
             Some(cx.tcx.def_span(before_item.owner_id)),
             format!("should be placed before `{}`", cx.tcx.item_name(before_item.owner_id)),
         );
@@ -259,6 +273,121 @@ impl ArbitrarySourceItemOrdering {
             Some(cx.tcx.def_span(before_item.owner_id)),
             format!("should be placed before `{}`", cx.tcx.item_name(before_item.owner_id)),
         );
+    }
+
+    /// Checks the ordering of items in an impl block against the configured
+    /// associated item kind order, alphabetically within each kind.
+    fn check_impl_alphabetical(&self, cx: &LateContext<'_>, trait_impl: &rustc_hir::Impl<'_>) {
+        let mut cur_t: Option<(ImplItemId, Ident)> = None;
+
+        for &item in trait_impl.items {
+            let span = cx.tcx.def_span(item.owner_id);
+            let ident = cx.tcx.item_ident(item.owner_id);
+            if span.in_external_macro(cx.sess().source_map()) {
+                continue;
+            }
+
+            if let Some((cur_t, cur_ident)) = cur_t {
+                let cur_t_kind = convert_assoc_item_kind(cx, cur_t.owner_id);
+                let cur_t_kind_index = self.assoc_types_order.index_of(&cur_t_kind);
+                let item_kind = convert_assoc_item_kind(cx, item.owner_id);
+                let item_kind_index = self.assoc_types_order.index_of(&item_kind);
+
+                if cur_t_kind == item_kind && cur_ident.name.as_str() > ident.name.as_str() {
+                    Self::lint_member_name(cx, ident, cur_ident);
+                } else if cur_t_kind_index > item_kind_index {
+                    self.lint_impl_item(cx, item, cur_t);
+                }
+            }
+            cur_t = Some((item, ident));
+        }
+    }
+
+    /// Checks the ordering of items in a trait impl against the order in
+    /// which they are declared in the trait definition.
+    ///
+    /// Falls back to the alphabetical check for impl blocks without a trait.
+    fn check_impl_trait_def_order(&self, cx: &LateContext<'_>, trait_impl: &rustc_hir::Impl<'_>) {
+        let Some(trait_order) = get_trait_item_order(cx, trait_impl) else {
+            // Bare impl blocks have no trait definition to compare against.
+            self.check_impl_alphabetical(cx, trait_impl);
+            return;
+        };
+
+        let mut cur_t: Option<(ImplItemId, Ident)> = None;
+
+        for &item in trait_impl.items {
+            let span = cx.tcx.def_span(item.owner_id);
+            let ident = cx.tcx.item_ident(item.owner_id);
+            if span.in_external_macro(cx.sess().source_map()) {
+                continue;
+            }
+
+            if let Some((cur_t, cur_ident)) = cur_t {
+                // Compare positions in the trait definition.
+                let cur_pos = trait_order.iter().position(|n| *n == cur_ident.name);
+                let item_pos = trait_order.iter().position(|n| *n == ident.name);
+                if let (Some(cur_pos), Some(item_pos)) = (cur_pos, item_pos)
+                    && cur_pos > item_pos
+                {
+                    Self::lint_trait_impl_item(cx, item, cur_t);
+                }
+            }
+            cur_t = Some((item, ident));
+        }
+    }
+
+    /// Checks impl items, accepting either the alphabetical + kind ordering
+    /// or the trait definition order. Lints only when both are violated.
+    ///
+    /// Fallbacks to the alphabetical check for impl blocks without a trait.
+    fn check_impl_alphabetical_or_trait_def_order(&self, cx: &LateContext<'_>, trait_impl: &rustc_hir::Impl<'_>) {
+        let Some(trait_order) = get_trait_item_order(cx, trait_impl) else {
+            // Bare impl blocks have no trait definition to compare against,
+            // so only the alphabetical ordering applies.
+            self.check_impl_alphabetical(cx, trait_impl);
+            return;
+        };
+
+        let mut cur_t: Option<(ImplItemId, Ident)> = None;
+
+        for &item in trait_impl.items {
+            let span = cx.tcx.def_span(item.owner_id);
+            let ident = cx.tcx.item_ident(item.owner_id);
+            if span.in_external_macro(cx.sess().source_map()) {
+                continue;
+            }
+
+            if let Some((cur_t, cur_ident)) = cur_t {
+                let cur_t_kind = convert_assoc_item_kind(cx, cur_t.owner_id);
+                let cur_t_kind_index = self.assoc_types_order.index_of(&cur_t_kind);
+                let item_kind = convert_assoc_item_kind(cx, item.owner_id);
+                let item_kind_index = self.assoc_types_order.index_of(&item_kind);
+
+                // Same check as in `check_impl_alphabetical`
+                let alpha_violation = if cur_t_kind == item_kind {
+                    cur_ident.name.as_str() > ident.name.as_str()
+                } else {
+                    cur_t_kind_index > item_kind_index
+                };
+
+                // Same check as in `check_impl_trait_def_order`
+                let trait_violation = matches!(
+                    (
+                        trait_order.iter().position(|n| *n == cur_ident.name),
+                        trait_order.iter().position(|n| *n == ident.name),
+                    ),
+                    (Some(cur_pos), Some(item_pos)) if cur_pos > item_pos
+                );
+
+                // Accepting either ordering means linting only when the pair
+                // satisfies neither of them.
+                if alpha_violation && trait_violation {
+                    Self::lint_trait_impl_item(cx, item, cur_t);
+                }
+            }
+            cur_t = Some((item, ident));
+        }
     }
 }
 
@@ -340,30 +469,17 @@ impl<'tcx> LateLintPass<'tcx> for ArbitrarySourceItemOrdering {
                     cur_t = Some((item, ident));
                 }
             },
-            ItemKind::Impl(trait_impl) if self.enable_ordering_for_impl => {
-                let mut cur_t: Option<(ImplItemId, Ident)> = None;
-
-                for &item in trait_impl.items {
-                    let span = cx.tcx.def_span(item.owner_id);
-                    let ident = cx.tcx.item_ident(item.owner_id);
-                    if span.in_external_macro(cx.sess().source_map()) {
-                        continue;
-                    }
-
-                    if let Some((cur_t, cur_ident)) = cur_t {
-                        let cur_t_kind = convert_assoc_item_kind(cx, cur_t.owner_id);
-                        let cur_t_kind_index = self.assoc_types_order.index_of(&cur_t_kind);
-                        let item_kind = convert_assoc_item_kind(cx, item.owner_id);
-                        let item_kind_index = self.assoc_types_order.index_of(&item_kind);
-
-                        if cur_t_kind == item_kind && cur_ident.name.as_str() > ident.name.as_str() {
-                            Self::lint_member_name(cx, ident, cur_ident);
-                        } else if cur_t_kind_index > item_kind_index {
-                            self.lint_impl_item(cx, item, cur_t);
-                        }
-                    }
-                    cur_t = Some((item, ident));
-                }
+            ItemKind::Impl(trait_impl) if self.enable_ordering_for_impl => match self.trait_impl_item_order {
+                // Match trait impl item orderings based on the configured ordering.
+                TraitImplItemOrder::Alphabetical => {
+                    self.check_impl_alphabetical(cx, trait_impl);
+                },
+                TraitImplItemOrder::TraitItemOrdering => {
+                    self.check_impl_trait_def_order(cx, trait_impl);
+                },
+                TraitImplItemOrder::AlphabeticalOrTraitItemOrdering => {
+                    self.check_impl_alphabetical_or_trait_def_order(cx, trait_impl);
+                },
             },
             _ => {}, // Catch-all for `ItemKinds` that don't have fields.
         }
@@ -565,4 +681,19 @@ fn get_item_name(item: &Item<'_>) -> Option<String> {
         },
         _ => item.kind.ident().map(|name| name.as_str().to_owned()),
     }
+}
+
+/// Returns the associated item names of the implemented trait in
+/// definition order, or `None` if the impl block has no trait.
+fn get_trait_item_order(cx: &LateContext<'_>, trait_impl: &rustc_hir::Impl<'_>) -> Option<Vec<Symbol>> {
+    trait_impl
+        .of_trait
+        .and_then(|t| t.trait_ref.trait_def_id())
+        .map(|def_id| {
+            cx.tcx
+                .associated_items(def_id)
+                .in_definition_order()
+                .map(rustc_middle::ty::AssocItem::name)
+                .collect()
+        })
 }

--- a/clippy_test_deps/Cargo.lock
+++ b/clippy_test_deps/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]

--- a/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order.rs
@@ -1,0 +1,46 @@
+//@rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order
+//@check-pass
+#![deny(clippy::arbitrary_source_item_ordering)]
+
+struct Languages;
+struct Language;
+struct Iter<'a, T>(&'a [&'a T]);
+
+impl<'a> Iterator for Iter<'a, Language> {
+    type Item = &'a Language;
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+// Follows the trait definition order (but not alphabetical order):
+// accepted, because either ordering is allowed in this mode.
+impl<'a> IntoIterator for &'a Languages {
+    type Item = &'a Language;
+    type IntoIter = Iter<'a, Language>;
+    fn into_iter(self) -> Self::IntoIter {
+        todo!()
+    }
+}
+
+struct AlsoLanguages;
+
+// Follows the alphabetical order (but not the trait definition order):
+// also accepted in this mode.
+impl<'a> IntoIterator for &'a AlsoLanguages {
+    type IntoIter = Iter<'a, Language>;
+    type Item = &'a Language;
+    fn into_iter(self) -> Self::IntoIter {
+        todo!()
+    }
+}
+
+// Bare impls only have the alphabetical ordering to compare against.
+struct BareImpl;
+impl BareImpl {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+fn main() {}

--- a/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order.rs
@@ -43,4 +43,70 @@ impl BareImpl {
     fn c() {}
 }
 
+// Default trait impl ordering.
+trait WithDefault {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+trait WithDefault2 {
+    fn a();
+    fn b();
+    fn c();
+}
+
+struct SkipMiddle;
+
+impl WithDefault for SkipMiddle {
+    fn a() {}
+    fn c() {}
+}
+
+struct FullImpl;
+
+impl WithDefault for FullImpl {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+impl WithDefault2 for FullImpl {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+// Tests `const` in trait.
+trait ConstTrait {
+    const A: bool;
+    const B: bool;
+    const C: bool;
+    fn method();
+}
+
+struct FullImpl3;
+
+impl ConstTrait for FullImpl3 {
+    const A: bool = true;
+    const B: bool = false;
+    const C: bool = true;
+    fn method() {}
+}
+
+trait ConstTrait2 {
+    const A: bool = true;
+    const B: bool = false;
+    const C: bool = true;
+    fn method() {}
+}
+
+struct SkipImpl;
+
+// Skips `B` `C`, keeps order of `A` and `C`.
+impl ConstTrait2 for SkipImpl {
+    const A: bool = true;
+    fn method() {}
+}
+
 fn main() {}

--- a/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs
@@ -22,12 +22,85 @@ impl MixedOrder for WrongInBothOrders {
     fn b() {}
 }
 
+trait WithDefault {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+struct SkipMiddleFailed;
+
+impl WithDefault for SkipMiddleFailed {
+    fn c() {}
+    fn a() {}
+    //~^ arbitrary_source_item_ordering
+}
+
+struct FullImplFailed;
+
+impl WithDefault for FullImplFailed {
+    fn c() {}
+    fn a() {}
+    //~^ arbitrary_source_item_ordering
+    fn b() {}
+}
+
+trait WithDefault2 {
+    fn a();
+    fn b();
+    fn c();
+}
+
+struct FullImplFailed2;
+
+impl WithDefault2 for FullImplFailed2 {
+    fn b() {}
+    fn a() {}
+    //~^ arbitrary_source_item_ordering
+    fn c() {}
+}
+
 // Bare impls fall back to the alphabetical check.
 struct BareImpl;
+
 impl BareImpl {
     fn b() {}
     fn a() {}
     //~^ arbitrary_source_item_ordering
+}
+
+// Tests `const` in trait failed by invalid alphabetical order.
+trait ConstTrait {
+    const A: bool;
+    const B: bool;
+    const C: bool;
+    fn method();
+}
+
+struct FullImplFailed3;
+
+impl ConstTrait for FullImplFailed3 {
+    const A: bool = true;
+    const C: bool = true;
+    const B: bool = false;
+    //~^ arbitrary_source_item_ordering
+    fn method() {}
+}
+
+trait ConstTrait2 {
+    const A: bool = true;
+    const B: bool = false;
+    const C: bool = true;
+    fn method() {}
+}
+
+struct SkipMiddleFailed2;
+
+impl ConstTrait2 for SkipMiddleFailed2 {
+    const C: bool = true;
+    const A: bool = true;
+    //~^ arbitrary_source_item_ordering
+    fn method() {}
 }
 
 fn main() {}

--- a/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs
@@ -1,0 +1,33 @@
+//@rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order
+#![deny(clippy::arbitrary_source_item_ordering)]
+
+// Trait definition order: b, a, c. Deliberately unordered to make the
+// trait definition order differ from the alphabetical order; its own
+// ordering check is not what this test is about.
+#[allow(clippy::arbitrary_source_item_ordering)]
+trait MixedOrder {
+    fn b();
+    fn a();
+    fn c();
+}
+
+struct WrongInBothOrders;
+
+// `c, a, b`: the pair (c, a) violates the alphabetical order, and in the
+// trait definition `c` comes after `a`, so it violates both orderings.
+impl MixedOrder for WrongInBothOrders {
+    fn c() {}
+    fn a() {}
+    //~^ arbitrary_source_item_ordering
+    fn b() {}
+}
+
+// Bare impls fall back to the alphabetical check.
+struct BareImpl;
+impl BareImpl {
+    fn b() {}
+    fn a() {}
+    //~^ arbitrary_source_item_ordering
+}
+
+fn main() {}

--- a/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.stderr
+++ b/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.stderr
@@ -15,17 +15,77 @@ note: the lint level is defined here
 LL | #![deny(clippy::arbitrary_source_item_ordering)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:35:5
+   |
+LL |     fn a() {}
+   |     ^^^^^^
+   |
+note: should be placed before `c`
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:34:5
+   |
+LL |     fn c() {}
+   |     ^^^^^^
+
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:43:5
+   |
+LL |     fn a() {}
+   |     ^^^^^^
+   |
+note: should be placed before `c`
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:42:5
+   |
+LL |     fn c() {}
+   |     ^^^^^^
+
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:58:5
+   |
+LL |     fn a() {}
+   |     ^^^^^^
+   |
+note: should be placed before `b`
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:57:5
+   |
+LL |     fn b() {}
+   |     ^^^^^^
+
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:29:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:68:8
    |
 LL |     fn a() {}
    |        ^
    |
 note: should be placed before `b`
-  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:28:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:67:8
    |
 LL |     fn b() {}
    |        ^
 
-error: aborting due to 2 previous errors
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:85:5
+   |
+LL |     const B: bool = false;
+   |     ^^^^^^^^^^^^^
+   |
+note: should be placed before `C`
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:84:5
+   |
+LL |     const C: bool = true;
+   |     ^^^^^^^^^^^^^
+
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:101:5
+   |
+LL |     const A: bool = true;
+   |     ^^^^^^^^^^^^^
+   |
+note: should be placed before `C`
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:100:5
+   |
+LL |     const C: bool = true;
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.stderr
+++ b/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.stderr
@@ -1,0 +1,31 @@
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:20:5
+   |
+LL |     fn a() {}
+   |     ^^^^^^
+   |
+note: should be placed before `c`
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:19:5
+   |
+LL |     fn c() {}
+   |     ^^^^^^
+note: the lint level is defined here
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:2:9
+   |
+LL | #![deny(clippy::arbitrary_source_item_ordering)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:29:8
+   |
+LL |     fn a() {}
+   |        ^
+   |
+note: should be placed before `b`
+  --> tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/alphabetical_or_trait_item_order_failed.rs:28:8
+   |
+LL |     fn b() {}
+   |        ^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/clippy.toml
+++ b/tests/ui-toml/arbitrary_source_item_ordering/alphabetical_or_trait_item_order/clippy.toml
@@ -1,0 +1,1 @@
+trait-impl-item-order = "alphabetical_or_trait_item_ordering"

--- a/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/clippy.toml
+++ b/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/clippy.toml
@@ -1,0 +1,1 @@
+trait-impl-item-order = "trait_item_ordering"

--- a/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order.rs
@@ -1,0 +1,24 @@
+//@rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order
+//@check-pass
+#![deny(clippy::arbitrary_source_item_ordering)]
+
+struct Languages;
+struct Language;
+struct Iter<'a, T>(&'a [&'a T]);
+
+impl<'a> Iterator for Iter<'a, Language> {
+    type Item = &'a Language;
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+impl<'a> IntoIterator for &'a Languages {
+    type Item = &'a Language;
+    type IntoIter = Iter<'a, Language>;
+    fn into_iter(self) -> Self::IntoIter {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order.rs
@@ -21,4 +21,74 @@ impl<'a> IntoIterator for &'a Languages {
     }
 }
 
+// Default trait impl ordering.
+trait WithDefault {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+struct SkipMiddle;
+
+impl WithDefault for SkipMiddle {
+    fn a() {}
+    fn c() {}
+}
+
+struct FullImpl;
+
+impl WithDefault for FullImpl {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+trait WithDefault2 {
+    fn a();
+    fn b();
+    fn c();
+}
+
+struct FullImpl2;
+
+impl WithDefault2 for FullImpl2 {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+// Tests `const` in trait.
+trait ConstTrait {
+    const A: bool;
+    const B: bool;
+    const C: bool;
+    fn method();
+}
+
+struct FullImpl3;
+
+// Tests `const` in trait without value.
+impl ConstTrait for FullImpl3 {
+    const A: bool = true;
+    const B: bool = false;
+    const C: bool = true;
+    fn method() {}
+}
+
+trait ConstTrait2 {
+    const A: bool = true;
+    const B: bool = false;
+    const C: bool = true;
+    fn method() {}
+}
+
+struct SkipImpl;
+
+// Tests skipped `const` in trait.
+impl ConstTrait2 for SkipImpl {
+    const A: bool = true;
+    const C: bool = true;
+    fn method() {}
+}
+
 fn main() {}

--- a/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs
@@ -20,6 +20,21 @@ impl AlphaOrder for WrongInBothOrders {
     //~^ arbitrary_source_item_ordering
 }
 
+trait AlphaOrder2 {
+    fn a() {}
+    fn b() {}
+    fn c() {}
+}
+
+struct WrongInBothOrder2;
+
+impl AlphaOrder2 for WrongInBothOrder2 {
+    fn a() {}
+    fn c() {}
+    fn b() {}
+    //~^ arbitrary_source_item_ordering
+}
+
 // Bare impls have no trait definition to compare against, so the
 // trait_item_ordering mode falls back to the alphabetical check.
 struct BareImpl;
@@ -48,6 +63,43 @@ impl<'a> IntoIterator for &'a Languages {
     type Item = &'a Language;
     //~^ arbitrary_source_item_ordering
     type IntoIter = Iter<'a, Language>;
+}
+
+// Tests `const` in trait when failed by invalid trait definition order (e.g. Not in alphabetical
+// order).
+trait ConstTrait {
+    const A: bool;
+    const B: bool;
+    const C: bool;
+    fn method();
+}
+
+struct WrongInBothOrder3;
+
+impl ConstTrait for WrongInBothOrder3 {
+    const A: bool = true;
+    const C: bool = true;
+    const B: bool = false;
+    //~^ arbitrary_source_item_ordering
+    fn method() {}
+}
+
+// Tests skipped trait which has `const` in trait failed by invalid trait definition order (e.g. Not
+// in alphabetical order).
+trait SkipConstTrait {
+    const A: bool = true;
+    const B: bool = false;
+    const C: bool = true;
+    fn method() {}
+}
+
+struct WrongInBothOrder4;
+
+impl SkipConstTrait for WrongInBothOrder4 {
+    const C: bool = true;
+    const A: bool = true;
+    //~^ arbitrary_source_item_ordering
+    fn method() {}
 }
 
 fn main() {}

--- a/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs
+++ b/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs
@@ -1,0 +1,53 @@
+//@revisions: trait_def
+//@rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order
+#![deny(clippy::arbitrary_source_item_ordering)]
+
+// A trait whose definition order happens to be alphabetical.
+trait AlphaOrder {
+    fn a();
+    fn b();
+    fn c();
+}
+
+struct WrongInBothOrders;
+
+// `a, c, b` violates both the alphabetical order and the trait
+// definition order, so it is linted in every mode.
+impl AlphaOrder for WrongInBothOrders {
+    fn a() {}
+    fn c() {}
+    fn b() {}
+    //~^ arbitrary_source_item_ordering
+}
+
+// Bare impls have no trait definition to compare against, so the
+// trait_item_ordering mode falls back to the alphabetical check.
+struct BareImpl;
+impl BareImpl {
+    fn a() {}
+    fn c() {}
+    fn b() {}
+    //~^ arbitrary_source_item_ordering
+}
+
+struct Languages;
+struct Language;
+struct Iter<'a, T>(&'a [&'a T]);
+
+impl<'a> Iterator for Iter<'a, Language> {
+    type Item = &'a Language;
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+impl<'a> IntoIterator for &'a Languages {
+    fn into_iter(self) -> Self::IntoIter {
+        todo!()
+    }
+    type Item = &'a Language;
+    //~^ arbitrary_source_item_ordering
+    type IntoIter = Iter<'a, Language>;
+}
+
+fn main() {}

--- a/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.trait_def.stderr
+++ b/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.trait_def.stderr
@@ -15,29 +15,65 @@ note: the lint level is defined here
 LL | #![deny(clippy::arbitrary_source_item_ordering)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:34:5
+   |
+LL |     fn b() {}
+   |     ^^^^^^
+   |
+note: should be placed before `c`
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:33:5
+   |
+LL |     fn c() {}
+   |     ^^^^^^
+
 error: incorrect ordering of items (must be alphabetically ordered)
-  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:29:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:44:8
    |
 LL |     fn b() {}
    |        ^
    |
 note: should be placed before `c`
-  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:28:8
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:43:8
    |
 LL |     fn c() {}
    |        ^
 
 error: incorrect ordering of impl items (should follow the trait definition order)
-  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:48:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:63:5
    |
 LL |     type Item = &'a Language;
    |     ^^^^^^^^^
    |
 note: should be placed before `into_iter`
-  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:45:5
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:60:5
    |
 LL |     fn into_iter(self) -> Self::IntoIter {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:82:5
+   |
+LL |     const B: bool = false;
+   |     ^^^^^^^^^^^^^
+   |
+note: should be placed before `C`
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:81:5
+   |
+LL |     const C: bool = true;
+   |     ^^^^^^^^^^^^^
+
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:100:5
+   |
+LL |     const A: bool = true;
+   |     ^^^^^^^^^^^^^
+   |
+note: should be placed before `C`
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:99:5
+   |
+LL |     const C: bool = true;
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.trait_def.stderr
+++ b/tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.trait_def.stderr
@@ -1,0 +1,43 @@
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:19:5
+   |
+LL |     fn b() {}
+   |     ^^^^^^
+   |
+note: should be placed before `c`
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:18:5
+   |
+LL |     fn c() {}
+   |     ^^^^^^
+note: the lint level is defined here
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:3:9
+   |
+LL | #![deny(clippy::arbitrary_source_item_ordering)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: incorrect ordering of items (must be alphabetically ordered)
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:29:8
+   |
+LL |     fn b() {}
+   |        ^
+   |
+note: should be placed before `c`
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:28:8
+   |
+LL |     fn c() {}
+   |        ^
+
+error: incorrect ordering of impl items (should follow the trait definition order)
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:48:5
+   |
+LL |     type Item = &'a Language;
+   |     ^^^^^^^^^
+   |
+note: should be placed before `into_iter`
+  --> tests/ui-toml/arbitrary_source_item_ordering/trait_definition_order/trait_definition_order_failed.rs:45:5
+   |
+LL |     fn into_iter(self) -> Self::IntoIter {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -86,6 +86,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            too-many-arguments-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
+           trait-impl-item-order
            trivial-copy-size-limit
            type-complexity-threshold
            unnecessary-box-size
@@ -188,6 +189,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            too-many-arguments-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
+           trait-impl-item-order
            trivial-copy-size-limit
            type-complexity-threshold
            unnecessary-box-size
@@ -290,6 +292,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            too-many-arguments-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
+           trait-impl-item-order
            trivial-copy-size-limit
            type-complexity-threshold
            unnecessary-box-size


### PR DESCRIPTION
Add configuration options for trait impl item ordering

Implements three-mode configuration for `arbitrary_source_item_ordering`:
- `alphabetical` (default, preserves current behavior)
- `trait_item_ordering` (follow trait definition order)
- `alphabetical_or_trait_item_ordering` (accept either ordering)

This allows users to choose the ordering style that best fits their codebase. 
Traits like `IntoIterator` with non-alphabetical definition orders can now be 
handled gracefully without false positives.

The default behavior is unchanged, maintaining backward compatibility.

changelog: [`arbitrary_source_item_ordering`]: add configurable trait impl item ordering modes

Closes rust-lang/rust-clippy#17241