### PR TITLE
Fix the swapped arguments in `redundant_closure`'s late-bound region check

### DIFF
--- a/clippy_lints/src/attrs/deprecated_cfg_attr.rs
+++ b/clippy_lints/src/attrs/deprecated_cfg_attr.rs
@@ -2,7 +2,7 @@ use super::{Attribute, DEPRECATED_CFG_ATTR, DEPRECATED_CLIPPY_CFG_ATTR, unnecess
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::msrvs::{self, MsrvStack};
 use clippy_utils::sym;
-use rustc_ast::AttrStyle;
+use rustc_ast::{AttrStyle, MetaItemInner};
 use rustc_errors::Applicability;
 use rustc_lint::EarlyContext;
 
@@ -53,7 +53,7 @@ pub(super) fn check_clippy(cx: &EarlyContext<'_>, attr: &Attribute) {
     if attr.has_name(sym::cfg)
         && let Some(list) = attr.meta_item_list()
     {
-        for item in list.iter().filter_map(|item| item.meta_item()) {
+        for item in list.iter().filter_map(MetaItemInner::meta_item) {
             check_deprecated_cfg_recursively(cx, item);
         }
     }
@@ -63,7 +63,7 @@ fn check_deprecated_cfg_recursively(cx: &EarlyContext<'_>, attr: &rustc_ast::Met
     if let Some(ident) = attr.ident() {
         if matches!(ident.name, sym::any | sym::all | sym::not) {
             let Some(list) = attr.meta_item_list() else { return };
-            for item in list.iter().filter_map(|item| item.meta_item()) {
+            for item in list.iter().filter_map(MetaItemInner::meta_item) {
                 check_deprecated_cfg_recursively(cx, item);
             }
         } else {

--- a/clippy_lints/src/definition_in_module_root.rs
+++ b/clippy_lints/src/definition_in_module_root.rs
@@ -3,6 +3,7 @@ use rustc_ast::ast::{self, Inline, ItemKind, ModKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext as _};
 use rustc_session::impl_lint_pass;
 use rustc_span::{FileName, SourceFile, sym};
+use std::path::Path;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -153,7 +154,7 @@ fn has_macro_export(item: &ast::Item) -> bool {
 fn is_mod_rs(file: &SourceFile) -> bool {
     if let FileName::Real(name) = &file.name {
         name.local_path()
-            .and_then(|p| p.file_name())
+            .and_then(Path::file_name)
             .is_some_and(|n| n == "mod.rs")
     } else {
         false

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -334,7 +334,7 @@ fn has_late_bound_to_non_late_bound_regions(from_sig: FnSig<'_>, to_sig: FnSig<'
         if from_subs.len() != to_subs.len() {
             return true;
         }
-        for (from_arg, to_arg) in to_subs.iter().zip(from_subs) {
+        for (from_arg, to_arg) in from_subs.iter().zip(to_subs) {
             match (from_arg.kind(), to_arg.kind()) {
                 (GenericArgKind::Lifetime(from_region), GenericArgKind::Lifetime(to_region)) => {
                     if check_region(from_region, to_region) {

--- a/clippy_lints/src/loops/infinite_loop.rs
+++ b/clippy_lints/src/loops/infinite_loop.rs
@@ -219,7 +219,7 @@ fn is_never_return(ret_ty: FnRetTy<'_>) -> bool {
             bounds,
             ..
         }) => {
-            if let Some(trait_ref) = bounds.iter().find_map(|b| b.trait_ref())
+            if let Some(trait_ref) = bounds.iter().find_map(hir::GenericBound::trait_ref)
                 && let Some(segment) = trait_ref
                     .path
                     .segments

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -687,3 +687,24 @@ mod issue_13094 {
             .collect()
     }
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/14215
+fn early_bound_region_in_adt() {
+    use std::marker::PhantomData;
+
+    struct Guard<'a, S> {
+        _data: PhantomData<&'a S>,
+    }
+
+    impl<S> Guard<'_, S> {
+        fn do_something(_this: &mut Self) {}
+    }
+
+    fn takes_guard_fn<S, F>(_func: F)
+    where
+        F: FnOnce(&mut Guard<S>),
+    {
+    }
+
+    takes_guard_fn::<i32, _>(|s| Guard::do_something(s));
+}

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -687,3 +687,24 @@ mod issue_13094 {
             .collect()
     }
 }
+
+// https://github.com/rust-lang/rust-clippy/issues/14215
+fn early_bound_region_in_adt() {
+    use std::marker::PhantomData;
+
+    struct Guard<'a, S> {
+        _data: PhantomData<&'a S>,
+    }
+
+    impl<S> Guard<'_, S> {
+        fn do_something(_this: &mut Self) {}
+    }
+
+    fn takes_guard_fn<S, F>(_func: F)
+    where
+        F: FnOnce(&mut Guard<S>),
+    {
+    }
+
+    takes_guard_fn::<i32, _>(|s| Guard::do_something(s));
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#14215

`redundant_closure` only reduces `|x| f(x)` to `f` when both signatures agree on which regions are late-bound, because rustc cannot late bind an early-bound region. The helper that compares a type's generic arguments zipped the two lists in the wrong order, inverting the directional `check_region` so that the case it exists to reject was let through. Only ADTs were affected, since a region held directly, as in `&'a u32`, takes the `ty::Ref` arm. So for a bound like `FnOnce(&mut Guard<S>)` the lint offered a machine-applicable rewrite that fails to compile with `implementation of FnOnce is not general enough`.

This zips them in the same order as the call site and the rest of the function.

Correcting the direction also fixes the opposite error, where a safe rewrite was rejected. Four such closures in clippy's own source are now caught by `redundant_closure_for_method_calls`, so this reduces them as well to keep dogfood passing.

changelog: [`redundant_closure`]: don't suggest a non-compiling rewrite when an early-bound region sits inside an ADT
