### PR TITLE
  Fix `needless_range_loop` false positive with nested indexing

### DIFF
--- a/clippy_lints/src/loops/needless_range_loop.rs
+++ b/clippy_lints/src/loops/needless_range_loop.rs
@@ -2,7 +2,7 @@ use super::NEEDLESS_RANGE_LOOP;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::snippet;
 use clippy_utils::ty::has_iter_method;
-use clippy_utils::visitors::is_local_used;
+use clippy_utils::visitors::{is_const_evaluatable, is_local_used};
 use clippy_utils::{SpanlessEq, contains_name, higher, is_integer_literal, peel_hir_expr_while, sugg};
 use rustc_ast::ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
@@ -43,6 +43,7 @@ pub(super) fn check<'tcx>(
             unnamed_indexed_indirectly: false,
             indexed_directly: FxIndexMap::default(),
             unnamed_indexed_directly: false,
+            has_dynamic_indexed_container: false,
             referenced: FxHashSet::default(),
             nonindex: false,
             prefer_mutable: false,
@@ -53,6 +54,7 @@ pub(super) fn check<'tcx>(
         if visitor.indexed_indirectly.is_empty()
             && !visitor.unnamed_indexed_indirectly
             && !visitor.unnamed_indexed_directly
+            && !visitor.has_dynamic_indexed_container
             && visitor.indexed_directly.len() == 1
         {
             let (indexed, (indexed_extent, indexed_ty)) = visitor
@@ -239,6 +241,9 @@ struct VarVisitor<'a, 'tcx> {
     indexed_directly: FxIndexMap<Symbol, (Option<region::Scope>, Ty<'tcx>)>,
     /// directly indexed literals, like `[1, 2, 3][i]`
     unnamed_indexed_directly: bool,
+    /// Whether the loop variable indexes a container selected by a non-constant expression.
+    /// For example, in `a[sum % 5][i]`, iterating over `a` would change the program's semantics.
+    has_dynamic_indexed_container: bool,
     /// Any names that are used outside an index operation.
     /// Used to detect things like `&mut vec` used together with `vec[i]`
     referenced: FxHashSet<Symbol>,
@@ -256,10 +261,17 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
         // It is `true` if all indices are direct
         let mut index_used_directly = true;
 
+        // Track whether the loop variable has been found while walking from the outermost index
+        // towards the base expression. Any later non-constant index selects the container indexed
+        // by the loop variable, so it cannot be replaced by an iterator over the base expression.
+        let mut found_loop_index = false;
+        let mut indexed_container_is_stable = true;
+
         // Handle initial index
         if is_local_used(self.cx, idx, self.var) {
             used_cnt += 1;
             index_used_directly &= matches!(idx.kind, ExprKind::Path(_));
+            found_loop_index = true;
         }
         // Handle nested indices
         let seqexpr = peel_hir_expr_while(seqexpr, |e| {
@@ -267,12 +279,20 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
                 if is_local_used(self.cx, idx, self.var) {
                     used_cnt += 1;
                     index_used_directly &= matches!(idx.kind, ExprKind::Path(_));
+                    found_loop_index = true;
+                } else if found_loop_index && !is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), idx) {
+                    indexed_container_is_stable = false;
                 }
                 Some(e)
             } else {
                 None
             }
         });
+
+        if !indexed_container_is_stable {
+            self.has_dynamic_indexed_container = true;
+            return false;
+        }
 
         match used_cnt {
             0 => return true,

--- a/clippy_lints/src/loops/needless_range_loop.rs
+++ b/clippy_lints/src/loops/needless_range_loop.rs
@@ -265,7 +265,6 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
         // towards the base expression. Any later non-constant index selects the container indexed
         // by the loop variable, so it cannot be replaced by an iterator over the base expression.
         let mut found_loop_index = false;
-        let mut indexed_container_is_stable = true;
 
         // Handle initial index
         if is_local_used(self.cx, idx, self.var) {
@@ -281,7 +280,7 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
                     index_used_directly &= matches!(idx.kind, ExprKind::Path(_));
                     found_loop_index = true;
                 } else if found_loop_index && !is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), idx) {
-                    indexed_container_is_stable = false;
+                    self.has_dynamic_indexed_container = true;
                 }
                 Some(e)
             } else {
@@ -289,8 +288,7 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
             }
         });
 
