### PR TITLE
Rewrite `min_ident_chars`

### DIFF
--- a/clippy_lints/src/min_ident_chars.rs
+++ b/clippy_lints/src/min_ident_chars.rs
@@ -1,18 +1,18 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::span_lint;
+use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::is_from_proc_macro;
+use core::iter;
+use core::num::NonZero;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_hir::def::{DefKind, Res};
-use rustc_hir::intravisit::{Visitor, walk_item, walk_trait_item};
+use rustc_errors::pluralize;
 use rustc_hir::{
-    GenericParamKind, HirId, Impl, ImplItem, ImplItemImplKind, ImplItemKind, Item, ItemKind, ItemLocalId, Node, Pat,
-    PatKind, TraitItem, UsePath,
+    FieldDef, HirId, ImplItem, ImplItemImplKind, ImplItemKind, Item, ItemKind, Node, Pat, PatKind, TraitFn, TraitItem,
+    TraitItemKind, UseKind, Variant,
 };
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
-use rustc_span::symbol::Ident;
-use rustc_span::{Span, Symbol};
-use std::borrow::Cow;
+use rustc_span::{Ident, Symbol};
+use std::borrow::Cow::{self, Borrowed, Owned};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -50,234 +50,185 @@ impl_lint_pass!(MinIdentChars => [MIN_IDENT_CHARS]);
 
 pub struct MinIdentChars {
     allowed_idents_below_min_chars: FxHashSet<String>,
-    min_ident_chars_threshold: u64,
+    min_chars_threshold: u64,
+    /// The number of parameter bindings which still need to be skipped for the current
+    /// function.
+    ///
+    /// Impl trait functions have special rules are handled in `check_impl_item` since
+    /// they have special rules. This is used to signal to `check_pat` the number of parameter
+    current_fn_params_remaining: u32,
 }
 
 impl MinIdentChars {
     pub fn new(conf: &'static Conf) -> Self {
         Self {
             allowed_idents_below_min_chars: conf.allowed_idents_below_min_chars.iter().cloned().collect(),
-            min_ident_chars_threshold: conf.min_ident_chars_threshold,
+            min_chars_threshold: conf.min_ident_chars_threshold,
+            current_fn_params_remaining: 0,
         }
     }
 
     #[expect(clippy::cast_possible_truncation)]
-    fn is_ident_too_short(&self, cx: &LateContext<'_>, str: &str, span: Span) -> bool {
-        !span.in_external_macro(cx.sess().source_map())
-            && str.len() <= self.min_ident_chars_threshold as usize
-            && !str.starts_with('_')
-            && !str.is_empty()
-            && !self.allowed_idents_below_min_chars.contains(str)
+    fn check_sym(&self, s: Symbol) -> Option<NonZero<usize>> {
+        let s = s.as_str();
+        if s.len() / 4 <= self.min_chars_threshold as usize
+            && !s.starts_with('_')
+            && !self.allowed_idents_below_min_chars.contains(s)
+            && let len = s.chars().count()
+            && let Some(missing) = (self.min_chars_threshold as usize).checked_sub(len)
+        {
+            NonZero::new(missing + 1)
+        } else {
+            None
+        }
+    }
+
+    fn lint_msg(&self, missing: NonZero<usize>) -> Cow<'static, str> {
+        if self.min_chars_threshold == 1 {
+            Borrowed("this identifier consists of only a single character")
+        } else {
+            let n = missing.get();
+            Owned(format!("this identifier is {n} character{} too short", pluralize!(n)))
+        }
+    }
+
+    fn emit(&self, cx: &LateContext<'_>, ident: Ident, missing: NonZero<usize>) {
+        if !ident.span.in_external_macro(cx.tcx.sess.source_map()) && !is_from_proc_macro(cx, &ident) {
+            span_lint_and_then(cx, MIN_IDENT_CHARS, ident.span, self.lint_msg(missing), |diag| {
+                // FIXME(@Jarcho): Capture a span from the config and point to it here.
+                if self.min_chars_threshold != 1 {
+                    diag.note_once(format!("the configured threshold is {}", self.min_chars_threshold));
+                }
+            });
+        }
+    }
+
+    fn emit_hir(&self, cx: &LateContext<'_>, id: HirId, ident: Ident, missing: NonZero<usize>) {
+        if !ident.span.in_external_macro(cx.tcx.sess.source_map()) && !is_from_proc_macro(cx, &ident) {
+            span_lint_hir_and_then(cx, MIN_IDENT_CHARS, id, ident.span, self.lint_msg(missing), |diag| {
+                diag.note_once(format!("the configured threshold is {}", self.min_chars_threshold));
+            });
+        }
     }
 }
 
 impl LateLintPass<'_> for MinIdentChars {
