### PR TITLE
feature: Check `-Zhint-msrv` on nightly

### DIFF
--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -955,9 +955,16 @@ impl Conf {
             Conf::default()
         };
 
-        let cargo_msrv = env::var("CARGO_PKG_RUST_VERSION")
-            .ok()
-            .and_then(|v| parse_version(Symbol::intern(&v)));
+        let cargo_msrv = if sess.is_nightly_build()
+            && let Some(msrv) = sess.opts.unstable_opts.hint_msrv
+        {
+            Some(msrv)
+        } else {
+            env::var("CARGO_PKG_RUST_VERSION")
+                .ok()
+                .and_then(|v| parse_version(Symbol::intern(&v)))
+        };
+
         match (&conf.msrv, cargo_msrv) {
             (None, Some(cargo_msrv)) => conf.msrv = Some(cargo_msrv),
             (Some(clippy_msrv), Some(cargo_msrv)) => {


### PR DESCRIPTION
When on a nightly build, gather the MSRV from `-Zhint-msrv` as well as `package.rust-version`.
This is to enable this feature to get more testing; there have been objections to adding MSRV-affecting lints to rustc before this feature is stabilised, and without those lints in rustc it's difficult to test and stabilise the feature. Clippy already has MSRV aware lints, so make it aware of the new dedicated flag.

Rust tracking issue: https://github.com/rust-lang/rust/issues/157574

changelog: respect `-Zhint-msrv`

