### PR TITLE
Add ifs_as_logical_ops lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6983,6 +6983,7 @@ Released 2018-09-13
 [`if_not_else`]: https://rust-lang.github.io/rust-clippy/main/index.html#if_not_else
 [`if_same_then_else`]: https://rust-lang.github.io/rust-clippy/main/index.html#if_same_then_else
 [`if_then_some_else_none`]: https://rust-lang.github.io/rust-clippy/main/index.html#if_then_some_else_none
+[`ifs_as_logical_ops`]: https://rust-lang.github.io/rust-clippy/main/index.html#ifs_as_logical_ops
 [`ifs_same_cond`]: https://rust-lang.github.io/rust-clippy/main/index.html#ifs_same_cond
 [`ignore_without_reason`]: https://rust-lang.github.io/rust-clippy/main/index.html#ignore_without_reason
 [`ignored_unit_patterns`]: https://rust-lang.github.io/rust-clippy/main/index.html#ignored_unit_patterns

--- a/clippy_dev/src/serve.rs
+++ b/clippy_dev/src/serve.rs
@@ -85,10 +85,9 @@ fn is_metadata_outdated(time: SystemTime) -> bool {
     dir.map_while(|e| log_err_and_continue(e, ".".as_ref())).any(|e| {
         let name = e.file_name();
         let name_bytes = name.as_encoded_bytes();
-        if (name_bytes.starts_with(b"clippy_lints") && name_bytes != b"clippy_lints_internal")
-            || name_bytes == b"clippy_config"
-        {
-            WalkDir::new(&name)
+        ((name_bytes.starts_with(b"clippy_lints") && name_bytes != b"clippy_lints_internal")
+            || name_bytes == b"clippy_config")
+            && WalkDir::new(&name)
                 .into_iter()
                 .map_while(|e| log_err_and_continue(e, name.as_ref()))
                 .filter(|e| e.file_type().is_file())
@@ -97,8 +96,5 @@ fn is_metadata_outdated(time: SystemTime) -> bool {
                         .and_then(|m| log_err_and_continue(m.modified(), e.path()))
                 })
                 .any(|ftime| time < ftime)
-        } else {
-            false
-        }
     })
 }

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -215,6 +215,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::ifs::IF_SAME_THEN_ELSE_INFO,
     crate::ifs::IFS_SAME_COND_INFO,
     crate::ifs::SAME_FUNCTIONS_IN_IF_CONDITION_INFO,
+    crate::ifs_as_logical_ops::IFS_AS_LOGICAL_OPS_INFO,
     crate::ignored_unit_patterns::IGNORED_UNIT_PATTERNS_INFO,
     crate::impl_hash_with_borrow_str_and_bytes::IMPL_HASH_BORROW_WITH_STR_AND_BYTES_INFO,
     crate::implicit_hasher::IMPLICIT_HASHER_INFO,

--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -255,11 +255,8 @@ fn is_mutable_pat(cx: &LateContext<'_>, pat: &hir::Pat<'_>, tys: &mut DefIdSet) 
     if let hir::PatKind::Wild = pat.kind {
         return false; // ignore `_` patterns
     }
