### PR TITLE
`unnecessary_unwrap_unchecked`: don't trigger inside the `_unchecked` fn

### DIFF
--- a/clippy_lints/src/methods/unnecessary_unwrap_unchecked.rs
+++ b/clippy_lints/src/methods/unnecessary_unwrap_unchecked.rs
@@ -188,7 +188,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, recv: 
         return;
     }
     let expected_ret_ty = cx.typeck_results().expr_ty(expr);
-    let (variant, checked_span, unchecked_sugg, unchecked_full_path) = match recv.kind {
+    let (variant, checked_span, unchecked_sugg, unchecked_full_path, unchecked_def_id) = match recv.kind {
         // Construct `Variant::Fn(_)`, if applicable. This is necessary for us to handle
         // functions like `std::str::from_utf8_unchecked`.
         ExprKind::Call(path, _)
@@ -213,6 +213,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, recv: 
                     unchecked_ident.to_string()
                 },
                 unchecked_full_path,
+                unchecked_def_id,
             )
         },
         // We unfortunately must handle `A::a(&a)` and `a.a()` separately, this handles the
@@ -233,6 +234,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, recv: 
                 checked_ident.span,
                 unchecked_ident.to_string(),
                 unchecked_full_path,
+                unchecked.def_id,
             )
         },
         // ... And now the latter ^^
@@ -250,10 +252,16 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, recv: 
                 checked_ident.span,
                 unchecked_ident.to_string(),
                 unchecked_full_path,
+                unchecked.def_id,
             )
         },
         _ => return,
     };
+
+    // Do not lint from inside the `_unchecked` function itself
+    if unchecked_def_id.as_local() == Some(expr.hir_id.owner.def_id) {
+        return;
+    }
 
     if !is_from_proc_macro(cx, expr) {
         span_lint_and_then(cx, UNNECESSARY_UNWRAP_UNCHECKED, expr.span, variant.msg(), |diag| {

--- a/clippy_test_deps/Cargo.lock
+++ b/clippy_test_deps/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]

--- a/tests/ui/unnecessary_unwrap_unchecked.fixed
+++ b/tests/ui/unnecessary_unwrap_unchecked.fixed
@@ -102,3 +102,72 @@ fn main() {
         unsafe { std::str::from_utf8(&[]).unwrap_unchecked() };
     }
 }
+
+mod issue17349 {
+    pub enum Foo {
+        A,
+        B,
+        C,
+    }
+
+    impl Foo {
+        pub const fn from_u8(value: u8) -> Option<Self> {
+            match value {
+                0 => Some(Self::A),
+                1 => Some(Self::B),
+                2 => Some(Self::C),
+                _ => None,
+            }
+        }
+
+        /// # Safety
+        ///
+        /// The value must be either 0, 1 or 2
+        pub const unsafe fn from_u8_unchecked(value: u8) -> Self {
+            // Don't lint from inside the `_unchecked` associated function itself
+            unsafe { Self::from_u8(value).unwrap_unchecked() }
+        }
+
+        pub const fn to_bool(&self) -> Option<bool> {
+            match self {
+                Self::A => Some(false),
+                Self::B => Some(true),
+                Self::C => None,
+            }
+        }
+
+        /// # Safety
+        ///
+        /// The value must be either `Self::A` or `Self::B`
+        pub const unsafe fn to_bool_unchecked(&self) -> bool {
+            // Don't lint from inside the `_unchecked` method itself
+            unsafe { self.to_bool().unwrap_unchecked() }
+        }
+    }
+
+    pub const fn from_u8(value: u8) -> Option<Foo> {
+        Foo::from_u8(value)
+    }
+
+    /// # Safety
+    ///
+    /// The value must be either 0, 1 or 2
+    pub const unsafe fn from_u8_unchecked(value: u8) -> Foo {
+        // Don't lint from inside the `_unchecked` function itself
+        unsafe { from_u8(value).unwrap_unchecked() }
+    }
+
+    pub fn from_u16(value: u16) -> Option<Foo> {
+        Foo::from_u8(u8::try_from(value).ok()?)
+    }
+
+    /// # Safety
+    ///
+    /// The value must be either 0, 1 or 2
+    pub unsafe fn from_u16_unchecked(value: u16) -> Foo {
+        // Don't lint from inside the `_unchecked` function itself
+        // even in the presence of intermediate bodies.
+        let cl = || unsafe { from_u16(value).unwrap_unchecked() };
+        cl()
+    }
+}

--- a/tests/ui/unnecessary_unwrap_unchecked.rs
+++ b/tests/ui/unnecessary_unwrap_unchecked.rs
@@ -102,3 +102,72 @@ fn main() {
         unsafe { std::str::from_utf8(&[]).unwrap_unchecked() };
     }
 }
+
+mod issue17349 {
+    pub enum Foo {
+        A,
+        B,
+        C,
+    }
+
+    impl Foo {
+        pub const fn from_u8(value: u8) -> Option<Self> {
+            match value {
+                0 => Some(Self::A),
+                1 => Some(Self::B),
+                2 => Some(Self::C),
+                _ => None,
+            }
+        }
+
+        /// # Safety
+        ///
+        /// The value must be either 0, 1 or 2
+        pub const unsafe fn from_u8_unchecked(value: u8) -> Self {
+            // Don't lint from inside the `_unchecked` associated function itself
+            unsafe { Self::from_u8(value).unwrap_unchecked() }
+        }
+
+        pub const fn to_bool(&self) -> Option<bool> {
+            match self {
+                Self::A => Some(false),
+                Self::B => Some(true),
+                Self::C => None,
+            }
+        }
+
+        /// # Safety
+        ///
+        /// The value must be either `Self::A` or `Self::B`
+        pub const unsafe fn to_bool_unchecked(&self) -> bool {
+            // Don't lint from inside the `_unchecked` method itself
+            unsafe { self.to_bool().unwrap_unchecked() }
+        }
+    }
+
+    pub const fn from_u8(value: u8) -> Option<Foo> {
+        Foo::from_u8(value)
+    }
+
+    /// # Safety
+    ///
+    /// The value must be either 0, 1 or 2
+    pub const unsafe fn from_u8_unchecked(value: u8) -> Foo {
+        // Don't lint from inside the `_unchecked` function itself
+        unsafe { from_u8(value).unwrap_unchecked() }
+    }
+
+    pub fn from_u16(value: u16) -> Option<Foo> {
+        Foo::from_u8(u8::try_from(value).ok()?)
+    }
+
+    /// # Safety
+    ///
+    /// The value must be either 0, 1 or 2
+    pub unsafe fn from_u16_unchecked(value: u16) -> Foo {
+        // Don't lint from inside the `_unchecked` function itself
+        // even in the presence of intermediate bodies.
+        let cl = || unsafe { from_u16(value).unwrap_unchecked() };
+        cl()
+    }
+}


### PR DESCRIPTION
changelog:  [`unnecessary_unwrap_unchecked`]: don't trigger inside the `_unchecked` function itself

Fixes rust-lang/rust-clippy#17349 

<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [Backport to 1.98.0](https://github.com/rust-lang/rust-clippy/pull/17351#issuecomment-4881886915) by [samueltardieu](https://github.com/samueltardieu)

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->