### PR TITLE
`mixed_read_write_in_expression`: fix broken link to reference

### DIFF
--- a/clippy_lints/src/mixed_read_write_in_expression.rs
+++ b/clippy_lints/src/mixed_read_write_in_expression.rs
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// order of sub-expressions.
     ///
     /// ### Why restrict this?
-    /// While [the evaluation order of sub-expressions] is fully specified in Rust,
+    /// While [the evaluation order of sub-expressions][order] is fully specified in Rust,
     /// it still may be confusing to read an expression where the evaluation order
     /// affects its behavior.
     ///
@@ -72,7 +72,7 @@ declare_clippy_lint! {
     /// let a = tmp + x;
     /// ```
     ///
-    /// [order]: (https://doc.rust-lang.org/reference/expressions.html?highlight=subexpression#evaluation-order-of-operands)
+    /// [order]: https://doc.rust-lang.org/reference/expressions.html?highlight=subexpression#evaluation-order-of-operands
     #[clippy::version = "pre 1.29.0"]
     pub MIXED_READ_WRITE_IN_EXPRESSION,
     restriction,


### PR DESCRIPTION
changelog: [`mixed_read_write_in_expression`]: fix broken link to reference