-        if !indexed_container_is_stable {
-            self.has_dynamic_indexed_container = true;
+        if self.has_dynamic_indexed_container {
             return false;
         }
 

--- a/clippy_lints/src/loops/needless_range_loop.rs
+++ b/clippy_lints/src/loops/needless_range_loop.rs
@@ -5,7 +5,7 @@ use super::NEEDLESS_RANGE_LOOP;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::snippet;
 use clippy_utils::ty::has_iter_method;
-use clippy_utils::visitors::is_local_used;
+use clippy_utils::visitors::{is_const_evaluatable, is_local_used};
 use clippy_utils::{SpanlessEq, SpanlessHash, contains_name, higher, is_integer_literal, peel_hir_expr_while, sugg};
 use rustc_ast::ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
@@ -46,6 +46,7 @@ pub(super) fn check<'tcx>(
             unnamed_indexed_indirectly: false,
             indexed_directly: FxIndexMap::default(),
             unnamed_indexed_directly: false,
+            has_dynamic_indexed_container: false,
             referenced: FxHashSet::default(),
             nonindex: false,
             prefer_mutable: false,
@@ -56,6 +57,7 @@ pub(super) fn check<'tcx>(
         if visitor.indexed_indirectly.is_empty()
             && !visitor.unnamed_indexed_indirectly
             && !visitor.unnamed_indexed_directly
+            && !visitor.has_dynamic_indexed_container
             && let mut indexed_directly_iter = visitor.indexed_directly.into_iter()
             && let Some(((indexed, indexed_extended), (indexed_extent, indexed_span))) = indexed_directly_iter.next()
             && indexed_directly_iter.next().is_none()
@@ -245,6 +247,9 @@ struct VarVisitor<'a, 'tcx> {
     indexed_directly: FxIndexMap<(Symbol, SpanlessExpr<'a, 'tcx>), (Option<region::Scope>, Span)>,
     /// directly indexed literals, like `[1, 2, 3][i]`
     unnamed_indexed_directly: bool,
+    /// Whether the loop variable indexes a container selected by a non-constant expression.
+    /// For example, in `a[sum % 5][i]`, iterating over `a` would change the program's semantics.
+    has_dynamic_indexed_container: bool,
     /// Any names that are used outside an index operation.
     /// Used to detect things like `&mut vec` used together with `vec[i]`
     referenced: FxHashSet<Symbol>,
@@ -262,10 +267,17 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
         // It is `true` if all indices are direct
         let mut index_used_directly = true;
 
+        // Track whether the loop variable has been found while walking from the outermost index
+        // towards the base expression. Any later non-constant index selects the container indexed
+        // by the loop variable, so it cannot be replaced by an iterator over the base expression.
+        let mut found_loop_index = false;
+        let mut indexed_container_is_stable = true;
+
         // Handle initial index
         if is_local_used(self.cx, idx, self.var) {
             used_cnt += 1;
             index_used_directly &= matches!(idx.kind, ExprKind::Path(_));
+            found_loop_index = true;
         }
         // Handle nested indices
         // For example, in `a.b[0][i][i]`, we will have `nested_seqexpr` be `a.b[0]`, with the corresponding
@@ -277,6 +289,7 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
             {
                 used_cnt += 1;
                 index_used_directly &= matches!(idx.kind, ExprKind::Path(_));
+                found_loop_index = true;
                 nested_seqexpr_index_span = e.span;
                 Some(inner)
             } else {
@@ -284,12 +297,22 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
             }
         });
         let seqexpr = peel_hir_expr_while(nested_seqexpr, |e| {
-            if let ExprKind::Index(inner, _, _) | ExprKind::Field(inner, _) = e.kind {
-                Some(inner)
-            } else {
-                None
+            match e.kind {
+                ExprKind::Index(inner, idx, _) => {
+                    if found_loop_index && !is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), idx) {
+                        indexed_container_is_stable = false;
+                    }
+                    Some(inner)
+                },
+                ExprKind::Field(inner, _) => Some(inner),
+                _ => None,
             }
         });
+
+        if !indexed_container_is_stable {
+            self.has_dynamic_indexed_container = true;
+            return false;
+        }
 
         match used_cnt {
             0 => return true,

--- a/clippy_lints/src/loops/needless_range_loop.rs
+++ b/clippy_lints/src/loops/needless_range_loop.rs
@@ -248,7 +248,8 @@ struct VarVisitor<'a, 'tcx> {
     /// directly indexed literals, like `[1, 2, 3][i]`
     unnamed_indexed_directly: bool,
     /// Whether the loop variable indexes a container selected by a non-constant expression.
-    /// For example, in `a[sum % 5][i]`, iterating over `a` would change the program's semantics.
+    /// For example, in `a[sum % 5][i]`, evaluating `a[sum % 5]` once before the loop would change
+    /// the program's semantics.
     has_dynamic_indexed_container: bool,
     /// Any names that are used outside an index operation.
     /// Used to detect things like `&mut vec` used together with `vec[i]`
@@ -267,17 +268,10 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
         // It is `true` if all indices are direct
         let mut index_used_directly = true;
 
-        // Track whether the loop variable has been found while walking from the outermost index
-        // towards the base expression. Any later non-constant index selects the container indexed
-        // by the loop variable, so it cannot be replaced by an iterator over the base expression.
-        let mut found_loop_index = false;
-        let mut indexed_container_is_stable = true;
-
         // Handle initial index
         if is_local_used(self.cx, idx, self.var) {
             used_cnt += 1;
             index_used_directly &= matches!(idx.kind, ExprKind::Path(_));
-            found_loop_index = true;
         }
         // Handle nested indices
         // For example, in `a.b[0][i][i]`, we will have `nested_seqexpr` be `a.b[0]`, with the corresponding
@@ -289,32 +283,25 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
             {
                 used_cnt += 1;
                 index_used_directly &= matches!(idx.kind, ExprKind::Path(_));
-                found_loop_index = true;
                 nested_seqexpr_index_span = e.span;
                 Some(inner)
             } else {
                 None
             }
         });
