### PR TITLE
Fix `four_forward_slashes` false positive on inner doc comments

### DIFF
--- a/clippy_lints/src/four_forward_slashes.rs
+++ b/clippy_lints/src/four_forward_slashes.rs
@@ -1,8 +1,10 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::SpanExt as _;
 use itertools::Itertools as _;
+use rustc_ast::AttrStyle;
 use rustc_errors::Applicability;
-use rustc_hir::Item;
+use rustc_hir::attrs::AttributeKind;
+use rustc_hir::{Attribute, Item};
 use rustc_lint::{LateContext, LateLintPass, LintContext as _};
 use rustc_session::declare_lint_pass;
 use rustc_span::Span;
@@ -48,7 +50,19 @@ impl<'tcx> LateLintPass<'tcx> for FourForwardSlashes {
             .tcx
             .hir_attrs(item.hir_id())
             .iter()
-            .filter(|i| i.is_doc_comment().is_some())
+            // Only fold in OUTER doc comments. An inner doc (`//!`) inside the item's
+            // body lowers onto the item with `AttrStyle::Inner`; folding its span drags
+            // `end_line` down into the body, so the upward `////` scan then flags a
+            // regular comment there (see #16168).
+            .filter(|i| {
+                matches!(
+                    i,
+                    Attribute::Parsed(AttributeKind::DocComment {
+                        style: AttrStyle::Outer,
+                        ..
+                    })
+                )
+            })
             .fold(item.span.shrink_to_lo(), |span, attr| span.to(attr.span()));
         let (Some(file), _, _, end_line, _) = sm.span_to_location_info(span) else {
             return;

--- a/tests/ui/four_forward_slashes.fixed
+++ b/tests/ui/four_forward_slashes.fixed
@@ -47,3 +47,10 @@ with_span! {
     //// don't lint me bozo
     fn f() {}
 }
+
+// Regression test for #16168: an inner doc comment (`//!`) inside the body must not
+// drag the `////` scan down into the body and flag a regular comment there.
+fn inner_doc() {
+    //// I am not a doc comment!
+    //! inner doc comment
+}

--- a/tests/ui/four_forward_slashes.rs
+++ b/tests/ui/four_forward_slashes.rs
@@ -47,3 +47,10 @@ with_span! {
     //// don't lint me bozo
     fn f() {}
 }
+
+// Regression test for #16168: an inner doc comment (`//!`) inside the body must not
+// drag the `////` scan down into the body and flag a regular comment there.
+fn inner_doc() {
+    //// I am not a doc comment!
+    //! inner doc comment
+}


### PR DESCRIPTION
`four_forward_slashes` scans the lines above an item for `////` comments and suggests turning them into `///`. It derives the item's start line from a span folded over the item's doc-comment attributes, but that fold included *inner* doc comments (`//!`).

An inner `//!` inside a body lowers onto the item with `AttrStyle::Inner`; folding its span pushes the item's end line down into the body, so the upward scan then flags a regular `////` comment there. Applying the suggestion rewrites it to `///`, which documents nothing and fails to compile (E0585).

Repro from the issue:

```rust
pub fn main() {
    //// I am not a doc comment!
    //! another comment
}
```

Fix: fold in outer doc comments only, mirroring the existing pattern in `clippy_lints/src/doc/suspicious_doc_comments.rs`. A genuine `////` typo above an item still lints, and I added a regression test for the inner-doc case.

Fixes rust-lang/rust-clippy#16168

changelog: [`four_forward_slashes`]: no longer fires on `////` comments that sit above an inner doc comment (`//!`) in an item's body

---

Disclosure: I used AI assistance to help diagnose the root cause and draft this change. It's a small, self-contained fix that I've reviewed, tested locally (`cargo uitest` + `cargo dev fmt`), and can explain.
