### PR TITLE
lints: `constant_bool_expr`: detect constant booleans expressions using `&&` or `||`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6832,6 +6832,7 @@ Released 2018-09-13
 [`confusing_method_to_numeric_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#confusing_method_to_numeric_cast
 [`const_is_empty`]: https://rust-lang.github.io/rust-clippy/master/index.html#const_is_empty
 [`const_static_lifetime`]: https://rust-lang.github.io/rust-clippy/master/index.html#const_static_lifetime
+[`constant_bool_expr`]: https://rust-lang.github.io/rust-clippy/master/index.html#constant_bool_expr
 [`copy_iterator`]: https://rust-lang.github.io/rust-clippy/master/index.html#copy_iterator
 [`crate_in_macro_def`]: https://rust-lang.github.io/rust-clippy/master/index.html#crate_in_macro_def
 [`create_dir`]: https://rust-lang.github.io/rust-clippy/master/index.html#create_dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6950,6 +6950,7 @@ Released 2018-09-13
 [`confusing_method_to_numeric_cast`]: https://rust-lang.github.io/rust-clippy/main/index.html#confusing_method_to_numeric_cast
 [`const_is_empty`]: https://rust-lang.github.io/rust-clippy/main/index.html#const_is_empty
 [`const_static_lifetime`]: https://rust-lang.github.io/rust-clippy/main/index.html#const_static_lifetime
+[`constant_bool_expr`]: https://rust-lang.github.io/rust-clippy/main/index.html#constant_bool_expr
 [`copy_iterator`]: https://rust-lang.github.io/rust-clippy/main/index.html#copy_iterator
 [`crate_in_macro_def`]: https://rust-lang.github.io/rust-clippy/main/index.html#crate_in_macro_def
 [`create_dir`]: https://rust-lang.github.io/rust-clippy/main/index.html#create_dir

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -1,5 +1,6 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_hir_and_then};
+use clippy_utils::consts::{ConstEvalCtxt, Constant};
+use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg, span_lint_hir_and_then};
 use clippy_utils::higher::has_let_expr;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef as _;
@@ -16,6 +17,34 @@ use rustc_session::impl_lint_pass;
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Span, Symbol, SyntaxContext};
 use std::fmt::Write as _;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for boolean expressions that end up constant, always `true` or `false`.
+    ///
+    /// ### Why is this bad?
+    /// This is most likely a logic bug.
+    ///
+    /// ### Limitations
+    /// This lint only checks against literals and constant expressions since it cannot determine
+    /// if `a == bar() && a == foo()` will actually be different or not at runtime.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let a = 99;
+    /// if a != 100 || a != 101 { println!("Hello {a}"); } // Always true
+    /// if a == 100 && a == 101 { println!("Hello {a}"); } // Always false
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let a = 99;
+    /// println!("Hello {a}");
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub CONSTANT_BOOL_EXPR,
+    correctness,
+    "checks for boolean expressions that end up constant"
+}
 
 declare_clippy_lint! {
     /// ### What it does
@@ -77,7 +106,11 @@ declare_clippy_lint! {
     "boolean expressions that contain terminals which can be eliminated"
 }
 
-impl_lint_pass!(NonminimalBool => [NONMINIMAL_BOOL, OVERLY_COMPLEX_BOOL_EXPR]);
+impl_lint_pass!(NonminimalBool => [
+    CONSTANT_BOOL_EXPR,
+    NONMINIMAL_BOOL,
+    OVERLY_COMPLEX_BOOL_EXPR,
+]);
 
 // For each pairs, both orders are considered.
 const METHODS_WITH_NEGATION: [(Option<RustcVersion>, Symbol, Symbol); 3] = [
@@ -110,17 +143,18 @@ impl<'tcx> LateLintPass<'tcx> for NonminimalBool {
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        match expr.kind {
+        if let ExprKind::Binary(op, left, right) = expr.kind {
+            check_for_constant_bool_expr(cx, expr, op.node, left, right);
+
             // This check the case where an element in a boolean comparison is inverted, like:
             //
             // ```
             // let a = true;
             // !a == false;
             // ```
-            ExprKind::Binary(op, left, right) if matches!(op.node, BinOpKind::Eq | BinOpKind::Ne) => {
+            if matches!(op.node, BinOpKind::Eq | BinOpKind::Ne) {
                 check_inverted_bool_in_condition(cx, expr.span, op.node, left, right);
-            },
-            _ => {},
+            }
         }
     }
 }
