### PR TITLE
lints: `rest_pattern_accessible_fields`: fix typo `accesible` -> `accessible`

### DIFF
--- a/clippy_lints/src/rest_when_destructuring_struct.rs
+++ b/clippy_lints/src/rest_when_destructuring_struct.rs
@@ -9,7 +9,7 @@ use std::fmt::Write as _;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Disallow the use of rest patterns for accesible fields
+    /// Disallow the use of rest patterns for accessible fields
     ///
     /// ### Why restrict this?
     /// It might lead to unhandled fields when the struct changes.


### PR DESCRIPTION
changelog: none
