### PR TITLE
fix(non_zero_suggestions): don't lint signed integer div/rem as NonZero

### DIFF
--- a/clippy_lints/src/non_zero_suggestions.rs
+++ b/clippy_lints/src/non_zero_suggestions.rs
@@ -52,7 +52,13 @@ impl<'tcx> LateLintPass<'tcx> for NonZeroSuggestions {
         if let ExprKind::Binary(op, _, rhs) = expr.kind
             && matches!(op.node, BinOpKind::Div | BinOpKind::Rem)
         {
-            check_non_zero_conversion(cx, rhs, Applicability::MachineApplicable);
+            // `Div<NonZero<T>>` and `Rem<NonZero<T>>` are only implemented for unsigned
+            // integer types; signed integer types do not have these impls, so suggesting
+            // `NonZeroI*::from(x)` as the divisor produces code that won't compile.
+            let rhs_ty = cx.typeck_results().expr_ty(rhs);
+            if matches!(rhs_ty.kind(), ty::Uint(_)) {
+                check_non_zero_conversion(cx, rhs, Applicability::MachineApplicable);
+            }
         } else {
             // Check if the parent expression is a binary operation
             let parent_is_binary = cx.tcx.hir_parent_iter(expr.hir_id).any(|(_, node)| {

--- a/tests/ui/non_zero_suggestions.fixed
+++ b/tests/ui/non_zero_suggestions.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::non_zero_suggestions)]
-use std::num::{NonZeroI8, NonZeroI16, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
+use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
 
 fn main() {
     /// Positive test cases (lint should trigger)
@@ -45,6 +45,12 @@ fn main() {
     let k: u64 = 300;
     let l = NonZeroU32::new(15).unwrap();
     let r9 = k / NonZeroU64::from(l);
+
+    // Signed integers in div/rem: must NOT trigger because i64 / NonZeroI64 is not in std
+    let s: i64 = 10;
+    let t = NonZeroI32::new(3).unwrap();
+    let r10 = s / i64::from(t.get());
+    let r11 = s % i64::from(t.get());
 }
 
 // Additional function to test the lint in a different context

--- a/tests/ui/non_zero_suggestions.rs
+++ b/tests/ui/non_zero_suggestions.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::non_zero_suggestions)]
-use std::num::{NonZeroI8, NonZeroI16, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
+use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
 
 fn main() {
     /// Positive test cases (lint should trigger)
@@ -45,6 +45,12 @@ fn main() {
     let k: u64 = 300;
     let l = NonZeroU32::new(15).unwrap();
     let r9 = k / NonZeroU64::from(l);
+
+    // Signed integers in div/rem: must NOT trigger because i64 / NonZeroI64 is not in std
+    let s: i64 = 10;
+    let t = NonZeroI32::new(3).unwrap();
+    let r10 = s / i64::from(t.get());
+    let r11 = s % i64::from(t.get());
 }
 
 // Additional function to test the lint in a different context

--- a/tests/ui/non_zero_suggestions.stderr
+++ b/tests/ui/non_zero_suggestions.stderr
@@ -26,13 +26,13 @@ LL |     let x = u64::from(NonZeroU32::new(5).unwrap().get());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU64::from(NonZeroU32::new(5).unwrap())`
 
 error: consider using `NonZeroU64::from()` for more efficient and type-safe conversion
-  --> tests/ui/non_zero_suggestions.rs:52:9
+  --> tests/ui/non_zero_suggestions.rs:58:9
    |
 LL |     x / u64::from(y.get())
    |         ^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU64::from(y)`
 
 error: consider using `NonZeroU64::from()` for more efficient and type-safe conversion
-  --> tests/ui/non_zero_suggestions.rs:62:22
+  --> tests/ui/non_zero_suggestions.rs:68:22
    |
 LL |         self.value / u64::from(divisor.get())
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU64::from(divisor)`


### PR DESCRIPTION
## Summary

Fixes rust-lang/rust-clippy#17382.

`Div<NonZero<T>>` and `Rem<NonZero<T>>` are only implemented for **unsigned** integer types in std. The lint was suggesting `NonZeroI*::from(x)` as the RHS of `/` or `%` when the divisor was derived from a signed `NonZero` type, which produces code that fails to compile:

```rust
let s: i64 = 10;
let t = NonZeroI32::new(3).unwrap();

// Before fix: lint fires and auto-fixes to:
let quotient = s / NonZeroI64::from(t); // error: i64 / NonZeroI64 not implemented
```

### Root Cause

In `check_expr`, the `Div | Rem` branch called `check_non_zero_conversion` unconditionally. The `get_target_non_zero_type` function returned `NonZeroI*` for signed types too, but the corresponding arithmetic impls do not exist in std.

### Fix

Guard the div/rem path: only call `check_non_zero_conversion` when the RHS type is `ty::Uint(_)`. Signed types still benefit from the lint in non-div/rem contexts (e.g., plain `let x: i64 = i64::from(nz.get())` → `NonZeroI64::from(nz)`).

## Test Plan

- Added negative test cases for `i64 / i64::from(nz.get())` and `i64 % i64::from(nz.get())` to `tests/ui/non_zero_suggestions.rs` - these must NOT trigger the lint.
- Existing positive test cases for unsigned types remain unchanged.

changelog: [`non_zero_suggestions`] Fix false positive when suggesting NonZero for signed integer div/rem