### PR TITLE
fix(needless_return_with_question_mark): skip when removing return ca…

### DIFF
--- a/clippy_lints/src/returns/needless_return_with_question_mark.rs
+++ b/clippy_lints/src/returns/needless_return_with_question_mark.rs
@@ -1,6 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::res::{MaybeDef, MaybeQPath};
-use clippy_utils::{is_from_proc_macro, is_inside_let_else};
+use clippy_utils::res::{MaybeDef, MaybeQPath, MaybeResPath};
+use clippy_utils::usage::local_used_after_expr;
+use clippy_utils::{higher, is_from_proc_macro, is_inside_let_else};
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::ResultErr;
 use rustc_hir::{Expr, ExprKind, HirId, MatchSource, Node, Stmt, StmtKind};
@@ -31,6 +32,20 @@ pub(super) fn check_stmt<'tcx>(cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
         && !is_from_proc_macro(cx, expr)
         && !stmt_needs_never_type(cx, stmt.hir_id)
     {
+        // get the hir id of parent of return statement
+        for (_hir_id, node) in cx.tcx.hir_parent_iter(expr.hir_id) {
+            if let Node::Expr(parent_expr) = node {
+                if let Some(if_let) = higher::IfLet::hir(cx, parent_expr) {
+                    let scrutinee = if_let.let_expr;
+                    if let Some(local_id) = scrutinee.res_local_id()
+                        && local_used_after_expr(cx, local_id, parent_expr)
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+
         span_lint_and_sugg(
             cx,
             NEEDLESS_RETURN_WITH_QUESTION_MARK,

--- a/clippy_lints/src/returns/needless_return_with_question_mark.rs
+++ b/clippy_lints/src/returns/needless_return_with_question_mark.rs
@@ -1,11 +1,14 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::res::{MaybeDef as _, MaybeQPath as _};
-use clippy_utils::{is_from_proc_macro, is_inside_let_else};
+use clippy_utils::res::{MaybeDef, MaybeQPath, MaybeResPath};
+use clippy_utils::usage::local_used_after_expr;
+use clippy_utils::visitors::for_each_expr_without_closures;
+use clippy_utils::{higher, is_from_proc_macro, is_inside_let_else};
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::ResultErr;
 use rustc_hir::{Expr, ExprKind, HirId, MatchSource, Node, Stmt, StmtKind};
 use rustc_lint::{LateContext, LintContext as _};
 use rustc_middle::ty::adjustment::Adjust;
+use std::ops::ControlFlow;
 
 use super::NEEDLESS_RETURN_WITH_QUESTION_MARK;
 
@@ -31,6 +34,51 @@ pub(super) fn check_stmt<'tcx>(cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
         && !is_from_proc_macro(cx, expr)
         && !stmt_needs_never_type(cx, stmt.hir_id)
     {
+        // get the hir id of parent of return statement
+        for (_hir_id, node) in cx.tcx.hir_parent_iter(expr.hir_id) {
+            if let Node::Expr(parent_expr) = node {
+                if let Some(if_let_or_match) = higher::IfLetOrMatch::parse(cx, parent_expr) {
+                    if let higher::IfLetOrMatch::IfLet(_, pat, ..) = if_let_or_match {
+                        // get the pattern of the if let and check if it uses ref keyword if it does we do lint.
+                        let explicit_ref = pat.contains_explicit_ref_binding();
+                        if explicit_ref.is_none() {
+                            let scrutinee = if_let_or_match.scrutinee();
+                            if let Some(local_id) = scrutinee.res_local_id()
+                                && local_used_after_expr(cx, local_id, parent_expr)
+                            {
+                                return;
+                            }
+                        }
+                    };
+                    if let higher::IfLetOrMatch::Match(_, arms, ..) = if_let_or_match {
+                        for arm in arms {
+                            //check each arms binding and then same as code above to see if local used after expr
+                            let found_it = for_each_expr_without_closures(arm.body, |e| {
+                                if e.hir_id == expr.hir_id {
+                                    ControlFlow::Break(())
+                                } else {
+                                    ControlFlow::Continue(())
+                                }
+                            })
+                            .is_some();
+                            if found_it {
+                                // check if the pattern of the arm uses ref keyword if it does we do lint.
+                                let explicit_ref = arm.pat.contains_explicit_ref_binding();
+                                if explicit_ref.is_none() {
+                                    let scrutinee = if_let_or_match.scrutinee();
+                                    if let Some(local_id) = scrutinee.res_local_id()
+                                        && local_used_after_expr(cx, local_id, parent_expr)
+                                    {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         span_lint_and_sugg(
             cx,
             NEEDLESS_RETURN_WITH_QUESTION_MARK,

--- a/tests/ui/needless_return_with_question_mark.fixed
+++ b/tests/ui/needless_return_with_question_mark.fixed
@@ -117,7 +117,16 @@ fn issue11982_no_conversion() {
         Ok(())
     }
 }
-
+#[allow(clippy::unnecessary_literal_unwrap)]
+fn issue17421_no_lint_partial_move_after_if_let() -> Result<(), String> {
+    let v: Result<String, String> = Err("".to_string());
+    if let Err(e) = v {
+        return Err(e)?;
+    }
+    let v = v.unwrap();
+    println!("{}", v);
+    Ok(())
+}
 fn general_return() {
     fn foo(ok: bool) -> Result<(), ()> {
         let bar = Result::Ok(Result::<(), ()>::Ok(()));

--- a/tests/ui/needless_return_with_question_mark.fixed
+++ b/tests/ui/needless_return_with_question_mark.fixed
@@ -117,7 +117,39 @@ fn issue11982_no_conversion() {
         Ok(())
     }
 }
+#[allow(clippy::unnecessary_literal_unwrap)]
+fn issue17421_no_lint_partial_move_after_if_let() -> Result<(), String> {
+    let v: Result<String, String> = Err("".to_string());
+    if let Err(e) = v {
+        return Err(e)?;
+    }
+    let v = v.unwrap();
+    println!("{}", v);
+    Ok(())
+}
 
+#[allow(clippy::let_unit_value, clippy::unnecessary_literal_unwrap)]
+fn issue17421_ref_binding_still_lints() -> Result<(), String> {
+    let v: Result<(), String> = Err("foo".to_string());
+    if let Err(ref _u) = v {
+        Err("bar".to_string())?;
+        //~^ needless_return_with_question_mark
+    }
+    let _ = v.unwrap();
+    Ok(())
+}
+#[allow(clippy::single_match, clippy::let_unit_value, clippy::unnecessary_literal_unwrap)]
+fn issue17421_no_lint_partial_move_after_match() -> Result<(), String> {
+    let v: Result<(), String> = Err("foo".to_string());
+    match v {
+        _whole @ Err(_) => {
+            return Err("bar".to_string())?;
+        }
+        Ok(_) => {}
+    }
+    let _ = v.unwrap();
+    Ok(())
+}
 fn general_return() {
     fn foo(ok: bool) -> Result<(), ()> {
         let bar = Result::Ok(Result::<(), ()>::Ok(()));

--- a/tests/ui/needless_return_with_question_mark.rs
+++ b/tests/ui/needless_return_with_question_mark.rs
@@ -117,7 +117,16 @@ fn issue11982_no_conversion() {
         Ok(())
     }
 }
-
+#[allow(clippy::unnecessary_literal_unwrap)]
+fn issue17421_no_lint_partial_move_after_if_let() -> Result<(), String> {
+    let v: Result<String, String> = Err("".to_string());
+    if let Err(e) = v {
+        return Err(e)?;
+    }
+    let v = v.unwrap();
+    println!("{}", v);
+    Ok(())
+}
 fn general_return() {
     fn foo(ok: bool) -> Result<(), ()> {
         let bar = Result::Ok(Result::<(), ()>::Ok(()));

--- a/tests/ui/needless_return_with_question_mark.rs
+++ b/tests/ui/needless_return_with_question_mark.rs
@@ -117,7 +117,39 @@ fn issue11982_no_conversion() {
         Ok(())
     }
 }
+#[allow(clippy::unnecessary_literal_unwrap)]
+fn issue17421_no_lint_partial_move_after_if_let() -> Result<(), String> {
+    let v: Result<String, String> = Err("".to_string());
+    if let Err(e) = v {
+        return Err(e)?;
+    }
+    let v = v.unwrap();
+    println!("{}", v);
+    Ok(())
+}
 
+#[allow(clippy::let_unit_value, clippy::unnecessary_literal_unwrap)]
+fn issue17421_ref_binding_still_lints() -> Result<(), String> {
+    let v: Result<(), String> = Err("foo".to_string());
+    if let Err(ref _u) = v {
+        return Err("bar".to_string())?;
+        //~^ needless_return_with_question_mark
+    }
+    let _ = v.unwrap();
+    Ok(())
+}
+#[allow(clippy::single_match, clippy::let_unit_value, clippy::unnecessary_literal_unwrap)]
+fn issue17421_no_lint_partial_move_after_match() -> Result<(), String> {
+    let v: Result<(), String> = Err("foo".to_string());
+    match v {
+        _whole @ Err(_) => {
+            return Err("bar".to_string())?;
+        },
+        Ok(_) => {},
+    }
+    let _ = v.unwrap();
+    Ok(())
+}
 fn general_return() {
     fn foo(ok: bool) -> Result<(), ()> {
         let bar = Result::Ok(Result::<(), ()>::Ok(()));

--- a/tests/ui/needless_return_with_question_mark.stderr
+++ b/tests/ui/needless_return_with_question_mark.stderr
@@ -14,19 +14,19 @@ LL |         return Err(())?;
    |         ^^^^^^^ help: remove it
 
 error: unneeded `return` statement with `?` operator
-  --> tests/ui/needless_return_with_question_mark.rs:133:9
+  --> tests/ui/needless_return_with_question_mark.rs:142:9
    |
 LL |         return Err(())?;
    |         ^^^^^^^ help: remove it
 
 error: unneeded `return` statement with `?` operator
-  --> tests/ui/needless_return_with_question_mark.rs:142:13
+  --> tests/ui/needless_return_with_question_mark.rs:151:13
    |
 LL |             return Err(())?;
    |             ^^^^^^^ help: remove it
 
 error: unneeded `return` statement with `?` operator
-  --> tests/ui/needless_return_with_question_mark.rs:162:5
+  --> tests/ui/needless_return_with_question_mark.rs:171:5
    |
 LL |     return Err(())?;
    |     ^^^^^^^ help: remove it

--- a/tests/ui/needless_return_with_question_mark.stderr
+++ b/tests/ui/needless_return_with_question_mark.stderr
@@ -14,22 +14,28 @@ LL |         return Err(())?;
    |         ^^^^^^^ help: remove it
 
 error: unneeded `return` statement with `?` operator
-  --> tests/ui/needless_return_with_question_mark.rs:133:9
+  --> tests/ui/needless_return_with_question_mark.rs:135:9
+   |
+LL |         return Err("bar".to_string())?;
+   |         ^^^^^^^ help: remove it
+
+error: unneeded `return` statement with `?` operator
+  --> tests/ui/needless_return_with_question_mark.rs:165:9
    |
 LL |         return Err(())?;
    |         ^^^^^^^ help: remove it
 
 error: unneeded `return` statement with `?` operator
-  --> tests/ui/needless_return_with_question_mark.rs:142:13
+  --> tests/ui/needless_return_with_question_mark.rs:174:13
    |
 LL |             return Err(())?;
    |             ^^^^^^^ help: remove it
 
 error: unneeded `return` statement with `?` operator
-  --> tests/ui/needless_return_with_question_mark.rs:162:5
+  --> tests/ui/needless_return_with_question_mark.rs:194:5
    |
 LL |     return Err(())?;
    |     ^^^^^^^ help: remove it
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
changelog: [`needless_return_with_question_mark`]: don't lint when removing the return would cause a partial move error

When the return is inside an if let that partially moves the scrutinee, and the scrutinee is used after the block, removing return breaks the borrow checker. This skips the lint in that case.
fixes rust-lang/rust-clippy#17421