### PR TITLE
Respect the configured MSRV in `implicit_saturating_sub`'s `if x != 0 { x -= 1 }` rewrite

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -941,6 +941,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`filter_map_next`](https://rust-lang.github.io/rust-clippy/master/index.html#filter_map_next)
 * [`from_over_into`](https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into)
 * [`if_then_some_else_none`](https://rust-lang.github.io/rust-clippy/master/index.html#if_then_some_else_none)
+* [`implicit_saturating_sub`](https://rust-lang.github.io/rust-clippy/master/index.html#implicit_saturating_sub)
 * [`index_refutable_slice`](https://rust-lang.github.io/rust-clippy/master/index.html#index_refutable_slice)
 * [`inefficient_to_string`](https://rust-lang.github.io/rust-clippy/master/index.html#inefficient_to_string)
 * [`io_other_error`](https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -796,6 +796,7 @@ define_Conf! {
         filter_map_next,
         from_over_into,
         if_then_some_else_none,
+        implicit_saturating_sub,
         index_refutable_slice,
         inefficient_to_string,
         io_other_error,

--- a/clippy_lints/src/implicit_saturating_sub.rs
+++ b/clippy_lints/src/implicit_saturating_sub.rs
@@ -104,7 +104,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitSaturatingSub {
             // Check if the conditional expression is a binary operation
             && let ExprKind::Binary(ref cond_op, cond_left, cond_right) = cond.kind
         {
-            check_with_condition(cx, expr, cond_op.node, cond_left, cond_right, then);
+            check_with_condition(cx, expr, cond_op.node, cond_left, cond_right, then, self.msrv);
         } else if let Some(higher::If {
             cond,
             then: if_block,
@@ -309,6 +309,7 @@ fn check_with_condition<'tcx>(
     cond_left: &Expr<'tcx>,
     cond_right: &Expr<'tcx>,
     then: &Expr<'tcx>,
+    msrv: Msrv,
 ) {
     // Ensure that the binary operator is >, !=, or <
     if (BinOpKind::Ne == cond_op || BinOpKind::Gt == cond_op || BinOpKind::Lt == cond_op)
@@ -339,6 +340,10 @@ fn check_with_condition<'tcx>(
 
         // Check if the variable in the condition statement is an integer
         if !cx.typeck_results().expr_ty(cond_var).is_integral() {
+            return;
+        }
+
+        if is_in_const_context(cx) && !msrv.meets(cx, msrvs::SATURATING_SUB_CONST) {
             return;
         }
 

--- a/tests/ui/implicit_saturating_sub.fixed
+++ b/tests/ui/implicit_saturating_sub.fixed
@@ -278,3 +278,23 @@ fn wrongly_unmangled_macros() {
     let b = 20u64;
     let _ = test_big!(a).saturating_sub(test_little!(b));
 }
+
+#[clippy::msrv = "1.46.0"]
+pub const fn const_msrv_too_low(mut x: u32) -> u32 {
+    if x != 0 {
+        x -= 1;
+    }
+    x
+}
+
+#[clippy::msrv = "1.47.0"]
+pub const fn const_msrv_ok(mut x: u32) -> u32 {
+    x = x.saturating_sub(1);
+    x
+}
+
+#[clippy::msrv = "1.46.0"]
+pub fn nonconst_msrv_low(mut x: u32) -> u32 {
+    x = x.saturating_sub(1);
+    x
+}

--- a/tests/ui/implicit_saturating_sub.rs
+++ b/tests/ui/implicit_saturating_sub.rs
@@ -357,3 +357,29 @@ fn wrongly_unmangled_macros() {
         0
     };
 }
+
+#[clippy::msrv = "1.46.0"]
+pub const fn const_msrv_too_low(mut x: u32) -> u32 {
+    if x != 0 {
+        x -= 1;
+    }
+    x
+}
+
+#[clippy::msrv = "1.47.0"]
+pub const fn const_msrv_ok(mut x: u32) -> u32 {
+    if x != 0 {
+        //~^ implicit_saturating_sub
+        x -= 1;
+    }
+    x
+}
+
+#[clippy::msrv = "1.46.0"]
+pub fn nonconst_msrv_low(mut x: u32) -> u32 {
+    if x != 0 {
+        //~^ implicit_saturating_sub
+        x -= 1;
+    }
+    x
+}

--- a/tests/ui/implicit_saturating_sub.stderr
+++ b/tests/ui/implicit_saturating_sub.stderr
@@ -256,5 +256,23 @@ LL | |         0
 LL | |     };
    | |_____^ help: replace it with: `test_big!(a).saturating_sub(test_little!(b))`
 
-error: aborting due to 29 previous errors
+error: implicitly performing saturating subtraction
+  --> tests/ui/implicit_saturating_sub.rs:371:5
+   |
+LL | /     if x != 0 {
+LL | |
+LL | |         x -= 1;
+LL | |     }
+   | |_____^ help: try: `x = x.saturating_sub(1);`
+
+error: implicitly performing saturating subtraction
+  --> tests/ui/implicit_saturating_sub.rs:380:5
+   |
+LL | /     if x != 0 {
+LL | |
+LL | |         x -= 1;
+LL | |     }
+   | |_____^ help: try: `x = x.saturating_sub(1);`
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17403

`implicit_saturating_sub` rewrites `if x != 0 { x -= 1 }` into `x = x.saturating_sub(1)`. `saturating_sub` is only usable in a `const fn` since Rust 1.47, so in a `const fn` with a lower configured MSRV the rewrite does not compile.

rust-lang/rust-clippy#16309 already added this MSRV check to the `if a >= b { 0 } else { b - a }` path, but the condition path (`if x != 0 { x -= 1 }`) was left unguarded. This threads the MSRV into that path and applies the same check, so the lint stays quiet when the suggested `saturating_sub` would be too new for the const context.

The lint reads the MSRV but was missing from the list of MSRV affected lints in the configuration docs, so this registers it there as well.

changelog: [`implicit_saturating_sub`]: respect the configured MSRV in const contexts for the `if x != 0 { x -= 1 }` rewrite
