### PR TITLE
fix(multiple_unsafe_ops_per_block): false positive in with write to union field

### DIFF
--- a/clippy_lints/src/multiple_unsafe_ops_per_block.rs
+++ b/clippy_lints/src/multiple_unsafe_ops_per_block.rs
@@ -168,6 +168,15 @@ impl<'tcx> UnsafeExprCollector<'tcx> {
 
         self.visit_expr(base);
     }
+
+    fn visit_lhs(&mut self, mut expr: &'tcx hir::Expr<'tcx>) {
+        while let ExprKind::Field(base, _) = expr.kind
+            && self.typeck_results.expr_adjustments(base).is_empty()
+        {
+            expr = base;
+        }
+        self.visit_expr(expr);
+    }
 }
 
 impl UnsafeExprCollector<'_> {
@@ -249,7 +258,7 @@ impl<'tcx> Visitor<'tcx> for UnsafeExprCollector<'tcx> {
                 }
             },
 
-            ExprKind::AssignOp(_, lhs, rhs) | ExprKind::Assign(lhs, rhs, _) => {
+            ExprKind::AssignOp(_, lhs, rhs) | ExprKind::Assign(lhs, rhs, _)
                 if matches!(
                     lhs.kind,
                     ExprKind::Path(QPath::Resolved(
@@ -265,10 +274,17 @@ impl<'tcx> Visitor<'tcx> for UnsafeExprCollector<'tcx> {
                             ..
                         }
                     ))
-                ) {
-                    self.insert_span(expr.span, "modification of a mutable static occurs here");
-                    return self.visit_expr(rhs);
-                }
+                ) =>
+            {
+                self.insert_span(expr.span, "modification of a mutable static occurs here");
+                self.visit_expr(rhs);
+                return;
+            },
+
+            ExprKind::Assign(lhs, rhs, _) => {
+                self.visit_lhs(lhs);
+                self.visit_expr(rhs);
+                return;
             },
 
             _ => {},

--- a/tests/ui/multiple_unsafe_ops_per_block.rs
+++ b/tests/ui/multiple_unsafe_ops_per_block.rs
@@ -510,4 +510,105 @@ fn issue17453() {
         }
     }
 }
+
+fn issue17454() {
+    #[derive(Clone, Copy)]
+    union Example {
+        f1: u32,
+        f2: bool,
+        f3: S,
+        f4: [u32; 2],
+    }
+    #[derive(Clone, Copy)]
+    struct S {
+        x: u32,
+    }
+    struct HoldsExample {
+        e: Example,
+    }
+
+    // no lint: writing to a union field is safe, raw pointer deref is the only unsafe op
+    fn set_union_value(target: &mut HoldsExample, value: *const u32) {
+        unsafe {
+            target.e.f1 = *value;
+        };
+    }
+
+    // no lint: writing to a nested union field is safe, raw pointer deref is the only unsafe op
+    fn set_union_value_nested(target: &mut HoldsExample, value: *const u32) {
+        unsafe {
+            target.e.f3.x = *value;
+        };
+    }
+
+    // no lint: writing to a union field inside safe indexing is safe, raw pointer deref is the only
+    // unsafe op
+    fn set_union_value_indexed(target: &mut [HoldsExample], i: usize, value: *const u32) {
+        unsafe {
+            target[i].e.f1 = *value;
+        };
+    }
+
+    unsafe fn unsafe_index() -> usize {
+        0
+    }
+
+    // lint: raw pointer dereference and unsafe function call inside the index expression
+    fn set_union_value_unsafe_indexed(target: &mut [HoldsExample], value: *const u32) {
+        unsafe {
+            //~^ multiple_unsafe_ops_per_block
+            target[unsafe_index()].e.f1 = *value;
+        };
+    }
+
+    // lint: `+=` reads the union field as well as writing it
+    fn add_to_union_value(target: &mut HoldsExample, value: *const u32) {
+        unsafe {
+            //~^ multiple_unsafe_ops_per_block
+            target.e.f1 += *value;
+        };
+    }
+
+    // lint: indexing into a union field reads it
+    fn set_union_elem(target: &mut HoldsExample, value: *const u32) {
+        unsafe {
+            //~^ multiple_unsafe_ops_per_block
+            target.e.f4[0] = *value;
+        };
+    }
+
+    struct Inner {
+        x: u32,
+    }
+    union HoldsRef<'a> {
+        r: &'a mut Inner,
+    }
+    struct Outer<'a> {
+        u: HoldsRef<'a>,
+    }
+
+    // lint: reading the `&mut Inner` out of the union is a real union read
+    fn write_through_union_ref(target: &mut Outer<'_>, value: *const u32) {
+        unsafe {
+            //~^ multiple_unsafe_ops_per_block
+            target.u.r.x = *value;
+        };
+    }
+
+    #[derive(Clone, Copy)]
+    union Nested {
+        inner: Example,
+    }
+    struct HoldsNested {
+        n: Nested,
+    }
+
+    // no lint: writing through nested unions is safe, raw pointer deref is the only unsafe op
+    fn set_nested(target: &mut HoldsNested, value: *const u32) {
+        unsafe {
+            target.n.inner.f1 = *value;
+        };
+    }
+}
+
 fn main() {}

