### PR TITLE
Fix `manual_c_str_literals` suggestion when the trailing backslash is escaped

### DIFF
--- a/clippy_lints/src/methods/manual_c_str_literals.rs
+++ b/clippy_lints/src/methods/manual_c_str_literals.rs
@@ -31,7 +31,7 @@ pub(super) fn check_as_ptr<'tcx>(
         && !get_parent_expr(cx, casts_removed).is_some_and(
             |parent| matches!(parent.kind, ExprKind::Call(func, _) if is_c_str_function(cx, func).is_some()),
         )
-        && let Some(sugg) = rewrite_as_cstr(cx, lit.span)
+        && let Some(sugg) = rewrite_as_cstr(cx, lit.span, lit.node)
         && msrv.meets(cx, msrvs::C_STR_LITERALS)
     {
         span_lint_and_sugg(
@@ -77,7 +77,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, func: &Expr<'_>, args
                     && let ExprKind::Lit(lit) = arg.kind
                     && let LitKind::ByteStr(_, StrStyle::Cooked) | LitKind::Str(_, StrStyle::Cooked) = lit.node =>
             {
-                check_from_bytes(cx, expr, arg, fn_name);
+                check_from_bytes(cx, expr, arg, lit.node, fn_name);
             },
             sym::from_ptr => check_from_ptr(cx, expr, arg),
             _ => {},
@@ -92,7 +92,7 @@ fn check_from_ptr(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>) {
         && !lit.span.from_expansion()
         && let ExprKind::Lit(lit) = lit.kind
         && let LitKind::ByteStr(_, StrStyle::Cooked) = lit.node
-        && let Some(sugg) = rewrite_as_cstr(cx, lit.span)
+        && let Some(sugg) = rewrite_as_cstr(cx, lit.span, lit.node)
     {
         span_lint_and_sugg(
             cx,
@@ -106,7 +106,7 @@ fn check_from_ptr(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>) {
     }
 }
 /// Checks `CStr::from_bytes_with_nul(b"foo\0")`
-fn check_from_bytes(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, method: Symbol) {
+fn check_from_bytes(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, lit: LitKind, method: Symbol) {
     let (span, applicability) = if let Some(parent) = get_parent_expr(cx, expr)
         && let ExprKind::MethodCall(method, ..) = parent.kind
         && [sym::unwrap, sym::expect].contains(&method.ident.name)
@@ -120,7 +120,7 @@ fn check_from_bytes(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, metho
         (expr.span, Applicability::HasPlaceholders)
     };
 
-    let Some(sugg) = rewrite_as_cstr(cx, arg.span) else {
+    let Some(sugg) = rewrite_as_cstr(cx, arg.span, lit) else {
         return;
     };
 
@@ -139,7 +139,11 @@ fn check_from_bytes(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, metho
 /// `b"foo\0"` -> `c"foo"`
 ///
 /// Returns `None` if it doesn't end in a NUL byte.
-fn rewrite_as_cstr(cx: &LateContext<'_>, span: Span) -> Option<String> {
+fn rewrite_as_cstr(cx: &LateContext<'_>, span: Span, lit: LitKind) -> Option<String> {
+    if !is_nul_terminated(lit) {
+        return None;
+    }
+
     let mut sugg = String::from("c") + snippet(cx, span.source_callsite(), "..").trim_start_matches('b');
 
     // NUL byte should always be right before the closing quote.
@@ -164,6 +168,16 @@ fn rewrite_as_cstr(cx: &LateContext<'_>, span: Span) -> Option<String> {
     }
 
     Some(sugg)
+}
+
+/// Checks whether the `ByteString` or `String` literal ends with a `NUL` character
+fn is_nul_terminated(lit: LitKind) -> bool {
+    match lit {
+        LitKind::ByteStr(content, _) => content.as_byte_str().last() == Some(&0),
+        // In UTF-8, no multi-byte character can contain a NUL byte
+        LitKind::Str(content, _) => content.as_str().as_bytes().last() == Some(&0),
+        _ => false,
+    }
 }
 
 fn get_cast_target<'tcx>(e: &'tcx Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {

--- a/tests/ui/manual_c_str_literals.edition2021.fixed
+++ b/tests/ui/manual_c_str_literals.edition2021.fixed
@@ -45,6 +45,8 @@ fn main() {
     //~[edition2021]^ manual_c_str_literals
     c"foo\\0sdsd";
     //~[edition2021]^ manual_c_str_literals
+    CStr::from_bytes_with_nul(b"foo\\0").unwrap();
+    CStr::from_bytes_with_nul(b"bar\\x00").unwrap();
     CStr::from_bytes_with_nul(br"foo\\0sdsd\0").unwrap();
     CStr::from_bytes_with_nul(br"foo\x00").unwrap();
     CStr::from_bytes_with_nul(br##"foo#a\0"##).unwrap();
@@ -53,8 +55,12 @@ fn main() {
     //~[edition2021]^ manual_c_str_literals
     unsafe { c"foo" };
     //~[edition2021]^ manual_c_str_literals
+    unsafe { CStr::from_ptr(b"foo\\0".as_ptr().cast()) };
+    unsafe { CStr::from_ptr(b"bar\\x00".as_ptr().cast()) };
     let _: *const _ = c"foo".as_ptr();
     //~[edition2021]^ manual_c_str_literals
+    let _: *const _ = b"foo\\0".as_ptr();
+    let _: *const _ = b"bar\\x00".as_ptr();
     let _: *const _ = c"foo".as_ptr();
     //~[edition2021]^ manual_c_str_literals
     let _: *const _ = "foo".as_ptr(); // not a C-string

--- a/tests/ui/manual_c_str_literals.edition2021.stderr
+++ b/tests/ui/manual_c_str_literals.edition2021.stderr
@@ -32,49 +32,49 @@ LL |     CStr::from_bytes_with_nul(b"foo\\0sdsd\0").unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"foo\\0sdsd"`
 
 error: calling `CStr::from_ptr` with a byte string literal
-  --> tests/ui/manual_c_str_literals.rs:52:14
+  --> tests/ui/manual_c_str_literals.rs:54:14
    |
 LL |     unsafe { CStr::from_ptr(b"foo\0".as_ptr().cast()) };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"foo"`
 
 error: calling `CStr::from_ptr` with a byte string literal
-  --> tests/ui/manual_c_str_literals.rs:54:14
+  --> tests/ui/manual_c_str_literals.rs:56:14
    |
 LL |     unsafe { CStr::from_ptr(b"foo\0".as_ptr() as *const _) };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"foo"`
 
 error: manually constructing a nul-terminated string
-  --> tests/ui/manual_c_str_literals.rs:56:23
+  --> tests/ui/manual_c_str_literals.rs:60:23
    |
 LL |     let _: *const _ = b"foo\0".as_ptr();
    |                       ^^^^^^^^ help: use a `c""` literal: `c"foo"`
 
 error: manually constructing a nul-terminated string
-  --> tests/ui/manual_c_str_literals.rs:58:23
+  --> tests/ui/manual_c_str_literals.rs:64:23
    |
 LL |     let _: *const _ = "foo\0".as_ptr();
    |                       ^^^^^^^ help: use a `c""` literal: `c"foo"`
 
 error: manually constructing a nul-terminated string
-  --> tests/ui/manual_c_str_literals.rs:62:23
+  --> tests/ui/manual_c_str_literals.rs:68:23
    |
 LL |     let _: *const _ = b"foo\0".as_ptr().cast::<i8>();
    |                       ^^^^^^^^ help: use a `c""` literal: `c"foo"`
 
 error: manually constructing a nul-terminated string
-  --> tests/ui/manual_c_str_literals.rs:66:13
+  --> tests/ui/manual_c_str_literals.rs:72:13
    |
 LL |     let _ = "电脑\\\0".as_ptr();
    |             ^^^^^^^^^^ help: use a `c""` literal: `c"电脑\\"`
 
 error: manually constructing a nul-terminated string
-  --> tests/ui/manual_c_str_literals.rs:68:13
+  --> tests/ui/manual_c_str_literals.rs:74:13
    |
 LL |     let _ = "电脑\0".as_ptr();
    |             ^^^^^^^^ help: use a `c""` literal: `c"电脑"`
 
 error: manually constructing a nul-terminated string
-  --> tests/ui/manual_c_str_literals.rs:70:13
+  --> tests/ui/manual_c_str_literals.rs:76:13
    |
 LL |     let _ = "电脑\x00".as_ptr();
    |             ^^^^^^^^^^ help: use a `c""` literal: `c"电脑"`

--- a/tests/ui/manual_c_str_literals.rs
+++ b/tests/ui/manual_c_str_literals.rs
@@ -45,6 +45,8 @@ fn main() {
     //~[edition2021]^ manual_c_str_literals
     CStr::from_bytes_with_nul(b"foo\\0sdsd\0").unwrap();
     //~[edition2021]^ manual_c_str_literals
+    CStr::from_bytes_with_nul(b"foo\\0").unwrap();
+    CStr::from_bytes_with_nul(b"bar\\x00").unwrap();
     CStr::from_bytes_with_nul(br"foo\\0sdsd\0").unwrap();
     CStr::from_bytes_with_nul(br"foo\x00").unwrap();
     CStr::from_bytes_with_nul(br##"foo#a\0"##).unwrap();
@@ -53,8 +55,12 @@ fn main() {
     //~[edition2021]^ manual_c_str_literals
     unsafe { CStr::from_ptr(b"foo\0".as_ptr() as *const _) };
     //~[edition2021]^ manual_c_str_literals
+    unsafe { CStr::from_ptr(b"foo\\0".as_ptr().cast()) };
+    unsafe { CStr::from_ptr(b"bar\\x00".as_ptr().cast()) };
     let _: *const _ = b"foo\0".as_ptr();
     //~[edition2021]^ manual_c_str_literals
+    let _: *const _ = b"foo\\0".as_ptr();
+    let _: *const _ = b"bar\\x00".as_ptr();
     let _: *const _ = "foo\0".as_ptr();
     //~[edition2021]^ manual_c_str_literals
     let _: *const _ = "foo".as_ptr(); // not a C-string


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17357

`manual_c_str_literals` rewrites a nul-terminated byte string literal into a `c"..."` literal by stripping the trailing NUL from the source text. It decided that a text ending in `\0` or `\x00` was a NUL terminator, without checking whether that backslash was itself escaped. For a literal like `b"foo\\0"`, which is `foo` followed by a backslash and the digit `0` and does not end in a NUL byte, it still stripped the last characters and produced `c"foo\"`, which does not compile.

It now checks the parsed literal first and only offers the rewrite when the byte string actually ends in a NUL byte, so literals that do not end in a NUL are left alone.

changelog: [`manual_c_str_literals`]: don't emit a non-compiling suggestion for a byte string ending in an escaped backslash