-    if cx.tcx.has_typeck_results(pat.hir_id.owner.def_id) {
-        is_mutable_ty(cx, cx.tcx.typeck(pat.hir_id.owner.def_id).pat_ty(pat), tys)
-    } else {
-        false
-    }
+    cx.tcx.has_typeck_results(pat.hir_id.owner.def_id)
+        && is_mutable_ty(cx, cx.tcx.typeck(pat.hir_id.owner.def_id).pat_ty(pat), tys)
 }
 
 fn is_mutable_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, tys: &mut DefIdSet) -> bool {

--- a/clippy_lints/src/ifs_as_logical_ops.rs
+++ b/clippy_lints/src/ifs_as_logical_ops.rs
@@ -1,0 +1,116 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::higher::If;
+use clippy_utils::source::{SpanExt as _, walk_span_to_context};
+use clippy_utils::sugg::Sugg;
+use clippy_utils::{is_else_clause, is_from_proc_macro, peel_blocks};
+use rustc_ast::LitKind;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext as _};
+use rustc_session::declare_lint_pass;
+use rustc_span::Span;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Warn about cases where `x && y` could be used in place of an if condition.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `x && y` is more standard as a construction, and makes it clearer that this is just an and.
+    /// It is also less verbose.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # fn a() -> bool { false }
+    /// fn b(b1: bool) -> bool {
+    ///     if b1 { a() } else { false}
+    /// }
+    ///
+    /// ```
+    ///
+    /// Could be written
+    ///
+    /// ```no_run
+    /// # fn a() -> bool { false }
+    /// fn b(b1: bool) -> bool {
+    ///     b1 && a()
+    /// }
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub IFS_AS_LOGICAL_OPS,
+    pedantic,
+    "`if` conditions that can be rewritten as logical operators"
+}
+
+declare_lint_pass!(IfsAsLogicalOps => [IFS_AS_LOGICAL_OPS]);
+
+impl<'tcx> LateLintPass<'tcx> for IfsAsLogicalOps {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>) {
+        // Make sure the if block is not an if-let block.
+        if let Some(If {cond: if_cond, then, r#else: Some(els)}) = If::hir(e)
+            && let ExprKind::Block(then_block, _label) = then.kind
+            // Check if the if-block has only a trailing expression
+            && then_block.stmts.is_empty()
+            && let Some(then_block_inner_expr) = then_block.expr
+            // And that the else block consists of only the boolean 'false'.
+            && let ExprKind::Block(else_block, _label) = els.kind
+            && else_block.stmts.is_empty()
+            && let Some(else_block_inner_expr) = else_block.expr
+            && let ExprKind::Lit(lit) = else_block_inner_expr.kind
+            && matches!(lit.node, LitKind::Bool(false))
+            // We do not emit this lint if the expression diverges.
+            && !cx.typeck_results().expr_ty(then_block_inner_expr).is_never()
+            // Make sure that the expression is only in a single macro context
+            && let ctxt = e.span.ctxt()
+            && ctxt == then_block.span.ctxt()
+            && ctxt == else_block.span.ctxt()
+            && ctxt == else_block_inner_expr.span.ctxt()
+            && ctxt == lit.span.ctxt()
+            && !ctxt.in_external_macro(cx.sess().source_map())
+            && !is_from_proc_macro(cx,e)
+        {
+            // Do not lint if the statement is trivially a boolean.
+            if let ExprKind::Lit(lit_ptr) = peel_blocks(then_block_inner_expr).kind
+                && let LitKind::Bool(_) = lit_ptr.node
+            {
+                return;
+            }
+
+            if let Some(walked_then_block_inner) = walk_span_to_context(then_block_inner_expr.span, ctxt)
+                && check_that_nested_spans_have_no_comments(then_block.span, walked_then_block_inner, cx)
+                && check_that_nested_spans_have_no_comments(else_block.span, else_block_inner_expr.span, cx)
+            {
+                let mut applicability = if ctxt.is_root() {
+                    Applicability::MachineApplicable
+                } else {
+                    Applicability::MaybeIncorrect
+                };
+
+                let mut sugg = Sugg::hir_with_context(cx, if_cond, ctxt, "_", &mut applicability);
+                let rhs_sugg = Sugg::hir_with_context(cx, then_block_inner_expr, ctxt, "_", &mut applicability);
+
+                sugg = sugg.and(&rhs_sugg);
+
+                if is_else_clause(cx.tcx, e) {
+                    sugg = sugg.blockify();
+                }
+
+                span_lint_and_sugg(
+                    cx,
+                    IFS_AS_LOGICAL_OPS,
+                    e.span,
+                    "if expression that could be written as a logical and expression",
+                    "try",
+                    sugg.to_string(),
+                    applicability,
+                );
+            }
+        }
+    }
+}
+
+fn check_that_nested_spans_have_no_comments(outer_span: Span, inner_span: Span, cx: &LateContext<'_>) -> bool {
+    (outer_span.lo()..inner_span.lo()).check_text(cx, |src| src.trim_end() == "{")
+        && (inner_span.hi()..outer_span.hi()).check_text(cx, |src| src.trim_start() == "}")
+}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -153,6 +153,7 @@ mod if_let_mutex;
 mod if_not_else;
 mod if_then_some_else_none;
 mod ifs;
+mod ifs_as_logical_ops;
 mod ignored_unit_patterns;
 mod impl_hash_with_borrow_str_and_bytes;
 mod implicit_hasher;
@@ -869,6 +870,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        IfsAsLogicalOps: ifs_as_logical_ops::IfsAsLogicalOps = ifs_as_logical_ops::IfsAsLogicalOps,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -8,7 +8,6 @@ use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass, Lint, LintContext as _};
 use rustc_session::impl_lint_pass;
 use rustc_span::Span;
