### PR TITLE
add `foo_functions` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6948,6 +6948,7 @@ Released 2018-09-13
 [`fn_to_numeric_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#fn_to_numeric_cast
 [`fn_to_numeric_cast_any`]: https://rust-lang.github.io/rust-clippy/master/index.html#fn_to_numeric_cast_any
 [`fn_to_numeric_cast_with_truncation`]: https://rust-lang.github.io/rust-clippy/master/index.html#fn_to_numeric_cast_with_truncation
+[`foo_functions`]: https://rust-lang.github.io/rust-clippy/master/index.html#foo_functions
 [`for_kv_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#for_kv_map
 [`for_loop_over_option`]: https://rust-lang.github.io/rust-clippy/master/index.html#for_loop_over_option
 [`for_loop_over_result`]: https://rust-lang.github.io/rust-clippy/master/index.html#for_loop_over_result

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -172,6 +172,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::float_literal::LOSSY_FLOAT_LITERAL_INFO,
     crate::floating_point_arithmetic::IMPRECISE_FLOPS_INFO,
     crate::floating_point_arithmetic::SUBOPTIMAL_FLOPS_INFO,
+    crate::foo_functions::FOO_FUNCTIONS_INFO,
     crate::format::USELESS_FORMAT_INFO,
     crate::format_args::FORMAT_IN_FORMAT_ARGS_INFO,
     crate::format_args::POINTER_FORMAT_INFO,

--- a/clippy_lints/src/foo_functions.rs
+++ b/clippy_lints/src/foo_functions.rs
@@ -1,0 +1,52 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_ast::ast::{Fn, NodeId};
+use rustc_ast::visit::FnKind;
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for ... (describe what the lint matches).
+    ///
+    /// ### Why is this bad?
+    /// Supply the reason for linting the code.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// // A short example of code that triggers the lint
+    /// ```
+    ///
+    /// Use instead:
+    /// ```rust,ignore
+    /// // A short example of improved code that doesn't trigger the lint
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub FOO_FUNCTIONS,
+    pedantic,
+    "function named `foo`, which is not a descriptive name"
+}
+
+declare_lint_pass!(FooFunctions => [FOO_FUNCTIONS]);
+
+impl EarlyLintPass for FooFunctions {
+    fn check_fn(&mut self, cx: &EarlyContext<'_>, fn_kind: FnKind<'_>, span: rustc_span::Span, _: NodeId) {
+        if is_foo_fn(fn_kind) {
+            span_lint_and_help(
+                cx,
+                FOO_FUNCTIONS,
+                span,
+                "function named `foo`",
+                None,
+                "consider using a more meaningful name",
+            );
+        }
+    }
+}
+
+fn is_foo_fn(fn_kind: FnKind<'_>) -> bool {
+    match fn_kind {
+        FnKind::Fn(_, _, Fn { ident, .. }) => ident.name.as_str() == "foo",
+        FnKind::Closure(..) => false,
+    }
+}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -141,6 +141,7 @@ mod fallible_impl_from;
 mod field_scoped_visibility_modifiers;
 mod float_literal;
 mod floating_point_arithmetic;
+mod foo_functions;
 mod format;
 mod format_args;
 mod format_impl;
@@ -545,6 +546,7 @@ rustc_lint::early_lint_methods!(
         EmptyLineAfter: empty_line_after::EmptyLineAfter = empty_line_after::EmptyLineAfter::new(),
         InlineTraitBounds: inline_trait_bounds::InlineTraitBounds = inline_trait_bounds::InlineTraitBounds::default(),
         DefinitionInModuleRoot: definition_in_module_root::DefinitionInModuleRoot = definition_in_module_root::DefinitionInModuleRoot::default(),
+        FooFunctions: foo_functions::FooFunctions = foo_functions::FooFunctions,
         // add early passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/tests/ui/foo_functions.rs
+++ b/tests/ui/foo_functions.rs
@@ -1,0 +1,28 @@
+#![allow(unused)]
+#![warn(clippy::foo_functions)]
+
+struct A;
+impl A {
+    pub fn fo(&self) {}
+    pub fn foo(&self) {}
+    //~^ foo_functions
+    pub fn food(&self) {}
+}
+
+trait B {
+    fn fo(&self) {}
+    fn foo(&self) {}
+    //~^ foo_functions
+    fn food(&self) {}
+}
+
+fn fo() {}
+fn foo() {}
+//~^ foo_functions
+fn food() {}
+
+fn main() {
+    foo();
+    let a = A;
+    a.foo();
+}

--- a/tests/ui/foo_functions.stderr
+++ b/tests/ui/foo_functions.stderr
@@ -1,0 +1,28 @@
+error: function named `foo`
+  --> tests/ui/foo_functions.rs:7:5
+   |
+LL |     pub fn foo(&self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a more meaningful name
+   = note: `-D clippy::foo-functions` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::foo_functions)]`
+
+error: function named `foo`
+  --> tests/ui/foo_functions.rs:14:5
+   |
+LL |     fn foo(&self) {}
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a more meaningful name
+
+error: function named `foo`
+  --> tests/ui/foo_functions.rs:20:1
+   |
+LL | fn foo() {}
+   | ^^^^^^^^^^^
+   |
+   = help: consider using a more meaningful name
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`lint_name`]: your change
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
