### PR TITLE
Add required parentheses when the `needless_bool` suggestion is an operand

### DIFF
--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg};
+use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{
@@ -112,33 +112,34 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
             && !span_contains_comment(cx, e.span)
         {
             let reduce = |ret, not| {
-                let mut applicability = Applicability::MachineApplicable;
-                let snip = Sugg::hir_with_context(cx, cond, e.span.ctxt(), "<predicate>", &mut applicability);
-                let mut snip = if not { !snip } else { snip };
-
-                if ret {
-                    snip = snip.make_return();
-                }
-
-                if is_else_clause(cx.tcx, e) {
-                    snip = snip.blockify();
-                }
-
-                if (condition_needs_parentheses(cond) && is_parent_stmt(cx, e.hir_id))
-                    || is_receiver_of_method_call(cx, e)
-                    || is_as_argument(cx, e)
-                {
-                    snip = snip.maybe_paren();
-                }
-
-                span_lint_and_sugg(
+                span_lint_and_then(
                     cx,
                     NEEDLESS_BOOL,
                     e.span,
                     "this if-then-else expression returns a bool literal",
-                    "you can reduce it to",
-                    snip.to_string(),
-                    applicability,
+                    |diag| {
+                        let mut applicability = Applicability::MachineApplicable;
+                        let snip = Sugg::hir_with_context(cx, cond, e.span.ctxt(), "<predicate>", &mut applicability);
+                        let mut snip = if not { !snip } else { snip };
+
+                        if ret {
+                            snip = snip.make_return();
+                        }
+
+                        if is_else_clause(cx.tcx, e) {
+                            snip = snip.blockify();
+                        }
+
+                        if (condition_needs_parentheses(cond) && is_parent_stmt(cx, e.hir_id))
+                            || is_receiver_of_method_call(cx, e)
+                            || is_as_argument(cx, e)
+                            || is_operand_of_binary_or_unary(cx, e)
+                        {
+                            snip = snip.maybe_paren();
+                        }
+
+                        diag.span_suggestion(e.span, "you can reduce it to", snip.to_string(), applicability);
+                    },
                 );
             };
             if let Some(a) = fetch_bool_block(then)
@@ -230,4 +231,11 @@ fn fetch_assign<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<(&'tcx Expr<'tcx>, bool)
 
 fn is_as_argument(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
     matches!(get_parent_expr(cx, e).map(|e| e.kind), Some(ExprKind::Cast(_, _)))
+}
+
+fn is_operand_of_binary_or_unary(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
+    matches!(
+        get_parent_expr(cx, e).map(|e| e.kind),
+        Some(ExprKind::Binary(..) | ExprKind::Unary(..))
+    )
 }

--- a/tests/ui/needless_bool/fixable.fixed
+++ b/tests/ui/needless_bool/fixable.fixed
@@ -158,6 +158,24 @@ fn issue12846() {
     //~^ needless_bool
 }
 
+fn operands_need_parentheses() {
+    let a = true;
+    let b = false;
+    let z = true;
+
+    // parentheses are needed here
+    let _x = (a || b) && z;
+    //~^ needless_bool
+    let _x = (a || b) == z;
+    //~^ needless_bool
+    let _x = !(a || b);
+    //~^ needless_bool
+
+    // parentheses are not needed here
+    let _x = a && z;
+    //~^ needless_bool
+}
+
 fn wrongly_unmangled_macros() {
     macro_rules! test_expr {
         ($val:expr) => {

--- a/tests/ui/needless_bool/fixable.rs
+++ b/tests/ui/needless_bool/fixable.rs
@@ -218,6 +218,24 @@ fn issue12846() {
     //~^ needless_bool
 }
 
+fn operands_need_parentheses() {
+    let a = true;
+    let b = false;
+    let z = true;
+
+    // parentheses are needed here
+    let _x = if a || b { true } else { false } && z;
+    //~^ needless_bool
+    let _x = if a || b { true } else { false } == z;
+    //~^ needless_bool
+    let _x = !if a || b { true } else { false };
+    //~^ needless_bool
+
+    // parentheses are not needed here
+    let _x = if a { true } else { false } && z;
+    //~^ needless_bool
+}
+
 fn wrongly_unmangled_macros() {
     macro_rules! test_expr {
         ($val:expr) => {

--- a/tests/ui/needless_bool/fixable.stderr
+++ b/tests/ui/needless_bool/fixable.stderr
@@ -210,7 +210,31 @@ LL |     let _x = if a { true } else { false }.then(|| todo!());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `a`
 
 error: this if-then-else expression returns a bool literal
-  --> tests/ui/needless_bool/fixable.rs:229:5
+  --> tests/ui/needless_bool/fixable.rs:227:14
+   |
+LL |     let _x = if a || b { true } else { false } && z;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `(a || b)`
+
+error: this if-then-else expression returns a bool literal
+  --> tests/ui/needless_bool/fixable.rs:229:14
+   |
+LL |     let _x = if a || b { true } else { false } == z;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `(a || b)`
+
+error: this if-then-else expression returns a bool literal
+  --> tests/ui/needless_bool/fixable.rs:231:15
+   |
+LL |     let _x = !if a || b { true } else { false };
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `(a || b)`
+
+error: this if-then-else expression returns a bool literal
+  --> tests/ui/needless_bool/fixable.rs:235:14
+   |
+LL |     let _x = if a { true } else { false } && z;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `a`
+
+error: this if-then-else expression returns a bool literal
+  --> tests/ui/needless_bool/fixable.rs:247:5
    |
 LL | /     if test_expr!(x) {
 LL | |         true
@@ -219,5 +243,5 @@ LL | |         false
 LL | |     };
    | |_____^ help: you can reduce it to: `test_expr!(x)`
 
-error: aborting due to 25 previous errors
+error: aborting due to 29 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17347

`needless_bool` reduces `if cond { true } else { false }` to `cond`. The braces make the if-then-else a single unit, so when the whole expression is an operand of another operator the reduced form needs parentheses to keep the same grouping. Without them the automatic fix changes operator precedence and the meaning of the code. For example `if a || b { true } else { false } && z` was turned into `a || b && z`, which parses as `a || (b && z)` and no longer matches the original.

The suggestion already parenthesizes the reduced expression when it is the receiver of a method call or the operand of an `as` cast. This adds the same handling when the if-then-else is an operand of a binary or unary operator, so the examples above now suggest `(a || b)`.

changelog: [`needless_bool`]: add parentheses to the suggestion when the if-then-else is used as an operand of a binary or unary operator