### PR TITLE
fix(manual_div_ceil): avoid suggestions that change evaluation count

### DIFF
--- a/clippy_lints/src/operators/manual_div_ceil.rs
+++ b/clippy_lints/src/operators/manual_div_ceil.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::{MaybeDef as _, MaybeQPath as _};
 use clippy_utils::sugg::{Sugg, has_enclosing_paren};
-use clippy_utils::{SpanlessEq, sym};
+use clippy_utils::{eq_expr_value, sym};
 use rustc_ast::{BinOpKind, LitIntType, LitKind, UnOp};
 use rustc_data_structures::packed::Pu128;
 use rustc_errors::Applicability;
@@ -29,7 +29,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, op: BinOpKind, lhs: &
                     && inner_op.node == BinOpKind::Add
                     && sub_op.node == BinOpKind::Sub
                     && check_literal(sub_rhs)
-                    && SpanlessEq::new(cx).eq_expr(ctxt, sub_lhs, rhs)
+                    && eq_expr_value(cx, ctxt, sub_lhs, rhs)
                 {
                     build_suggestion(cx, expr, inner_lhs, rhs, &mut applicability);
                     return;
@@ -40,7 +40,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, op: BinOpKind, lhs: &
                     && inner_op.node == BinOpKind::Add
                     && sub_op.node == BinOpKind::Sub
                     && check_literal(sub_rhs)
-                    && SpanlessEq::new(cx).eq_expr(ctxt, sub_lhs, rhs)
+                    && eq_expr_value(cx, ctxt, sub_lhs, rhs)
                 {
                     build_suggestion(cx, expr, inner_rhs, rhs, &mut applicability);
                     return;
@@ -51,7 +51,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, op: BinOpKind, lhs: &
                     && inner_op.node == BinOpKind::Sub
                     && add_op.node == BinOpKind::Add
                     && check_literal(inner_rhs)
-                    && SpanlessEq::new(cx).eq_expr(ctxt, add_rhs, rhs)
+                    && eq_expr_value(cx, ctxt, add_rhs, rhs)
                 {
                     build_suggestion(cx, expr, add_lhs, rhs, &mut applicability);
                 }
@@ -77,7 +77,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, op: BinOpKind, lhs: &
             ExprKind::MethodCall(method, receiver, [next_multiple_of_arg], _)
                 if method.ident.name == sym::next_multiple_of
                     && check_int_ty(cx.typeck_results().expr_ty(receiver))
-                    && SpanlessEq::new(cx).eq_expr(ctxt, next_multiple_of_arg, rhs) =>
+                    && eq_expr_value(cx, ctxt, next_multiple_of_arg, rhs) =>
             {
                 // x.next_multiple_of(Y) / Y
                 build_suggestion(cx, expr, receiver, rhs, &mut applicability);
@@ -89,7 +89,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, op: BinOpKind, lhs: &
                     .assoc_fn_parent(cx)
                     .opt_impl_ty(cx)
                     && check_int_ty(impl_ty_binder.skip_binder())
-                    && SpanlessEq::new(cx).eq_expr(ctxt, next_multiple_of_arg, rhs)
+                    && eq_expr_value(cx, ctxt, next_multiple_of_arg, rhs)
                 {
                     build_suggestion(cx, expr, receiver, rhs, &mut applicability);
                 }

--- a/tests/ui/manual_div_ceil.fixed
+++ b/tests/ui/manual_div_ceil.fixed
@@ -143,3 +143,15 @@ fn issue_16219() {
     let z = MyStruct(x);
     let _ = z.next_multiple_of(8) / 8;
 }
+
+fn side_effects() {
+    use core::hint::black_box;
+
+    // No lint: each expression calls `black_box` twice, while the suggested
+    // `div_ceil` expression would only call it once.
+    let _ = (33 + (black_box(4) - 1)) / black_box(4);
+    let _ = ((black_box(4) - 1) + 33) / black_box(4);
+    let _ = (33 + black_box(4) - 1) / black_box(4);
+    let _ = 33_u32.next_multiple_of(black_box(4)) / black_box(4);
+    let _ = u32::next_multiple_of(33, black_box(4)) / black_box(4);
+}

--- a/tests/ui/manual_div_ceil.rs
+++ b/tests/ui/manual_div_ceil.rs
@@ -143,3 +143,15 @@ fn issue_16219() {
     let z = MyStruct(x);
     let _ = z.next_multiple_of(8) / 8;
 }
+
+fn side_effects() {
+    use core::hint::black_box;
+
+    // No lint: each expression calls `black_box` twice, while the suggested
+    // `div_ceil` expression would only call it once.
+    let _ = (33 + (black_box(4) - 1)) / black_box(4);
+    let _ = ((black_box(4) - 1) + 33) / black_box(4);
+    let _ = (33 + black_box(4) - 1) / black_box(4);
+    let _ = 33_u32.next_multiple_of(black_box(4)) / black_box(4);
+    let _ = u32::next_multiple_of(33, black_box(4)) / black_box(4);
+}


### PR DESCRIPTION


changelog: [`manual_div_ceil`]: avoid suggestions that change the evaluation count of side-effectful divisors

Fixes rust-lang/rust-clippy#17467
