### PR TITLE
Fix `needless_raw_string_hashes` miscounting hashes after two adjacent quotes

### DIFF
--- a/clippy_lints/src/raw_strings.rs
+++ b/clippy_lints/src/raw_strings.rs
@@ -143,19 +143,20 @@ impl RawStrings {
             // `once` so a raw string ending in hashes is still checked
             let num = str.as_bytes().iter().chain(once(&0)).try_fold(0u8, |acc, &b| {
                 match b {
-                    b'"' if !following_quote => (following_quote, req) = (true, 1),
                     b'#' => req += u8::from(following_quote),
-                    _ => {
-                        if following_quote {
-                            following_quote = false;
+                    b'"' if !following_quote => (following_quote, req) = (true, 1),
+                    _ if following_quote => {
+                        let ended = req;
+                        // a quote also starts a new run, e.g. `""#` requires two hashes
+                        (following_quote, req) = (b == b'"', 1);
 
-                            if req == max {
-                                return ControlFlow::Break(req);
-                            }
-
-                            return ControlFlow::Continue(acc.max(req));
+                        if ended == max {
+                            return ControlFlow::Break(ended);
                         }
+
+                        return ControlFlow::Continue(acc.max(ended));
                     },
+                    _ => {},
                 }
 
                 ControlFlow::Continue(acc)

--- a/tests/ui/needless_raw_string_hashes.fixed
+++ b/tests/ui/needless_raw_string_hashes.fixed
@@ -52,3 +52,10 @@ fn issue_13503() {
     // Test arguments as well
     println!("{}", r"foobar".len());
 }
+
+fn issue_11737() {
+    r##"task test(execute: "") {r#""#}"##;
+    r##"a quote pair followed by a hash: ""#"##;
+    r##"a gap between the quotes: r#"_"#"##;
+    r##"a gap between the quotes: "_"#"##;
+}

--- a/tests/ui/needless_raw_string_hashes.rs
+++ b/tests/ui/needless_raw_string_hashes.rs
@@ -52,3 +52,10 @@ fn issue_13503() {
     // Test arguments as well
     println!("{}", r"foobar".len());
 }
+
+fn issue_11737() {
+    r##"task test(execute: "") {r#""#}"##;
+    r##"a quote pair followed by a hash: ""#"##;
+    r##"a gap between the quotes: r#"_"#"##;
+    r##"a gap between the quotes: "_"#"##;
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#11737

`needless_raw_string_hashes` scans the literal for the longest run of hashes following a quote, since that decides how many hashes the literal needs. The arm that starts a run is guarded by `if !following_quote`, so a second quote in a row falls through to the catch-all arm instead, which ends the run and clears `following_quote`. The hashes after that quote are then added to nothing, and the run they belong to is never counted.

An empty inner raw string produces exactly that byte sequence, so `r##"{r#""#}"##` was reported as needing only one hash. Applying the machine-applicable suggestion terminates the literal early at the inner `"#` and fails to compile with `error[E0765]: unterminated double quote string`.

The catch-all arm now starts a new run when the byte that ended the previous one is itself a quote.

changelog: [`needless_raw_string_hashes`]: don't drop the hashes that follow two adjacent quotes
