### PR TITLE
Add `option_zip_none` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7310,6 +7310,7 @@ Released 2018-09-13
 [`option_map_unwrap_or_else`]: https://rust-lang.github.io/rust-clippy/main/index.html#option_map_unwrap_or_else
 [`option_option`]: https://rust-lang.github.io/rust-clippy/main/index.html#option_option
 [`option_unwrap_used`]: https://rust-lang.github.io/rust-clippy/main/index.html#option_unwrap_used
+[`option_zip_none`]: https://rust-lang.github.io/rust-clippy/main/index.html#option_zip_none
 [`or_fun_call`]: https://rust-lang.github.io/rust-clippy/main/index.html#or_fun_call
 [`or_then_unwrap`]: https://rust-lang.github.io/rust-clippy/main/index.html#or_then_unwrap
 [`out_of_bounds_indexing`]: https://rust-lang.github.io/rust-clippy/main/index.html#out_of_bounds_indexing

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -462,6 +462,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::OPTION_AS_REF_DEREF_INFO,
     crate::methods::OPTION_FILTER_MAP_INFO,
     crate::methods::OPTION_MAP_OR_NONE_INFO,
+    crate::methods::OPTION_ZIP_NONE_INFO,
     crate::methods::OR_FUN_CALL_INFO,
     crate::methods::OR_THEN_UNWRAP_INFO,
     crate::methods::PATH_BUF_PUSH_OVERWRITE_INFO,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -94,6 +94,7 @@ mod open_options;
 mod option_as_ref_cloned;
 mod option_as_ref_deref;
 mod option_map_or_none;
+mod option_zip_none;
 mod or_fun_call;
 mod or_then_unwrap;
 mod path_buf_push_overwrite;
@@ -2981,6 +2982,28 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for calls of the form `Option::zip(_, None)` or `Option::zip(None, _)`.
+    ///
+    /// ### Why is this bad?
+    /// `Option::zip` with `None` always returns `None`.
+    ///
+    /// ### Example
+    /// ```ignore
+    /// let foo = Some(5);
+    /// foo.zip(None);
+    /// ```
+    /// Use instead:
+    /// ```ignore
+    /// None
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub OPTION_ZIP_NONE,
+    suspicious,
+    "calling `.zip(None)` on an `Option` always returns `None`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for calls to `.or(foo(..))`, `.unwrap_or(foo(..))`,
     /// `.or_insert(foo(..))` etc., and suggests to use `.or_else(|| foo(..))`,
     /// `.unwrap_or_else(|| foo(..))`, `.unwrap_or_default()` or `.or_default()`
@@ -5019,6 +5042,7 @@ impl_lint_pass!(Methods => [
     OPTION_AS_REF_DEREF,
     OPTION_FILTER_MAP,
     OPTION_MAP_OR_NONE,
+    OPTION_ZIP_NONE,
     OR_FUN_CALL,
     OR_THEN_UNWRAP,
     PATH_BUF_PUSH_OVERWRITE,
@@ -5173,6 +5197,7 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
                     &self.unwrap_allowed_ids,
                     &self.unwrap_allowed_aliases,
                 );
+                option_zip_none::check_call(cx, expr, func, args);
             },
             ExprKind::MethodCall(..) => {
                 self.check_methods(cx, expr);
@@ -5995,6 +6020,9 @@ impl Methods {
                         &self.unwrap_allowed_aliases,
                         unwrap_expect_used::Variant::Unwrap,
                     );
+                },
+                (sym::zip, [arg]) => {
+                    option_zip_none::check_method(cx, expr, recv, arg);
                 },
                 _ => {},
             }

