### PR TITLE
fix(blocks_in_conditions): Don't lint if the block creates temporarie…

### DIFF
--- a/clippy_lints/src/blocks_in_conditions.rs
+++ b/clippy_lints/src/blocks_in_conditions.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_block_with_applicability;
-use clippy_utils::{contains_return, higher, is_from_proc_macro};
+use clippy_utils::{contains_return, higher, is_from_proc_macro, leaks_droppable_temporary};
 use rustc_errors::Applicability;
 use rustc_hir::{BlockCheckMode, Expr, ExprKind, MatchSource};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
@@ -90,6 +90,14 @@ impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
                         // Linting should not be triggered to cases where `return` is included in the condition.
                         // #9911
                         if contains_return(block.expr) {
+                            return;
+                        }
+
+                        // Don't lint if the block creates temporaries with significant drops that need
+                        // to be dropped at the end of the block (e.g., MutexGuard).
+                        // Removing the braces would extend the lifetime of these temporaries.
+                        // #15112
+                        if leaks_droppable_temporary(cx, ex) {
                             return;
                         }
 

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -3416,6 +3416,19 @@ pub fn leaks_droppable_temporary_with_limited_lifetime<'tcx>(cx: &LateContext<'t
     .is_break()
 }
 
+/// Returns true if `expr` creates any temporary that has a significant drop and does not consume
+/// it.
+pub fn leaks_droppable_temporary<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
+    for_each_unconsumed_temporary(cx, expr, |temporary_ty| {
+        if temporary_ty.has_significant_drop(cx.tcx, cx.typing_env()) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .is_break()
+}
+
 /// Returns true if the specified `expr` requires coercion,
 /// meaning that it either has a coercion or propagates a coercion from one of its sub expressions.
 ///

--- a/tests/ui/blocks_in_conditions.fixed
+++ b/tests/ui/blocks_in_conditions.fixed
@@ -109,4 +109,66 @@ fn in_closure() {
     }
 }
 
+fn issue_15112() {
+    {
+        let v = std::sync::Mutex::new(0);
+        match { *v.lock().unwrap() } {
+            1 => {
+                todo!()
+            },
+            2 => {
+                todo!()
+            },
+            _ => {},
+        }
+    }
+
+    {
+        // No Drop impl, so braces should be removed
+        struct Foo;
+
+        impl Foo {
+            fn foo(&self) -> i32 {
+                0
+            }
+        }
+
+        match Foo.foo() {
+            //~^ ERROR: omit braces around single expression condition
+            1 => {
+                todo!()
+            },
+            2 => {
+                todo!()
+            },
+            _ => {},
+        }
+    }
+
+    {
+        // Drop impl, so braces should be kept
+        struct Bar;
+
+        impl Drop for Bar {
+            fn drop(&mut self) {}
+        }
+
+        impl Bar {
+            fn bar(&self) -> i32 {
+                0
+            }
+        }
+
+        match { Bar.bar() } {
+            1 => {
+                todo!()
+            },
+            2 => {
+                todo!()
+            },
+            _ => {},
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/blocks_in_conditions.rs
+++ b/tests/ui/blocks_in_conditions.rs
@@ -109,4 +109,66 @@ fn in_closure() {
     }
 }
 
+fn issue_15112() {
+    {
+        let v = std::sync::Mutex::new(0);
+        match { *v.lock().unwrap() } {
+            1 => {
+                todo!()
+            },
+            2 => {
+                todo!()
+            },
+            _ => {},
+        }
+    }
+
+    {
+        // No Drop impl, so braces should be removed
+        struct Foo;
+
+        impl Foo {
+            fn foo(&self) -> i32 {
+                0
+            }
+        }
+
+        match { Foo.foo() } {
+            //~^ ERROR: omit braces around single expression condition
+            1 => {
+                todo!()
+            },
+            2 => {
+                todo!()
+            },
+            _ => {},
+        }
+    }
+
+    {
+        // Drop impl, so braces should be kept
+        struct Bar;
+
+        impl Drop for Bar {
+            fn drop(&mut self) {}
+        }
+
+        impl Bar {
+            fn bar(&self) -> i32 {
+                0
+            }
+        }
+
+        match { Bar.bar() } {
+            1 => {
+                todo!()
+            },
+            2 => {
+                todo!()
+            },
+            _ => {},
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/blocks_in_conditions.stderr
+++ b/tests/ui/blocks_in_conditions.stderr
@@ -25,5 +25,11 @@ error: omit braces around single expression condition
 LL |     if { true } { 6 } else { 10 }
    |        ^^^^^^^^ help: try: `true`
 
-error: aborting due to 2 previous errors
+error: omit braces around single expression condition
+  --> tests/ui/blocks_in_conditions.rs:136:15
+   |
+LL |         match { Foo.foo() } {
+   |               ^^^^^^^^^^^^^ help: try: `Foo.foo()`
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#15112

changelog: [`blocks_in_conditions`]: Don't lint when removing braces would extend the lifetime of temporaries with significant drops (e.g., `MutexGuard`)