### PR TITLE
Update `clippy_test_deps/Cargo.lock`

### DIFF
--- a/clippy_test_deps/Cargo.lock
+++ b/clippy_test_deps/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]


### PR DESCRIPTION
The corresponding `Cargo.toml` was updated in 9e2be9dcbc1e78390170564828c9cb025f0efe43.

changelog: none