@@ -676,4 +710,110 @@ fn implements_ord(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     cx.tcx
         .get_diagnostic_item(sym::Ord)
         .is_some_and(|id| implements_trait(cx, ty, id, &[]))
+}
+
+fn check_for_constant_bool_expr<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    op: BinOpKind,
+    left: &'tcx Expr<'_>,
+    right: &'tcx Expr<'_>,
+) {
+    match op {
+        BinOpKind::Or => detect_always_true_or(cx, expr, left, right),
+        BinOpKind::And => detect_always_false_and(cx, expr, left, right),
+        _ => (),
+    }
+}
+
+// `left_lhs != left_rhs || right_lhs != right_rhs`
+fn detect_always_true_or<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    left: &'tcx Expr<'_>,
+    right: &'tcx Expr<'_>,
+) {
+    let ExprKind::Binary(left_op, left_lhs, left_rhs) = left.kind else {
+        return;
+    };
+    let ExprKind::Binary(right_op, right_lhs, right_rhs) = right.kind else {
+        return;
+    };
+    if left_op.node != BinOpKind::Ne || right_op.node != BinOpKind::Ne {
+        return;
+    }
+
+    if detect_variants(cx, expr, left_lhs, right_lhs, left_rhs, right_rhs) {
+        span_lint(
+            cx,
+            CONSTANT_BOOL_EXPR,
+            expr.span,
+            "expression always evaluates to `true`",
+        );
+    }
+}
+
+// `left_lhs == left_rhs && right_lhs == right_rhs`
+fn detect_always_false_and<'tcx>(
+    cx: &LateContext<'tcx>,
+    e: &'tcx Expr<'_>,
+    left: &'tcx Expr<'_>,
+    right: &'tcx Expr<'_>,
+) {
+    let ExprKind::Binary(left_op, left_lhs, left_rhs) = left.kind else {
+        return;
+    };
+    let ExprKind::Binary(right_op, right_lhs, right_rhs) = right.kind else {
+        return;
+    };
+    if left_op.node != BinOpKind::Eq || right_op.node != BinOpKind::Eq {
+        return;
+    }
+
+    if detect_variants(cx, e, left_lhs, right_lhs, left_rhs, right_rhs) {
+        span_lint(cx, CONSTANT_BOOL_EXPR, e.span, "expression always evaluates to `false`");
+    }
+}
+
+fn detect_variants<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    left_lhs: &'tcx Expr<'_>,
+    right_lhs: &'tcx Expr<'_>,
+    left_rhs: &'tcx Expr<'_>,
+    right_rhs: &'tcx Expr<'_>,
+) -> bool {
+    let ctxt = expr.span.ctxt();
+
+    let detect_variant = |left_a, right_a, left_cmp: &Expr<'_>, right_cmp: &Expr<'_>| {
+        // If the `a` expression is not the same on both sides, there is no need to go further
+        if !eq_expr_value(cx, ctxt, left_a, right_a) {
+            return false;
+        }
+
+        let const_ctx = ConstEvalCtxt::new(cx);
+
+        // We try to look into constants and const blocks, but if that fails we fall back to handling
+        // literals only
+        if let Some(left_evaluated) = const_ctx.eval(left_cmp)
+            && let Some(right_evaluated) = const_ctx.eval(right_cmp)
+            && left_evaluated != Constant::Err
+            && right_evaluated != Constant::Err
+        {
+            left_evaluated != right_evaluated
+        } else {
+            matches!(left_cmp.kind, ExprKind::Lit(_))
+                && matches!(right_cmp.kind, ExprKind::Lit(_))
+                && !eq_expr_value(cx, ctxt, left_cmp, right_cmp)
+        }
+    };
+
+    // (a CMP_OP _) BIN_OP (a CMP_OP _)
+    detect_variant(left_lhs, right_lhs, left_rhs, right_rhs)
+        // (a CMP_OP _) BIN_OP (_ CMP_OP a)
+        || detect_variant(left_lhs, right_rhs, left_rhs, right_lhs)
+        // (_ CMP_OP a) BIN_OP (a CMP_OP _)
+        || detect_variant(left_rhs, right_lhs, left_lhs, right_rhs)
+        // (_ CMP_OP a) BIN_OP (_ CMP_OP a)
+        || detect_variant(left_rhs, right_rhs, left_lhs, right_lhs)
 }

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -1,5 +1,6 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_hir_and_then};
+use clippy_utils::consts::{ConstEvalCtxt, Constant};
+use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg, span_lint_hir_and_then};
 use clippy_utils::higher::has_let_expr;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef as _;
