### PR TITLE
Fix collapsible_match incorrect suggestion when arm block has a label

### DIFF
--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -165,11 +165,19 @@ fn check_arm<'tcx>(
                 let (paren_start, inner_if_span, paren_end) = peel_parens(cx, inner_expr.span);
                 let inner_if = inner_if_span.split_at(2).0;
                 let mut sugg = vec![(inner.then.span.shrink_to_lo(), "=> ".to_string())];
+
+                
                 if matches!(outer_then_body.kind, ExprKind::Block(..)) {
-                    let outer_then_open_bracket = outer_then_body
-                        .span
-                        .split_at(1)
-                        .0
+                    let block_span = outer_then_body.span;
+                    // The Block Span can start with a label so finding actual opening braces instead of assuming it's first Byte
+                    let block_snippet = snippet(cx, block_span, "");
+                    let brace_offset = block_snippet.find('{').unwrap_or(0);
+                    let brace_pos = block_span.lo() + BytePos(brace_offset as u32);
+
+                    let label_prefix = block_snippet[..brace_offset].trim();
+                    let outer_then_open_bracket = block_span
+                        .with_lo(brace_pos)
+                        .with_hi(brace_pos + BytePos(1))
                         .with_leading_whitespace(cx)
                         .into_span();
                     let outer_then_closing_bracket = {
@@ -180,6 +188,10 @@ fn check_arm<'tcx>(
                     };
                     sugg.push((outer_arrow_end.to(outer_then_open_bracket), String::new()));
                     sugg.push((outer_then_closing_bracket, String::new()));
+
+                    if !label_prefix.is_empty(){
+                        sugg[0].1 = format!("=> {label_prefix} ");
+                    }
                 } else {
                     sugg.push((outer_arrow_end.until(inner_if), " ".to_string()));
                 }

--- a/tests/ui/collapsible_match_fixable.fixed
+++ b/tests/ui/collapsible_match_fixable.fixed
@@ -75,3 +75,20 @@ fn issue16894() {
         //~^ collapsible_match
     };
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/17427
+// `collapsible_match` suggested wrong spans when the outer arm's block has a
+// label, deleting the label's leading `'` instead of preserving it after `=>`.
+fn issue17427() {
+    let x: Result<Option<u8>, ()> = Ok(Some(1));
+    match x {
+        Ok(Some(_c))
+            if true => 'label: {
+                //~^ collapsible_match
+                let Some(_y) = Some(0) else {
+                    break 'label;
+                };
+            },
+        _ => (),
+    }
+}

--- a/tests/ui/collapsible_match_fixable.rs
+++ b/tests/ui/collapsible_match_fixable.rs
@@ -77,3 +77,21 @@ fn issue16894() {
         //~^ collapsible_match
     };
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/17427
+// `collapsible_match` suggested wrong spans when the outer arm's block has a
+// label, deleting the label's leading `'` instead of preserving it after `=>`.
+fn issue17427() {
+    let x: Result<Option<u8>, ()> = Ok(Some(1));
+    match x {
+        Ok(Some(_c)) => 'label: {
+            if true {
+                //~^ collapsible_match
+                let Some(_y) = Some(0) else {
+                    break 'label;
+                };
+            }
+        },
+        _ => (),
+    }
+}

--- a/tests/ui/collapsible_match_fixable.stderr
+++ b/tests/ui/collapsible_match_fixable.stderr
@@ -112,5 +112,26 @@ LL -         11 => 0, 12 => if a == b { 1 } else { 0 }, _ => 0,
 LL +         11 => 0, 12 if a == b => { 1 }, _ => 0,
    |
 
-error: aborting due to 8 previous errors
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:88:13
+   |
+LL | /             if true {
+LL | |
+LL | |                 let Some(_y) = Some(0) else {
+LL | |                     break 'label;
+LL | |                 };
+LL | |             }
+   | |_____________^
+   |
+help: collapse nested if block
+   |
+LL ~         Ok(Some(_c))
+LL ~             if true => 'label: {
+LL |
+...
+LL |                 };
+LL ~             },
+   |
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17427

`collapsible_match` was computing the wrong span for the opening brace
of a match arm's block when that block had a label (e.g. `'label: { ... }`).
It assumed the first byte of the block's span was always `{`, which only
holds when there's no label — with a label present, the suggestion ended
up deleting the leading `'` of the label instead of the arrow, producing
code that failed to compile ("unclosed delimiter").

This finds the actual `{` position instead of assuming it's the first byte,
and re-inserts the label text after the `=>` in the suggestion so it isn't
silently dropped.

Added a regression test (`issue17427` in `tests/ui/collapsible_match_fixable.rs`)
covering the labeled-block case, verified via both `.stderr` and `.fixed`
(rustfix-applied output actually compiles).

changelog: [`collapsible_match`]: fix incorrect suggestion span causing a
compile error when the outer match arm's block has a label