### PR TITLE
fix(`legacy_numeric_constants`): make fixes machine-applicable

### DIFF
--- a/clippy_lints/src/legacy_numeric_constants.rs
+++ b/clippy_lints/src/legacy_numeric_constants.rs
@@ -139,7 +139,7 @@ impl<'tcx> LateLintPass<'tcx> for LegacyNumericConstants {
                     expr.span,
                     "use the associated constant instead",
                     sugg,
-                    Applicability::MaybeIncorrect,
+                    Applicability::MachineApplicable,
                 );
             });
         }


### PR DESCRIPTION
They did start out like that,[^1] but then the authors decided to start linting the cases with import statements, and reduced applicability when those needed to be removed,[^2] as they couldn't offer an autofix for that. But eventually, the handling of imports was split out completely[^3] -- however, the suggestions were left as `MaybeIncorrect`. This commit fixes that.

Motivated by https://www.youtube.com/watch?v=bAINppA0BSU&t=14830s

changelog: [`legacy_numeric_constants`]: make fixes machine-applicable

[^1]: https://github.com/rust-lang/rust-clippy/pull/10997/commits/1612dd859e22f9338f95553fcbcf6701feb12309#diff-12bd001af48f0dbcf8687655ff257353d54c12d8b1f1377daf7825329b639cc4R108
[^2]: https://github.com/rust-lang/rust-clippy/pull/10997/commits/d5c15a464ee8f3fe9e84ffcece04e276578b46d7#diff-103b7ced60e2ad02f44b53bee4b58c812952604af640e5bbe0063c482bbfa01dR183-R187
[^3]: https://github.com/rust-lang/rust-clippy/blob/29a54a85e55fcdd701e5fad26e8a076de6cb275a/clippy_lints/src/legacy_numeric_constants.rs#L113-L115