### PR TITLE
New lint: `vec_from_literal_array`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7630,6 +7630,7 @@ Released 2018-09-13
 [`useless_transmute`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_transmute
 [`useless_vec`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
 [`vec_box`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_box
+[`vec_from_literal_array`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_from_literal_array
 [`vec_init_then_push`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_init_then_push
 [`vec_resize_to_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_resize_to_zero
 [`verbose_bit_mask`]: https://rust-lang.github.io/rust-clippy/master/index.html#verbose_bit_mask

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -813,6 +813,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::useless_concat::USELESS_CONCAT_INFO,
     crate::useless_conversion::USELESS_CONVERSION_INFO,
     crate::useless_vec::USELESS_VEC_INFO,
+    crate::vec_from_literal_array::VEC_FROM_LITERAL_ARRAY_INFO,
     crate::vec_init_then_push::VEC_INIT_THEN_PUSH_INFO,
     crate::visibility::NEEDLESS_PUB_SELF_INFO,
     crate::visibility::PUB_WITH_SHORTHAND_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -402,6 +402,7 @@ mod use_self;
 mod useless_concat;
 mod useless_conversion;
 mod useless_vec;
+mod vec_from_literal_array;
 mod vec_init_then_push;
 mod visibility;
 mod volatile_composites;
@@ -869,6 +870,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        VecFromLiteralArray: vec_from_literal_array::VecFromLiteralArray = vec_from_literal_array::VecFromLiteralArray,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/vec_from_literal_array.rs
+++ b/clippy_lints/src/vec_from_literal_array.rs
@@ -4,6 +4,7 @@ use clippy_utils::sym;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::AssocContainer;
 use rustc_session::declare_lint_pass;
 
 declare_clippy_lint! {
@@ -38,6 +39,13 @@ impl LateLintPass<'_> for VecFromLiteralArray {
             && let ExprKind::Array(_) = receiver.kind
             && args.is_empty()
         {
+            // Make sure that this to_vec() doesn't come from a trait
+            if let Some(method_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
+                && let assoc = cx.tcx.associated_item(method_def_id)
+                && assoc.container != AssocContainer::InherentImpl
+            {
+                return;
+            }
             let mut app = Applicability::MachineApplicable;
             let (recv, _) = snippet_with_context(cx, receiver.span, expr.span.ctxt(), "_", &mut app);
             span_lint_and_sugg(

--- a/clippy_lints/src/vec_from_literal_array.rs
+++ b/clippy_lints/src/vec_from_literal_array.rs
@@ -15,6 +15,8 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     ///
     /// It is clearer and may be more performant to use the `vec!` macro.
+    /// Calling `.to_vec()` also requires that the array values be clonable;
+    /// `vec!` has no such requirement.
     ///
     /// ### Example
     /// ```no_run

--- a/clippy_lints/src/vec_from_literal_array.rs
+++ b/clippy_lints/src/vec_from_literal_array.rs
@@ -38,6 +38,7 @@ impl LateLintPass<'_> for VecFromLiteralArray {
             && method_name.ident.name == sym::to_vec
             && let ExprKind::Array(_) = receiver.kind
             && args.is_empty()
+            && !receiver.span.from_expansion()
         {
             // Make sure that this to_vec() doesn't come from a trait
             if let Some(method_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)

--- a/clippy_lints/src/vec_from_literal_array.rs
+++ b/clippy_lints/src/vec_from_literal_array.rs
@@ -1,0 +1,54 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::sym;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for vec creation by calling `.to_vec()` on a literal array.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// It is clearer to use the `vec!` macro.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let value = [1, 2, 3].to_vec();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let value = vec![1, 2, 3];
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub VEC_FROM_LITERAL_ARRAY,
+    pedantic,
+    "creating vec with to_vec() on literal array"
+}
+
+declare_lint_pass!(VecFromLiteralArray => [VEC_FROM_LITERAL_ARRAY]);
+
+impl LateLintPass<'_> for VecFromLiteralArray {
+    fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+        if let ExprKind::MethodCall(method_name, receiver, args, _) = expr.kind
+            && method_name.ident.name == sym::to_vec
+            && let ExprKind::Array(_) = receiver.kind
+            && args.is_empty()
+        {
+            let mut app = Applicability::MachineApplicable;
+            let (recv, _) = snippet_with_context(cx, receiver.span, expr.span.ctxt(), "_", &mut app);
+            span_lint_and_sugg(
+                cx,
+                VEC_FROM_LITERAL_ARRAY,
+                expr.span,
+                "creating a vec with a literal array",
+                "try",
+                format!("vec!{recv}"),
+                app,
+            );
+        }
+    }
+}

--- a/clippy_lints/src/vec_from_literal_array.rs
+++ b/clippy_lints/src/vec_from_literal_array.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad?
     ///
-    /// It is clearer to use the `vec!` macro.
+    /// It is clearer and may be more performant to use the `vec!` macro.
     ///
     /// ### Example
     /// ```no_run

--- a/tests/ui/vec_from_literal_array.fixed
+++ b/tests/ui/vec_from_literal_array.fixed
@@ -40,6 +40,14 @@ macro_rules! get_array {
     };
 }
 
+struct HasToVec;
+
+impl HasToVec {
+    fn to_vec(&self) -> Vec<u32> {
+        vec![1, 2, 3]
+    }
+}
+
 fn main() {
     let _v1: Vec<_> = vec![1, 2, 3];
     //~^ vec_from_literal_array
@@ -62,4 +70,6 @@ fn main() {
     }
     // Should not trigger the lint - array comes from a macro
     let _v7: Vec<u32> = get_array!().to_vec();
+    // Should not trigger the lint - not called on an array literal
+    let _v8: Vec<u32> = HasToVec.to_vec();
 }

--- a/tests/ui/vec_from_literal_array.fixed
+++ b/tests/ui/vec_from_literal_array.fixed
@@ -1,0 +1,42 @@
+#![warn(clippy::vec_from_literal_array)]
+
+fn get_fixed_number() -> u32 {
+    5
+}
+
+fn double_number(n: u32) -> u32 {
+    n * 2
+}
+
+fn print_vec(v: Vec<u32>) {
+    println!("{v:?}");
+}
+
+macro_rules! get_macro_number {
+    () => {
+        14
+    };
+}
+
+macro_rules! double_macro_number {
+    ($n:literal) => {
+        $n * 2
+    };
+}
+
+fn main() {
+    let _v1: Vec<_> = vec![1, 2, 3];
+    //~^ vec_from_literal_array
+    let _v2: Vec<_> = vec![4, get_fixed_number(), 6];
+    //~^ vec_from_literal_array
+    let _v3: Vec<_> = vec![7, double_number(8), 9];
+    //~^ vec_from_literal_array
+    print_vec(
+        vec![10, 11, 12],
+        //~^ vec_from_literal_array
+    );
+    let _v4: Vec<_> = vec![13, get_macro_number!(), 15];
+    //~^ vec_from_literal_array
+    let _v5: Vec<_> = vec![16, double_macro_number!(17), 18];
+    //~^ vec_from_literal_array
+}

--- a/tests/ui/vec_from_literal_array.fixed
+++ b/tests/ui/vec_from_literal_array.fixed
@@ -34,6 +34,12 @@ mod with_extension_trait {
     impl<T, const N: usize> CustomVec for [T; N] {}
 }
 
+macro_rules! get_array {
+    () => {
+        [1, 2, 3]
+    };
+}
+
 fn main() {
     let _v1: Vec<_> = vec![1, 2, 3];
     //~^ vec_from_literal_array
@@ -54,4 +60,6 @@ fn main() {
         use with_extension_trait::CustomVec;
         let _v6: Vec<u32> = ["a", "b", "c"].to_vec();
     }
+    // Should not trigger the lint - array comes from a macro
+    let _v7: Vec<u32> = get_array!().to_vec();
 }

--- a/tests/ui/vec_from_literal_array.fixed
+++ b/tests/ui/vec_from_literal_array.fixed
@@ -24,6 +24,16 @@ macro_rules! double_macro_number {
     };
 }
 
+mod with_extension_trait {
+    pub trait CustomVec {
+        fn to_vec(&self) -> Vec<u32> {
+            vec![1, 2, 3]
+        }
+    }
+
+    impl<T, const N: usize> CustomVec for [T; N] {}
+}
+
 fn main() {
     let _v1: Vec<_> = vec![1, 2, 3];
     //~^ vec_from_literal_array
@@ -39,4 +49,9 @@ fn main() {
     //~^ vec_from_literal_array
     let _v5: Vec<_> = vec![16, double_macro_number!(17), 18];
     //~^ vec_from_literal_array
+    // Should not trigger the lint - not the built-in to_vec() method
+    {
+        use with_extension_trait::CustomVec;
+        let _v6: Vec<u32> = ["a", "b", "c"].to_vec();
+    }
 }

--- a/tests/ui/vec_from_literal_array.rs
+++ b/tests/ui/vec_from_literal_array.rs
@@ -34,6 +34,12 @@ mod with_extension_trait {
     impl<T, const N: usize> CustomVec for [T; N] {}
 }
 
+macro_rules! get_array {
+    () => {
+        [1, 2, 3]
+    };
+}
+
 fn main() {
     let _v1: Vec<_> = [1, 2, 3].to_vec();
     //~^ vec_from_literal_array
@@ -54,4 +60,6 @@ fn main() {
         use with_extension_trait::CustomVec;
         let _v6: Vec<u32> = ["a", "b", "c"].to_vec();
     }
+    // Should not trigger the lint - array comes from a macro
+    let _v7: Vec<u32> = get_array!().to_vec();
 }

--- a/tests/ui/vec_from_literal_array.rs
+++ b/tests/ui/vec_from_literal_array.rs
@@ -40,6 +40,14 @@ macro_rules! get_array {
     };
 }
 
+struct HasToVec;
+
+impl HasToVec {
+    fn to_vec(&self) -> Vec<u32> {
+        vec![1, 2, 3]
+    }
+}
+
 fn main() {
     let _v1: Vec<_> = [1, 2, 3].to_vec();
     //~^ vec_from_literal_array
@@ -62,4 +70,6 @@ fn main() {
     }
     // Should not trigger the lint - array comes from a macro
     let _v7: Vec<u32> = get_array!().to_vec();
+    // Should not trigger the lint - not called on an array literal
+    let _v8: Vec<u32> = HasToVec.to_vec();
 }

--- a/tests/ui/vec_from_literal_array.rs
+++ b/tests/ui/vec_from_literal_array.rs
@@ -24,6 +24,16 @@ macro_rules! double_macro_number {
     };
 }
 
+mod with_extension_trait {
+    pub trait CustomVec {
+        fn to_vec(&self) -> Vec<u32> {
+            vec![1, 2, 3]
+        }
+    }
+
+    impl<T, const N: usize> CustomVec for [T; N] {}
+}
+
 fn main() {
     let _v1: Vec<_> = [1, 2, 3].to_vec();
     //~^ vec_from_literal_array
@@ -39,4 +49,9 @@ fn main() {
     //~^ vec_from_literal_array
     let _v5: Vec<_> = [16, double_macro_number!(17), 18].to_vec();
     //~^ vec_from_literal_array
+    // Should not trigger the lint - not the built-in to_vec() method
+    {
+        use with_extension_trait::CustomVec;
+        let _v6: Vec<u32> = ["a", "b", "c"].to_vec();
+    }
 }

--- a/tests/ui/vec_from_literal_array.rs
+++ b/tests/ui/vec_from_literal_array.rs
@@ -1,0 +1,42 @@
+#![warn(clippy::vec_from_literal_array)]
+
+fn get_fixed_number() -> u32 {
+    5
+}
+
+fn double_number(n: u32) -> u32 {
+    n * 2
+}
+
+fn print_vec(v: Vec<u32>) {
+    println!("{v:?}");
+}
+
+macro_rules! get_macro_number {
+    () => {
+        14
+    };
+}
+
+macro_rules! double_macro_number {
+    ($n:literal) => {
+        $n * 2
+    };
+}
+
+fn main() {
+    let _v1: Vec<_> = [1, 2, 3].to_vec();
+    //~^ vec_from_literal_array
+    let _v2: Vec<_> = [4, get_fixed_number(), 6].to_vec();
+    //~^ vec_from_literal_array
+    let _v3: Vec<_> = [7, double_number(8), 9].to_vec();
+    //~^ vec_from_literal_array
+    print_vec(
+        [10, 11, 12].to_vec(),
+        //~^ vec_from_literal_array
+    );
+    let _v4: Vec<_> = [13, get_macro_number!(), 15].to_vec();
+    //~^ vec_from_literal_array
+    let _v5: Vec<_> = [16, double_macro_number!(17), 18].to_vec();
+    //~^ vec_from_literal_array
+}

--- a/tests/ui/vec_from_literal_array.stderr
+++ b/tests/ui/vec_from_literal_array.stderr
@@ -1,5 +1,5 @@
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:28:23
+  --> tests/ui/vec_from_literal_array.rs:38:23
    |
 LL |     let _v1: Vec<_> = [1, 2, 3].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^ help: try: `vec![1, 2, 3]`
@@ -8,31 +8,31 @@ LL |     let _v1: Vec<_> = [1, 2, 3].to_vec();
    = help: to override `-D warnings` add `#[allow(clippy::vec_from_literal_array)]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:30:23
+  --> tests/ui/vec_from_literal_array.rs:40:23
    |
 LL |     let _v2: Vec<_> = [4, get_fixed_number(), 6].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![4, get_fixed_number(), 6]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:32:23
+  --> tests/ui/vec_from_literal_array.rs:42:23
    |
 LL |     let _v3: Vec<_> = [7, double_number(8), 9].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![7, double_number(8), 9]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:35:9
+  --> tests/ui/vec_from_literal_array.rs:45:9
    |
 LL |         [10, 11, 12].to_vec(),
    |         ^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![10, 11, 12]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:38:23
+  --> tests/ui/vec_from_literal_array.rs:48:23
    |
 LL |     let _v4: Vec<_> = [13, get_macro_number!(), 15].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![13, get_macro_number!(), 15]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:40:23
+  --> tests/ui/vec_from_literal_array.rs:50:23
    |
 LL |     let _v5: Vec<_> = [16, double_macro_number!(17), 18].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![16, double_macro_number!(17), 18]`

--- a/tests/ui/vec_from_literal_array.stderr
+++ b/tests/ui/vec_from_literal_array.stderr
@@ -1,0 +1,41 @@
+error: creating a vec with a literal array
+  --> tests/ui/vec_from_literal_array.rs:28:23
+   |
+LL |     let _v1: Vec<_> = [1, 2, 3].to_vec();
+   |                       ^^^^^^^^^^^^^^^^^^ help: try: `vec![1, 2, 3]`
+   |
+   = note: `-D clippy::vec-from-literal-array` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::vec_from_literal_array)]`
+
+error: creating a vec with a literal array
+  --> tests/ui/vec_from_literal_array.rs:30:23
+   |
+LL |     let _v2: Vec<_> = [4, get_fixed_number(), 6].to_vec();
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![4, get_fixed_number(), 6]`
+
+error: creating a vec with a literal array
+  --> tests/ui/vec_from_literal_array.rs:32:23
+   |
+LL |     let _v3: Vec<_> = [7, double_number(8), 9].to_vec();
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![7, double_number(8), 9]`
+
+error: creating a vec with a literal array
+  --> tests/ui/vec_from_literal_array.rs:35:9
+   |
+LL |         [10, 11, 12].to_vec(),
+   |         ^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![10, 11, 12]`
+
+error: creating a vec with a literal array
+  --> tests/ui/vec_from_literal_array.rs:38:23
+   |
+LL |     let _v4: Vec<_> = [13, get_macro_number!(), 15].to_vec();
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![13, get_macro_number!(), 15]`
+
+error: creating a vec with a literal array
+  --> tests/ui/vec_from_literal_array.rs:40:23
+   |
+LL |     let _v5: Vec<_> = [16, double_macro_number!(17), 18].to_vec();
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![16, double_macro_number!(17), 18]`
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/vec_from_literal_array.stderr
+++ b/tests/ui/vec_from_literal_array.stderr
@@ -1,5 +1,5 @@
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:38:23
+  --> tests/ui/vec_from_literal_array.rs:44:23
    |
 LL |     let _v1: Vec<_> = [1, 2, 3].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^ help: try: `vec![1, 2, 3]`
