### PR TITLE
new lint: `manual_map_err`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7124,6 +7124,7 @@ Released 2018-09-13
 [`manual_let_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else
 [`manual_main_separator_str`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_main_separator_str
 [`manual_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
+[`manual_map_err`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_map_err
 [`manual_memcpy`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_memcpy
 [`manual_midpoint`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_midpoint
 [`manual_next_back`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_next_back

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -319,6 +319,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::manual_is_power_of_two::MANUAL_IS_POWER_OF_TWO_INFO,
     crate::manual_let_else::MANUAL_LET_ELSE_INFO,
     crate::manual_main_separator_str::MANUAL_MAIN_SEPARATOR_STR_INFO,
+    crate::manual_map_err::MANUAL_MAP_ERR_INFO,
     crate::manual_non_exhaustive::MANUAL_NON_EXHAUSTIVE_INFO,
     crate::manual_noop_waker::MANUAL_NOOP_WAKER_INFO,
     crate::manual_option_as_slice::MANUAL_OPTION_AS_SLICE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -217,6 +217,7 @@ mod manual_is_ascii_check;
 mod manual_is_power_of_two;
 mod manual_let_else;
 mod manual_main_separator_str;
+mod manual_map_err;
 mod manual_non_exhaustive;
 mod manual_noop_waker;
 mod manual_option_as_slice;

--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -1,3 +1,4 @@
+use crate::manual_map_err::MANUAL_MAP_ERR;
 use crate::question_mark::{QUESTION_MARK, QuestionMark};
 use clippy_config::types::MatchLintBehaviour;
 use clippy_utils::diagnostics::span_lint_and_then;
@@ -58,6 +59,9 @@ impl<'tcx> QuestionMark {
             && let Some(if_let_or_match) = IfLetOrMatch::parse(cx, init)
             && !stmt.span.in_external_macro(cx.sess().source_map())
             && self.msrv.meets(cx, msrvs::LET_ELSE)
+            // `manual_map_err` suggests `?` for the same shape; let it own the statement rather
+            // than reporting it twice.
+            && (is_lint_allowed(cx, MANUAL_MAP_ERR, stmt.hir_id) || !self.manual_map_err_will_lint(cx, init))
         {
             match if_let_or_match {
                 IfLetOrMatch::IfLet(if_let_expr, let_pat, if_then, if_else, ..) => {

--- a/clippy_lints/src/manual_map_err.rs
+++ b/clippy_lints/src/manual_map_err.rs
@@ -3,7 +3,7 @@ use clippy_utils::higher::IfLetOrMatch;
 use clippy_utils::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _};
 use clippy_utils::source::{indent_of, reindent_multiline, snippet_with_context};
 use clippy_utils::sugg::Sugg;
-use clippy_utils::ty::{expr_type_is_certain, is_copy};
+use clippy_utils::ty::{expr_type_is_certain, implements_trait, is_copy};
 use clippy_utils::usage::local_used_after_expr;
 use clippy_utils::{
     CaptureKind, can_move_expr_to_closure, fn_def_id_with_node_args, is_else_clause, is_in_const_context,
@@ -80,9 +80,11 @@ enum ErrPat {
     Wild,
 }
 
-/// The `Err(..)` arm of the match: what it binds and the error value that gets returned.
+/// The `Err(..)` arm of the match: what it binds, the returned `Err(..)` call, and the error value
+/// inside it.
 struct ErrArm<'tcx> {
     pat: ErrPat,
+    err_call: &'tcx Expr<'tcx>,
     err_expr: &'tcx Expr<'tcx>,
 }
 
@@ -121,10 +123,13 @@ fn parse_err_pat(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<ErrPat> {
     }
 }
 
-/// Checks that `body` is `return Err(<err_expr>)`, returning `<err_expr>`. Uses
-/// `peel_blocks_with_stmt` so that the common `Err(_) => { return Err(e); }` form, where the
+/// Checks that `body` is `return Err(<err_expr>)`, returning the `Err(..)` call and `<err_expr>`.
+/// Uses `peel_blocks_with_stmt` so that the common `Err(_) => { return Err(e); }` form, where the
 /// `return` is a statement rather than a tail expression, is recognised too.
-fn parse_return_err<'tcx>(cx: &LateContext<'_>, body: &'tcx Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+fn parse_return_err<'tcx>(
+    cx: &LateContext<'_>,
+    body: &'tcx Expr<'tcx>,
+) -> Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>)> {
     let ret = peel_blocks_with_stmt(body);
     // A macro such as `anyhow::bail!` expands to `return Err(..)`. Rewriting it would put the
     // `return` inside a `map_err` closure, where it would return from the closure instead of the
@@ -134,7 +139,7 @@ fn parse_return_err<'tcx>(cx: &LateContext<'_>, body: &'tcx Expr<'tcx>) -> Optio
         && let ExprKind::Call(err_ctor, [err_expr]) = returned.kind
         && err_ctor.res(cx).ctor_parent(cx).is_lang_item(cx, ResultErr)
     {
-        Some(err_expr)
+        Some((returned, err_expr))
     } else {
         None
     }
@@ -155,21 +160,50 @@ fn is_local_or_local_into(cx: &LateContext<'_>, expr: &Expr<'_>, val: HirId) -> 
 }
 
 /// In `return Err(e)`, the type of `e` is pinned to the function's error type, and that pin is what
-/// picks `Self` for a call to a trait associated function such as `de::Error::invalid_type(..)`.
-/// Behind `?` the pin is gone: `?` inserts a `From` conversion, so the closure's error type only
-/// has to satisfy `From<_>` and `Self` becomes ambiguous (E0790/E0283).
+/// picks `Self` for a call to a trait associated function such as `de::Error::invalid_type(..)`, or
+/// the output type of a generic trait method such as `.into()`. Behind `?` the pin is gone: `?`
+/// inserts a `From` conversion, so the closure's error type only has to satisfy `From<_>` and the
+/// call becomes ambiguous (E0790/E0283).
 fn err_type_needs_return_context(cx: &LateContext<'_>, err_expr: &Expr<'_>) -> bool {
-    // Only a call naming the trait itself (`Trait::assoc(..)`) leaves `Self` to inference. A method
-    // call takes it from the receiver, and `Ty::assoc(..)` / `<Ty as Trait>::assoc(..)` spell it out.
-    if let ExprKind::Call(callee, _) = err_expr.kind
-        && let ExprKind::Path(QPath::Resolved(None, path)) = callee.kind
-        && let Res::Def(DefKind::AssocFn, def_id) = path.res
-        && cx.tcx.trait_of_assoc(def_id).is_some()
-    {
-        !expr_type_is_certain(cx, err_expr)
-    } else {
-        false
-    }
+    let via_trait = match err_expr.kind {
+        // Only a call naming the trait itself (`Trait::assoc(..)`) leaves `Self` to inference.
+        // `Ty::assoc(..)` and `<Ty as Trait>::assoc(..)` spell it out.
+        ExprKind::Call(callee, _) => {
+            if let ExprKind::Path(QPath::Resolved(None, path)) = callee.kind
+                && let Res::Def(DefKind::AssocFn, def_id) = path.res
+            {
+                cx.tcx.trait_of_assoc(def_id).is_some()
+            } else {
+                false
+            }
+        },
+        // A trait method with a generic output, `.into()` above all. This is conservative: some
+        // `.into()` calls would still infer behind `?` when only one `From` impl fits, but which
+        // ones cannot be told from here.
+        ExprKind::MethodCall(..) => cx
+            .typeck_results()
+            .type_dependent_def_id(err_expr.hir_id)
+            .and_then(|def_id| cx.tcx.trait_of_assoc(def_id))
+            .is_some(),
+        _ => false,
+    };
+    via_trait && !expr_type_is_certain(cx, err_expr)
+}
+
+/// `?` ends the suggestion with a `From` conversion to the function's error type, so a `From` impl
+/// must exist from the error expression's own type. `return Err(e)` was not so constrained: there
+/// `e` could also rely on an unsize coercion, e.g. `Box<ConcreteError>` returned from a function
+/// whose error type is `Box<dyn Error>` with no `From` impl to bridge them.
+fn from_conversion_exists<'tcx>(cx: &LateContext<'tcx>, err_call: &Expr<'tcx>, err_expr: &Expr<'tcx>) -> bool {
+    let err_ty = cx.typeck_results().expr_ty(err_expr);
+    let ty::Adt(adt, args) = cx.typeck_results().expr_ty(err_call).kind() else {
+        return false;
+    };
+    cx.tcx.is_diagnostic_item(sym::Result, adt.did())
+        && cx
+            .tcx
+            .get_diagnostic_item(sym::From)
+            .is_some_and(|from_trait| implements_trait(cx, args.type_at(1), from_trait, &[err_ty.into()]))
 }
 
 /// `.map()` and `.map_err()` take the scrutinee by value, so it must be an owned `Result` with no
@@ -231,7 +265,7 @@ fn parse_arms<'tcx>(
 
     let (binding, binding_span) = parse_ok_pat(cx, ok_arm.pat)?;
     let err_pat = parse_err_pat(cx, err_arm.pat)?;
-    let err_expr = parse_return_err(cx, err_arm.body)?;
+    let (err_call, err_expr) = parse_return_err(cx, err_arm.body)?;
 
     // `Err(e) => return Err(e)` and `Err(e) => return Err(e.into())` are `question_mark`'s job.
     if let ErrPat::Binding(err_id, _) = err_pat
@@ -246,7 +280,11 @@ fn parse_arms<'tcx>(
             binding_span,
             body: peel_blocks(ok_arm.body),
         },
-        ErrArm { pat: err_pat, err_expr },
+        ErrArm {
+            pat: err_pat,
+            err_call,
+            err_expr,
+        },
     ))
 }
 
