### PR TITLE
Fix collapsible_match suggesting wrong span when arm block has a label

### DIFF
--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -165,11 +165,19 @@ fn check_arm<'tcx>(
                 let (paren_start, inner_if_span, paren_end) = peel_parens(cx, inner_expr.span);
                 let inner_if = inner_if_span.split_at(2).0;
                 let mut sugg = vec![(inner.then.span.shrink_to_lo(), "=> ".to_string())];
+
                 if matches!(outer_then_body.kind, ExprKind::Block(..)) {
-                    let outer_then_open_bracket = outer_then_body
-                        .span
-                        .split_at(1)
-                        .0
+                    let block_span = outer_then_body.span;
+                    // The Block Span can start with a label so finding actual opening braces instead of assuming it's
+                    // first Byte
+                    let block_snippet = snippet(cx, block_span, "");
+                    let brace_offset = block_snippet.find('{').unwrap_or(0);
+                    let brace_pos = block_span.lo() + BytePos(u32::try_from(brace_offset).unwrap());
+
+                    let label_prefix = block_snippet[..brace_offset].trim();
+                    let outer_then_open_bracket = block_span
+                        .with_lo(brace_pos)
+                        .with_hi(brace_pos + BytePos(1))
                         .with_leading_whitespace(cx)
                         .into_span();
                     let outer_then_closing_bracket = {
@@ -180,6 +188,10 @@ fn check_arm<'tcx>(
                     };
                     sugg.push((outer_arrow_end.to(outer_then_open_bracket), String::new()));
                     sugg.push((outer_then_closing_bracket, String::new()));
+
+                    if !label_prefix.is_empty() {
+                        sugg[0].1 = format!("=> {label_prefix} ");
+                    }
                 } else {
                     sugg.push((outer_arrow_end.until(inner_if), " ".to_string()));
                 }

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -171,7 +171,9 @@ fn check_arm<'tcx>(
                     // The Block Span can start with a label so finding actual opening braces instead of assuming it's
                     // first Byte
                     let block_snippet = snippet(cx, block_span, "");
-                    let brace_offset = block_snippet.find('{').unwrap_or(0);
+                    let Some(brace_offset) = block_snippet.find('{') else {
+                        return;
+                    };
                     let brace_pos = block_span.lo() + BytePos(u32::try_from(brace_offset).unwrap());
 
                     let label_prefix = block_snippet[..brace_offset].trim();

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -171,12 +171,24 @@ fn check_arm<'tcx>(
                     // The Block Span can start with a label so finding actual opening braces instead of assuming it's
                     // first Byte
                     let block_snippet = snippet(cx, block_span, "");