--- a/clippy_lints/src/methods/option_zip_none.rs
+++ b/clippy_lints/src/methods/option_zip_none.rs
@@ -1,0 +1,87 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::res::{MaybeDef as _, MaybeTypeckRes as _};
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::{is_none_expr, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::LateContext;
+
+use super::OPTION_ZIP_NONE;
+
+fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg: &Expr<'_>) {
+    let recv_is_none = is_none_expr(cx, recv);
+    let arg_is_none = is_none_expr(cx, arg);
+
+    if !recv_is_none && !arg_is_none {
+        return;
+    }
+
+    span_lint_and_then(
+        cx,
+        OPTION_ZIP_NONE,
+        expr.span,
+        "calling `.zip()` on an `Option` where one side is `None` always returns `None`",
+        |diag| {
+            let mut app = Applicability::MaybeIncorrect;
+            let ctxt = expr.span.ctxt();
+            let none_snippet = if recv_is_none {
+                snippet_with_context(cx, recv.span, ctxt, "_", &mut app).0
+            } else {
+                snippet_with_context(cx, arg.span, ctxt, "_", &mut app).0
+            };
+
+            if let ExprKind::MethodCall(_, _, _, call_span) = expr.kind {
+                if recv_is_none && !arg_is_none {
+                    let arg_snip = snippet_with_context(cx, arg.span, ctxt, "_", &mut app).0;
+                    diag.span_suggestion(
+                        expr.span,
+                        "if you meant to zip the contents of the `Option` with `None`, use `Option::map`",
+                        format!("{arg_snip}.map(|n| ({none_snippet}, n))"),
+                        app,
+                    );
+                } else if !recv_is_none && arg_is_none {
+                    diag.span_suggestion(
+                        call_span,
+                        "if you meant to zip the contents of the `Option` with `None`, use `Option::map`",
+                        format!("map(|n| (n, {none_snippet}))"),
+                        app,
+                    );
+                }
+            }
+        },
+    );
+}
+
+pub(super) fn check_call(cx: &LateContext<'_>, expr: &Expr<'_>, func: &Expr<'_>, args: &[Expr<'_>]) {
+    if let [left, right] = args
+        && let ExprKind::Path(ref qpath) = func.kind
+        && let Some(def_id) = cx.qpath_res(qpath, func.hir_id).opt_def_id()
+        && cx.tcx.item_name(def_id) == sym::zip
+        && def_id.opt_parent(cx).opt_impl_ty(cx).is_some_and(|impl_ty| {
+            impl_ty
+                .instantiate_identity()
+                .skip_norm_wip()
+                .ty_adt_def()
+                .is_some_and(|adt| cx.tcx.is_diagnostic_item(sym::Option, adt.did()))
+        })
+    {
+        emit_lint(cx, expr, left, right);
+    }
+}
+
+pub(super) fn check_method(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg: &Expr<'_>) {
+    if cx
+        .ty_based_def(expr)
+        .opt_parent(cx)
+        .opt_impl_ty(cx)
+        .is_some_and(|impl_ty| {
+            impl_ty
+                .instantiate_identity()
+                .skip_norm_wip()
+                .ty_adt_def()
+                .is_some_and(|adt| cx.tcx.is_diagnostic_item(sym::Option, adt.did()))
+        })
+    {
+        emit_lint(cx, expr, recv, arg);
+    }
+}

--- a/tests/ui/manual_option_zip.fixed
+++ b/tests/ui/manual_option_zip.fixed
@@ -1,5 +1,6 @@
 #![warn(clippy::manual_option_zip)]
 #![expect(clippy::bind_instead_of_map)]
+#![allow(clippy::option_zip_none)]
 
 fn main() {}
 

--- a/tests/ui/manual_option_zip.rs
+++ b/tests/ui/manual_option_zip.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::manual_option_zip)]
 #![expect(clippy::bind_instead_of_map)]
+#![allow(clippy::option_zip_none)]
 
 fn main() {}
 

