### PR TITLE
refactor: use `is_none_{expr,pattern}` in more places

### DIFF
--- a/clippy_lints/src/loops/manual_find.rs
+++ b/clippy_lints/src/loops/manual_find.rs
@@ -1,13 +1,12 @@
 use super::MANUAL_FIND;
 use super::utils::make_iterator_snippet;
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _};
+use clippy_utils::res::MaybeResPath as _;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::implements_trait;
 use clippy_utils::usage::contains_return_break_continue_macro;
-use clippy_utils::{as_some_expr, higher, peel_blocks_with_stmt};
+use clippy_utils::{as_some_expr, higher, is_none_expr, peel_blocks_with_stmt};
 use rustc_errors::Applicability;
-use rustc_hir::lang_items::LangItem;
 use rustc_hir::{BindingMode, Block, Expr, ExprKind, HirId, Node, Pat, PatKind, Stmt, StmtKind};
 use rustc_lint::LateContext;
 use rustc_span::Span;
@@ -149,7 +148,7 @@ fn last_stmt_and_ret<'tcx>(
         && let Some((_, Node::Block(block))) = parent_iter.next()
         && let Some((last_stmt, last_ret)) = extract(block)
         && last_stmt.hir_id == node_hir
-        && last_ret.res(cx).ctor_parent(cx).is_lang_item(cx, LangItem::OptionNone)
+        && is_none_expr(cx, last_ret)
         && let Some((_, Node::Expr(_block))) = parent_iter.next()
         // This includes the function header
         && let Some((_, func)) = parent_iter.next()

--- a/clippy_lints/src/matches/collapsible_match.rs
+++ b/clippy_lints/src/matches/collapsible_match.rs
@@ -1,15 +1,16 @@
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::higher::{If, IfLetOrMatch};
 use clippy_utils::msrvs::Msrv;
-use clippy_utils::res::{MaybeDef as _, MaybeResPath as _};
+use clippy_utils::res::MaybeResPath as _;
 use clippy_utils::source::{IntoSpan as _, SpanExt as _, snippet};
 use clippy_utils::usage::mutated_variables;
 use clippy_utils::visitors::is_local_used;
-use clippy_utils::{SpanlessEq, get_ref_operators, is_unit_expr, peel_blocks_with_stmt, peel_ref_operators};
+use clippy_utils::{
+    SpanlessEq, get_ref_operators, is_none_pattern, is_unit_expr, peel_blocks_with_stmt, peel_ref_operators,
+};
 use rustc_ast::BorrowKind;
 use rustc_errors::{Applicability, MultiSpan};
-use rustc_hir::LangItem::OptionNone;
-use rustc_hir::{Arm, Expr, ExprKind, HirId, HirIdSet, Pat, PatExpr, PatExprKind, PatKind};
+use rustc_hir::{Arm, Expr, ExprKind, HirId, HirIdSet, Pat, PatKind};
 use rustc_hir_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
 use rustc_lint::LateContext;
 use rustc_middle::mir::FakeReadCause;
@@ -216,18 +217,7 @@ fn arm_is_wild_like(cx: &LateContext<'_>, arm: &Arm<'_>) -> bool {
     if arm.guard.is_some() {
         return false;
     }
-    match arm.pat.kind {
-        PatKind::Binding(..) | PatKind::Wild => true,
-        PatKind::Expr(PatExpr {
-            kind: PatExprKind::Path(qpath),
-            hir_id,
-            ..
-        }) => cx
-            .qpath_res(qpath, *hir_id)
-            .ctor_parent(cx)
-            .is_lang_item(cx, OptionNone),
-        _ => false,
-    }
+    matches!(arm.pat.kind, PatKind::Binding(..) | PatKind::Wild) || is_none_pattern(cx, arm.pat)
 }
 
 fn find_pat_binding_and_is_innermost_parent_pat_struct(pat: &Pat<'_>, hir_id: HirId) -> (Option<(Ident, Span)>, bool) {

--- a/clippy_lints/src/matches/manual_filter.rs
+++ b/clippy_lints/src/matches/manual_filter.rs
@@ -1,12 +1,11 @@
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
-use clippy_utils::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _};
+use clippy_utils::res::{MaybeDef as _, MaybeResPath as _};
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::is_copy;
 use clippy_utils::visitors::contains_unsafe_block;
 use clippy_utils::{as_some_expr, span_contains_comment};
 use rustc_errors::Applicability;
