### PR TITLE
add relative import paths lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7389,6 +7389,7 @@ Released 2018-09-13
 [`ref_patterns`]: https://rust-lang.github.io/rust-clippy/master/index.html#ref_patterns
 [`regex_creation_in_loops`]: https://rust-lang.github.io/rust-clippy/master/index.html#regex_creation_in_loops
 [`regex_macro`]: https://rust-lang.github.io/rust-clippy/master/index.html#regex_macro
+[`relative_paths`]: https://rust-lang.github.io/rust-clippy/master/index.html#relative_paths
 [`renamed_function_params`]: https://rust-lang.github.io/rust-clippy/master/index.html#renamed_function_params
 [`repeat_once`]: https://rust-lang.github.io/rust-clippy/master/index.html#repeat_once
 [`repeat_vec_with_capacity`]: https://rust-lang.github.io/rust-clippy/master/index.html#repeat_vec_with_capacity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7515,6 +7515,7 @@ Released 2018-09-13
 [`ref_patterns`]: https://rust-lang.github.io/rust-clippy/main/index.html#ref_patterns
 [`regex_creation_in_loops`]: https://rust-lang.github.io/rust-clippy/main/index.html#regex_creation_in_loops
 [`regex_macro`]: https://rust-lang.github.io/rust-clippy/main/index.html#regex_macro
+[`relative_paths`]: https://rust-lang.github.io/rust-clippy/main/index.html#relative_paths
 [`renamed_function_params`]: https://rust-lang.github.io/rust-clippy/main/index.html#renamed_function_params
 [`repeat_once`]: https://rust-lang.github.io/rust-clippy/main/index.html#repeat_once
 [`repeat_vec_with_capacity`]: https://rust-lang.github.io/rust-clippy/main/index.html#repeat_vec_with_capacity

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -687,6 +687,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::regex::INVALID_REGEX_INFO,
     crate::regex::REGEX_CREATION_IN_LOOPS_INFO,
     crate::regex::TRIVIAL_REGEX_INFO,
+    crate::relative_paths::RELATIVE_PATHS_INFO,
     crate::repeat_vec_with_capacity::REPEAT_VEC_WITH_CAPACITY_INFO,
     crate::replace_box::REPLACE_BOX_INFO,
     crate::reserve_after_initialization::RESERVE_AFTER_INITIALIZATION_INFO,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -684,6 +684,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::regex::INVALID_REGEX_INFO,
     crate::regex::REGEX_CREATION_IN_LOOPS_INFO,
     crate::regex::TRIVIAL_REGEX_INFO,
+    crate::relative_paths::RELATIVE_PATHS_INFO,
     crate::repeat_vec_with_capacity::REPEAT_VEC_WITH_CAPACITY_INFO,
     crate::replace_box::REPLACE_BOX_INFO,
     crate::reserve_after_initialization::RESERVE_AFTER_INITIALIZATION_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -326,6 +326,7 @@ mod ref_option_ref;
 mod ref_patterns;
 mod reference;
 mod regex;
+mod relative_paths;
 mod repeat_vec_with_capacity;
 mod replace_box;
 mod reserve_after_initialization;