@@ -262,7 +300,7 @@ fn parse_expr<'tcx>(
         },
         IfLetOrMatch::IfLet(scrutinee, let_pat, if_then, Some(if_else), _) => {
             let (binding, binding_span) = parse_ok_pat(cx, let_pat)?;
-            let err_expr = parse_return_err(cx, if_else)?;
+            let (err_call, err_expr) = parse_return_err(cx, if_else)?;
             Some((
                 scrutinee,
                 OkArm {
@@ -273,6 +311,7 @@ fn parse_expr<'tcx>(
                 // `if let Ok(v) = r { .. } else { return Err(e) }` never binds the error.
                 ErrArm {
                     pat: ErrPat::Wild,
+                    err_call,
                     err_expr,
                 },
             ))
@@ -306,6 +345,7 @@ impl QuestionMark {
             || !is_owned_result(cx, scrutinee)
             || !bodies_can_become_closures(cx, expr, ok_arm.body, err_arm.err_expr)
             || err_type_needs_return_context(cx, err_arm.err_expr)
+            || !from_conversion_exists(cx, err_arm.err_call, err_arm.err_expr)
         {
             return None;
         }

--- a/clippy_lints/src/manual_map_err.rs
+++ b/clippy_lints/src/manual_map_err.rs
@@ -1,0 +1,406 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::higher::IfLetOrMatch;
+use clippy_utils::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _};
+use clippy_utils::source::{indent_of, reindent_multiline, snippet_with_context};
+use clippy_utils::sugg::Sugg;
+use clippy_utils::ty::{expr_type_is_certain, is_copy};
+use clippy_utils::usage::local_used_after_expr;
+use clippy_utils::{
+    CaptureKind, can_move_expr_to_closure, fn_def_id_with_node_args, is_else_clause, is_in_const_context,
+    is_lint_allowed, msrvs, peel_blocks, peel_blocks_with_stmt, span_contains_cfg, span_contains_comment, sym,
+};
+use rustc_ast::BindingMode;
+use rustc_errors::Applicability;
+use rustc_hir::LangItem::{ResultErr, ResultOk};
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::{Arm, ByRef, Expr, ExprKind, HirId, MatchSource, Node, Pat, PatKind, QPath, Stmt, StmtKind};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+use rustc_span::Span;
+
+use crate::question_mark::QuestionMark;
+use crate::question_mark_used::QUESTION_MARK_USED;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `match` and `if let` expressions on a `Result` whose error arm
+    /// unconditionally returns a *different* error, and which can therefore be
+    /// written with `map`, `map_err` and the `?` operator.
+    ///
+    /// ### Why is this bad?
+    /// The combinator form is shorter, keeps the happy path unindented, and makes
+    /// it obvious that the error arm only translates the error rather than doing
+    /// arbitrary work.
+    ///
+    /// ### Known problems
+    /// When the error value is discarded, the suggestion produces a
+    /// `map_err(|_| ..)` closure, which [`map_err_ignore`] flags in turn. The two
+    /// lints disagree by design: this one is about the control flow, that one is
+    /// about throwing the source error away.
+    ///
+    /// [`map_err_ignore`]: https://rust-lang.github.io/rust-clippy/master/index.html#map_err_ignore
+    ///
+    /// ### Example
+    /// ```
+    /// # #[derive(Debug)] struct Error;
+    /// # fn parse(s: &str) -> Result<u32, std::num::ParseIntError> { s.parse() }
+    /// fn f(s: &str) -> Result<Option<u32>, Error> {
+    ///     let value = match parse(s) {
+    ///         Ok(v) => Some(v),
+    ///         Err(_) => return Err(Error),
+    ///     };
+    ///     Ok(value)
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```
+    /// # #[derive(Debug)] struct Error;
+    /// # fn parse(s: &str) -> Result<u32, std::num::ParseIntError> { s.parse() }
+    /// fn f(s: &str) -> Result<Option<u32>, Error> {
+    ///     let value = parse(s).map(Some).map_err(|_| Error)?;
+    ///     Ok(value)
+    /// }
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub MANUAL_MAP_ERR,
+    pedantic,
+    "manual implementation of `map_err` combined with the `?` operator"
+}
+
+/// The `Ok(..)` arm of the match: the binding it introduces and the body it evaluates to.
+struct OkArm<'tcx> {
+    binding: HirId,
+    binding_span: Span,
+    body: &'tcx Expr<'tcx>,
+}
+
+/// What the `Err(..)` pattern binds, which becomes the `map_err` closure parameter.
+enum ErrPat {
+    Binding(HirId, Span),
+    Wild,
+}
+
+/// The `Err(..)` arm of the match: what it binds and the error value that gets returned.
+struct ErrArm<'tcx> {
+    pat: ErrPat,
+    err_expr: &'tcx Expr<'tcx>,
+}
+
+/// Checks that `pat` is `Ok(binding)` with a plain by-value binding and no subpattern.
+fn parse_ok_pat(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<(HirId, Span)> {
+    if let PatKind::TupleStruct(qpath, [inner], ddpos) = &pat.kind
+        && ddpos.as_opt_usize().is_none()
+        && cx
+            .qpath_res(qpath, pat.hir_id)
+            .ctor_parent(cx)
+            .is_lang_item(cx, ResultOk)
+        && let PatKind::Binding(BindingMode(ByRef::No, _), binding, _, None) = inner.kind
+    {
+        Some((binding, inner.span))
+    } else {
+        None
+    }
+}
+
+/// Checks that `pat` is `Err(binding)` or `Err(_)`, both by value.
+fn parse_err_pat(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<ErrPat> {
+    if let PatKind::TupleStruct(qpath, [inner], ddpos) = &pat.kind
+        && ddpos.as_opt_usize().is_none()
+        && cx
+            .qpath_res(qpath, pat.hir_id)
+            .ctor_parent(cx)
+            .is_lang_item(cx, ResultErr)
+    {
+        match inner.kind {
+            PatKind::Binding(BindingMode(ByRef::No, _), binding, _, None) => Some(ErrPat::Binding(binding, inner.span)),
+            PatKind::Wild => Some(ErrPat::Wild),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+/// Checks that `body` is `return Err(<err_expr>)`, returning `<err_expr>`. Uses
+/// `peel_blocks_with_stmt` so that the common `Err(_) => { return Err(e); }` form, where the
+/// `return` is a statement rather than a tail expression, is recognised too.
+fn parse_return_err<'tcx>(cx: &LateContext<'_>, body: &'tcx Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    let ret = peel_blocks_with_stmt(body);
+    // A macro such as `anyhow::bail!` expands to `return Err(..)`. Rewriting it would put the
+    // `return` inside a `map_err` closure, where it would return from the closure instead of the
+    // function, so only an explicit `return` written at this call site can be linted.
+    if !ret.span.from_expansion()
+        && let ExprKind::Ret(Some(returned)) = ret.kind
+        && let ExprKind::Call(err_ctor, [err_expr]) = returned.kind
+        && err_ctor.res(cx).ctor_parent(cx).is_lang_item(cx, ResultErr)
+    {
+        Some(err_expr)
+    } else {
+        None
+    }
+}
+
+/// Checks if `expr` is `val` or `val.into()`. Those cases belong to `question_mark`, which
+/// suggests a plain `?`, so this lint must not fire on them.
+fn is_local_or_local_into(cx: &LateContext<'_>, expr: &Expr<'_>, val: HirId) -> bool {
+    let is_into_call = fn_def_id_with_node_args(cx, expr)
+        .and_then(|(fn_def_id, _)| cx.tcx.trait_of_assoc(fn_def_id))
+        .is_some_and(|trait_def_id| cx.tcx.is_diagnostic_item(sym::Into, trait_def_id));
+    match expr.kind {
+        ExprKind::MethodCall(_, recv, [], _) | ExprKind::Call(_, [recv]) => {
+            is_into_call && recv.res_local_id() == Some(val)
+        },
+        _ => expr.res_local_id() == Some(val),
+    }
+}
+
+/// In `return Err(e)`, `e`'s type is pinned to the function's error type, and that pin is what
+/// picks `Self` for a call to a trait associated function such as `de::Error::invalid_type(..)`.
+/// Behind `?` the pin is gone: `?` inserts a `From` conversion, so the closure's error type only
+/// has to satisfy `From<_>` and `Self` becomes ambiguous (E0790/E0283).
+fn err_type_needs_return_context(cx: &LateContext<'_>, err_expr: &Expr<'_>) -> bool {
+    // Only a call naming the trait itself (`Trait::assoc(..)`) leaves `Self` to inference. A method
+    // call takes it from the receiver, and `Ty::assoc(..)` / `<Ty as Trait>::assoc(..)` spell it out.
+    if let ExprKind::Call(callee, _) = err_expr.kind
+        && let ExprKind::Path(QPath::Resolved(None, path)) = callee.kind
+        && let Res::Def(DefKind::AssocFn, def_id) = path.res
+        && cx.tcx.trait_of_assoc(def_id).is_some()
+    {
+        !expr_type_is_certain(cx, err_expr)
+    } else {
+        false
+    }
+}
+
+/// `.map()` and `.map_err()` take the scrutinee by value, so it must be an owned `Result` with no
+/// adjustments applied to it.
+fn is_owned_result(cx: &LateContext<'_>, scrutinee: &Expr<'_>) -> bool {
+    cx.typeck_results().expr_adjustments(scrutinee).is_empty()
+        && matches!(cx.typeck_results().expr_ty(scrutinee).kind(), ty::Adt(adt, _)
+            if cx.tcx.is_diagnostic_item(sym::Result, adt.did()))
+}
+
+/// Both arm bodies are moved into separate closures, which is only sound if each body can become a
+/// closure at all, and if the moves the closures perform are not observable elsewhere.
+fn bodies_can_become_closures<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    ok_body: &'tcx Expr<'tcx>,
+    err_expr: &'tcx Expr<'tcx>,
+) -> bool {
+    let Some(ok_captures) = can_move_expr_to_closure(cx, ok_body) else {
+        return false;
+    };
+    let Some(err_captures) = can_move_expr_to_closure(cx, err_expr) else {
+        return false;
+    };
+
+    let moves = |kind: &CaptureKind| matches!(kind, CaptureKind::Value | CaptureKind::Use);
+
+    // Only one arm of a `match` runs, so a local may be consumed by both arms. Two closures would
+    // both have to own it.
+    if ok_captures
+        .iter()
+        .any(|(id, kind)| moves(kind) && err_captures.get(id).is_some_and(moves))
+    {
+        return false;
+    }
+
+    // Each arm consumed a local only on the branch that was taken, and that branch then diverged.
+    // A closure consumes it unconditionally, so anything still needed afterwards must not be moved.
+    !ok_captures.iter().chain(err_captures.iter()).any(|(&id, kind)| {
+        moves(kind) && !is_copy(cx, cx.typeck_results().node_type(id)) && local_used_after_expr(cx, id, expr)
+    })
+}
+
+fn parse_arms<'tcx>(
+    cx: &LateContext<'tcx>,
+    arm1: &'tcx Arm<'tcx>,
+    arm2: &'tcx Arm<'tcx>,
+) -> Option<(OkArm<'tcx>, ErrArm<'tcx>)> {
+    if arm1.guard.is_some() || arm2.guard.is_some() {
+        return None;
+    }
+
+    // Accept the arms in either order.
+    let (ok_arm, err_arm) = if parse_ok_pat(cx, arm1.pat).is_some() {
+        (arm1, arm2)
+    } else {
+        (arm2, arm1)
+    };
+
+    let (binding, binding_span) = parse_ok_pat(cx, ok_arm.pat)?;
+    let err_pat = parse_err_pat(cx, err_arm.pat)?;
+    let err_expr = parse_return_err(cx, err_arm.body)?;
+
+    // `Err(e) => return Err(e)` and `Err(e) => return Err(e.into())` are `question_mark`'s job.
+    if let ErrPat::Binding(err_id, _) = err_pat
+        && is_local_or_local_into(cx, err_expr, err_id)
+    {
+        return None;
+    }
+
+    Some((
+        OkArm {
+            binding,
+            binding_span,
+            body: peel_blocks(ok_arm.body),
+        },
+        ErrArm { pat: err_pat, err_expr },
+    ))
+}
+
+/// Destructures either supported shape into a scrutinee and the two arms.
+fn parse_expr<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+) -> Option<(&'tcx Expr<'tcx>, OkArm<'tcx>, ErrArm<'tcx>)> {
+    match IfLetOrMatch::parse(cx, expr)? {
+        IfLetOrMatch::Match(scrutinee, [arm1, arm2], MatchSource::Normal | MatchSource::Postfix) => {
+            let (ok_arm, err_arm) = parse_arms(cx, arm1, arm2)?;
+            Some((scrutinee, ok_arm, err_arm))
+        },
+        IfLetOrMatch::IfLet(scrutinee, let_pat, if_then, Some(if_else), _) => {
+            let (binding, binding_span) = parse_ok_pat(cx, let_pat)?;
+            let err_expr = parse_return_err(cx, if_else)?;
+            Some((
+                scrutinee,
+                OkArm {
+                    binding,
+                    binding_span,
+                    body: peel_blocks(if_then),
+                },
+                // `if let Ok(v) = r { .. } else { return Err(e) }` never binds the error.
+                ErrArm {
+                    pat: ErrPat::Wild,
+                    err_expr,
+                },
+            ))
+        },
+        _ => None,
+    }
+}
+
+impl QuestionMark {
+    /// Everything this lint checks, short of emitting. Also used by `manual_let_else` to decide
+    /// whether to step aside.
+    fn manual_map_err_applies<'tcx>(
+        &self,
+        cx: &LateContext<'tcx>,
+        expr: &'tcx Expr<'tcx>,
+    ) -> Option<(&'tcx Expr<'tcx>, OkArm<'tcx>, ErrArm<'tcx>)> {
+        // Cheapest first: flag checks, then the HIR shape, then the queries, and only then the
+        // source scan and the visitors.
+        if expr.span.from_expansion()
+            // `?` is unusable in these three contexts.
+            || self.inside_try_block()
+            || !self.msrv.meets(cx, msrvs::QUESTION_MARK_OPERATOR)
+        {
+            return None;
+        }
+
+        let (scrutinee, ok_arm, err_arm) = parse_expr(cx, expr)?;
+
+        if is_in_const_context(cx)
+            // Suggesting `?` is pointless for someone who has banned it.
+            || !is_lint_allowed(cx, QUESTION_MARK_USED, expr.hir_id)
+            || span_contains_cfg(cx, expr.span)
+            || !is_owned_result(cx, scrutinee)
+            || !bodies_can_become_closures(cx, expr, ok_arm.body, err_arm.err_expr)
+            || err_type_needs_return_context(cx, err_arm.err_expr)
+        {
+            return None;
+        }
+
+        Some((scrutinee, ok_arm, err_arm))
+    }
+
+    pub(crate) fn check_manual_map_err<'tcx>(&self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if let Some((scrutinee, ok_arm, err_arm)) = self.manual_map_err_applies(cx, expr) {
+            emit(cx, expr, scrutinee, &ok_arm, &err_arm);
+        }
+    }
+
+    /// Whether `manual_map_err` will fire on `expr`, so that `manual_let_else` can defer to it
+    /// rather than have both pedantic lints report the same statement.
+    pub(crate) fn manual_map_err_will_lint<'tcx>(&self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
+        self.manual_map_err_applies(cx, expr).is_some()
+    }
+}
+
+fn emit<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    scrutinee: &'tcx Expr<'tcx>,
+    ok_arm: &OkArm<'tcx>,
+    err_arm: &ErrArm<'tcx>,
+) {
+    // Rewriting would drop any comment inside the removed arms, so downgrade the suggestion.
+    let mut app = if span_contains_comment(cx, expr.span) {
+        Applicability::MaybeIncorrect
+    } else {
+        Applicability::MachineApplicable
+    };
+    let ctxt = expr.span.ctxt();
+
+    // The scrutinee already starts at the column the suggestion will occupy, so its continuation
+    // lines are left alone. The arm bodies, on the other hand, are pulled out of the arms and so
+    // need shifting from the arm indentation to the expression's.
+    let indent = indent_of(cx, expr.span);
+    let arm_snippet = |span, app: &mut Applicability| {
+        reindent_multiline(&snippet_with_context(cx, span, ctxt, "..", app).0, true, indent)
+    };
+
+    let scrut = Sugg::hir_with_context(cx, scrutinee, ctxt, "..", &mut app).maybe_paren();
+
+    // `Ok(v) => v` is the identity, so no `.map()` is needed.
+    let map = if ok_arm.body.res_local_id() == Some(ok_arm.binding) {
+        String::new()
+    } else {
+        format!(
+            ".map(|{}| {})",
+            arm_snippet(ok_arm.binding_span, &mut app),
+            arm_snippet(ok_arm.body.span, &mut app)
+        )
+    };
+
+    let err_binding = match err_arm.pat {
+        ErrPat::Binding(_, span) => arm_snippet(span, &mut app),
+        ErrPat::Wild => "_".to_string(),
+    };
+    let err_expr = arm_snippet(err_arm.err_expr.span, &mut app);
+
+    // A `match`/`if let` used as a statement is a complete statement on its own, but `expr?` is
+    // not, so it has to grow the semicolon the original did not need.
+    let semi = if matches!(
+        cx.tcx.parent_hir_node(expr.hir_id),
+        Node::Stmt(Stmt {
+            kind: StmtKind::Expr(_),
+            ..
+        })
+    ) {
+        ";"
+    } else {
+        ""
+    };
+
+    let sugg = format!("{scrut}{map}.map_err(|{err_binding}| {err_expr})?{semi}");
+
+    // An `else` must be followed by a block, so an `if let` that is itself an else clause needs
+    // its replacement wrapped rather than spliced in bare.
+    let sugg = if is_else_clause(cx.tcx, expr) {
+        reindent_multiline(&format!("{{\n    {sugg}\n}}"), true, indent)
+    } else {
+        sugg
+    };
+
+    span_lint_and_sugg(
+        cx,
+        MANUAL_MAP_ERR,
+        expr.span,
+        "this can be replaced with `map_err` and `?`",
+        "try",
+        sugg,
+        app,
+    );
+}

--- a/clippy_lints/src/manual_map_err.rs
+++ b/clippy_lints/src/manual_map_err.rs
@@ -46,7 +46,7 @@ declare_clippy_lint! {
     /// # fn parse(s: &str) -> Result<u32, std::num::ParseIntError> { s.parse() }
     /// fn f(s: &str) -> Result<Option<u32>, Error> {
     ///     let value = match parse(s) {
-    ///         Ok(v) => Some(v),
+    ///         Ok(v) => Some(v + 1),
     ///         Err(_) => return Err(Error),
     ///     };
     ///     Ok(value)
@@ -57,7 +57,7 @@ declare_clippy_lint! {
     /// # #[derive(Debug)] struct Error;
     /// # fn parse(s: &str) -> Result<u32, std::num::ParseIntError> { s.parse() }
     /// fn f(s: &str) -> Result<Option<u32>, Error> {
-    ///     let value = parse(s).map(Some).map_err(|_| Error)?;
+    ///     let value = parse(s).map(|v| Some(v + 1)).map_err(|_| Error)?;
     ///     Ok(value)
     /// }
     /// ```
@@ -154,7 +154,7 @@ fn is_local_or_local_into(cx: &LateContext<'_>, expr: &Expr<'_>, val: HirId) -> 
     }
 }
 