-use std::iter;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -351,11 +350,7 @@ impl LiteralDigitGrouping {
         }
 
         let group_sizes: Vec<usize> = num_lit.integer.split('_').map(str::len).collect();
-        if UUID_GROUP_LENS.len() == group_sizes.len() {
-            iter::zip(&UUID_GROUP_LENS, &group_sizes).all(|(&a, &b)| a == b)
-        } else {
-            false
-        }
+        group_sizes == UUID_GROUP_LENS
     }
 
     /// Given the sizes of the digit groups of both integral and fractional

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -257,11 +257,9 @@ fn has_no_effect(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
                     cx.qpath_res(qpath, callee.hir_id),
                     Res::Def(DefKind::Struct | DefKind::Variant | DefKind::Ctor(..), ..)
                 );
-                if def_matched || is_range_literal(expr) {
-                    !expr_ty_has_significant_drop(cx, expr) && args.iter().all(|arg| has_no_effect(cx, arg))
-                } else {
-                    false
-                }
+                (def_matched || is_range_literal(expr))
+                    && !expr_ty_has_significant_drop(cx, expr)
+                    && args.iter().all(|arg| has_no_effect(cx, arg))
             } else {
                 false
             }

--- a/clippy_lints/src/unit_types/unit_arg.rs
+++ b/clippy_lints/src/unit_types/unit_arg.rs
@@ -40,14 +40,12 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         .into_iter()
         .chain(args)
         .filter(|arg| {
-            if cx.typeck_results().expr_ty(arg).is_unit() && !utils::is_unit_literal(arg) {
-                !matches!(
+            cx.typeck_results().expr_ty(arg).is_unit()
+                && !utils::is_unit_literal(arg)
+                && !matches!(
                     &arg.kind,
                     ExprKind::Match(.., MatchSource::TryDesugar(_)) | ExprKind::Path(..)
                 )
-            } else {
-                false
-            }
         })
         .collect::<Vec<_>>();
     if !args_to_recover.is_empty() && !is_from_proc_macro(cx, expr) {

--- a/clippy_utils/src/hir_utils.rs
+++ b/clippy_utils/src/hir_utils.rs
@@ -852,12 +852,11 @@ impl HirEqInterExpr<'_, '_, '_> {
     }
 
     fn eq_path_parameters(&mut self, left: &GenericArgs<'_>, right: &GenericArgs<'_>) -> bool {
-        if left.parenthesized == right.parenthesized {
-            over(left.args, right.args, |l, r| self.eq_generic_arg(l, r)) // FIXME(flip1995): may not work
-                && over(left.constraints, right.constraints, |l, r| self.eq_assoc_eq_constraint(l, r))
-        } else {
-            false
-        }
+        left.parenthesized == right.parenthesized
+            && over(left.args, right.args, |l, r| self.eq_generic_arg(l, r)) // FIXME(flip1995): may not work
+            && over(left.constraints, right.constraints, |l, r| {
+                self.eq_assoc_eq_constraint(l, r)
+            })
     }
 
     pub fn eq_path_segments<'tcx>(

--- a/tests/ui/ifs_as_logical_ops.fixed
+++ b/tests/ui/ifs_as_logical_ops.fixed
@@ -1,0 +1,183 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::ifs_as_logical_ops)]
+#![expect(clippy::needless_bool)]
+
+extern crate proc_macros;
+use proc_macros::{external, with_span};
+
+fn main() {
+    // test code goes here
+}
+
+fn basic_lint_test(b1: bool, b2: bool) -> bool {
+    b1 && b2
+    //~^ ifs_as_logical_ops
+}
+
+fn lint_test_with_cfg_as_second_argument(b1: bool, b2: bool) -> bool {
+    if b1 { b2 } else { cfg!(false) }
+}
+
+fn nested_expressions_produces_lint(b1: bool, b2: bool) -> bool {
+    b1 && { b2 }
+    //~^ ifs_as_logical_ops
+}
+
+fn diverging_does_not_produce_lint(b1: bool, b2: bool) -> bool {
+    if b1 { panic!() } else { false }
+}
+
+fn complex_expressions_do_not_produce_lint(b1: bool, b2: bool) -> bool {
+    if b1 {
+        let mut some_value = 100;
+        if some_value < 50 {
+            return true;
+        }
+        true
+    } else {
+        false
+    }
+}
+
+fn example_with_if_comment_before_expr_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        // SAFETY: Always starts with ^[ and ends with m.
+        chars.len() > 5
+    } else {
+        false
+    }
+}
+
+fn example_with_if_comment_after_expr_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        chars.len() > 5
+        // SAFETY: Always starts with ^[ and ends with m.
+    } else {
+        false
+    }
+}
+
+fn example_with_else_comment_before_expr_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        chars.len() > 5
+    } else {
+        // Watch out! Comment!
+        false
+    }
+}
+
+fn example_with_else_comment_after_expr_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        chars.len() > 5
+    } else {
+        false
+        // Watch out! Comment!
+    }
+}
+
+fn example_with_cfg_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        #[cfg(false)]
+        return 2 * 2 == 5;
+        chars.len() > 5
+    } else {
+        false
+    }
+}
+
+fn example_with_debug_does_not_lint(b1: bool) -> bool {
+    if b1 {
+        dbg!("Something");
+        true
+    } else {
+        false
+    }
+}
+
+fn basic_if_let_does_not_lint(b1: bool, b2: Option<i32>) -> bool {
+    if let Some(30) = b2 { b1 } else { false }
+}
+
+fn if_and_let_does_not_lint(b1: bool, b2: Option<i32>, b3: bool) -> bool {
+    if b1 && let Some(b) = b2 { b3 } else { false }
+}
+
+fn if_let_complex_does_not_lint(b1: bool, b2: Option<i32>, b3: bool) -> bool {
+    if let Some(b) = b2
+        && b1
+    {
+        b3
+    } else {
+        false
+    }
+}
+
+fn else_if_does_lint(b1: bool, b2: bool, b3: bool) -> bool {
+    if b1 {
+        // There is some expansion here.
+        let _ = 40;
+        false
+    } else { b2 && b3 }
+    //~^^^^^ ifs_as_logical_ops
+}
+
+fn needless_bool_clash_does_not_lint(x: bool) -> bool {
+    if x { true } else { false }
+}
+
+macro_rules! always_return_true {
+    () => {
+        true
+    };
+}
+
+fn needless_bool_macro_clash_does_not_lint(b1: bool) -> bool {
+    if b1 { always_return_true!() } else { false }
+}
+
+macro_rules! nothing {
+    () => {};
+}
+
+fn empty_expansion_does_not_lint(b1: bool, b2: bool) -> bool {
+    if b1 {
+        nothing!();
+        b2
+    } else {
+        false
+    }
+}
+
+fn macro_with_comment_does_not_lint(b1: bool, num: i32) -> bool {
+    macro_rules! b2 {
+        () => {{ num > 33 }};
+    }
+    if b1 {
+        // watch out! Comment!
+        b2!()
+    } else {
+        false
+    }
+}
+
+fn macro_without_comment_does_lint(b1: bool, num: i32) -> bool {
+    macro_rules! b2 {
+        () => {{ num > 33 }};
+    }
+    b1 && b2!()
+    //~^ ifs_as_logical_ops
+}
+
+fn proc_macro_tests() {
+    proc_macros::external! {
+        fn would_lint_usually(b1: bool, num: i32) -> bool {
+            if b1 { num > 30 } else { false }
+        }
+    }
+    proc_macros::with_span! {
+        span
+        fn would_lint_usually_2(b1: bool, num: i32) -> bool {
+            if b1 { num > 30 } else { false }
+        }
+    }
+}

