### PR TITLE
New lint: `const_size_windows` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6831,6 +6831,7 @@ Released 2018-09-13
 [`comparison_to_empty`]: https://rust-lang.github.io/rust-clippy/master/index.html#comparison_to_empty
 [`confusing_method_to_numeric_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#confusing_method_to_numeric_cast
 [`const_is_empty`]: https://rust-lang.github.io/rust-clippy/master/index.html#const_is_empty
+[`const_size_windows`]: https://rust-lang.github.io/rust-clippy/master/index.html#const_size_windows
 [`const_static_lifetime`]: https://rust-lang.github.io/rust-clippy/master/index.html#const_static_lifetime
 [`copy_iterator`]: https://rust-lang.github.io/rust-clippy/master/index.html#copy_iterator
 [`crate_in_macro_def`]: https://rust-lang.github.io/rust-clippy/master/index.html#crate_in_macro_def

--- a/clippy_lints/src/comparison_chain.rs
+++ b/clippy_lints/src/comparison_chain.rs
@@ -80,9 +80,9 @@ impl<'tcx> LateLintPass<'tcx> for ComparisonChain {
             return;
         }
 
-        for cond in conds.windows(2) {
+        for [left, right] in conds.array_windows() {
             if let (&ExprKind::Binary(ref kind1, lhs1, rhs1), &ExprKind::Binary(ref kind2, lhs2, rhs2)) =
-                (&cond[0].kind, &cond[1].kind)
+                (&left.kind, &right.kind)
             {
                 if !kind_is_cmp(kind1.node) || !kind_is_cmp(kind2.node) {
                     return;

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -379,6 +379,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::CLONED_INSTEAD_OF_COPIED_INFO,
     crate::methods::COLLAPSIBLE_STR_REPLACE_INFO,
     crate::methods::CONST_IS_EMPTY_INFO,
+    crate::methods::CONST_SIZE_WINDOWS_INFO,
     crate::methods::DOUBLE_ENDED_ITERATOR_LAST_INFO,
     crate::methods::DRAIN_COLLECT_INFO,
     crate::methods::ERR_EXPECT_INFO,

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -147,8 +147,9 @@ declare_lint_pass!(Formatting => [
 
 impl EarlyLintPass for Formatting {
     fn check_block(&mut self, cx: &EarlyContext<'_>, block: &Block) {
-        for w in block.stmts.windows(2) {
-            if let (StmtKind::Expr(first), StmtKind::Expr(second) | StmtKind::Semi(second)) = (&w[0].kind, &w[1].kind) {
+        for [left, right] in block.stmts.array_windows() {
+            if let (StmtKind::Expr(first), StmtKind::Expr(second) | StmtKind::Semi(second)) = (&left.kind, &right.kind)
+            {
                 check_missing_else(cx, first, second);
             }
         }

--- a/clippy_lints/src/inconsistent_struct_constructor.rs
+++ b/clippy_lints/src/inconsistent_struct_constructor.rs
@@ -155,11 +155,11 @@ fn suggestion<'tcx>(
     def_order_map: &FxHashMap<Symbol, usize>,
 ) -> String {
     let ws = fields
-        .windows(2)
-        .map(|w| {
-            let w0_span = field_with_attrs_span(cx.tcx, &w[0]);
-            let w1_span = field_with_attrs_span(cx.tcx, &w[1]);
-            let span = w0_span.between(w1_span);
+        .array_windows()
+        .map(|[left, right]| {
+            let left_span = field_with_attrs_span(cx.tcx, left);
+            let right_span = field_with_attrs_span(cx.tcx, right);
+            let span = left_span.between(right_span);
             snippet(cx, span, " ")
         })
         .collect::<Vec<_>>();

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -22,7 +22,9 @@ use super::{MATCH_BOOL, SINGLE_MATCH, SINGLE_MATCH_ELSE};
 /// span, e.g. a string literal `"//"`, but we know that this isn't the case for empty
 /// match arms.
 fn empty_arm_has_comment(cx: &LateContext<'_>, span: Span) -> bool {
-    span.check_text(cx, |text| text.as_bytes().windows(2).any(|w| w == b"//" || w == b"/*"))
+    span.check_text(cx, |text| {
+        text.as_bytes().array_windows::<2>().any(|w| w == b"//" || w == b"/*")
+    })
 }
 
 pub(crate) fn check<'tcx>(

--- a/clippy_lints/src/methods/const_size_windows.rs
+++ b/clippy_lints/src/methods/const_size_windows.rs
@@ -1,0 +1,293 @@
+use super::CONST_SIZE_WINDOWS;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::Msrv;
+use clippy_utils::res::{MaybeDef as _, MaybeTypeckRes as _};
+use clippy_utils::source::snippet_opt;
+use clippy_utils::ty::{deref_chain, implements_trait};
+use clippy_utils::visitors::is_const_evaluatable;
+use clippy_utils::{contains_name, msrvs, sym};
+use rustc_ast::LitKind;
+use rustc_data_structures::packed::Pu128;
+use rustc_errors::Applicability;
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Expr, ExprKind, ImplItemKind, Item, ItemKind, Node, QPath, TraitFn, TraitItemKind, UnOp};
+use rustc_lint::LateContext;
+use rustc_middle::ty::{AssocTag, EarlyBinder, Ty, Unnormalized};
+use rustc_span::{Span, Symbol};
+use std::ops::Not as _;
+
+const ARRAY_WINDOWS: Symbol = sym::array_windows;
+const WINDOWS: Symbol = sym::windows;
+const SLICE: Symbol = sym::slice;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Suggestion {
+    span_location: SpanLocation,
+    code: String,
+    destructuring_example: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum SpanLocation {
+    MethodCall,
+    EntireExpression,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DestructuredArray {
+    array_snippet: String,
+    extent: DestructuringExtent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum DestructuringExtent {
+    Full,
+    Partial,
+}
+
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    recv: &'tcx Expr<'tcx>,
+    size_arg: &'tcx Expr<'tcx>,
+    call_span: Span,
+    msrv: Msrv,
+) {
+    // Ignore cases where entire expression originates from a macro.
+    if expr.span.from_expansion() {
+        return;
+    }
+
+    // Ignore Rust versions where `slice::array_windows` has not stabilized
+    if !msrv.meets(cx, msrvs::ARRAY_WINDOWS) {
+        return;
+    }
+
+    if is_const_size_window(cx, expr, size_arg) {
+        span_lint_and_then(
+            cx,
+            CONST_SIZE_WINDOWS,
+            call_span,
+            format!("using `{SLICE}::{WINDOWS}` with a constant size instead of `{SLICE}::{ARRAY_WINDOWS}`"),
+            |diag| {
+                if let Some(Suggestion {
+                    span_location,
+                    code,
+                    destructuring_example,
+                }) = compute_suggestion(cx, recv, size_arg)
+                {
+                    let span = match span_location {
+                        SpanLocation::MethodCall => call_span,
+                        SpanLocation::EntireExpression => expr.span,
+                    };
+                    diag.span_suggestion(span, "use", code, Applicability::MachineApplicable);
+
+                    if let Some(example) = destructuring_example {
+                        diag.note(format!("this allows array destructuring: `{example}`"));
+                    }
+                } else {
+                    diag.span_help(call_span, format!("consider using `{SLICE}::{ARRAY_WINDOWS}` here"));
+                }
+            },
+        );
+    }
+}
+
+fn is_const_size_window<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, size_arg: &'tcx Expr<'_>) -> bool {
+    let is_slice_method_call = cx
+        .ty_based_def(expr)
+        .opt_parent(cx)
+        .opt_impl_ty(cx)
+        .map(EarlyBinder::instantiate_identity)
+        .map(Unnormalized::skip_normalization)
+        .is_some_and(Ty::is_slice);
+
+    is_slice_method_call && is_const_evaluatable(cx.tcx, cx.typeck_results(), size_arg)
+}
+
+fn compute_suggestion<'tcx>(
+    cx: &LateContext<'tcx>,
+    recv: &'tcx Expr<'tcx>,
+    size_arg: &'tcx Expr<'tcx>,
+) -> Option<Suggestion> {
+    let recv_snippet = snippet_opt(cx, recv.span.source_callsite())?;
+    let size_arg_snippet = snippet_opt(cx, size_arg.span.source_callsite())?;
+
+    let size_generic_const_arg = if expr_needs_braces_in_const_arg(size_arg) {
+        format!("{{ {size_arg_snippet} }}")
+    } else {
+        size_arg_snippet
+    };
+
+    let is_ucfs_required = is_array_windows_method_call_ambiguous(cx, recv);
+
+    let (span_location, code) = if is_ucfs_required {
+        (
+            SpanLocation::EntireExpression,
+            format!(
+                "<[_]>::{ARRAY_WINDOWS}::<{size_generic_const_arg}>({})",
+                normalize_expr_to_single_ref(cx, recv)?
+            ),
+        )
+    } else {
+        (
+            SpanLocation::MethodCall,
+            format!("{ARRAY_WINDOWS}::<{size_generic_const_arg}>()"),
+        )
+    };
+
+    let destructuring_example =
+        build_destructured_array(cx, size_arg).and_then(|DestructuredArray { array_snippet, extent }| {
+            let iterator_expr_snippet = match extent {
+                DestructuringExtent::Full if is_ucfs_required => {
+                    format!("<[_]>::{ARRAY_WINDOWS}({})", normalize_expr_to_single_ref(cx, recv)?)
+                },
+                DestructuringExtent::Full => format!("{recv_snippet}.{ARRAY_WINDOWS}()"),
+                DestructuringExtent::Partial if is_ucfs_required => format!(
+                    "<[_]>::{ARRAY_WINDOWS}::<{size_generic_const_arg}>({})",
+                    normalize_expr_to_single_ref(cx, recv)?
+                ),
+                DestructuringExtent::Partial => format!("{recv_snippet}.{ARRAY_WINDOWS}::<{size_generic_const_arg}>()"),
+            };
+
+            Some(format!("for {array_snippet} in {iterator_expr_snippet}"))
+        });
+
+    Some(Suggestion {
+        span_location,
+        code,
+        destructuring_example,
+    })
+}
+
+fn build_destructured_array(cx: &LateContext<'_>, size_arg: &Expr<'_>) -> Option<DestructuredArray> {
+    const MAX_HINTED_DESTRUCTURED_ARRAY_LENGTH: u128 = 5;
+    let containing_fn = get_containing_fn(cx, size_arg)?;
+    let is_unused_name = |name: &&str| !contains_name(Symbol::intern(name), containing_fn, cx);
+
+    let destructured_array = if let ExprKind::Lit(lit) = size_arg.kind
+        && let LitKind::Int(Pu128(length), _) = lit.node
+        && length <= MAX_HINTED_DESTRUCTURED_ARRAY_LENGTH
+        && let length = length as usize
+        && !size_arg.span.from_expansion()
+    {
+        const EXACT_LEN_POTENTIAL_NAMES: &[&[&str]] = &[&["left", "right"], &["x", "y", "z"]];
+
+        const ANY_LEN_POTENTIAL_NAMES: &[&[&str]] = &[
+            &["item_1", "item_2", "item_3", "item_4", "item_5"],
+            &["el_1", "el_2", "el_3", "el_4", "el_5"],
+            &["x1", "x2", "x3", "x4", "x5"],
+        ];
+
+        let comma_separated_variables = EXACT_LEN_POTENTIAL_NAMES
+            .iter()
+            .filter(|names| names.len() == length)
+            .chain(ANY_LEN_POTENTIAL_NAMES.iter().filter(|names| names.len() >= length))
+            .map(|names| &names[..length])
+            .find(|names| names.iter().all(is_unused_name))?
+            .join(", ");
+
+        DestructuredArray {
+            array_snippet: format!("[{comma_separated_variables}]"),
+            extent: DestructuringExtent::Full,
+        }
+    } else {
+        const POTENTIAL_NAMES: &[&str] = &["item", "element", "el", "a", "x"];
+        let name = POTENTIAL_NAMES.iter().find(|name| is_unused_name(name))?;
+        DestructuredArray {
+            array_snippet: format!("[{name}, ..]"),
+            extent: DestructuringExtent::Partial,
+        }
+    };
+
+    Some(destructured_array)
+}
+
+fn expr_needs_braces_in_const_arg(expr: &Expr<'_>) -> bool {
+    expr.span.from_expansion()
+        || match &expr.kind {
+            ExprKind::Lit(_) => false,
+            ExprKind::Path(QPath::Resolved(None, path)) => {
+                path.segments.len() != 1 || path.segments[0].args.is_none().not()
+            },
+            _ => true,
+        }
+}
+
+/// We are overly careful with this check: we allow FP because our goal is never allowing FN.
+/// The worst-case scenario of being overly careful is that UCFS is suggested when it isn't strictly
+/// necessary.
+fn is_array_windows_method_call_ambiguous(cx: &LateContext<'_>, recv: &Expr<'_>) -> bool {
+    let typeck_results = cx.typeck_results();
+    let candidate_recv_types: Vec<_> = [typeck_results.expr_ty(recv), typeck_results.expr_ty_adjusted(recv)]
+        .into_iter()
+        .flat_map(|ty| deref_chain(cx, ty))
+        .collect();
+
+    let recv_may_implements_trait = |trait_def_id: DefId| {
+        candidate_recv_types
+            .iter()
+            .any(|&ty| implements_trait(cx, ty, trait_def_id, &[]))
+    };
+
+    cx.tcx
+        .visible_traits()
+        .filter(|&trait_def_id| trait_declares_array_windows(cx, trait_def_id))
+        .any(recv_may_implements_trait)
+}
+
+fn trait_declares_array_windows(cx: &LateContext<'_>, trait_def_id: DefId) -> bool {
+    cx.tcx
+        .associated_items(trait_def_id)
+        .filter_by_name_unhygienic(ARRAY_WINDOWS)
+        .any(|item| item.tag() == AssocTag::Fn)
+}
+
+fn get_containing_fn<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>) -> Option<&'tcx Expr<'tcx>> {
+    let parent_item = cx.tcx.hir_get_parent_item(expr.hir_id);
+
+    let body_id = match cx.tcx.hir_node_by_def_id(parent_item.def_id) {
+        Node::Item(Item {
+            kind: ItemKind::Fn { body, .. },
+            ..
+        })
+        | Node::ImplItem(rustc_hir::ImplItem {
+            kind: ImplItemKind::Fn(_, body),
+            ..
+        })
+        | Node::TraitItem(rustc_hir::TraitItem {
+            kind: TraitItemKind::Fn(_, TraitFn::Provided(body)),
+            ..
+        }) => Some(*body),
+        _ => None,
+    };
+
+    Some(cx.tcx.hir_body(body_id?).value)
+}
+
+/// Attempt to produce a snippet of type &T by removing/adding `&` and `*` operators.
+/// If this is not possible, return `None`.
+/// Stops at macro expansion.
+///
+/// Examples:
+/// if `expr` is of type `T` -> `&expr`
+/// if `expr` is of type `&T` -> `expr`
+/// if `expr` is of type `&&T` -> `*expr`
+fn normalize_expr_to_single_ref(cx: &LateContext<'_>, recv: &Expr<'_>) -> Option<String> {
+    // Peel & and * until we reach macro expansion or core referent
+    let mut referent = recv;
+    while !referent.span.from_expansion()
+        && let ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(UnOp::Deref, inner) = referent.kind
+    {
+        referent = inner;
+    }
+
+    let referent_snippet = snippet_opt(cx, referent.span.source_callsite())?;
+    let snippet = if cx.typeck_results().expr_ty(referent).is_ref() {
+        referent_snippet
+    } else {
+        format!("&{referent_snippet}")
+    };
+
+    Some(snippet)
+}

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -16,6 +16,7 @@ mod clone_on_copy;
 mod clone_on_ref_ptr;
 mod cloned_instead_of_copied;
 mod collapsible_str_replace;
+mod const_size_windows;
 mod double_ended_iterator_last;
 mod drain_collect;
 mod err_expect;
@@ -538,6 +539,38 @@ declare_clippy_lint! {
     pub CONST_IS_EMPTY,
     suspicious,
     "is_empty() called on strings known at compile time"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for usage of `slice::windows` with a constant window size that can be replaced
+    /// with `slice::array_windows`.
+    ///
+    /// ### Why is this bad?
+    /// `slice::windows` yields `&[T]` slices, whose length is only known at runtime.
+    /// `slice::array_windows` yields fixed-size `&[T; N]` arrays instead, so the
+    /// length is known at compile time and each window can be destructured directly.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// fn foo(values: &[u8]) {
+    ///     for pair in values.windows(2) {
+    ///         println!("{} {}", pair[0], pair[1]);
+    ///     }
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// fn foo(values: &[u8]) {
+    ///     for [left, right] in values.array_windows() {
+    ///         println!("{left} {right}");
+    ///     }
+    /// }
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub CONST_SIZE_WINDOWS,
+    style,
+    "using `slice::windows` with a constant size instead of `slice::array_windows`"
 }
 
 declare_clippy_lint! {
@@ -4936,6 +4969,7 @@ impl_lint_pass!(Methods => [
     CLONE_ON_REF_PTR,
     COLLAPSIBLE_STR_REPLACE,
     CONST_IS_EMPTY,
+    CONST_SIZE_WINDOWS,
     DOUBLE_ENDED_ITERATOR_LAST,
     DRAIN_COLLECT,
     ERR_EXPECT,
@@ -5994,6 +6028,9 @@ impl Methods {
                         &self.unwrap_allowed_aliases,
                         unwrap_expect_used::Variant::Unwrap,
                     );
+                },
+                (sym::windows, [size_arg]) => {
+                    const_size_windows::check(cx, expr, recv, size_arg, call_span, self.msrv);
                 },
                 _ => {},
             }

--- a/clippy_lints/src/redundant_closure_call.rs
+++ b/clippy_lints/src/redundant_closure_call.rs
@@ -270,12 +270,12 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClosureCall {
             closure_usage_count.count
         }
 
-        for w in block.stmts.windows(2) {
-            if let hir::StmtKind::Let(local) = w[0].kind
+        for [left, right] in block.stmts.array_windows() {
+            if let hir::StmtKind::Let(local) = left.kind
                 && let Some(t) = local.init
                 && let ExprKind::Closure { .. } = t.kind
                 && let hir::PatKind::Binding(_, _, ident, _) = local.pat.kind
-                && let hir::StmtKind::Semi(second) = w[1].kind
+                && let hir::StmtKind::Semi(second) = right.kind
                 && let ExprKind::Assign(_, call, _) = second.kind
                 && let ExprKind::Call(closure, _) = call.kind
                 && let ExprKind::Path(hir::QPath::Resolved(_, path)) = closure.kind

--- a/clippy_lints_internal/src/repeated_is_diagnostic_item.rs
+++ b/clippy_lints_internal/src/repeated_is_diagnostic_item.rs
@@ -125,10 +125,9 @@ impl<'tcx> LateLintPass<'tcx> for RepeatedIsDiagnosticItem {
     fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'_>) {
         for [(cond1, stmt1_span), (cond2, stmt2_span)] in block
             .stmts
-            .windows(2)
-            .filter_map(|pair| {
-                if let [if1, if2] = pair
-                    && let StmtKind::Expr(e1) | StmtKind::Semi(e1) = if1.kind
+            .array_windows()
+            .filter_map(|[if1, if2]| {
+                if let StmtKind::Expr(e1) | StmtKind::Semi(e1) = if1.kind
                     && let ExprKind::If(cond1, ..) = e1.kind
                     && let StmtKind::Expr(e2) | StmtKind::Semi(e2) = if2.kind
                     && let ExprKind::If(cond2, ..) = e2.kind

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -25,7 +25,7 @@ macro_rules! msrv_aliases {
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
     1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
-    1,94,0 { EULER_GAMMA, GOLDEN_RATIO }
+    1,94,0 { EULER_GAMMA, GOLDEN_RATIO, ARRAY_WINDOWS }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }
     1,91,0 { DURATION_FROM_MINUTES_HOURS }
     1,89,0 { NONNULL_FROM_MUT }

--- a/clippy_utils/src/str_utils.rs
+++ b/clippy_utils/src/str_utils.rs
@@ -162,7 +162,7 @@ pub fn camel_case_split(s: &str) -> Vec<&str> {
         offsets.insert(0, 0);
     }
 
-    offsets.windows(2).map(|w| &s[w[0]..w[1]]).collect()
+    offsets.array_windows().map(|[left, right]| &s[*left..*right]).collect()
 }
 
 /// Dealing with string comparison can be complicated, this struct ensures that both the

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -134,6 +134,7 @@ generate! {
     append,
     applicability,
     arg,
+    array_windows,
     as_bytes,
     as_deref,
     as_deref_mut,

--- a/tests/ui/const_size_windows/true_negatives.rs
+++ b/tests/ui/const_size_windows/true_negatives.rs
@@ -1,0 +1,106 @@
+//@check-pass
+#![warn(clippy::const_size_windows)]
+
+macro_rules! number {
+    () => {
+        (0..100).count()
+    };
+}
+
+macro_rules! as_window_pairs {
+    ($slice:expr) => {{
+        let s: &[_] = $slice;
+        s.windows(2)
+    }};
+}
+
+fn get_number() -> usize {
+    (0..100).filter(|num| num % 2 == 0).count()
+}
+
+fn slice_windows_variable_size(slice: &[u8], size: usize) {
+    for window in slice.windows(size) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn slice_windows_fn_variable_size(slice: &[u8]) {
+    for window in slice.windows(get_number()) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn slice_windows_macro_variable_size(slice: &[u8]) {
+    for window in slice.windows(number!()) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn vec_windows_variable_size(vector: Vec<u8>, size: usize) {
+    for window in vector.windows(size) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn array_windows_variable_size(array: [u8; 3], size: usize) {
+    for window in array.windows(size) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn array_generic_length_windows_variable_size<const LENGTH: usize>(array: [u8; LENGTH], size: usize) {
+    for window in array.windows(size) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn inline_vec_windows_variable_size(size: usize) {
+    #[expect(clippy::useless_vec)]
+    for window in vec![1, 2, 3].windows(size) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn inline_array_windows_variable_size(size: usize) {
+    for window in [1, 2, 3].windows(size) {
+        let window: &[i32] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn inline_slice_windows_variable_size(size: usize) {
+    for window in [1, 2, 3, 4, 5][..=2].windows(size) {
+        let window: &[i32] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn into_slice_windows_variable_size<'a>(into_slice: impl Into<&'a [u8]>, size: usize) {
+    for window in into_slice.into().windows(size) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn deref_slice_windows_variable_size(deref_slice: impl std::ops::Deref<Target = [u8]>, size: usize) {
+    for window in (*deref_slice).windows(size) {
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn macro_containing_slice_windows_literal_size(slice: &[u8]) {
+    for pair in as_window_pairs!(slice) {
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn main() {}

--- a/tests/ui/const_size_windows/true_positives.fixed
+++ b/tests/ui/const_size_windows/true_positives.fixed
@@ -1,0 +1,145 @@
+#![warn(clippy::const_size_windows)]
+
+macro_rules! two {
+    () => {
+        2usize
+    };
+}
+
+const fn get_two() -> usize {
+    2
+}
+
+fn slice_windows_literal_size(slice: &[u8]) {
+    for pair in slice.array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn slice_windows_literal_size_three(slice: &[u8]) {
+    for triplet in slice.array_windows::<3>() {
+        //~^ const_size_windows
+        let triplet: &[u8] = triplet;
+        println!("{} {} {}", triplet[0], triplet[1], triplet[2]);
+    }
+}
+
+fn slice_windows_const_size(slice: &[u8]) {
+    const TWO: usize = 2;
+    for pair in slice.array_windows::<TWO>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn slice_windows_param_const_size<const SIZE: usize>(slice: &[u8]) {
+    for window in slice.array_windows::<SIZE>() {
+        //~^ const_size_windows
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn slice_windows_const_fn_size(slice: &[u8]) {
+    for pair in slice.array_windows::<{ get_two() }>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn slice_windows_inline_const_macro_size(slice: &[u8]) {
+    for pair in slice.array_windows::<{ two!() }>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn vec_windows_literal_size(vector: Vec<u8>) {
+    for pair in vector.array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_literal_size(array: [u8; 3]) {
+    for pair in array.array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn array_generic_length_windows_literal_size<const LENGTH: usize>(array: [u8; LENGTH]) {
+    for pair in array.array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn inline_vec_windows_literal_size() {
+    #[expect(clippy::useless_vec)]
+    for pair in vec![1, 2, 3].array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn inline_array_windows_literal_size() {
+    for pair in [1, 2, 3].array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn inline_slice_windows_literal_size() {
+    for pair in [1, 2, 3, 4, 5][..=2].array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn into_slice_windows_literal_size<'a>(into_slice: impl Into<&'a [u8]>) {
+    for pair in into_slice.into().array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn deref_slice_windows_literal_size(deref_slice: impl std::ops::Deref<Target = [u8]>) {
+    for pair in (*deref_slice).array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn deref_coerced_slice_windows_literal_size(deref_slice: impl std::ops::Deref<Target = [u8]>) {
+    for pair in deref_slice.array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn shadowed_destruct_variables() {
+    let vec: Vec<u8> = vec![1, 2, 3];
+    let (left, right) = (0, 1);
+    let (x, y) = (0, 1);
+
+    for pair in vec.array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}

--- a/tests/ui/const_size_windows/true_positives.rs
+++ b/tests/ui/const_size_windows/true_positives.rs
@@ -1,0 +1,145 @@
+#![warn(clippy::const_size_windows)]
+
+macro_rules! two {
+    () => {
+        2usize
+    };
+}
+
+const fn get_two() -> usize {
+    2
+}
+
+fn slice_windows_literal_size(slice: &[u8]) {
+    for pair in slice.windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn slice_windows_literal_size_three(slice: &[u8]) {
+    for triplet in slice.windows(3) {
+        //~^ const_size_windows
+        let triplet: &[u8] = triplet;
+        println!("{} {} {}", triplet[0], triplet[1], triplet[2]);
+    }
+}
+
+fn slice_windows_const_size(slice: &[u8]) {
+    const TWO: usize = 2;
+    for pair in slice.windows(TWO) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn slice_windows_param_const_size<const SIZE: usize>(slice: &[u8]) {
+    for window in slice.windows(SIZE) {
+        //~^ const_size_windows
+        let window: &[u8] = window;
+        println!("{}", window[0]);
+    }
+}
+
+fn slice_windows_const_fn_size(slice: &[u8]) {
+    for pair in slice.windows(get_two()) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn slice_windows_inline_const_macro_size(slice: &[u8]) {
+    for pair in slice.windows(two!()) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn vec_windows_literal_size(vector: Vec<u8>) {
+    for pair in vector.windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_literal_size(array: [u8; 3]) {
+    for pair in array.windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn array_generic_length_windows_literal_size<const LENGTH: usize>(array: [u8; LENGTH]) {
+    for pair in array.windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn inline_vec_windows_literal_size() {
+    #[expect(clippy::useless_vec)]
+    for pair in vec![1, 2, 3].windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn inline_array_windows_literal_size() {
+    for pair in [1, 2, 3].windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn inline_slice_windows_literal_size() {
+    for pair in [1, 2, 3, 4, 5][..=2].windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn into_slice_windows_literal_size<'a>(into_slice: impl Into<&'a [u8]>) {
+    for pair in into_slice.into().windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn deref_slice_windows_literal_size(deref_slice: impl std::ops::Deref<Target = [u8]>) {
+    for pair in (*deref_slice).windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn deref_coerced_slice_windows_literal_size(deref_slice: impl std::ops::Deref<Target = [u8]>) {
+    for pair in deref_slice.windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}
+
+fn shadowed_destruct_variables() {
+    let vec: Vec<u8> = vec![1, 2, 3];
+    let (left, right) = (0, 1);
+    let (x, y) = (0, 1);
+
+    for pair in vec.windows(2) {
+        //~^ const_size_windows
+        let pair: &[u8] = pair;
+        println!("{} {}", pair[0], pair[1]);
+    }
+}

--- a/tests/ui/const_size_windows/true_positives.stderr
+++ b/tests/ui/const_size_windows/true_positives.stderr
@@ -1,0 +1,132 @@
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:14:23
+   |
+LL |     for pair in slice.windows(2) {
+   |                       ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in slice.array_windows()`
+   = note: `-D clippy::const-size-windows` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::const_size_windows)]`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:22:26
+   |
+LL |     for triplet in slice.windows(3) {
+   |                          ^^^^^^^^^^ help: use: `array_windows::<3>()`
+   |
+   = note: this allows array destructuring: `for [x, y, z] in slice.array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:31:23
+   |
+LL |     for pair in slice.windows(TWO) {
+   |                       ^^^^^^^^^^^^ help: use: `array_windows::<TWO>()`
+   |
+   = note: this allows array destructuring: `for [item, ..] in slice.array_windows::<TWO>()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:39:25
+   |
+LL |     for window in slice.windows(SIZE) {
+   |                         ^^^^^^^^^^^^^ help: use: `array_windows::<SIZE>()`
+   |
+   = note: this allows array destructuring: `for [item, ..] in slice.array_windows::<SIZE>()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:47:23
+   |
+LL |     for pair in slice.windows(get_two()) {
+   |                       ^^^^^^^^^^^^^^^^^^ help: use: `array_windows::<{ get_two() }>()`
+   |
+   = note: this allows array destructuring: `for [item, ..] in slice.array_windows::<{ get_two() }>()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:55:23
+   |
+LL |     for pair in slice.windows(two!()) {
+   |                       ^^^^^^^^^^^^^^^ help: use: `array_windows::<{ two!() }>()`
+   |
+   = note: this allows array destructuring: `for [item, ..] in slice.array_windows::<{ two!() }>()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:63:24
+   |
+LL |     for pair in vector.windows(2) {
+   |                        ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in vector.array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:71:23
+   |
+LL |     for pair in array.windows(2) {
+   |                       ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in array.array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:79:23
+   |
+LL |     for pair in array.windows(2) {
+   |                       ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in array.array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:88:31
+   |
+LL |     for pair in vec![1, 2, 3].windows(2) {
+   |                               ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in vec![1, 2, 3].array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:96:27
+   |
+LL |     for pair in [1, 2, 3].windows(2) {
+   |                           ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in [1, 2, 3].array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:104:39
+   |
+LL |     for pair in [1, 2, 3, 4, 5][..=2].windows(2) {
+   |                                       ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in [1, 2, 3, 4, 5][..=2].array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:112:35
+   |
+LL |     for pair in into_slice.into().windows(2) {
+   |                                   ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in into_slice.into().array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:120:32
+   |
+LL |     for pair in (*deref_slice).windows(2) {
+   |                                ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in (*deref_slice).array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:128:29
+   |
+LL |     for pair in deref_slice.windows(2) {
+   |                             ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in deref_slice.array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/true_positives.rs:140:21
+   |
+LL |     for pair in vec.windows(2) {
+   |                     ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [item_1, item_2] in vec.array_windows()`
+
+error: aborting due to 16 previous errors
+

--- a/tests/ui/const_size_windows/with_array_windows_impl.fixed
+++ b/tests/ui/const_size_windows/with_array_windows_impl.fixed
@@ -1,0 +1,156 @@
+#![warn(clippy::const_size_windows)]
+
+trait DefinesArrayWindows {
+    fn array_windows<const LENGTH: usize>(&self) -> [char; LENGTH] {
+        ['🪟'; LENGTH]
+    }
+}
+
+#[derive(Debug)]
+struct ArrayWindowsStub;
+
+impl DefinesArrayWindows for Vec<ArrayWindowsStub> {}
+
+mod array_methods_mod {
+    trait InnerDefinesArrayWindows {
+        fn array_windows<const LENGTH: usize>(&self) -> [char; LENGTH] {
+            ['🪟'; LENGTH]
+        }
+    }
+    #[derive(Debug)]
+    pub struct ArrayWindowsStub;
+    impl InnerDefinesArrayWindows for Vec<ArrayWindowsStub> {}
+}
+
+use array_methods_mod::ArrayWindowsStub as ModArrayWindowsStub;
+
+fn array_windows_implemented_by_public_trait(vec: Vec<ArrayWindowsStub>) {
+    for pair in <[_]>::array_windows::<2>(&vec) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_in_mod(vec: Vec<ModArrayWindowsStub>) {
+    for pair in <[_]>::array_windows::<2>(&vec) {
+        //~^ const_size_windows
+        let pair: &[ModArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_nested_trait() {
+    #[derive(Debug)]
+    struct Stub;
+    trait DefinesArrayWindows {
+        fn array_windows<const LENGTH: usize>(&self) -> [char; LENGTH] {
+            ['🪟'; LENGTH]
+        }
+    }
+
+    impl DefinesArrayWindows for Vec<Stub> {}
+
+    #[allow(clippy::useless_vec)]
+    let vec = vec![Stub, Stub, Stub];
+    for pair in <[_]>::array_windows::<2>(&vec) {
+        //~^ const_size_windows
+        let pair: &[Stub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_public_trait_with_macro() {
+    #[expect(clippy::useless_vec)]
+    for pair in <[_]>::array_windows::<2>(&vec![ArrayWindowsStub, ArrayWindowsStub, ArrayWindowsStub]) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_borrowed(#[expect(clippy::ptr_arg)] vec: &Vec<ArrayWindowsStub>) {
+    for pair in <[_]>::array_windows::<2>(vec) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_dereferenced(#[allow(clippy::ptr_arg)] vec: &Vec<ArrayWindowsStub>) {
+    for pair in <[_]>::array_windows::<2>(vec) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_with_ref() {
+    #[derive(Debug)]
+    struct Stub;
+    impl DefinesArrayWindows for &Vec<Stub> {}
+
+    let vec = vec![Stub, Stub, Stub];
+    #[allow(clippy::needless_borrow)]
+    for pair in <[_]>::array_windows::<2>(&vec) {
+        //~^ const_size_windows
+        let pair: &[Stub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_with_deref(
+    derefs_into_vec_stub: impl std::ops::Deref<Target = Vec<ArrayWindowsStub>>,
+) {
+    for pair in <[_]>::array_windows::<2>(&derefs_into_vec_stub) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_with_deref_coercion(
+    derefs_into_vec_stub: impl std::ops::Deref<Target = Vec<ArrayWindowsStub>>,
+) {
+    for pair in <[_]>::array_windows::<2>(&derefs_into_vec_stub) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_not_implemented_by_trait(vec: Vec<String>) {
+    #[derive(Debug)]
+    struct Stub;
+    impl DefinesArrayWindows for Vec<Stub> {}
+
+    for pair in vec.array_windows::<2>() {
+        //~^ const_size_windows
+        let pair: &[String] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_with_double_borrowed_vec_macro() {
+    macro_rules! double_borrowed_vec {
+        ($($x:expr),* $(,)?) => {
+            &&vec![$($x),*]
+        };
+    }
+
+    #[derive(Debug)]
+    struct Stub;
+    trait DefinesArrayWindows {
+        fn array_windows<const LENGTH: usize>(&self) -> [char; LENGTH] {
+            ['🪟'; LENGTH]
+        }
+    }
+
+    impl DefinesArrayWindows for &&Vec<Stub> {}
+
+    for pair in <[_]>::array_windows::<2>(double_borrowed_vec![Stub, Stub, Stub]) {
+        //~^ const_size_windows
+        let pair: &[Stub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}

--- a/tests/ui/const_size_windows/with_array_windows_impl.rs
+++ b/tests/ui/const_size_windows/with_array_windows_impl.rs
@@ -1,0 +1,156 @@
+#![warn(clippy::const_size_windows)]
+
+trait DefinesArrayWindows {
+    fn array_windows<const LENGTH: usize>(&self) -> [char; LENGTH] {
+        ['🪟'; LENGTH]
+    }
+}
+
+#[derive(Debug)]
+struct ArrayWindowsStub;
+
+impl DefinesArrayWindows for Vec<ArrayWindowsStub> {}
+
+mod array_methods_mod {
+    trait InnerDefinesArrayWindows {
+        fn array_windows<const LENGTH: usize>(&self) -> [char; LENGTH] {
+            ['🪟'; LENGTH]
+        }
+    }
+    #[derive(Debug)]
+    pub struct ArrayWindowsStub;
+    impl InnerDefinesArrayWindows for Vec<ArrayWindowsStub> {}
+}
+
+use array_methods_mod::ArrayWindowsStub as ModArrayWindowsStub;
+
+fn array_windows_implemented_by_public_trait(vec: Vec<ArrayWindowsStub>) {
+    for pair in vec.windows(2) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_in_mod(vec: Vec<ModArrayWindowsStub>) {
+    for pair in vec.windows(2) {
+        //~^ const_size_windows
+        let pair: &[ModArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_nested_trait() {
+    #[derive(Debug)]
+    struct Stub;
+    trait DefinesArrayWindows {
+        fn array_windows<const LENGTH: usize>(&self) -> [char; LENGTH] {
+            ['🪟'; LENGTH]
+        }
+    }
+
+    impl DefinesArrayWindows for Vec<Stub> {}
+
+    #[allow(clippy::useless_vec)]
+    let vec = vec![Stub, Stub, Stub];
+    for pair in vec.windows(2) {
+        //~^ const_size_windows
+        let pair: &[Stub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_public_trait_with_macro() {
+    #[expect(clippy::useless_vec)]
+    for pair in vec![ArrayWindowsStub, ArrayWindowsStub, ArrayWindowsStub].windows(2) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_borrowed(#[expect(clippy::ptr_arg)] vec: &Vec<ArrayWindowsStub>) {
+    for pair in vec.windows(2) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_dereferenced(#[allow(clippy::ptr_arg)] vec: &Vec<ArrayWindowsStub>) {
+    for pair in (*vec).windows(2) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_with_ref() {
+    #[derive(Debug)]
+    struct Stub;
+    impl DefinesArrayWindows for &Vec<Stub> {}
+
+    let vec = vec![Stub, Stub, Stub];
+    #[allow(clippy::needless_borrow)]
+    for pair in (&vec).windows(2) {
+        //~^ const_size_windows
+        let pair: &[Stub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_with_deref(
+    derefs_into_vec_stub: impl std::ops::Deref<Target = Vec<ArrayWindowsStub>>,
+) {
+    for pair in (*derefs_into_vec_stub).windows(2) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_by_trait_with_deref_coercion(
+    derefs_into_vec_stub: impl std::ops::Deref<Target = Vec<ArrayWindowsStub>>,
+) {
+    for pair in derefs_into_vec_stub.windows(2) {
+        //~^ const_size_windows
+        let pair: &[ArrayWindowsStub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_not_implemented_by_trait(vec: Vec<String>) {
+    #[derive(Debug)]
+    struct Stub;
+    impl DefinesArrayWindows for Vec<Stub> {}
+
+    for pair in vec.windows(2) {
+        //~^ const_size_windows
+        let pair: &[String] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}
+
+fn array_windows_implemented_with_double_borrowed_vec_macro() {
+    macro_rules! double_borrowed_vec {
+        ($($x:expr),* $(,)?) => {
+            &&vec![$($x),*]
+        };
+    }
+
+    #[derive(Debug)]
+    struct Stub;
+    trait DefinesArrayWindows {
+        fn array_windows<const LENGTH: usize>(&self) -> [char; LENGTH] {
+            ['🪟'; LENGTH]
+        }
+    }
+
+    impl DefinesArrayWindows for &&Vec<Stub> {}
+
+    for pair in double_borrowed_vec![Stub, Stub, Stub].windows(2) {
+        //~^ const_size_windows
+        let pair: &[Stub] = pair;
+        println!("{:#?} {:#?}", pair[0], pair[1]);
+    }
+}

--- a/tests/ui/const_size_windows/with_array_windows_impl.stderr
+++ b/tests/ui/const_size_windows/with_array_windows_impl.stderr
@@ -1,0 +1,112 @@
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:28:21
+   |
+LL |     for pair in vec.windows(2) {
+   |                 ----^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(&vec)`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(&vec)`
+   = note: `-D clippy::const-size-windows` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::const_size_windows)]`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:36:21
+   |
+LL |     for pair in vec.windows(2) {
+   |                 ----^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(&vec)`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(&vec)`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:56:21
+   |
+LL |     for pair in vec.windows(2) {
+   |                 ----^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(&vec)`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(&vec)`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:65:76
+   |
+LL |     for pair in vec![ArrayWindowsStub, ArrayWindowsStub, ArrayWindowsStub].windows(2) {
+   |                 -----------------------------------------------------------^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(&vec![ArrayWindowsStub, ArrayWindowsStub, ArrayWindowsStub])`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(&vec![ArrayWindowsStub, ArrayWindowsStub, ArrayWindowsStub])`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:73:21
+   |
+LL |     for pair in vec.windows(2) {
+   |                 ----^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(vec)`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(vec)`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:81:24
+   |
+LL |     for pair in (*vec).windows(2) {
+   |                 -------^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(vec)`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(vec)`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:95:24
+   |
+LL |     for pair in (&vec).windows(2) {
+   |                 -------^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(&vec)`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(&vec)`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:105:41
+   |
+LL |     for pair in (*derefs_into_vec_stub).windows(2) {
+   |                 ------------------------^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(&derefs_into_vec_stub)`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(&derefs_into_vec_stub)`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:115:38
+   |
+LL |     for pair in derefs_into_vec_stub.windows(2) {
+   |                 ---------------------^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(&derefs_into_vec_stub)`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(&derefs_into_vec_stub)`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:127:21
+   |
+LL |     for pair in vec.windows(2) {
+   |                     ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in vec.array_windows()`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_array_windows_impl.rs:151:56
+   |
+LL |     for pair in double_borrowed_vec![Stub, Stub, Stub].windows(2) {
+   |                 ---------------------------------------^^^^^^^^^^
+   |                 |
+   |                 help: use: `<[_]>::array_windows::<2>(double_borrowed_vec![Stub, Stub, Stub])`
+   |
+   = note: this allows array destructuring: `for [left, right] in <[_]>::array_windows(double_borrowed_vec![Stub, Stub, Stub])`
+
+error: aborting due to 11 previous errors
+

--- a/tests/ui/const_size_windows/with_windows_impl.fixed
+++ b/tests/ui/const_size_windows/with_windows_impl.fixed
@@ -1,0 +1,110 @@
+#![warn(clippy::const_size_windows)]
+
+trait DefinesWindows {
+    fn windows(&self, size: usize) -> impl Iterator<Item = char> {
+        std::iter::repeat_n('🪟', size)
+    }
+}
+
+#[derive(Debug)]
+struct WindowsStub;
+
+impl DefinesWindows for Vec<WindowsStub> {}
+
+mod array_methods_mod {
+    trait InnerDefinesWindows {
+        fn windows(&self, size: usize) -> impl Iterator<Item = char> {
+            std::iter::repeat_n('🪟', size)
+        }
+    }
+    #[derive(Debug)]
+    pub struct WindowsStub;
+    impl InnerDefinesWindows for Vec<WindowsStub> {}
+}
+
+use array_methods_mod::WindowsStub as ModWindowsStub;
+
+fn windows_implemented_by_public_trait(vec: Vec<ModWindowsStub>) {
+    for window in vec.array_windows::<2>() {
+        //~^ const_size_windows
+        let window: &[ModWindowsStub] = window;
+        println!("{:#?} {:#?}", window[0], window[1]);
+    }
+}
+
+fn windows_implemented_by_trait_in_mod(vec: Vec<ModWindowsStub>) {
+    for window in vec.array_windows::<2>() {
+        //~^ const_size_windows
+        let window: &[ModWindowsStub] = window;
+        println!("{:#?} {:#?}", window[0], window[1]);
+    }
+}
+
+fn windows_implemented_by_nested_trait() {
+    #[derive(Debug)]
+    struct Stub;
+    trait DefinesWindows {
+        fn windows(&self, size: usize) -> impl Iterator<Item = char> {
+            std::iter::repeat_n('🪟', size)
+        }
+    }
+
+    impl DefinesWindows for Vec<Stub> {}
+
+    let vec = vec![Stub, Stub, Stub];
+    for emoji in vec.windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_public_trait_with_macro() {
+    for emoji in vec![WindowsStub, WindowsStub, WindowsStub].windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_borrowed(vec: &Vec<WindowsStub>) {
+    for emoji in vec.windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_dereferenced(vec: &Vec<WindowsStub>) {
+    for emoji in (*vec).windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_with_ref() {
+    #[derive(Debug)]
+    struct Stub;
+    impl DefinesWindows for &Vec<Stub> {}
+
+    let vec = vec![Stub, Stub, Stub];
+    for emoji in (&vec).windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_with_deref(derefs_into_windows_impl: impl std::ops::Deref<Target = Vec<WindowsStub>>) {
+    for emoji in (*derefs_into_windows_impl).windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_with_deref_coercion(
+    derefs_into_windows_impl: impl std::ops::Deref<Target = Vec<WindowsStub>>,
+) {
+    for emoji in derefs_into_windows_impl.windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn main() {}

--- a/tests/ui/const_size_windows/with_windows_impl.rs
+++ b/tests/ui/const_size_windows/with_windows_impl.rs
@@ -1,0 +1,110 @@
+#![warn(clippy::const_size_windows)]
+
+trait DefinesWindows {
+    fn windows(&self, size: usize) -> impl Iterator<Item = char> {
+        std::iter::repeat_n('🪟', size)
+    }
+}
+
+#[derive(Debug)]
+struct WindowsStub;
+
+impl DefinesWindows for Vec<WindowsStub> {}
+
+mod array_methods_mod {
+    trait InnerDefinesWindows {
+        fn windows(&self, size: usize) -> impl Iterator<Item = char> {
+            std::iter::repeat_n('🪟', size)
+        }
+    }
+    #[derive(Debug)]
+    pub struct WindowsStub;
+    impl InnerDefinesWindows for Vec<WindowsStub> {}
+}
+
+use array_methods_mod::WindowsStub as ModWindowsStub;
+
+fn windows_implemented_by_public_trait(vec: Vec<ModWindowsStub>) {
+    for window in vec.windows(2) {
+        //~^ const_size_windows
+        let window: &[ModWindowsStub] = window;
+        println!("{:#?} {:#?}", window[0], window[1]);
+    }
+}
+
+fn windows_implemented_by_trait_in_mod(vec: Vec<ModWindowsStub>) {
+    for window in vec.windows(2) {
+        //~^ const_size_windows
+        let window: &[ModWindowsStub] = window;
+        println!("{:#?} {:#?}", window[0], window[1]);
+    }
+}
+
+fn windows_implemented_by_nested_trait() {
+    #[derive(Debug)]
+    struct Stub;
+    trait DefinesWindows {
+        fn windows(&self, size: usize) -> impl Iterator<Item = char> {
+            std::iter::repeat_n('🪟', size)
+        }
+    }
+
+    impl DefinesWindows for Vec<Stub> {}
+
+    let vec = vec![Stub, Stub, Stub];
+    for emoji in vec.windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_public_trait_with_macro() {
+    for emoji in vec![WindowsStub, WindowsStub, WindowsStub].windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_borrowed(vec: &Vec<WindowsStub>) {
+    for emoji in vec.windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_dereferenced(vec: &Vec<WindowsStub>) {
+    for emoji in (*vec).windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_with_ref() {
+    #[derive(Debug)]
+    struct Stub;
+    impl DefinesWindows for &Vec<Stub> {}
+
+    let vec = vec![Stub, Stub, Stub];
+    for emoji in (&vec).windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_with_deref(derefs_into_windows_impl: impl std::ops::Deref<Target = Vec<WindowsStub>>) {
+    for emoji in (*derefs_into_windows_impl).windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn windows_implemented_by_trait_with_deref_coercion(
+    derefs_into_windows_impl: impl std::ops::Deref<Target = Vec<WindowsStub>>,
+) {
+    for emoji in derefs_into_windows_impl.windows(2) {
+        let emoji: char = emoji;
+        println!("{emoji:#?}");
+    }
+}
+
+fn main() {}

--- a/tests/ui/const_size_windows/with_windows_impl.stderr
+++ b/tests/ui/const_size_windows/with_windows_impl.stderr
@@ -1,0 +1,20 @@
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_windows_impl.rs:28:23
+   |
+LL |     for window in vec.windows(2) {
+   |                       ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in vec.array_windows()`
+   = note: `-D clippy::const-size-windows` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::const_size_windows)]`
+
+error: using `slice::windows` with a constant size instead of `slice::array_windows`
+  --> tests/ui/const_size_windows/with_windows_impl.rs:36:23
+   |
+LL |     for window in vec.windows(2) {
+   |                       ^^^^^^^^^^ help: use: `array_windows::<2>()`
+   |
+   = note: this allows array destructuring: `for [left, right] in vec.array_windows()`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/missing_asserts_for_indexing_unfixable.rs
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::missing_asserts_for_indexing)]
+#![allow(clippy::const_size_windows)]
 
 fn sum(v: &[u8]) -> u8 {
     v[0] + v[1] + v[2] + v[3] + v[4]

--- a/tests/ui/missing_asserts_for_indexing_unfixable.stderr
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.stderr
@@ -1,5 +1,5 @@
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:4:5
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:5:5
    |
 LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    |     ^^^^   ^^^^   ^^^^   ^^^^   ^^^^
@@ -10,7 +10,7 @@ LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    = help: to override `-D warnings` add `#[allow(clippy::missing_asserts_for_indexing)]`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:9:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:10:13
    |
 LL |     let _ = v[0];
    |             ^^^^
@@ -21,7 +21,7 @@ LL |     let _ = v[1..4];
    = help: consider asserting the length before indexing: `assert!(v.len() > 3);`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:16:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:17:13
    |
 LL |     let a = v[0];
    |             ^^^^
@@ -34,7 +34,7 @@ LL |     let c = v[2];
    = help: consider asserting the length before indexing: `assert!(v.len() > 2);`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:25:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:26:13
    |
 LL |     let _ = v1[0] + v1[12];
    |             ^^^^^   ^^^^^^
@@ -42,7 +42,7 @@ LL |     let _ = v1[0] + v1[12];
    = help: consider asserting the length before indexing: `assert!(v1.len() > 12);`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:27:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:28:13
    |
 LL |     let _ = v2[5] + v2[15];
    |             ^^^^^   ^^^^^^
@@ -50,7 +50,7 @@ LL |     let _ = v2[5] + v2[15];
    = help: consider asserting the length before indexing: `assert!(v2.len() > 15);`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:34:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:35:13
    |
 LL |     let _ = v2[5] + v2[15];
    |             ^^^^^   ^^^^^^
@@ -58,7 +58,7 @@ LL |     let _ = v2[5] + v2[15];
    = help: consider asserting the length before indexing: `assert!(v2.len() > 15);`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:44:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:45:13
    |
 LL |     let _ = f.v[0] + f.v[1];
    |             ^^^^^^   ^^^^^^
@@ -66,7 +66,7 @@ LL |     let _ = f.v[0] + f.v[1];
    = help: consider asserting the length before indexing: `assert!(f.v.len() > 1);`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:58:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:59:13
    |
 LL |     let _ = x[0] + x[1];
    |             ^^^^   ^^^^
@@ -74,7 +74,7 @@ LL |     let _ = x[0] + x[1];
    = help: consider asserting the length before indexing: `assert!(x.len() > 1);`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:76:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:77:13
    |
 LL |     let _ = v1[1] + v1[2];
    |             ^^^^^   ^^^^^
@@ -82,7 +82,7 @@ LL |     let _ = v1[1] + v1[2];
    = help: consider asserting the length before indexing: `assert!(v1.len() > 2);`
 
 error: indexing into a slice multiple times without an `assert`
-  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:84:13
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:85:13
    |
 LL |     let _ = v1[0] + v1[1] + v1[2];
    |             ^^^^^   ^^^^^   ^^^^^

--- a/tests/ui/while_let_on_iterator.fixed
+++ b/tests/ui/while_let_on_iterator.fixed
@@ -2,7 +2,8 @@
 #![expect(
     clippy::redundant_closure_call,
     clippy::single_range_in_vec_init,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::const_size_windows
 )]
 
 fn base() {

--- a/tests/ui/while_let_on_iterator.rs
+++ b/tests/ui/while_let_on_iterator.rs
@@ -2,7 +2,8 @@
 #![expect(
     clippy::redundant_closure_call,
     clippy::single_range_in_vec_init,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::const_size_windows
 )]
 
 fn base() {

--- a/tests/ui/while_let_on_iterator.stderr
+++ b/tests/ui/while_let_on_iterator.stderr
@@ -1,5 +1,5 @@
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:10:5
+  --> tests/ui/while_let_on_iterator.rs:11:5
    |
 LL |     while let Option::Some(x) = iter.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in iter`
@@ -8,193 +8,193 @@ LL |     while let Option::Some(x) = iter.next() {
    = help: to override `-D warnings` add `#[allow(clippy::while_let_on_iterator)]`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:16:5
+  --> tests/ui/while_let_on_iterator.rs:17:5
    |
 LL |     while let Some(x) = iter.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in iter`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:22:5
+  --> tests/ui/while_let_on_iterator.rs:23:5
    |
 LL |     while let Some(_) = iter.next() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in iter`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:99:9
+  --> tests/ui/while_let_on_iterator.rs:100:9
    |
 LL |         while let Some([..]) = it.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for [..] in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:107:9
+  --> tests/ui/while_let_on_iterator.rs:108:9
    |
 LL |         while let Some([_x]) = it.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for [_x] in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:121:9
+  --> tests/ui/while_let_on_iterator.rs:122:9
    |
 LL |         while let Some(x @ [_]) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x @ [_] in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:142:9
+  --> tests/ui/while_let_on_iterator.rs:143:9
    |
 LL |         while let Some(_) = y.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in y`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:200:9
+  --> tests/ui/while_let_on_iterator.rs:201:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:212:5
+  --> tests/ui/while_let_on_iterator.rs:213:5
    |
 LL |     while let Some(n) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for n in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:215:9
+  --> tests/ui/while_let_on_iterator.rs:216:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:225:9
+  --> tests/ui/while_let_on_iterator.rs:226:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:235:9
+  --> tests/ui/while_let_on_iterator.rs:236:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:253:9
+  --> tests/ui/while_let_on_iterator.rs:254:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:269:13
+  --> tests/ui/while_let_on_iterator.rs:270:13
    |
 LL |             while let Some(i) = self.0.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for i in self.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:302:13
+  --> tests/ui/while_let_on_iterator.rs:303:13
    |
 LL |             while let Some(i) = self.0.0.0.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for i in self.0.0.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:332:5
+  --> tests/ui/while_let_on_iterator.rs:333:5
    |
 LL |     while let Some(n) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for n in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:345:9
+  --> tests/ui/while_let_on_iterator.rs:346:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:360:5
+  --> tests/ui/while_let_on_iterator.rs:361:5
    |
 LL |     while let Some(x) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:372:5
+  --> tests/ui/while_let_on_iterator.rs:373:5
    |
 LL |     while let Some(x) = it.0.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:408:5
+  --> tests/ui/while_let_on_iterator.rs:409:5
    |
 LL |     while let Some(x) = s.x.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in s.x.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:416:5
+  --> tests/ui/while_let_on_iterator.rs:417:5
    |
 LL |     while let Some(x) = x[0].next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in x[0].by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:425:9
+  --> tests/ui/while_let_on_iterator.rs:426:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:436:9
+  --> tests/ui/while_let_on_iterator.rs:437:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:447:9
+  --> tests/ui/while_let_on_iterator.rs:448:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:458:9
+  --> tests/ui/while_let_on_iterator.rs:459:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:471:9
+  --> tests/ui/while_let_on_iterator.rs:472:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:482:5
+  --> tests/ui/while_let_on_iterator.rs:483:5
    |
 LL |     'label: while let Some(n) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'label: for n in it`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:494:13
+  --> tests/ui/while_let_on_iterator.rs:495:13
    |
 LL |             while let Some(r) = self.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for r in &mut *self`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:510:13
+  --> tests/ui/while_let_on_iterator.rs:511:13
    |
 LL |             while let Some(r) = self.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for r in self.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:536:9
+  --> tests/ui/while_let_on_iterator.rs:537:9
    |
 LL |         while let Some(_) = x.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in &mut ***x`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:558:9
+  --> tests/ui/while_let_on_iterator.rs:559:9
    |
 LL |         while let Some(_) = x.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in &mut **x`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:589:9
+  --> tests/ui/while_let_on_iterator.rs:590:9
    |
 LL |         while let Some(_) = x.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in x.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> tests/ui/while_let_on_iterator.rs:596:5
+  --> tests/ui/while_let_on_iterator.rs:597:5
    |
 LL |     while let Some(..) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in it`


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17440)*

See rust-lang/rust-clippy#6580

New lint `const_size_windows` (style category). Checks for `slice::windows` with constant window size that can be replaced with `slice::array_windows`, enabling array destructuring.  

Verifies that:
* Call is `windows` method (`slice` impl).
* Arg `size` is usable as generic const param.
* Method call is not from a macro expansion (but receiver and args can be, individually).
* Rust version >=1.94.0 (see `array_windows` stabilization [[1](https://doc.rust-lang.org/stable/releases.html#version-1940-2026-03-05)]).

Code suggestions:
* Suggests ~`MachineApplicable`~ `MaybeIncorrect` code with ~source-equivalent~  comparable `slice::array_windows` call.
* Checks for `array_windows` having an impl on another trait for the receiver. Suggest UFCS in those cases.
* Checks if `size` is a complex const requiring surrounding braces.

Also emits a "note":
* Shows an example of a for loop using array destructuring on the iterator items with comparable `slice::array_windows` call. 
* Example accounts for the const-evaluatable size if possible: `size = 2` destructures to `[left, right]`, `size = 3` to `[x, y, z]` etc. No generic arg needed.
* If code-example variables are already in use, alternative variable names are used.

Limitations of the lint:
* **Does not** destructure iterated items as its code suggestion. Instead, the emitted "note" has an example of potential destructuring.
* **Does not** detect usages of `slice::chunks` with const size. The `chunks` method does not have a clean equivalent transformation since `as_chunks` has a different return type [[2](https://github.com/rust-lang/rust-clippy/issues/6580#issuecomment-5011673147)].  

Open question: **Should this be a `perf` lint or a `style` lint?**
* The original issue rust-lang/rust-clippy#6580 suggests this as a `perf` lint.
* I did not find any benchmarks comparing `slice::array_windows` to `slice::windows`.
* The release notes for `slice::array_windows` mention optimization [[3](https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/#array-windows)]: 
   * > If we had used the older `.windows(4)` iterator, then that argument would be a slice which we would have to index manually, _hoping_ that runtime bounds-checking will be optimized away.

changelog: new lint: [`const_size_windows`]

---

- \[x] Followed [lint naming conventions][lint_naming]: _"Deny const-size windows" / "Allow const-size windows"_ 
- \[x] Added passing UI tests (including committed `.stderr` file): _29 positive test cases, 19 negative test cases_
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`