### PR TITLE
new_without_default: don't suggest a machine-applicable fix under a consumed attribute macro

### DIFF
--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -1,11 +1,12 @@
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::return_ty;
-use clippy_utils::source::{indent_of, reindent_multiline, snippet_with_applicability};
+use clippy_utils::source::{indent_of, reindent_multiline, snippet_opt, snippet_with_applicability};
 use clippy_utils::sugg::DiagExt;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::{Attribute, HirIdSet};
+use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty::AssocKind;
 use rustc_session::impl_lint_pass;
@@ -119,7 +120,11 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                     return;
                 }
 
-                let mut app = Applicability::MachineApplicable;
+                let mut app = if impl_has_hidden_attr(cx, item) {
+                    Applicability::MaybeIncorrect
+                } else {
+                    Applicability::MachineApplicable
+                };
                 let attrs_sugg = {
                     let mut sugg = String::new();
                     for attr in cx.tcx.hir_attrs(assoc_item_hir_id) {
@@ -198,6 +203,100 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
     }
 }
 
+/// Checks whether `suggest_prepend_item` would misplace an attribute that belongs to `item`
+/// itself, rather than to the newly suggested `impl Default`.
+///
+/// Two cases are covered:
+/// - An attribute that is still visible in the HIR (e.g. `#[cfg(..)]`, `#[allow(..)]`, a doc
+///   comment, ...): inserting the suggestion right before `item.span` would leave that attribute
+///   attached to the *new* impl instead of the original one.
+/// - An outer attribute *macro* (e.g. `PyO3`'s `#[pymethods]`) that gets fully consumed during
+///   macro expansion and therefore leaves nothing behind in `hir_attrs`, even though the source
+///   still has it written immediately above the impl block. Blindly applying the suggestion then
+///   ends up wrapping the wrong item in that macro, which can fail to compile (see
+///   rust-lang/rust-clippy#17361).
+fn impl_has_hidden_attr(cx: &LateContext<'_>, item: &hir::Item<'_>) -> bool {
+    if !cx.tcx.hir_attrs(item.hir_id()).is_empty() {
+        return true;
+    }
+
+    // `hir_attrs` is empty, but that's exactly what a fully-consumed outer attribute macro looks
+    // like: the macro rewrites/consumes the whole item during expansion, so nothing is left in
+    // the HIR, even though the source still has it written immediately above the impl block.
+    if item.span.from_expansion() {
+        return false;
+    }
+
+    let tcx = cx.tcx;
+
+    // Rather than classifying the raw text above the impl in isolation -- which can't reliably
+    // tell a consumed attribute macro apart from ordinary code that just happens to sit right
+    // above the impl, the exact bug that kept reappearing here (see rust-lang/rust-clippy#17361)
+    // -- ask the HIR directly what the previous sibling item in this same scope is, and only look
+    // at the source gap between that sibling and this impl. A *visible* attribute belonging to
+    // either neighbour is already included in that neighbour's own span (checked above for this
+    // item; the same holds for whatever came before it), so it can never leak into that gap: the
+    // only things a real gap can ever contain are whitespace, comments, and leftover text from a
+    // fully-consumed attribute macro.
+    // Not a plain module (e.g. an impl nested inside a function body): there's no cheap way to
+    // enumerate its lexical siblings here, so stay on the safe side rather than assume there's
+    // nothing hidden above this impl.
+    let (hir::OwnerNode::Item(&hir::Item {
+        kind: hir::ItemKind::Mod(_, siblings),
+        ..
+    })
+    | hir::OwnerNode::Crate(siblings)) = tcx.hir_owner_node(tcx.hir_get_parent_item(item.hir_id()))
+    else {
+        return true;
+    };
+
+    let prev_end = siblings
+        .item_ids
+        .iter()
+        .filter(|id| id.owner_id != item.owner_id)
+        .map(|id| tcx.hir_item(*id).span.hi())
+        .filter(|hi| *hi <= item.span.lo())
+        .max()
+        // No previous sibling: the impl is the first item in this module (or the crate root), so
+        // the gap starts right at the module's own body.
+        .unwrap_or_else(|| siblings.spans.inner_span.lo());
+
+    if prev_end > item.span.lo() {
+        // Should never happen for well-formed HIR, but don't assume anything is safe if it does.
+        return true;
+    }
+
+    let gap = item.span.shrink_to_lo().with_lo(prev_end);
+    let Some(snippet) = snippet_opt(cx, gap) else {
+        // Can't recover the source snippet to inspect: stay on the safe side rather than assume
+        // there's nothing hidden above this impl.
+        return true;
+    };
+
+    gap_contains_attr_residue(&snippet)
+}
+
+/// Checks whether `snippet` contains a `#` token outside of any comment or string literal -- the
+/// one piece of source text a fully-consumed outer attribute macro invocation always leaves
+/// behind, even though the attribute itself disappears from the HIR entirely (see
+/// `impl_has_hidden_attr`).
+///
+/// This only needs to answer "is there an attribute-shaped token here at all", not fully parse
+/// one: `snippet` is always the gap between two known HIR items (or a module/crate start and the
+/// first item in it), so any `#` found in it cannot belong to either neighbour and must be a
+/// leftover attribute -- unlike the raw text directly above an item in isolation, which can be
+/// ordinary code that merely happens to look attribute-adjacent (the source of the false
+/// positives this function's predecessors kept running into, see rust-lang/rust-clippy#17361).
+///
+/// Tokenizing with `rustc_lexer` (instead of a hand-rolled scan) is what makes "outside of any
+/// comment or string" correct for free: every string form (plain, raw, byte, C-string) and every
+/// comment form is each already lexed as one coherent token, so a `#` that's merely part of one
+/// (e.g. a raw string's `r#".."#` delimiters, or a `#` typed inside a `// comment`) is never
+/// mistaken for a real attribute's `#`.
+fn gap_contains_attr_residue(snippet: &str) -> bool {
+    tokenize(snippet, FrontmatterAllowed::No).any(|t| t.kind == TokenKind::Pound)
+}
+
 fn create_new_without_default_suggest_msg(
     attrs_sugg: &str,
     self_type_snip: &str,
@@ -211,4 +310,87 @@ fn create_new_without_default_suggest_msg(
         Self::new()
     }}
 }}")
