### PR TITLE
Enable community reviews feature in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -117,3 +117,9 @@ users_on_vacation = [
     "@samueltardieu",
     "@ada4a",
 ]
+
+# Require community reviews before automatic assignment
+# Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment.html#community-reviews
+[assign.community_reviews]
+minimum_approvals = 2
+label = "S-waiting-on-community-reviews"


### PR DESCRIPTION
This PR enables [the community reviews feature](https://forge.rust-lang.org/triagebot/pr-assignment.html#community-reviews) in triagebot.

It's configured to require **2 approvals** before automatic assignment kicks in; manual assignments (`r?`) bypass this requirement.

It's signaled (and controlled) on a PR with the `S-waiting-on-community-reviews` label ~~(to be created)~~.

Context:
 - [#general > Article: Open Code Review at Bevy](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/Article.3A.20Open.20Code.20Review.20at.20Bevy/with/604251242)
 - [#clippy > External approvals and review](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/External.20approvals.20and.20review/with/604254405)
 - [Together for a healthier Clippy](https://blog.rust-lang.org/inside-rust/2026/07/06/unite-for-clippy/)

cc @samueltardieu @blyxyas

changelog: "none"