-use rustc_hir::LangItem::OptionNone;
 use rustc_hir::{Arm, Expr, ExprKind, HirId, Pat, PatKind};
 use rustc_lint::LateContext;
 use rustc_span::{Span, SyntaxContext, sym};
@@ -74,10 +73,7 @@ fn is_some_expr(cx: &LateContext<'_>, target: HirId, ctxt: SyntaxContext, expr: 
 }
 
 fn is_none_expr(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    if let Some(inner_expr) = peels_blocks_incl_unsafe_opt(expr) {
-        return inner_expr.res(cx).ctor_parent(cx).is_lang_item(cx, OptionNone);
-    }
-    false
+    peels_blocks_incl_unsafe_opt(expr).is_some_and(|inner_expr| clippy_utils::is_none_expr(cx, inner_expr))
 }
 
 // given the closure: `|<pattern>| <expr>`

--- a/clippy_lints/src/matches/manual_unwrap_or.rs
+++ b/clippy_lints/src/matches/manual_unwrap_or.rs
@@ -42,12 +42,13 @@ fn get_none<'tcx>(cx: &LateContext<'_>, arm: &Arm<'tcx>, allow_wildcard: bool) -
         && cx.tcx.lang_items().get(LangItem::OptionNone) == Some(def_id)
     {
         Some(arm.body)
-    } else if let PatKind::TupleStruct(QPath::Resolved(_, path), _, _)= arm.pat.kind
-        && let Some(def_id) = path.res.opt_def_id()
-        // Since it comes from a pattern binding, we need to get the parent to actually match
-        // against it.
-        && let Some(def_id) = cx.tcx.opt_parent(def_id)
-        && cx.tcx.lang_items().get(LangItem::ResultErr) == Some(def_id)
+    } else if let PatKind::TupleStruct(QPath::Resolved(_, path), _, _) = arm.pat.kind
+        && (path.res)
+            .opt_def_id()
+            // Since it comes from a pattern binding, we need to get the parent to actually match
+            // against it.
+            .opt_parent(cx)
+            .is_lang_item(cx, LangItem::ResultErr)
     {
         Some(arm.body)
     } else if let PatKind::Wild = arm.pat.kind

--- a/clippy_lints/src/matches/manual_unwrap_or.rs
+++ b/clippy_lints/src/matches/manual_unwrap_or.rs
@@ -4,7 +4,7 @@ use clippy_utils::source::{SpanExt as _, indent_of, reindent_multiline};
 use rustc_ast::{BindingMode, ByRef};
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
-use rustc_hir::{Arm, Expr, ExprKind, HirId, LangItem, Pat, PatExpr, PatExprKind, PatKind, QPath};
+use rustc_hir::{Arm, Expr, ExprKind, HirId, LangItem, Pat, PatKind, QPath};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{GenericArgKind, Ty};
 use rustc_span::sym;
@@ -13,7 +13,7 @@ use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::{expr_type_is_certain, implements_trait, is_copy};
 use clippy_utils::usage::local_used_after_expr;
-use clippy_utils::{is_default_equivalent, is_lint_allowed, peel_blocks, span_contains_comment};
+use clippy_utils::{is_default_equivalent, is_lint_allowed, is_none_pattern, peel_blocks, span_contains_comment};
 
 use super::{MANUAL_UNWRAP_OR, MANUAL_UNWRAP_OR_DEFAULT};
 
