### PR TITLE
Don't reuse cargo clippy --fix results for regular checks

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -33,6 +33,8 @@ use std::io::Write as _;
 use std::path::Path;
 use std::process::ExitCode;
 
+const CLIPPY_FIX_ARGS_MARKER: &str = "__CLIPPY_FIX__";
+
 /// If a command-line option matches `find_arg`, then apply the predicate `pred` on its value. If
 /// true, then return it. The parameter is assumed to be either `--arg=value` or `--arg value`.
 fn arg_value(args: &[String], find_arg: &str, pred: impl Fn(&str) -> bool) -> bool {
@@ -285,7 +287,7 @@ fn main() -> ExitCode {
             .unwrap_or_default()
             .split("__CLIPPY_HACKERY__")
             .filter_map(|s| match s {
-                "" => None,
+                "" | CLIPPY_FIX_ARGS_MARKER => None,
                 "--no-deps" => {
                     no_deps = true;
                     None

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ use std::io::Write as _;
 use std::path::PathBuf;
 use std::process::{self, Command, exit};
 
+const CLIPPY_FIX_ARGS_MARKER: &str = "__CLIPPY_FIX__";
+
 fn show_help() {
     if writeln!(&mut anstream::stdout().lock(), "{}", help_message()).is_err() {
         exit(rustc_driver::EXIT_FAILURE);
@@ -113,6 +115,8 @@ impl ClippyCmd {
         let clippy_args: String = self
             .clippy_args
             .iter()
+            .map(String::as_str)
+            .chain((self.cargo_subcommand == "fix").then_some(CLIPPY_FIX_ARGS_MARKER))
             .fold(String::new(), |s, arg| s + arg + "__CLIPPY_HACKERY__");
 
         // Currently, `CLIPPY_TERMINAL_WIDTH` is used only to format "unknown field" error messages.

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -143,3 +143,65 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
     // Make sure Cargo is aware of the new `--cfg` flag.
     lint_path_dep();
 }
+
+#[test]
+fn test_fix_does_not_cache_capped_lints() {
+    if IS_RUSTC_TEST_SUITE {
+        return;
+    }
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let target_dir = root.join("target").join("workspace_test_fix_cache");
+    let cwd = root.join("tests/workspace_test");
+
+    Command::new("cargo")
+        .current_dir(&cwd)
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .arg("clean")
+        .args(["-p", "fix-cache"])
+        .output()
+        .unwrap();
+
+    let fix = Command::new(&*CARGO_CLIPPY_PATH)
+        .current_dir(&cwd)
+        .env("CARGO_INCREMENTAL", "0")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .arg("clippy")
+        .args([
+            "-p",
+            "fix-cache",
+            "--no-deps",
+            "--all-targets",
+            "--fix",
+            "--allow-dirty",
+            "--allow-staged",
+        ])
+        .arg("--")
+        .arg("-Cdebuginfo=0")
+        .arg("-Dwarnings")
+        .output()
+        .unwrap();
+
+    assert!(
+        fix.status.success(),
+        "status: {}\nstdout: {}\nstderr: {}",
+        fix.status,
+        String::from_utf8_lossy(&fix.stdout),
+        String::from_utf8_lossy(&fix.stderr)
+    );
+
+    let check = Command::new(&*CARGO_CLIPPY_PATH)
+        .current_dir(&cwd)
+        .env("CARGO_INCREMENTAL", "0")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .arg("clippy")
+        .args(["-p", "fix-cache", "--no-deps", "--all-targets"])
+        .arg("--")
+        .arg("-Cdebuginfo=0")
+        .arg("-Dwarnings")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&check.stderr);
+    assert!(!check.status.success(), "status: {}\nstderr: {stderr}", check.status);
+    assert!(stderr.contains("error: use of `println!`"), "{stderr}");
+}

--- a/tests/workspace_test/Cargo.toml
+++ b/tests/workspace_test/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2018"
 
 [workspace]
-members = ["subcrate", "module_style/pass_no_mod_with_dep_in_subdir", "module_style/pass_mod_with_dep_in_subdir"]
+members = ["fix_cache", "subcrate", "module_style/pass_no_mod_with_dep_in_subdir", "module_style/pass_mod_with_dep_in_subdir"]

--- a/tests/workspace_test/fix_cache/Cargo.toml
+++ b/tests/workspace_test/fix_cache/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fix-cache"
+version = "0.1.0"
+edition = "2024"

--- a/tests/workspace_test/fix_cache/src/lib.rs
+++ b/tests/workspace_test/fix_cache/src/lib.rs
@@ -1,0 +1,5 @@
+#![warn(clippy::print_stdout)]
+
+pub fn print() {
+    println!("fix cache");
+}


### PR DESCRIPTION
`cargo clippy --fix` caps lints, but its successful result used the same Clippy argument fingerprint as a later regular check. Cargo could then reuse warnings that should have become errors.

This includes the fix invocation in the tracked fingerprint and removes the marker before invoking rustc. The workspace regression covers `--fix` followed by a check with `-Dwarnings`.

Fixes rust-lang/rust-clippy#17444

changelog: Fix `cargo clippy --fix` results being reused by later checks
