### PR TITLE
`tests_outside_test_module`: put code in backticks in the lint message

### DIFF
--- a/clippy_lints/src/tests_outside_test_module.rs
+++ b/clippy_lints/src/tests_outside_test_module.rs
@@ -66,9 +66,9 @@ impl LateLintPass<'_> for TestsOutsideTestModule {
                 cx,
                 TESTS_OUTSIDE_TEST_MODULE,
                 sp,
-                "this function marked with #[test] is outside a #[cfg(test)] module",
+                "this function marked with `#[test]` is outside a `#[cfg(test)]` module",
                 |diag| {
-                    diag.note("move it to a testing module marked with #[cfg(test)]");
+                    diag.note("move it to a testing module marked with `#[cfg(test)]`");
                 },
             );
         }

--- a/tests/ui/tests_outside_test_module.rs
+++ b/tests/ui/tests_outside_test_module.rs
@@ -8,8 +8,8 @@ fn main() {
 // Should lint
 #[test]
 fn my_test() {}
-//~^ ERROR: this function marked with #[test] is outside a #[cfg(test)] module
-//~| NOTE: move it to a testing module marked with #[cfg(test)]
+//~^ ERROR: this function marked with `#[test]` is outside a `#[cfg(test)]` module
+//~| NOTE: move it to a testing module marked with `#[cfg(test)]`
 
 #[cfg(test)]
 mod tests {

--- a/tests/ui/tests_outside_test_module.stderr
+++ b/tests/ui/tests_outside_test_module.stderr
@@ -1,10 +1,10 @@
-error: this function marked with #[test] is outside a #[cfg(test)] module
+error: this function marked with `#[test]` is outside a `#[cfg(test)]` module
   --> tests/ui/tests_outside_test_module.rs:10:1
    |
 LL | fn my_test() {}
    | ^^^^^^^^^^^^^^^
    |
-   = note: move it to a testing module marked with #[cfg(test)]
+   = note: move it to a testing module marked with `#[cfg(test)]`
    = note: `-D clippy::tests-outside-test-module` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::tests_outside_test_module)]`
 


### PR DESCRIPTION


changelog: none