@@ -16,6 +17,34 @@ use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Span, Symbol, SyntaxContext};
 use std::fmt::Write as _;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for boolean expressions that end up constant, always `true` or `false`.
+    ///
+    /// ### Why is this bad?
+    /// This is most likely a logic bug.
+    ///
+    /// ### Limitations
+    /// This lint only checks against literals and constant expressions since it cannot determine
+    /// if `a == bar() && a == foo()` will actually be different or not at runtime.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let a = 99;
+    /// if a != 100 || a != 101 { println!("Hello {a}"); } // Always true
+    /// if a == 100 && a == 101 { println!("Hello {a}"); } // Always false
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let a = 99;
+    /// println!("Hello {a}");
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub CONSTANT_BOOL_EXPR,
+    correctness,
+    "checks for boolean expressions that end up constant"
+}
 
 declare_clippy_lint! {
     /// ### What it does
@@ -77,7 +106,11 @@ declare_clippy_lint! {
     "boolean expressions that contain terminals which can be eliminated"
 }
 
-impl_lint_pass!(NonminimalBool => [NONMINIMAL_BOOL, OVERLY_COMPLEX_BOOL_EXPR]);
+impl_lint_pass!(NonminimalBool => [
+    CONSTANT_BOOL_EXPR,
+    NONMINIMAL_BOOL,
+    OVERLY_COMPLEX_BOOL_EXPR,
+]);
 
 // For each pairs, both orders are considered.
 const METHODS_WITH_NEGATION: [(Option<RustcVersion>, Symbol, Symbol); 3] = [
@@ -110,17 +143,18 @@ impl<'tcx> LateLintPass<'tcx> for NonminimalBool {
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        match expr.kind {
+        if let ExprKind::Binary(op, left, right) = expr.kind {
+            check_for_constant_bool_expr(cx, expr, op.node, left, right);
+
             // This check the case where an element in a boolean comparison is inverted, like:
             //
             // ```
             // let a = true;
             // !a == false;
             // ```
-            ExprKind::Binary(op, left, right) if matches!(op.node, BinOpKind::Eq | BinOpKind::Ne) => {
+            if matches!(op.node, BinOpKind::Eq | BinOpKind::Ne) {
                 check_inverted_bool_in_condition(cx, expr.span, op.node, left, right);
-            },
-            _ => {},
+            }
         }
     }
 }
@@ -676,4 +710,110 @@ fn implements_ord(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     cx.tcx
         .get_diagnostic_item(sym::Ord)
         .is_some_and(|id| implements_trait(cx, ty, id, &[]))
+}
+
+fn check_for_constant_bool_expr<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    op: BinOpKind,
+    left: &'tcx Expr<'_>,
+    right: &'tcx Expr<'_>,
+) {
+    match op {
+        BinOpKind::Or => detect_always_true_or(cx, expr, left, right),
+        BinOpKind::And => detect_always_false_and(cx, expr, left, right),
+        _ => (),
+    }
+}
+
+// `left_lhs != left_rhs || right_lhs != right_rhs`
+fn detect_always_true_or<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    left: &'tcx Expr<'_>,
+    right: &'tcx Expr<'_>,
+) {
+    let ExprKind::Binary(left_op, left_lhs, left_rhs) = left.kind else {
+        return;
+    };
+    let ExprKind::Binary(right_op, right_lhs, right_rhs) = right.kind else {
+        return;
+    };
+    if left_op.node != BinOpKind::Ne || right_op.node != BinOpKind::Ne {
+        return;
+    }
+
+    if detect_variants(cx, expr, left_lhs, right_lhs, left_rhs, right_rhs) {
+        span_lint(
+            cx,
+            CONSTANT_BOOL_EXPR,
+            expr.span,
+            "expression always evaluates to `true`",
+        );
+    }
+}
+
+// `left_lhs == left_rhs && right_lhs == right_rhs`
+fn detect_always_false_and<'tcx>(
+    cx: &LateContext<'tcx>,
+    e: &'tcx Expr<'_>,
+    left: &'tcx Expr<'_>,
+    right: &'tcx Expr<'_>,
+) {
+    let ExprKind::Binary(left_op, left_lhs, left_rhs) = left.kind else {
+        return;
+    };
+    let ExprKind::Binary(right_op, right_lhs, right_rhs) = right.kind else {
+        return;
+    };
+    if left_op.node != BinOpKind::Eq || right_op.node != BinOpKind::Eq {
+        return;
+    }
+
+    if detect_variants(cx, e, left_lhs, right_lhs, left_rhs, right_rhs) {
+        span_lint(cx, CONSTANT_BOOL_EXPR, e.span, "expression always evaluates to `false`");
+    }
+}
+
+fn detect_variants<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    left_lhs: &'tcx Expr<'_>,
+    right_lhs: &'tcx Expr<'_>,
+    left_rhs: &'tcx Expr<'_>,
+    right_rhs: &'tcx Expr<'_>,
+) -> bool {
+    let ctxt = expr.span.ctxt();
+
+    let detect_variant = |left_a, right_a, left_cmp: &Expr<'_>, right_cmp: &Expr<'_>| {
+        // If the `a` expression is not the same on both sides, there is no need to go further
+        if !eq_expr_value(cx, ctxt, left_a, right_a) {
+            return false;
+        }
+
+        let const_ctx = ConstEvalCtxt::new(cx);
+
+        // We try to look into constants and const blocks, but if that fails we fall back to handling
+        // literals only
+        if let Some(left_evaluated) = const_ctx.eval(left_cmp)
+            && let Some(right_evaluated) = const_ctx.eval(right_cmp)
+            && left_evaluated != Constant::Err
+            && right_evaluated != Constant::Err
+        {
+            left_evaluated != right_evaluated
+        } else {
+            matches!(left_cmp.kind, ExprKind::Lit(_))
+                && matches!(right_cmp.kind, ExprKind::Lit(_))
+                && !eq_expr_value(cx, ctxt, left_cmp, right_cmp)
+        }
+    };
+
+    // (a CMP_OP _) BIN_OP (a CMP_OP _)
+    detect_variant(left_lhs, right_lhs, left_rhs, right_rhs)
+        // (a CMP_OP _) BIN_OP (_ CMP_OP a)
+        || detect_variant(left_lhs, right_rhs, left_rhs, right_lhs)
+        // (_ CMP_OP a) BIN_OP (a CMP_OP _)
+        || detect_variant(left_rhs, right_lhs, left_lhs, right_rhs)
+        // (_ CMP_OP a) BIN_OP (_ CMP_OP a)
+        || detect_variant(left_rhs, right_rhs, left_lhs, right_lhs)
 }

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -41,6 +41,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::bool_assert_comparison::BOOL_ASSERT_COMPARISON_INFO,
     crate::bool_comparison::BOOL_COMPARISON_INFO,
     crate::bool_to_int_with_if::BOOL_TO_INT_WITH_IF_INFO,
