### PR TITLE
Partly disable `unneeded_wildcard_pattern` when `rest_pattern_accessible_field` is enabled

### DIFF
--- a/clippy_lints/src/misc_early/unneeded_wildcard_pattern.rs
+++ b/clippy_lints/src/misc_early/unneeded_wildcard_pattern.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_ast::ast::{Pat, PatFieldsRest, PatKind};
 use rustc_errors::Applicability;
-use rustc_lint::EarlyContext;
+use rustc_lint::{EarlyContext, LintContext as _};
 use rustc_span::Span;
 
 use super::UNNEEDED_WILDCARD_PATTERN;
@@ -40,6 +40,8 @@ pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
             .take_while(|patfield| matches!(patfield.pat.kind, PatKind::Wild))
             .enumerate()
             .last()
+        // Only run if `rest_pattern_accessible_field` is Allow, as they otherwise will contradict each other.
+        && cx.get_lint_level_spec(crate::rest_when_destructuring_struct::REST_PATTERN_ACCESSIBLE_FIELD).is_allow()
     {
         // Unlike the tuples above, structs have patfields rather than patterns, and separate out the
         // `..` into a separate parameter. Also, the `..` can only be at the end of the pattern.

--- a/tests/ui/rest_pattern_accessible_field.fixed
+++ b/tests/ui/rest_pattern_accessible_field.fixed
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 //@aux-build:non-exhaustive-struct.rs
 #![warn(clippy::rest_pattern_accessible_field)]
-#![allow(clippy::unneeded_wildcard_pattern)]
+#![warn(clippy::unneeded_wildcard_pattern)]
 
 use non_exhaustive_struct::{NonExhaustiveStruct, NonExhaustiveStructNoPrivateFields};
 

--- a/tests/ui/rest_pattern_accessible_field.rs
+++ b/tests/ui/rest_pattern_accessible_field.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 //@aux-build:non-exhaustive-struct.rs
 #![warn(clippy::rest_pattern_accessible_field)]
-#![allow(clippy::unneeded_wildcard_pattern)]
+#![warn(clippy::unneeded_wildcard_pattern)]
 
 use non_exhaustive_struct::{NonExhaustiveStruct, NonExhaustiveStructNoPrivateFields};
 


### PR DESCRIPTION
Since rust-lang/rust-clippy#16733 (related issue: rust-lang/rust-clippy#16638) `unneeded_wildcard_pattern` have supported struct patterns, but this is directly contradictory to the lint `rest_pattern_accessible_field` introduced in rust-lang/rust-clippy#15000.

This change disable the `unneeded_wildcard_pattern` check for struct patterns if the `rest_pattern_accessible_field` lint is enabled.

Example:
```rust
#![allow(unused)]
#![warn(clippy::rest_pattern_accessible_field)]
#![warn(clippy::unneeded_wildcard_pattern)]

fn main() {
   struct Struct4 {
        a: u32,
        b: u32,
        c: u32,
        d: u32,
    }

    let fourval = Struct4 {
        a: 5,
        b: 10,
        c: 15,
        d: 20,
    };

    let Struct4 { a, b, c: _, .. } = fourval;
}
```

Before:
```
warning: this pattern is unneeded as the `..` pattern can match that element
  --> example.rs:20:25
   |
20 |     let Struct4 { a, b, c: _, .. } = fourval;
   |                         ^^^^^^ help: remove it
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_wildcard_pattern
note: the lint level is defined here
  --> example.rs:3:9
   |
 3 | #![warn(clippy::unneeded_wildcard_pattern)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: struct destructuring with rest (`..`)
  --> example.rs:20:9
   |
20 |     let Struct4 { a, b, c: _, .. } = fourval;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#rest_pattern_accessible_field
note: the lint level is defined here
  --> example.rs:2:9
   |
 2 | #![warn(clippy::rest_pattern_accessible_field)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: consider explicitly ignoring remaining fields with wildcard patterns (`x: _`)
   |
20 -     let Struct4 { a, b, c: _, .. } = fourval;
20 +     let Struct4 { a, b, c: _, d: _ } = fourval;
   |
```

After:
```
warning: struct destructuring with rest (`..`)
  --> example.rs:20:9
   |
20 |     let Struct4 { a, b, c: _, .. } = fourval;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#rest_pattern_accessible_field
note: the lint level is defined here
  --> example.rs:2:9
   |
 2 | #![warn(clippy::rest_pattern_accessible_field)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: consider explicitly ignoring remaining fields with wildcard patterns (`x: _`)
   |
20 -     let Struct4 { a, b, c: _, .. } = fourval;
20 +     let Struct4 { a, b, c: _, d: _ } = fourval;
   |

warning: 1 warning emitted
```

changelog: [`unneeded_wildcard_pattern`]: Partly disable when [`rest_pattern_accessible_field`] is enabled.
