### PR TITLE
test(`ref_binding_to_reference`): enable autofix

### DIFF
--- a/tests/ui/ref_binding_to_reference.fixed
+++ b/tests/ui/ref_binding_to_reference.fixed
@@ -49,43 +49,43 @@ fn main() {
 
     // Err, reference to a &String
     match Some(&x) {
-        Some(ref x) => m2!(x),
+        Some(x) => m2!(&x),
         //~^ ref_binding_to_reference
         None => return,
     }
 
     // Err, reference to a &String
-    let _ = |&ref x: &&String| {
+    let _ = |&x: &&String| {
         //~^ ref_binding_to_reference
 
-        let _: &&String = x;
+        let _: &&String = &x;
     };
 }
 
 // Err, reference to a &String
-fn f2<'a>(&ref x: &&'a String) -> &'a String {
+fn f2<'a>(&x: &&'a String) -> &'a String {
     //~^ ref_binding_to_reference
 
-    let _: &&String = x;
-    *x
+    let _: &&String = &x;
+    x
 }
 
 trait T1 {
     // Err, reference to a &String
-    fn f(&ref x: &&String) {
+    fn f(&x: &&String) {
         //~^ ref_binding_to_reference
 
-        let _: &&String = x;
+        let _: &&String = &x;
     }
 }
 
 struct S;
 impl T1 for S {
     // Err, reference to a &String
-    fn f(&ref x: &&String) {
+    fn f(&x: &&String) {
         //~^ ref_binding_to_reference
 
-        let _: &&String = x;
+        let _: &&String = &x;
     }
 }
 

--- a/tests/ui/ref_binding_to_reference.stderr
+++ b/tests/ui/ref_binding_to_reference.stderr
@@ -1,39 +1,11 @@
 error: this pattern creates a reference to a reference
-  --> tests/ui/ref_binding_to_reference.rs:29:14
-   |
-LL |         Some(ref x) => x,
-   |              ^^^^^
-   |
-   = note: `-D clippy::ref-binding-to-reference` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::ref_binding_to_reference)]`
-help: try
-   |
-LL -         Some(ref x) => x,
-LL +         Some(x) => &x,
-   |
-
-error: this pattern creates a reference to a reference
-  --> tests/ui/ref_binding_to_reference.rs:36:14
-   |
-LL |         Some(ref x) => {
-   |              ^^^^^
-   |
-help: try
-   |
-LL ~         Some(x) => {
-LL |
-LL |
-LL |             f1(x);
-LL ~             f1(x);
-LL ~             &x
-   |
-
-error: this pattern creates a reference to a reference
-  --> tests/ui/ref_binding_to_reference.rs:48:14
+  --> tests/ui/ref_binding_to_reference.rs:52:14
    |
 LL |         Some(ref x) => m2!(x),
    |              ^^^^^
    |
+   = note: `-D clippy::ref-binding-to-reference` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::ref_binding_to_reference)]`
 help: try
    |
 LL -         Some(ref x) => m2!(x),
@@ -41,7 +13,7 @@ LL +         Some(x) => m2!(&x),
    |
 
 error: this pattern creates a reference to a reference
-  --> tests/ui/ref_binding_to_reference.rs:54:15
+  --> tests/ui/ref_binding_to_reference.rs:58:15
    |
 LL |     let _ = |&ref x: &&String| {
    |               ^^^^^
@@ -55,7 +27,7 @@ LL ~         let _: &&String = &x;
    |
 
 error: this pattern creates a reference to a reference
-  --> tests/ui/ref_binding_to_reference.rs:62:12
+  --> tests/ui/ref_binding_to_reference.rs:66:12
    |
 LL | fn f2<'a>(&ref x: &&'a String) -> &'a String {
    |            ^^^^^
@@ -70,7 +42,7 @@ LL ~     x
    |
 
 error: this pattern creates a reference to a reference
-  --> tests/ui/ref_binding_to_reference.rs:71:11
+  --> tests/ui/ref_binding_to_reference.rs:75:11
    |
 LL |     fn f(&ref x: &&String) {
    |           ^^^^^
@@ -84,7 +56,7 @@ LL ~         let _: &&String = &x;
    |
 
 error: this pattern creates a reference to a reference
-  --> tests/ui/ref_binding_to_reference.rs:81:11
+  --> tests/ui/ref_binding_to_reference.rs:85:11
    |
 LL |     fn f(&ref x: &&String) {
    |           ^^^^^
@@ -97,5 +69,5 @@ LL |
 LL ~         let _: &&String = &x;
    |
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Multi-span suggestions work now! Unlike the lint, unfortunately -- see https://github.com/rust-lang/rust-clippy/issues/17370.

changelog: none