### PR TITLE
fix(multiple_unsafe_ops_per_block): false positive in with taking an reference to a static, but not reading/writing it

### DIFF
--- a/clippy_lints/src/multiple_unsafe_ops_per_block.rs
+++ b/clippy_lints/src/multiple_unsafe_ops_per_block.rs
@@ -126,6 +126,48 @@ impl<'tcx> UnsafeExprCollector<'tcx> {
         unsafe_ops.sort_unstable();
         unsafe_ops
     }
+
+    fn visit_raw_addr_of(&mut self, inner: &'tcx hir::Expr<'tcx>) {
+        let mut base = inner;
+        let mut has_fields = false;
+        while let ExprKind::Field(prefix, _) = base.kind
+            && self.typeck_results.expr_adjustments(prefix).is_empty()
+        {
+            base = prefix;
+            has_fields = true;
+        }
+
+        if has_fields {
+            return self.visit_expr(base);
+        }
+
+        // Direct address-of operations under `&raw` do not read/write the place, so they are safe
+        // for mutable statics and raw pointer dereferences.
+        if let ExprKind::Path(QPath::Resolved(
+            _,
+            hir::Path {
+                res:
+                    Res::Def(
+                        DefKind::Static {
+                            mutability: Mutability::Mut,
+                            ..
+                        },
+                        _,
+                    ),
+                ..
+            },
+        )) = base.kind
+        {
+            return;
+        }
+        if let ExprKind::Unary(UnOp::Deref, ptr_expr) = base.kind
+            && self.typeck_results.expr_ty(ptr_expr).is_raw_ptr()
+        {
+            return self.visit_expr(ptr_expr);
+        }
+
+        self.visit_expr(base);
+    }
 }
 
 impl UnsafeExprCollector<'_> {
@@ -157,13 +199,8 @@ impl<'tcx> Visitor<'tcx> for UnsafeExprCollector<'tcx> {
 
             ExprKind::InlineAsm(_) => self.insert_span(expr.span, "inline assembly used here"),
 
