### PR TITLE
perf: Bail out of the `disallowed_methods` rule if the disallowed list is empty.

### DIFF
--- a/clippy_lints/src/disallowed_methods.rs
+++ b/clippy_lints/src/disallowed_methods.rs
@@ -88,6 +88,9 @@ impl DisallowedMethods {
 
 impl<'tcx> LateLintPass<'tcx> for DisallowedMethods {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        if self.disallowed.is_empty() {
+            return;
+        }
         if expr.span.desugaring_kind().is_some() {
             return;
         }


### PR DESCRIPTION
This matches the same check from [`disallowed_macros`](https://github.com/rust-lang/rust-clippy/blob/d22d01ee1332567e7bafd610f1aa9115e10fc0cb/clippy_lints/src/disallowed_macros.rs#L99) and skips unnecessary work when the rule has been enabled but not configured.

changelog: none