### PR TITLE
print_literal: escape brace-valued escape sequences in suggestion

### DIFF
--- a/clippy_lints/src/write/literal.rs
+++ b/clippy_lints/src/write/literal.rs
@@ -1,3 +1,6 @@
+use std::iter::Peekable;
+use std::str::Chars;
+
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::macros::format_arg_removal_span;
 use clippy_utils::source::SpanExt as _;
@@ -261,69 +264,74 @@ fn escape_braces(literal: &str, preserve_unicode_escapes: bool) -> String {
             },
             // An escape sequence may hide a brace (`\x7b`) or contain braces that belong to the
             // escape syntax rather than the value (`\u{…}`), so it needs special handling.
-            '\\' if preserve_unicode_escapes => {
-                escaped.push('\\');
-                match chars.peek().copied() {
-                    // `\x7b` / `\x7d`: a brace written as a hex escape. Double up the whole escape so
-                    // that it decodes to `{{` / `}}`.
-                    Some('x') => {
-                        escaped.push('x');
-                        chars.next();
-                        let mut digits = String::new();
-                        while digits.len() < 2 {
-                            match chars.peek() {
-                                Some(&c) if c.is_ascii_hexdigit() => {
-                                    digits.push(c);
-                                    escaped.push(c);
-                                    chars.next();
-                                },
-                                _ => break,
-                            }
-                        }
-                        if matches!(u32::from_str_radix(&digits, 16), Ok(0x7B | 0x7D)) {
-                            escaped.push('\\');
-                            escaped.push('x');
-                            escaped.push_str(&digits);
-                        }
-                    },
-                    // `\u{7b}` / `\u{7d}`: a brace written as a unicode escape. Other unicode escapes
-                    // (`\u{ab123}`) are copied verbatim, braces and all.
-                    Some('u') => {
-                        escaped.push('u');
-                        chars.next();
-                        if chars.peek() == Some(&'{') {
-                            let mut sequence = String::from("\\u");
-                            let mut value = String::new();
-                            let mut closed = false;
-                            for c in chars.by_ref() {
-                                escaped.push(c);
-                                sequence.push(c);
-                                match c {
-                                    '}' => {
-                                        closed = true;
-                                        break;
-                                    },
-                                    '_' | '{' => {},
-                                    _ => value.push(c),
-                                }
-                            }
-                            if closed && matches!(u32::from_str_radix(&value, 16), Ok(0x7B | 0x7D)) {
-                                escaped.push_str(&sequence);
-                            }
-                        }
-                    },
-                    // Any other escape (`\\`, `\n`, `\"`, …): copy the escaped character verbatim so
-                    // that it is not mistaken for the start of another escape or for a brace.
-                    Some(c) => {
-                        escaped.push(c);
-                        chars.next();
-                    },
-                    None => {},
-                }
-            },
+            '\\' if preserve_unicode_escapes => escape_backslash(&mut escaped, &mut chars),
             _ => escaped.push(ch),
         }
     }
 
     escaped
+}
+
+/// Handles a `\`-escape for [`escape_braces`] when unicode escapes are preserved. The leading `\`
+/// has already been matched by the caller; this consumes the rest of the escape from `chars` and
+/// appends it. `\x7b`/`\x7d` and `\u{7b}`/`\u{7d}` decode to braces, so the whole escape is doubled
+/// up to survive the format-string parser; every other escape (and any non-brace `\u{…}`) is copied
+/// verbatim so it is not re-scanned as the start of another escape or as a brace.
+fn escape_backslash(escaped: &mut String, chars: &mut Peekable<Chars<'_>>) {
+    escaped.push('\\');
+    match chars.peek().copied() {
+        // `\x7b` / `\x7d`: a brace written as a hex escape.
+        Some('x') => {
+            escaped.push('x');
+            chars.next();
+            let mut digits = String::new();
+            while digits.len() < 2 {
+                match chars.peek() {
+                    Some(&c) if c.is_ascii_hexdigit() => {
+                        digits.push(c);
+                        escaped.push(c);
+                        chars.next();
+                    },
+                    _ => break,
+                }
+            }
+            if matches!(u32::from_str_radix(&digits, 16), Ok(0x7B | 0x7D)) {
+                escaped.push('\\');
+                escaped.push('x');
+                escaped.push_str(&digits);
+            }
+        },
+        // `\u{7b}` / `\u{7d}`: a brace written as a unicode escape. Other unicode escapes
+        // (`\u{ab123}`) are copied verbatim, braces and all.
+        Some('u') => {
+            escaped.push('u');
+            chars.next();
+            if chars.peek() == Some(&'{') {
+                let mut sequence = String::from("\\u");
+                let mut value = String::new();
+                let mut closed = false;
+                for c in chars.by_ref() {
+                    escaped.push(c);
+                    sequence.push(c);
+                    match c {
+                        '}' => {
+                            closed = true;
+                            break;
+                        },
+                        '_' | '{' => {},
+                        _ => value.push(c),
+                    }
+                }
+                if closed && matches!(u32::from_str_radix(&value, 16), Ok(0x7B | 0x7D)) {
+                    escaped.push_str(&sequence);
+                }
+            }
+        },
+        // Any other escape (`\\`, `\n`, `\"`, …): copy the escaped character verbatim.
+        Some(c) => {
+            escaped.push(c);
+            chars.next();
+        },
+        None => {},
+    }
 }