-/// In `return Err(e)`, `e`'s type is pinned to the function's error type, and that pin is what
+/// In `return Err(e)`, the type of `e` is pinned to the function's error type, and that pin is what
 /// picks `Self` for a call to a trait associated function such as `de::Error::invalid_type(..)`.
 /// Behind `?` the pin is gone: `?` inserts a `From` conversion, so the closure's error type only
 /// has to satisfy `From<_>` and `Self` becomes ambiguous (E0790/E0283).
@@ -291,8 +291,8 @@ impl QuestionMark {
     ) -> Option<(&'tcx Expr<'tcx>, OkArm<'tcx>, ErrArm<'tcx>)> {
         // Cheapest first: flag checks, then the HIR shape, then the queries, and only then the
         // source scan and the visitors.
+        // `?` is unusable in these three contexts.
         if expr.span.from_expansion()
-            // `?` is unusable in these three contexts.
             || self.inside_try_block()
             || !self.msrv.meets(cx, msrvs::QUESTION_MARK_OPERATOR)
         {
@@ -398,7 +398,7 @@ fn emit<'tcx>(
         cx,
         MANUAL_MAP_ERR,
         expr.span,
-        "this can be replaced with `map_err` and `?`",
+        "this can be replaced with `map`, `map_err` and `?`",
         "try",
         sugg,
         app,

--- a/clippy_lints/src/manual_map_err.rs
+++ b/clippy_lints/src/manual_map_err.rs
@@ -292,9 +292,7 @@ impl QuestionMark {
         // Cheapest first: flag checks, then the HIR shape, then the queries, and only then the
         // source scan and the visitors.
         // `?` is unusable in these three contexts.
-        if expr.span.from_expansion()
-            || self.inside_try_block()
-            || !self.msrv.meets(cx, msrvs::QUESTION_MARK_OPERATOR)
+        if expr.span.from_expansion() || self.inside_try_block() || !self.msrv.meets(cx, msrvs::QUESTION_MARK_OPERATOR)
         {
             return None;
         }

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -1,4 +1,5 @@
 use crate::manual_let_else::MANUAL_LET_ELSE;
+use crate::manual_map_err::MANUAL_MAP_ERR;
 use crate::question_mark_used::QUESTION_MARK_USED;
 use clippy_config::Conf;
 use clippy_config::types::MatchLintBehaviour;
@@ -52,7 +53,7 @@ declare_clippy_lint! {
     "checks for expressions that could be replaced by the `?` operator"
 }
 
-impl_lint_pass!(QuestionMark => [MANUAL_LET_ELSE, QUESTION_MARK]);
+impl_lint_pass!(QuestionMark => [MANUAL_LET_ELSE, MANUAL_MAP_ERR, QUESTION_MARK]);
 
 pub struct QuestionMark {
     pub(crate) msrv: Msrv,
@@ -599,7 +600,7 @@ fn check_if_let_some_or_err_and_early_return<'tcx>(cx: &LateContext<'tcx>, expr:
 }
 
 impl QuestionMark {
-    fn inside_try_block(&self) -> bool {
+    pub(crate) fn inside_try_block(&self) -> bool {
         self.try_block_depth_stack.last() > Some(&0)
     }
 }
@@ -663,6 +664,7 @@ impl<'tcx> LateLintPass<'tcx> for QuestionMark {
 
             if self.inferred_ret_closure_stack == 0 {
                 check_if_try_match(cx, expr);
+                self.check_manual_map_err(cx, expr);
             }
         }
     }

--- a/tests/ui/manual_map_err.fixed
+++ b/tests/ui/manual_map_err.fixed
@@ -1,0 +1,323 @@
+#![feature(try_blocks)]
+#![warn(clippy::manual_map_err)]
+#![allow(
+    clippy::manual_let_else,
+    clippy::needless_late_init,
+    clippy::needless_question_mark,
+    clippy::question_mark,
+    clippy::redundant_closure,
+    clippy::unnecessary_wraps,
+    unused
+)]
+
+#[derive(Debug)]
+struct Error;
+
+#[derive(Debug)]
+enum IfFrom {
+    All,
+    Group(u32),
+}
+
+fn parse(s: &str) -> Result<u32, std::num::ParseIntError> {
+    s.parse()
+}
+
+// The case from uutils/coreutils#13620: the `Ok` arm wraps the value, the `Err` arm returns an
+// unrelated error.
+fn wrapping_ok_arm(s: &str) -> Result<IfFrom, Error> {
+    let filter = parse(s).map(|g| IfFrom::Group(g)).map_err(|_| Error)?;
+    Ok(filter)
+}
+
+// Identity `Ok` arm: only `map_err` is needed.
+fn identity_ok_arm(s: &str) -> Result<u32, Error> {
+    let v = parse(s).map_err(|_| Error)?;
+    Ok(v)
+}
+
+// The bound error is used to build a different error.
+fn uses_err_binding(s: &str) -> Result<u32, String> {
+    let v = parse(s).map(|v| v * 2).map_err(|e| format!("bad: {e}"))?;
+    Ok(v)
+}
+
+// Arms in reverse order.
+fn reversed_arms(s: &str) -> Result<u32, Error> {
+    let v = parse(s).map(|v| v + 1).map_err(|_| Error)?;
+    Ok(v)
+}
+
+// Braced `Ok` arm body.
+fn braced_ok_body(s: &str) -> Result<u32, Error> {
+    let v = parse(s).map(|v| {
+        let doubled = v * 2;
+        doubled + 1
+    }).map_err(|_| Error)?;
+    Ok(v)
+}
+
+// The `if let` form.
+fn if_let_form(s: &str) -> Result<IfFrom, Error> {
+    let filter = parse(s).map(|g| IfFrom::Group(g)).map_err(|_| Error)?;
+    Ok(filter)
+}
+
+// Not in a `let`: the match is the tail expression.
+fn tail_position(s: &str) -> Result<IfFrom, Error> {
+    Ok(parse(s).map(|g| IfFrom::Group(g)).map_err(|_| Error)?)
+}
+
+// A comment inside the match would be dropped by the rewrite, so the suggestion is emitted as
+// `MaybeIncorrect` and rustfix leaves the code alone.
+fn has_comment(s: &str) -> Result<u32, Error> {
+    let v = parse(s).map(|v| v * 2).map_err(|_| Error)?;
+    Ok(v)
+}
+
+// `cfg` on an arm makes the rewrite unsound.
+fn has_cfg(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        #[cfg(not(feature = "nope"))]
+        Ok(v) => v * 2,
+        #[cfg(feature = "nope")]
+        Ok(v) => v * 3,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// An `if let` that is itself the `else` clause of an outer `if` needs braces around the
+// replacement, since `else` must be followed by a block.
+fn if_let_is_else_clause(s: &str, cond: bool) -> Result<u32, Error> {
+    let v = if cond {
+        0
+    } else {
+        parse(s).map(|v| v * 2).map_err(|_| Error)?
+    };
+    Ok(v)
+}
+
+// Used as a statement rather than for its value. A `match` needs no trailing semicolon there, but
+// the `expr?` replacing it does. (winnow's `repeat` combinators look like this.)
+fn as_statement(s: &str, acc: &mut Vec<u32>) -> Result<(), Error> {
+    parse(s).map(|v| {
+        acc.push(v);
+    }).map_err(|_| Error)?;
+
+    acc.push(0);
+    Ok(())
+}
+
+//
+// Negative cases below: none of these should lint.
+//
+
+// A `bail!`-style macro expands to `return Err(..)`. Moving it into a `map_err` closure would
+// return from the closure instead of the function, so this must not lint.
+macro_rules! bail {
+    ($msg:literal) => {
+        return Err(Error)
+    };
+}
+
+fn err_arm_is_bail_macro(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => v * 2,
+        Err(_) => bail!("nope"),
+    };
+    Ok(v)
+}
+
+// The error value itself may come from a macro, as long as the `return` does not.
+fn err_expr_from_macro(s: &str) -> Result<u32, String> {
+    let v = parse(s).map(|v| v * 2).map_err(|_| format!("nope: {s}"))?;
+    Ok(v)
+}
+
+// `Trait::assoc_fn(..)` gets its `Self` from the expected error type. `?` inserts a `From`
+// conversion, so that expectation disappears and the call becomes ambiguous. (serde_yaml does
+// this with `de::Error::invalid_type`.)
+trait MakeErr {
+    fn make(msg: &str) -> Self;
+}
+impl MakeErr for Error {
+    fn make(_: &str) -> Self {
+        Error
+    }
+}
+
+fn err_from_trait_assoc_fn(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(_) => return Err(MakeErr::make("nope")),
+    };
+    Ok(v)
+}
+
+// `question_mark`'s job: the error is returned as is.
+fn same_error(s: &str) -> Result<u32, std::num::ParseIntError> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(e) => return Err(e),
+    };
+    Ok(v)
+}
+
+// `question_mark`'s job: the error is only `into()`-converted.
+fn error_into(s: &str) -> Result<u32, Box<dyn std::error::Error>> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(e) => return Err(e.into()),
+    };
+    Ok(v)
+}
+
+// `Option`, not `Result`.
+fn on_option(o: Option<u32>) -> Result<u32, Error> {
+    let v = match o {
+        Some(v) => v,
+        None => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `Ok` arm body escapes the enclosing function, so it cannot move into a closure.
+fn ok_body_returns(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => {
+            if v == 0 {
+                return Err(Error);
+            }
+            v
+        },
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `Ok` arm body uses `?`, which also escapes.
+fn ok_body_uses_question_mark(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => parse(s).map_err(|_| Error)? + v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `Ok` arm body breaks out of a loop.
+#[allow(clippy::never_loop)]
+fn ok_body_breaks(s: &str) -> Result<u32, Error> {
+    loop {
+        let v = match parse(s) {
+            Ok(v) => break,
+            Err(_) => return Err(Error),
+        };
+    }
+    Ok(0)
+}
+
+// Matching on a reference: `map`/`map_err` need an owned `Result`.
+fn on_reference(r: &Result<u32, Error>) -> Result<u32, Error> {
+    let v = match r {
+        Ok(v) => *v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The error arm moves `guard`, but the `match` only did so on the diverging branch, so `guard` is
+// still live afterwards. A `map_err` closure would move it unconditionally. (lock_api does this.)
+struct Guard(u32);
+impl Drop for Guard {
+    fn drop(&mut self) {}
+}
+
+fn moved_local_used_after(guard: Guard) -> Result<u32, (Guard, String)> {
+    let data = match parse("1") {
+        Ok(data) => data,
+        Err(e) => return Err((guard, e.to_string())),
+    };
+    drop(guard);
+    Ok(data)
+}
+
+// Same shape, but nothing uses the moved local afterwards, so the rewrite is fine.
+fn moved_local_not_used_after(guard: Guard) -> Result<u32, (Guard, String)> {
+    let data = parse("1").map_err(|e| (guard, e.to_string()))?;
+    Ok(data)
+}
+
+// Both arms move the same local, which would be a double move across two closures.
+fn shared_move(s: &str, owned: String) -> Result<String, String> {
+    let v = match parse(s) {
+        Ok(_) => owned,
+        Err(_) => return Err(owned),
+    };
+    Ok(v)
+}
+
+// Guards disable the rewrite.
+fn with_guard(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) if v > 0 => v,
+        Ok(_) => return Err(Error),
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `Err` arm does something other than `return Err(..)`.
+fn err_arm_panics(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(_) => panic!("nope"),
+    };
+    Ok(v)
+}
+
+// `by ref` binding.
+fn ref_binding(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(ref v) => *v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// Inside a `try` block `?` targets a different type.
+fn in_try_block(s: &str) -> Result<u32, Error> {
+    let r: Result<u32, Error> = try {
+        match parse(s) {
+            Ok(v) => v,
+            Err(_) => return Err(Error),
+        }
+    };
+    r
+}
+
+// `?` is not usable in a const context.
+const fn in_const_fn(r: Result<u32, Error>) -> Result<u32, Error> {
+    let v = match r {
+        Ok(v) => v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+#[clippy::msrv = "1.12"]
+fn msrv_too_low(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => v * 2,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+#[clippy::msrv = "1.13"]
+fn msrv_ok(s: &str) -> Result<u32, Error> {
+    let v = parse(s).map(|v| v * 2).map_err(|_| Error)?;
+    Ok(v)
+}
+
+fn main() {}

--- a/tests/ui/manual_map_err.fixed
+++ b/tests/ui/manual_map_err.fixed
@@ -1,13 +1,13 @@
 #![feature(try_blocks)]
 #![warn(clippy::manual_map_err)]
 #![allow(
+    unused,
     clippy::manual_let_else,
     clippy::needless_late_init,
     clippy::needless_question_mark,
     clippy::question_mark,
     clippy::redundant_closure,
-    clippy::unnecessary_wraps,
-    unused
+    clippy::unnecessary_wraps
 )]
 
 #[derive(Debug)]

--- a/tests/ui/manual_map_err.fixed
+++ b/tests/ui/manual_map_err.fixed
@@ -110,7 +110,8 @@ fn as_statement(s: &str, acc: &mut Vec<u32>) -> Result<(), Error> {
 }
 
 //
-// Negative cases below: none of these should lint.
+// Each case below shows a reason not to lint; some are paired with a contrasting nearby
+// variant that does lint.
 //
 
 // A `bail!`-style macro expands to `return Err(..)`. Moving it into a `map_err` closure would

--- a/tests/ui/manual_map_err.fixed
+++ b/tests/ui/manual_map_err.fixed
@@ -156,6 +156,41 @@ fn err_from_trait_assoc_fn(s: &str) -> Result<u32, Error> {
     Ok(v)
 }
 
+// The `.into()` target is pinned by the `return Err(..)` position. Behind `?`, which adds its own
+// `From` conversion, the intermediate type is ambiguous (E0283). (uutils' tac does this.)
+#[derive(Debug)]
+struct WrappedErr(std::num::ParseIntError);
+impl std::fmt::Display for WrappedErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+impl std::error::Error for WrappedErr {}
+
+fn err_into_needs_return_context(s: &str) -> Result<u32, Box<dyn std::error::Error>> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(e) => return Err(WrappedErr(e).into()),
+    };
+    Ok(v)
+}
+
+// `Err(Box::new(..))` relies on the unsize coercion `Box<ConcreteErr>` to `Box<dyn MyError>`,
+// which only happens in the pinned `return` position. `?` needs a `From` impl instead, and no
+// such impl exists. (uutils' ls does this with its `UError` trait.)
+trait MyError {}
+#[derive(Debug)]
+struct ConcreteErr;
+impl MyError for ConcreteErr {}
+
+fn err_box_needs_unsize_coercion(s: &str) -> Result<u32, Box<dyn MyError>> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(_) => return Err(Box::new(ConcreteErr)),
+    };
+    Ok(v)
+}
+
 // `question_mark`'s job: the error is returned as is.
 fn same_error(s: &str) -> Result<u32, std::num::ParseIntError> {
     let v = match parse(s) {

--- a/tests/ui/manual_map_err.rs
+++ b/tests/ui/manual_map_err.rs
@@ -1,0 +1,378 @@
+#![feature(try_blocks)]
+#![warn(clippy::manual_map_err)]
+#![allow(
+    clippy::manual_let_else,
+    clippy::needless_late_init,
+    clippy::needless_question_mark,
+    clippy::question_mark,
+    clippy::redundant_closure,
+    clippy::unnecessary_wraps,
+    unused
+)]
+
+#[derive(Debug)]
+struct Error;
+
+#[derive(Debug)]
+enum IfFrom {
+    All,
+    Group(u32),
+}
+
+fn parse(s: &str) -> Result<u32, std::num::ParseIntError> {
+    s.parse()
+}
+
+// The case from uutils/coreutils#13620: the `Ok` arm wraps the value, the `Err` arm returns an
+// unrelated error.
+fn wrapping_ok_arm(s: &str) -> Result<IfFrom, Error> {
+    let filter = match parse(s) {
+        //~^ manual_map_err
+        Ok(g) => IfFrom::Group(g),
+        Err(_) => {
+            return Err(Error);
+        },
+    };
+    Ok(filter)
+}
+
+// Identity `Ok` arm: only `map_err` is needed.
+fn identity_ok_arm(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        //~^ manual_map_err
+        Ok(v) => v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The bound error is used to build a different error.
+fn uses_err_binding(s: &str) -> Result<u32, String> {
+    let v = match parse(s) {
+        //~^ manual_map_err
+        Ok(v) => v * 2,
+        Err(e) => return Err(format!("bad: {e}")),
+    };
+    Ok(v)
+}
+
+// Arms in reverse order.
+fn reversed_arms(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        //~^ manual_map_err
+        Err(_) => return Err(Error),
+        Ok(v) => v + 1,
+    };
+    Ok(v)
+}
+
+// Braced `Ok` arm body.
+fn braced_ok_body(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        //~^ manual_map_err
+        Ok(v) => {
+            let doubled = v * 2;
+            doubled + 1
+        },
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `if let` form.
+fn if_let_form(s: &str) -> Result<IfFrom, Error> {
+    let filter = if let Ok(g) = parse(s) {
+        //~^ manual_map_err
+        IfFrom::Group(g)
+    } else {
+        return Err(Error);
+    };
+    Ok(filter)
+}
+
+// Not in a `let`: the match is the tail expression.
+fn tail_position(s: &str) -> Result<IfFrom, Error> {
+    Ok(match parse(s) {
+        //~^ manual_map_err
+        Ok(g) => IfFrom::Group(g),
+        Err(_) => return Err(Error),
+    })
+}
+
+// A comment inside the match would be dropped by the rewrite, so the suggestion is emitted as
+// `MaybeIncorrect` and rustfix leaves the code alone.
+fn has_comment(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        //~^ manual_map_err
+        // this comment would be lost
+        Ok(v) => v * 2,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// `cfg` on an arm makes the rewrite unsound.
+fn has_cfg(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        #[cfg(not(feature = "nope"))]
+        Ok(v) => v * 2,
+        #[cfg(feature = "nope")]
+        Ok(v) => v * 3,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// An `if let` that is itself the `else` clause of an outer `if` needs braces around the
+// replacement, since `else` must be followed by a block.
+fn if_let_is_else_clause(s: &str, cond: bool) -> Result<u32, Error> {
+    let v = if cond {
+        0
+    } else if let Ok(v) = parse(s) {
+        //~^ manual_map_err
+        v * 2
+    } else {
+        return Err(Error);
+    };
+    Ok(v)
+}
+
+// Used as a statement rather than for its value. A `match` needs no trailing semicolon there, but
+// the `expr?` replacing it does. (winnow's `repeat` combinators look like this.)
+fn as_statement(s: &str, acc: &mut Vec<u32>) -> Result<(), Error> {
+    match parse(s) {
+        //~^ manual_map_err
+        Ok(v) => {
+            acc.push(v);
+        },
+        Err(_) => return Err(Error),
+    }
+
+    acc.push(0);
+    Ok(())
+}
+
+//
+// Negative cases below: none of these should lint.
+//
+
+// A `bail!`-style macro expands to `return Err(..)`. Moving it into a `map_err` closure would
+// return from the closure instead of the function, so this must not lint.
+macro_rules! bail {
+    ($msg:literal) => {
+        return Err(Error)
+    };
+}
+
+fn err_arm_is_bail_macro(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => v * 2,
+        Err(_) => bail!("nope"),
+    };
+    Ok(v)
+}
+
+// The error value itself may come from a macro, as long as the `return` does not.
+fn err_expr_from_macro(s: &str) -> Result<u32, String> {
+    let v = match parse(s) {
+        //~^ manual_map_err
+        Ok(v) => v * 2,
+        Err(_) => return Err(format!("nope: {s}")),
+    };
+    Ok(v)
+}
+
+// `Trait::assoc_fn(..)` gets its `Self` from the expected error type. `?` inserts a `From`
+// conversion, so that expectation disappears and the call becomes ambiguous. (serde_yaml does
+// this with `de::Error::invalid_type`.)
+trait MakeErr {
+    fn make(msg: &str) -> Self;
+}
+impl MakeErr for Error {
+    fn make(_: &str) -> Self {
+        Error
+    }
+}
+
+fn err_from_trait_assoc_fn(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(_) => return Err(MakeErr::make("nope")),
+    };
+    Ok(v)
+}
+
+// `question_mark`'s job: the error is returned as is.
+fn same_error(s: &str) -> Result<u32, std::num::ParseIntError> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(e) => return Err(e),
+    };
+    Ok(v)
+}
+
+// `question_mark`'s job: the error is only `into()`-converted.
+fn error_into(s: &str) -> Result<u32, Box<dyn std::error::Error>> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(e) => return Err(e.into()),
+    };
+    Ok(v)
+}
+
+// `Option`, not `Result`.
+fn on_option(o: Option<u32>) -> Result<u32, Error> {
+    let v = match o {
+        Some(v) => v,
+        None => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `Ok` arm body escapes the enclosing function, so it cannot move into a closure.
+fn ok_body_returns(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => {
+            if v == 0 {
+                return Err(Error);
+            }
+            v
+        },
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `Ok` arm body uses `?`, which also escapes.
+fn ok_body_uses_question_mark(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => parse(s).map_err(|_| Error)? + v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `Ok` arm body breaks out of a loop.
+#[allow(clippy::never_loop)]
+fn ok_body_breaks(s: &str) -> Result<u32, Error> {
+    loop {
+        let v = match parse(s) {
+            Ok(v) => break,
+            Err(_) => return Err(Error),
+        };
+    }
+    Ok(0)
+}
+
+// Matching on a reference: `map`/`map_err` need an owned `Result`.
+fn on_reference(r: &Result<u32, Error>) -> Result<u32, Error> {
+    let v = match r {
+        Ok(v) => *v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The error arm moves `guard`, but the `match` only did so on the diverging branch, so `guard` is
+// still live afterwards. A `map_err` closure would move it unconditionally. (lock_api does this.)
+struct Guard(u32);
+impl Drop for Guard {
+    fn drop(&mut self) {}
+}
+
+fn moved_local_used_after(guard: Guard) -> Result<u32, (Guard, String)> {
+    let data = match parse("1") {
+        Ok(data) => data,
+        Err(e) => return Err((guard, e.to_string())),
+    };
+    drop(guard);
+    Ok(data)
+}
+
+// Same shape, but nothing uses the moved local afterwards, so the rewrite is fine.
+fn moved_local_not_used_after(guard: Guard) -> Result<u32, (Guard, String)> {
+    let data = match parse("1") {
+        //~^ manual_map_err
+        Ok(data) => data,
+        Err(e) => return Err((guard, e.to_string())),
+    };
+    Ok(data)
+}
+
+// Both arms move the same local, which would be a double move across two closures.
+fn shared_move(s: &str, owned: String) -> Result<String, String> {
+    let v = match parse(s) {
+        Ok(_) => owned,
+        Err(_) => return Err(owned),
+    };
+    Ok(v)
+}
+
+// Guards disable the rewrite.
+fn with_guard(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) if v > 0 => v,
+        Ok(_) => return Err(Error),
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// The `Err` arm does something other than `return Err(..)`.
+fn err_arm_panics(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(_) => panic!("nope"),
+    };
+    Ok(v)
+}
+
+// `by ref` binding.
+fn ref_binding(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(ref v) => *v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+// Inside a `try` block `?` targets a different type.
+fn in_try_block(s: &str) -> Result<u32, Error> {
+    let r: Result<u32, Error> = try {
+        match parse(s) {
+            Ok(v) => v,
+            Err(_) => return Err(Error),
+        }
+    };
+    r
+}
+
+// `?` is not usable in a const context.
+const fn in_const_fn(r: Result<u32, Error>) -> Result<u32, Error> {
+    let v = match r {
+        Ok(v) => v,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+#[clippy::msrv = "1.12"]
+fn msrv_too_low(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        Ok(v) => v * 2,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+#[clippy::msrv = "1.13"]
+fn msrv_ok(s: &str) -> Result<u32, Error> {
+    let v = match parse(s) {
+        //~^ manual_map_err
+        Ok(v) => v * 2,
+        Err(_) => return Err(Error),
+    };
+    Ok(v)
+}
+
+fn main() {}

--- a/tests/ui/manual_map_err.rs
+++ b/tests/ui/manual_map_err.rs
@@ -203,6 +203,41 @@ fn err_from_trait_assoc_fn(s: &str) -> Result<u32, Error> {
     Ok(v)
 }
 
+// The `.into()` target is pinned by the `return Err(..)` position. Behind `?`, which adds its own
+// `From` conversion, the intermediate type is ambiguous (E0283). (uutils' tac does this.)
+#[derive(Debug)]
+struct WrappedErr(std::num::ParseIntError);
+impl std::fmt::Display for WrappedErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+impl std::error::Error for WrappedErr {}
+
+fn err_into_needs_return_context(s: &str) -> Result<u32, Box<dyn std::error::Error>> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(e) => return Err(WrappedErr(e).into()),
+    };
+    Ok(v)
+}
+
+// `Err(Box::new(..))` relies on the unsize coercion `Box<ConcreteErr>` to `Box<dyn MyError>`,
+// which only happens in the pinned `return` position. `?` needs a `From` impl instead, and no
+// such impl exists. (uutils' ls does this with its `UError` trait.)
+trait MyError {}
+#[derive(Debug)]
+struct ConcreteErr;
+impl MyError for ConcreteErr {}
+
+fn err_box_needs_unsize_coercion(s: &str) -> Result<u32, Box<dyn MyError>> {
+    let v = match parse(s) {
+        Ok(v) => v,
+        Err(_) => return Err(Box::new(ConcreteErr)),
+    };
+    Ok(v)
+}
+
 // `question_mark`'s job: the error is returned as is.
 fn same_error(s: &str) -> Result<u32, std::num::ParseIntError> {
     let v = match parse(s) {

--- a/tests/ui/manual_map_err.rs
+++ b/tests/ui/manual_map_err.rs
@@ -1,13 +1,13 @@
 #![feature(try_blocks)]
 #![warn(clippy::manual_map_err)]
 #![allow(
+    unused,
     clippy::manual_let_else,
     clippy::needless_late_init,
     clippy::needless_question_mark,
     clippy::question_mark,
     clippy::redundant_closure,
-    clippy::unnecessary_wraps,
-    unused
+    clippy::unnecessary_wraps
 )]
 
 #[derive(Debug)]

--- a/tests/ui/manual_map_err.rs
+++ b/tests/ui/manual_map_err.rs
@@ -153,7 +153,8 @@ fn as_statement(s: &str, acc: &mut Vec<u32>) -> Result<(), Error> {
 }
 
 //
-// Negative cases below: none of these should lint.
+// Each case below shows a reason not to lint; some are paired with a contrasting nearby
+// variant that does lint.
 //
 
 // A `bail!`-style macro expands to `return Err(..)`. Moving it into a `map_err` closure would

--- a/tests/ui/manual_map_err.stderr
+++ b/tests/ui/manual_map_err.stderr
@@ -1,4 +1,4 @@
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:29:18
    |
 LL |       let filter = match parse(s) {
@@ -14,7 +14,7 @@ LL | |     };
    = note: `-D clippy::manual-map-err` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_map_err)]`
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:41:13
    |
 LL |       let v = match parse(s) {
@@ -25,7 +25,7 @@ LL | |         Err(_) => return Err(Error),
 LL | |     };
    | |_____^ help: try: `parse(s).map_err(|_| Error)?`
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:51:13
    |
 LL |       let v = match parse(s) {
@@ -36,7 +36,7 @@ LL | |         Err(e) => return Err(format!("bad: {e}")),
 LL | |     };
    | |_____^ help: try: `parse(s).map(|v| v * 2).map_err(|e| format!("bad: {e}"))?`
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:61:13
    |
 LL |       let v = match parse(s) {
@@ -47,7 +47,7 @@ LL | |         Ok(v) => v + 1,
 LL | |     };
    | |_____^ help: try: `parse(s).map(|v| v + 1).map_err(|_| Error)?`
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:71:13
    |
 LL |       let v = match parse(s) {
@@ -68,7 +68,7 @@ LL +         doubled + 1
 LL ~     }).map_err(|_| Error)?;
    |
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:84:18
    |
 LL |       let filter = if let Ok(g) = parse(s) {
@@ -80,7 +80,7 @@ LL | |         return Err(Error);
 LL | |     };
    | |_____^ help: try: `parse(s).map(|g| IfFrom::Group(g)).map_err(|_| Error)?`
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:95:8
    |
 LL |       Ok(match parse(s) {
@@ -91,7 +91,7 @@ LL | |         Err(_) => return Err(Error),
 LL | |     })
    | |_____^ help: try: `parse(s).map(|g| IfFrom::Group(g)).map_err(|_| Error)?`
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:105:13
    |
 LL |       let v = match parse(s) {
@@ -103,7 +103,7 @@ LL | |         Err(_) => return Err(Error),
 LL | |     };
    | |_____^ help: try: `parse(s).map(|v| v * 2).map_err(|_| Error)?`
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:131:12
    |
 LL |       } else if let Ok(v) = parse(s) {
@@ -122,7 +122,7 @@ LL +         parse(s).map(|v| v * 2).map_err(|_| Error)?
 LL ~     };
    |
 
-error: this can be replaced with `map_err` and `?`
+error: this can be replaced with `map`, `map_err` and `?`
   --> tests/ui/manual_map_err.rs:143:5
    |
 LL | /     match parse(s) {
@@ -141,8 +141,8 @@ LL +         acc.push(v);
 LL +     }).map_err(|_| Error)?;
    |
 
-error: this can be replaced with `map_err` and `?`
-  --> tests/ui/manual_map_err.rs:177:13
+error: this can be replaced with `map`, `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:178:13
    |
 LL |       let v = match parse(s) {
    |  _____________^
@@ -152,8 +152,8 @@ LL | |         Err(_) => return Err(format!("nope: {s}")),
 LL | |     };
    | |_____^ help: try: `parse(s).map(|v| v * 2).map_err(|_| format!("nope: {s}"))?`
 
-error: this can be replaced with `map_err` and `?`
-  --> tests/ui/manual_map_err.rs:294:16
+error: this can be replaced with `map`, `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:295:16
    |
 LL |       let data = match parse("1") {
    |  ________________^
@@ -163,8 +163,8 @@ LL | |         Err(e) => return Err((guard, e.to_string())),
 LL | |     };
    | |_____^ help: try: `parse("1").map_err(|e| (guard, e.to_string()))?`
 
-error: this can be replaced with `map_err` and `?`
-  --> tests/ui/manual_map_err.rs:370:13
+error: this can be replaced with `map`, `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:371:13
    |
 LL |       let v = match parse(s) {
    |  _____________^

--- a/tests/ui/manual_map_err.stderr
+++ b/tests/ui/manual_map_err.stderr
@@ -153,7 +153,7 @@ LL | |     };
    | |_____^ help: try: `parse(s).map(|v| v * 2).map_err(|_| format!("nope: {s}"))?`
 
 error: this can be replaced with `map`, `map_err` and `?`
-  --> tests/ui/manual_map_err.rs:295:16
+  --> tests/ui/manual_map_err.rs:330:16
    |
 LL |       let data = match parse("1") {
    |  ________________^
@@ -164,7 +164,7 @@ LL | |     };
    | |_____^ help: try: `parse("1").map_err(|e| (guard, e.to_string()))?`
 
 error: this can be replaced with `map`, `map_err` and `?`
-  --> tests/ui/manual_map_err.rs:371:13
+  --> tests/ui/manual_map_err.rs:406:13
    |
 LL |       let v = match parse(s) {
    |  _____________^

--- a/tests/ui/manual_map_err.stderr
+++ b/tests/ui/manual_map_err.stderr
@@ -1,0 +1,178 @@
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:29:18
+   |
+LL |       let filter = match parse(s) {
+   |  __________________^
+LL | |
+LL | |         Ok(g) => IfFrom::Group(g),
+LL | |         Err(_) => {
+LL | |             return Err(Error);
+LL | |         },
+LL | |     };
+   | |_____^ help: try: `parse(s).map(|g| IfFrom::Group(g)).map_err(|_| Error)?`
+   |
+   = note: `-D clippy::manual-map-err` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_map_err)]`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:41:13
+   |
+LL |       let v = match parse(s) {
+   |  _____________^
+LL | |
+LL | |         Ok(v) => v,
+LL | |         Err(_) => return Err(Error),
+LL | |     };
+   | |_____^ help: try: `parse(s).map_err(|_| Error)?`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:51:13
+   |
+LL |       let v = match parse(s) {
+   |  _____________^
+LL | |
+LL | |         Ok(v) => v * 2,
+LL | |         Err(e) => return Err(format!("bad: {e}")),
+LL | |     };
+   | |_____^ help: try: `parse(s).map(|v| v * 2).map_err(|e| format!("bad: {e}"))?`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:61:13
+   |
+LL |       let v = match parse(s) {
+   |  _____________^
+LL | |
+LL | |         Err(_) => return Err(Error),
+LL | |         Ok(v) => v + 1,
+LL | |     };
+   | |_____^ help: try: `parse(s).map(|v| v + 1).map_err(|_| Error)?`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:71:13
+   |
+LL |       let v = match parse(s) {
+   |  _____________^
+LL | |
+LL | |         Ok(v) => {
+LL | |             let doubled = v * 2;
+...  |
+LL | |         Err(_) => return Err(Error),
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     let v = parse(s).map(|v| {
+LL +         let doubled = v * 2;
+LL +         doubled + 1
+LL ~     }).map_err(|_| Error)?;
+   |
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:84:18
+   |
+LL |       let filter = if let Ok(g) = parse(s) {
+   |  __________________^
+LL | |
+LL | |         IfFrom::Group(g)
+LL | |     } else {
+LL | |         return Err(Error);
+LL | |     };
+   | |_____^ help: try: `parse(s).map(|g| IfFrom::Group(g)).map_err(|_| Error)?`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:95:8
+   |
+LL |       Ok(match parse(s) {
+   |  ________^
+LL | |
+LL | |         Ok(g) => IfFrom::Group(g),
+LL | |         Err(_) => return Err(Error),
+LL | |     })
+   | |_____^ help: try: `parse(s).map(|g| IfFrom::Group(g)).map_err(|_| Error)?`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:105:13
+   |
+LL |       let v = match parse(s) {
+   |  _____________^
+LL | |
+LL | |         // this comment would be lost
+LL | |         Ok(v) => v * 2,
+LL | |         Err(_) => return Err(Error),
+LL | |     };
+   | |_____^ help: try: `parse(s).map(|v| v * 2).map_err(|_| Error)?`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:131:12
+   |
+LL |       } else if let Ok(v) = parse(s) {
+   |  ____________^
+LL | |
+LL | |         v * 2
+LL | |     } else {
+LL | |         return Err(Error);
+LL | |     };
+   | |_____^
+   |
+help: try
+   |
+LL ~     } else {
+LL +         parse(s).map(|v| v * 2).map_err(|_| Error)?
+LL ~     };
+   |
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:143:5
+   |
+LL | /     match parse(s) {
+LL | |
+LL | |         Ok(v) => {
+LL | |             acc.push(v);
+LL | |         },
+LL | |         Err(_) => return Err(Error),
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     parse(s).map(|v| {
+LL +         acc.push(v);
+LL +     }).map_err(|_| Error)?;
+   |
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:177:13
+   |
+LL |       let v = match parse(s) {
+   |  _____________^
+LL | |
+LL | |         Ok(v) => v * 2,
+LL | |         Err(_) => return Err(format!("nope: {s}")),
+LL | |     };
+   | |_____^ help: try: `parse(s).map(|v| v * 2).map_err(|_| format!("nope: {s}"))?`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:294:16
+   |
+LL |       let data = match parse("1") {
+   |  ________________^
+LL | |
+LL | |         Ok(data) => data,
+LL | |         Err(e) => return Err((guard, e.to_string())),
+LL | |     };
+   | |_____^ help: try: `parse("1").map_err(|e| (guard, e.to_string()))?`
+
+error: this can be replaced with `map_err` and `?`
+  --> tests/ui/manual_map_err.rs:370:13
+   |
+LL |       let v = match parse(s) {
+   |  _____________^
+LL | |
+LL | |         Ok(v) => v * 2,
+LL | |         Err(_) => return Err(Error),
+LL | |     };
+   | |_____^ help: try: `parse(s).map(|v| v * 2).map_err(|_| Error)?`
+
+error: aborting due to 13 previous errors
+


### PR DESCRIPTION
Suggests `map`/`map_err`/`?` for a two-arm `match` or `if let` on a `Result` whose `Err` arm unconditionally returns a *different* error:

    match parse_gid_from_str(g) {
        Ok(g) => IfFrom::Group(g),
        Err(_) => return Err(USimpleError::new(1, msg)),
    }
    // -> parse_gid_from_str(g).map(|g| IfFrom::Group(g))
    //        .map_err(|_| USimpleError::new(1, msg))?

`question_mark` only accepts an `Err` arm returning the bound error or `err.into()`, so this covers the remaining family and bails whenever that lint applies; `manual_let_else` defers to it for the same reason. It lives in the `QuestionMark` pass, as `manual_let_else` does, to reuse the try-block, inferred-return-closure, MSRV and const-context guards that suggesting `?` needs.

Category is `pedantic`, since the `match` form is a defensible style choice.

changelog: new lint: `manual_map_err`
