### PR TITLE
fix `missing_asserts_for_indexing` ignores match for length

### DIFF
--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -124,23 +124,9 @@ fn len_comparison<'hir>(
 }
 
 /// Checks if the index expression is inside a `match` on the slice's length
-/// whose arms make the indexing infallible, e.g.
-///
-/// ```no_run
-/// # let supported: &[u8] = &[];
-/// match supported.len() {
-///     0 => {},
-///     1 => println!("{}", supported[0]),
-///     _ => println!("{} or {}", supported[0], supported[1]),
-/// }
-/// ```
-///
-/// Here the `0` and `1` arms rule out all lengths below 2, so `supported[0]`
-/// and `supported[1]` in the wildcard arm cannot fail and the bounds checks
-/// are elided without an `assert!`. The lint should not fire in this case.
-///
+/// whose arms make the indexing infallible.
 /// This only applies when the non-wildcard arms are integer literals that
-/// contiguously cover `0..=max` (see [`match_arms_bound_len `]); otherwise the wildcard
+/// contiguously cover `0..=max` otherwise the wildcard
 /// arm gives no lower bound on the length and the lint fires as usual.
 fn is_index_covered_by_match(cx: &LateContext<'_>, index_expr: &Expr<'_>, slice: &Expr<'_>) -> bool {
     for (_, node) in cx.tcx.hir_parent_iter(index_expr.hir_id) {

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -157,7 +157,7 @@ fn match_arms_bound_len(cx: &LateContext<'_>, index_expr: &Expr<'_>, arms: &[Arm
         return false;
     };
 
-    let mut excluded = Vec::new();
+    let mut matched_lens = Vec::new();
     for arm in arms {
         if arm.guard.is_some() {
             return false;
@@ -174,19 +174,19 @@ fn match_arms_bound_len(cx: &LateContext<'_>, index_expr: &Expr<'_>, arms: &[Arm
         let LitKind::Int(Pu128(n), _) = lit.node else {
             return false;
         };
-        excluded.push(n as usize);
+        matched_lens.push(n as usize);
     }
 
-    if excluded.is_empty() {
+    if matched_lens.is_empty() {
         return false;
     }
 
-    excluded.sort_unstable();
-    excluded.dedup();
+    matched_lens.sort_unstable();
+    matched_lens.dedup();
 
     // literals must be exactly 0..=max, so `_` implies len > max
-    let max = *excluded.last().unwrap();
-    excluded.len() == max + 1 && index <= max
+    let max = *matched_lens.last().unwrap();
+    matched_lens.len() == max + 1 && index <= max
 }
 
 fn is_slice_len_expr(cx: &LateContext<'_>, expr: &Expr<'_>, slice: &Expr<'_>) -> bool {

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -148,7 +148,7 @@ fn is_index_covered_by_match(cx: &LateContext<'_>, index_expr: &Expr<'_>, slice:
             Node::Expr(expr) => {
                 if let ExprKind::Match(scrutinee, arms, MatchSource::Normal) = expr.kind
                     && is_slice_len_expr(cx, scrutinee, slice)
-                    && match_arms_bound_len (cx, index_expr, arms)
+                    && match_arms_bound_len(cx, index_expr, arms)
                 {
                     return arms.iter().any(|arm| is_wild(arm.pat));
                 }
@@ -163,7 +163,7 @@ fn is_index_covered_by_match(cx: &LateContext<'_>, index_expr: &Expr<'_>, slice:
 /// Checks if the non-wildcard arms are integer literals contiguously covering
 /// `0..=max`, so that the wildcard arm implies `len > max`. Returns `true`
 /// only if the index used is at most `max`, i.e. provably in bounds.
-fn match_arms_bound_len (cx: &LateContext<'_>, index_expr: &Expr<'_>, arms: &[Arm<'_>]) -> bool {
+fn match_arms_bound_len(cx: &LateContext<'_>, index_expr: &Expr<'_>, arms: &[Arm<'_>]) -> bool {
     let ExprKind::Index(_, index_lit, _) = index_expr.kind else {
         return false;
     };

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -7,12 +7,12 @@ use clippy_utils::higher::{If, Range};
 use clippy_utils::macros::{find_assert_eq_args, first_node_macro_backtrace, root_macro_call};
 use clippy_utils::source::{snippet, snippet_with_applicability};
 use clippy_utils::visitors::for_each_expr_without_closures;
-use clippy_utils::{eq_expr_value, hash_expr};
+use clippy_utils::{eq_expr_value, hash_expr, is_wild};
 use rustc_ast::{BinOpKind, LitKind, RangeLimits};
 use rustc_data_structures::packed::Pu128;
 use rustc_data_structures::unhash::UnindexMap;
 use rustc_errors::{Applicability, Diag};
-use rustc_hir::{Block, Body, Expr, ExprKind, UnOp};
+use rustc_hir::{Arm, Block, Body, Expr, ExprKind, MatchSource, Node, PatExprKind, PatKind, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 use rustc_span::{Span, Spanned, Symbol, sym};
@@ -120,6 +120,96 @@ fn len_comparison<'hir>(
         (Rel::Eq, int_lit_pat!(left), _) => Some((LengthComparison::LengthEqualInt, left as usize, right)),
         (Rel::Eq, _, int_lit_pat!(right)) => Some((LengthComparison::LengthEqualInt, right as usize, left)),
         _ => None,
+    }
+}
+
+/// Checks if the index expression is inside a `match` on the slice's length
+/// whose arms make the indexing infallible, e.g.
+///
+/// ```no_run
+/// # let supported: &[u8] = &[];
+/// match supported.len() {
+///     0 => {},
+///     1 => println!("{}", supported[0]),
+///     _ => println!("{} or {}", supported[0], supported[1]),
+/// }
+/// ```
+///
+/// Here the `0` and `1` arms rule out all lengths below 2, so `supported[0]`
+/// and `supported[1]` in the wildcard arm cannot fail and the bounds checks
+/// are elided without an `assert!`. The lint should not fire in this case.
+///
+/// This only applies when the non-wildcard arms are integer literals that
+/// contiguously cover `0..=max` (see [`match_arms_bound_len `]); otherwise the wildcard
+/// arm gives no lower bound on the length and the lint fires as usual.
+fn is_index_covered_by_match(cx: &LateContext<'_>, index_expr: &Expr<'_>, slice: &Expr<'_>) -> bool {
+    for (_, node) in cx.tcx.hir_parent_iter(index_expr.hir_id) {
+        match node {
+            Node::Expr(expr) => {
+                if let ExprKind::Match(scrutinee, arms, MatchSource::Normal) = expr.kind
+                    && is_slice_len_expr(cx, scrutinee, slice)
+                    && match_arms_bound_len (cx, index_expr, arms)
+                {
+                    return arms.iter().any(|arm| is_wild(arm.pat));
+                }
+            },
+            Node::Block(_) | Node::Stmt(_) | Node::Arm(_) | Node::LetStmt(_) => {},
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// Checks if the non-wildcard arms are integer literals contiguously covering
+/// `0..=max`, so that the wildcard arm implies `len > max`. Returns `true`
+/// only if the index used is at most `max`, i.e. provably in bounds.
+fn match_arms_bound_len (cx: &LateContext<'_>, index_expr: &Expr<'_>, arms: &[Arm<'_>]) -> bool {
+    let ExprKind::Index(_, index_lit, _) = index_expr.kind else {
+        return false;
+    };
+    let Some(index) = upper_index_expr(cx, index_lit) else {
+        return false;
+    };
+
+    let mut excluded = Vec::new();
+    for arm in arms {
+        if arm.guard.is_some() {
+            return false;
+        }
+        if is_wild(arm.pat) {
+            continue;
+        }
+        let PatKind::Expr(pat_expr) = arm.pat.kind else {
+            return false;
+        };
+        let PatExprKind::Lit { lit, .. } = pat_expr.kind else {
+            return false;
+        };
+        let LitKind::Int(Pu128(n), _) = lit.node else {
+            return false;
+        };
+        excluded.push(n as usize);
+    }
+
+    if excluded.is_empty() {
+        return false;
+    }
+
+    excluded.sort_unstable();
+    excluded.dedup();
+
+    // literals must be exactly 0..=max, so `_` implies len > max
+    let max = *excluded.last().unwrap();
+    excluded.len() == max + 1 && index <= max
+}
+
+fn is_slice_len_expr(cx: &LateContext<'_>, expr: &Expr<'_>, slice: &Expr<'_>) -> bool {
+    if let ExprKind::MethodCall(method, recv, [], _) = expr.kind
+        && method.ident.name == sym::len
+    {
+        eq_expr_value(cx, expr.span.ctxt(), recv, slice)
+    } else {
+        false
     }
 }
 
@@ -239,6 +329,7 @@ fn check_index<'hir>(cx: &LateContext<'_>, expr: &'hir Expr<'hir>, map: &mut Uni
     if let ExprKind::Index(slice, index_lit, _) = expr.kind
         && cx.typeck_results().expr_ty_adjusted(slice).peel_refs().is_slice()
         && let Some(index) = upper_index_expr(cx, index_lit)
+        && !is_index_covered_by_match(cx, expr, slice)
     {
         let hash = hash_expr(cx, slice);
 

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -129,17 +129,19 @@ fn len_comparison<'hir>(
 /// contiguously cover `0..=max` otherwise the wildcard
 /// arm gives no lower bound on the length and the lint fires as usual.
 fn is_index_covered_by_match(cx: &LateContext<'_>, index_expr: &Expr<'_>, slice: &Expr<'_>) -> bool {
+    let mut containing_arm = None;
     for (_, node) in cx.tcx.hir_parent_iter(index_expr.hir_id) {
         match node {
             Node::Expr(expr) => {
                 if let ExprKind::Match(scrutinee, arms, MatchSource::Normal) = expr.kind
                     && is_slice_len_expr(cx, scrutinee, slice)
-                    && match_arms_bound_len(cx, index_expr, arms)
+                    && match_arms_bound_len(cx, index_expr, arms, containing_arm)
                 {
                     return arms.iter().any(|arm| is_wild(arm.pat));
                 }
             },
-            Node::Block(_) | Node::Stmt(_) | Node::Arm(_) | Node::LetStmt(_) => {},
+            Node::Block(_) | Node::Stmt(_) | Node::LetStmt(_) => {},
+            Node::Arm(arm) => containing_arm = Some(arm),
             _ => return false,
         }
     }
@@ -149,13 +151,27 @@ fn is_index_covered_by_match(cx: &LateContext<'_>, index_expr: &Expr<'_>, slice:
 /// Checks if the non-wildcard arms are integer literals contiguously covering
 /// `0..=max`, so that the wildcard arm implies `len > max`. Returns `true`
 /// only if the index used is at most `max`, i.e. provably in bounds.
-fn match_arms_bound_len(cx: &LateContext<'_>, index_expr: &Expr<'_>, arms: &[Arm<'_>]) -> bool {
+fn match_arms_bound_len(
+    cx: &LateContext<'_>,
+    index_expr: &Expr<'_>,
+    arms: &[Arm<'_>],
+    containing_arm: Option<&Arm<'_>>,
+) -> bool {
     let ExprKind::Index(_, index_lit, _) = index_expr.kind else {
         return false;
     };
     let Some(index) = upper_index_expr(cx, index_lit) else {
         return false;
     };
+
+    // index inside a literal arm `n => ...`: len is exactly `n` there,
+    // so anything at or past `n` is out of bounds
+    if let Some(arm) = containing_arm
+        && let Some(n) = arm_len_literal(arm)
+        && index >= n
+    {
+        return false;
+    }
 
     let mut matched_lens = Vec::new();
     for arm in arms {
@@ -165,28 +181,31 @@ fn match_arms_bound_len(cx: &LateContext<'_>, index_expr: &Expr<'_>, arms: &[Arm
         if is_wild(arm.pat) {
             continue;
         }
-        let PatKind::Expr(pat_expr) = arm.pat.kind else {
+        let Some(n) = arm_len_literal(arm) else {
             return false;
         };
-        let PatExprKind::Lit { lit, .. } = pat_expr.kind else {
-            return false;
-        };
-        let LitKind::Int(Pu128(n), _) = lit.node else {
-            return false;
-        };
-        matched_lens.push(n as usize);
-    }
-
-    if matched_lens.is_empty() {
-        return false;
+        matched_lens.push(n);
     }
 
     matched_lens.sort_unstable();
     matched_lens.dedup();
 
     // literals must be exactly 0..=max, so `_` implies len > max
-    let max = *matched_lens.last().unwrap();
+    let Some(&max) = matched_lens.last() else {
+        return false;
+    };
     matched_lens.len() == max + 1 && index <= max
+}
+
+fn arm_len_literal(arm: &Arm<'_>) -> Option<usize> {
+    if let PatKind::Expr(pat_expr) = arm.pat.kind
+        && let PatExprKind::Lit { lit, .. } = pat_expr.kind
+        && let LitKind::Int(Pu128(n), _) = lit.node
+    {
+        Some(n as usize)
+    } else {
+        None
+    }
 }
 
 fn is_slice_len_expr(cx: &LateContext<'_>, expr: &Expr<'_>, slice: &Expr<'_>) -> bool {

--- a/tests/ui/missing_asserts_for_indexing.fixed
+++ b/tests/ui/missing_asserts_for_indexing.fixed
@@ -198,6 +198,17 @@ mod issue17398 {
             _ => println!("{} {} {}", supported[0], supported[1], supported[2]),
         }
     }
+
+    // The `2 =>` arm's `supported[2]` is NOT suppressed (len == 2 there),
+    // but single remaining access never lints, same as `single_access`.
+    fn literal_arm_single_unsuppressed(supported: &[u8]) {
+        match supported.len() {
+            0 => {},
+            1 => {},
+            2 => println!("{} {}", supported[0], supported[2]),
+            _ => println!("{} {}", supported[0], supported[2]),
+        }
+    }
 }
 
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing.fixed
+++ b/tests/ui/missing_asserts_for_indexing.fixed
@@ -180,4 +180,24 @@ mod issue15988 {
     }
 }
 
+mod issue17398 {
+    // ok
+    fn fix_match_case(supported: &[u8]) {
+        match supported.len() {
+            0 => {},
+            1 => println!("{}", supported[0]),
+            _ => println!("{} or {}", supported[0], supported[1]),
+        }
+    }
+
+    // ok
+    fn one_index_too_high(supported: &[u8]) {
+        match supported.len() {
+            0 => {},
+            1 => {},
+            _ => println!("{} {} {}", supported[0], supported[1], supported[2]),
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing.rs
+++ b/tests/ui/missing_asserts_for_indexing.rs
@@ -198,6 +198,17 @@ mod issue17398 {
             _ => println!("{} {} {}", supported[0], supported[1], supported[2]),
         }
     }
+
+    // The `2 =>` arm's `supported[2]` is NOT suppressed (len == 2 there),
+    // but single remaining access never lints, same as `single_access`.
+    fn literal_arm_single_unsuppressed(supported: &[u8]) {
+        match supported.len() {
+            0 => {},
+            1 => {},
+            2 => println!("{} {}", supported[0], supported[2]),
+            _ => println!("{} {}", supported[0], supported[2]),
+        }
+    }
 }
 
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing.rs
+++ b/tests/ui/missing_asserts_for_indexing.rs
@@ -180,4 +180,24 @@ mod issue15988 {
     }
 }
 
+mod issue17398 {
+    // ok
+    fn fix_match_case(supported: &[u8]) {
+        match supported.len() {
+            0 => {},
+            1 => println!("{}", supported[0]),
+            _ => println!("{} or {}", supported[0], supported[1]),
+        }
+    }
+
+    // ok
+    fn one_index_too_high(supported: &[u8]) {
+        match supported.len() {
+            0 => {},
+            1 => {},
+            _ => println!("{} {} {}", supported[0], supported[1], supported[2]),
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing_unfixable.rs
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.rs
@@ -85,4 +85,42 @@ fn issue14255(v1: &[u8]) {
     //~^ missing_asserts_for_indexing
 }
 
+// not contiguous from 0: `_` can still be 0
+fn non_contiguous(supported: &[u8]) {
+    match supported.len() {
+        5 => {},
+        _ => println!("{} or {}", supported[0], supported[1]),
+        //~^ missing_asserts_for_indexing
+    }
+}
+
+// wildcard only: no length information
+#[allow(clippy::match_single_binding)]
+fn wildcard_only(supported: &[u8]) {
+    match supported.len() {
+        _ => println!("{} or {}", supported[0], supported[1]),
+        //~^ missing_asserts_for_indexing
+    }
+}
+
+// guard defeats the exclusion
+fn with_guard(supported: &[u8], flag: bool) {
+    match supported.len() {
+        0 if flag => {},
+        1 => {},
+        _ => println!("{} or {}", supported[0], supported[1]),
+        //~^ missing_asserts_for_indexing
+    }
+}
+
+// arms only guarantee len > 1, but 2 and 3 are indexed
+fn index_too_high(supported: &[u8]) {
+    match supported.len() {
+        0 => {},
+        1 => {},
+        _ => println!("{} {}", supported[2], supported[3]),
+        //~^ missing_asserts_for_indexing
+    }
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing_unfixable.rs
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.rs
@@ -123,4 +123,15 @@ fn index_too_high(supported: &[u8]) {
     }
 }
 
+// literal arm pins len to exactly 2, so indexing at 2 and 3 must lint
+fn literal_arm_out_of_bounds(supported: &[u8]) {
+    match supported.len() {
+        0 => {},
+        1 => {},
+        2 => println!("{} {}", supported[2], supported[3]),
+        //~^ missing_asserts_for_indexing
+        _ => {},
+    }
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing_unfixable.stderr
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.stderr
@@ -89,5 +89,37 @@ LL |     let _ = v1[0] + v1[1] + v1[2];
    |
    = help: consider asserting the length before indexing: `assert!(v1.len() > 2);`
 
-error: aborting due to 10 previous errors
+error: indexing into a slice multiple times without an `assert`
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:92:35
+   |
+LL |         _ => println!("{} or {}", supported[0], supported[1]),
+   |                                   ^^^^^^^^^^^^  ^^^^^^^^^^^^
+   |
+   = help: consider asserting the length before indexing: `assert!(supported.len() > 1);`
+
+error: indexing into a slice multiple times without an `assert`
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:101:35
+   |
+LL |         _ => println!("{} or {}", supported[0], supported[1]),
+   |                                   ^^^^^^^^^^^^  ^^^^^^^^^^^^
+   |
+   = help: consider asserting the length before indexing: `assert!(supported.len() > 1);`
+
+error: indexing into a slice multiple times without an `assert`
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:111:35
+   |
+LL |         _ => println!("{} or {}", supported[0], supported[1]),
+   |                                   ^^^^^^^^^^^^  ^^^^^^^^^^^^
+   |
+   = help: consider asserting the length before indexing: `assert!(supported.len() > 1);`
+
+error: indexing into a slice multiple times without an `assert`
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:121:32
+   |
+LL |         _ => println!("{} {}", supported[2], supported[3]),
+   |                                ^^^^^^^^^^^^  ^^^^^^^^^^^^
+   |
+   = help: consider asserting the length before indexing: `assert!(supported.len() > 3);`
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/missing_asserts_for_indexing_unfixable.stderr
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.stderr
@@ -121,5 +121,13 @@ LL |         _ => println!("{} {}", supported[2], supported[3]),
    |
    = help: consider asserting the length before indexing: `assert!(supported.len() > 3);`
 
-error: aborting due to 14 previous errors
+error: indexing into a slice multiple times without an `assert`
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:131:32
+   |
+LL |         2 => println!("{} {}", supported[2], supported[3]),
+   |                                ^^^^^^^^^^^^  ^^^^^^^^^^^^
+   |
+   = help: consider asserting the length before indexing: `assert!(supported.len() > 3);`
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17398

`missing_asserts_for_indexing` previously ignored `match` expressions, so indexing inside a `match` on the slice's length was linted even when the match arms already guarantee the indices are in bounds. For example:

```rust
match supported.len() { // `match` without assert
    0 => {},
    1 => println!("{}", supported[0]),
    _ => println!("{} or {}", supported[0], supported[1]),
}
```

Here the `0` and `1` arms rule out all lengths below 2, so the indexing in the wildcard arm cannot fail and the bounds checks are already elided without an `assert!`.

This PR suppresses the lint for an index inside a `match` on `slice.len()` when the non-wildcard arms are integer literals contiguously covering `0..=max` (so the wildcard arm implies `len > max`) and the index is at most `max`.

The check is deliberately conservative and falls back to linting as before when:

- the arm literals don't contiguously cover `0..=max` (e.g. `5 => .., _ => ..`, where `_` can still be `0`)
- any arm has a guard
- an arm uses an or-pattern or any non-literal pattern (e.g. `0 | 1 => ..` is safe in principle but not analyzed)

One behavioral note: suppression is per-index. If a `match` guarantees `len > 1` but the wildcard arm indexes `[0]`, `[1]` and `[2]`, only `[2]` remains unsuppressed, which is equivalent to a single unchecked access and therefore doesn't lint (consistent with the lint never firing on single accesses).

changelog: [`missing_asserts_for_indexing`]: fix false positive when a `match` on the slice length guarantees the indices are in bounds