### PR TITLE
Fix `invalid_upcast_comparisons` treating non-widening casts as upcasts

### DIFF
--- a/clippy_lints/src/operators/invalid_upcast_comparisons.rs
+++ b/clippy_lints/src/operators/invalid_upcast_comparisons.rs
@@ -2,7 +2,7 @@ use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::LateContext;
 use rustc_middle::ty::layout::LayoutOf as _;
-use rustc_middle::ty::{self, IntTy, UintTy};
+use rustc_middle::ty::{self, IntTy, Ty, UintTy};
 use rustc_span::Span;
 
 use clippy_utils::comparisons;
@@ -36,8 +36,8 @@ fn numeric_cast_precast_bounds(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<
     if let ExprKind::Cast(cast_exp, _) = expr.kind {
         let pre_cast_ty = cx.typeck_results().expr_ty(cast_exp);
         let cast_ty = cx.typeck_results().expr_ty(expr);
-        // if it's a cast from i32 to u32 wrapping will invalidate all these checks
-        if cx.layout_of(pre_cast_ty).ok().map(|l| l.size) == cx.layout_of(cast_ty).ok().map(|l| l.size) {
+        // only a widening cast carries the bounds over unchanged
+        if !is_upcast(cx, pre_cast_ty, cast_ty) {
             return None;
         }
         match pre_cast_ty.kind() {
@@ -62,6 +62,17 @@ fn numeric_cast_precast_bounds(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<
     } else {
         None
     }
+}
+
+fn is_upcast<'tcx>(cx: &LateContext<'tcx>, from: Ty<'tcx>, to: Ty<'tcx>) -> bool {
+    match (from.kind(), to.kind()) {
+        (ty::Int(_) | ty::Uint(_), ty::Int(_)) | (ty::Uint(_), ty::Uint(_)) => {},
+        _ => return false,
+    }
+    let (Ok(from_layout), Ok(to_layout)) = (cx.layout_of(from), cx.layout_of(to)) else {
+        return false;
+    };
+    from_layout.size.bits() < to_layout.size.bits()
 }
 
 fn upcast_comparison_bounds_err<'tcx>(

--- a/tests/ui/invalid_upcast_comparisons.rs
+++ b/tests/ui/invalid_upcast_comparisons.rs
@@ -139,3 +139,13 @@ fn issue15662() {
     (add_one!(x) as u32) > 300;
     //~^ invalid_upcast_comparisons
 }
+
+fn issue7648() {
+    let u64: u64 = mk_value();
+    let u16: u16 = mk_value();
+    let i8: i8 = mk_value();
+
+    (u64 as i32) < 0;
+    (u16 as i8) < 0;
+    (i8 as u64) > 200;
+}


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#7648

`invalid_upcast_comparisons` decides a comparison is always true or false by applying the bounds of the pre-cast type to the cast expression, which only holds while the cast preserves the value. `numeric_cast_precast_bounds` bailed out only when both types had the same size, so a narrowing cast such as `u64 as i32`, or a sign-losing widening one such as `i8 as u64`, kept the source bounds. For `b: u64`, `(b as i32) < 0` was reported as always false, but `u64::MAX as i32` is `-1`.

Also `println!("{}",  128u16 as i8);` -> `-128`, so `(u16 as i8) < 0` is not always `false`.

The bail-out now keeps only casts to a strictly wider integer type whose signedness can represent the whole source range.

changelog: [`invalid_upcast_comparisons`]: don't draw conclusions from a cast that is not a widening cast