--- a/tests/ui/ifs_as_logical_ops.rs
+++ b/tests/ui/ifs_as_logical_ops.rs
@@ -1,0 +1,187 @@
+//@aux-build:proc_macros.rs
+#![warn(clippy::ifs_as_logical_ops)]
+#![expect(clippy::needless_bool)]
+
+extern crate proc_macros;
+use proc_macros::{external, with_span};
+
+fn main() {
+    // test code goes here
+}
+
+fn basic_lint_test(b1: bool, b2: bool) -> bool {
+    if b1 { b2 } else { false }
+    //~^ ifs_as_logical_ops
+}
+
+fn lint_test_with_cfg_as_second_argument(b1: bool, b2: bool) -> bool {
+    if b1 { b2 } else { cfg!(false) }
+}
+
+fn nested_expressions_produces_lint(b1: bool, b2: bool) -> bool {
+    if b1 { { b2 } } else { false }
+    //~^ ifs_as_logical_ops
+}
+
+fn diverging_does_not_produce_lint(b1: bool, b2: bool) -> bool {
+    if b1 { panic!() } else { false }
+}
+
+fn complex_expressions_do_not_produce_lint(b1: bool, b2: bool) -> bool {
+    if b1 {
+        let mut some_value = 100;
+        if some_value < 50 {
+            return true;
+        }
+        true
+    } else {
+        false
+    }
+}
+
+fn example_with_if_comment_before_expr_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        // SAFETY: Always starts with ^[ and ends with m.
+        chars.len() > 5
+    } else {
+        false
+    }
+}
+
+fn example_with_if_comment_after_expr_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        chars.len() > 5
+        // SAFETY: Always starts with ^[ and ends with m.
+    } else {
+        false
+    }
+}
+
+fn example_with_else_comment_before_expr_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        chars.len() > 5
+    } else {
+        // Watch out! Comment!
+        false
+    }
+}
+
+fn example_with_else_comment_after_expr_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        chars.len() > 5
+    } else {
+        false
+        // Watch out! Comment!
+    }
+}
+
+fn example_with_cfg_does_not_lint(chars: Vec<char>) -> bool {
+    if !chars.is_empty() {
+        #[cfg(false)]
+        return 2 * 2 == 5;
+        chars.len() > 5
+    } else {
+        false
+    }
+}
+
+fn example_with_debug_does_not_lint(b1: bool) -> bool {
+    if b1 {
+        dbg!("Something");
+        true
+    } else {
+        false
+    }
+}
+
+fn basic_if_let_does_not_lint(b1: bool, b2: Option<i32>) -> bool {
+    if let Some(30) = b2 { b1 } else { false }
+}
+
+fn if_and_let_does_not_lint(b1: bool, b2: Option<i32>, b3: bool) -> bool {
+    if b1 && let Some(b) = b2 { b3 } else { false }
+}
+
+fn if_let_complex_does_not_lint(b1: bool, b2: Option<i32>, b3: bool) -> bool {
+    if let Some(b) = b2
+        && b1
+    {
+        b3
+    } else {
+        false
+    }
+}
+
+fn else_if_does_lint(b1: bool, b2: bool, b3: bool) -> bool {
+    if b1 {
+        // There is some expansion here.
+        let _ = 40;
+        false
+    } else if b2 {
+        b3
+    } else {
+        false
+    }
+    //~^^^^^ ifs_as_logical_ops
+}
+
+fn needless_bool_clash_does_not_lint(x: bool) -> bool {
+    if x { true } else { false }
+}
+
+macro_rules! always_return_true {
+    () => {
+        true
+    };
+}
+
+fn needless_bool_macro_clash_does_not_lint(b1: bool) -> bool {
+    if b1 { always_return_true!() } else { false }
+}
+
+macro_rules! nothing {
+    () => {};
+}
+
+fn empty_expansion_does_not_lint(b1: bool, b2: bool) -> bool {
+    if b1 {
+        nothing!();
+        b2
+    } else {
+        false
+    }
+}
+
+fn macro_with_comment_does_not_lint(b1: bool, num: i32) -> bool {
+    macro_rules! b2 {
+        () => {{ num > 33 }};
+    }
+    if b1 {
+        // watch out! Comment!
+        b2!()
+    } else {
+        false
+    }
+}
+
+fn macro_without_comment_does_lint(b1: bool, num: i32) -> bool {
+    macro_rules! b2 {
+        () => {{ num > 33 }};
+    }
+    if b1 { b2!() } else { false }
+    //~^ ifs_as_logical_ops
+}
+
+fn proc_macro_tests() {
+    proc_macros::external! {
+        fn would_lint_usually(b1: bool, num: i32) -> bool {
+            if b1 { num > 30 } else { false }
+        }
+    }
+    proc_macros::with_span! {
+        span
+        fn would_lint_usually_2(b1: bool, num: i32) -> bool {
+            if b1 { num > 30 } else { false }
+        }
+    }
+}