--- a/tests/ui/multiple_unsafe_ops_per_block.stderr
+++ b/tests/ui/multiple_unsafe_ops_per_block.stderr
@@ -587,5 +587,85 @@ note: unsafe function call occurs here
 LL |             not_very_safe();
    |             ^^^^^^^^^^^^^^^
 
-error: aborting due to 27 previous errors
+error: this `unsafe` block contains 2 unsafe operations, expected only one
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:558:9
+   |
+LL | /         unsafe {
+LL | |
+LL | |             target[unsafe_index()].e.f1 = *value;
+LL | |         };
+   | |_________^
+   |
+note: raw pointer dereference occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:560:43
+   |
+LL |             target[unsafe_index()].e.f1 = *value;
+   |                                           ^^^^^^
+note: unsafe function call occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:560:20
+   |
+LL |             target[unsafe_index()].e.f1 = *value;
+   |                    ^^^^^^^^^^^^^^
+
+error: this `unsafe` block contains 2 unsafe operations, expected only one
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:566:9
+   |
+LL | /         unsafe {
+LL | |
+LL | |             target.e.f1 += *value;
+LL | |         };
+   | |_________^
+   |
+note: raw pointer dereference occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:568:28
+   |
+LL |             target.e.f1 += *value;
+   |                            ^^^^^^
+note: union field access occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:568:13
+   |
+LL |             target.e.f1 += *value;
+   |             ^^^^^^^^^^^
+
+error: this `unsafe` block contains 2 unsafe operations, expected only one
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:574:9
+   |
+LL | /         unsafe {
+LL | |
+LL | |             target.e.f4[0] = *value;
+LL | |         };
+   | |_________^
+   |
+note: raw pointer dereference occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:576:30
+   |
+LL |             target.e.f4[0] = *value;
+   |                              ^^^^^^
+note: union field access occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:576:13
+   |
+LL |             target.e.f4[0] = *value;
+   |             ^^^^^^^^^^^
+
+error: this `unsafe` block contains 2 unsafe operations, expected only one
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:592:9
+   |
+LL | /         unsafe {
+LL | |
+LL | |             target.u.r.x = *value;
+LL | |         };
+   | |_________^
+   |
+note: raw pointer dereference occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:594:28
+   |
+LL |             target.u.r.x = *value;
+   |                            ^^^^^^
+note: union field access occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:594:13
+   |
+LL |             target.u.r.x = *value;
+   |             ^^^^^^^^^^
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
changelog: [`multiple_unsafe_ops_per_block`]: fix false positive detecting safe writes to union fields as unsafe

Fixes rust-lang/rust-clippy#17454

First of all thanks for the work on clippy.
I looked over the opened issues what is happening and the first one seemed like a simple and easy fix. It was :)

The issue is:

- READS from unions are considered unsafe (good)
- WRITES, which are safe, were also considered unsafe (bad)

so slight tightening of the rules, adding tests for all the subcases that I could possibly think of and off we go.