--- a/clippy_lints/src/write/literal.rs
+++ b/clippy_lints/src/write/literal.rs
@@ -240,45 +240,89 @@ fn conservative_unescape(literal: &str) -> Result<String, UnescapeErr> {
     if err { Err(UnescapeErr::Lint) } else { Ok(unescaped) }
 }
 
-/// Replaces `{` with `{{` and `}` with `}}`. If `preserve_unicode_escapes` is `true` the braces
-/// in `\u{xxxx}` are left unmodified
-#[expect(clippy::match_same_arms)]
+/// Doubles up every brace so that a string literal can be safely inlined into a (non-raw) format
+/// string. This covers literal braces (`{`, `}`) as well as braces produced by escape sequences
+/// (`\x7b`, `\u{7d}`), because the format string parser sees them only after unescaping. Escape
+/// sequences that do not evaluate to a brace (e.g. `\u{ab123}`) and the braces that are part of the
+/// `\u{…}` escape syntax are left untouched.
+///
+/// If `preserve_unicode_escapes` is `false` (the literal ends up in a raw format string) escape
+/// sequences do not exist, so only literal braces are doubled up.
 fn escape_braces(literal: &str, preserve_unicode_escapes: bool) -> String {
-    #[derive(Clone, Copy)]
-    enum State {
-        Normal,
-        Backslash,
-        UnicodeEscape,
-    }
-
     let mut escaped = String::with_capacity(literal.len());
-    let mut state = State::Normal;
+    let mut chars = literal.chars().peekable();
 
-    for ch in literal.chars() {
-        state = match (ch, state) {
-            // Escape braces outside of unicode escapes by doubling them up
-            ('{' | '}', State::Normal) => {
+    while let Some(ch) = chars.next() {
+        match ch {
+            // A brace in the value: double it up.
+            '{' | '}' => {
                 escaped.push(ch);
-                State::Normal
+                escaped.push(ch);
             },
-            // If `preserve_unicode_escapes` isn't enabled stay in `State::Normal`, otherwise:
-            //
-            // \u{aaaa} \\ \x01
-            // ^        ^  ^
-            ('\\', State::Normal) if preserve_unicode_escapes => State::Backslash,
-            // \u{aaaa}
-            //  ^
-            ('u', State::Backslash) => State::UnicodeEscape,
-            // \xAA \\
-            //  ^    ^
-            (_, State::Backslash) => State::Normal,
-            // \u{aaaa}
-            //        ^
-            ('}', State::UnicodeEscape) => State::Normal,
-            _ => state,
-        };
-
-        escaped.push(ch);
+            // An escape sequence may hide a brace (`\x7b`) or contain braces that belong to the
+            // escape syntax rather than the value (`\u{…}`), so it needs special handling.
+            '\\' if preserve_unicode_escapes => {
+                escaped.push('\\');
+                match chars.peek().copied() {
+                    // `\x7b` / `\x7d`: a brace written as a hex escape. Double up the whole escape so
+                    // that it decodes to `{{` / `}}`.
+                    Some('x') => {
+                        escaped.push('x');
+                        chars.next();
+                        let mut digits = String::new();
+                        while digits.len() < 2 {
+                            match chars.peek() {
+                                Some(&c) if c.is_ascii_hexdigit() => {
+                                    digits.push(c);
+                                    escaped.push(c);
+                                    chars.next();
+                                },
+                                _ => break,
+                            }
+                        }
+                        if matches!(u32::from_str_radix(&digits, 16), Ok(0x7B | 0x7D)) {
+                            escaped.push('\\');
+                            escaped.push('x');
+                            escaped.push_str(&digits);
+                        }
+                    },
+                    // `\u{7b}` / `\u{7d}`: a brace written as a unicode escape. Other unicode escapes
+                    // (`\u{ab123}`) are copied verbatim, braces and all.
+                    Some('u') => {
+                        escaped.push('u');
+                        chars.next();
+                        if chars.peek() == Some(&'{') {
+                            let mut sequence = String::from("\\u");
+                            let mut value = String::new();
+                            let mut closed = false;
+                            for c in chars.by_ref() {
+                                escaped.push(c);
+                                sequence.push(c);
+                                match c {
+                                    '}' => {
+                                        closed = true;
+                                        break;
+                                    },
+                                    '_' | '{' => {},
+                                    _ => value.push(c),
+                                }
+                            }
+                            if closed && matches!(u32::from_str_radix(&value, 16), Ok(0x7B | 0x7D)) {
+                                escaped.push_str(&sequence);
+                            }
+                        }
+                    },
+                    // Any other escape (`\\`, `\n`, `\"`, …): copy the escaped character verbatim so
+                    // that it is not mistaken for the start of another escape or for a brace.
+                    Some(c) => {
+                        escaped.push(c);
+                        chars.next();
+                    },
+                    None => {},
+                }
+            },
+            _ => escaped.push(ch),
+        }
     }
 
     escaped

--- a/tests/ui/print_literal.fixed
+++ b/tests/ui/print_literal.fixed
@@ -82,6 +82,15 @@ fn main() {
     //~^ print_literal
     println!("\x7b\x7b\x7d\x7d");
     //~^ print_literal
+    // When the literal ends up in a raw format string, or comes from a raw string literal, there
+    // are no escape sequences: `\x7b` and `\u{7b}` are literal text, so only the braces they
+    // contain are doubled up
+    println!(r"\x7b \u{{7b}}");
+    //~^ print_literal
+    println!(r"\x7b \u{{7b}}");
+    //~^ print_literal
+    println!("\\x7b \\u{{7b}}");
+    //~^ print_literal
 
     println!("mixed: {{hello}} {world}");
     //~^ print_literal

--- a/tests/ui/print_literal.fixed
+++ b/tests/ui/print_literal.fixed
@@ -74,6 +74,14 @@ fn main() {
     //~^ print_literal
     println!("\\\\u{{1234}}");
     //~^ print_literal
+    // Escape sequences that evaluate to braces must be doubled up as well, otherwise the suggestion
+    // would inline a brace into the format string and fail to compile (see #16478)
+    println!("\x7B\x7Ba\x7D\x7D \x7B\x7Bb\x7D\x7D");
+    //~^ print_literal
+    println!("\u{7B}\u{7B}a\u{7D}\u{7D}");
+    //~^ print_literal
+    println!("\x7b\x7b\x7d\x7d");
+    //~^ print_literal
 
     println!("mixed: {{hello}} {world}");
     //~^ print_literal

--- a/tests/ui/print_literal.fixed
+++ b/tests/ui/print_literal.fixed
@@ -74,23 +74,6 @@ fn main() {
     //~^ print_literal
     println!("\\\\u{{1234}}");
     //~^ print_literal
-    // Escape sequences that evaluate to braces must be doubled up as well, otherwise the suggestion
-    // would inline a brace into the format string and fail to compile (see #16478)
-    println!("\x7B\x7Ba\x7D\x7D \x7B\x7Bb\x7D\x7D");
-    //~^ print_literal
-    println!("\u{7B}\u{7B}a\u{7D}\u{7D}");
-    //~^ print_literal
-    println!("\x7b\x7b\x7d\x7d");
-    //~^ print_literal
-    // When the literal ends up in a raw format string, or comes from a raw string literal, there
-    // are no escape sequences: `\x7b` and `\u{7b}` are literal text, so only the braces they
-    // contain are doubled up
-    println!(r"\x7b \u{{7b}}");
-    //~^ print_literal
-    println!(r"\x7b \u{{7b}}");
-    //~^ print_literal
-    println!("\\x7b \\u{{7b}}");
-    //~^ print_literal
 
     println!("mixed: {{hello}} {world}");
     //~^ print_literal
@@ -134,4 +117,24 @@ fn issue_15576() {
         "Hello name: x is {1:.*} (which {1} with {0} places)", 5, 0.01
     );
     //~^^ print_literal
+}
+
+fn issue_16478() {
+    // Escape sequences that evaluate to braces must be doubled up as well, otherwise the suggestion
+    // would inline a brace into the format string and fail to compile
+    println!("\x7B\x7Ba\x7D\x7D \x7B\x7Bb\x7D\x7D");
+    //~^ print_literal
+    println!("\u{7B}\u{7B}a\u{7D}\u{7D}");
+    //~^ print_literal
+    println!("\x7b\x7b\x7d\x7d");
+    //~^ print_literal
+    // When the literal ends up in a raw format string, or comes from a raw string literal, there
+    // are no escape sequences: `\x7b` and `\u{7b}` are literal text, so only the braces they
+    // contain are doubled up
+    println!(r"\x7b \u{{7b}}");
+    //~^ print_literal
+    println!(r"\x7b \u{{7b}}");
+    //~^ print_literal
+    println!("\\x7b \\u{{7b}}");
+    //~^ print_literal
 }

--- a/tests/ui/print_literal.fixed
+++ b/tests/ui/print_literal.fixed
@@ -128,6 +128,12 @@ fn issue_16478() {
     //~^ print_literal
     println!("\x7b\x7b\x7d\x7d");
     //~^ print_literal
+    // A single brace on its own
+    println!("\x7B\x7Ba");
+    //~^ print_literal
+    // Consecutive braces each get doubled
+    println!("\x7B\x7B\x7B\x7Ba\x7D\x7D\x7D\x7D");
+    //~^ print_literal
     // When the literal ends up in a raw format string, or comes from a raw string literal, there
     // are no escape sequences: `\x7b` and `\u{7b}` are literal text, so only the braces they
     // contain are doubled up

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -82,6 +82,15 @@ fn main() {
     //~^ print_literal
     println!("{}", "\x7b\x7d");
     //~^ print_literal
+    // When the literal ends up in a raw format string, or comes from a raw string literal, there
+    // are no escape sequences: `\x7b` and `\u{7b}` are literal text, so only the braces they
+    // contain are doubled up
+    println!(r"{}", r"\x7b \u{7b}");
+    //~^ print_literal
+    println!(r"{}", "\\x7b \\u{7b}");
+    //~^ print_literal
+    println!("{}", r"\x7b \u{7b}");
+    //~^ print_literal
 
     println!("mixed: {} {world}", "{hello}");
     //~^ print_literal

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -74,6 +74,14 @@ fn main() {
     //~^ print_literal
     println!("{}", "\\\\u{1234}");
     //~^ print_literal
+    // Escape sequences that evaluate to braces must be doubled up as well, otherwise the suggestion
+    // would inline a brace into the format string and fail to compile (see #16478)
+    println!("{}", "\x7Ba\x7D \x7Bb\x7D");
+    //~^ print_literal
+    println!("{}", "\u{7B}a\u{7D}");
+    //~^ print_literal
+    println!("{}", "\x7b\x7d");
+    //~^ print_literal
 
     println!("mixed: {} {world}", "{hello}");
     //~^ print_literal

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -130,6 +130,12 @@ fn issue_16478() {
     //~^ print_literal
     println!("{}", "\x7b\x7d");
     //~^ print_literal
+    // A single brace on its own
+    println!("{}", "\x7Ba");
+    //~^ print_literal
+    // Consecutive braces each get doubled
+    println!("{}", "\x7B\x7Ba\x7D\x7D");
+    //~^ print_literal
     // When the literal ends up in a raw format string, or comes from a raw string literal, there
     // are no escape sequences: `\x7b` and `\u{7b}` are literal text, so only the braces they
     // contain are doubled up

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -74,23 +74,6 @@ fn main() {
     //~^ print_literal
     println!("{}", "\\\\u{1234}");
     //~^ print_literal
-    // Escape sequences that evaluate to braces must be doubled up as well, otherwise the suggestion
-    // would inline a brace into the format string and fail to compile (see #16478)
-    println!("{}", "\x7Ba\x7D \x7Bb\x7D");
-    //~^ print_literal
-    println!("{}", "\u{7B}a\u{7D}");
-    //~^ print_literal
-    println!("{}", "\x7b\x7d");
-    //~^ print_literal
-    // When the literal ends up in a raw format string, or comes from a raw string literal, there
-    // are no escape sequences: `\x7b` and `\u{7b}` are literal text, so only the braces they
-    // contain are doubled up
-    println!(r"{}", r"\x7b \u{7b}");
-    //~^ print_literal
-    println!(r"{}", "\\x7b \\u{7b}");
-    //~^ print_literal
-    println!("{}", r"\x7b \u{7b}");
-    //~^ print_literal
 
     println!("mixed: {} {world}", "{hello}");
     //~^ print_literal
@@ -136,4 +119,24 @@ fn issue_15576() {
         "name", 5, "x", 0.01
     );
     //~^^ print_literal
+}
+
+fn issue_16478() {
+    // Escape sequences that evaluate to braces must be doubled up as well, otherwise the suggestion
+    // would inline a brace into the format string and fail to compile
+    println!("{}", "\x7Ba\x7D \x7Bb\x7D");
+    //~^ print_literal
+    println!("{}", "\u{7B}a\u{7D}");
+    //~^ print_literal
+    println!("{}", "\x7b\x7d");
+    //~^ print_literal
+    // When the literal ends up in a raw format string, or comes from a raw string literal, there
+    // are no escape sequences: `\x7b` and `\u{7b}` are literal text, so only the braces they
+    // contain are doubled up
+    println!(r"{}", r"\x7b \u{7b}");
+    //~^ print_literal
+    println!(r"{}", "\\x7b \\u{7b}");
+    //~^ print_literal
+    println!("{}", r"\x7b \u{7b}");
+    //~^ print_literal
 }

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -217,7 +217,43 @@ LL +     println!("\x7b\x7b\x7d\x7d");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:86:35
+  --> tests/ui/print_literal.rs:88:21
+   |
+LL |     println!(r"{}", r"\x7b \u{7b}");
+   |                     ^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!(r"{}", r"\x7b \u{7b}");
+LL +     println!(r"\x7b \u{{7b}}");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:90:21
+   |
+LL |     println!(r"{}", "\\x7b \\u{7b}");
+   |                     ^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!(r"{}", "\\x7b \\u{7b}");
+LL +     println!(r"\x7b \u{{7b}}");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:92:20
+   |
+LL |     println!("{}", r"\x7b \u{7b}");
+   |                    ^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", r"\x7b \u{7b}");
+LL +     println!("\\x7b \\u{{7b}}");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:95:35
    |
 LL |     println!("mixed: {} {world}", "{hello}");
    |                                   ^^^^^^^^^
@@ -229,7 +265,7 @@ LL +     println!("mixed: {{hello}} {world}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:91:20
+  --> tests/ui/print_literal.rs:100:20
    |
 LL |     println!("{}", r#"""#);
    |                    ^^^^^^
@@ -241,7 +277,7 @@ LL +     println!("\"");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:95:9
+  --> tests/ui/print_literal.rs:104:9
    |
 LL | /         r#"
 LL | |
@@ -266,7 +302,7 @@ LL ~ "
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:108:52
+  --> tests/ui/print_literal.rs:117:52
    |
 LL |     println!("Hello {3} is {0:2$.1$}", 0.01, 2, 3, "x");
    |                                                    ^^^
@@ -278,7 +314,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:110:49
+  --> tests/ui/print_literal.rs:119:49
    |
 LL |     println!("Hello {2} is {0:3$.1$}", 0.01, 2, "x", 3);
    |                                                 ^^^
@@ -290,7 +326,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:112:46
+  --> tests/ui/print_literal.rs:121:46
    |
 LL |     println!("Hello {1} is {0:3$.2$}", 0.01, "x", 2, 3);
    |                                              ^^^
@@ -302,7 +338,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:114:40
+  --> tests/ui/print_literal.rs:123:40
    |
 LL |     println!("Hello {0} is {1:3$.2$}", "x", 0.01, 2, 3);
    |                                        ^^^
@@ -314,7 +350,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:119:36
+  --> tests/ui/print_literal.rs:128:36
    |
 LL |     println!("Hello {} is {2:.*}", "x", 5, 0.01);
    |                                    ^^^
@@ -326,7 +362,7 @@ LL +     println!("Hello x is {1:.*}", 5, 0.01);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:122:36
+  --> tests/ui/print_literal.rs:131:36
    |
 LL |     println!("Hello {} is {:.p$}", "x", 0.01, p = 5);
    |                                    ^^^
@@ -338,7 +374,7 @@ LL +     println!("Hello x is {:.p$}", 0.01, p = 5);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:127:9
+  --> tests/ui/print_literal.rs:136:9
    |
 LL |         "name", 5, "x", 0.01
    |         ^^^^^^^^^^^^^^
@@ -350,5 +386,5 @@ LL -         "name", 5, "x", 0.01
 LL +         "Hello name: x is {1:.*} (which {1} with {0} places)", 5, 0.01
    |
 
-error: aborting due to 28 previous errors
+error: aborting due to 31 previous errors
 

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -351,7 +351,31 @@ LL +     println!("\x7b\x7b\x7d\x7d");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:136:21
+  --> tests/ui/print_literal.rs:134:20
+   |
+LL |     println!("{}", "\x7Ba");
+   |                    ^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", "\x7Ba");
+LL +     println!("\x7B\x7Ba");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:137:20
+   |
+LL |     println!("{}", "\x7B\x7Ba\x7D\x7D");
+   |                    ^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", "\x7B\x7Ba\x7D\x7D");
+LL +     println!("\x7B\x7B\x7B\x7Ba\x7D\x7D\x7D\x7D");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:142:21
    |
 LL |     println!(r"{}", r"\x7b \u{7b}");
    |                     ^^^^^^^^^^^^^^
@@ -363,7 +387,7 @@ LL +     println!(r"\x7b \u{{7b}}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:138:21
+  --> tests/ui/print_literal.rs:144:21
    |
 LL |     println!(r"{}", "\\x7b \\u{7b}");
    |                     ^^^^^^^^^^^^^^^
@@ -375,7 +399,7 @@ LL +     println!(r"\x7b \u{{7b}}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:140:20
+  --> tests/ui/print_literal.rs:146:20
    |
 LL |     println!("{}", r"\x7b \u{7b}");
    |                    ^^^^^^^^^^^^^^
@@ -386,5 +410,5 @@ LL -     println!("{}", r"\x7b \u{7b}");
 LL +     println!("\\x7b \\u{{7b}}");
    |
 
-error: aborting due to 31 previous errors
+error: aborting due to 33 previous errors
 

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -181,79 +181,7 @@ LL +     println!("\\\\u{{1234}}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:79:20
-   |
-LL |     println!("{}", "\x7Ba\x7D \x7Bb\x7D");
-   |                    ^^^^^^^^^^^^^^^^^^^^^
-   |
-help: try
-   |
-LL -     println!("{}", "\x7Ba\x7D \x7Bb\x7D");
-LL +     println!("\x7B\x7Ba\x7D\x7D \x7B\x7Bb\x7D\x7D");
-   |
-
-error: literal with an empty format string
-  --> tests/ui/print_literal.rs:81:20
-   |
-LL |     println!("{}", "\u{7B}a\u{7D}");
-   |                    ^^^^^^^^^^^^^^^
-   |
-help: try
-   |
-LL -     println!("{}", "\u{7B}a\u{7D}");
-LL +     println!("\u{7B}\u{7B}a\u{7D}\u{7D}");
-   |
-
-error: literal with an empty format string
-  --> tests/ui/print_literal.rs:83:20
-   |
-LL |     println!("{}", "\x7b\x7d");
-   |                    ^^^^^^^^^^
-   |
-help: try
-   |
-LL -     println!("{}", "\x7b\x7d");
-LL +     println!("\x7b\x7b\x7d\x7d");
-   |
-
-error: literal with an empty format string
-  --> tests/ui/print_literal.rs:88:21
-   |
-LL |     println!(r"{}", r"\x7b \u{7b}");
-   |                     ^^^^^^^^^^^^^^
-   |
-help: try
-   |
-LL -     println!(r"{}", r"\x7b \u{7b}");
-LL +     println!(r"\x7b \u{{7b}}");
-   |
-
-error: literal with an empty format string
-  --> tests/ui/print_literal.rs:90:21
-   |
-LL |     println!(r"{}", "\\x7b \\u{7b}");
-   |                     ^^^^^^^^^^^^^^^
-   |
-help: try
-   |
-LL -     println!(r"{}", "\\x7b \\u{7b}");
-LL +     println!(r"\x7b \u{{7b}}");
-   |
-
-error: literal with an empty format string
-  --> tests/ui/print_literal.rs:92:20
-   |
-LL |     println!("{}", r"\x7b \u{7b}");
-   |                    ^^^^^^^^^^^^^^
-   |
-help: try
-   |
-LL -     println!("{}", r"\x7b \u{7b}");
-LL +     println!("\\x7b \\u{{7b}}");
-   |
-
-error: literal with an empty format string
-  --> tests/ui/print_literal.rs:95:35
+  --> tests/ui/print_literal.rs:78:35
    |
 LL |     println!("mixed: {} {world}", "{hello}");
    |                                   ^^^^^^^^^
@@ -265,7 +193,7 @@ LL +     println!("mixed: {{hello}} {world}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:100:20
+  --> tests/ui/print_literal.rs:83:20
    |
 LL |     println!("{}", r#"""#);
    |                    ^^^^^^
@@ -277,7 +205,7 @@ LL +     println!("\"");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:104:9
+  --> tests/ui/print_literal.rs:87:9
    |
 LL | /         r#"
 LL | |
@@ -302,7 +230,7 @@ LL ~ "
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:117:52
+  --> tests/ui/print_literal.rs:100:52
    |
 LL |     println!("Hello {3} is {0:2$.1$}", 0.01, 2, 3, "x");
    |                                                    ^^^
@@ -314,7 +242,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:119:49
+  --> tests/ui/print_literal.rs:102:49
    |
 LL |     println!("Hello {2} is {0:3$.1$}", 0.01, 2, "x", 3);
    |                                                 ^^^
@@ -326,7 +254,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:121:46
+  --> tests/ui/print_literal.rs:104:46
    |
 LL |     println!("Hello {1} is {0:3$.2$}", 0.01, "x", 2, 3);
    |                                              ^^^
@@ -338,7 +266,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:123:40
+  --> tests/ui/print_literal.rs:106:40
    |
 LL |     println!("Hello {0} is {1:3$.2$}", "x", 0.01, 2, 3);
    |                                        ^^^
@@ -350,7 +278,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:128:36
+  --> tests/ui/print_literal.rs:111:36
    |
 LL |     println!("Hello {} is {2:.*}", "x", 5, 0.01);
    |                                    ^^^
@@ -362,7 +290,7 @@ LL +     println!("Hello x is {1:.*}", 5, 0.01);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:131:36
+  --> tests/ui/print_literal.rs:114:36
    |
 LL |     println!("Hello {} is {:.p$}", "x", 0.01, p = 5);
    |                                    ^^^
@@ -374,7 +302,7 @@ LL +     println!("Hello x is {:.p$}", 0.01, p = 5);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:136:9
+  --> tests/ui/print_literal.rs:119:9
    |
 LL |         "name", 5, "x", 0.01
    |         ^^^^^^^^^^^^^^
@@ -384,6 +312,78 @@ help: try
 LL -         "Hello {}: {2} is {3:.*} (which {3} with {1} places)",
 LL -         "name", 5, "x", 0.01
 LL +         "Hello name: x is {1:.*} (which {1} with {0} places)", 5, 0.01
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:127:20
+   |
+LL |     println!("{}", "\x7Ba\x7D \x7Bb\x7D");
+   |                    ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", "\x7Ba\x7D \x7Bb\x7D");
+LL +     println!("\x7B\x7Ba\x7D\x7D \x7B\x7Bb\x7D\x7D");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:129:20
+   |
+LL |     println!("{}", "\u{7B}a\u{7D}");
+   |                    ^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", "\u{7B}a\u{7D}");
+LL +     println!("\u{7B}\u{7B}a\u{7D}\u{7D}");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:131:20
+   |
+LL |     println!("{}", "\x7b\x7d");
+   |                    ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", "\x7b\x7d");
+LL +     println!("\x7b\x7b\x7d\x7d");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:136:21
+   |
+LL |     println!(r"{}", r"\x7b \u{7b}");
+   |                     ^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!(r"{}", r"\x7b \u{7b}");
+LL +     println!(r"\x7b \u{{7b}}");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:138:21
+   |
+LL |     println!(r"{}", "\\x7b \\u{7b}");
+   |                     ^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!(r"{}", "\\x7b \\u{7b}");
+LL +     println!(r"\x7b \u{{7b}}");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:140:20
+   |
+LL |     println!("{}", r"\x7b \u{7b}");
+   |                    ^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", r"\x7b \u{7b}");
+LL +     println!("\\x7b \\u{{7b}}");
    |
 
 error: aborting due to 31 previous errors

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -181,7 +181,43 @@ LL +     println!("\\\\u{{1234}}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:78:35
+  --> tests/ui/print_literal.rs:79:20
+   |
+LL |     println!("{}", "\x7Ba\x7D \x7Bb\x7D");
+   |                    ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", "\x7Ba\x7D \x7Bb\x7D");
+LL +     println!("\x7B\x7Ba\x7D\x7D \x7B\x7Bb\x7D\x7D");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:81:20
+   |
+LL |     println!("{}", "\u{7B}a\u{7D}");
+   |                    ^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", "\u{7B}a\u{7D}");
+LL +     println!("\u{7B}\u{7B}a\u{7D}\u{7D}");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:83:20
+   |
+LL |     println!("{}", "\x7b\x7d");
+   |                    ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     println!("{}", "\x7b\x7d");
+LL +     println!("\x7b\x7b\x7d\x7d");
+   |
+
+error: literal with an empty format string
+  --> tests/ui/print_literal.rs:86:35
    |
 LL |     println!("mixed: {} {world}", "{hello}");
    |                                   ^^^^^^^^^
@@ -193,7 +229,7 @@ LL +     println!("mixed: {{hello}} {world}");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:83:20
+  --> tests/ui/print_literal.rs:91:20
    |
 LL |     println!("{}", r#"""#);
    |                    ^^^^^^
@@ -205,7 +241,7 @@ LL +     println!("\"");
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:87:9
+  --> tests/ui/print_literal.rs:95:9
    |
 LL | /         r#"
 LL | |
@@ -230,7 +266,7 @@ LL ~ "
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:100:52
+  --> tests/ui/print_literal.rs:108:52
    |
 LL |     println!("Hello {3} is {0:2$.1$}", 0.01, 2, 3, "x");
    |                                                    ^^^
@@ -242,7 +278,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:102:49
+  --> tests/ui/print_literal.rs:110:49
    |
 LL |     println!("Hello {2} is {0:3$.1$}", 0.01, 2, "x", 3);
    |                                                 ^^^
@@ -254,7 +290,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:104:46
+  --> tests/ui/print_literal.rs:112:46
    |
 LL |     println!("Hello {1} is {0:3$.2$}", 0.01, "x", 2, 3);
    |                                              ^^^
@@ -266,7 +302,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:106:40
+  --> tests/ui/print_literal.rs:114:40
    |
 LL |     println!("Hello {0} is {1:3$.2$}", "x", 0.01, 2, 3);
    |                                        ^^^
@@ -278,7 +314,7 @@ LL +     println!("Hello x is {0:2$.1$}", 0.01, 2, 3);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:111:36
+  --> tests/ui/print_literal.rs:119:36
    |
 LL |     println!("Hello {} is {2:.*}", "x", 5, 0.01);
    |                                    ^^^
@@ -290,7 +326,7 @@ LL +     println!("Hello x is {1:.*}", 5, 0.01);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:114:36
+  --> tests/ui/print_literal.rs:122:36
    |
 LL |     println!("Hello {} is {:.p$}", "x", 0.01, p = 5);
    |                                    ^^^
@@ -302,7 +338,7 @@ LL +     println!("Hello x is {:.p$}", 0.01, p = 5);
    |
 
 error: literal with an empty format string
-  --> tests/ui/print_literal.rs:119:9
+  --> tests/ui/print_literal.rs:127:9
    |
 LL |         "name", 5, "x", 0.01
    |         ^^^^^^^^^^^^^^
@@ -314,5 +350,5 @@ LL -         "name", 5, "x", 0.01
 LL +         "Hello name: x is {1:.*} (which {1} with {0} places)", 5, 0.01
    |
 
-error: aborting due to 25 previous errors
+error: aborting due to 28 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16478

`escape_braces` only doubled up literal `{` / `}` characters. A string literal argument containing an escape sequence that *evaluates* to a brace (e.g. `\x7b`, `\u{7d}`) was therefore inlined into the format string unchanged. Since a format string is unescaped before its `{}` placeholders are parsed, the resulting brace was then interpreted as the start of a format argument, so the suggestion did not compile:

```rust
println!("{}", "\x7Ba\x7D \x7Bb\x7D");
// was suggested as `println!("\x7Ba\x7D \x7Bb\x7D")`, i.e. `println!("{a} {b}")` -> error
```

Now escape sequences that evaluate to a brace are doubled up as well (`\x7b` -> `\x7b\x7b`, `\u{7d}` -> `\u{7d}\u{7d}`), so the argument is still printed verbatim. Non-brace unicode escapes (`\u{ab123}`) and the braces that are part of the `\u{…}` escape syntax are left untouched.

changelog: [`print_literal`], [`write_literal`]: don't produce a suggestion that fails to compile when the argument contains an escape sequence that evaluates to a brace (e.g. `\x7b`)