@@ -8,31 +8,31 @@ LL |     let _v1: Vec<_> = [1, 2, 3].to_vec();
    = help: to override `-D warnings` add `#[allow(clippy::vec_from_literal_array)]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:40:23
+  --> tests/ui/vec_from_literal_array.rs:46:23
    |
 LL |     let _v2: Vec<_> = [4, get_fixed_number(), 6].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![4, get_fixed_number(), 6]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:42:23
+  --> tests/ui/vec_from_literal_array.rs:48:23
    |
 LL |     let _v3: Vec<_> = [7, double_number(8), 9].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![7, double_number(8), 9]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:45:9
+  --> tests/ui/vec_from_literal_array.rs:51:9
    |
 LL |         [10, 11, 12].to_vec(),
    |         ^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![10, 11, 12]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:48:23
+  --> tests/ui/vec_from_literal_array.rs:54:23
    |
 LL |     let _v4: Vec<_> = [13, get_macro_number!(), 15].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![13, get_macro_number!(), 15]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:50:23
+  --> tests/ui/vec_from_literal_array.rs:56:23
    |
 LL |     let _v5: Vec<_> = [16, double_macro_number!(17), 18].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![16, double_macro_number!(17), 18]`

--- a/tests/ui/vec_from_literal_array.stderr
+++ b/tests/ui/vec_from_literal_array.stderr
@@ -1,5 +1,5 @@
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:44:23
+  --> tests/ui/vec_from_literal_array.rs:52:23
    |
 LL |     let _v1: Vec<_> = [1, 2, 3].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^ help: try: `vec![1, 2, 3]`