+    crate::booleans::CONSTANT_BOOL_EXPR_INFO,
     crate::booleans::NONMINIMAL_BOOL_INFO,
     crate::booleans::OVERLY_COMPLEX_BOOL_EXPR_INFO,
     crate::borrow_deref_ref::BORROW_DEREF_REF_INFO,

--- a/tests/ui/collapsible_if.fixed
+++ b/tests/ui/collapsible_if.fixed
@@ -1,5 +1,9 @@
 #![allow(clippy::eq_op, clippy::needless_ifs)]
-#![expect(clippy::assertions_on_constants, clippy::redundant_pattern_matching)]
+#![expect(
+    clippy::assertions_on_constants,
+    clippy::constant_bool_expr,
+    clippy::redundant_pattern_matching
+)]
 
 #[rustfmt::skip]
 #[warn(clippy::collapsible_if)]

--- a/tests/ui/collapsible_if.rs
+++ b/tests/ui/collapsible_if.rs
@@ -1,5 +1,9 @@
 #![allow(clippy::eq_op, clippy::needless_ifs)]
-#![expect(clippy::assertions_on_constants, clippy::redundant_pattern_matching)]
+#![expect(
+    clippy::assertions_on_constants,
+    clippy::constant_bool_expr,
+    clippy::redundant_pattern_matching
+)]
 
 #[rustfmt::skip]
 #[warn(clippy::collapsible_if)]

