### PR TITLE
Add new lint: `manual_highest_one`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7110,6 +7110,7 @@ Released 2018-09-13
 [`manual_find_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_find_map
 [`manual_flatten`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_flatten
 [`manual_hash_one`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_hash_one
+[`manual_highest_one`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_highest_one
 [`manual_ignore_case_cmp`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_ignore_case_cmp
 [`manual_ilog2`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_ilog2
 [`manual_inspect`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -313,6 +313,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::manual_float_methods::MANUAL_IS_FINITE_INFO,
     crate::manual_float_methods::MANUAL_IS_INFINITE_INFO,
     crate::manual_hash_one::MANUAL_HASH_ONE_INFO,
+    crate::manual_highest_one::MANUAL_HIGHEST_ONE_INFO,
     crate::manual_ignore_case_cmp::MANUAL_IGNORE_CASE_CMP_INFO,
     crate::manual_ilog2::MANUAL_ILOG2_INFO,
     crate::manual_is_ascii_check::MANUAL_IS_ASCII_CHECK_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -207,6 +207,7 @@ mod manual_checked_ops;
 mod manual_clamp;
 mod manual_float_methods;
 mod manual_hash_one;
+mod manual_highest_one;
 mod manual_ignore_case_cmp;
 mod manual_ilog2;
 mod manual_is_ascii_check;
@@ -869,6 +870,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        ManualHighestOne: manual_highest_one::ManualHighestOne = manual_highest_one::ManualHighestOne::new(conf),
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/manual_highest_one.rs
+++ b/clippy_lints/src/manual_highest_one.rs
@@ -1,0 +1,434 @@
+use clippy_config::Conf;
+use clippy_utils::comparisons::{Rel, normalize_comparison};
+use clippy_utils::consts::{ConstEvalCtxt, Constant, integer_const, is_zero_integer_const};
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::res::{HasHirId as _, MaybeDef as _};
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::{eq_expr_value, sym};
+use rustc_errors::Applicability;
+use rustc_hir::{Arm, BinOpKind, Expr, ExprKind, MatchSource, Node, PatKind, QPath};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, Ty};
+use rustc_session::impl_lint_pass;
+use rustc_span::{Span, Symbol, SyntaxContext};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for manual implementations of `x.highest_one()`.
+    ///
+    /// ### Why is this bad?
+    /// Manual implementation of `highest_one()` is error-prone and less readable.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let x: u32 = 5;
+    /// let i = 31 - x.leading_zeros();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let x: u32 = 5;
+    /// let i = x.highest_one().unwrap();
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub MANUAL_HIGHEST_ONE,
+    complexity,
+    "manually reimplementing `highest_one`"
+}
+
+impl_lint_pass!(ManualHighestOne => [MANUAL_HIGHEST_ONE]);
+
+pub struct ManualHighestOne {
+    msrv: Msrv,
+}
+
+impl ManualHighestOne {
+    pub fn new(conf: &Conf) -> Self {
+        Self { msrv: conf.msrv.into() }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for ManualHighestOne {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if !self.msrv.meets(cx, msrvs::HIGHEST_ONE) || expr.span.from_expansion() {
+            return;
+        }
+
+        match IntTy::new(cx, expr) {
+            Some(IntTy::Option) => {
+                if let Some(recv) = extract_recv_from_highest_one_equiv(cx, expr, true) {
+                    lint_basic_pattern(cx, expr.span, recv, IntTy::Option);
+                }
+                return;
+            },
+            Some(IntTy::Raw) => (),
+            _ => return,
+        }
+
+        let Some(recv) = extract_recv_from_highest_one_equiv(cx, expr, false) else {
+            return;
+        };
+        let h1_expr = expr;
+
+        match IntTy::new(cx, recv) {
+            Some(IntTy::NonZero) => {
+                lint_basic_pattern(cx, h1_expr.span, recv, IntTy::NonZero);
+                return;
+            },
+            Some(IntTy::Raw) => (),
+            _ => return,
+        }
+
+        // Walk the node up
+        let mut hir_id = h1_expr.hir_id();
+        loop {
+            match cx.tcx.parent_hir_node(hir_id) {
+                Node::Arm(arm) => hir_id = arm.hir_id,
+                Node::Block(block)
+                    // Otherwise, this block may have side effect
+                    if block.stmts.is_empty() && block.expr.is_some_and(|e| e.hir_id == hir_id) =>
+                {
+                    hir_id = block.hir_id;
+                },
+                Node::Expr(expr) => match expr.kind {
+                    ExprKind::Block(..) => hir_id = expr.hir_id,
+                    ExprKind::If(condition, then_block, Some(else_block))
+                        if matches!(else_block.kind, ExprKind::Block(..)) =>
+                    {
+                        if lint_if_pattern(cx, expr.span, condition, then_block, else_block, h1_expr, recv) {
+                            return;
+                        }
+                        break;
+                    },
+                    ExprKind::Match(scrutinee, [arm1, arm2], MatchSource::Normal) => {
+                        if lint_match_pattern(cx, expr.span, scrutinee, arm1, arm2, h1_expr, recv) {
+                            return;
+                        }
+                        break;
+                    },
+                    _ => break,
+                },
+                _ => break,
+            }
+        }
+
+        lint_basic_pattern(cx, h1_expr.span, recv, IntTy::Raw);
+    }
+}
+
+enum IntTy {
+    Raw,
+    NonZero,
+    Option,
+}
+
+impl IntTy {
+    fn new<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> Option<Self> {
+        let ty = cx.typeck_results().expr_ty(expr);
+
+        match ty.kind() {
+            ty::Int(..) | ty::Uint(..) => Some(Self::Raw),
+            ty::Adt(def, arg) if def.is_diag_item(&cx.tcx, sym::NonZero) => match arg.type_at(0).kind() {
+                ty::Int(..) | ty::Uint(..) => Some(Self::NonZero),
+                _ => None,
+            },
+            ty::Adt(def, arg) if def.is_diag_item(&cx.tcx, sym::Option) => match arg.type_at(0).kind() {
+                ty::Int(..) | ty::Uint(..) => Some(Self::Option),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn basic_suggestion(self) -> &'static str {
+        match self {
+            IntTy::Raw => ".highest_one().unwrap()",
+            IntTy::NonZero | IntTy::Option => ".highest_one()",
+        }
+    }
+}
+
+fn lint_basic_pattern<'tcx>(cx: &LateContext<'tcx>, span: Span, recv: &'tcx Expr<'tcx>, int_ty: IntTy) {
+    let mut app = Applicability::MaybeIncorrect;
+    let sugg = {
+        let (recv_str, _) = snippet_with_context(cx, recv.span, span.ctxt(), "..", &mut app);
+
+        format!("{recv_str}{}", int_ty.basic_suggestion())
+    };
+    span_lint_and_sugg(
+        cx,
+        MANUAL_HIGHEST_ONE,
+        span,
+        "manually reimplementing `highest_one`",
+        "try",
+        sugg,
+        app,
+    );
+}
+
+fn lint_if_pattern<'tcx>(
+    cx: &LateContext<'tcx>,
+    span: Span,
+    condition: &'tcx Expr<'tcx>,
+    then_block: &'tcx Expr<'tcx>,
+    else_block: &'tcx Expr<'tcx>,
+    h1_expr: &'tcx Expr<'tcx>,
+    recv_of_h1: &'tcx Expr<'tcx>,
+) -> bool {
+    // normalize condition: `0 ? x`
+    let (rel, value) = {
+        if let ExprKind::Binary(bin_op, lhs, rhs) = condition.kind
+            && let Some((rel, lhs, rhs)) = normalize_comparison(bin_op.node, lhs, rhs)
+        {
+            // 0 == x, 0 != x, 0 < x
+            if is_zero_integer_const(cx, lhs, condition.span.ctxt()) && !lhs.span.from_expansion() && {
+                matches!(rel, Rel::Eq | Rel::Ne) || {
+                    matches!(rel, Rel::Lt) && matches!(cx.typeck_results().expr_ty(rhs).kind(), ty::Uint(..))
+                }
+            } {
+                (rel, rhs)
+            } else
+            // 0 == x, 0 != x
+            if is_zero_integer_const(cx, rhs, condition.span.ctxt())
+                && !rhs.span.from_expansion()
+                && matches!(rel, Rel::Eq | Rel::Ne)
+            {
+                (rel, lhs)
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    };
+    // `value` and `recv_of_h1` must indicate the same entity
+    if !eq_expr_value(cx, span.ctxt(), value, recv_of_h1) {
+        return false;
+    }
+
+    // if x == 0 {} else { h1 }
+    // if x != 0 { h1 } else {}
+    // if 0 < unsigned { h1 } else {}
+    let recv_in_then_block = cx.tcx.hir_parent_iter(h1_expr.hir_id).any(|v| v.0 == then_block.hir_id);
+    if (rel == Rel::Eq) == recv_in_then_block {
+        return false;
+    }
+
+    // Because suggestion may trigger `unnecessary_lazy_evaluations` lint
+    let mut app = Applicability::MaybeIncorrect;
+
+    let sugg = {
+        let (recv_str, _) = snippet_with_context(cx, recv_of_h1.span, h1_expr.span.ctxt(), "..", &mut app);
+        // the arm other than the one equivalent to `highest_one`
+        let (else_str, _) = if recv_in_then_block {
+            snippet_with_context(cx, else_block.span, span.ctxt(), "..", &mut app)
+        } else {
+            snippet_with_context(cx, then_block.span, span.ctxt(), "..", &mut app)
+        };
+
+        format!("{recv_str}.highest_one().unwrap_or_else(|| {else_str})")
+    };
+
+    span_lint_and_sugg(
+        cx,
+        MANUAL_HIGHEST_ONE,
+        span,
+        "manually reimplementing `highest_one`",
+        "try",
+        sugg,
+        app,
+    );
+
+    true
+}
+
+fn lint_match_pattern<'tcx>(
+    cx: &LateContext<'tcx>,
+    span: Span,
+    scrutinee: &'tcx Expr<'tcx>,
+    arm1: &'tcx Arm<'tcx>,
+    arm2: &'tcx Arm<'tcx>,
+    h1_expr: &'tcx Expr<'tcx>,
+    recv_of_h1: &'tcx Expr<'tcx>,
+) -> bool {
+    // match u {
+    //     0 => do_something(),
+    //     _ => u.highest_one_equiv(),
+    // }
+    if
+    // `0` pattern
+    arm1.guard.is_none()
+        && let PatKind::Expr(pat_expr) = arm1.pat.kind
+        && !pat_expr.span.from_expansion()
+        && ConstEvalCtxt::new(cx).eval_pat_expr(pat_expr) == Some(Constant::Int(0))
+        // `_` pattern
+        && arm2.guard.is_none()
+        && let PatKind::Wild = arm2.pat.kind
+        && arm2.body.hir_id == h1_expr.hir_id
+        // same item
+        && eq_expr_value(cx, span.ctxt(), scrutinee, recv_of_h1)
+    {
+        // Because suggestion may trigger `unnecessary_lazy_evaluations` lint
+        let mut app = Applicability::MaybeIncorrect;
+
+        let sugg = {
+            let (recv_str, _) = snippet_with_context(cx, recv_of_h1.span, h1_expr.span.ctxt(), "..", &mut app);
+            let (else_str, _) = snippet_with_context(cx, arm1.body.span, span.ctxt(), "..", &mut app);
+
+            format!("{recv_str}.highest_one().unwrap_or_else(|| {else_str})")
+        };
+
+        span_lint_and_sugg(
+            cx,
+            MANUAL_HIGHEST_ONE,
+            span,
+            "manually reimplementing `highest_one`",
+            "try",
+            sugg,
+            app,
+        );
+
+        true
+    } else {
+        false
+    }
+}
+
+/// Returns `x` of `BITS - 1 - x.leading_zeros()`-like expressions.
+fn extract_recv_from_highest_one_equiv<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    checked: bool,
+) -> Option<&'tcx Expr<'tcx>> {
+    // lhs - rhs
+    let (lhs, rhs) = if checked {
+        if let Some((recv, [arg])) = unpack_method_call(expr, sym::checked_sub) {
+            (recv, arg)
+        } else {
+            return None;
+        }
+    } else {
+        unpack_bin_op(expr, BinOpKind::Sub)?
+    };
+
+    // lhs = x.bit_width()
+    // rhs = 1
+    if let Some((recv, [])) = unpack_method_call(lhs, sym::bit_width)
+        && integer_const(cx, rhs, expr.span.ctxt()) == Some(1)
+    {
+        return Some(recv);
+    }
+
+    // lhs = nonzero.bit_width().get()
+    // rhs = 1
+    if let Some((recv, [])) = unpack_method_call(lhs, sym::get)
+        && let Some((recv, [])) = unpack_method_call(recv, sym::bit_width)
+        && integer_const(cx, rhs, expr.span.ctxt()) == Some(1)
+    {
+        return Some(recv);
+    }
+
+    // lhs = const
+    // rhs = x.leading_zeros()
+    if let Some((recv,[])) = unpack_method_call(rhs, sym::leading_zeros)
+        && !recv.span.from_expansion()
+        && let Some(lit) = integer_const(cx, lhs, expr.span.ctxt())
+        // check constant
+        && let ty = cx.typeck_results().expr_ty(recv)
+        && let Some(bits) = bit_width(cx, ty)
+        && lit == bits.wrapping_sub(1)
+    {
+        return Some(recv);
+    }
+
+    // `x.leading_zeros()` and `1` can be swapped.
+
+    // lhs = BITS - 1
+    // rhs = x.leading_zeros()
+    if let Some((inner_lhs, inner_rhs)) = unpack_bin_op(lhs, BinOpKind::Sub)
+        && let Some(recv) = check_one_and_extract_recv_of_lz(cx, expr,inner_rhs, rhs)
+        && !recv.span.from_expansion()
+        // check BITS
+        && let ty = cx.typeck_results().expr_ty(recv)
+        && integer_const_or_bits(cx, inner_lhs, expr.span.ctxt()) == bit_width(cx, ty)
+    {
+        return Some(recv);
+    }
+
+    // lhs = BITS
+    // rhs = 1 + x.leading_zeros()
+    if let Some(( inner_lhs, inner_rhs)) = unpack_bin_op(rhs, BinOpKind::Add)
+        && let Some(recv) = check_one_and_extract_recv_of_lz(cx, expr,inner_lhs, inner_rhs)
+        && !recv.span.from_expansion()
+        // check BITS
+        && let ty = cx.typeck_results().expr_ty(recv)
+        && integer_const_or_bits(cx, lhs, expr.span.ctxt()) == bit_width(cx, ty)
+    {
+        return Some(recv);
+    }
+
+    None
+}
+
+fn check_one_and_extract_recv_of_lz<'tcx>(
+    cx: &LateContext<'_>,
+    h1_expr: &'tcx Expr<'tcx>,
+    expr1: &'tcx Expr<'tcx>,
+    expr2: &'tcx Expr<'tcx>,
+) -> Option<&'tcx Expr<'tcx>> {
+    if let Some((recv, [])) = unpack_method_call(expr1, sym::leading_zeros)
+        && integer_const(cx, expr2, h1_expr.span.ctxt()) == Some(1)
+    {
+        Some(recv)
+    } else if let Some((recv, [])) = unpack_method_call(expr2, sym::leading_zeros)
+        && integer_const(cx, expr1, h1_expr.span.ctxt()) == Some(1)
+    {
+        Some(recv)
+    } else {
+        None
+    }
+}
+
+fn bit_width<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<u128> {
+    match ty.kind() {
+        ty::Uint(uint_ty) => uint_ty.bit_width().map(u128::from),
+        ty::Int(int_ty) => int_ty.bit_width().map(u128::from),
+        ty::Adt(adt_def, args) if adt_def.is_diag_item(cx, sym::NonZero) => bit_width(cx, args[0].expect_ty()),
+        _ => None,
+    }
+}
+
+// from <https://github.com/rust-lang/rust-clippy/pull/17472#discussion_r3703083830>
+fn integer_const_or_bits(cx: &LateContext<'_>, expr: &Expr<'_>, ctxt: SyntaxContext) -> Option<u128> {
+    integer_const(cx, expr, ctxt).or_else(|| {
+        if let ExprKind::Path(QPath::TypeRelative(hir_ty, segment)) = expr.kind
+            && segment.ident.name == sym::BITS
+        {
+            bit_width(cx, cx.typeck_results().node_type(hir_ty.hir_id))
+        } else {
+            None
+        }
+    })
+}
+
+// Returns `(a, [b, ..])` of `a.method(b, ..)`
+fn unpack_method_call<'tcx>(expr: &'tcx Expr<'tcx>, method: Symbol) -> Option<(&'tcx Expr<'tcx>, &'tcx [Expr<'tcx>])> {
+    if let ExprKind::MethodCall(path, recv, args, _) = expr.kind
+        && path.ident.name == method
+    {
+        Some((recv, args))
+    } else {
+        None
+    }
+}
+
+// Returns `(a, b)` of `a ? b`
+fn unpack_bin_op<'tcx>(expr: &'tcx Expr<'tcx>, kind: BinOpKind) -> Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>)> {
+    if let ExprKind::Binary(bin_op, lhs, rhs) = expr.kind
+        && bin_op.node == kind
+    {
+        Some((lhs, rhs))
+    } else {
+        None
+    }
+}

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -25,7 +25,7 @@ macro_rules! msrv_aliases {
 
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
-    1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
+    1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH, HIGHEST_ONE }
     1,94,0 { EULER_GAMMA, GOLDEN_RATIO }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }
     1,91,0 { DURATION_FROM_MINUTES_HOURS }

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -146,6 +146,7 @@ generate! {
     back,
     binary_heap_pop_if,
     binaryheap_iter,
+    bit_width,
     bool_then,
     borrow,
     borrow_mut,

--- a/tests/ui/manual_highest_one.fixed
+++ b/tests/ui/manual_highest_one.fixed
@@ -1,0 +1,146 @@
+#![warn(clippy::manual_highest_one)]
+
+use std::hint::black_box;
+use std::num::NonZeroU32;
+
+// This macro is transparent because the span of `$e` is not updated during expansion.
+macro_rules! identity {
+    ( $e:expr ) => {
+        $e
+    };
+}
+
+macro_rules! one {
+    () => {
+        1
+    };
+}
+macro_rules! thirty_one {
+    () => {
+        31
+    };
+}
+macro_rules! double {
+    ( $i:ident ) => {
+        2 * $i
+    };
+}
+
+fn main() {
+    let u = 5_u32;
+    let i = -5_i32;
+    let nz = NonZeroU32::new(5).unwrap();
+
+    // --- Integer type ---
+    #[allow(clippy::manual_ilog2, reason = "This pattern is shared.")]
+    let _ = u.highest_one().unwrap(); //~ manual_highest_one
+    let _ = u.highest_one().unwrap(); //~ manual_highest_one
+    let _ = u.highest_one().unwrap(); //~ manual_highest_one
+    let _ = u.highest_one().unwrap(); //~ manual_highest_one
+    let _ = u.highest_one().unwrap(); //~ manual_highest_one
+    let _ = u.highest_one().unwrap(); //~ manual_highest_one
+
+    let _ = u.highest_one(); //~ manual_highest_one
+    let _ = u.highest_one(); //~ manual_highest_one
+    let _ = u.highest_one(); //~ manual_highest_one
+    let _ = u.highest_one(); //~ manual_highest_one
+
+    let _ = i.highest_one().unwrap(); //~ manual_highest_one
+    let _ = i.highest_one().unwrap(); //~ manual_highest_one
+    let _ = i.highest_one().unwrap(); //~ manual_highest_one
+    let _ = i.highest_one().unwrap(); //~ manual_highest_one
+    let _ = i.highest_one().unwrap(); //~ manual_highest_one
+
+    // --- Nonzero type ---
+    let _ = nz.highest_one(); //~ manual_highest_one
+    let _ = nz.highest_one(); //~ manual_highest_one
+    let _ = nz.highest_one(); //~ manual_highest_one
+    let _ = nz.highest_one(); //~ manual_highest_one
+    let _ = nz.highest_one(); //~ manual_highest_one
+
+    // --- In if block ---
+    let _ = u.highest_one().unwrap_or_else(|| {
+        //~^ manual_highest_one
+        todo!()
+    });
+    let _ = u.highest_one().unwrap_or_else(|| {
+        //~^ manual_highest_one
+        todo!()
+    });
+    let _ = u.highest_one().unwrap_or_else(|| {
+        todo!()
+    });
+    let _ = u.highest_one().unwrap_or_else(|| {
+        todo!()
+    });
+    let _ = if i > 0 {
+        i.highest_one().unwrap() //~ manual_highest_one
+    } else {
+        todo!()
+    };
+
+    // This should not be linted because ..
+    let _ = if u == 0 {
+        todo!()
+    } else {
+        // this arm may change state
+        black_box(u);
+        u.highest_one().unwrap() //~ manual_highest_one
+    };
+    // Whereas, this should be linted.
+    let _ = u.highest_one().unwrap_or_else(|| {
+        //~^ manual_highest_one
+        black_box(u);
+        todo!()
+    });
+
+    // --- In match arm ---
+    let _ = u.highest_one().unwrap_or_else(|| {
+            black_box(u);
+            todo!()
+        });
+    let _ = match u {
+        0 => todo!(),
+        _ => {
+            black_box(u);
+            u.highest_one().unwrap() //~ manual_highest_one
+        },
+    };
+    let _ = match u {
+        0 => u.highest_one().unwrap(), //~ manual_highest_one
+        _ => todo!(),
+    };
+
+    // --- Macro ---
+    // `identity!` macro cannot be detected because span is not updated during expansion,
+    // so this is a false positive.
+    let _ = u.highest_one().unwrap(); //~ manual_highest_one
+    let _ = u.highest_one().unwrap(); //~ manual_highest_one
+    // We are very conservative about macro, so these should not be linted.
+    let _ = 31 - double!(u).leading_zeros();
+    let _ = thirty_one!() - u.leading_zeros();
+    let _ = (u32::BITS - one!()) - u.leading_zeros();
+    let _ = (u32::BITS - u.leading_zeros()) - one!();
+    let _ = u32::BITS - (one!() + u.leading_zeros());
+    let _ = u32::BITS - (u.leading_zeros() + one!());
+    // Whereas, this case should be linted.
+    let _ = double!(u).highest_one().unwrap(); //~ manual_highest_one
+
+    macro_rules! ignore_me {
+        () => {
+            let _ = 31 - u.leading_zeros();
+            let _ = u32::BITS - 1 - u.leading_zeros();
+            let _ = u32::BITS - (1 + u.leading_zeros());
+        };
+    }
+    ignore_me!();
+
+    // False negative
+    let _ = if u == 0 {
+        let v = u;
+        v.highest_one().unwrap() //~ manual_highest_one
+    } else {
+        let _ = "Rust is fast, memory-safe and productive.";
+        3
+    };
+}

--- a/tests/ui/manual_highest_one.rs
+++ b/tests/ui/manual_highest_one.rs
@@ -1,0 +1,162 @@
+#![warn(clippy::manual_highest_one)]
+
+use std::hint::black_box;
+use std::num::NonZeroU32;
+
+// This macro is transparent because the span of `$e` is not updated during expansion.
+macro_rules! identity {
+    ( $e:expr ) => {
+        $e
+    };
+}
+
+macro_rules! one {
+    () => {
+        1
+    };
+}
+macro_rules! thirty_one {
+    () => {
+        31
+    };
+}
+macro_rules! double {
+    ( $i:ident ) => {
+        2 * $i
+    };
+}
+
+fn main() {
+    let u = 5_u32;
+    let i = -5_i32;
+    let nz = NonZeroU32::new(5).unwrap();
+
+    // --- Integer type ---
+    #[allow(clippy::manual_ilog2, reason = "This pattern is shared.")]
+    let _ = 31 - u.leading_zeros(); //~ manual_highest_one
+    let _ = u32::BITS - 1 - u.leading_zeros(); //~ manual_highest_one
+    let _ = u32::BITS - u.leading_zeros() - 1; //~ manual_highest_one
+    let _ = u32::BITS - (1 + u.leading_zeros()); //~ manual_highest_one
+    let _ = u32::BITS - (u.leading_zeros() + 1); //~ manual_highest_one
+    let _ = u.bit_width() - 1; //~ manual_highest_one
+
+    let _ = 31_u32.checked_sub(u.leading_zeros()); //~ manual_highest_one
+    let _ = u32::BITS.checked_sub(u.leading_zeros() + 1); //~ manual_highest_one
+    let _ = (u32::BITS - 1).checked_sub(u.leading_zeros()); //~ manual_highest_one
+    let _ = u.bit_width().checked_sub(1); //~ manual_highest_one
+
+    let _ = 31 - i.leading_zeros(); //~ manual_highest_one
+    let _ = i32::BITS - 1 - i.leading_zeros(); //~ manual_highest_one
+    let _ = i32::BITS - i.leading_zeros() - 1; //~ manual_highest_one
+    let _ = i32::BITS - (1 + i.leading_zeros()); //~ manual_highest_one
+    let _ = i32::BITS - (i.leading_zeros() + 1); //~ manual_highest_one
+
+    // --- Nonzero type ---
+    let _ = 31 - nz.leading_zeros(); //~ manual_highest_one
+    let _ = NonZeroU32::BITS - 1 - nz.leading_zeros(); //~ manual_highest_one
+    let _ = NonZeroU32::BITS - (1 + nz.leading_zeros()); //~ manual_highest_one
+    let _ = NonZeroU32::BITS - (nz.leading_zeros() + 1); //~ manual_highest_one
+    let _ = nz.bit_width().get() - 1; //~ manual_highest_one
+
+    // --- In if block ---
+    let _ = if u == 0 {
+        //~^ manual_highest_one
+        todo!()
+    } else {
+        u.bit_width() - 1
+    };
+    let _ = if 0 == u {
+        //~^ manual_highest_one
+        todo!()
+    } else {
+        u.bit_width() - 1
+    };
+    let _ = if u != 0 {
+        //~^ manual_highest_one
+        u.bit_width() - 1
+    } else {
+        todo!()
+    };
+    let _ = if u > 0 {
+        //~^ manual_highest_one
+        u.bit_width() - 1
+    } else {
+        todo!()
+    };
+    let _ = if i > 0 {
+        31 - i.leading_zeros() //~ manual_highest_one
+    } else {
+        todo!()
+    };
+
+    // This should not be linted because ..
+    let _ = if u == 0 {
+        todo!()
+    } else {
+        // this arm may change state
+        black_box(u);
+        u.bit_width() - 1 //~ manual_highest_one
+    };
+    // Whereas, this should be linted.
+    let _ = if u == 0 {
+        //~^ manual_highest_one
+        black_box(u);
+        todo!()
+    } else {
+        u.bit_width() - 1
+    };
+
+    // --- In match arm ---
+    let _ = match u {
+        //~^ manual_highest_one
+        0 => {
+            black_box(u);
+            todo!()
+        },
+        _ => u.bit_width() - 1,
+    };
+    let _ = match u {
+        0 => todo!(),
+        _ => {
+            black_box(u);
+            u.bit_width() - 1 //~ manual_highest_one
+        },
+    };
+    let _ = match u {
+        0 => u.bit_width() - 1, //~ manual_highest_one
+        _ => todo!(),
+    };
+
+    // --- Macro ---
+    // `identity!` macro cannot be detected because span is not updated during expansion,
+    // so this is a false positive.
+    let _ = identity!(31) - u.leading_zeros(); //~ manual_highest_one
+    let _ = 31 - identity!(u).leading_zeros(); //~ manual_highest_one
+    // We are very conservative about macro, so these should not be linted.
+    let _ = 31 - double!(u).leading_zeros();
+    let _ = thirty_one!() - u.leading_zeros();
+    let _ = (u32::BITS - one!()) - u.leading_zeros();
+    let _ = (u32::BITS - u.leading_zeros()) - one!();
+    let _ = u32::BITS - (one!() + u.leading_zeros());
+    let _ = u32::BITS - (u.leading_zeros() + one!());
+    // Whereas, this case should be linted.
+    let _ = double!(u).bit_width() - 1; //~ manual_highest_one
+
+    macro_rules! ignore_me {
+        () => {
+            let _ = 31 - u.leading_zeros();
+            let _ = u32::BITS - 1 - u.leading_zeros();
+            let _ = u32::BITS - (1 + u.leading_zeros());
+        };
+    }
+    ignore_me!();
+
+    // False negative
+    let _ = if u == 0 {
+        let v = u;
+        31 - v.leading_zeros() //~ manual_highest_one
+    } else {
+        let _ = "Rust is fast, memory-safe and productive.";
+        3
+    };
+}

--- a/tests/ui/manual_highest_one.stderr
+++ b/tests/ui/manual_highest_one.stderr
@@ -1,0 +1,294 @@
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:36:13
+   |
+LL |     let _ = 31 - u.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+   |
+   = note: `-D clippy::manual-highest-one` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_highest_one)]`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:37:13
+   |
+LL |     let _ = u32::BITS - 1 - u.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:38:13
+   |
+LL |     let _ = u32::BITS - u.leading_zeros() - 1;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:39:13
+   |
+LL |     let _ = u32::BITS - (1 + u.leading_zeros());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:40:13
+   |
+LL |     let _ = u32::BITS - (u.leading_zeros() + 1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:41:13
+   |
+LL |     let _ = u.bit_width() - 1;
+   |             ^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:43:13
+   |
+LL |     let _ = 31_u32.checked_sub(u.leading_zeros());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:44:13
+   |
+LL |     let _ = u32::BITS.checked_sub(u.leading_zeros() + 1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:45:13
+   |
+LL |     let _ = (u32::BITS - 1).checked_sub(u.leading_zeros());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:46:13
+   |
+LL |     let _ = u.bit_width().checked_sub(1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:48:13
+   |
+LL |     let _ = 31 - i.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `i.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:49:13
+   |
+LL |     let _ = i32::BITS - 1 - i.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `i.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:50:13
+   |
+LL |     let _ = i32::BITS - i.leading_zeros() - 1;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `i.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:51:13
+   |
+LL |     let _ = i32::BITS - (1 + i.leading_zeros());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `i.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:52:13
+   |
+LL |     let _ = i32::BITS - (i.leading_zeros() + 1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `i.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:55:13
+   |
+LL |     let _ = 31 - nz.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `nz.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:56:13
+   |
+LL |     let _ = NonZeroU32::BITS - 1 - nz.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `nz.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:57:13
+   |
+LL |     let _ = NonZeroU32::BITS - (1 + nz.leading_zeros());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `nz.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:58:13
+   |
+LL |     let _ = NonZeroU32::BITS - (nz.leading_zeros() + 1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `nz.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:59:13
+   |
+LL |     let _ = nz.bit_width().get() - 1;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `nz.highest_one()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:62:13
+   |
+LL |       let _ = if u == 0 {
+   |  _____________^
+LL | |
+LL | |         todo!()
+LL | |     } else {
+LL | |         u.bit_width() - 1
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     let _ = u.highest_one().unwrap_or_else(|| {
+LL +
+LL +         todo!()
+LL ~     });
+   |
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:68:13
+   |
+LL |       let _ = if 0 == u {
+   |  _____________^
+LL | |
+LL | |         todo!()
+LL | |     } else {
+LL | |         u.bit_width() - 1
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     let _ = u.highest_one().unwrap_or_else(|| {
+LL +
+LL +         todo!()
+LL ~     });
+   |
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:74:13
+   |
+LL |       let _ = if u != 0 {
+   |  _____________^
+LL | |
+LL | |         u.bit_width() - 1
+LL | |     } else {
+LL | |         todo!()
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     let _ = u.highest_one().unwrap_or_else(|| {
+LL +         todo!()
+LL ~     });
+   |
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:80:13
+   |
+LL |       let _ = if u > 0 {
+   |  _____________^
+LL | |
+LL | |         u.bit_width() - 1
+LL | |     } else {
+LL | |         todo!()
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     let _ = u.highest_one().unwrap_or_else(|| {
+LL +         todo!()
+LL ~     });
+   |
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:87:9
+   |
+LL |         31 - i.leading_zeros()
+   |         ^^^^^^^^^^^^^^^^^^^^^^ help: try: `i.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:98:9
+   |
+LL |         u.bit_width() - 1
+   |         ^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:101:13
+   |
+LL |       let _ = if u == 0 {
+   |  _____________^
+LL | |
+LL | |         black_box(u);
+LL | |         todo!()
+LL | |     } else {
+LL | |         u.bit_width() - 1
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     let _ = u.highest_one().unwrap_or_else(|| {
+LL +
+LL +         black_box(u);
+LL +         todo!()
+LL ~     });
+   |
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:110:13
+   |
+LL |       let _ = match u {
+   |  _____________^
+LL | |
+LL | |         0 => {
+LL | |             black_box(u);
+...  |
+LL | |         _ => u.bit_width() - 1,
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     let _ = u.highest_one().unwrap_or_else(|| {
+LL +             black_box(u);
+LL +             todo!()
+LL ~         });
+   |
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:122:13
+   |
+LL |             u.bit_width() - 1
+   |             ^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:126:14
+   |
+LL |         0 => u.bit_width() - 1,
+   |              ^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:133:13
+   |
+LL |     let _ = identity!(31) - u.leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:134:13
+   |
+LL |     let _ = 31 - identity!(u).leading_zeros();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u.highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:143:13
+   |
+LL |     let _ = double!(u).bit_width() - 1;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `double!(u).highest_one().unwrap()`
+
+error: manually reimplementing `highest_one`
+  --> tests/ui/manual_highest_one.rs:157:9
+   |
+LL |         31 - v.leading_zeros()
+   |         ^^^^^^^^^^^^^^^^^^^^^^ help: try: `v.highest_one().unwrap()`
+
+error: aborting due to 34 previous errors
+

--- a/tests/ui/manual_ilog2.fixed
+++ b/tests/ui/manual_ilog2.fixed
@@ -1,4 +1,5 @@
 //@aux-build:proc_macros.rs
+#![allow(clippy::manual_highest_one)]
 #![warn(clippy::manual_ilog2)]
 #![expect(clippy::unnecessary_operation)]
 

--- a/tests/ui/manual_ilog2.rs
+++ b/tests/ui/manual_ilog2.rs
@@ -1,4 +1,5 @@
 //@aux-build:proc_macros.rs
+#![allow(clippy::manual_highest_one)]
 #![warn(clippy::manual_ilog2)]
 #![expect(clippy::unnecessary_operation)]
 

--- a/tests/ui/manual_ilog2.stderr
+++ b/tests/ui/manual_ilog2.stderr
@@ -1,5 +1,5 @@
 error: manually reimplementing `ilog2`
-  --> tests/ui/manual_ilog2.rs:8:5
+  --> tests/ui/manual_ilog2.rs:9:5
    |
 LL |     31 - a.leading_zeros();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.ilog2()`
@@ -8,25 +8,25 @@ LL |     31 - a.leading_zeros();
    = help: to override `-D warnings` add `#[allow(clippy::manual_ilog2)]`
 
 error: manually reimplementing `ilog2`
-  --> tests/ui/manual_ilog2.rs:9:5
+  --> tests/ui/manual_ilog2.rs:10:5
    |
 LL |     a.ilog(2);
    |     ^^^^^^^^^ help: try: `a.ilog2()`
 
 error: manually reimplementing `ilog2`
-  --> tests/ui/manual_ilog2.rs:11:5
+  --> tests/ui/manual_ilog2.rs:12:5
    |
 LL |     63 - b.leading_zeros();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `b.ilog2()`
 
 error: manually reimplementing `ilog2`
-  --> tests/ui/manual_ilog2.rs:45:15
+  --> tests/ui/manual_ilog2.rs:46:15
    |
 LL |     let log = 31 - access!(x).leading_zeros();
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `access!(x).ilog2()`
 
 error: manually reimplementing `ilog2`
-  --> tests/ui/manual_ilog2.rs:47:15
+  --> tests/ui/manual_ilog2.rs:48:15
    |
 LL |     let log = access!(x).ilog(2);
    |               ^^^^^^^^^^^^^^^^^^ help: try: `access!(x).ilog2()`


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17472)*

implementation of https://github.com/rust-lang/rust-clippy/issues/16985#issue-4414925038

checklist

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally (except for `cargo test --test dogfood` because `tikv_jemalloc_sys` is not resolved)
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

changelog: [`manual_highest_one`]: add new lint to check manual implementation of `highest_one()`