### PR TITLE
match_same_arms: keep arm-level expectations working under an outer allow

### DIFF
--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -1111,7 +1111,13 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                 if source == MatchSource::Normal {
                     let is_match_like_matches = self.msrv.meets(cx, msrvs::MATCHES_MACRO)
                         && match_like_matches::check_match(cx, expr, ex, arms);
-                    if !(is_match_like_matches || is_lint_allowed(cx, MATCH_SAME_ARMS, expr.hir_id)) {
+                    // Even when the lint is allowed on the match expression, an arm can carry its
+                    // own `#[expect]`/`#[warn]` attribute, which `match_same_arms::check` handles
+                    // at arm granularity. Only skip the check when no arm has attributes.
+                    if !(is_match_like_matches
+                        || (is_lint_allowed(cx, MATCH_SAME_ARMS, expr.hir_id)
+                            && arms.iter().all(|arm| cx.tcx.hir_attrs(arm.hir_id).is_empty())))
+                    {
                         match_same_arms::check(cx, arms);
                     }
 

--- a/tests/ui/match_same_arms_expect.rs
+++ b/tests/ui/match_same_arms_expect.rs
@@ -1,0 +1,18 @@
+//! An `#[expect(clippy::match_same_arms)]` on a match arm must still work when the lint is
+//! allowed on an enclosing scope.
+//@check-pass
+#![allow(clippy::match_same_arms)]
+
+fn allowed_outer_expect_inner(x: u32) -> u32 {
+    match x {
+        #[expect(clippy::match_same_arms)]
+        1 => 42,
+        #[expect(clippy::match_same_arms)]
+        2 => 42,
+        _ => 0,
+    }
+}
+
+fn main() {
+    allowed_outer_expect_inner(1);
+}


### PR DESCRIPTION
The fast path from rust-lang/rust-clippy#17272 skips `match_same_arms::check` when the lint is allowed at the match expression. But running that check is also what tells the compiler that an `#[expect]` on an individual arm caught the lint. With the fast path, the compiler thinks the expected lint never fired and warns on both arms:

```rust
#[allow(clippy::match_same_arms)]
fn f(x: u32) -> u32 {
    match x {
        #[expect(clippy::match_same_arms)]
        1 => 42,
        #[expect(clippy::match_same_arms)]
        2 => 42,
        _ => 0,
    }
}
```

Fix: only take the fast path when no arm has attributes.

Before rust-lang/rust-clippy#17272 the snippet compiled without warnings, on master it warns twice, with this fix it is clean again. I added a ui test for it.

changelog: none
