### PR TITLE
Fix ICE when resolving local in `unnecessary_unwrap_unchecked`

### DIFF
--- a/clippy_lints/src/methods/unnecessary_unwrap_unchecked.rs
+++ b/clippy_lints/src/methods/unnecessary_unwrap_unchecked.rs
@@ -194,7 +194,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, recv: 
         ExprKind::Call(path, _)
             if let ExprKind::Path(qpath) = path.kind
                 && let checked_ident = last_path_segment(&qpath).ident
-                && let checked_def_id = path.res(cx).def_id()
+                && let Some(checked_def_id) = path.res(cx).opt_def_id()
                 && let Some((unchecked_def_id, unchecked_ident)) =
                     find_unchecked_sibling_fn(cx, checked_def_id, checked_ident)
                 && same_functions_modulo_safety(cx, checked_def_id, unchecked_def_id, expected_ret_ty) =>
@@ -220,7 +220,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, recv: 
         ExprKind::Call(path, _)
             if let ExprKind::Path(qpath) = path.kind
                 && let checked_ident = last_path_segment(&qpath).ident
-                && let checked_def_id = path.res(cx).def_id()
+                && let Some(checked_def_id) = path.res(cx).opt_def_id()
                 && let Some((unchecked, unchecked_ident)) =
                     find_unchecked_sibling_method(cx, checked_def_id, checked_ident)
                 && let ty::AssocKind::Fn { has_self, .. } = unchecked.kind

--- a/tests/ui/crashes/ice-17352.rs
+++ b/tests/ui/crashes/ice-17352.rs
@@ -1,0 +1,6 @@
+//@ check-pass
+#![warn(clippy::unnecessary_unwrap_unchecked)]
+
+fn issue17352(x: impl Fn() -> Option<u32>) {
+    _ = unsafe { x().unwrap_unchecked() };
+}


### PR DESCRIPTION
changelog: [`unnecessary_unwrap_unchecked`]: fix ICE when resolving path to local variable

Fixes rust-lang/rust-clippy#17352 

<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [Backport to 1.98.0](https://github.com/rust-lang/rust-clippy/pull/17353#issuecomment-4881942074) by [samueltardieu](https://github.com/samueltardieu)

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->