-                    let Some(brace_offset) = block_snippet.find('{') else {
+                    let mut byte_pos: u32 = 0;
+                    let mut brace_offset = None;
+
+                    for token in rustc_lexer::tokenize(&block_snippet, rustc_lexer::FrontmatterAllowed::No) {
+                        if token.kind == rustc_lexer::TokenKind::OpenBrace {
+                            brace_offset = Some(byte_pos);
+                            break;
+                        }
+                        byte_pos += token.len;
+                    }
+
+                    let Some(brace_offset) = brace_offset else {
                         return;
                     };
-                    let brace_pos = block_span.lo() + BytePos(u32::try_from(brace_offset).unwrap());
+                    let brace_offset_usize = brace_offset as usize;
+                    let brace_pos = block_span.lo() + BytePos(brace_offset);
 
-                    let label_prefix = block_snippet[..brace_offset].trim();
+                    let label_prefix = block_snippet[..brace_offset_usize].trim();
                     let outer_then_open_bracket = block_span
                         .with_lo(brace_pos)
                         .with_hi(brace_pos + BytePos(1))

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -172,12 +172,24 @@ fn check_arm<'tcx>(
                     // The Block Span can start with a label so finding actual opening braces instead of assuming it's
                     // first Byte
                     let block_snippet = snippet(cx, block_span, "");
-                    let Some(brace_offset) = block_snippet.find('{') else {
+                    let mut byte_pos: u32 = 0;
+                    let mut brace_offset = None;
+
+                    for token in rustc_lexer::tokenize(&block_snippet, rustc_lexer::FrontmatterAllowed::No) {
+                        if token.kind == rustc_lexer::TokenKind::OpenBrace {
+                            brace_offset = Some(byte_pos);
+                            break;
+                        }
+                        byte_pos += token.len;
+                    }
+
+                    let Some(brace_offset) = brace_offset else {
                         return;
                     };
-                    let brace_pos = block_span.lo() + BytePos(u32::try_from(brace_offset).unwrap());
+                    let brace_offset_usize = brace_offset as usize;
+                    let brace_pos = block_span.lo() + BytePos(brace_offset);
 
-                    let label_prefix = block_snippet[..brace_offset].trim();
+                    let label_prefix = block_snippet[..brace_offset_usize].trim();
                     let outer_then_open_bracket = block_span
                         .with_lo(brace_pos)
                         .with_hi(brace_pos + BytePos(1))

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -172,7 +172,9 @@ fn check_arm<'tcx>(
                     // The Block Span can start with a label so finding actual opening braces instead of assuming it's
                     // first Byte
                     let block_snippet = snippet(cx, block_span, "");
-                    let brace_offset = block_snippet.find('{').unwrap_or(0);
+                    let Some(brace_offset) = block_snippet.find('{') else {
+                        return;
+                    };
                     let brace_pos = block_span.lo() + BytePos(u32::try_from(brace_offset).unwrap());
 
                     let label_prefix = block_snippet[..brace_offset].trim();

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -1,3 +1,5 @@
+use super::{COLLAPSIBLE_MATCH, pat_contains_disallowed_or};
+use crate::collapsible_if::{parens_around, peel_parens};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::higher::{If, IfLetOrMatch};
 use clippy_utils::msrvs::Msrv;
@@ -7,6 +9,7 @@ use clippy_utils::usage::mutated_variables;
 use clippy_utils::visitors::is_local_used;
 use clippy_utils::{
     SpanlessEq, get_ref_operators, is_none_pattern, is_unit_expr, peel_blocks_with_stmt, peel_ref_operators,
+    tokenize_with_text,
 };
 use rustc_ast::BorrowKind;
 use rustc_errors::{Applicability, MultiSpan};
@@ -16,9 +19,6 @@ use rustc_lint::LateContext;
 use rustc_middle::mir::FakeReadCause;
 use rustc_middle::ty;
 use rustc_span::{BytePos, Ident, Span, SyntaxContext};
-
-use super::{COLLAPSIBLE_MATCH, pat_contains_disallowed_or};
-use crate::collapsible_if::{parens_around, peel_parens};
 
 pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>], msrv: Msrv) {
     if let Some(els_arm) = arms.iter().rfind(|arm| arm_is_wild_like(cx, arm)) {
@@ -172,24 +172,18 @@ fn check_arm<'tcx>(
                     // The Block Span can start with a label so finding actual opening braces instead of assuming it's
                     // first Byte
                     let block_snippet = snippet(cx, block_span, "");
-                    let mut byte_pos: u32 = 0;
-                    let mut brace_offset = None;
 
-                    for token in rustc_lexer::tokenize(&block_snippet, rustc_lexer::FrontmatterAllowed::No) {
-                        if token.kind == rustc_lexer::TokenKind::OpenBrace {
-                            brace_offset = Some(byte_pos);
-                            break;
-                        }
-                        byte_pos += token.len;
-                    }
-
-                    let Some(brace_offset) = brace_offset else {
+                    let Some((_, _, brace_range)) = tokenize_with_text(&block_snippet)
+                        .find(|(token, _, _)| *token == rustc_lexer::TokenKind::OpenBrace)
+                    else {
                         return;
                     };
-                    let brace_offset_usize = brace_offset as usize;
+
+                    let brace_offset = u32::try_from(brace_range.start).unwrap();
+
                     let brace_pos = block_span.lo() + BytePos(brace_offset);
 
-                    let label_prefix = block_snippet[..brace_offset_usize].trim();
+                    let label_prefix = block_snippet.get(..brace_range.start).unwrap_or("").trim();
                     let outer_then_open_bracket = block_span
                         .with_lo(brace_pos)
                         .with_hi(brace_pos + BytePos(1))

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -167,23 +167,23 @@ fn check_arm<'tcx>(
                 let inner_if = inner_if_span.split_at(2).0;
                 let mut sugg = vec![(inner.then.span.shrink_to_lo(), "=> ".to_string())];
 
-                if matches!(outer_then_body.kind, ExprKind::Block(..)) {
+                if let ExprKind::Block(block, label) = outer_then_body.kind {
                     let block_span = outer_then_body.span;
-                    // The Block Span can start with a label so finding actual opening braces instead of assuming it's
-                    // first Byte
-                    let block_snippet = snippet(cx, block_span, "");
-
-                    let Some((_, _, brace_range)) = tokenize_with_text(&block_snippet)
+                    let search_start = if let Some(label) = label {
+                        label.ident.span.hi()
+                    } else {
+                        block_span.lo()
+                    };
+                    let gap_span = block_span.with_lo(search_start).with_hi(block.span.hi());
+                    let gap_snippet = snippet(cx, gap_span, "");
+                    let Some((_, _, brace_range)) = tokenize_with_text(&gap_snippet)
                         .find(|(token, _, _)| *token == rustc_lexer::TokenKind::OpenBrace)
                     else {
                         return;
                     };
-
                     let brace_offset = u32::try_from(brace_range.start).unwrap();
+                    let brace_pos = search_start + BytePos(brace_offset);
 
-                    let brace_pos = block_span.lo() + BytePos(brace_offset);
-
-                    let label_prefix = block_snippet.get(..brace_range.start).unwrap_or("").trim();
                     let outer_then_open_bracket = block_span
                         .with_lo(brace_pos)
                         .with_hi(brace_pos + BytePos(1))
@@ -198,6 +198,14 @@ fn check_arm<'tcx>(
                     sugg.push((outer_arrow_end.to(outer_then_open_bracket), String::new()));
                     sugg.push((outer_then_closing_bracket, String::new()));
 
+                    let prefix_start = if let Some(label) = label {
+                        label.ident.span.lo()
+                    } else {
+                        block_span.lo()
+                    };
+                    let label_prefix = snippet(cx, block_span.with_lo(prefix_start).with_hi(brace_pos), "")
+                        .trim()
+                        .to_string();
                     if !label_prefix.is_empty() {
                         sugg[0].1 = format!("=> {label_prefix} ");
                     }

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -166,11 +166,19 @@ fn check_arm<'tcx>(
                 let (paren_start, inner_if_span, paren_end) = peel_parens(cx, inner_expr.span);
                 let inner_if = inner_if_span.split_at(2).0;
                 let mut sugg = vec![(inner.then.span.shrink_to_lo(), "=> ".to_string())];
+
                 if matches!(outer_then_body.kind, ExprKind::Block(..)) {
-                    let outer_then_open_bracket = outer_then_body
-                        .span
-                        .split_at(1)
-                        .0
+                    let block_span = outer_then_body.span;
+                    // The Block Span can start with a label so finding actual opening braces instead of assuming it's
+                    // first Byte
+                    let block_snippet = snippet(cx, block_span, "");
+                    let brace_offset = block_snippet.find('{').unwrap_or(0);
+                    let brace_pos = block_span.lo() + BytePos(u32::try_from(brace_offset).unwrap());
+
+                    let label_prefix = block_snippet[..brace_offset].trim();
+                    let outer_then_open_bracket = block_span
+                        .with_lo(brace_pos)
+                        .with_hi(brace_pos + BytePos(1))
                         .with_leading_whitespace(cx)
                         .into_span();
                     let outer_then_closing_bracket = {
@@ -181,6 +189,10 @@ fn check_arm<'tcx>(
                     };
                     sugg.push((outer_arrow_end.to(outer_then_open_bracket), String::new()));
                     sugg.push((outer_then_closing_bracket, String::new()));
+
+                    if !label_prefix.is_empty() {
+                        sugg[0].1 = format!("=> {label_prefix} ");
+                    }
                 } else {
                     sugg.push((outer_arrow_end.until(inner_if), " ".to_string()));
                 }

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -168,6 +168,9 @@ fn check_arm<'tcx>(
                 let mut sugg = vec![(inner.then.span.shrink_to_lo(), "=> ".to_string())];
 
                 if let ExprKind::Block(block, label) = outer_then_body.kind {
+                    if label.is_some() && outer_then_body.span.from_expansion() {
+                        return;
+                    }
                     let block_span = outer_then_body.span;
                     let search_start = if let Some(label) = label {
                         label.ident.span.hi()

--- a/tests/ui/collapsible_match_fixable.fixed
+++ b/tests/ui/collapsible_match_fixable.fixed
@@ -75,3 +75,20 @@ fn issue16894() {
         //~^ collapsible_match
     };
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/17427
+// `collapsible_match` suggested wrong spans when the outer arm's block has a
+// label, deleting the label's leading `'` instead of preserving it after `=>`.
+fn issue17427() {
+    let x: Result<Option<u8>, ()> = Ok(Some(1));
+    match x {
+        Ok(Some(_c))
+            if true => 'label: {
+                //~^ collapsible_match
+                let Some(_y) = Some(0) else {
+                    break 'label;
+                };
+            },
+        _ => (),
+    }
+}

--- a/tests/ui/collapsible_match_fixable.fixed
+++ b/tests/ui/collapsible_match_fixable.fixed
@@ -92,3 +92,17 @@ fn issue17427() {
         _ => (),
     }
 }
+
+fn issue17427_comment_before_brace() {
+    let x: Result<Option<u8>, ()> = Ok(Some(1));
+    match x {
+        Ok(Some(_c))
+            if true => 'label: /* { .... } */ {
+                //~^ collapsible_match
+                let Some(_y) = Some(0) else {
+                    break 'label;
+                };
+            },
+        _ => (),
+    }
+}

--- a/tests/ui/collapsible_match_fixable.rs
+++ b/tests/ui/collapsible_match_fixable.rs
@@ -77,3 +77,21 @@ fn issue16894() {
         //~^ collapsible_match
     };
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/17427
+// `collapsible_match` suggested wrong spans when the outer arm's block has a
+// label, deleting the label's leading `'` instead of preserving it after `=>`.
+fn issue17427() {
+    let x: Result<Option<u8>, ()> = Ok(Some(1));
+    match x {
+        Ok(Some(_c)) => 'label: {
+            if true {
+                //~^ collapsible_match
+                let Some(_y) = Some(0) else {
+                    break 'label;
+                };
+            }
+        },
+        _ => (),
+    }
+}

--- a/tests/ui/collapsible_match_fixable.rs
+++ b/tests/ui/collapsible_match_fixable.rs
@@ -95,3 +95,18 @@ fn issue17427() {
         _ => (),
     }
 }
+
+fn issue17427_comment_before_brace() {
+    let x: Result<Option<u8>, ()> = Ok(Some(1));
+    match x {
+        Ok(Some(_c)) => 'label: /* { .... } */ {
+            if true {
+                //~^ collapsible_match
+                let Some(_y) = Some(0) else {
+                    break 'label;
+                };
+            }
+        },
+        _ => (),
+    }
+}

--- a/tests/ui/collapsible_match_fixable.stderr
+++ b/tests/ui/collapsible_match_fixable.stderr
@@ -112,5 +112,26 @@ LL -         11 => 0, 12 => if a == b { 1 } else { 0 }, _ => 0,
 LL +         11 => 0, 12 if a == b => { 1 }, _ => 0,
    |
 
-error: aborting due to 8 previous errors
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:88:13
+   |
+LL | /             if true {
+LL | |
+LL | |                 let Some(_y) = Some(0) else {
+LL | |                     break 'label;
+LL | |                 };
+LL | |             }
+   | |_____________^
+   |
+help: collapse nested if block
+   |
+LL ~         Ok(Some(_c))
+LL ~             if true => 'label: {
+LL |
+...
+LL |                 };
+LL ~             },
+   |
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/collapsible_match_fixable.stderr
+++ b/tests/ui/collapsible_match_fixable.stderr
@@ -133,5 +133,26 @@ LL |                 };
 LL ~             },
    |
 
