### PR TITLE
inline_modules: ignore cfg(test) modules in test builds

### DIFF
--- a/clippy_utils/src/ast_utils/mod.rs
+++ b/clippy_utils/src/ast_utils/mod.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
 
 use crate::{both, over};
+use rustc_ast::attr::data_structures::CfgEntry;
 use rustc_ast::{self as ast, HasAttrs, *};
 use rustc_span::sym;
 use rustc_span::symbol::Ident;
@@ -1042,7 +1043,7 @@ fn eq_delim_args(l: &DelimArgs, r: &DelimArgs) -> bool {
         && l.tokens.iter().zip(r.tokens.iter()).all(|(a, b)| a.eq_unspanned(b))
 }
 
-/// Checks whether `#[cfg(test)]` is directly applied to `item`.
+/// Checks whether `item` is gated on `#[cfg(test)]`.
 pub fn is_cfg_test(item: &impl HasAttrs) -> bool {
     item.attrs().iter().any(|attr| {
         if attr.has_name(sym::cfg)
@@ -1050,8 +1051,20 @@ pub fn is_cfg_test(item: &impl HasAttrs) -> bool {
             && item_list.iter().any(|item| item.has_name(sym::test))
         {
             true
+        } else if attr.has_name(sym::cfg_trace)
+            && let AttrItemKind::Parsed(EarlyParsedAttribute::CfgTrace(cfg)) = &attr.get_normal_item().args
+        {
+            requires_test_cfg(cfg)
         } else {
             false
         }
     })
+}
+
+fn requires_test_cfg(cfg: &CfgEntry) -> bool {
+    match cfg {
+        CfgEntry::NameValue { name: sym::test, .. } => true,
+        CfgEntry::All(subs, _) => subs.iter().any(requires_test_cfg),
+        _ => false,
+    }
 }

--- a/tests/ui/inline_modules_cfg_test.rs
+++ b/tests/ui/inline_modules_cfg_test.rs
@@ -1,0 +1,17 @@
+//@check-pass
+//@compile-flags: --cfg test
+
+#![warn(clippy::inline_modules)]
+#![allow(clippy::non_minimal_cfg)]
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    mod nested {}
+}
+
+#[cfg(all(test))]
+mod tests_in_all {
+    mod nested {}
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17342

`inline_modules` already skips modules that still have a visible `#[cfg(test)]` attribute, but test builds keep the cfg-expanded item and preserve the original cfg in `cfg_trace`. Because the AST helper only checked visible `cfg` attributes, `cargo clippy --all-targets -- -Wclippy::inline-modules` still warned on inline test modules.

This teaches `is_cfg_test` to also recognize preserved `cfg_trace(test)` conditions, and adds a UI regression test for the `--cfg test` case. The `cfg_trace` handling is conservative: it covers direct `test` gating and `all(test, ...)`, while leaving `any(test, ...)` alone because those items may also be compiled outside test builds.

Validation:
- Red check: with the source fix temporarily reverted, `TESTNAME=inline_modules_cfg_test /Users/rahul/.cargo/bin/rustup run nightly-2026-06-25 cargo uitest` failed with `inline module found` diagnostics.
- `TESTNAME=inline_modules_cfg_test /Users/rahul/.cargo/bin/rustup run nightly-2026-06-25 cargo uitest`
- `TESTNAME=module_style/inline_mod /Users/rahul/.cargo/bin/rustup run nightly-2026-06-25 cargo uitest`
- `/Users/rahul/.cargo/bin/rustup run nightly-2026-06-25 cargo test -p clippy_utils`
- `/Users/rahul/.cargo/bin/rustup run nightly-2026-06-25 rustfmt --check clippy_utils/src/ast_utils/mod.rs tests/ui/inline_modules_cfg_test.rs`
- `git diff --check`

changelog: [`inline_modules`]: don't lint `#[cfg(test)]` inline modules in test builds