@@ -34,13 +34,7 @@ fn get_some(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<HirId> {
 }
 
 fn get_none<'tcx>(cx: &LateContext<'_>, arm: &Arm<'tcx>, allow_wildcard: bool) -> Option<&'tcx Expr<'tcx>> {
-    if let PatKind::Expr(PatExpr { kind: PatExprKind::Path(QPath::Resolved(_, path)), .. }) = arm.pat.kind
-        && let Some(def_id) = path.res.opt_def_id()
-        // Since it comes from a pattern binding, we need to get the parent to actually match
-        // against it.
-        && let Some(def_id) = cx.tcx.opt_parent(def_id)
-        && cx.tcx.lang_items().get(LangItem::OptionNone) == Some(def_id)
-    {
+    if is_none_pattern(cx, arm.pat) {
         Some(arm.body)
     } else if let PatKind::TupleStruct(QPath::Resolved(_, path), _, _) = arm.pat.kind
         && (path.res)

--- a/clippy_lints/src/matches/needless_match.rs
+++ b/clippy_lints/src/matches/needless_match.rs
@@ -1,13 +1,13 @@
 use super::NEEDLESS_MATCH;
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::res::{MaybeDef as _, MaybeQPath as _};
+use clippy_utils::res::MaybeDef as _;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::same_type_modulo_regions;
 use clippy_utils::{
-    SpanlessEq, eq_expr_value, get_parent_expr_for_hir, higher, is_else_clause, over, peel_blocks_with_stmt,
+    SpanlessEq, eq_expr_value, get_parent_expr_for_hir, higher, is_else_clause, is_none_expr, over,
+    peel_blocks_with_stmt,
 };
 use rustc_errors::Applicability;
-use rustc_hir::LangItem::OptionNone;
 use rustc_hir::{
     Arm, BindingMode, ByRef, Expr, ExprKind, ItemKind, Node, Pat, PatExpr, PatExprKind, PatKind, Path, QPath,
 };
@@ -108,8 +108,7 @@ fn check_if_let_inner(cx: &LateContext<'_>, ctxt: SyntaxContext, if_let: &higher
             }
             let let_expr_ty = cx.typeck_results().expr_ty(if_let.let_expr);
             if let_expr_ty.is_diag_item(cx, sym::Option) {
-                return else_expr.res(cx).ctor_parent(cx).is_lang_item(cx, OptionNone)
-                    || eq_expr_value(cx, ctxt, if_let.let_expr, else_expr);
+                return is_none_expr(cx, else_expr) || eq_expr_value(cx, ctxt, if_let.let_expr, else_expr);
             }
             return eq_expr_value(cx, ctxt, if_let.let_expr, else_expr);
         }

--- a/clippy_lints/src/methods/map_unwrap_or.rs
+++ b/clippy_lints/src/methods/map_unwrap_or.rs
@@ -1,13 +1,14 @@
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::is_none_expr;
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::res::{MaybeDef as _, MaybeResPath as _};
+use clippy_utils::res::MaybeDef as _;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::is_copy;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
 use rustc_hir::intravisit::{Visitor, walk_expr, walk_path};
-use rustc_hir::{ExprKind, HirId, LangItem, Node, PatKind, Path, QPath};
+use rustc_hir::{ExprKind, HirId, Node, PatKind, Path, QPath};
 use rustc_lint::LateContext;
 use rustc_middle::hir::nested_filter;
 use rustc_span::{Span, sym};
@@ -82,12 +83,7 @@ pub(super) fn check<'tcx>(
     let unwrap_snippet = snippet_with_applicability(cx, unwrap_arg.span, "..", &mut applicability);
     // lint message
 
-    let suggest_kind = if recv_ty_kind == sym::Option
-        && unwrap_arg
-            .basic_res()
-            .ctor_parent(cx)
-            .is_lang_item(cx, LangItem::OptionNone)
-    {
+    let suggest_kind = if recv_ty_kind == sym::Option && is_none_expr(cx, unwrap_arg) {
         SuggestedKind::AndThen
     }
     // is_some_and is stabilised && `unwrap_or` argument is false; suggest `is_some_and` instead

--- a/clippy_lints/src/methods/unnecessary_filter_map.rs
+++ b/clippy_lints/src/methods/unnecessary_filter_map.rs
@@ -1,13 +1,12 @@
 use super::utils::clone_or_copy_needed;
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _, MaybeTypeckRes as _};
+use clippy_utils::res::{MaybeDef as _, MaybeResPath as _, MaybeTypeckRes as _};
 use clippy_utils::ty::{is_copy, option_arg_ty};
 use clippy_utils::usage::mutated_variables;
 use clippy_utils::visitors::{Descend, for_each_expr_without_closures};
-use clippy_utils::{as_some_expr, sym};
+use clippy_utils::{as_some_expr, is_none_expr, sym};
 use core::ops::ControlFlow;
 use rustc_hir as hir;
-use rustc_hir::LangItem::{OptionNone, OptionSome};
 use rustc_lint::LateContext;
 use rustc_span::Span;
 use std::fmt::Display;
@@ -111,25 +110,18 @@ impl Display for Kind {
 // returns (found_mapping, found_filtering)
 fn check_expression<'tcx>(cx: &LateContext<'tcx>, arg_id: hir::HirId, expr: &'tcx hir::Expr<'_>) -> (bool, bool) {
     match expr.kind {
-        hir::ExprKind::Path(ref path)
-            if cx
-                .qpath_res(path, expr.hir_id)
-                .ctor_parent(cx)
-                .is_lang_item(cx, OptionNone) =>
-        {
+        hir::ExprKind::Path(_) if is_none_expr(cx, expr) => {
             // None
             (false, true)
         },
-        hir::ExprKind::Call(func, args) => {
-            if func.res(cx).ctor_parent(cx).is_lang_item(cx, OptionSome) {
-                if args[0].res_local_id() == Some(arg_id) {
-                    // Some(arg_id)
-                    return (false, false);
-                }
+        hir::ExprKind::Call(..) if let Some(found_arg) = as_some_expr(cx, expr) => {
+            if found_arg.res_local_id() == Some(arg_id) {
+                // Some(arg_id)
+                (false, false)
+            } else {
                 // Some(not arg_id)
-                return (true, false);
+                (true, false)
             }
-            (true, true)
         },
         hir::ExprKind::MethodCall(segment, recv, [arg], _)
             if segment.ident.name == sym::then_some

--- a/clippy_lints/src/partialeq_to_none.rs
+++ b/clippy_lints/src/partialeq_to_none.rs
@@ -1,8 +1,8 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::res::{MaybeDef as _, MaybeQPath as _};
-use clippy_utils::{peel_hir_expr_refs, peel_ref_operators, sugg};
+use clippy_utils::res::MaybeDef as _;
+use clippy_utils::{is_none_expr, peel_hir_expr_refs, peel_ref_operators, sugg};
 use rustc_errors::Applicability;
-use rustc_hir::{BinOpKind, Expr, ExprKind, LangItem};
+use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 use rustc_span::sym;
@@ -56,14 +56,8 @@ impl<'tcx> LateLintPass<'tcx> for PartialeqToNone {
         };
 
         // If the expression is a literal `Option::None`
-        let is_none_ctor = |expr: &Expr<'_>| {
-            !expr.span.from_expansion()
-                && peel_hir_expr_refs(expr)
-                    .0
-                    .res(cx)
-                    .ctor_parent(cx)
-                    .is_lang_item(cx, LangItem::OptionNone)
-        };
+        let is_none_ctor =
+            |expr: &Expr<'_>| !expr.span.from_expansion() && is_none_expr(cx, peel_hir_expr_refs(expr).0);
 
         let mut applicability = Applicability::MachineApplicable;
 

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -11,8 +11,8 @@ use clippy_utils::ty::{implements_trait, is_copy};
 use clippy_utils::usage::local_used_after_expr;
 use clippy_utils::{
     eq_expr_value, fn_def_id_with_node_args, higher, is_else_clause, is_in_const_context, is_lint_allowed,
-    pat_and_expr_can_be_question_mark, peel_blocks, peel_blocks_with_stmt, span_contains_cfg, span_contains_comment,
-    sym,
+    is_none_expr, is_none_pattern, pat_and_expr_can_be_question_mark, peel_blocks, peel_blocks_with_stmt,
+    span_contains_cfg, span_contains_comment, sym,
 };
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::{self, OptionNone, OptionSome, ResultErr, ResultOk};
@@ -420,10 +420,10 @@ fn check_arm_is_none_or_err<'tcx>(cx: &LateContext<'tcx>, mode: TryMode, arm: &A
         },
         TryMode::Option => {
             // Check the pat is `None`
-            if arm.pat.res(cx).ctor_parent(cx).is_lang_item(cx, OptionNone)
+            if is_none_pattern(cx, arm.pat)
                 // Check `=> return None`
                 && let ExprKind::Ret(Some(ret_expr)) = arm_body.kind
-                && ret_expr.res(cx).ctor_parent(cx).is_lang_item(cx, OptionNone)
+                && is_none_expr(cx, ret_expr)
                 && !ret_expr.span.from_expansion()
             {
                 true

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -223,11 +223,13 @@ fn is_early_return(smbl: Symbol, cx: &LateContext<'_>, if_block: &IfBlockType<'_
                         // We only need to check `if let Some(x) = option` not `if let None = option`,
                         // because the later one will be suggested as `if option.is_none()` thus causing conflict.
                         res.ctor_parent(cx).is_lang_item(cx, OptionSome)
-                            && matches!(if_else, Some(inner) if expr_return_none_or_err(smbl, cx, inner, let_expr, None))
+                            && if_else.is_some_and(|inner| expr_return_none_or_err(smbl, cx, inner, let_expr, None))
                     },
                     sym::Result => {
                         (res.ctor_parent(cx).is_lang_item(cx, ResultOk)
-                            && matches!(if_else, Some(inner) if expr_return_none_or_err(smbl, cx, inner, let_expr, Some(let_pat_sym))))
+                            && if_else.is_some_and(|inner| {
+                                expr_return_none_or_err(smbl, cx, inner, let_expr, Some(let_pat_sym))
+                            }))
                             || res.ctor_parent(cx).is_lang_item(cx, ResultErr)
                                 && expr_return_none_or_err(smbl, cx, if_then, let_expr, Some(let_pat_sym))
                                 && if_else.is_none()

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -121,7 +121,7 @@ use visitors::{Visitable, for_each_unconsumed_temporary};
 use crate::ast_utils::unordered_over;
 use crate::higher::Range;
 use crate::msrvs::Msrv;
-use crate::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _};
+use crate::res::{MaybeDef as _, MaybeResPath as _};
 use crate::source::HasSourceMap;
 use crate::ty::{adt_and_variant_of_res, can_partially_move_ty, expr_sig, is_copy, is_recursively_primitive_type};
 use crate::visitors::for_each_expr_without_closures;
@@ -299,13 +299,13 @@ pub fn is_lang_item_or_ctor(cx: &LateContext<'_>, did: DefId, item: LangItem) ->
 
 /// Checks is `expr` is `None`
 pub fn is_none_expr(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    expr.res(cx).ctor_parent(cx).is_lang_item(cx, OptionNone)
+    expr.basic_res().ctor_parent(cx).is_lang_item(cx, OptionNone)
 }
 
 /// If `expr` is `Some(inner)`, returns `inner`
 pub fn as_some_expr<'tcx>(cx: &LateContext<'_>, expr: &'tcx Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
     if let ExprKind::Call(e, [arg]) = expr.kind
-        && e.res(cx).ctor_parent(cx).is_lang_item(cx, OptionSome)
+        && e.basic_res().ctor_parent(cx).is_lang_item(cx, OptionSome)
     {
         Some(arg)
     } else {


### PR DESCRIPTION
More intuitive that the manual incantations imo.

changelog: none