### PR TITLE
Split too_many_lines_in_file into total-lines and code-lines thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,11 @@ Current stable, released 2026-04-16
 * [`suspicious_to_owned`] improve lint messages
   [#16376](https://github.com/rust-lang/rust-clippy/pull/16376)
 
+### New Lints
+
+* Added [`too_many_lines_in_file`] to `restriction`
+  [#16675](https://github.com/rust-lang/rust-clippy/pull/16675)
+
 ## Rust 1.94
 
 Current stable, released 2026-03-05
@@ -7499,6 +7504,7 @@ Released 2018-09-13
 [`too_long_first_doc_paragraph`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
 [`too_many_arguments`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
 [`too_many_lines`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines
+[`too_many_lines_in_file`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines_in_file
 [`toplevel_ref_arg`]: https://rust-lang.github.io/rust-clippy/master/index.html#toplevel_ref_arg
 [`trailing_empty_array`]: https://rust-lang.github.io/rust-clippy/master/index.html#trailing_empty_array
 [`trait_duplication_in_bounds`]: https://rust-lang.github.io/rust-clippy/master/index.html#trait_duplication_in_bounds
@@ -7737,6 +7743,7 @@ Released 2018-09-13
 [`suppress-restriction-lint-in-const`]: https://doc.rust-lang.org/clippy/lint_configuration.html#suppress-restriction-lint-in-const
 [`too-large-for-stack`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-large-for-stack
 [`too-many-arguments-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-arguments-threshold
+[`too-many-lines-in-file-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-lines-in-file-threshold
 [`too-many-lines-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-lines-threshold
 [`trait-assoc-item-kinds-order`]: https://doc.rust-lang.org/clippy/lint_configuration.html#trait-assoc-item-kinds-order
 [`trait-impl-item-order`]: https://doc.rust-lang.org/clippy/lint_configuration.html#trait-impl-item-order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7743,6 +7743,7 @@ Released 2018-09-13
 [`suppress-restriction-lint-in-const`]: https://doc.rust-lang.org/clippy/lint_configuration.html#suppress-restriction-lint-in-const
 [`too-large-for-stack`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-large-for-stack
 [`too-many-arguments-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-arguments-threshold
+[`too-many-code-lines-in-file-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-code-lines-in-file-threshold
 [`too-many-lines-in-file-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-lines-in-file-threshold
 [`too-many-lines-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#too-many-lines-threshold
 [`trait-assoc-item-kinds-order`]: https://doc.rust-lang.org/clippy/lint_configuration.html#trait-assoc-item-kinds-order

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -1149,6 +1149,16 @@ The maximum number of argument a function or method can have
 * [`too_many_arguments`](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments)
 
 
+## `too-many-lines-in-file-threshold`
+The maximum number of lines a source file can have
+
+**Default Value:** `1000`
+
+---
+**Affected lints:**
+* [`too_many_lines_in_file`](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines_in_file)
+
+
 ## `too-many-lines-threshold`
 The maximum number of lines a function or method can have
 

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -1149,8 +1149,20 @@ The maximum number of argument a function or method can have
 * [`too_many_arguments`](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments)
 
 
+## `too-many-code-lines-in-file-threshold`
+The maximum number of lines of code (excluding blank lines and comment-only lines)
+a source file can have. Defaults to `u32::MAX`, which effectively disables this check.
+
+**Default Value:** `4294967295`
+
+---
+**Affected lints:**
+* [`too_many_lines_in_file`](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines_in_file)
+
+
 ## `too-many-lines-in-file-threshold`
-The maximum number of lines a source file can have
+The maximum number of lines (excluding blank lines, but including comment-only lines)
+a source file can have
 
 **Default Value:** `1000`
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -912,7 +912,12 @@ define_Conf! {
     /// The maximum number of argument a function or method can have
     #[lints(too_many_arguments)]
     too_many_arguments_threshold: u64 = 7,
-    /// The maximum number of lines a source file can have
+    /// The maximum number of lines of code (excluding blank lines and comment-only lines)
+    /// a source file can have. Defaults to `u32::MAX`, which effectively disables this check.
+    #[lints(too_many_lines_in_file)]
+    too_many_code_lines_in_file_threshold: u32 = u32::MAX,
+    /// The maximum number of lines (excluding blank lines, but including comment-only lines)
+    /// a source file can have
     #[lints(too_many_lines_in_file)]
     too_many_lines_in_file_threshold: u32 = 1000,
     /// The maximum number of lines a function or method can have

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -912,6 +912,9 @@ define_Conf! {
     /// The maximum number of argument a function or method can have
     #[lints(too_many_arguments)]
     too_many_arguments_threshold: u64 = 7,
+    /// The maximum number of lines a source file can have
+    #[lints(too_many_lines_in_file)]
+    too_many_lines_in_file_threshold: u64 = 1000,
     /// The maximum number of lines a function or method can have
     #[lints(too_many_lines)]
     too_many_lines_threshold: u64 = 100,

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -914,7 +914,7 @@ define_Conf! {
     too_many_arguments_threshold: u64 = 7,
     /// The maximum number of lines a source file can have
     #[lints(too_many_lines_in_file)]
-    too_many_lines_in_file_threshold: u64 = 1000,
+    too_many_lines_in_file_threshold: u32 = 1000,
     /// The maximum number of lines a function or method can have
     #[lints(too_many_lines)]
     too_many_lines_threshold: u64 = 100,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -738,6 +738,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::time_subtraction::UNCHECKED_TIME_SUBTRACTION_INFO,
     crate::to_digit_is_some::TO_DIGIT_IS_SOME_INFO,
     crate::to_string_trait_impl::TO_STRING_TRAIT_IMPL_INFO,
+    crate::too_many_lines_in_file::TOO_MANY_LINES_IN_FILE_INFO,
     crate::toplevel_ref_arg::TOPLEVEL_REF_ARG_INFO,
     crate::trailing_empty_array::TRAILING_EMPTY_ARRAY_INFO,
     crate::trait_bounds::TRAIT_DUPLICATION_IN_BOUNDS_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -362,6 +362,7 @@ mod tests_outside_test_module;
 mod time_subtraction;
 mod to_digit_is_some;
 mod to_string_trait_impl;
+mod too_many_lines_in_file;
 mod toplevel_ref_arg;
 mod trailing_empty_array;
 mod trait_bounds;
@@ -543,6 +544,7 @@ rustc_lint::early_lint_methods!(
         EmptyLineAfter: empty_line_after::EmptyLineAfter = empty_line_after::EmptyLineAfter::new(),
         InlineTraitBounds: inline_trait_bounds::InlineTraitBounds = inline_trait_bounds::InlineTraitBounds::default(),
         DefinitionInModuleRoot: definition_in_module_root::DefinitionInModuleRoot = definition_in_module_root::DefinitionInModuleRoot::default(),
+        TooManyLinesInFile: too_many_lines_in_file::TooManyLinesInFile = too_many_lines_in_file::TooManyLinesInFile::new(conf),
         // add early passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/too_many_lines_in_file.rs
+++ b/clippy_lints/src/too_many_lines_in_file.rs
@@ -1,0 +1,114 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint;
+use rustc_ast::ast;
+use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
+use rustc_session::impl_lint_pass;
+use rustc_span::def_id::LOCAL_CRATE;
+use rustc_span::{FileName, Span, SyntaxContext};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for source files that have a large number of lines of code.
+    /// Blank lines and lines containing only comments are not counted.
+    ///
+    /// ### Why restrict this?
+    /// Large files are harder to navigate and understand. They often indicate
+    /// that a module has too many responsibilities and should be split into
+    /// smaller, more focused modules.
+    ///
+    /// ### Example
+    /// A file with more lines than the configured threshold will trigger this lint.
+    /// The fix is to split it into smaller modules.
+    ///
+    /// ### Configuration
+    /// The maximum number of lines is configured with `too-many-lines-in-file-threshold`
+    /// (default: `1000`).
+    #[clippy::version = "1.97.0"]
+    pub TOO_MANY_LINES_IN_FILE,
+    restriction,
+    "files with too many lines of code"
+}
+
+impl_lint_pass!(TooManyLinesInFile => [TOO_MANY_LINES_IN_FILE]);
+
+pub struct TooManyLinesInFile {
+    threshold: u64,
+}
+
+impl TooManyLinesInFile {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self {
+            threshold: conf.too_many_lines_in_file_threshold,
+        }
+    }
+}
+
+impl EarlyLintPass for TooManyLinesInFile {
+    fn check_crate(&mut self, cx: &EarlyContext<'_>, _: &ast::Crate) {
+        let source_map = cx.sess().source_map();
+        for file in source_map.files().iter() {
+            if file.cnum != LOCAL_CRATE {
+                continue;
+            }
+            if !matches!(file.name, FileName::Real(_)) {
+                continue;
+            }
+            let Some(src) = file.src.as_deref() else {
+                continue;
+            };
+
+            let mut line_count: u64 = 0;
+            let mut in_comment = false;
+            let mut threshold_exceeded_offset: Option<u32> = None;
+            let mut byte_offset: u32 = 0;
+
+            for mut line in src.lines() {
+                let line_start_offset = byte_offset;
+                byte_offset = byte_offset
+                    .saturating_add(u32::try_from(line.len()).unwrap_or(u32::MAX))
+                    .saturating_add(1); // +1 for newline
+                let mut code_in_line = false;
+                loop {
+                    line = line.trim_start();
+                    if line.is_empty() {
+                        break;
+                    }
+                    if in_comment {
+                        if let Some(i) = line.find("*/") {
+                            line = &line[i + 2..];
+                            in_comment = false;
+                            continue;
+                        }
+                    } else {
+                        let multi_idx = line.find("/*").unwrap_or(line.len());
+                        let single_idx = line.find("//").unwrap_or(line.len());
+                        code_in_line |= multi_idx > 0 && single_idx > 0;
+                        if multi_idx < single_idx {
+                            line = &line[multi_idx + 2..];
+                            in_comment = true;
+                            continue;
+                        }
+                    }
+                    break;
+                }
+                if code_in_line {
+                    line_count += 1;
+                    if line_count == self.threshold + 1 {
+                        threshold_exceeded_offset = Some(line_start_offset);
+                    }
+                }
+            }
+
+            if line_count > self.threshold {
+                let start = file.start_pos + rustc_span::BytePos(threshold_exceeded_offset.unwrap_or(0));
+                let span = Span::new(start, start, SyntaxContext::root(), None);
+                span_lint(
+                    cx,
+                    TOO_MANY_LINES_IN_FILE,
+                    span,
+                    format!("this file has too many lines ({line_count}/{})", self.threshold),
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/too_many_lines_in_file.rs
+++ b/clippy_lints/src/too_many_lines_in_file.rs
@@ -8,8 +8,8 @@ use rustc_span::{FileName, Span, SyntaxContext};
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for source files that have a large number of lines of code.
-    /// Blank lines and lines containing only comments are not counted.
+    /// Checks for source files that have a large number of lines.
+    /// Blank lines are not counted.
     ///
     /// ### Why restrict this?
     /// Large files are harder to navigate and understand. They often indicate
@@ -21,10 +21,15 @@ declare_clippy_lint! {
     /// The fix is to split it into smaller modules.
     ///
     /// ### Configuration
-    /// The maximum number of lines is configured with `too-many-lines-in-file-threshold`
-    /// (default: `1000`). Any `u32` value is valid, including `0` (which makes the lint
-    /// trigger on any file containing at least one line of code). Set it to `u32::MAX`
-    /// to effectively disable the lint.
+    /// The maximum number of lines (excluding blank lines, but including comment-only lines)
+    /// is configured with `too-many-lines-in-file-threshold` (default: `1000`).
+    ///
+    /// The maximum number of lines of code only (excluding blank lines and comment-only lines)
+    /// is configured separately with `too-many-code-lines-in-file-threshold`
+    /// (default: `u32::MAX`, i.e. effectively disabled).
+    ///
+    /// Both accept any `u32` value, including `0` (which makes the lint trigger on any file
+    /// containing at least one matching line).
     #[clippy::version = "1.97.0"]
     pub TOO_MANY_LINES_IN_FILE,
     restriction,
@@ -35,12 +40,14 @@ impl_lint_pass!(TooManyLinesInFile => [TOO_MANY_LINES_IN_FILE]);
 
 pub struct TooManyLinesInFile {
     threshold: u32,
+    code_threshold: u32,
 }
 
 impl TooManyLinesInFile {
     pub fn new(conf: &'static Conf) -> Self {
         Self {
             threshold: conf.too_many_lines_in_file_threshold,
+            code_threshold: conf.too_many_code_lines_in_file_threshold,
         }
     }
 }
@@ -60,8 +67,10 @@ impl EarlyLintPass for TooManyLinesInFile {
             };
 
             let mut line_count: u32 = 0;
+            let mut code_line_count: u32 = 0;
             let mut in_comment = false;
             let mut threshold_exceeded_offset: Option<u32> = None;
+            let mut code_threshold_exceeded_offset: Option<u32> = None;
             let mut byte_offset: u32 = 0;
 
             for mut line in src.lines() {
@@ -69,6 +78,7 @@ impl EarlyLintPass for TooManyLinesInFile {
                 byte_offset = byte_offset
                     .saturating_add(u32::try_from(line.len()).unwrap_or(u32::MAX))
                     .saturating_add(1); // +1 for newline
+                let has_content = !line.trim().is_empty();
                 let mut code_in_line = false;
                 loop {
                     line = line.trim_start();
@@ -93,10 +103,16 @@ impl EarlyLintPass for TooManyLinesInFile {
                     }
                     break;
                 }
-                if code_in_line {
+                if has_content {
                     line_count += 1;
                     if line_count == self.threshold.saturating_add(1) {
                         threshold_exceeded_offset = Some(line_start_offset);
+                    }
+                }
+                if code_in_line {
+                    code_line_count += 1;
+                    if code_line_count == self.code_threshold.saturating_add(1) {
+                        code_threshold_exceeded_offset = Some(line_start_offset);
                     }
                 }
             }
@@ -109,6 +125,20 @@ impl EarlyLintPass for TooManyLinesInFile {
                     TOO_MANY_LINES_IN_FILE,
                     span,
                     format!("this file has too many lines ({line_count}/{})", self.threshold),
+                );
+            }
+
+            if code_line_count > self.code_threshold {
+                let start = file.start_pos + rustc_span::BytePos(code_threshold_exceeded_offset.unwrap_or(0));
+                let span = Span::new(start, start, SyntaxContext::root(), None);
+                span_lint(
+                    cx,
+                    TOO_MANY_LINES_IN_FILE,
+                    span,
+                    format!(
+                        "this file has too many lines of code ({code_line_count}/{})",
+                        self.code_threshold
+                    ),
                 );
             }
         }

--- a/clippy_lints/src/too_many_lines_in_file.rs
+++ b/clippy_lints/src/too_many_lines_in_file.rs
@@ -22,7 +22,8 @@ declare_clippy_lint! {
     ///
     /// ### Configuration
     /// The maximum number of lines is configured with `too-many-lines-in-file-threshold`
-    /// (default: `1000`).
+    /// (default: `1000`). Any `u64` value is valid, including `0` (which makes the lint
+    /// trigger on any file containing at least one line of code).
     #[clippy::version = "1.97.0"]
     pub TOO_MANY_LINES_IN_FILE,
     restriction,

--- a/clippy_lints/src/too_many_lines_in_file.rs
+++ b/clippy_lints/src/too_many_lines_in_file.rs
@@ -22,8 +22,8 @@ declare_clippy_lint! {
     ///
     /// ### Configuration
     /// The maximum number of lines is configured with `too-many-lines-in-file-threshold`
-    /// (default: `1000`). Any `u64` value is valid, including `0` (which makes the lint
-    /// trigger on any file containing at least one line of code). Set it to `u64::MAX`
+    /// (default: `1000`). Any `u32` value is valid, including `0` (which makes the lint
+    /// trigger on any file containing at least one line of code). Set it to `u32::MAX`
     /// to effectively disable the lint.
     #[clippy::version = "1.97.0"]
     pub TOO_MANY_LINES_IN_FILE,
@@ -34,7 +34,7 @@ declare_clippy_lint! {
 impl_lint_pass!(TooManyLinesInFile => [TOO_MANY_LINES_IN_FILE]);
 
 pub struct TooManyLinesInFile {
-    threshold: u64,
+    threshold: u32,
 }
 
 impl TooManyLinesInFile {
@@ -59,7 +59,7 @@ impl EarlyLintPass for TooManyLinesInFile {
                 continue;
             };
 
-            let mut line_count: u64 = 0;
+            let mut line_count: u32 = 0;
             let mut in_comment = false;
             let mut threshold_exceeded_offset: Option<u32> = None;
             let mut byte_offset: u32 = 0;

--- a/clippy_lints/src/too_many_lines_in_file.rs
+++ b/clippy_lints/src/too_many_lines_in_file.rs
@@ -23,7 +23,8 @@ declare_clippy_lint! {
     /// ### Configuration
     /// The maximum number of lines is configured with `too-many-lines-in-file-threshold`
     /// (default: `1000`). Any `u64` value is valid, including `0` (which makes the lint
-    /// trigger on any file containing at least one line of code).
+    /// trigger on any file containing at least one line of code). Set it to `u64::MAX`
+    /// to effectively disable the lint.
     #[clippy::version = "1.97.0"]
     pub TOO_MANY_LINES_IN_FILE,
     restriction,
@@ -94,7 +95,7 @@ impl EarlyLintPass for TooManyLinesInFile {
                 }
                 if code_in_line {
                     line_count += 1;
-                    if line_count == self.threshold + 1 {
+                    if line_count == self.threshold.saturating_add(1) {
                         threshold_exceeded_offset = Some(line_start_offset);
                     }
                 }

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -84,6 +84,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            third-party
            too-large-for-stack
            too-many-arguments-threshold
+           too-many-lines-in-file-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
            trait-impl-item-order
@@ -187,6 +188,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            third-party
            too-large-for-stack
            too-many-arguments-threshold
+           too-many-lines-in-file-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
            trait-impl-item-order
@@ -290,6 +292,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            third-party
            too-large-for-stack
            too-many-arguments-threshold
+           too-many-lines-in-file-threshold
            too-many-lines-threshold
            trait-assoc-item-kinds-order
            trait-impl-item-order

--- a/tests/ui-toml/too_many_code_lines_in_file/clippy.toml
+++ b/tests/ui-toml/too_many_code_lines_in_file/clippy.toml
@@ -1,0 +1,1 @@
+too-many-code-lines-in-file-threshold = 2

--- a/tests/ui-toml/too_many_code_lines_in_file/too_many_code_lines_in_file.rs
+++ b/tests/ui-toml/too_many_code_lines_in_file/too_many_code_lines_in_file.rs
@@ -1,0 +1,9 @@
+#![warn(clippy::too_many_lines_in_file)]
+
+// one
+// two
+// three
+fn a() {}
+
+fn main() {}
+//~^ too_many_lines_in_file

--- a/tests/ui-toml/too_many_code_lines_in_file/too_many_code_lines_in_file.stderr
+++ b/tests/ui-toml/too_many_code_lines_in_file/too_many_code_lines_in_file.stderr
@@ -1,7 +1,7 @@
-error: this file has too many lines (7/3)
-  --> tests/ui-toml/too_many_lines_in_file/too_many_lines_in_file.rs:5:1
+error: this file has too many lines of code (3/2)
+  --> tests/ui-toml/too_many_code_lines_in_file/too_many_code_lines_in_file.rs:8:1
    |
-LL | fn c() {}
+LL | fn main() {}
    | ^
    |
    = note: `-D clippy::too-many-lines-in-file` implied by `-D warnings`

--- a/tests/ui-toml/too_many_lines_in_file/clippy.toml
+++ b/tests/ui-toml/too_many_lines_in_file/clippy.toml
@@ -1,0 +1,1 @@
+too-many-lines-in-file-threshold = 3

--- a/tests/ui-toml/too_many_lines_in_file/too_many_lines_in_file.rs
+++ b/tests/ui-toml/too_many_lines_in_file/too_many_lines_in_file.rs
@@ -1,0 +1,9 @@
+#![warn(clippy::too_many_lines_in_file)]
+
+fn a() {}
+fn b() {}
+fn c() {}
+//~^ too_many_lines_in_file
+fn d() {}
+
+fn main() {}

--- a/tests/ui-toml/too_many_lines_in_file/too_many_lines_in_file.stderr
+++ b/tests/ui-toml/too_many_lines_in_file/too_many_lines_in_file.stderr
@@ -1,0 +1,11 @@
+error: this file has too many lines (6/3)
+  --> tests/ui-toml/too_many_lines_in_file/too_many_lines_in_file.rs:5:1
+   |
+LL | fn c() {}
+   | ^
+   |
+   = note: `-D clippy::too-many-lines-in-file` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::too_many_lines_in_file)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
## Summary
Adds `clippy::too_many_lines_in_file` with a split configuration, addressing review feedback from iddm on rust-lang/rust-clippy#16675 (https://github.com/rust-lang/rust-clippy/pull/16675#discussion_r3590168783), which asked for separate configuration of "lines of code" vs "total lines including comments".

- `too-many-lines-in-file-threshold` (default `1000`) counts all non-blank lines, including comment-only lines.
- New, opt-in `too-many-code-lines-in-file-threshold` (default `u32::MAX`, i.e. disabled) counts code lines only, excluding comments.
- Both counters/thresholds use `u32` with saturating arithmetic to avoid overflow at extreme threshold values.

Note: this branch builds on the not-yet-merged rust-lang/rust-clippy#16675 (adds the lint itself), so this diff includes that PR's content plus the split-threshold commit on top.

## Test plan
- [x] `cargo check -p clippy_config -p clippy_lints`
- [x] `cargo uibless` (too_many_lines_in_file, too_many_code_lines_in_file UI tests pass)
- [x] `cargo bless --test config-metadata` (book/lint_configuration.md, CHANGELOG.md regenerated)