-            ExprKind::AddrOf(BorrowKind::Raw, _, mut inner) => {
-                while let ExprKind::Field(prefix, _) = inner.kind
-                    && self.typeck_results.expr_adjustments(prefix).is_empty()
-                {
-                    inner = prefix;
-                }
-                return self.visit_expr(inner);
+            ExprKind::AddrOf(BorrowKind::Raw, _, inner) => {
+                return self.visit_raw_addr_of(inner);
             },
 
             ExprKind::Field(e, _) if self.typeck_results.expr_ty(e).is_union() => {

--- a/tests/ui/multiple_unsafe_ops_per_block.rs
+++ b/tests/ui/multiple_unsafe_ops_per_block.rs
@@ -445,4 +445,69 @@ fn issue16116() {
     }
 }
 
+fn issue17453() {
+    static mut GLOBAL_INT: u32 = 5;
+
+    // no lint: taking a raw pointer to a mutable static is safe, only not_very_safe is unsafe
+    fn set_global_int() {
+        unsafe {
+            not_very_safe();
+            let _ = &raw mut GLOBAL_INT;
+        }
+    }
+
+    // no lint: taking a raw pointer to a dereferenced raw pointer is safe, only not_very_safe is unsafe
+    fn reborrow_raw(value: *mut u32) {
+        unsafe {
+            not_very_safe();
+            let _ = &raw mut *value;
+        }
+    }
+
+    // lint: two unsaves are:
+    // 1. taking a raw pointer to a **dereferenced** raw pointer with field access
+    // 2. not_very_safe
+    #[derive(Clone, Copy)]
+    struct S {
+        x: u32,
+    }
+    fn reborrow_raw_field(value: *mut S) {
+        unsafe {
+            //~^ multiple_unsafe_ops_per_block
+            not_very_safe();
+            let _ = &raw mut (*value).x;
+        }
+    }
+
+    struct Nested {
+        s: S,
+    }
+
+    // no lint: nested field access on a safe base under &raw is safe, only not_very_safe is unsafe
+    fn safe_nested(mut value: Nested) {
+        unsafe {
+            not_very_safe();
+            let _ = &raw mut value.s.x;
+        }
+    }
+
+    // lint: nested field access on a mutable static under &raw is unsafe, plus not_very_safe
+    static mut GLOBAL_STRUCT: Nested = Nested { s: S { x: 5 } };
+    fn unsafe_nested_static() {
+        unsafe {
+            //~^ multiple_unsafe_ops_per_block
+            not_very_safe();
+            let _ = &raw mut GLOBAL_STRUCT.s.x;
+        }
+    }
+
+    // lint: nested field access on a raw pointer deref under &raw is unsafe, plus not_very_safe
+    fn unsafe_nested_raw(ptr: *mut Nested) {
+        unsafe {
+            //~^ multiple_unsafe_ops_per_block
+            not_very_safe();
+            let _ = &raw mut (*ptr).s.x;
+        }
+    }
+}
 fn main() {}

--- a/tests/ui/multiple_unsafe_ops_per_block.stderr
+++ b/tests/ui/multiple_unsafe_ops_per_block.stderr
@@ -524,5 +524,68 @@ note: unsafe function call occurs here
 LL |         unsafe_with_arg!(foo());
    |                          ^^^^^
 
-error: aborting due to 24 previous errors
+error: this `unsafe` block contains 2 unsafe operations, expected only one
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:475:9
+   |
+LL | /         unsafe {
+LL | |
+LL | |             not_very_safe();
+LL | |             let _ = &raw mut (*value).x;
+LL | |         }
+   | |_________^
+   |
+note: raw pointer dereference occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:478:30
+   |
+LL |             let _ = &raw mut (*value).x;
+   |                              ^^^^^^^^
+note: unsafe function call occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:477:13
+   |
+LL |             not_very_safe();
+   |             ^^^^^^^^^^^^^^^
+
+error: this `unsafe` block contains 2 unsafe operations, expected only one
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:497:9
+   |
+LL | /         unsafe {
+LL | |
+LL | |             not_very_safe();
+LL | |             let _ = &raw mut GLOBAL_STRUCT.s.x;
+LL | |         }
+   | |_________^
+   |
+note: access of a mutable static occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:500:30
+   |
+LL |             let _ = &raw mut GLOBAL_STRUCT.s.x;
+   |                              ^^^^^^^^^^^^^
+note: unsafe function call occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:499:13
+   |
+LL |             not_very_safe();
+   |             ^^^^^^^^^^^^^^^
+
+error: this `unsafe` block contains 2 unsafe operations, expected only one
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:506:9
+   |
+LL | /         unsafe {
+LL | |
+LL | |             not_very_safe();
+LL | |             let _ = &raw mut (*ptr).s.x;
+LL | |         }
+   | |_________^
+   |
+note: raw pointer dereference occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:509:30
+   |
+LL |             let _ = &raw mut (*ptr).s.x;
+   |                              ^^^^^^
+note: unsafe function call occurs here
+  --> tests/ui/multiple_unsafe_ops_per_block.rs:508:13
+   |
+LL |             not_very_safe();
+   |             ^^^^^^^^^^^^^^^
+
+error: aborting due to 27 previous errors
 


### PR DESCRIPTION
Fix rust-lang/rust-clippy#17453

changelog: [`multiple_unsafe_ops_per_block`]: Fix false positive in taking an pointer to an mutable static, but not read/wrtiting it and not field projecting into it

Since I already looked into the other `multiple_unsafe_ops_per_block` issue, I thought it best to tackle this issue as well. It is a bit more complex because of how fields and paths interact, so a custom visiotor seemed appropriate to keep the code readable.

I also think I covered everything with tests as far as I can, so should be an easy review.