### PR TITLE
Add `EULER_GAMMA` and `GOLDEN_RATIO` to `approx_constant`

### DIFF
--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -42,7 +42,7 @@ declare_clippy_lint! {
 impl_lint_pass!(ApproxConstant => [APPROX_CONSTANT]);
 
 // Tuples are of the form (constant, name, min_digits, msrv)
-const KNOWN_CONSTS: [(f64, &str, usize, Option<RustcVersion>); 19] = [
+const KNOWN_CONSTS: [(f64, &str, usize, Option<RustcVersion>); 21] = [
     (f64::E, "E", 4, None),
     (f64::FRAC_1_PI, "FRAC_1_PI", 4, None),
     (f64::FRAC_1_SQRT_2, "FRAC_1_SQRT_2", 5, None),
@@ -62,6 +62,8 @@ const KNOWN_CONSTS: [(f64, &str, usize, Option<RustcVersion>); 19] = [
     (f64::PI, "PI", 3, None),
     (f64::SQRT_2, "SQRT_2", 5, None),
     (f64::TAU, "TAU", 3, Some(msrvs::TAU)),
+    (f64::EULER_GAMMA, "EULER_GAMMA", 5, Some(msrvs::EULER_GAMMA)),
+    (f64::GOLDEN_RATIO, "GOLDEN_RATIO", 5, Some(msrvs::GOLDEN_RATIO)),
 ];
 
 pub struct ApproxConstant {

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -26,6 +26,7 @@ macro_rules! msrv_aliases {
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
     1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
+    1,94,0 { EULER_GAMMA, GOLDEN_RATIO }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }
     1,91,0 { DURATION_FROM_MINUTES_HOURS }
     1,88,0 { LET_CHAINS, AS_CHUNKS }

--- a/tests/ui/approx_const.rs
+++ b/tests/ui/approx_const.rs
@@ -107,6 +107,22 @@ fn main() {
 
     let no_tau = 6.3;
 
+    let my_euler_gamma = 0.577215664901533;
+    //~^ approx_constant
+
+    let almost_euler_gamma = 0.5772;
+    //~^ approx_constant
+
+    let no_euler_gamma = 0.577;
+
+    let my_golden_ration = 1.618033988749895;
+    //~^ approx_constant
+
+    let almost_golden_ration = 1.6180;
+    //~^ approx_constant
+
+    let no_almost_golden_ration = 1.618;
+
     // issue #15194
     #[allow(clippy::excessive_precision)]
     let x: f64 = 3.1415926535897932384626433832;

--- a/tests/ui/approx_const.stderr
+++ b/tests/ui/approx_const.stderr
@@ -184,8 +184,40 @@ LL |     let almost_tau = 6.28;
    |
    = help: consider using the constant directly
 
+error: approximate value of `f{32, 64}::consts::EULER_GAMMA` found
+  --> tests/ui/approx_const.rs:110:26
+   |
+LL |     let my_euler_gamma = 0.577215664901533;
+   |                          ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using the constant directly
+
+error: approximate value of `f{32, 64}::consts::EULER_GAMMA` found
+  --> tests/ui/approx_const.rs:113:30
+   |
+LL |     let almost_euler_gamma = 0.5772;
+   |                              ^^^^^^
+   |
+   = help: consider using the constant directly
+
+error: approximate value of `f{32, 64}::consts::GOLDEN_RATIO` found
+  --> tests/ui/approx_const.rs:118:28
+   |
+LL |     let my_golden_ration = 1.618033988749895;
+   |                            ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using the constant directly
+
+error: approximate value of `f{32, 64}::consts::GOLDEN_RATIO` found
+  --> tests/ui/approx_const.rs:121:32
+   |
+LL |     let almost_golden_ration = 1.6180;
+   |                                ^^^^^^
+   |
+   = help: consider using the constant directly
+
 error: approximate value of `f{32, 64}::consts::PI` found
-  --> tests/ui/approx_const.rs:112:18
+  --> tests/ui/approx_const.rs:128:18
    |
 LL |     let x: f64 = 3.1415926535897932384626433832;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +225,7 @@ LL |     let x: f64 = 3.1415926535897932384626433832;
    = help: consider using the constant directly
 
 error: approximate value of `f{32, 64}::consts::PI` found
-  --> tests/ui/approx_const.rs:116:18
+  --> tests/ui/approx_const.rs:132:18
    |
 LL |     let _: f64 = 003.14159265358979311599796346854418516159057617187500;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -201,7 +233,7 @@ LL |     let _: f64 = 003.14159265358979311599796346854418516159057617187500;
    = help: consider using the constant directly
 
 error: approximate value of `f{32, 64}::consts::FRAC_1_SQRT_2` found
-  --> tests/ui/approx_const.rs:119:32
+  --> tests/ui/approx_const.rs:135:32
    |
 LL |     let almost_frac_1_sqrt_2 = 00.70711;
    |                                ^^^^^^^^
@@ -209,12 +241,12 @@ LL |     let almost_frac_1_sqrt_2 = 00.70711;
    = help: consider using the constant directly
 
 error: approximate value of `f{32, 64}::consts::FRAC_1_SQRT_2` found
-  --> tests/ui/approx_const.rs:122:32
+  --> tests/ui/approx_const.rs:138:32
    |
 LL |     let almost_frac_1_sqrt_2 = 00.707_11;
    |                                ^^^^^^^^^
    |
    = help: consider using the constant directly
 
-error: aborting due to 27 previous errors
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
The constants have been stabilized in Rust 1.94, so I figured why not add them?

changelog: [`approx_constant`]: Add `EULER_GAMMA` and `GOLDEN_RATIO` constants