-    fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
-        if self.min_ident_chars_threshold == 0 {
+    fn check_item(&mut self, cx: &LateContext<'_>, i: &Item<'_>) {
+        if self.min_chars_threshold == 0 {
             return;
         }
+        let ident = match i.kind {
+            ItemKind::Const(ident, ..)
+            | ItemKind::Enum(ident, ..)
+            | ItemKind::ExternCrate(None, ident)
+            | ItemKind::Fn { ident, .. }
+            | ItemKind::Macro(ident, ..)
+            | ItemKind::Mod(ident, _)
+            | ItemKind::Static(_, ident, ..)
+            | ItemKind::Struct(ident, ..)
+            | ItemKind::Trait { ident, .. }
+            | ItemKind::TraitAlias(_, ident, ..)
+            | ItemKind::TyAlias(ident, ..)
+            | ItemKind::Union(ident, ..) => ident,
+            ItemKind::Use(path, UseKind::Single(ident))
+                if path.segments.last().is_some_and(|p| p.ident.span != ident.span) =>
+            {
+                ident
+            },
 
-        walk_item(&mut IdentVisitor { conf: self, cx }, item);
+            ItemKind::ExternCrate(..)
+            | ItemKind::ForeignMod { .. }
+            | ItemKind::GlobalAsm { .. }
+            | ItemKind::Impl(_)
+            | ItemKind::Use(..) => return,
+        };
+        if let Some(missing) = self.check_sym(ident.name)
+            && !(matches!(i.kind, ItemKind::Fn { .. })
+                && cx.tcx.codegen_fn_attrs(i.owner_id.def_id).contains_extern_indicator())
+        {
+            self.emit(cx, ident, missing);
+        }
     }
 
-    fn check_trait_item(&mut self, cx: &LateContext<'_>, item: &TraitItem<'_>) {
-        if self.min_ident_chars_threshold == 0 {
+    fn check_trait_item(&mut self, cx: &LateContext<'_>, i: &TraitItem<'_>) {
+        if self.min_chars_threshold == 0 {
             return;
         }
-
-        // If the function is declared but not defined in a trait, check_pat isn't called so we need to
-        // check this explicitly
-        if matches!(&item.kind, rustc_hir::TraitItemKind::Fn(_, _)) {
-            let param_names = cx.tcx.fn_arg_idents(item.owner_id.to_def_id());
-            for ident in param_names.iter().flatten() {
-                let str = ident.as_str();
-                if self.is_ident_too_short(cx, str, ident.span) {
-                    emit_min_ident_chars(self, cx, str, ident.span);
+        if let TraitItemKind::Fn(_, TraitFn::Required(idents)) = i.kind {
+            for &ident in idents {
+                if let Some(ident) = ident
+                    && let Some(missing) = self.check_sym(ident.name)
+                {
+                    self.emit(cx, ident, missing);
                 }
             }
         }
-
-        walk_trait_item(&mut IdentVisitor { conf: self, cx }, item);
+        if let Some(missing) = self.check_sym(i.ident.name)
+            && !(matches!(i.kind, TraitItemKind::Fn(_, TraitFn::Provided(_)))
+                && cx.tcx.codegen_fn_attrs(i.owner_id.def_id).contains_extern_indicator())
+        {
+            self.emit(cx, i.ident, missing);
+        }
     }
 
-    // This is necessary as `Node::Pat`s are not visited in `visit_id`. :/
+    fn check_impl_item(&mut self, cx: &LateContext<'_>, i: &ImplItem<'_>) {
+        if self.min_chars_threshold == 0 {
+            return;
+        }
+        if let ImplItemImplKind::Trait {
+            trait_item_def_id: Ok(trait_item),
+            ..
+        } = i.impl_kind
+        {
+            // For trait impls only lint if the parameter names are different from the trait's.
+            if let ImplItemKind::Fn(_, body) = i.kind {
+                let mut named_params_count = 0;
+                for (trait_ident, param) in iter::zip(cx.tcx.fn_arg_idents(trait_item), cx.tcx.hir_body(body).params) {
+                    if let PatKind::Binding(_, _, ident, _) = param.pat.kind {
+                        named_params_count += 1;
+                        if trait_ident.is_none_or(|trait_ident| ident.name != trait_ident.name)
+                            && let Some(missing) = self.check_sym(ident.name)
+                        {
+                            self.emit_hir(cx, param.pat.hir_id, ident, missing);
+                        }
+                    }
+                }
+                // Signal the number of parameters to skip to `check_pat`.
+                // This needs to be added since impl items can technically appear inside
+                // both the function signature and generic predicates.
+                self.current_fn_params_remaining += named_params_count;
+            }
+        } else if let Some(missing) = self.check_sym(i.ident.name)
+            && !(matches!(i.kind, ImplItemKind::Fn(..))
+                && cx.tcx.codegen_fn_attrs(i.owner_id.def_id).contains_extern_indicator())
+        {
+            self.emit(cx, i.ident, missing);
+        }
+    }
+
+    fn check_field_def(&mut self, cx: &LateContext<'_>, f: &FieldDef<'_>) {
+        if let Some(missing) = self.check_sym(f.ident.name) {
+            self.emit(cx, f.ident, missing);
+        }
+    }
+
+    fn check_variant(&mut self, cx: &LateContext<'_>, v: &Variant<'_>) {
+        if let Some(missing) = self.check_sym(v.ident.name) {
+            self.emit(cx, v.ident, missing);
+        }
+    }
+
     fn check_pat(&mut self, cx: &LateContext<'_>, pat: &Pat<'_>) {
         if let PatKind::Binding(_, _, ident, ..) = pat.kind
-            && let str = ident.as_str()
-            && self.is_ident_too_short(cx, str, ident.span)
-            && is_not_in_trait_impl(cx, pat, ident)
+            && self.min_chars_threshold != 0
         {
-            emit_min_ident_chars(self, cx, str, ident.span);
+            if self.current_fn_params_remaining != 0
+                && let Node::Param(_) = cx.tcx.parent_hir_node(pat.hir_id)
+            {
+                self.current_fn_params_remaining -= 1;
+            } else if let Some(missing) = self.check_sym(ident.name) {
+                self.emit(cx, ident, missing);
+            }
         }
     }
-}
-
-struct IdentVisitor<'cx, 'tcx> {
-    conf: &'cx MinIdentChars,
-    cx: &'cx LateContext<'tcx>,
-}
-
-impl Visitor<'_> for IdentVisitor<'_, '_> {
-    fn visit_id(&mut self, hir_id: HirId) {
-        let Self { conf, cx } = *self;
-        // FIXME(#112534) Reimplementation of `find`, as it uses indexing, which can (and will in
-        // async functions, or really anything async) panic. This should probably be fixed on the
-        // rustc side, this is just a temporary workaround.
-        let node = if hir_id.local_id == ItemLocalId::from_u32(0) {
-            // In this case, we can just use `find`, `Owner`'s `node` field is private anyway so we can't
-            // reimplement it even if we wanted to
-            Some(cx.tcx.hir_node(hir_id))
-        } else {
-            let owner = cx.tcx.hir_owner_nodes(hir_id.owner);
-            owner.nodes.get(hir_id.local_id).copied().map(|p| p.node)
-        };
-        let Some(node) = node else {
-            return;
-        };
-        let Some(ident) = node.ident() else {
-            return;
-        };
-
-        let str = ident.as_str();
-        if conf.is_ident_too_short(cx, str, ident.span) {
-            // Check whether the node is part of a `impl` for a trait.
-            if matches!(cx.tcx.parent_hir_node(hir_id), Node::TraitRef(_)) {
-                return;
-            }
-
-            // Check whether the node is part of a `use` statement. We don't want to emit a warning if the user
-            // has no control over the type.
-            let usenode = opt_as_use_node(node).or_else(|| {
-                cx.tcx
-                    .hir_parent_iter(hir_id)
-                    .find_map(|(_, node)| opt_as_use_node(node))
-            });
-
-            // If the name of the identifier is the same as the one of the imported item, this means that we
-            // found a `use foo::bar`. We can early-return to not emit the warning.
-            // If however the identifier is different, this means it is an alias (`use foo::bar as baz`). In
-            // this case, we need to emit the warning for `baz`.
-            if let Some(imported_item_path) = usenode
-                // use `present_items` because it could be in any of type_ns, value_ns, macro_ns
-                && let Some(Res::Def(_, imported_item_defid)) = imported_item_path.res.value_ns
-                && cx.tcx.item_name(imported_item_defid).as_str() == str
-            {
-                return;
-            }
-
-            // `struct Array<T, const N: usize>([T; N])`
-            //                                   ^  ^
-            if let Node::PathSegment(path) = node {
-                if let Res::Def(def_kind, ..) = path.res
-                    && let DefKind::TyParam | DefKind::ConstParam = def_kind
-                {
-                    return;
-                }
-                if matches!(path.res, Res::PrimTy(..)) || path.res.opt_def_id().is_some_and(|def_id| !def_id.is_local())
-                {
-                    return;
-                }
-            }
-            // `struct Awa<T>(T)`
-            //             ^
-            if let Node::GenericParam(generic_param) = node
-                && let GenericParamKind::Type { .. } = generic_param.kind
-            {
-                return;
-            }
-
-            // `struct Array<T, const N: usize>([T; N])`
-            //                        ^
-            if let Node::GenericParam(generic_param) = node
-                && let GenericParamKind::Const { .. } = generic_param.kind
-            {
-                return;
-            }
-
-            if is_from_proc_macro(cx, &ident) {
-                return;
-            }
-
-            emit_min_ident_chars(conf, cx, str, ident.span);
-        }
-    }
-}
-
-fn emit_min_ident_chars(conf: &MinIdentChars, cx: &impl LintContext, ident: &str, span: Span) {
-    let help = if conf.min_ident_chars_threshold == 1 {
-        Cow::Borrowed("this ident consists of a single char")
-    } else {
-        Cow::Owned(format!(
-            "this ident is too short ({} <= {})",
-            ident.len(),
-            conf.min_ident_chars_threshold,
-        ))
-    };
-    span_lint(cx, MIN_IDENT_CHARS, span, help);
-}
-
-/// Attempt to convert the node to an [`ItemKind::Use`] node.
-///
-/// If it is, return the [`UsePath`] contained within.
-fn opt_as_use_node(node: Node<'_>) -> Option<&'_ UsePath<'_>> {
-    if let Node::Item(item) = node
-        && let ItemKind::Use(path, _) = item.kind
-    {
-        Some(path)
-    } else {
-        None
-    }
-}
-
-/// Check if a pattern is a function param in an impl block for a trait and that the param name is
-/// the same than in the trait definition.
-fn is_not_in_trait_impl(cx: &LateContext<'_>, pat: &Pat<'_>, ident: Ident) -> bool {
-    let parent_node = cx.tcx.parent_hir_node(pat.hir_id);
-    if !matches!(parent_node, Node::Param(_)) {
-        return true;
-    }
-
-    for (_, parent_node) in cx.tcx.hir_parent_iter(pat.hir_id) {
-        if let Node::ImplItem(impl_item) = parent_node
-            && matches!(impl_item.kind, ImplItemKind::Fn(_, _))
-        {
-            let impl_parent_node = cx.tcx.parent_hir_node(impl_item.hir_id());
-            if let Node::Item(parent_item) = impl_parent_node
-                && let ItemKind::Impl(Impl { of_trait: Some(_), .. }) = &parent_item.kind
-                && let Some(name) = get_param_name(impl_item, cx, ident)
-            {
-                return name != ident.name;
-            }
-
-            return true;
-        }
-    }
-
-    true
-}
-
-fn get_param_name(impl_item: &ImplItem<'_>, cx: &LateContext<'_>, ident: Ident) -> Option<Symbol> {
-    if let ImplItemImplKind::Trait {
-        trait_item_def_id: Ok(trait_item_def_id),
-        ..
-    } = impl_item.impl_kind
-    {
-        let trait_param_names = cx.tcx.fn_arg_idents(trait_item_def_id);
-
-        let ImplItemKind::Fn(_, body_id) = impl_item.kind else {
-            return None;
-        };
-
-        if let Some(param_index) = cx
-            .tcx
-            .hir_body_param_idents(body_id)
-            .position(|param_ident| param_ident.is_some_and(|param_ident| param_ident.span == ident.span))
-            && let Some(trait_param_name) = trait_param_names.get(param_index)
-            && let Some(trait_param_ident) = trait_param_name
-        {
-            return Some(trait_param_ident.name);
-        }
-    }
-
-    None
 }

--- a/tests/ui-toml/min_ident_chars/min_ident_chars.stderr
+++ b/tests/ui-toml/min_ident_chars/min_ident_chars.stderr
@@ -1,49 +1,50 @@
-error: this ident is too short (1 <= 3)
+error: this identifier is 3 characters too short
   --> tests/ui-toml/min_ident_chars/min_ident_chars.rs:6:41
    |
 LL | use extern_types::{Aaa, LONGER, M, N as W};
    |                                         ^
    |
+   = note: the configured threshold is 3
    = note: `-D clippy::min-ident-chars` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::min_ident_chars)]`
 
-error: this ident is too short (1 <= 3)
+error: this identifier is 3 characters too short
   --> tests/ui-toml/min_ident_chars/min_ident_chars.rs:9:11
    |
 LL | pub const N: u32 = 0;
    |           ^
 
-error: this ident is too short (3 <= 3)
+error: this identifier is 1 character too short
   --> tests/ui-toml/min_ident_chars/min_ident_chars.rs:15:5
    |
 LL |     aaa: Aaa,
    |     ^^^
 
-error: this ident is too short (3 <= 3)
+error: this identifier is 1 character too short
   --> tests/ui-toml/min_ident_chars/min_ident_chars.rs:21:9
    |
 LL |     let vvv = 1;
    |         ^^^
 
-error: this ident is too short (3 <= 3)
+error: this identifier is 1 character too short
   --> tests/ui-toml/min_ident_chars/min_ident_chars.rs:23:9
    |
 LL |     let uuu = 1;
    |         ^^^
 
-error: this ident is too short (1 <= 3)
+error: this identifier is 3 characters too short
   --> tests/ui-toml/min_ident_chars/min_ident_chars.rs:25:14
    |
 LL |     let (mut a, mut b) = (1, 2);
    |              ^
 
-error: this ident is too short (1 <= 3)
+error: this identifier is 3 characters too short
   --> tests/ui-toml/min_ident_chars/min_ident_chars.rs:25:21
    |
 LL |     let (mut a, mut b) = (1, 2);
    |                     ^
 
-error: this ident is too short (1 <= 3)
+error: this identifier is 3 characters too short
   --> tests/ui-toml/min_ident_chars/min_ident_chars.rs:28:9
    |
 LL |     for i in 0..1000 {}

--- a/tests/ui/min_ident_chars.rs
+++ b/tests/ui/min_ident_chars.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::min_ident_chars)]
 #![expect(irrefutable_let_patterns, nonstandard_style)]
-#![allow(clippy::struct_field_names)]
+#![allow(non_local_definitions, clippy::struct_field_names)]
 
 extern crate proc_macros;
 use proc_macros::{external, with_span};
@@ -173,3 +173,38 @@ impl D for Issue13396 {
     }
     fn long(long: i32) {}
 }
+
+const _: () = {
+    trait A {
+        //~^ min_ident_chars
+        fn f(h: [u32; 0]);
+        //~^ min_ident_chars
+        //~| min_ident_chars
+    }
+    impl A for () {
+        fn f(
+            h: [u32; {
+                impl A for u32 {
+                    fn f(
+                        h: [u32; {
+                            impl A for i32 {
+                                fn f(h: [u32; 0]) {
+                                    let h = 0; //~ min_ident_chars
+                                }
+                            }
+                            let h = 0; //~ min_ident_chars
+                            0
+                        }],
+                    ) {
+                        let h = 0; //~ min_ident_chars
+                    }
+                }
+                let h = 0; //~ min_ident_chars
+                0
+            }],
+        ) {
+            let h = 0; //~ min_ident_chars
+        }
+    }
+    let h = 0; //~ min_ident_chars
+};

--- a/tests/ui/min_ident_chars.stderr
+++ b/tests/ui/min_ident_chars.stderr
@@ -1,4 +1,4 @@
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:9:8
    |
 LL | struct A {
@@ -7,269 +7,325 @@ LL | struct A {
    = note: `-D clippy::min-ident-chars` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::min_ident_chars)]`
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:11:5
    |
 LL |     a: u32,
    |     ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:14:5
    |
 LL |     A: u32,
    |     ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:16:5
    |
 LL |     I: u32,
    |     ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:20:8
    |
 LL | struct B(u32);
    |        ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:23:8
    |
 LL | struct O {
    |        ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:25:5
    |
 LL |     o: u32,
    |     ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:31:6
    |
 LL | enum C {
    |      ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:33:5
    |
 LL |     D,
    |     ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:35:5
    |
 LL |     E,
    |     ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:37:5
    |
 LL |     F,
    |     ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:52:11
    |
 LL |     const A: u32 = 0;
    |           ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:54:10
    |
 LL |     type A;
    |          ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:56:8
    |
 LL |     fn a() {}
    |        ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:71:9
    |
 LL |     let h = 1;
    |         ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:73:9
    |
 LL |     let e = 2;
    |         ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:75:9
    |
 LL |     let l = 3;
    |         ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:77:9
    |
 LL |     let l = 4;
    |         ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:79:9
    |
 LL |     let o = 6;
    |         ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:84:10
    |
 LL |     let (h, o, w) = (1, 2, 3);
    |          ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:84:13
    |
 LL |     let (h, o, w) = (1, 2, 3);
    |             ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:87:10
    |
 LL |     for (a, (r, e)) in (0..1000).enumerate().enumerate() {}
    |          ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:87:14
    |
 LL |     for (a, (r, e)) in (0..1000).enumerate().enumerate() {}
    |              ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:87:17
    |
 LL |     for (a, (r, e)) in (0..1000).enumerate().enumerate() {}
    |                 ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:92:16
    |
 LL |     while let (d, o, _i, n, g) = (true, true, false, false, true) {}
    |                ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:92:19
    |
 LL |     while let (d, o, _i, n, g) = (true, true, false, false, true) {}
    |                   ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:92:29
    |
 LL |     while let (d, o, _i, n, g) = (true, true, false, false, true) {}
    |                             ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:99:9
    |
 LL |     let o = 1;
    |         ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:101:9
    |
 LL |     let o = O { o };
    |         ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:116:4
    |
 LL | fn b() {}
    |    ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:118:21
    |
 LL | fn wrong_pythagoras(a: f32, b: f32) -> f32 {
    |                     ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:118:29
    |
 LL | fn wrong_pythagoras(a: f32, b: f32) -> f32 {
    |                             ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:137:19
    |
 LL |     fn fmt(&self, g: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
    |                   ^
+   |
+   = note: the configured threshold is 1
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:144:14
    |
 LL |     let a = |f: i8| f;
    |              ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:144:9
    |
 LL |     let a = |f: i8| f;
    |         ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:149:7
    |
 LL | trait D {
    |       ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:151:10
    |
 LL |     fn f(g: i32);
    |          ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:151:8
    |
 LL |     fn f(g: i32);
    |        ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:156:8
    |
 LL |     fn g(arg: i8) {
    |        ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:158:12
    |
 LL |         fn c(d: u8) {}
    |            ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:158:14
    |
 LL |         fn c(d: u8) {}
    |              ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:166:12
    |
 LL |         fn h() {}
    |            ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:168:18
    |
 LL |         fn inner(a: i32) {}
    |                  ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:170:18
    |
 LL |         let a = |f: String| f;
    |                  ^
 
-error: this ident consists of a single char
+error: this identifier consists of only a single character
   --> tests/ui/min_ident_chars.rs:170:13
    |
 LL |         let a = |f: String| f;
    |             ^
 
-error: aborting due to 45 previous errors
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:178:11
+   |
+LL |     trait A {
+   |           ^
+
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:180:14
+   |
+LL |         fn f(h: [u32; 0]);
+   |              ^
+
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:180:12
+   |
+LL |         fn f(h: [u32; 0]);
+   |            ^
+
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:192:41
+   |
+LL | ...                   let h = 0;
+   |                           ^
+
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:195:33
+   |
+LL | ...                   let h = 0;
+   |                           ^
+
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:199:29
+   |
+LL |                         let h = 0;
+   |                             ^
+
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:202:21
+   |
+LL |                 let h = 0;
+   |                     ^
+
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:206:17
+   |
+LL |             let h = 0;
+   |                 ^
+
+error: this identifier consists of only a single character
+  --> tests/ui/min_ident_chars.rs:209:9
+   |
+LL |     let h = 0;
+   |         ^
+
+error: aborting due to 54 previous errors
 


### PR DESCRIPTION
Changes:
* Directly access the identifiers instead of using a visitor.
* Don't lint functions with linking related attributes (e.g. `no_mangle`).
* Delay checking for external macros.
* Check the length in code-points and not bytes.
* Only walk up the HIR tree if we need to check for trait impl function parameters.
* State the number of missing characters in the lint message.
 
changelog: none