-error: aborting due to 9 previous errors
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_fixable.rs:103:13
+   |
+LL | /             if true {
+LL | |
+LL | |                 let Some(_y) = Some(0) else {
+LL | |                     break 'label;
+LL | |                 };
+LL | |             }
+   | |_____________^
+   |
+help: collapse nested if block
+   |
+LL ~         Ok(Some(_c))
+LL ~             if true => 'label: /* { .... } */ {
+LL |
+...
+LL |                 };
+LL ~             },
+   |
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/collapsible_match_no_fix.rs
+++ b/tests/ui/collapsible_match_no_fix.rs
@@ -1,0 +1,27 @@
+//@no-rustfix
+#![warn(clippy::collapsible_match)]
+#![allow(clippy::single_match)]
+
+// https://github.com/rust-lang/rust-clippy/issues/17427
+// A labeled block whose label AND block both originate from a macro expansion
+// must not attempt a suggestion, since span arithmetic across the macro
+// boundary previously caused an ICE.
+macro_rules! labelled {
+    ($label:tt, $($stmts:stmt);*) => {
+        $label: { $($stmts);* }
+    };
+}
+
+fn issue17427_macro_label_and_block() {
+    let x: Result<Option<u8>, ()> = Ok(Some(1));
+    match x {
+        Ok(Some(_c)) => labelled!(
+            'label,
+            if true { println!("hi") }
+            //~^ collapsible_match
+        ),
+        _ => (),
+    }
+}
+
+fn main() {}

--- a/tests/ui/collapsible_match_no_fix.stderr
+++ b/tests/ui/collapsible_match_no_fix.stderr
@@ -1,0 +1,11 @@
+error: this `if` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match_no_fix.rs:20:13
+   |
+LL |             if true { println!("hi") }
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::collapsible-match` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::collapsible_match)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17437)*

Fixes rust-lang/rust-clippy#17427

`collapsible_match` was computing the wrong span for the opening brace
of a match arm's block when that block had a label (e.g. `'label: { ... }`).
It assumed the first byte of the block's span was always `{`, which only
holds when there's no label — with a label present, the suggestion ended
up deleting the leading `'` of the label instead of the arrow, producing
code that failed to compile ("unclosed delimiter").

This finds the actual `{` position instead of assuming it's the first byte,
and re-inserts the label text after the `=>` in the suggestion so it isn't
silently dropped.

Added a regression test (`issue17427` in `tests/ui/collapsible_match_fixable.rs`)
covering the labeled-block case, verified via both `.stderr` and `.fixed`
(rustfix-applied output actually compiles).

changelog: [`collapsible_match`]: fix incorrect suggestion span causing a
compile error when the outer match arm's block has a label