+}
+
+#[cfg(test)]
+mod tests_for_gap_contains_attr_residue {
+    use super::gap_contains_attr_residue;
+
+    #[test]
+    fn bare_attr_is_residue() {
+        assert!(gap_contains_attr_residue("#[pymethods]"));
+    }
+
+    #[test]
+    fn inner_attr_is_residue() {
+        assert!(gap_contains_attr_residue("#![pymethods]"));
+    }
+
+    #[test]
+    fn multiple_attrs_are_residue() {
+        assert!(gap_contains_attr_residue("#[foo]\n#[bar]"));
+    }
+
+    #[test]
+    fn multiline_attr_with_closing_bracket_on_own_line_is_residue() {
+        // The attribute's own `)]` lands on a line by itself: it's still one token stream to
+        // `rustc_lexer`, and the leading `#` is found regardless of where the rest of the
+        // attribute's tokens land.
+        assert!(gap_contains_attr_residue("#[gate_attr::pymethods(\n    note\n)]"));
+    }
+
+    #[test]
+    fn attr_with_surrounding_comments_and_blanks_is_residue() {
+        assert!(gap_contains_attr_residue("#[pymethods]\n\n// note about the impl\n"));
+    }
+
+    #[test]
+    fn attr_with_block_comment_is_residue() {
+        assert!(gap_contains_attr_residue("#[pymethods]\n/* multi\n   line\n   comment */"));
+    }
+
+    #[test]
+    fn empty_gap_is_not_residue() {
+        assert!(!gap_contains_attr_residue(""));
+    }
+
+    #[test]
+    fn whitespace_only_gap_is_not_residue() {
+        assert!(!gap_contains_attr_residue("\n\n    \n"));
+    }
+
+    #[test]
+    fn line_comment_only_gap_is_not_residue() {
+        assert!(!gap_contains_attr_residue("// just a comment, nothing special\n"));
+    }
+
+    #[test]
+    fn block_comment_only_gap_is_not_residue() {
+        assert!(!gap_contains_attr_residue("/* just a comment */\n"));
+    }
+
+    #[test]
+    fn pound_inside_line_comment_is_not_residue() {
+        // A `#` typed inside a `//` comment is part of the `LineComment` token, not a real
+        // attribute -- the historical bug class this whole mechanism exists to avoid (see
+        // rust-lang/rust-clippy#17361).
+        assert!(!gap_contains_attr_residue("// see issue #17361\n"));
+    }
+
+    #[test]
+    fn pound_inside_plain_string_is_not_residue() {
+        assert!(!gap_contains_attr_residue(r#"let _ = "contains a # sign";"#));
+    }
+
+    #[test]
+    fn pound_inside_raw_string_delimiters_is_not_residue() {
+        // The `#` characters that delimit a raw string (`r#".."#`) are part of that single
+        // `RawStr` token, not a standalone `Pound` token.
+        assert!(!gap_contains_attr_residue(r##"let _ = r#"contains a # sign"#;"##));
+    }
+
+    #[test]
+    fn plain_code_is_not_residue() {
+        assert!(!gap_contains_attr_residue("pub struct Foo;"));
+    }
 }

--- a/tests/ui/auxiliary/proc_macro_attr.rs
+++ b/tests/ui/auxiliary/proc_macro_attr.rs
@@ -175,6 +175,20 @@ pub fn with_empty_docs(_attr: TokenStream, input: TokenStream) -> TokenStream {
     .into()
 }
 
+// Mimics an outer attribute macro that, like PyO3's `#[pymethods]`, may only be applied to an
+// inherent impl block and rejects a trait impl. Used to reproduce rust-lang/rust-clippy#17361:
+// `new_without_default`'s suggestion must not be `MachineApplicable` here, since applying it
+// verbatim would move this attribute onto the newly suggested `impl Default` block, which then
+// fails to compile.
+#[proc_macro_attribute]
+pub fn fake_pymethods(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as ItemImpl);
+    if item.trait_.is_some() {
+        return quote!(compile_error!("fake_pymethods cannot be used on trait impl blocks");).into();
+    }
+    quote!(#item).into()
+}
+
 #[proc_macro_attribute]
 pub fn duplicated_attr(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as syn::Item);

--- a/tests/ui/new_without_default_derive_same_line.fixed
+++ b/tests/ui/new_without_default_derive_same_line.fixed
@@ -1,0 +1,85 @@
+// A `#[derive(..)]` (or any other outer attribute) that shares its source line with the item
+// it annotates -- e.g. `#[derive(Debug)] pub struct Foo;` -- belongs to that item, not to the
+// `impl` block written on the next line. The lint's source-sniffing fallback (which exists to
+// catch outer attribute *macros* fully consumed by expansion, see
+// new_without_default_outer_attr_macro.rs) must not mistake this for such a case and must keep
+// suggesting a machine-applicable fix.
+
+#![warn(clippy::new_without_default)]
+
+#[derive(Debug)]
+pub struct Foo;
+
+impl Default for Foo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Foo {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Foo
+    }
+}
+
+// Same false positive, but with the derive and the struct crammed onto one line, which is the
+// exact case that used to be misdetected as a hidden attribute on the `impl` below.
+#[rustfmt::skip]
+#[derive(Debug)] pub struct Bar;
+
+impl Default for Bar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Bar {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Bar
+    }
+}
+
+// Same false positive again, but the attribute's argument contains a `]` inside a string
+// literal. A naive bracket-counting scan would close on that `]` and misparse the rest of the
+// line as trailing code, wrongly concluding this attribute belongs to the `impl` below instead
+// of `Baz`.
+#[rustfmt::skip]
+#[doc = "]"] pub struct Baz;
+
+impl Default for Baz {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Baz {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Baz
+    }
+}
+
+// Same false positive again, but this time the line also carries a trailing `// comment` that
+// itself contains a `]`. Scanning the whole line (including the comment) for the last `]` would
+// land on the one in the comment instead of the attribute's own closing bracket, and then
+// misparse the real `pub struct Qux;` code as if it were more comment text, wrongly concluding
+// the attribute is standalone and belongs to the `impl` below instead of `Qux`.
+#[rustfmt::skip]
+#[doc = "]"] pub struct Qux; // trailing comment with a bracket ]
+
+impl Default for Qux {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Qux {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Qux
+    }
+}
+
+fn main() {}

--- a/tests/ui/new_without_default_derive_same_line.rs
+++ b/tests/ui/new_without_default_derive_same_line.rs
@@ -1,0 +1,61 @@
+// A `#[derive(..)]` (or any other outer attribute) that shares its source line with the item
+// it annotates -- e.g. `#[derive(Debug)] pub struct Foo;` -- belongs to that item, not to the
+// `impl` block written on the next line. The lint's source-sniffing fallback (which exists to
+// catch outer attribute *macros* fully consumed by expansion, see
+// new_without_default_outer_attr_macro.rs) must not mistake this for such a case and must keep
+// suggesting a machine-applicable fix.
+
+#![warn(clippy::new_without_default)]
+
+#[derive(Debug)]
+pub struct Foo;
+
+impl Foo {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Foo
+    }
+}
+
+// Same false positive, but with the derive and the struct crammed onto one line, which is the
+// exact case that used to be misdetected as a hidden attribute on the `impl` below.
+#[rustfmt::skip]
+#[derive(Debug)] pub struct Bar;
+
+impl Bar {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Bar
+    }
+}
+
+// Same false positive again, but the attribute's argument contains a `]` inside a string
+// literal. A naive bracket-counting scan would close on that `]` and misparse the rest of the
+// line as trailing code, wrongly concluding this attribute belongs to the `impl` below instead
+// of `Baz`.
+#[rustfmt::skip]
+#[doc = "]"] pub struct Baz;
+
+impl Baz {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Baz
+    }
+}
+
+// Same false positive again, but this time the line also carries a trailing `// comment` that
+// itself contains a `]`. Scanning the whole line (including the comment) for the last `]` would
+// land on the one in the comment instead of the attribute's own closing bracket, and then
+// misparse the real `pub struct Qux;` code as if it were more comment text, wrongly concluding
+// the attribute is standalone and belongs to the `impl` below instead of `Qux`.
+#[rustfmt::skip]
+#[doc = "]"] pub struct Qux; // trailing comment with a bracket ]
+
+impl Qux {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Qux
+    }
+}
+
+fn main() {}