@@ -8,31 +8,31 @@ LL |     let _v1: Vec<_> = [1, 2, 3].to_vec();
    = help: to override `-D warnings` add `#[allow(clippy::vec_from_literal_array)]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:46:23
+  --> tests/ui/vec_from_literal_array.rs:54:23
    |
 LL |     let _v2: Vec<_> = [4, get_fixed_number(), 6].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![4, get_fixed_number(), 6]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:48:23
+  --> tests/ui/vec_from_literal_array.rs:56:23
    |
 LL |     let _v3: Vec<_> = [7, double_number(8), 9].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![7, double_number(8), 9]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:51:9
+  --> tests/ui/vec_from_literal_array.rs:59:9
    |
 LL |         [10, 11, 12].to_vec(),
    |         ^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![10, 11, 12]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:54:23
+  --> tests/ui/vec_from_literal_array.rs:62:23
    |
 LL |     let _v4: Vec<_> = [13, get_macro_number!(), 15].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![13, get_macro_number!(), 15]`
 
 error: creating a vec with a literal array
-  --> tests/ui/vec_from_literal_array.rs:56:23
+  --> tests/ui/vec_from_literal_array.rs:64:23
    |
 LL |     let _v5: Vec<_> = [16, double_macro_number!(17), 18].to_vec();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec![16, double_macro_number!(17), 18]`


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17482)*

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Fixes rust-lang/rust-clippy#17478

---

changelog: [`vec_from_literal_array`]: add lint