--- a/tests/ui/collapsible_if.stderr
+++ b/tests/ui/collapsible_if.stderr
@@ -1,5 +1,5 @@
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:9:5
+  --> tests/ui/collapsible_if.rs:13:5
    |
 LL | /     if x == "hello" {
 LL | |         if y == "world" {
@@ -19,7 +19,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:16:5
+  --> tests/ui/collapsible_if.rs:20:5
    |
 LL | /     if x == "hello" || x == "world" {
 LL | |         if y == "world" || y == "hello" {
@@ -37,7 +37,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:23:5
+  --> tests/ui/collapsible_if.rs:27:5
    |
 LL | /     if x == "hello" && x == "world" {
 LL | |         if y == "world" || y == "hello" {
@@ -55,7 +55,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:30:5
+  --> tests/ui/collapsible_if.rs:34:5
    |
 LL | /     if x == "hello" || x == "world" {
 LL | |         if y == "world" && y == "hello" {
@@ -73,7 +73,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:37:5
+  --> tests/ui/collapsible_if.rs:41:5
    |
 LL | /     if x == "hello" && x == "world" {
 LL | |         if y == "world" && y == "hello" {
@@ -91,7 +91,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:44:5
+  --> tests/ui/collapsible_if.rs:48:5
    |
 LL | /     if 42 == 1337 {
 LL | |         if 'a' != 'A' {
@@ -109,7 +109,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:80:5
+  --> tests/ui/collapsible_if.rs:84:5
    |
 LL | /     if x == "hello" {
 LL | |         if y == "world" { // Collapsible
@@ -127,7 +127,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:108:5
+  --> tests/ui/collapsible_if.rs:112:5
    |
 LL | /     if matches!(true, true) {
 LL | |         if matches!(true, true) {}
@@ -141,7 +141,7 @@ LL ~         && matches!(true, true) {}
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:114:5
+  --> tests/ui/collapsible_if.rs:118:5
    |
 LL | /     if matches!(true, true) && truth() {
 LL | |         if matches!(true, true) {}
@@ -155,7 +155,7 @@ LL ~         && matches!(true, true) {}
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:126:5
+  --> tests/ui/collapsible_if.rs:130:5
    |
 LL | /     if true {
 LL | |         if true {
@@ -173,7 +173,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:143:5
+  --> tests/ui/collapsible_if.rs:147:5
    |
 LL | /     if true {
 LL | |         if true {
@@ -191,7 +191,7 @@ LL ~     ; 3
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui/collapsible_if.rs:190:5
+  --> tests/ui/collapsible_if.rs:194:5
    |
 LL | /     if true {
 LL | |         (if true {

--- a/tests/ui/constant_bool_expr.rs
+++ b/tests/ui/constant_bool_expr.rs
@@ -1,0 +1,41 @@
+#![warn(clippy::constant_bool_expr)]
+#![expect(clippy::needless_ifs)]
+
+fn main() {
+    let a = 99;
+
+    if a != 100 || a != 101 {}
+    //~^ constant_bool_expr
+    if a == 100 && a == 101 {}
+    //~^ constant_bool_expr
+
+    let _b = a != 100 || a != 101;
+    //~^ constant_bool_expr
+    let _b = a == 100 && a == 101;
+    //~^ constant_bool_expr
+
+    const A: i32 = 100;
+
+    let _b = a != A || a != 101;
+    //~^ constant_bool_expr
+    let _b = a == A && a == 101;
+    //~^ constant_bool_expr
+
+    let _b = a != A || a != const { 100 + 1 };
+    //~^ constant_bool_expr
+    let _b = a == A && a == const { 100 + 1 };
+    //~^ constant_bool_expr
+}
+
+const B: i32 = 100;
+const C: i32 = 99;
+
+const _: bool = C != B || C != const { 100 + 1 };
+//~^ constant_bool_expr
+const _: bool = C == B && C == const { 100 + 1 };
+//~^ constant_bool_expr
+
+static D: bool = C != B || C != const { 100 + 1 };
+//~^ constant_bool_expr
+static E: bool = C == B && C == const { 100 + 1 };
+//~^ constant_bool_expr

--- a/tests/ui/constant_bool_expr.stderr
+++ b/tests/ui/constant_bool_expr.stderr
@@ -1,0 +1,77 @@
+error: expression always evaluates to `true`
+  --> tests/ui/constant_bool_expr.rs:7:8
+   |
+LL |     if a != 100 || a != 101 {}
+   |        ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::constant-bool-expr` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::constant_bool_expr)]`
+
+error: expression always evaluates to `false`
+  --> tests/ui/constant_bool_expr.rs:9:8
+   |
+LL |     if a == 100 && a == 101 {}
+   |        ^^^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `true`
+  --> tests/ui/constant_bool_expr.rs:12:14
+   |
+LL |     let _b = a != 100 || a != 101;
+   |              ^^^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `false`
+  --> tests/ui/constant_bool_expr.rs:14:14
+   |
+LL |     let _b = a == 100 && a == 101;
+   |              ^^^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `true`
+  --> tests/ui/constant_bool_expr.rs:19:14
+   |
+LL |     let _b = a != A || a != 101;
+   |              ^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `false`
+  --> tests/ui/constant_bool_expr.rs:21:14
+   |
+LL |     let _b = a == A && a == 101;
+   |              ^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `true`
+  --> tests/ui/constant_bool_expr.rs:24:14
+   |
+LL |     let _b = a != A || a != const { 100 + 1 };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `false`
+  --> tests/ui/constant_bool_expr.rs:26:14
+   |
+LL |     let _b = a == A && a == const { 100 + 1 };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `true`
+  --> tests/ui/constant_bool_expr.rs:33:17
+   |
+LL | const _: bool = C != B || C != const { 100 + 1 };
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `false`
+  --> tests/ui/constant_bool_expr.rs:35:17
+   |
+LL | const _: bool = C == B && C == const { 100 + 1 };
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `true`
+  --> tests/ui/constant_bool_expr.rs:38:18
+   |
+LL | static D: bool = C != B || C != const { 100 + 1 };
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expression always evaluates to `false`
+  --> tests/ui/constant_bool_expr.rs:40:18
+   |
+LL | static E: bool = C == B && C == const { 100 + 1 };
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
+


### PR DESCRIPTION
Detects expressions of the form `a != b || a != c` or `a == b && a == c` (where `a`, `b`, and `c` are all unique expressions) to warn about them: they evaluate either always to `true` or always to `false`, which is very likely a logic bug.

Closes rust-lang/rust-clippy#853

changelog: [`constant_bool_expr`]: detect constant booleans expressions using `&&` or `||`