--- a/tests/ui/new_without_default_derive_same_line.stderr
+++ b/tests/ui/new_without_default_derive_same_line.stderr
@@ -1,0 +1,76 @@
+error: you should consider adding a `Default` implementation for `Foo`
+  --> tests/ui/new_without_default_derive_same_line.rs:14:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Foo
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::new-without-default` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::new_without_default)]`
+help: try adding this
+   |
+LL + impl Default for Foo {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Bar`
+  --> tests/ui/new_without_default_derive_same_line.rs:26:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Bar
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Bar {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Baz`
+  --> tests/ui/new_without_default_derive_same_line.rs:40:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Baz
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Baz {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Qux`
+  --> tests/ui/new_without_default_derive_same_line.rs:55:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Qux
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Qux {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/new_without_default_outer_attr_macro.rs
+++ b/tests/ui/new_without_default_outer_attr_macro.rs
@@ -1,0 +1,169 @@
+//@aux-build:proc_macro_attr.rs
+
+// The suggestion here must not be machine-applicable: applying it verbatim would move
+// `#[proc_macro_attr::fake_pymethods]` onto the newly suggested `impl Default` block instead of
+// leaving it on the original inherent impl, which fails to compile since the attribute (like
+// PyO3's `#[pymethods]`) cannot be applied to a trait impl. See rust-lang/rust-clippy#17361.
+//@no-rustfix
+
+#![warn(clippy::new_without_default)]
+
+extern crate proc_macro_attr;
+
+pub struct Foo;
+
+#[proc_macro_attr::fake_pymethods]
+impl Foo {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Foo
+    }
+}
+
+// Regression test: the attribute's arguments contain a `]` inside a string literal. A naive
+// bracket-counting scan of the source line would close on that `]` instead of the one that
+// actually ends the attribute, mis-parse the rest of the line, and conclude the line isn't a
+// standalone attribute after all -- silently reintroducing the exact bug above for any consumed
+// attribute macro whose args contain a `]` in a string (e.g. `#[cfg(feature = "x]y")]`).
+pub struct Baz;
+
+#[proc_macro_attr::dummy(note = "]")]
+impl Baz {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Baz
+    }
+}
+
+// Regression test: a trailing `// comment` after the attribute contains a `]`. Scanning the whole
+// line (including the comment) for the last `]` would land on the one in the comment text instead
+// of the attribute's own closing bracket, leave real comment text in the "tail", and wrongly
+// conclude the line isn't standalone after all -- silently reintroducing the exact bug above for
+// any consumed attribute macro with a bracket-containing trailing comment.
+pub struct Qux;
+
+#[proc_macro_attr::dummy(unused)] // uses obj[idx] pattern
+impl Qux {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Qux
+    }
+}
+
+// Regression test: the attribute's arguments contain a `//` inside a string literal. That must
+// not be mistaken for the start of a trailing line comment (which would then wrongly get
+// stripped along with everything after it, including the attribute's own closing bracket).
+pub struct Quux;
+
+#[proc_macro_attr::dummy(note = "http://example.com")]
+impl Quux {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Quux
+    }
+}
+
+// Regression test: the attribute's arguments contain a raw string whose content has a `"`
+// followed by ` // `. A scan that only tracks plain (non-raw) string state closes the "string"
+// on that inner `"`, then mistakes the real ` // bar"#)]` tail for a line comment and strips it,
+// which breaks the bracket scan and wrongly concludes the line isn't standalone after all --
+// silently reintroducing the exact bug above.
+pub struct Corge;
+
+#[proc_macro_attr::dummy(note = r#"foo" // bar"#)]
+impl Corge {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Corge
+    }
+}
+
+// Regression test: the attribute's own closing `)]` lands on a line of its own, above the impl.
+// Classifying only that single closing line (which starts with `)`, not `#`) would wrongly
+// conclude there's no attribute at all above the impl, reintroducing the exact bug above for any
+// multi-line consumed attribute macro invocation.
+pub struct Grault;
+
+#[proc_macro_attr::fake_pymethods(
+    note
+)]
+impl Grault {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Grault
+    }
+}
+
+// Regression test: a block comment sits between the attribute and the impl. A caller that only
+// skips `//` line comments (not `/* .. */` block comments) while walking upward would stop right
+// at this comment line and never see the attribute above it, reintroducing the exact bug above.
+pub struct Garply;
+
+#[proc_macro_attr::fake_pymethods]
+/* comment */
+impl Garply {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Garply
+    }
+}
+
+// Same as above, but the block comment itself spans multiple lines.
+pub struct Waldo;
+
+#[proc_macro_attr::fake_pymethods]
+/* multi
+   line
+   comment */
+impl Waldo {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Waldo
+    }
+}
+
+// Regression test: real code sits *directly* above the attribute, with no blank line at all
+// separating them. This is the actual PyO3 shape this lint exists to protect
+// (`#[pyclass] struct Foo;` immediately followed by `#[pymethods] impl Foo`), and every test
+// above this one happens to have a blank line between the preceding item and the attribute --
+// so none of them would have caught a check that only looked for a blank line as the boundary
+// of "the attribute above the impl". See rust-lang/rust-clippy#17361.
+pub struct Fred;
+#[proc_macro_attr::fake_pymethods]
+impl Fred {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Fred
+    }
+}
+
+// Same regression, but the real code directly above the attribute (no blank line) is the closing
+// brace of a preceding function rather than a struct declaration.
+pub struct Plugh;
+
+pub fn helper_for_plugh() {}
+#[proc_macro_attr::fake_pymethods]
+impl Plugh {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Plugh
+    }
+}
+
+// Regression test: a `//` comment sits directly above the impl (no blank line between the
+// comment and the impl), with the attribute above that separated by a blank line. Same
+// "no-blank-line-at-the-final-boundary" shape as the two tests above, just with a comment as the
+// last thing before the impl instead of nothing.
+pub struct Xyzzy;
+
+#[proc_macro_attr::fake_pymethods]
+
+// note about the impl
+impl Xyzzy {
+    pub fn new() -> Self {
+        //~^ new_without_default
+        Xyzzy
+    }
+}
+
+fn main() {}