-        let seqexpr = peel_hir_expr_while(nested_seqexpr, |e| {
-            match e.kind {
-                ExprKind::Index(inner, idx, _) => {
-                    if found_loop_index && !is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), idx) {
-                        indexed_container_is_stable = false;
-                    }
-                    Some(inner)
-                },
-                ExprKind::Field(inner, _) => Some(inner),
-                _ => None,
-            }
+        let seqexpr = peel_hir_expr_while(nested_seqexpr, |e| match e.kind {
+            ExprKind::Index(inner, idx, _) => {
+                if used_cnt != 0 && !is_const_evaluatable(self.cx.tcx, self.cx.typeck_results(), idx) {
+                    self.has_dynamic_indexed_container = true;
+                }
+                Some(inner)
+            },
+            ExprKind::Field(inner, _) => Some(inner),
+            _ => None,
         });
 
-        if !indexed_container_is_stable {
-            self.has_dynamic_indexed_container = true;
-            return false;
-        }
-
         match used_cnt {
+            _ if self.has_dynamic_indexed_container => return false,
             0 => return true,
             n if n > 1 => self.nonindex = true, // Optimize code like `a[i][i]`
             _ => {},

--- a/tests/ui/needless_range_loop.rs
+++ b/tests/ui/needless_range_loop.rs
@@ -237,3 +237,18 @@ fn issue_15068() {
         let _ = a[0][i];
     }
 }
+
+// Regression test for #17432: the container indexed by `i` changes between iterations.
+fn issue_17432(a: [[usize; 5]; 5]) {
+    let mut sum = 0;
+
+    for i in 0..5 {
+        sum += a[sum % 5][i];
+    }
+
+    // Keep linting when `i` selects the outer container.
+    for i in 0..5 {
+        //~^ needless_range_loop
+        let _ = a[i][sum % 5];
+    }
+}

--- a/tests/ui/needless_range_loop.rs
+++ b/tests/ui/needless_range_loop.rs
@@ -277,3 +277,18 @@ fn issue16631() {
         let _ = wrapper.0[i];
     }
 }
+
+// Regression test for #17432: the container indexed by `i` changes between iterations.
+fn issue_17432(a: [[usize; 5]; 5]) {
+    let mut sum = 0;
+
+    for i in 0..5 {
+        sum += a[sum % 5][i];
+    }
+
+    // Keep linting when `i` selects the outer container.
+    for i in 0..5 {
+        //~^ needless_range_loop
+        let _ = a[i][sum % 5];
+    }
+}

--- a/tests/ui/needless_range_loop.stderr
+++ b/tests/ui/needless_range_loop.stderr
@@ -192,5 +192,17 @@ LL -     for i in 0..MAX_LEN {
 LL +     for <item> in a.iter().take(MAX_LEN) {
    |
 
-error: aborting due to 16 previous errors
+error: the loop variable `i` is only used to index `a`
+  --> tests/ui/needless_range_loop.rs:250:14
+   |
+LL |     for i in 0..5 {
+   |              ^^^^
+   |
+help: consider using an iterator
+   |
+LL -     for i in 0..5 {
+LL +     for <item> in &a {
+   |
+
+error: aborting due to 17 previous errors
 

--- a/tests/ui/needless_range_loop.stderr
+++ b/tests/ui/needless_range_loop.stderr
@@ -340,5 +340,22 @@ LL -     for i in 0..3 {
 LL +     for <item> in &wrapper.0 {
    |
 
-error: aborting due to 20 previous errors
+error: the loop variable `i` is only used to index `a`
+  --> tests/ui/needless_range_loop.rs:290:14
+   |
+LL |     for i in 0..5 {
+   |              ^^^^
+   |
+note: for this index operation
+  --> tests/ui/needless_range_loop.rs:292:17
+   |
+LL |         let _ = a[i][sum % 5];
+   |                 ^^^^
+help: consider using an iterator
+   |
+LL -     for i in 0..5 {
+LL +     for <item> in &a {
+   |
+
+error: aborting due to 21 previous errors
 


### PR DESCRIPTION
`needless_range_loop` could emit an incorrect suggestion for nested indexing
  expressions such as `a[sum % 5][i]`.

  In this case, the container indexed by the loop variable may change between
  iterations, so replacing the range loop with an iterator over the base
  container would change the program's semantics.

  This detects non-constant container-selection indices while walking nested
  index expressions and suppresses the lint in those cases. The existing behavior
  is preserved when the loop variable selects the outer container.

  A regression test for the reported case and a corresponding positive test have
  been added.

  fixes rust-lang/rust-clippy#17432

  changelog: [`needless_range_loop`]: avoid false positives when indexing dynamically selected nested containers