@@ -870,6 +871,7 @@ rustc_lint::late_lint_methods!(
         RestWhenDestructuringStruct: rest_when_destructuring_struct::RestWhenDestructuringStruct = rest_when_destructuring_struct::RestWhenDestructuringStruct,
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
+        RelativePaths: relative_paths::RelativePaths = relative_paths::RelativePaths,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -325,6 +325,7 @@ mod ref_option_ref;
 mod ref_patterns;
 mod reference;
 mod regex;
+mod relative_paths;
 mod repeat_vec_with_capacity;
 mod replace_box;
 mod reserve_after_initialization;
@@ -806,6 +807,7 @@ rustc_lint::late_lint_methods!(
         FourForwardSlashes: four_forward_slashes::FourForwardSlashes = four_forward_slashes::FourForwardSlashes,
         ErrorImplError: error_impl_error::ErrorImplError = error_impl_error::ErrorImplError,
         AbsolutePaths: absolute_paths::AbsolutePaths = absolute_paths::AbsolutePaths::new(conf),
+        RelativePaths: relative_paths::RelativePaths = relative_paths::RelativePaths,
         RedundantLocals: redundant_locals::RedundantLocals = redundant_locals::RedundantLocals,
         IgnoredUnitPatterns: ignored_unit_patterns::IgnoredUnitPatterns = ignored_unit_patterns::IgnoredUnitPatterns,
         ReserveAfterInitialization: reserve_after_initialization::ReserveAfterInitialization = <reserve_after_initialization::ReserveAfterInitialization>::default(),

--- a/clippy_lints/src/relative_paths.rs
+++ b/clippy_lints/src/relative_paths.rs
@@ -1,0 +1,93 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_in_cfg_test;
+use rustc_errors::Applicability;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::{HirId, Path};
+use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
+use rustc_span::kw;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for paths written using `super`, `self,` or module names declared in the current module, instead
+    /// requiring that all imports are absolute via `crate`.
+    ///
+    /// Does not apply to `super::*` in test modules.
+    ///
+    /// ### Why restrict this?
+    ///
+    /// Enforces that items in the local crate are imported using a consistent style (always prefixed by `crate`).
+    /// Formatting tools can utilize this style to keep standard library, external, and local imports in separate
+    /// groups.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// pub mod foo {
+    ///     pub struct Bar;
+    /// }
+    ///
+    /// use foo::Bar;
+    /// # fn main() {}
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// pub mod foo {
+    ///     pub struct Bar;
+    /// }
+    ///
+    /// use crate::foo::Bar;
+    /// # fn main() {}
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub RELATIVE_PATHS,
+    restriction,
+    "checks for usage of relative module paths"
+}
+
+declare_lint_pass!(RelativePaths => [RELATIVE_PATHS]);
+
+impl LateLintPass<'_> for RelativePaths {
+    fn check_path(&mut self, cx: &LateContext<'_>, path: &Path<'_>, hir_id: HirId) {
+        let Res::Def(kind, def_id) = path.res else { return };
+
+        // Paths outside of the current crate are always absolute.
+        if !def_id.is_local() {
+            return;
+        }
+
+        // Only lint inside imports.
+        if let DefKind::Use = cx.tcx.def_kind(hir_id.owner) {
+            // Avoid double-reporting of struct constructor imports.
+            if let DefKind::Ctor(..) = kind {
+                return;
+            }
+
+            let is_relative = path.segments.first().is_some_and(|segment| {
+                let is_self = segment.ident.name == kw::SelfLower;
+                let is_super = segment.ident.name == kw::Super && !is_in_cfg_test(cx.tcx, hir_id);
+
+                let is_local_mod = if let Some(segment_def_id) = segment.res.opt_def_id() {
+                    segment_def_id.is_local() && !segment_def_id.is_crate_root()
+                } else {
+                    false
+                };
+
+                is_self || is_super || is_local_mod
+            });
+
+            if is_relative && cx.tcx.visibility(def_id).is_public() {
+                let suggestion = format!("crate::{}", cx.tcx.def_path_str(def_id));
+
+                span_lint_and_sugg(
+                    cx,
+                    RELATIVE_PATHS,
+                    path.span,
+                    "relative paths are restricted",
+                    "use an absolute path",
+                    suggestion,
+                    Applicability::MachineApplicable,
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/relative_paths.rs
+++ b/clippy_lints/src/relative_paths.rs
@@ -1,0 +1,94 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_in_cfg_test;
+use rustc_errors::Applicability;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::{HirId, Path};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+use rustc_span::kw;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for paths written using `super`, `self,` or module names declared in the current module, instead
+    /// requiring that all imports are absolute via `crate`.
+    ///
+    /// Does not apply to `super::*` in test modules.
+    ///
+    /// ### Why restrict this?
+    ///
+    /// Enforces that items in the local crate are imported using a consistent style (always prefixed by `crate`).
+    /// Formatting tools can utilize this style to keep standard library, external, and local imports in separate
+    /// groups.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// pub mod foo {
+    ///     pub struct Bar;
+    /// }
+    ///
+    /// use foo::Bar;
+    /// # fn main() {}
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// pub mod foo {
+    ///     pub struct Bar;
+    /// }
+    ///
+    /// use crate::foo::Bar;
+    /// # fn main() {}
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub RELATIVE_PATHS,
+    restriction,
+    "checks for usage of relative module paths"
+}
+
+declare_lint_pass!(RelativePaths => [RELATIVE_PATHS]);
+
+impl LateLintPass<'_> for RelativePaths {
+    fn check_path(&mut self, cx: &LateContext<'_>, path: &Path<'_>, hir_id: HirId) {
+        let Res::Def(kind, def_id) = path.res else { return };
+
+        // Paths outside of the current crate are always absolute.
+        if !def_id.is_local() {
+            return;
+        }
+
+        // Only lint inside imports.
+        if let DefKind::Use = cx.tcx.def_kind(hir_id.owner) {
+            // Avoid double-reporting of struct constructor imports.
+            if let DefKind::Ctor(..) = kind {
+                return;
+            }
+
+            let is_relative = path.segments.first().is_some_and(|segment| {
+                let is_self = segment.ident.name == kw::SelfLower;
+                let is_super = segment.ident.name == kw::Super && !is_in_cfg_test(cx.tcx, hir_id);
+
+                let is_local_mod = if let Some(segment_def_id) = segment.res.opt_def_id() {
+                    segment_def_id.is_local() && !segment_def_id.is_crate_root()
+                } else {
+                    false
+                };
+
+                is_self || is_super || is_local_mod
+            });
+
+            if is_relative && cx.tcx.visibility(def_id).is_public() {
+                let suggestion = format!("crate::{}", cx.tcx.def_path_str(def_id));
+
+                span_lint_and_sugg(
+                    cx,
+                    RELATIVE_PATHS,
+                    path.span,
+                    "relative paths are restricted",
+                    "use an absolute path",
+                    suggestion,
+                    Applicability::MachineApplicable,
+                );
+            }
+        }
+    }
+}

--- a/tests/ui/relative_paths.fixed
+++ b/tests/ui/relative_paths.fixed
@@ -1,0 +1,49 @@
+#![warn(clippy::relative_paths)]
+
+pub mod foo {
+    pub struct Foo;
+
+    pub mod bar {
+        pub struct Bar;
+
+        pub use crate::foo::baz::Baz;
+        //~^ relative_paths
+    }
+
+    pub use crate::foo::bar::Bar;
+    //~^ relative_paths
+
+    pub mod baz {
+        pub struct Baz;
+    }
+
+    mod inner {
+        pub mod child_a {
+            pub(super) struct Quux;
+        }
+
+        pub mod child_b {
+            use super::child_a::Quux; // OK, not accessible from the root
+        }
+    }
+}
+
+use crate::foo::bar::Baz;
+use crate::foo::bar::Bar;
+//~^ relative_paths
+
+fn main() {
+    let _: crate::foo::Foo = foo::Foo;
+    let _: foo::Foo = crate::foo::Foo;
+    let _: Baz = Baz;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*; // OK, common test idiom
+
+    #[test]
+    fn baz() {
+        let _ = Baz;
+    }
+}

--- a/tests/ui/relative_paths.rs
+++ b/tests/ui/relative_paths.rs
@@ -1,0 +1,49 @@
+#![warn(clippy::relative_paths)]
+
+pub mod foo {
+    pub struct Foo;
+
+    pub mod bar {
+        pub struct Bar;
+
+        pub use super::baz::Baz;
+        //~^ relative_paths
+    }
+
+    pub use self::bar::Bar;
+    //~^ relative_paths
+
+    pub mod baz {
+        pub struct Baz;
+    }
+
+    mod inner {
+        pub mod child_a {
+            pub(super) struct Quux;
+        }
+
+        pub mod child_b {
+            use super::child_a::Quux; // OK, not accessible from the root
+        }
+    }
+}
+
+use crate::foo::bar::Baz;
+use foo::bar::Bar;
+//~^ relative_paths
+
+fn main() {
+    let _: crate::foo::Foo = foo::Foo;
+    let _: foo::Foo = crate::foo::Foo;
+    let _: Baz = Baz;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*; // OK, common test idiom
+
+    #[test]
+    fn baz() {
+        let _ = Baz;
+    }
+}

--- a/tests/ui/relative_paths.stderr
+++ b/tests/ui/relative_paths.stderr
@@ -1,0 +1,23 @@
+error: relative paths are restricted
+  --> tests/ui/relative_paths.rs:9:17
+   |
+LL |         pub use super::baz::Baz;
+   |                 ^^^^^^^^^^^^^^^ help: use an absolute path: `crate::foo::baz::Baz`
+   |
+   = note: `-D clippy::relative-paths` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::relative_paths)]`
+
+error: relative paths are restricted
+  --> tests/ui/relative_paths.rs:13:13
+   |
+LL |     pub use self::bar::Bar;
+   |             ^^^^^^^^^^^^^^ help: use an absolute path: `crate::foo::bar::Bar`
+
+error: relative paths are restricted
+  --> tests/ui/relative_paths.rs:32:5
+   |
+LL | use foo::bar::Bar;
+   |     ^^^^^^^^^^^^^ help: use an absolute path: `crate::foo::bar::Bar`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#14605.
Fixes rust-lang/rust-clippy#12796.

I think this lint could theoretically be expanded to check for paths not inside imports, but the logic gets a bit complicated in that case.

changelog: [`relative_paths`]: create lint
