### PR TITLE
`type_complexity`: ignore opaque `impl Trait` bounds

### DIFF
--- a/clippy_lints/src/types/type_complexity.rs
+++ b/clippy_lints/src/types/type_complexity.rs
@@ -48,10 +48,6 @@ impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
     }
 
     fn visit_ty(&mut self, ty: &'tcx hir::Ty<'_, AmbigArg>) {
-        // Opaque `impl Trait` types cannot be extracted into type aliases on stable. Skip
-        // their subtree only when `type_alias_impl_trait` is not enabled for this crate.
-        let skip_nested_type = matches!(ty.kind, TyKind::OpaqueDef(..)) && !self.type_alias_impl_trait_enabled;
-
         let (add_score, sub_nest) = match ty.kind {
             // &x and *x have only small overhead; don't mess with nesting level
             TyKind::Ptr(..) | TyKind::Ref(..) => (1, 0),
@@ -82,7 +78,9 @@ impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
         };
         self.score += add_score;
         self.nest += sub_nest;
-        if !skip_nested_type {
+        // Opaque `impl Trait` types cannot be extracted into type aliases on stable. Skip
+        // their subtree only when `type_alias_impl_trait` is not enabled for this crate.
+        if self.type_alias_impl_trait_enabled || !matches!(ty.kind, TyKind::OpaqueDef(..)) {
             walk_ty(self, ty);
         }
         self.nest -= sub_nest;

--- a/clippy_lints/src/types/type_complexity.rs
+++ b/clippy_lints/src/types/type_complexity.rs
@@ -8,13 +8,15 @@ use rustc_span::{Span, sym};
 use super::TYPE_COMPLEXITY;
 
 pub(super) fn check(cx: &LateContext<'_>, ty: &hir::Ty<'_>, type_complexity_threshold: u64) -> bool {
-    let score = type_complexity_score(ty, cx.tcx.features().enabled(sym::type_alias_impl_trait));
+    let type_alias_impl_trait_enabled = cx.tcx.features().enabled(sym::type_alias_impl_trait);
+    let complexity = type_complexity_score(ty, type_alias_impl_trait_enabled);
 
-    if score > type_complexity_threshold {
+    if complexity.score > type_complexity_threshold {
         span_lint(
             cx,
             TYPE_COMPLEXITY,
-            ty.span,
+            stable_opaque_sibling_complexity_span(ty, type_alias_impl_trait_enabled, type_complexity_threshold)
+                .unwrap_or(complexity.span),
             "very complex type used. Consider factoring parts into `type` definitions",
         );
         true
@@ -23,24 +25,54 @@ pub(super) fn check(cx: &LateContext<'_>, ty: &hir::Ty<'_>, type_complexity_thre
     }
 }
 
-fn type_complexity_score(ty: &hir::Ty<'_>, type_alias_impl_trait_enabled: bool) -> u64 {
-    let mut visitor = TypeComplexityVisitor::new(type_alias_impl_trait_enabled);
+fn type_complexity_score(ty: &hir::Ty<'_>, type_alias_impl_trait_enabled: bool) -> Complexity {
+    let mut visitor = TypeComplexityVisitor::new(type_alias_impl_trait_enabled, ty.span);
     visitor.visit_ty_unambig(ty);
     visitor.into_score()
 }
 
-fn ambig_type_complexity_score(ty: &hir::Ty<'_, AmbigArg>, type_alias_impl_trait_enabled: bool) -> u64 {
-    let mut visitor = TypeComplexityVisitor::new(type_alias_impl_trait_enabled);
+fn ambig_type_complexity_score(ty: &hir::Ty<'_, AmbigArg>, type_alias_impl_trait_enabled: bool) -> Complexity {
+    let mut visitor = TypeComplexityVisitor::new(type_alias_impl_trait_enabled, ty.span);
     visitor.visit_ty(ty);
     visitor.into_score()
+}
+
+fn stable_opaque_sibling_complexity_span(
+    ty: &hir::Ty<'_>,
+    type_alias_impl_trait_enabled: bool,
+    type_complexity_threshold: u64,
+) -> Option<Span> {
+    if type_alias_impl_trait_enabled {
+        return None;
+    }
+
+    if let TyKind::Tup(tys) = ty.kind
+        && tys.iter().any(|ty| matches!(ty.kind, TyKind::OpaqueDef(_)))
+    {
+        tys.iter()
+            .filter(|ty| !matches!(ty.kind, TyKind::OpaqueDef(_)))
+            .map(|ty| type_complexity_score(ty, type_alias_impl_trait_enabled))
+            .filter(|complexity| complexity.score > type_complexity_threshold)
+            .max_by_key(|complexity| complexity.score)
+            .map(|complexity| complexity.span)
+    } else {
+        None
+    }
+}
+
+struct Complexity {
+    score: u64,
+    span: Span,
 }
 
 /// Walks a type and assigns a complexity score to it.
 struct TypeComplexityVisitor {
     /// total complexity score of the type
     score: u64,
+    /// span to report if the total complexity score exceeds the threshold
+    span: Span,
     /// highest complexity score found in stable opaque bounds that can be factored out separately
-    max_opaque_bound_score: u64,
+    max_opaque_bound: Option<Complexity>,
     /// current nesting level
     nest: u64,
     /// whether opaque `impl Trait` types can be named through `type_alias_impl_trait`
@@ -48,17 +80,24 @@ struct TypeComplexityVisitor {
 }
 
 impl TypeComplexityVisitor {
-    fn new(type_alias_impl_trait_enabled: bool) -> Self {
+    fn new(type_alias_impl_trait_enabled: bool, span: Span) -> Self {
         Self {
             score: 0,
-            max_opaque_bound_score: 0,
+            span,
+            max_opaque_bound: None,
             nest: 1,
             type_alias_impl_trait_enabled,
         }
     }
 
-    fn into_score(self) -> u64 {
-        self.score.max(self.max_opaque_bound_score)
+    fn into_score(self) -> Complexity {
+        match self.max_opaque_bound {
+            Some(max_opaque_bound) if max_opaque_bound.score > self.score => max_opaque_bound,
+            _ => Complexity {
+                score: self.score,
+                span: self.span,
+            },
+        }
     }
 }
 
@@ -103,13 +142,18 @@ impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
             && !self.type_alias_impl_trait_enabled
         {
             let mut visitor = OpaqueBoundComplexityVisitor {
-                max_score: 0,
+                max_score: Complexity {
+                    score: 0,
+                    span: ty.span,
+                },
                 type_alias_impl_trait_enabled: self.type_alias_impl_trait_enabled,
             };
             for bound in opaque_ty.bounds {
                 visitor.visit_param_bound(bound);
             }
-            self.max_opaque_bound_score = self.max_opaque_bound_score.max(visitor.max_score);
+            if visitor.max_score.score > self.max_opaque_bound.as_ref().map_or(0, |complexity| complexity.score) {
+                self.max_opaque_bound = Some(visitor.max_score);
+            }
         } else {
             walk_ty(self, ty);
         }
@@ -118,15 +162,16 @@ impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
 }
 
 struct OpaqueBoundComplexityVisitor {
-    max_score: u64,
+    max_score: Complexity,
     type_alias_impl_trait_enabled: bool,
 }
 
 impl<'tcx> Visitor<'tcx> for OpaqueBoundComplexityVisitor {
     fn visit_ty(&mut self, ty: &'tcx hir::Ty<'_, AmbigArg>) {
-        self.max_score = self
-            .max_score
-            .max(ambig_type_complexity_score(ty, self.type_alias_impl_trait_enabled));
+        let complexity = ambig_type_complexity_score(ty, self.type_alias_impl_trait_enabled);
+        if complexity.score > self.max_score.score {
+            self.max_score = complexity;
+        }
         walk_ty(self, ty);
     }
 }

--- a/clippy_lints/src/types/type_complexity.rs
+++ b/clippy_lints/src/types/type_complexity.rs
@@ -3,13 +3,17 @@ use rustc_abi::ExternAbi;
 use rustc_hir::intravisit::{InferKind, Visitor, VisitorExt as _, walk_ty};
 use rustc_hir::{self as hir, AmbigArg, GenericParamKind, TyKind};
 use rustc_lint::LateContext;
-use rustc_span::Span;
+use rustc_span::{Span, sym};
 
 use super::TYPE_COMPLEXITY;
 
 pub(super) fn check(cx: &LateContext<'_>, ty: &hir::Ty<'_>, type_complexity_threshold: u64) -> bool {
     let score = {
-        let mut visitor = TypeComplexityVisitor { score: 0, nest: 1 };
+        let mut visitor = TypeComplexityVisitor {
+            score: 0,
+            nest: 1,
+            type_alias_impl_trait_enabled: cx.tcx.features().enabled(sym::type_alias_impl_trait),
+        };
         visitor.visit_ty_unambig(ty);
         visitor.score
     };
@@ -33,6 +37,8 @@ struct TypeComplexityVisitor {
     score: u64,
     /// current nesting level
     nest: u64,
+    /// whether opaque `impl Trait` types can be named through `type_alias_impl_trait`
+    type_alias_impl_trait_enabled: bool,
 }
 
 impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
@@ -42,11 +48,10 @@ impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
     }
 
     fn visit_ty(&mut self, ty: &'tcx hir::Ty<'_, AmbigArg>) {
-        // Opaque types cannot be extracted into type aliases on stable. Ignore their
-        // bounds, but keep scoring surrounding type components that can be extracted.
-        if matches!(ty.kind, TyKind::OpaqueDef(..)) {
-            return;
-        }
+        // Opaque `impl Trait` types cannot be extracted into type aliases on stable. Skip
+        // their subtree only when `type_alias_impl_trait` is not enabled for this crate.
+        let skip_nested_type = matches!(ty.kind, TyKind::OpaqueDef(..)) && !self.type_alias_impl_trait_enabled;
+
         let (add_score, sub_nest) = match ty.kind {
             // &x and *x have only small overhead; don't mess with nesting level
             TyKind::Ptr(..) | TyKind::Ref(..) => (1, 0),
@@ -77,7 +82,9 @@ impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
         };
         self.score += add_score;
         self.nest += sub_nest;
-        walk_ty(self, ty);
+        if !skip_nested_type {
+            walk_ty(self, ty);
+        }
         self.nest -= sub_nest;
     }
 }

--- a/clippy_lints/src/types/type_complexity.rs
+++ b/clippy_lints/src/types/type_complexity.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint;
 use rustc_abi::ExternAbi;
-use rustc_hir::intravisit::{InferKind, Visitor, VisitorExt as _, walk_ty};
+use rustc_hir::intravisit::{InferKind, Visitor, VisitorExt as _, walk_generic_args, walk_ty};
 use rustc_hir::{self as hir, AmbigArg, GenericParamKind, TyKind};
 use rustc_lint::LateContext;
 use rustc_span::{Span, sym};
@@ -173,5 +173,16 @@ impl<'tcx> Visitor<'tcx> for OpaqueBoundComplexityVisitor {
             self.max_score = complexity;
         }
         walk_ty(self, ty);
+    }
+
+    fn visit_generic_args(&mut self, generic_args: &'tcx hir::GenericArgs<'tcx>) {
+        if let Some((inputs, output)) = generic_args.paren_sugar_inputs_output() {
+            for input in inputs {
+                self.visit_ty_unambig(input);
+            }
+            self.visit_ty_unambig(output);
+        } else {
+            walk_generic_args(self, generic_args);
+        }
     }
 }

--- a/clippy_lints/src/types/type_complexity.rs
+++ b/clippy_lints/src/types/type_complexity.rs
@@ -42,6 +42,11 @@ impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
     }
 
     fn visit_ty(&mut self, ty: &'tcx hir::Ty<'_, AmbigArg>) {
+        // Opaque types cannot be extracted into type aliases on stable. Ignore their
+        // bounds, but keep scoring surrounding type components that can be extracted.
+        if matches!(ty.kind, TyKind::OpaqueDef(..)) {
+            return;
+        }
         let (add_score, sub_nest) = match ty.kind {
             // &x and *x have only small overhead; don't mess with nesting level
             TyKind::Ptr(..) | TyKind::Ref(..) => (1, 0),

--- a/clippy_lints/src/types/type_complexity.rs
+++ b/clippy_lints/src/types/type_complexity.rs
@@ -8,15 +8,7 @@ use rustc_span::{Span, sym};
 use super::TYPE_COMPLEXITY;
 
 pub(super) fn check(cx: &LateContext<'_>, ty: &hir::Ty<'_>, type_complexity_threshold: u64) -> bool {
-    let score = {
-        let mut visitor = TypeComplexityVisitor {
-            score: 0,
-            nest: 1,
-            type_alias_impl_trait_enabled: cx.tcx.features().enabled(sym::type_alias_impl_trait),
-        };
-        visitor.visit_ty_unambig(ty);
-        visitor.score
-    };
+    let score = type_complexity_score(ty, cx.tcx.features().enabled(sym::type_alias_impl_trait));
 
     if score > type_complexity_threshold {
         span_lint(
@@ -31,14 +23,43 @@ pub(super) fn check(cx: &LateContext<'_>, ty: &hir::Ty<'_>, type_complexity_thre
     }
 }
 
+fn type_complexity_score(ty: &hir::Ty<'_>, type_alias_impl_trait_enabled: bool) -> u64 {
+    let mut visitor = TypeComplexityVisitor::new(type_alias_impl_trait_enabled);
+    visitor.visit_ty_unambig(ty);
+    visitor.into_score()
+}
+
+fn ambig_type_complexity_score(ty: &hir::Ty<'_, AmbigArg>, type_alias_impl_trait_enabled: bool) -> u64 {
+    let mut visitor = TypeComplexityVisitor::new(type_alias_impl_trait_enabled);
+    visitor.visit_ty(ty);
+    visitor.into_score()
+}
+
 /// Walks a type and assigns a complexity score to it.
 struct TypeComplexityVisitor {
     /// total complexity score of the type
     score: u64,
+    /// highest complexity score found in stable opaque bounds that can be factored out separately
+    max_opaque_bound_score: u64,
     /// current nesting level
     nest: u64,
     /// whether opaque `impl Trait` types can be named through `type_alias_impl_trait`
     type_alias_impl_trait_enabled: bool,
+}
+
+impl TypeComplexityVisitor {
+    fn new(type_alias_impl_trait_enabled: bool) -> Self {
+        Self {
+            score: 0,
+            max_opaque_bound_score: 0,
+            nest: 1,
+            type_alias_impl_trait_enabled,
+        }
+    }
+
+    fn into_score(self) -> u64 {
+        self.score.max(self.max_opaque_bound_score)
+    }
 }
 
 impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
@@ -78,11 +99,34 @@ impl<'tcx> Visitor<'tcx> for TypeComplexityVisitor {
         };
         self.score += add_score;
         self.nest += sub_nest;
-        // Opaque `impl Trait` types cannot be extracted into type aliases on stable. Skip
-        // their subtree only when `type_alias_impl_trait` is not enabled for this crate.
-        if self.type_alias_impl_trait_enabled || !matches!(ty.kind, TyKind::OpaqueDef(..)) {
+        if let TyKind::OpaqueDef(opaque_ty) = ty.kind
+            && !self.type_alias_impl_trait_enabled
+        {
+            let mut visitor = OpaqueBoundComplexityVisitor {
+                max_score: 0,
+                type_alias_impl_trait_enabled: self.type_alias_impl_trait_enabled,
+            };
+            for bound in opaque_ty.bounds {
+                visitor.visit_param_bound(bound);
+            }
+            self.max_opaque_bound_score = self.max_opaque_bound_score.max(visitor.max_score);
+        } else {
             walk_ty(self, ty);
         }
         self.nest -= sub_nest;
+    }
+}
+
+struct OpaqueBoundComplexityVisitor {
+    max_score: u64,
+    type_alias_impl_trait_enabled: bool,
+}
+
+impl<'tcx> Visitor<'tcx> for OpaqueBoundComplexityVisitor {
+    fn visit_ty(&mut self, ty: &'tcx hir::Ty<'_, AmbigArg>) {
+        self.max_score = self
+            .max_score
+            .max(ambig_type_complexity_score(ty, self.type_alias_impl_trait_enabled));
+        walk_ty(self, ty);
     }
 }

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -98,15 +98,10 @@ where
     left.into_iter().zip(right).map(<[I::Item; 2]>::from)
 }
 
-// Complexity inside an opaque type cannot be factored into a type alias either.
-fn complex_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
-    |_| {}
-}
-
 // The presence of an opaque type must not hide complexity in a sibling type that can be factored
 // out.
 fn complex_after_opaque() -> (impl Iterator<Item = u32>, Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
-    //~^ ERROR: very complex type used. Consider factoring parts into `type` definitions
+    //~^ type_complexity
     (std::iter::empty(), vec![])
 }
 

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -86,8 +86,6 @@ struct D {
     ),
 }
 
-fn main() {}
-
 // Should not warn, because factoring `impl Trait` into a type alias is not stable (#17195).
 fn issue_17195<I, J>(
     left: I,
@@ -107,7 +105,9 @@ fn complex_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
 
 // The presence of an opaque type must not hide complexity in a sibling type that can be factored
 // out.
-#[expect(clippy::type_complexity)]
 fn complex_after_opaque() -> (impl Iterator<Item = u32>, Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
+    //~^ ERROR: very complex type used. Consider factoring parts into `type` definitions
     (std::iter::empty(), vec![])
 }
+
+fn main() {}

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -87,3 +87,27 @@ struct D {
 }
 
 fn main() {}
+
+// Should not warn, because factoring `impl Trait` into a type alias is not stable (#17195).
+fn issue_17195<I, J>(
+    left: I,
+    right: J,
+) -> std::iter::Map<std::iter::Zip<I::IntoIter, J::IntoIter>, impl FnMut((I::Item, I::Item)) -> [I::Item; 2]>
+where
+    I: IntoIterator,
+    J: IntoIterator<Item = I::Item>,
+{
+    left.into_iter().zip(right).map(<[I::Item; 2]>::from)
+}
+
+// Complexity inside an opaque type cannot be factored into a type alias either.
+fn complex_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
+    |_| {}
+}
+
+// The presence of an opaque type must not hide complexity in a sibling type that can be factored
+// out.
+#[expect(clippy::type_complexity)]
+fn complex_after_opaque() -> (impl Iterator<Item = u32>, Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
+    (std::iter::empty(), vec![])
+}

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -90,7 +90,7 @@ struct MarkerBounds;
 trait MarkerBound<T> {}
 impl<T> MarkerBound<T> for MarkerBounds {}
 
-// Should not warn, because no individual type argument inside the opaque bounds is complex.
+// Should not warn, because extracting impl trait bounds to where is not currently stable.
 fn many_simple_opaque_bound_type_arguments() -> impl MarkerBound<[u8; 0]>
 + MarkerBound<[u8; 1]>
 + MarkerBound<[u8; 2]>

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -86,6 +86,23 @@ struct D {
     ),
 }
 
+struct MarkerBounds;
+trait MarkerBound<T> {}
+impl<T> MarkerBound<T> for MarkerBounds {}
+
+// Should not warn, because no individual type argument inside the opaque bounds is complex.
+fn many_simple_opaque_bound_type_arguments() -> impl MarkerBound<[u8; 0]>
+    + MarkerBound<[u8; 1]>
+    + MarkerBound<[u8; 2]>
+    + MarkerBound<[u8; 3]>
+    + MarkerBound<[u8; 4]>
+    + MarkerBound<[u8; 5]>
+    + MarkerBound<[u8; 6]>
+    + MarkerBound<[u8; 7]>
+    + MarkerBound<[u8; 8]> {
+    MarkerBounds
+}
+
 // Should not warn, because factoring `impl Trait` into a type alias is not stable (#17195).
 fn issue_17195<I, J>(
     left: I,
@@ -96,6 +113,12 @@ where
     J: IntoIterator<Item = I::Item>,
 {
     left.into_iter().zip(right).map(<[I::Item; 2]>::from)
+}
+
+// Complexity inside an opaque bound can still be factored out on stable.
+fn complex_aliasable_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
+    //~^ type_complexity
+    |_| {}
 }
 
 // The presence of an opaque type must not hide complexity in a sibling type that can be factored

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -92,14 +92,14 @@ impl<T> MarkerBound<T> for MarkerBounds {}
 
 // Should not warn, because no individual type argument inside the opaque bounds is complex.
 fn many_simple_opaque_bound_type_arguments() -> impl MarkerBound<[u8; 0]>
-    + MarkerBound<[u8; 1]>
-    + MarkerBound<[u8; 2]>
-    + MarkerBound<[u8; 3]>
-    + MarkerBound<[u8; 4]>
-    + MarkerBound<[u8; 5]>
-    + MarkerBound<[u8; 6]>
-    + MarkerBound<[u8; 7]>
-    + MarkerBound<[u8; 8]> {
++ MarkerBound<[u8; 1]>
++ MarkerBound<[u8; 2]>
++ MarkerBound<[u8; 3]>
++ MarkerBound<[u8; 4]>
++ MarkerBound<[u8; 5]>
++ MarkerBound<[u8; 6]>
++ MarkerBound<[u8; 7]>
++ MarkerBound<[u8; 8]> {
     MarkerBounds
 }
 

--- a/tests/ui/type_complexity.stderr
+++ b/tests/ui/type_complexity.stderr
@@ -91,5 +91,11 @@ error: very complex type used. Consider factoring parts into `type` definitions
 LL |     let _y: Vec<Vec<Box<(u32, u32, u32, u32)>>> = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 15 previous errors
+error: very complex type used. Consider factoring parts into `type` definitions
+  --> tests/ui/type_complexity.rs:108:30
+   |
+LL | fn complex_after_opaque() -> (impl Iterator<Item = u32>, Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 16 previous errors
 

--- a/tests/ui/type_complexity.stderr
+++ b/tests/ui/type_complexity.stderr
@@ -92,16 +92,16 @@ LL |     let _y: Vec<Vec<Box<(u32, u32, u32, u32)>>> = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:119:40
+  --> tests/ui/type_complexity.rs:119:47
    |
 LL | fn complex_aliasable_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:126:30
+  --> tests/ui/type_complexity.rs:126:58
    |
 LL | fn complex_after_opaque() -> (impl Iterator<Item = u32>, Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 17 previous errors
 

--- a/tests/ui/type_complexity.stderr
+++ b/tests/ui/type_complexity.stderr
@@ -92,10 +92,10 @@ LL |     let _y: Vec<Vec<Box<(u32, u32, u32, u32)>>> = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:119:47
+  --> tests/ui/type_complexity.rs:119:48
    |
 LL | fn complex_aliasable_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
   --> tests/ui/type_complexity.rs:126:58

--- a/tests/ui/type_complexity.stderr
+++ b/tests/ui/type_complexity.stderr
@@ -92,10 +92,16 @@ LL |     let _y: Vec<Vec<Box<(u32, u32, u32, u32)>>> = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:103:30
+  --> tests/ui/type_complexity.rs:119:40
+   |
+LL | fn complex_aliasable_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: very complex type used. Consider factoring parts into `type` definitions
+  --> tests/ui/type_complexity.rs:126:30
    |
 LL | fn complex_after_opaque() -> (impl Iterator<Item = u32>, Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 16 previous errors
+error: aborting due to 17 previous errors
 

--- a/tests/ui/type_complexity.stderr
+++ b/tests/ui/type_complexity.stderr
@@ -92,7 +92,7 @@ LL |     let _y: Vec<Vec<Box<(u32, u32, u32, u32)>>> = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:108:30
+  --> tests/ui/type_complexity.rs:103:30
    |
 LL | fn complex_after_opaque() -> (impl Iterator<Item = u32>, Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/type_complexity_type_alias_impl_trait.rs
+++ b/tests/ui/type_complexity_type_alias_impl_trait.rs
@@ -1,9 +1,21 @@
 #![feature(type_alias_impl_trait)]
 #![warn(clippy::type_complexity)]
 
-fn complex_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
-    //~^ type_complexity
-    |_| {}
+struct MarkerBounds;
+trait MarkerBound<T> {}
+impl<T> MarkerBound<T> for MarkerBounds {}
+
+fn many_simple_opaque_bound_type_arguments() -> impl MarkerBound<[u8; 0]>
+//~^ type_complexity
++ MarkerBound<[u8; 1]>
++ MarkerBound<[u8; 2]>
++ MarkerBound<[u8; 3]>
++ MarkerBound<[u8; 4]>
++ MarkerBound<[u8; 5]>
++ MarkerBound<[u8; 6]>
++ MarkerBound<[u8; 7]>
++ MarkerBound<[u8; 8]> {
+    MarkerBounds
 }
 
 fn main() {}

--- a/tests/ui/type_complexity_type_alias_impl_trait.rs
+++ b/tests/ui/type_complexity_type_alias_impl_trait.rs
@@ -1,0 +1,9 @@
+#![feature(type_alias_impl_trait)]
+#![warn(clippy::type_complexity)]
+
+fn complex_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
+    //~^ ERROR: very complex type used. Consider factoring parts into `type` definitions
+    |_| {}
+}
+
+fn main() {}

--- a/tests/ui/type_complexity_type_alias_impl_trait.rs
+++ b/tests/ui/type_complexity_type_alias_impl_trait.rs
@@ -2,7 +2,7 @@
 #![warn(clippy::type_complexity)]
 
 fn complex_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
-    //~^ ERROR: very complex type used. Consider factoring parts into `type` definitions
+    //~^ type_complexity
     |_| {}
 }
 

--- a/tests/ui/type_complexity_type_alias_impl_trait.stderr
+++ b/tests/ui/type_complexity_type_alias_impl_trait.stderr
@@ -1,8 +1,15 @@
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity_type_alias_impl_trait.rs:4:30
+  --> tests/ui/type_complexity_type_alias_impl_trait.rs:8:49
    |
-LL | fn complex_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |   fn many_simple_opaque_bound_type_arguments() -> impl MarkerBound<[u8; 0]>
+   |  _________________________________________________^
+LL | |
+LL | | + MarkerBound<[u8; 1]>
+LL | | + MarkerBound<[u8; 2]>
+...  |
+LL | | + MarkerBound<[u8; 7]>
+LL | | + MarkerBound<[u8; 8]> {
+   | |______________________^
    |
    = note: `-D clippy::type-complexity` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::type_complexity)]`

--- a/tests/ui/type_complexity_type_alias_impl_trait.stderr
+++ b/tests/ui/type_complexity_type_alias_impl_trait.stderr
@@ -1,0 +1,11 @@
+error: very complex type used. Consider factoring parts into `type` definitions
+  --> tests/ui/type_complexity_type_alias_impl_trait.rs:4:30
+   |
+LL | fn complex_opaque_bound() -> impl Fn(Vec<Vec<Box<(u32, u32, u32, u32)>>>) {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::type-complexity` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::type_complexity)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
changelog: [`type_complexity`]: avoid false positives for types containing opaque `impl Trait` bounds

fixes rust-lang/rust-clippy#17195

Opaque `impl Trait` bounds cannot be extracted into a stable type alias, so counting their internal structure can produce a warning with no usable refactoring. This change stops complexity scoring inside an opaque type while continuing to score surrounding containers and independently nameable sibling types.

The UI coverage includes the nested `impl FnMut` reproducer, a complex bound wholly inside an opaque return type, and an opaque-first tuple whose separate complex sibling must still trigger the lint.

Tested with:

- `TESTNAME=type_complexity cargo uitest` — both matching UI suites passed
- `cargo fmt --all --check`