--- a/tests/ui/manual_option_zip.stderr
+++ b/tests/ui/manual_option_zip.stderr
@@ -1,5 +1,5 @@
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:10:13
+  --> tests/ui/manual_option_zip.rs:11:13
    |
 LL |     let _ = a.and_then(|a| b.map(|b| (a, b)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(b)`
@@ -8,37 +8,37 @@ LL |     let _ = a.and_then(|a| b.map(|b| (a, b)));
    = help: to override `-D warnings` add `#[allow(clippy::manual_option_zip)]`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:16:13
+  --> tests/ui/manual_option_zip.rs:17:13
    |
 LL |     let _ = a.and_then(|a| b.map(|b| (a, b)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(b)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:21:13
+  --> tests/ui/manual_option_zip.rs:22:13
    |
 LL |     let _ = None::<i32>.and_then(|a| b.map(|b| (a, b)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `None::<i32>.zip(b)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:27:13
+  --> tests/ui/manual_option_zip.rs:28:13
    |
 LL |     let _ = a.and_then(|a| b.map(|b| (b, a)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `b.zip(a)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:34:13
+  --> tests/ui/manual_option_zip.rs:35:13
    |
 LL |     let _ = a.and_then(|a| { b.map(|b| (a, b)) });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(b)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:37:13
+  --> tests/ui/manual_option_zip.rs:38:13
    |
 LL |     let _ = a.and_then(|a| b.map(|b| { (a, b) }));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(b)`
 
 error: manual implementation of `Option::zip`
-  --> tests/ui/manual_option_zip.rs:40:13
+  --> tests/ui/manual_option_zip.rs:41:13
    |
 LL |     let _ = a.and_then(|a| { b.map(|b| { (a, b) }) });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `a.zip(b)`

--- a/tests/ui/option_zip_none.fixed
+++ b/tests/ui/option_zip_none.fixed
@@ -1,0 +1,78 @@
+#![warn(clippy::option_zip_none)]
+#![allow(clippy::needless_borrow)]
+mod edge_case {
+    trait MyZip {
+        fn zip(self, other: Option<()>) -> &'static str;
+    }
+
+    impl<T> MyZip for &Option<T> {
+        fn zip(self, _other: Option<()>) -> &'static str {
+            "not Option::zip"
+        }
+    }
+
+    pub fn test_custom_trait() {
+        let opt = Some(1);
+        let _ = (&opt).zip(None::<()>);
+    }
+
+    enum MyOption {
+        Some(i32),
+        None,
+    }
+
+    impl MyOption {
+        fn zip(self, _other: Option<()>) -> &'static str {
+            "not Option::zip"
+        }
+    }
+
+    pub fn test_custom_enum() {
+        let opt = MyOption::Some(1);
+        let _ = opt.zip(None::<()>);
+    }
+}
+
+fn main() {
+    let opt = Some(5);
+
+    let _ = opt.map(|n| (n, None::<()>));
+    //~^ option_zip_none
+
+    let _ = opt.zip(Some(42));
+
+    let iter = vec![1, 2, 3].into_iter();
+    let _ = iter.zip(std::iter::empty::<i32>());
+
+    let standard_opt = Some(1);
+    let _ = (&standard_opt).map(|n| (n, None::<()>));
+    //~^ option_zip_none
+
+    let _ = Some(1).map(|n| (None::<i32>, n));
+    //~^ option_zip_none
+
+    let _ = Some(1).map(|n| (n, None::<()>));
+    //~^ option_zip_none
+
+    macro_rules! macro_none {
+        () => {
+            None::<()>
+        };
+    }
+    let opt = Some(1);
+    let _ = opt.map(|n| (n, macro_none!()));
+    //~^ option_zip_none
+
+    macro_rules! macro_zip {
+        ($opt:expr) => {
+            $opt.zip(None::<()>)
+        };
+    }
+    let _ = macro_zip!(Some(1));
+    macro_rules! macro_zip_arg {
+        ($opt:expr, $arg:expr) => {
+            $opt.zip($arg)
+        };
+    }
+    let _ = macro_zip_arg!(Some(1), None::<()>);
+}

--- a/tests/ui/option_zip_none.rs
+++ b/tests/ui/option_zip_none.rs
@@ -1,0 +1,78 @@
+#![warn(clippy::option_zip_none)]
+#![allow(clippy::needless_borrow)]
+mod edge_case {
+    trait MyZip {
+        fn zip(self, other: Option<()>) -> &'static str;
+    }
+
+    impl<T> MyZip for &Option<T> {
+        fn zip(self, _other: Option<()>) -> &'static str {
+            "not Option::zip"
+        }
+    }
+
+    pub fn test_custom_trait() {
+        let opt = Some(1);
+        let _ = (&opt).zip(None::<()>);
+    }
+
+    enum MyOption {
+        Some(i32),
+        None,
+    }
+
+    impl MyOption {
+        fn zip(self, _other: Option<()>) -> &'static str {
+            "not Option::zip"
+        }
+    }
+
+    pub fn test_custom_enum() {
+        let opt = MyOption::Some(1);
+        let _ = opt.zip(None::<()>);
+    }
+}
+
+fn main() {
+    let opt = Some(5);
+
+    let _ = opt.zip(None::<()>);
+    //~^ option_zip_none
+
+    let _ = opt.zip(Some(42));
+
+    let iter = vec![1, 2, 3].into_iter();
+    let _ = iter.zip(std::iter::empty::<i32>());
+
+    let standard_opt = Some(1);
+    let _ = (&standard_opt).zip(None::<()>);
+    //~^ option_zip_none
+
+    let _ = None::<i32>.zip(Some(1));
+    //~^ option_zip_none
+
+    let _ = Some(1).zip(None::<()>);
+    //~^ option_zip_none
+
+    macro_rules! macro_none {
+        () => {
+            None::<()>
+        };
+    }
+    let opt = Some(1);
+    let _ = opt.zip(macro_none!());
+    //~^ option_zip_none
+
+    macro_rules! macro_zip {
+        ($opt:expr) => {
+            $opt.zip(None::<()>)
+        };
+    }
+    let _ = macro_zip!(Some(1));
+    macro_rules! macro_zip_arg {
+        ($opt:expr, $arg:expr) => {
+            $opt.zip($arg)
+        };
+    }
+    let _ = macro_zip_arg!(Some(1), None::<()>);
+}

--- a/tests/ui/option_zip_none.stderr
+++ b/tests/ui/option_zip_none.stderr
@@ -1,0 +1,64 @@
+error: calling `.zip()` on an `Option` where one side is `None` always returns `None`
+  --> tests/ui/option_zip_none.rs:39:13
+   |
+LL |     let _ = opt.zip(None::<()>);
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::option-zip-none` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::option_zip_none)]`
+help: if you meant to zip the contents of the `Option` with `None`, use `Option::map`
+   |
+LL -     let _ = opt.zip(None::<()>);
+LL +     let _ = opt.map(|n| (n, None::<()>));
+   |
+
+error: calling `.zip()` on an `Option` where one side is `None` always returns `None`
+  --> tests/ui/option_zip_none.rs:48:13
+   |
+LL |     let _ = (&standard_opt).zip(None::<()>);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: if you meant to zip the contents of the `Option` with `None`, use `Option::map`
+   |
+LL -     let _ = (&standard_opt).zip(None::<()>);
+LL +     let _ = (&standard_opt).map(|n| (n, None::<()>));
+   |
+
+error: calling `.zip()` on an `Option` where one side is `None` always returns `None`
+  --> tests/ui/option_zip_none.rs:51:13
+   |
+LL |     let _ = None::<i32>.zip(Some(1));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: if you meant to zip the contents of the `Option` with `None`, use `Option::map`
+   |
+LL -     let _ = None::<i32>.zip(Some(1));
+LL +     let _ = Some(1).map(|n| (None::<i32>, n));
+   |
+
+error: calling `.zip()` on an `Option` where one side is `None` always returns `None`
+  --> tests/ui/option_zip_none.rs:54:13
+   |
+LL |     let _ = Some(1).zip(None::<()>);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: if you meant to zip the contents of the `Option` with `None`, use `Option::map`
+   |
+LL -     let _ = Some(1).zip(None::<()>);
+LL +     let _ = Some(1).map(|n| (n, None::<()>));
+   |
+
+error: calling `.zip()` on an `Option` where one side is `None` always returns `None`
+  --> tests/ui/option_zip_none.rs:63:13
+   |
+LL |     let _ = opt.zip(macro_none!());
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: if you meant to zip the contents of the `Option` with `None`, use `Option::map`
+   |
+LL -     let _ = opt.zip(macro_none!());
+LL +     let _ = opt.map(|n| (n, macro_none!()));
+   |
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/option_zip_none_unfixable.rs
+++ b/tests/ui/option_zip_none_unfixable.rs
@@ -1,0 +1,9 @@
+//@no-rustfix
+#![warn(clippy::option_zip_none)]
+
+fn main() {
+    let _: Option<(i32, ())> = Option::zip(Some(1), None::<()>);
+    //~^ option_zip_none
+    let _: Option<((), i32)> = Option::zip(None::<()>, Some(1));
+    //~^ option_zip_none
+}

--- a/tests/ui/option_zip_none_unfixable.stderr
+++ b/tests/ui/option_zip_none_unfixable.stderr
@@ -1,0 +1,17 @@
+error: calling `.zip()` on an `Option` where one side is `None` always returns `None`
+  --> tests/ui/option_zip_none_unfixable.rs:5:32
+   |
+LL |     let _: Option<(i32, ())> = Option::zip(Some(1), None::<()>);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::option-zip-none` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::option_zip_none)]`
+
+error: calling `.zip()` on an `Option` where one side is `None` always returns `None`
+  --> tests/ui/option_zip_none_unfixable.rs:7:32
+   |
+LL |     let _: Option<((), i32)> = Option::zip(None::<()>, Some(1));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17465)*

fixes rust-lang/rust-clippy#17462 
Adds a new `suspicious` late lint `option_zip_none` that checks for calls of the form `Option::zip(None)`. 

As noted in the issue, this always yields `None` and is almost certainly a logic bug where the user intended to either just write `None` or use `.map(|x| (x, None))`.

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

changelog: [`option_zip_none`]: Add new lint to check for `Option::zip(None)`