--- a/tests/ui/ifs_as_logical_ops.stderr
+++ b/tests/ui/ifs_as_logical_ops.stderr
@@ -1,0 +1,34 @@
+error: if expression that could be written as a logical and expression
+  --> tests/ui/ifs_as_logical_ops.rs:13:5
+   |
+LL |     if b1 { b2 } else { false }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b1 && b2`
+   |
+   = note: `-D clippy::ifs-as-logical-ops` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::ifs_as_logical_ops)]`
+
+error: if expression that could be written as a logical and expression
+  --> tests/ui/ifs_as_logical_ops.rs:22:5
+   |
+LL |     if b1 { { b2 } } else { false }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b1 && { b2 }`
+
+error: if expression that could be written as a logical and expression
+  --> tests/ui/ifs_as_logical_ops.rs:120:12
+   |
+LL |       } else if b2 {
+   |  ____________^
+LL | |         b3
+LL | |     } else {
+LL | |         false
+LL | |     }
+   | |_____^ help: try: `{ b2 && b3 }`
+
+error: if expression that could be written as a logical and expression
+  --> tests/ui/ifs_as_logical_ops.rs:171:5
+   |
+LL |     if b1 { b2!() } else { false }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b1 && b2!()`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/ifs_as_logical_ops_unfixable.rs
+++ b/tests/ui/ifs_as_logical_ops_unfixable.rs
@@ -1,0 +1,7 @@
+#![warn(clippy::ifs_as_logical_ops)]
+//@no-rustfix
+fn unfixable_example(x: bool, y: bool, z: bool) -> bool {
+    if x { if y { z } else { false } } else { false }
+    //~^ ifs_as_logical_ops
+    //~| ifs_as_logical_ops
+}