--- a/tests/ui/new_without_default_outer_attr_macro.stderr
+++ b/tests/ui/new_without_default_outer_attr_macro.stderr
@@ -1,0 +1,202 @@
+error: you should consider adding a `Default` implementation for `Foo`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:17:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Foo
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::new-without-default` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::new_without_default)]`
+help: try adding this
+   |
+LL + impl Default for Foo {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Baz`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:32:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Baz
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Baz {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Qux`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:47:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Qux
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Qux {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Quux`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:60:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Quux
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Quux {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Corge`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:75:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Corge
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Corge {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Grault`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:91:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Grault
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Grault {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Garply`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:105:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Garply
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Garply {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Waldo`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:119:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Waldo
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Waldo {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Fred`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:134:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Fred
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Fred {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Plugh`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:147:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Plugh
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Plugh {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: you should consider adding a `Default` implementation for `Xyzzy`
+  --> tests/ui/new_without_default_outer_attr_macro.rs:163:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |
+LL | |         Xyzzy
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Xyzzy {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: aborting due to 11 previous errors
+


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17361

When an `impl` comes from an attribute macro that is fully consumed during expansion (PyO3's `#[pymethods]` in the issue), the attribute is absent from the HIR but still sits in the source above the impl. The `MachineApplicable` suggestion inserts `impl Default for T` right there, so rustfix moves the consumed attribute onto the new `impl Default` and the build breaks with `pymethods cannot be used on trait impl blocks`.

The fix looks at the source gap between the impl and its previous sibling item (via HIR). A visible attribute is inside its owner's span, so anything left in that gap is whitespace, comments, or leftover attribute-macro residue. If a bare `#` token is present there, the impl likely carries a consumed macro attribute, so the suggestion is downgraded to `MaybeIncorrect` and rustfix no longer touches it. Ordinary cases (a `#[derive]` on the struct above, a plain impl) keep the machine-applicable fix.

Added UI cases with real code directly above the attribute (the shape the previous coverage missed), plus unit tests for the gap check.

---

changelog: [`new_without_default`]: don't emit a machine-applicable suggestion when the impl comes from a consumed attribute macro
