### PR TITLE
fix: evaluate inline const blocks with the const evaluator

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -21,9 +21,11 @@ use rustc_lexer::{FrontmatterAllowed, tokenize};
 use rustc_lint::LateContext;
 use rustc_middle::mir::ConstValue;
 use rustc_middle::mir::interpret::{Scalar, alloc_range};
-use rustc_middle::ty::{self, FloatTy, IntTy, ScalarInt, Ty, TyCtxt, TypeckResults, UintTy};
+use rustc_middle::ty::{
+    self, FloatTy, InlineConstArgs, InlineConstArgsParts, IntTy, ScalarInt, Ty, TyCtxt, TypeckResults, UintTy,
+};
 use rustc_middle::{bug, mir, span_bug};
-use rustc_span::{Symbol, SyntaxContext};
+use rustc_span::{Span, Symbol, SyntaxContext};
 use std::cell::Cell;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
@@ -618,11 +620,43 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
             .and_then(|c| mir_to_const(self.tcx, c, self.typeck.node_type(hir_id)))
     }
 
+    /// Folds the body of an inline const block, falling back to the compiler's const evaluator for
+    /// bodies which can't be folded here, e.g. `const { size_of::<u64>() }`.
+    fn const_block(&self, block: &ConstBlock, span: Span) -> Option<Constant> {
+        if let Some(c) = self.expr(self.tcx.hir_body(block.body).value) {
+            return Some(c);
+        }
+
+        let did = block.def_id.to_def_id();
+        let typeck_root_def_id = self.tcx.typeck_root_def_id(did);
+        let identity_args = ty::GenericArgs::identity_for_item(self.tcx, typeck_root_def_id);
+        // Don't try to fully evaluate consts inside code whose bounds can't be satisfied. The
+        // compiler never evaluates such a body itself, so doing it here would report errors for
+        // code which builds fine.
+        if self
+            .tcx
+            .instantiate_and_check_impossible_clauses((typeck_root_def_id, identity_args))
+        {
+            return None;
+        }
+
+        // The value depends on items the folding above can't see, so it isn't locally defined.
+        self.source.set(ConstantSource::NonLocal);
+        let ty = self.typeck.node_type(block.hir_id);
+        let parent_args = self.tcx.erase_and_anonymize_regions(identity_args);
+        let args = InlineConstArgs::new(self.tcx, InlineConstArgsParts { parent_args, ty }).args;
+        let val = self
+            .tcx
+            .const_eval_resolve(self.typing_env, mir::UnevaluatedConst::new(did, args), span)
+            .ok()?;
+        mir_to_const(self.tcx, val, ty)
+    }
+
     /// Simple constant folding: Insert an expression, get a constant or none.
     fn expr(&self, e: &Expr<'_>) -> Option<Constant> {
         self.check_ctxt(e.span.ctxt());
         match e.kind {
-            ExprKind::ConstBlock(ConstBlock { body, .. }) => self.expr(self.tcx.hir_body(body).value),
+            ExprKind::ConstBlock(ref block) => self.const_block(block, e.span),
             ExprKind::DropTemps(e) => self.expr(e),
             ExprKind::Path(ref qpath) => self.qpath(qpath, e.hir_id),
             ExprKind::Block(block, _) => {

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -760,4 +760,33 @@ pub fn issue_17005() {
     let _ = 0xf301_0000u32 + id_u16() as u32;
 }
 
+pub fn issue_17263(f: u64) -> u64 {
+    const SIZE: u64 = std::mem::size_of::<u64>() as u64;
+
+    let _ = f.saturating_div(SIZE);
+    let _ = f.saturating_div(const { SIZE });
+    let _ = f.saturating_div(const { std::mem::size_of::<u64>() as u64 });
+    let _ = f / const { std::mem::size_of::<u64>() as u64 };
+    let _ = f % const { std::mem::size_of::<u64>() as u64 };
+
+    const fn one() -> u64 {
+        1
+    }
+    let _ = f.saturating_div(const { one() });
+
+    let _ = f.saturating_div(const { std::mem::size_of::<()>() as u64 });
+    //~^ arithmetic_side_effects
+    let _ = f / const { std::mem::size_of::<()>() as u64 };
+    //~^ arithmetic_side_effects
+    let _ = f % const { std::mem::size_of::<()>() as u64 };
+    //~^ arithmetic_side_effects
+
+    f
+}
+
+pub fn issue_17263_generic<T>(f: u64) -> u64 {
+    f.saturating_div(const { std::mem::size_of::<T>() as u64 })
+    //~^ arithmetic_side_effects
+}
+
 fn main() {}

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -787,5 +787,29 @@ error: arithmetic operation that can potentially result in unexpected side-effec
 LL |     let _ = Duration::from_secs(86400 * shift(1));
    |                                 ^^^^^^^^^^^^^^^^
 
-error: aborting due to 131 previous errors
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> tests/ui/arithmetic_side_effects.rs:777:30
+   |
+LL |     let _ = f.saturating_div(const { std::mem::size_of::<()>() as u64 });
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> tests/ui/arithmetic_side_effects.rs:779:13
+   |
+LL |     let _ = f / const { std::mem::size_of::<()>() as u64 };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> tests/ui/arithmetic_side_effects.rs:781:13
+   |
+LL |     let _ = f % const { std::mem::size_of::<()>() as u64 };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> tests/ui/arithmetic_side_effects.rs:788:22
+   |
+LL |     f.saturating_div(const { std::mem::size_of::<T>() as u64 })
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 135 previous errors
 

--- a/tests/ui/crashes/inline-const-impossible-bounds.rs
+++ b/tests/ui/crashes/inline-const-impossible-bounds.rs
@@ -1,0 +1,18 @@
+// Evaluating an inline const block inside an item whose bounds can't be satisfied must not report
+// the evaluation failure, as the compiler never evaluates that body itself.
+#![feature(trivial_bounds)]
+#![warn(clippy::arithmetic_side_effects)]
+
+struct TrickClippy(str);
+
+impl TrickClippy {
+    fn trick_clippy(f: u64) -> u64
+    where
+        Self: Sized,
+    {
+        f.saturating_div(const { size_of::<Self>() as u64 })
+        //~^ arithmetic_side_effects
+    }
+}
+
+fn main() {}

--- a/tests/ui/crashes/inline-const-impossible-bounds.rs
+++ b/tests/ui/crashes/inline-const-impossible-bounds.rs
@@ -1,5 +1,6 @@
-// Evaluating an inline const block inside an item whose bounds can't be satisfied must not report
-// the evaluation failure, as the compiler never evaluates that body itself.
+// `Self` is unsized, so the `where Self: Sized` bound is unsatisfiable and rustc never evaluates
+// this body. Clippy must not force the evaluation itself: that would emit `error[E0080]` for code
+// which compiles fine. The lint below still fires, since the divisor stays unknown.
 #![feature(trivial_bounds)]
 #![warn(clippy::arithmetic_side_effects)]
 

--- a/tests/ui/crashes/inline-const-impossible-bounds.rs
+++ b/tests/ui/crashes/inline-const-impossible-bounds.rs
@@ -3,10 +3,10 @@
 #![feature(trivial_bounds)]
 #![warn(clippy::arithmetic_side_effects)]
 
-struct TrickClippy(str);
+struct UnreachableConst(str);
 
-impl TrickClippy {
-    fn trick_clippy(f: u64) -> u64
+impl UnreachableConst {
+    fn unreachable(f: u64) -> u64
     where
         Self: Sized,
     {

--- a/tests/ui/crashes/inline-const-impossible-bounds.stderr
+++ b/tests/ui/crashes/inline-const-impossible-bounds.stderr
@@ -1,0 +1,11 @@
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> tests/ui/crashes/inline-const-impossible-bounds.rs:13:26
+   |
+LL |         f.saturating_div(const { size_of::<Self>() as u64 })
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::arithmetic-side-effects` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::arithmetic_side_effects)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/crashes/inline-const-impossible-bounds.stderr
+++ b/tests/ui/crashes/inline-const-impossible-bounds.stderr
@@ -1,5 +1,5 @@
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/crashes/inline-const-impossible-bounds.rs:13:26
+  --> tests/ui/crashes/inline-const-impossible-bounds.rs:14:26
    |
 LL |         f.saturating_div(const { size_of::<Self>() as u64 })
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
`ConstEvalCtxt` folded the body of a `const { .. }` block syntactically, so bodies it can't fold came back as unknown and `arithmetic_side_effects` reported a possibly-zero divisor:

```rust
let _ = x.saturating_div(const { SIZE });                    // ok, body is a path
let _ = x.saturating_div(const { size_of::<u64>() as u64 }); // linted, body is a call
```

Fixed in `ConstEvalCtxt` rather than in the lint, so all callers benefit: keep the existing fold as the fast path, fall back to `const_eval_resolve` when it fails.

Two notes for review:

- The CTFE result is marked `ConstantSource::NonLocal`, as `fetch_path` does for named consts, since the value comes from items the folder can't see. Lints using `eval_local` / `eval_full_int` therefore don't pick it up, leaving `identity_op` and friends unchanged.
- Items whose bounds can't be satisfied are skipped, the same guard `fetch_path` got in rust-lang/rust-clippy#16950. Without it clippy forces evaluation of a body the compiler never evaluates, emitting `error[E0080]` for code that builds fine. See `tests/ui/crashes/inline-const-impossible-bounds.rs`.

Zero-valued and generic const blocks still lint.

fixes rust-lang/rust-clippy#17263

changelog: [`arithmetic_side_effects`]: no longer lints operations whose operand is an inline `const` block with a known safe value
