### PR TITLE
Place generated impl block after the existing impl block

### DIFF
--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -179,7 +179,7 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                     impl_item.span,
                     format!("you should consider adding a `Default` implementation for `{self_type_snip}`"),
                     |diag| {
-                        diag.suggest_prepend_item(
+                        diag.suggest_append_item(
                             cx,
                             item.span,
                             "try adding this",

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -715,19 +715,19 @@ pub trait DiagExt<T: LintContext> {
         applicability: Applicability,
     );
 
-    /// Suggest to add an item before another.
+    /// Suggest to add an item after another.
     ///
     /// The item should not be indented (except for inner indentation).
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// diag.suggest_prepend_item(cx, item,
+    /// diag.suggest_append_item(cx, item,
     /// "fn foo() {
     ///     bar();
     /// }");
     /// ```
-    fn suggest_prepend_item(&mut self, cx: &T, item: Span, msg: &str, new_item: &str, applicability: Applicability);
+    fn suggest_append_item(&mut self, cx: &T, item: Span, msg: &str, new_item: &str, applicability: Applicability);
 
     /// Suggest to completely remove an item.
     ///
@@ -759,24 +759,19 @@ impl<T: LintContext> DiagExt<T> for rustc_errors::Diag<'_, ()> {
         }
     }
 
-    fn suggest_prepend_item(&mut self, cx: &T, item: Span, msg: &str, new_item: &str, applicability: Applicability) {
+    fn suggest_append_item(&mut self, cx: &T, item: Span, msg: &str, new_item: &str, applicability: Applicability) {
         if let Some(indent) = indentation(cx, item) {
-            let span = item.with_hi(item.lo());
-
-            let mut first = true;
-            let new_item = new_item
-                .lines()
-                .map(|l| {
-                    if first {
-                        first = false;
-                        format!("{l}\n")
-                    } else {
-                        format!("{indent}{l}\n")
-                    }
-                })
-                .collect::<String>();
-
-            self.span_suggestion(span, msg.to_string(), format!("{new_item}\n{indent}"), applicability);
+            let span = item.shrink_to_hi();
+            let mut new_item_code = String::new();
+            for l in new_item.lines() {
+                writeln!(new_item_code, "{indent}{l}").unwrap();
+            }
+            self.span_suggestion(
+                span,
+                msg.to_string(),
+                format!("\n\n{}", new_item_code.strip_suffix('\n').unwrap()),
+                applicability,
+            );
         }
     }
 

--- a/tests/ui/new_without_default.fixed
+++ b/tests/ui/new_without_default.fixed
@@ -3,12 +3,6 @@
 
 pub struct Foo;
 
-impl Default for Foo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Foo {
     pub fn new() -> Foo {
         //~^ new_without_default
@@ -17,19 +11,25 @@ impl Foo {
     }
 }
 
-pub struct Bar;
-
-impl Default for Bar {
+impl Default for Foo {
     fn default() -> Self {
         Self::new()
     }
 }
+
+pub struct Bar;
 
 impl Bar {
     pub fn new() -> Self {
         //~^ new_without_default
 
         Bar
+    }
+}
+
+impl Default for Bar {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -91,17 +91,17 @@ pub struct LtKo<'a> {
     foo: &'a bool,
 }
 
-impl<'c> Default for LtKo<'c> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<'c> LtKo<'c> {
     pub fn new() -> LtKo<'c> {
         //~^ new_without_default
 
         unimplemented!()
+    }
+}
+
+impl<'c> Default for LtKo<'c> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -131,17 +131,17 @@ impl PrivateItem {
 
 pub struct Const;
 
-impl Default for Const {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Const {
     pub const fn new() -> Const {
         //~^ new_without_default
         Const
     } // While Default is not const, it can still call const functions, so we should lint this
+}
+
+impl Default for Const {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 pub struct IgnoreGenericNew;
@@ -197,12 +197,6 @@ pub struct NewNotEqualToDerive {
     foo: i32,
 }
 
-impl Default for NewNotEqualToDerive {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl NewNotEqualToDerive {
     // This `new` implementation is not equal to a derived `Default`, so do not suggest deriving.
     pub fn new() -> Self {
@@ -212,14 +206,14 @@ impl NewNotEqualToDerive {
     }
 }
 
-// see #6933
-pub struct FooGenerics<T>(std::marker::PhantomData<T>);
-impl<T> Default for FooGenerics<T> {
+impl Default for NewNotEqualToDerive {
     fn default() -> Self {
         Self::new()
     }
 }
 
+// see #6933
+pub struct FooGenerics<T>(std::marker::PhantomData<T>);
 impl<T> FooGenerics<T> {
     pub fn new() -> Self {
         //~^ new_without_default
@@ -228,13 +222,13 @@ impl<T> FooGenerics<T> {
     }
 }
 
-pub struct BarGenerics<T>(std::marker::PhantomData<T>);
-impl<T: Copy> Default for BarGenerics<T> {
+impl<T> Default for FooGenerics<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
+pub struct BarGenerics<T>(std::marker::PhantomData<T>);
 impl<T: Copy> BarGenerics<T> {
     pub fn new() -> Self {
         //~^ new_without_default
@@ -243,15 +237,15 @@ impl<T: Copy> BarGenerics<T> {
     }
 }
 
+impl<T: Copy> Default for BarGenerics<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub mod issue7220 {
     pub struct Foo<T> {
         _bar: *mut T,
-    }
-
-    impl<T> Default for Foo<T> {
-        fn default() -> Self {
-            Self::new()
-        }
     }
 
     impl<T> Foo<T> {
@@ -259,6 +253,12 @@ pub mod issue7220 {
             //~^ new_without_default
 
             todo!()
+        }
+    }
+
+    impl<T> Default for Foo<T> {
+        fn default() -> Self {
+            Self::new()
         }
     }
 }
@@ -298,15 +298,6 @@ where
     _kv: Option<(K, V)>,
 }
 
-impl<K, V> Default for MyStruct<K, V>
-where
-    K: std::hash::Hash + Eq + PartialEq,
- {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<K, V> MyStruct<K, V>
 where
     K: std::hash::Hash + Eq + PartialEq,
@@ -317,16 +308,18 @@ where
     }
 }
 
-// From issue #14552, but with `#[cfg]`s that are actually `true` in the uitest context
-
-pub struct NewWithCfg;
-#[cfg(not(test))]
-impl Default for NewWithCfg {
+impl<K, V> Default for MyStruct<K, V>
+where
+    K: std::hash::Hash + Eq + PartialEq,
+ {
     fn default() -> Self {
         Self::new()
     }
 }
 
+// From issue #14552, but with `#[cfg]`s that are actually `true` in the uitest context
+
+pub struct NewWithCfg;
 impl NewWithCfg {
     #[cfg(not(test))]
     pub fn new() -> Self {
@@ -335,15 +328,14 @@ impl NewWithCfg {
     }
 }
 
-pub struct NewWith2Cfgs;
 #[cfg(not(test))]
-#[cfg(panic = "unwind")]
-impl Default for NewWith2Cfgs {
+impl Default for NewWithCfg {
     fn default() -> Self {
         Self::new()
     }
 }
 
+pub struct NewWith2Cfgs;
 impl NewWith2Cfgs {
     #[cfg(not(test))]
     #[cfg(panic = "unwind")]
@@ -353,13 +345,15 @@ impl NewWith2Cfgs {
     }
 }
 
-pub struct NewWithExtraneous;
-impl Default for NewWithExtraneous {
+#[cfg(not(test))]
+#[cfg(panic = "unwind")]
+impl Default for NewWith2Cfgs {
     fn default() -> Self {
         Self::new()
     }
 }
 
+pub struct NewWithExtraneous;
 impl NewWithExtraneous {
     #[inline]
     pub fn new() -> Self {
@@ -368,20 +362,26 @@ impl NewWithExtraneous {
     }
 }
 
-pub struct NewWithCfgAndExtraneous;
-#[cfg(not(test))]
-impl Default for NewWithCfgAndExtraneous {
+impl Default for NewWithExtraneous {
     fn default() -> Self {
         Self::new()
     }
 }
 
+pub struct NewWithCfgAndExtraneous;
 impl NewWithCfgAndExtraneous {
     #[cfg(not(test))]
     #[inline]
     pub fn new() -> Self {
         //~^ new_without_default
         unimplemented!()
+    }
+}
+
+#[cfg(not(test))]
+impl Default for NewWithCfgAndExtraneous {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -413,16 +413,6 @@ pub mod issue16255 {
         marker: PhantomData<T>,
     }
 
-    impl<T> Default for Foo<T>
-    where
-        T: Display,
-        T: Clone,
-     {
-        fn default() -> Self {
-            Self::new()
-        }
-    }
-
     impl<T> Foo<T>
     where
         T: Display,
@@ -436,8 +426,28 @@ pub mod issue16255 {
         }
     }
 
+    impl<T> Default for Foo<T>
+    where
+        T: Display,
+        T: Clone,
+     {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     pub struct Bar<T> {
         marker: PhantomData<T>,
+    }
+
+    impl<T> Bar<T> {
+        pub fn new() -> Self
+        //~^ new_without_default
+        where
+            T: Clone,
+        {
+            Self { marker: PhantomData }
+        }
     }
 
     impl<T> Default for Bar<T>
@@ -448,14 +458,30 @@ pub mod issue16255 {
             Self::new()
         }
     }
+}
 
-    impl<T> Bar<T> {
-        pub fn new() -> Self
-        //~^ new_without_default
-        where
-            T: Clone,
-        {
-            Self { marker: PhantomData }
+pub mod issue17361 {
+    //! This test ensures that attributes applied to the impl block
+    //! containing `fn new()` do not get mistakenly applied to the
+    //! newly generated `Default` trait impl. This has been the
+    //! case because the `Default` trait impl was inserted right
+    //! before the existing impl block, but after the attributes.
+
+    #![deny(clippy::unwrap_used, reason = "check that expect below stays put")]
+
+    pub struct S;
+
+    #[expect(clippy::unwrap_used, reason = "without it, new() fails to compile")]
+    impl S {
+        pub fn new() -> S {
+            //~^ new_without_default
+            std::hint::black_box(Some(S)).unwrap()
+        }
+    }
+
+    impl Default for S {
+        fn default() -> Self {
+            Self::new()
         }
     }
 }

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -355,3 +355,23 @@ pub mod issue16255 {
         }
     }
 }
+
+pub mod issue17361 {
+    //! This test ensures that attributes applied to the impl block
+    //! containing `fn new()` do not get mistakenly applied to the
+    //! newly generated `Default` trait impl. This has been the
+    //! case because the `Default` trait impl was inserted right
+    //! before the existing impl block, but after the attributes.
+
+    #![deny(clippy::unwrap_used, reason = "check that expect below stays put")]
+
+    pub struct S;
+
+    #[expect(clippy::unwrap_used, reason = "without it, new() fails to compile")]
+    impl S {
+        pub fn new() -> S {
+            //~^ new_without_default
+            std::hint::black_box(Some(S)).unwrap()
+        }
+    }
+}

--- a/tests/ui/new_without_default.stderr
+++ b/tests/ui/new_without_default.stderr
@@ -12,6 +12,8 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::new_without_default)]`
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl Default for Foo {
 LL +     fn default() -> Self {
 LL +         Self::new()
@@ -31,6 +33,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl Default for Bar {
 LL +     fn default() -> Self {
 LL +         Self::new()
@@ -50,6 +54,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl<'c> Default for LtKo<'c> {
 LL +     fn default() -> Self {
 LL +         Self::new()
@@ -68,6 +74,8 @@ LL | |     } // While Default is not const, it can still call const functions, s
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl Default for Const {
 LL +     fn default() -> Self {
 LL +         Self::new()
@@ -87,6 +95,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl Default for NewNotEqualToDerive {
 LL +     fn default() -> Self {
 LL +         Self::new()
@@ -106,6 +116,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl<T> Default for FooGenerics<T> {
 LL +     fn default() -> Self {
 LL +         Self::new()
@@ -125,6 +137,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl<T: Copy> Default for BarGenerics<T> {
 LL +     fn default() -> Self {
 LL +         Self::new()
@@ -144,13 +158,13 @@ LL | |         }
    |
 help: try adding this
    |
-LL ~     impl<T> Default for Foo<T> {
+LL ~     }
+LL + 
+LL +     impl<T> Default for Foo<T> {
 LL +         fn default() -> Self {
 LL +             Self::new()
 LL +         }
 LL +     }
-LL + 
-LL ~     impl<T> Foo<T> {
    |
 
 error: you should consider adding a `Default` implementation for `MyStruct<K, V>`
@@ -164,6 +178,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl<K, V> Default for MyStruct<K, V>
 LL + where
 LL +     K: std::hash::Hash + Eq + PartialEq,
@@ -185,6 +201,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + #[cfg(not(test))]
 LL + impl Default for NewWithCfg {
 LL +     fn default() -> Self {
@@ -204,6 +222,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + #[cfg(not(test))]
 LL + #[cfg(panic = "unwind")]
 LL + impl Default for NewWith2Cfgs {
@@ -224,6 +244,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + impl Default for NewWithExtraneous {
 LL +     fn default() -> Self {
 LL +         Self::new()
@@ -242,6 +264,8 @@ LL | |     }
    |
 help: try adding this
    |
+LL ~ }
+LL + 
 LL + #[cfg(not(test))]
 LL + impl Default for NewWithCfgAndExtraneous {
 LL +     fn default() -> Self {
@@ -264,7 +288,9 @@ LL | |         }
    |
 help: try adding this
    |
-LL ~     impl<T> Default for Foo<T>
+LL ~     }
+LL + 
+LL +     impl<T> Default for Foo<T>
 LL +     where
 LL +         T: Display,
 LL +         T: Clone,
@@ -273,8 +299,6 @@ LL +         fn default() -> Self {
 LL +             Self::new()
 LL +         }
 LL +     }
-LL + 
-LL ~     impl<T> Foo<T>
    |
 
 error: you should consider adding a `Default` implementation for `Bar<T>`
@@ -291,7 +315,9 @@ LL | |         }
    |
 help: try adding this
    |
-LL ~     impl<T> Default for Bar<T>
+LL ~     }
+LL + 
+LL +     impl<T> Default for Bar<T>
 LL +     where
 LL +         T: Clone,
 LL +      {
@@ -299,9 +325,27 @@ LL +         fn default() -> Self {
 LL +             Self::new()
 LL +         }
 LL +     }
-LL + 
-LL ~     impl<T> Bar<T> {
    |
 
-error: aborting due to 15 previous errors
+error: you should consider adding a `Default` implementation for `S`
+  --> tests/ui/new_without_default.rs:372:9
+   |
+LL | /         pub fn new() -> S {
+LL | |
+LL | |             std::hint::black_box(Some(S)).unwrap()
+LL | |         }
+   | |_________^
+   |
+help: try adding this
+   |
+LL ~     }
+LL + 
+LL +     impl Default for S {
+LL +         fn default() -> Self {
+LL +             Self::new()
+LL +         }
+LL +     }
+   |
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Placing the generated impl block before the existing one means that the attributes of the existing block will be applied to the newly generated one. Generating the new impl block after the existing one is safer.

changelog: [`new_without_default`]: be more robust in the presence of attributes on the impl block containing the `new()` implementation

Fixes rust-lang/rust-clippy#17361 (confirmed on original code)