--- a/tests/ui/ifs_as_logical_ops_unfixable.stderr
+++ b/tests/ui/ifs_as_logical_ops_unfixable.stderr
@@ -1,0 +1,17 @@
+error: if expression that could be written as a logical and expression
+  --> tests/ui/ifs_as_logical_ops_unfixable.rs:4:5
+   |
+LL |     if x { if y { z } else { false } } else { false }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x && if y { z } else { false }`
+   |
+   = note: `-D clippy::ifs-as-logical-ops` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::ifs_as_logical_ops)]`
+
+error: if expression that could be written as a logical and expression
+  --> tests/ui/ifs_as_logical_ops_unfixable.rs:4:12
+   |
+LL |     if x { if y { z } else { false } } else { false }
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `y && z`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This PR supersedes https://github.com/rust-lang/rust-clippy/pull/14904. All the content is kept the same, apart from some small changes:
- removed the accidentally committed `.DS_Store` directory (https://github.com/rust-lang/rust-clippy/pull/14904#pullrequestreview-3888682898)
- updated the rustc version (https://github.com/rust-lang/rust-clippy/pull/14904#discussion_r2883159290)
- restored the `is_from_proc_macro` check (https://github.com/rust-lang/rust-clippy/pull/14904#discussion_r2869949682)
- restored the comment in `hir_utils.rs` accidentally removed in the dogfooding commit
 
The original description follows:

Fixes https://github.com/rust-lang/rust-clippy/issues/14865 by adding the ifs_as_logical_ops lint.

Only adds the conjunctive version (transform if x else y => x && y) for now.

changelog: [`ifs_as_logical_ops`] : "Warn about cases where `x && y` could be used in place of if conditions"
