### PR TITLE
Configuration: Add `too_long_first_doc_paragraph` lint to the `check-private-items` list

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -530,6 +530,7 @@ Whether to also run the listed lints on private items.
 * [`missing_errors_doc`](https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc)
 * [`missing_panics_doc`](https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc)
 * [`missing_safety_doc`](https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc)
+* [`too_long_first_doc_paragraph`](https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph)
 * [`unnecessary_safety_doc`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_safety_doc)
 
 

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -530,6 +530,7 @@ Whether to also run the listed lints on private items.
 * [`missing_errors_doc`](https://rust-lang.github.io/rust-clippy/main/index.html#missing_errors_doc)
 * [`missing_panics_doc`](https://rust-lang.github.io/rust-clippy/main/index.html#missing_panics_doc)
 * [`missing_safety_doc`](https://rust-lang.github.io/rust-clippy/main/index.html#missing_safety_doc)
+* [`too_long_first_doc_paragraph`](https://rust-lang.github.io/rust-clippy/main/index.html#too_long_first_doc_paragraph)
 * [`unnecessary_safety_doc`](https://rust-lang.github.io/rust-clippy/main/index.html#unnecessary_safety_doc)
 
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -472,7 +472,13 @@ define_Conf! {
     #[lints(inconsistent_struct_constructor)]
     check_inconsistent_struct_field_initializers("check-inconsistent-struct-field-initializers"): bool = false,
     /// Whether to also run the listed lints on private items.
-    #[lints(missing_errors_doc, missing_panics_doc, missing_safety_doc, unnecessary_safety_doc)]
+    #[lints(
+        missing_errors_doc,
+        missing_panics_doc,
+        missing_safety_doc,
+        too_long_first_doc_paragraph,
+        unnecessary_safety_doc,
+    )]
     check_private_items("check-private-items"): bool = false,
     /// The maximum cognitive complexity a function can have
     #[lints(cognitive_complexity)]


### PR DESCRIPTION
I [enabled](https://github.com/tock/tock/pull/5004) the `check-private-items` configuration option and I found that the setting affects the `too_long_first_doc_paragraph` lint, however, that is not documented. I believe this change adds the connection between the lint and the configuration option so that it will show up in the [docs](https://rust-lang.github.io/rust-clippy/master/?search=too_long_first_doc_paragraph#too_long_first_doc_paragraph).

The line became more than 120 characters so I believe I formatted it correctly on multiple lines, following the `msrv` example. Also, I preserved the alphabetical ordering.

changelog: [`too_long_first_doc_paragraph`]: add `check-private-items` as documented config option.
