### PR TITLE
Improve documentation for `doc_comment_double_space_linebreaks`

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -69,18 +69,18 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Detects doc comment linebreaks that use double spaces to separate lines, instead of back-slash (`\`).
+    /// Detects doc comments that use double spaces as hard line break, instead of backslash (`\`).
     ///
     /// ### Why is this bad?
-    /// Double spaces, when used as doc comment linebreaks, can be difficult to see, and may
-    /// accidentally be removed during automatic formatting or manual refactoring. The use of a back-slash (`\`)
+    /// Double spaces, when used as hard line break in doc comments, can be difficult to see, and may
+    /// accidentally be removed during automatic formatting or manual refactoring. The use of a backslash (`\`)
     /// is clearer in this regard.
     ///
     /// ### Example
-    /// The two replacement dots in this example represent a double space.
+    /// The two replacement dots (`··`) in this example represent a double space.
     /// ```no_run
-    /// /// This command takes two numbers as inputs and··
-    /// /// adds them together, and then returns the result.
+    /// /// This function adds two numbers and returns the result··
+    /// /// Overflow can occur when the max value is exceeded.
     /// fn add(l: i32, r: i32) -> i32 {
     ///     l + r
     /// }
@@ -88,8 +88,8 @@ declare_clippy_lint! {
     ///
     /// Use instead:
     /// ```no_run
-    /// /// This command takes two numbers as inputs and\
-    /// /// adds them together, and then returns the result.
+    /// /// This function adds two numbers and returns the result\
+    /// /// Overflow can occur when the max value is exceeded.
     /// fn add(l: i32, r: i32) -> i32 {
     ///     l + r
     /// }
@@ -97,7 +97,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.87.0"]
     pub DOC_COMMENT_DOUBLE_SPACE_LINEBREAKS,
     pedantic,
-    "double-space used for doc comment linebreak instead of `\\`"
+    "double space used for doc comment hard line break instead of `\\`"
 }
 
 declare_clippy_lint! {

--- a/tests/ui/doc/doc_comment_double_space_linebreaks.fixed
+++ b/tests/ui/doc/doc_comment_double_space_linebreaks.fixed
@@ -5,7 +5,7 @@
 #![expect(clippy::empty_docs)]
 
 //~v doc_comment_double_space_linebreaks
-//! Should warn on double space linebreaks\
+//! Should warn on double space line breaks\
 //! in file/module doc comment
 
 /// Should not warn on single-line doc comments
@@ -35,12 +35,12 @@ fn normal_comment() {
 
 //~v doc_comment_double_space_linebreaks
 /// Should warn when doc comment uses double space\
-/// as a line-break, even when there are multiple\
+/// as a line break, even when there are multiple\
 /// in a row
 fn double_space_doc_comment() {}
 
-/// Should not warn when back-slash is used \
-/// as a line-break
+/// Should not warn when backslash is used \
+/// as a line break
 fn back_slash_doc_comment() {}
 
 //~v doc_comment_double_space_linebreaks

--- a/tests/ui/doc/doc_comment_double_space_linebreaks.rs
+++ b/tests/ui/doc/doc_comment_double_space_linebreaks.rs
@@ -5,7 +5,7 @@
 #![expect(clippy::empty_docs)]
 
 //~v doc_comment_double_space_linebreaks
-//! Should warn on double space linebreaks  
+//! Should warn on double space line breaks  
 //! in file/module doc comment
 
 /// Should not warn on single-line doc comments
@@ -35,12 +35,12 @@ fn normal_comment() {
 
 //~v doc_comment_double_space_linebreaks
 /// Should warn when doc comment uses double space  
-/// as a line-break, even when there are multiple  
+/// as a line break, even when there are multiple  
 /// in a row
 fn double_space_doc_comment() {}
 
-/// Should not warn when back-slash is used \
-/// as a line-break
+/// Should not warn when backslash is used \
+/// as a line break
 fn back_slash_doc_comment() {}
 
 //~v doc_comment_double_space_linebreaks

--- a/tests/ui/doc/doc_comment_double_space_linebreaks.stderr
+++ b/tests/ui/doc/doc_comment_double_space_linebreaks.stderr
@@ -1,8 +1,8 @@
 error: doc comment uses two spaces for a hard line break
-  --> tests/ui/doc/doc_comment_double_space_linebreaks.rs:8:43
+  --> tests/ui/doc/doc_comment_double_space_linebreaks.rs:8:44
    |
-LL | //! Should warn on double space linebreaks  
-   |                                           ^^
+LL | //! Should warn on double space line breaks  
+   |                                            ^^
    |
    = help: replace this double space with a backslash: `\`
    = note: `-D clippy::doc-comment-double-space-linebreaks` implied by `-D warnings`
@@ -13,7 +13,7 @@ error: doc comment uses two spaces for a hard line break
    |
 LL | /// Should warn when doc comment uses double space  
    |                                                   ^^
-LL | /// as a line-break, even when there are multiple  
+LL | /// as a line break, even when there are multiple  
    |                                                  ^^
    |
    = help: replace this double space with a backslash: `\`


### PR DESCRIPTION
Changes:
- Makes the use case of the lint clearer
  - Explicitly mention that double space / `\` is used as "hard line break"
    That is the [term used by CommonMark](https://spec.commonmark.org/0.31.2/#hard-line-breaks), and was already used by the Clippy error message
  - Improve example
    You would not put a hard line break in the middle of a sentence
- Use consistent spelling for "line break" and "backslash"
  For "line break" it seems the spelling "linebreak" [exists as well](https://en.wiktionary.org/wiki/linebreak), but might be less common? And there were a few occurrences of "line break" already in other parts of the code (and in the Clippy error message for this lint).

changelog: none
