### PR TITLE
clippy_dev: bump rustc-literal-escaper to 0.0.8

### DIFF
--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.4", features = ["derive"] }
 indoc = "1.0"
 itertools = "0.15"
 opener = "0.8"
-rustc-literal-escaper = "0.0.7"
+rustc-literal-escaper = "0.0.8"
 walkdir = "2.3"
 
 [package.metadata.rust-analyzer]


### PR DESCRIPTION
We've been running this way at work for a while and forgot to send the patch upstream.

changelog: none
