### PR TITLE
fix(redundant_clone): Make `visit_local_usage` analyse loop bodies instead of giving up on them

### DIFF
--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -1,11 +1,13 @@
-use std::iter;
+use std::{iter, mem};
 
 use rustc_data_structures::either::Either;
 use rustc_hir::{Expr, HirId};
+use rustc_index::IndexVec;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
-    BasicBlock, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, StatementKind, TerminatorKind, traversal,
+    BasicBlock, BasicBlockData, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, StatementKind,
+    TerminatorKind,
 };
 use rustc_middle::ty::TyCtxt;
 
@@ -29,33 +31,119 @@ pub fn visit_local_usage<const N: usize>(
     mir: &Body<'_>,
     location: Location,
 ) -> Option<[LocalUsage; N]> {
-    let init = [const {
-        LocalUsage {
-            local_use_locs: Vec::new(),
-            local_consume_or_mutate_locs: Vec::new(),
+    let live_on_entry = reachable_while_storage_live(&locals, mir, location)?;
+
+    let mut v = V {
+        locals: &locals,
+        location,
+        results: [const {
+            LocalUsage {
+                local_use_locs: Vec::new(),
+                local_consume_or_mutate_locs: Vec::new(),
+            }
+        }; N],
+    };
+
+    for &tbb in mir.basic_blocks.reverse_postorder() {
+        if live_on_entry[tbb] != 0 {
+            v.visit_basic_block_data(tbb, &mir.basic_blocks[tbb]);
         }
-    }; N];
+    }
 
-    traversal::Postorder::new(&mir.basic_blocks, location.block, None)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .try_fold(init, |usage, tbb| {
-            let tdata = &mir.basic_blocks[tbb];
+    Some(v.results)
+}
 
-            // Give up on loops
-            if tdata.terminator().successors().any(|s| s == location.block) {
+/// Starting from the specified location, determines which blocks may be entered while any of the
+/// `locals` are still live.
+///
+/// Returns:
+/// - `None` if `location.block` may be re-entered while any of the locals are live.
+/// - `Some` with (for each [`BasicBlock`]) a bitset representing which of the locals are
+///   potentially live at the start of the block. Bit `i` stands for `locals[i]`. The exception is
+///   `location.block`, which is entered at `location` and therefore has every bit set.
+fn reachable_while_storage_live<const N: usize>(
+    locals: &[Local; N],
+    mir: &Body<'_>,
+    location: Location,
+) -> Option<IndexVec<BasicBlock, u8>> {
+    fn join(base: &mut u8, other: u8) -> bool {
+        let new = *base | other;
+        mem::replace(base, new) != new
+    }
+    fn enqueue(state: &mut u8) -> bool {
+        let new = *state | ENQUEUED_FLAG;
+        mem::replace(state, new) != new
+    }
+    fn dequeue(state: &mut u8) {
+        *state &= !ENQUEUED_FLAG;
+    }
+
+    const ENQUEUED_FLAG: u8 = 0b1000_0000;
+    const {
+        assert!(
+            N <= ENQUEUED_FLAG.trailing_zeros() as usize,
+            "implementation isn't well suited for handling a larger number locals nor do we have any reason to pass a larger number"
+        );
+    }
+
+    // Kills every local which is `StorageDead`-ed by a statement of `bb_data` at or after `start`.
+    let apply_deaths = |bb_data: &BasicBlockData<'_>, start: usize, mut live: u8| {
+        // `start` is past the end when `location` points at the terminator.
+        for stmt in bb_data.statements.get(start..).unwrap_or_default() {
+            if let StatementKind::StorageDead(killed) = stmt.kind
+                && let Some(slot) = locals.iter().position(|&local| local == killed)
+            {
+                live &= !(1 << slot);
+            }
+        }
+        live
+    };
+
+    // Walk forward over the successors of `location`.
+    // Each block's state packs the locals which are live on entry into the low `N` bits, plus a flag
+    // marking the block as queued.
+
+    let mut states = IndexVec::from_raw(vec![0; mir.basic_blocks.len()]);
+    let mut queue = Vec::new();
+    // Assumed to have all locals live, so fully filled
+    let init = u8::MAX >> (u8::BITS as usize - N);
+    states[location.block] = init;
+
+    // `location.block` is the only block entered part-way through, so it is walked separately.
+    // Reaching it again in the loop below means a cycle closed around `location`.
+    let bb_data = &mir.basic_blocks[location.block];
+    let result = apply_deaths(bb_data, location.statement_index + 1, init);
+    // A path is not followed past the point where every local is dead, as no statement there can
+    // refer to the values being tracked.
+    // A local declared inside a loop is therefore treated as distinct on each iteration.
+    if result != 0 {
+        for succ in bb_data.terminator().successors() {
+            if succ == location.block {
                 return None;
             }
+            if join(&mut states[succ], result) && enqueue(&mut states[succ]) {
+                queue.push(succ);
+            }
+        }
+    }
 
-            let mut v = V {
-                locals: &locals,
-                location,
-                results: usage,
-            };
-            v.visit_basic_block_data(tbb, tdata);
-            Some(v.results)
-        })
+    while let Some(bb) = queue.pop() {
+        dequeue(&mut states[bb]);
+        let bb_data = &mir.basic_blocks[bb];
+        let result = apply_deaths(bb_data, 0, states[bb]);
+        if result != 0 {
+            for succ in bb_data.terminator().successors() {
+                if succ == location.block {
+                    return None;
+                }
+                if join(&mut states[succ], result) && enqueue(&mut states[succ]) {
+                    queue.push(succ);
+                }
+            }
+        }
+    }
+
+    Some(states)
 }
 
 struct V<'a, const N: usize> {

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -6,7 +6,7 @@ use rustc_index::IndexVec;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
-    BasicBlock, BasicBlockData, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, Statement, StatementKind,
+    BasicBlock, BasicBlockData, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, StatementKind,
     TerminatorKind,
 };
 use rustc_middle::ty::TyCtxt;
@@ -53,18 +53,9 @@ pub fn visit_local_usage<const N: usize>(
     Some(v.results)
 }
 
-/// The tracked values that are still live, as a set of idx of `locals`
-type Live = DenseBitSet<usize>;
-
-/// The [`Local`] whose value `stmt` kills, if any.
-fn killed_local(stmt: &Statement<'_>) -> Option<Local> {
-    match stmt.kind {
-        StatementKind::StorageDead(local) => Some(local),
-        _ => None,
-    }
-}
-
-/// Returns the blocks reachable from `location` in which `locals` still hold their values.
+/// Which `locals` still hold their values when each block is entered, as a bit mask of idx.
+/// A block which is unreachable from `location`, or only reachable once every local is dead, is
+/// left at zero.
 ///
 /// A path is walked until every local has been `StorageDead`-ed.
 /// No statement past that point can refer to the values being tracked.
@@ -76,12 +67,14 @@ fn reachable_while_storage_live<const N: usize>(
     locals: &[Local; N],
     mir: &Body<'_>,
     location: Location,
-) -> Option<DenseBitSet<BasicBlock>> {
+) -> Option<IndexVec<BasicBlock, u8>> {
+    const ENQUEUED_FLAG: u8 = 0b1000_0000;
+    const { assert!(N <= ENQUEUED_FLAG.trailing_zeros() as usize) }
+
     fn join(base: &mut u8, other: u8) -> bool {
         let new = *base | other;
         mem::replace(base, new) != new
     }
-    const ENQUEUED_FLAG: u8 = 0b1000_0000;
     fn enqueue(state: &mut u8) -> bool {
         let new = *state | ENQUEUED_FLAG;
         mem::replace(state, new) != new
@@ -90,15 +83,30 @@ fn reachable_while_storage_live<const N: usize>(
         *state &= !ENQUEUED_FLAG;
     }
 
+    // Kills every local which is `StorageDead`-ed by a statement of `bb_data` at or after `start`.
+    let apply_deaths = |bb_data: &BasicBlockData<'_>, start: usize, mut live: u8| {
+        // `start` is past the end when `location` points at the terminator.
+        for stmt in bb_data.statements.get(start..).unwrap_or_default() {
+            if let StatementKind::StorageDead(killed) = stmt.kind
+                && let Some(slot) = locals.iter().position(|&local| local == killed)
+            {
+                live &= !(1 << slot);
+            }
+        }
+        live
+    };
+
     let mut states = IndexVec::from_raw(vec![0; mir.basic_blocks.len()]);
     let mut queue = Vec::new();
-    let init = !(0u8 << N);
+    let init = !(!0u8 << N);
     states[location.block] = init;
 
+    // `location.block` is the only block entered part-way through, so it is walked separately.
+    // Reaching it again in the loop below means a cycle closed around `location`.
     let bb_data = &mir.basic_blocks[location.block];
     let result = apply_deaths(bb_data, location.statement_index + 1, init);
     if result != 0 {
-        for succ in mir.basic_blocks[location.block].terminator().successors() {
+        for succ in bb_data.terminator().successors() {
             if succ == location.block {
                 return None;
             }

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -82,7 +82,7 @@ fn reachable_while_storage_live<const N: usize>(
         assert!(
             N <= ENQUEUED_FLAG.trailing_zeros() as usize,
             "implementation isn't well suited for handling a larger number locals nor do we have any reason to pass a larger number"
-        )
+        );
     }
 
     // Kills every local which is `StorageDead`-ed by a statement of `bb_data` at or after `start`.

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -1,13 +1,13 @@
-use std::iter;
-use std::ops::Range;
+use std::{iter, mem};
 
 use rustc_data_structures::either::Either;
-use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::{Expr, HirId};
+use rustc_index::IndexVec;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
-    BasicBlock, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, Statement, StatementKind, TerminatorKind,
+    BasicBlock, BasicBlockData, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, Statement, StatementKind,
+    TerminatorKind,
 };
 use rustc_middle::ty::TyCtxt;
 
@@ -31,7 +31,7 @@ pub fn visit_local_usage<const N: usize>(
     mir: &Body<'_>,
     location: Location,
 ) -> Option<[LocalUsage; N]> {
-    let blocks = reachable_while_storage_live(&locals, mir, location)?;
+    let live_on_entry = reachable_while_storage_live(&locals, mir, location)?;
 
     let mut v = V {
         locals: &locals,
@@ -45,7 +45,7 @@ pub fn visit_local_usage<const N: usize>(
     };
 
     for &tbb in mir.basic_blocks.reverse_postorder() {
-        if blocks.contains(tbb) {
+        if live_on_entry[tbb] != 0 {
             v.visit_basic_block_data(tbb, &mir.basic_blocks[tbb]);
         }
     }
@@ -77,54 +77,54 @@ fn reachable_while_storage_live<const N: usize>(
     mir: &Body<'_>,
     location: Location,
 ) -> Option<DenseBitSet<BasicBlock>> {
-    let remove_killed = |bb: BasicBlock, range: Range<usize>, live: &mut Live| {
-        for slot in mir.basic_blocks[bb].statements[range]
-            .iter()
-            .filter_map(killed_local)
-            .filter_map(|killed| locals.iter().position(|&local| local == killed))
-        {
-            live.remove(slot);
-        }
-    };
-    let successors = |bb: BasicBlock, live: &Live| {
-        mir.basic_blocks[bb]
-            .terminator()
-            .successors()
-            .map(|succ| (succ, live.clone()))
-            .collect::<Vec<_>>()
-    };
-
-    let mut blocks = DenseBitSet::new_empty(mir.basic_blocks.len());
-    blocks.insert(location.block);
-
-    let mut seen = FxHashSet::default();
-    let mut worklist = Vec::new();
-    // `location.block` is the only block entered part-way through, so it is walked separately.
-    // Reaching it again in the loop below means a cycle closed around `location`.
-    let stmts = mir.basic_blocks[location.block].statements.len();
-    let after_location = (location.statement_index + 1).min(stmts);
-    let mut live = Live::new_filled(N);
-    remove_killed(location.block, after_location..stmts, &mut live);
-    if !live.is_empty() {
-        worklist.extend(successors(location.block, &live));
+    fn join(base: &mut u8, other: u8) -> bool {
+        let new = *base | other;
+        mem::replace(base, new) != new
+    }
+    const ENQUEUED_FLAG: u8 = 0b1000_0000;
+    fn enqueue(state: &mut u8) -> bool {
+        let new = *state | ENQUEUED_FLAG;
+        mem::replace(state, new) != new
+    }
+    fn dequeue(state: &mut u8) {
+        *state &= !ENQUEUED_FLAG;
     }
 
-    while let Some((bb, mut live)) = worklist.pop() {
-        if bb == location.block {
-            return None;
-        }
-        if !seen.insert((bb, live.clone())) {
-            continue;
-        }
-        blocks.insert(bb);
+    let mut states = IndexVec::from_raw(vec![0; mir.basic_blocks.len()]);
+    let mut queue = Vec::new();
+    let init = !(0u8 << N);
+    states[location.block] = init;
 
-        remove_killed(bb, 0..mir.basic_blocks[bb].statements.len(), &mut live);
-        if !live.is_empty() {
-            worklist.extend(successors(bb, &live));
+    let bb_data = &mir.basic_blocks[location.block];
+    let result = apply_deaths(bb_data, location.statement_index + 1, init);
+    if result != 0 {
+        for succ in mir.basic_blocks[location.block].terminator().successors() {
+            if succ == location.block {
+                return None;
+            }
+            if join(&mut states[succ], result) && enqueue(&mut states[succ]) {
+                queue.push(succ);
+            }
         }
     }
 
-    Some(blocks)
+    while let Some(bb) = queue.pop() {
+        dequeue(&mut states[bb]);
+        let bb_data = &mir.basic_blocks[bb];
+        let result = apply_deaths(bb_data, 0, states[bb]);
+        if result != 0 {
+            for succ in bb_data.terminator().successors() {
+                if succ == location.block {
+                    return None;
+                }
+                if join(&mut states[succ], result) && enqueue(&mut states[succ]) {
+                    queue.push(succ);
+                }
+            }
+        }
+    }
+
+    Some(states)
 }
 
 struct V<'a, const N: usize> {

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -1,11 +1,14 @@
 use std::iter;
+use std::ops::Range;
 
 use rustc_data_structures::either::Either;
+use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::{Expr, HirId};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
-    BasicBlock, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, StatementKind, TerminatorKind, traversal,
+    BasicBlock, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, Statement, StatementKind, TerminatorKind,
+    traversal,
 };
 use rustc_middle::ty::TyCtxt;
 
@@ -29,33 +32,104 @@ pub fn visit_local_usage<const N: usize>(
     mir: &Body<'_>,
     location: Location,
 ) -> Option<[LocalUsage; N]> {
-    let init = [const {
-        LocalUsage {
-            local_use_locs: Vec::new(),
-            local_consume_or_mutate_locs: Vec::new(),
-        }
-    }; N];
+    let blocks = reachable_while_storage_live(&locals, mir, location)?;
 
-    traversal::Postorder::new(&mir.basic_blocks, location.block, None)
+    let mut v = V {
+        locals: &locals,
+        location,
+        results: [const {
+            LocalUsage {
+                local_use_locs: Vec::new(),
+                local_consume_or_mutate_locs: Vec::new(),
+            }
+        }; N],
+    };
+
+    for tbb in traversal::Postorder::new(&mir.basic_blocks, location.block, None)
         .collect::<Vec<_>>()
         .into_iter()
         .rev()
-        .try_fold(init, |usage, tbb| {
-            let tdata = &mir.basic_blocks[tbb];
+    {
+        if blocks.contains(tbb) {
+            v.visit_basic_block_data(tbb, &mir.basic_blocks[tbb]);
+        }
+    }
 
-            // Give up on loops
-            if tdata.terminator().successors().any(|s| s == location.block) {
-                return None;
-            }
+    Some(v.results)
+}
 
-            let mut v = V {
-                locals: &locals,
-                location,
-                results: usage,
-            };
-            v.visit_basic_block_data(tbb, tdata);
-            Some(v.results)
-        })
+/// The tracked values that are still live, as a set of idx of `locals`
+type Live = DenseBitSet<usize>;
+
+/// The [`Local`] whose value `stmt` kills, if any.
+fn killed_local(stmt: &Statement<'_>) -> Option<Local> {
+    match stmt.kind {
+        StatementKind::StorageDead(local) => Some(local),
+        _ => None,
+    }
+}
+
+/// Returns the blocks reachable from `location` in which `locals` still hold their values.
+///
+/// A path is walked until every local has been `StorageDead`-ed.
+/// No statement past that point can refer to the values being tracked.
+/// A local declared inside a loop is therefore distinct on each iteration.
+///
+/// Returns `None` if `location.block` is reachable again while some local is still live.
+/// The statements preceding `location` then run a second time and cannot be ordered against it.
+fn reachable_while_storage_live<const N: usize>(
+    locals: &[Local; N],
+    mir: &Body<'_>,
+    location: Location,
+) -> Option<DenseBitSet<BasicBlock>> {
+    let remove_killed = |bb: BasicBlock, range: Range<usize>, live: &mut Live| {
+        for slot in mir.basic_blocks[bb].statements[range]
+            .iter()
+            .filter_map(killed_local)
+            .filter_map(|killed| locals.iter().position(|&local| local == killed))
+        {
+            live.remove(slot);
+        }
+    };
+    let successors = |bb: BasicBlock, live: &Live| {
+        mir.basic_blocks[bb]
+            .terminator()
+            .successors()
+            .map(|succ| (succ, live.clone()))
+            .collect::<Vec<_>>()
+    };
+
+    let mut blocks = DenseBitSet::new_empty(mir.basic_blocks.len());
+    blocks.insert(location.block);
+
+    let mut seen = FxHashSet::default();
+    let mut worklist = Vec::new();
+    // `location.block` is the only block entered part-way through, so it is walked separately.
+    // Reaching it again in the loop below means a cycle closed around `location`.
+    let stmts = mir.basic_blocks[location.block].statements.len();
+    let after_location = (location.statement_index + 1).min(stmts);
+    let mut live = Live::new_filled(N);
+    remove_killed(location.block, after_location..stmts, &mut live);
+    if !live.is_empty() {
+        worklist.extend(successors(location.block, &live));
+    }
+
+    while let Some((bb, mut live)) = worklist.pop() {
+        if bb == location.block {
+            return None;
+        }
+        if !seen.insert((bb, live.clone())) {
+            continue;
+        }
+        blocks.insert(bb);
+
+        remove_killed(bb, 0..mir.basic_blocks[bb].statements.len(), &mut live);
+        if !live.is_empty() {
+            worklist.extend(successors(bb, &live));
+        }
+    }
+
+    Some(blocks)
 }
 
 struct V<'a, const N: usize> {

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -53,23 +53,18 @@ pub fn visit_local_usage<const N: usize>(
     Some(v.results)
 }
 
-/// Which `locals` still hold their values when each block is entered, as a bit mask of idx.
-/// A block which is unreachable from `location`, or only reachable once every local is dead, is
-/// left at zero.
+/// Starting from the specified location, determines which of the successor blocks may be entered
+/// while any of the `locals` are still live.
 ///
-/// A path is walked until every local has been `StorageDead`-ed.
-/// No statement past that point can refer to the values being tracked.
-/// A local declared inside a loop is therefore distinct on each iteration.
-///
-/// Returns `None` if `location.block` is reachable again while some local is still live.
-/// The statements preceding `location` then run a second time and cannot be ordered against it.
+/// Returns:
+/// - `None` if `location.block` may be re-entered while any of the locals are live.
+/// - `Some` with (for each [`BasicBlock`]) a bitset representing which of the locals are
+///   potentially live at the start of the block. Bit `i` stands for `locals[i]`.
 fn reachable_while_storage_live<const N: usize>(
     locals: &[Local; N],
     mir: &Body<'_>,
     location: Location,
 ) -> Option<IndexVec<BasicBlock, u8>> {
-    const ENQUEUED_FLAG: u8 = 0b1000_0000;
-
     fn join(base: &mut u8, other: u8) -> bool {
         let new = *base | other;
         mem::replace(base, new) != new
@@ -82,7 +77,13 @@ fn reachable_while_storage_live<const N: usize>(
         *state &= !ENQUEUED_FLAG;
     }
 
-    const { assert!(N <= ENQUEUED_FLAG.trailing_zeros() as usize) }
+    const ENQUEUED_FLAG: u8 = 0b1000_0000;
+    const {
+        assert!(
+            N <= ENQUEUED_FLAG.trailing_zeros() as usize,
+            "implementation isn't well suited for handling a larger number locals nor do we have any reason to pass a larger number"
+        )
+    }
 
     // Kills every local which is `StorageDead`-ed by a statement of `bb_data` at or after `start`.
     let apply_deaths = |bb_data: &BasicBlockData<'_>, start: usize, mut live: u8| {
@@ -97,8 +98,13 @@ fn reachable_while_storage_live<const N: usize>(
         live
     };
 
+    // Walk forward over the successors of `location`.
+    // Each block's state packs the locals which are live on entry into the low `N` bits, plus a flag
+    // marking the block as queued.
+
     let mut states = IndexVec::from_raw(vec![0; mir.basic_blocks.len()]);
     let mut queue = Vec::new();
+    // Assumed to have all locals live, so fully filled
     let init = u8::MAX >> (u8::BITS as usize - N);
     states[location.block] = init;
 
@@ -106,6 +112,9 @@ fn reachable_while_storage_live<const N: usize>(
     // Reaching it again in the loop below means a cycle closed around `location`.
     let bb_data = &mir.basic_blocks[location.block];
     let result = apply_deaths(bb_data, location.statement_index + 1, init);
+    // A path is not followed past the point where every local is dead, as no statement there can
+    // refer to the values being tracked.
+    // A local declared inside a loop is therefore treated as distinct on each iteration.
     if result != 0 {
         for succ in bb_data.terminator().successors() {
             if succ == location.block {

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -99,7 +99,7 @@ fn reachable_while_storage_live<const N: usize>(
 
     let mut states = IndexVec::from_raw(vec![0; mir.basic_blocks.len()]);
     let mut queue = Vec::new();
-    let init = !(!0u8 << N);
+    let init = u8::MAX >> (u8::BITS as usize - N);
     states[location.block] = init;
 
     // `location.block` is the only block entered part-way through, so it is walked separately.

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -8,7 +8,6 @@ use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
     BasicBlock, Body, InlineAsmOperand, Local, Location, Place, START_BLOCK, Statement, StatementKind, TerminatorKind,
-    traversal,
 };
 use rustc_middle::ty::TyCtxt;
 
@@ -45,11 +44,7 @@ pub fn visit_local_usage<const N: usize>(
         }; N],
     };
 
-    for tbb in traversal::Postorder::new(&mir.basic_blocks, location.block, None)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-    {
+    for &tbb in mir.basic_blocks.reverse_postorder() {
         if blocks.contains(tbb) {
             v.visit_basic_block_data(tbb, &mir.basic_blocks[tbb]);
         }

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -69,7 +69,6 @@ fn reachable_while_storage_live<const N: usize>(
     location: Location,
 ) -> Option<IndexVec<BasicBlock, u8>> {
     const ENQUEUED_FLAG: u8 = 0b1000_0000;
-    const { assert!(N <= ENQUEUED_FLAG.trailing_zeros() as usize) }
 
     fn join(base: &mut u8, other: u8) -> bool {
         let new = *base | other;
@@ -82,6 +81,8 @@ fn reachable_while_storage_live<const N: usize>(
     fn dequeue(state: &mut u8) {
         *state &= !ENQUEUED_FLAG;
     }
+
+    const { assert!(N <= ENQUEUED_FLAG.trailing_zeros() as usize) }
 
     // Kills every local which is `StorageDead`-ed by a statement of `bb_data` at or after `start`.
     let apply_deaths = |bb_data: &BasicBlockData<'_>, start: usize, mut live: u8| {

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -313,3 +313,77 @@ mod hir_prefilter {
         //~^ redundant_clone
     }
 }
+
+mod issue16096 {
+    fn loop_body(n: usize) -> Vec<String> {
+        let mut out = Vec::new();
+        for _ in 0..n {
+            let s = String::new();
+            out.push(s);
+            //~^ redundant_clone
+        }
+        out
+    }
+
+    fn loop_with_continue(n: usize, c: bool) {
+        for _ in 0..n {
+            let s = String::new();
+            let t = s;
+            //~^ redundant_clone
+            if c {
+                continue;
+            }
+            drop(t);
+        }
+    }
+
+    fn nested_loop(n: usize) {
+        for _ in 0..n {
+            let s = String::new();
+            let t = s;
+            //~^ redundant_clone
+            for _ in 0..n {
+                println!("{t}");
+            }
+        }
+    }
+
+    // every arm has its own scope, and they converge on the block below the `match`
+    fn match_arm_scopes(n: u8, out: &mut Vec<String>) {
+        match n {
+            0 => {
+                let s = String::new();
+                out.push(s);
+                //~^ redundant_clone
+            },
+            1 => {
+                let s = String::new();
+                out.push(s);
+                //~^ redundant_clone
+            },
+            _ => {},
+        }
+        out.push(String::new());
+    }
+
+    // `s` dies at the end of the inner block, `t` stays live past it
+    fn inner_scope(c: bool) {
+        let t;
+        {
+            let s = String::new();
+            t = s;
+            //~^ redundant_clone
+        }
+        if c {
+            drop(t);
+        }
+    }
+
+    fn early_exit(v: Option<u8>) -> Option<String> {
+        let s = String::new();
+        let t = s;
+        //~^ redundant_clone
+        v?;
+        Some(t)
+    }
+}

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -328,4 +328,113 @@ mod issue16096 {
         }
         out
     }
+
+    fn loop_with_continue(n: usize, c: bool) {
+        for _ in 0..n {
+            let s = String::new();
+            let t = s;
+            //~^ redundant_clone
+            if c {
+                continue;
+            }
+            drop(t);
+        }
+    }
+
+    fn nested_loop(n: usize) {
+        for _ in 0..n {
+            let s = String::new();
+            let t = s;
+            //~^ redundant_clone
+            for _ in 0..n {
+                println!("{t}");
+            }
+        }
+    }
+
+    fn clone_before_loop(n: usize) {
+        let s = String::new();
+        let t = s.clone(); // ok: `s` is used by the next iteration
+        for _ in 0..n {
+            println!("{s}");
+        }
+        drop(t);
+    }
+
+    fn break_carries_clone(n: usize, c: bool) -> Option<String> {
+        let mut out = None;
+        for _ in 0..n {
+            let s = String::new();
+            let t = s.clone(); // ok: `s` is used by the iterations which don't break
+            if c {
+                out = Some(t);
+                break;
+            }
+            println!("{s}");
+        }
+        out
+    }
+
+    // every arm has its own scope, and they converge on the block below the `match`
+    fn match_arm_scopes(n: u8, out: &mut Vec<String>) {
+        match n {
+            0 => {
+                let s = String::new();
+                out.push(s);
+                //~^ redundant_clone
+            },
+            1 => {
+                let s = String::new();
+                out.push(s);
+                //~^ redundant_clone
+            },
+            _ => {},
+        }
+        out.push(String::new());
+    }
+
+    // `s` dies at the end of the inner block, `t` stays live past it
+    fn inner_scope(c: bool) {
+        let t;
+        {
+            let s = String::new();
+            t = s;
+            //~^ redundant_clone
+        }
+        if c {
+            drop(t);
+        }
+    }
+
+    fn early_exit(v: Option<u8>) -> Option<String> {
+        let s = String::new();
+        let t = s;
+        //~^ redundant_clone
+        v?;
+        Some(t)
+    }
+
+    fn used_after_merge(c: bool) {
+        let s = String::new();
+        let t = s.clone(); // ok: `s` is used once the branches have merged
+        if c {
+            drop(t);
+        }
+        println!("{s}");
+    }
+
+    // `may_panic` unwinding gives every block below it a second predecessor
+    fn unwind_edge(c: bool) {
+        fn may_panic() -> String {
+            unimplemented!()
+        }
+
+        let s = String::new();
+        let t = s.clone(); // ok: `s` is used after the call
+        let _u = may_panic();
+        if c {
+            drop(t);
+        }
+        println!("{s}");
+    }
 }

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -291,3 +291,41 @@ mod issue13900 {
         }
     }
 }
+
+mod issue16096 {
+    // `algo` is declared inside the loop, so it is a fresh value on each iteration and the
+    // clone is redundant regardless of how the iteration ends.
+    fn try_from_bytes(bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
+        let mut pipeline = Vec::new();
+        let mut index = 0;
+        while index < bytes.len() {
+            match bytes[index] {
+                0 => {
+                    let algo = vec![];
+                    pipeline.push(algo);
+                    //~^ redundant_clone
+                },
+                1 => {
+                    let algo = vec![];
+                    pipeline.push(algo);
+                    //~^ redundant_clone
+                    return Some(pipeline);
+                },
+                _ => {},
+            }
+            index += 1;
+        }
+
+        None
+    }
+
+    fn loop_body(n: usize) -> Vec<String> {
+        let mut out = Vec::new();
+        for _ in 0..n {
+            let s = String::new();
+            out.push(s);
+            //~^ redundant_clone
+        }
+        out
+    }
+}

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -373,19 +373,4 @@ mod issue16096 {
         }
         println!("{s}");
     }
-
-    // `may_panic` unwinding gives every block below it a second predecessor
-    fn unwind_edge(c: bool) {
-        fn may_panic() -> String {
-            unimplemented!()
-        }
-
-        let s = String::new();
-        let t = s.clone(); // ok: `s` is used after the call
-        let _u = may_panic();
-        if c {
-            drop(t);
-        }
-        println!("{s}");
-    }
 }

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -293,32 +293,6 @@ mod issue13900 {
 }
 
 mod issue16096 {
-    // `algo` is declared inside the loop, so it is a fresh value on each iteration and the
-    // clone is redundant regardless of how the iteration ends.
-    fn try_from_bytes(bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
-        let mut pipeline = Vec::new();
-        let mut index = 0;
-        while index < bytes.len() {
-            match bytes[index] {
-                0 => {
-                    let algo = vec![];
-                    pipeline.push(algo);
-                    //~^ redundant_clone
-                },
-                1 => {
-                    let algo = vec![];
-                    pipeline.push(algo);
-                    //~^ redundant_clone
-                    return Some(pipeline);
-                },
-                _ => {},
-            }
-            index += 1;
-        }
-
-        None
-    }
-
     fn loop_body(n: usize) -> Vec<String> {
         let mut out = Vec::new();
         for _ in 0..n {
@@ -350,29 +324,6 @@ mod issue16096 {
                 println!("{t}");
             }
         }
-    }
-
-    fn clone_before_loop(n: usize) {
-        let s = String::new();
-        let t = s.clone(); // ok: `s` is used by the next iteration
-        for _ in 0..n {
-            println!("{s}");
-        }
-        drop(t);
-    }
-
-    fn break_carries_clone(n: usize, c: bool) -> Option<String> {
-        let mut out = None;
-        for _ in 0..n {
-            let s = String::new();
-            let t = s.clone(); // ok: `s` is used by the iterations which don't break
-            if c {
-                out = Some(t);
-                break;
-            }
-            println!("{s}");
-        }
-        out
     }
 
     // every arm has its own scope, and they converge on the block below the `match`

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -313,3 +313,77 @@ mod hir_prefilter {
         //~^ redundant_clone
     }
 }
+
+mod issue16096 {
+    fn loop_body(n: usize) -> Vec<String> {
+        let mut out = Vec::new();
+        for _ in 0..n {
+            let s = String::new();
+            out.push(s.clone());
+            //~^ redundant_clone
+        }
+        out
+    }
+
+    fn loop_with_continue(n: usize, c: bool) {
+        for _ in 0..n {
+            let s = String::new();
+            let t = s.clone();
+            //~^ redundant_clone
+            if c {
+                continue;
+            }
+            drop(t);
+        }
+    }
+
+    fn nested_loop(n: usize) {
+        for _ in 0..n {
+            let s = String::new();
+            let t = s.clone();
+            //~^ redundant_clone
+            for _ in 0..n {
+                println!("{t}");
+            }
+        }
+    }
+
+    // every arm has its own scope, and they converge on the block below the `match`
+    fn match_arm_scopes(n: u8, out: &mut Vec<String>) {
+        match n {
+            0 => {
+                let s = String::new();
+                out.push(s.clone());
+                //~^ redundant_clone
+            },
+            1 => {
+                let s = String::new();
+                out.push(s.clone());
+                //~^ redundant_clone
+            },
+            _ => {},
+        }
+        out.push(String::new());
+    }
+
+    // `s` dies at the end of the inner block, `t` stays live past it
+    fn inner_scope(c: bool) {
+        let t;
+        {
+            let s = String::new();
+            t = s.clone();
+            //~^ redundant_clone
+        }
+        if c {
+            drop(t);
+        }
+    }
+
+    fn early_exit(v: Option<u8>) -> Option<String> {
+        let s = String::new();
+        let t = s.clone();
+        //~^ redundant_clone
+        v?;
+        Some(t)
+    }
+}

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -291,3 +291,41 @@ mod issue13900 {
         }
     }
 }
+
+mod issue16096 {
+    // `algo` is declared inside the loop, so it is a fresh value on each iteration and the
+    // clone is redundant regardless of how the iteration ends.
+    fn try_from_bytes(bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
+        let mut pipeline = Vec::new();
+        let mut index = 0;
+        while index < bytes.len() {
+            match bytes[index] {
+                0 => {
+                    let algo = vec![];
+                    pipeline.push(algo.clone());
+                    //~^ redundant_clone
+                },
+                1 => {
+                    let algo = vec![];
+                    pipeline.push(algo.clone());
+                    //~^ redundant_clone
+                    return Some(pipeline);
+                },
+                _ => {},
+            }
+            index += 1;
+        }
+
+        None
+    }
+
+    fn loop_body(n: usize) -> Vec<String> {
+        let mut out = Vec::new();
+        for _ in 0..n {
+            let s = String::new();
+            out.push(s.clone());
+            //~^ redundant_clone
+        }
+        out
+    }
+}

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -293,32 +293,6 @@ mod issue13900 {
 }
 
 mod issue16096 {
-    // `algo` is declared inside the loop, so it is a fresh value on each iteration and the
-    // clone is redundant regardless of how the iteration ends.
-    fn try_from_bytes(bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
-        let mut pipeline = Vec::new();
-        let mut index = 0;
-        while index < bytes.len() {
-            match bytes[index] {
-                0 => {
-                    let algo = vec![];
-                    pipeline.push(algo.clone());
-                    //~^ redundant_clone
-                },
-                1 => {
-                    let algo = vec![];
-                    pipeline.push(algo.clone());
-                    //~^ redundant_clone
-                    return Some(pipeline);
-                },
-                _ => {},
-            }
-            index += 1;
-        }
-
-        None
-    }
-
     fn loop_body(n: usize) -> Vec<String> {
         let mut out = Vec::new();
         for _ in 0..n {
@@ -350,29 +324,6 @@ mod issue16096 {
                 println!("{t}");
             }
         }
-    }
-
-    fn clone_before_loop(n: usize) {
-        let s = String::new();
-        let t = s.clone(); // ok: `s` is used by the next iteration
-        for _ in 0..n {
-            println!("{s}");
-        }
-        drop(t);
-    }
-
-    fn break_carries_clone(n: usize, c: bool) -> Option<String> {
-        let mut out = None;
-        for _ in 0..n {
-            let s = String::new();
-            let t = s.clone(); // ok: `s` is used by the iterations which don't break
-            if c {
-                out = Some(t);
-                break;
-            }
-            println!("{s}");
-        }
-        out
     }
 
     // every arm has its own scope, and they converge on the block below the `match`

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -373,19 +373,4 @@ mod issue16096 {
         }
         println!("{s}");
     }
-
-    // `may_panic` unwinding gives every block below it a second predecessor
-    fn unwind_edge(c: bool) {
-        fn may_panic() -> String {
-            unimplemented!()
-        }
-
-        let s = String::new();
-        let t = s.clone(); // ok: `s` is used after the call
-        let _u = may_panic();
-        if c {
-            drop(t);
-        }
-        println!("{s}");
-    }
 }

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -328,4 +328,113 @@ mod issue16096 {
         }
         out
     }
+
+    fn loop_with_continue(n: usize, c: bool) {
+        for _ in 0..n {
+            let s = String::new();
+            let t = s.clone();
+            //~^ redundant_clone
+            if c {
+                continue;
+            }
+            drop(t);
+        }
+    }
+
+    fn nested_loop(n: usize) {
+        for _ in 0..n {
+            let s = String::new();
+            let t = s.clone();
+            //~^ redundant_clone
+            for _ in 0..n {
+                println!("{t}");
+            }
+        }
+    }
+
+    fn clone_before_loop(n: usize) {
+        let s = String::new();
+        let t = s.clone(); // ok: `s` is used by the next iteration
+        for _ in 0..n {
+            println!("{s}");
+        }
+        drop(t);
+    }
+
+    fn break_carries_clone(n: usize, c: bool) -> Option<String> {
+        let mut out = None;
+        for _ in 0..n {
+            let s = String::new();
+            let t = s.clone(); // ok: `s` is used by the iterations which don't break
+            if c {
+                out = Some(t);
+                break;
+            }
+            println!("{s}");
+        }
+        out
+    }
+
+    // every arm has its own scope, and they converge on the block below the `match`
+    fn match_arm_scopes(n: u8, out: &mut Vec<String>) {
+        match n {
+            0 => {
+                let s = String::new();
+                out.push(s.clone());
+                //~^ redundant_clone
+            },
+            1 => {
+                let s = String::new();
+                out.push(s.clone());
+                //~^ redundant_clone
+            },
+            _ => {},
+        }
+        out.push(String::new());
+    }
+
+    // `s` dies at the end of the inner block, `t` stays live past it
+    fn inner_scope(c: bool) {
+        let t;
+        {
+            let s = String::new();
+            t = s.clone();
+            //~^ redundant_clone
+        }
+        if c {
+            drop(t);
+        }
+    }
+
+    fn early_exit(v: Option<u8>) -> Option<String> {
+        let s = String::new();
+        let t = s.clone();
+        //~^ redundant_clone
+        v?;
+        Some(t)
+    }
+
+    fn used_after_merge(c: bool) {
+        let s = String::new();
+        let t = s.clone(); // ok: `s` is used once the branches have merged
+        if c {
+            drop(t);
+        }
+        println!("{s}");
+    }
+
+    // `may_panic` unwinding gives every block below it a second predecessor
+    fn unwind_edge(c: bool) {
+        fn may_panic() -> String {
+            unimplemented!()
+        }
+
+        let s = String::new();
+        let t = s.clone(); // ok: `s` is used after the call
+        let _u = may_panic();
+        if c {
+            drop(t);
+        }
+        println!("{s}");
+    }
 }

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -204,5 +204,89 @@ note: this value is dropped without further use
 LL |         let _ = identity!(value.clone());
    |                           ^^^^^
 
-error: aborting due to 17 previous errors
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:322:23
+   |
+LL |             out.push(s.clone());
+   |                       ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:322:22
+   |
+LL |             out.push(s.clone());
+   |                      ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:331:22
+   |
+LL |             let t = s.clone();
+   |                      ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:331:21
+   |
+LL |             let t = s.clone();
+   |                     ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:343:22
+   |
+LL |             let t = s.clone();
+   |                      ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:343:21
+   |
+LL |             let t = s.clone();
+   |                     ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:356:27
+   |
+LL |                 out.push(s.clone());
+   |                           ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:356:26
+   |
+LL |                 out.push(s.clone());
+   |                          ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:361:27
+   |
+LL |                 out.push(s.clone());
+   |                           ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:361:26
+   |
+LL |                 out.push(s.clone());
+   |                          ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:374:18
+   |
+LL |             t = s.clone();
+   |                  ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:374:17
+   |
+LL |             t = s.clone();
+   |                 ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:384:18
+   |
+LL |         let t = s.clone();
+   |                  ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:384:17
+   |
+LL |         let t = s.clone();
+   |                 ^
+
+error: aborting due to 24 previous errors
 

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -216,5 +216,77 @@ note: this value is dropped without further use
 LL |             out.push(s.clone());
    |                      ^
 
-error: aborting due to 18 previous errors
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:335:22
+   |
+LL |             let t = s.clone();
+   |                      ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:335:21
+   |
+LL |             let t = s.clone();
+   |                     ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:347:22
+   |
+LL |             let t = s.clone();
+   |                      ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:347:21
+   |
+LL |             let t = s.clone();
+   |                     ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:383:27
+   |
+LL |                 out.push(s.clone());
+   |                           ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:383:26
+   |
+LL |                 out.push(s.clone());
+   |                          ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:388:27
+   |
+LL |                 out.push(s.clone());
+   |                           ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:388:26
+   |
+LL |                 out.push(s.clone());
+   |                          ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:401:18
+   |
+LL |             t = s.clone();
+   |                  ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:401:17
+   |
+LL |             t = s.clone();
+   |                 ^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:411:18
+   |
+LL |         let t = s.clone();
+   |                  ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:411:17
+   |
+LL |         let t = s.clone();
+   |                 ^
+
+error: aborting due to 24 previous errors
 

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -180,5 +180,41 @@ note: this value is dropped without further use
 LL |     foo(&x.clone(), move || {
    |          ^
 
-error: aborting due to 15 previous errors
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:305:39
+   |
+LL |                     pipeline.push(algo.clone());
+   |                                       ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:305:35
+   |
+LL |                     pipeline.push(algo.clone());
+   |                                   ^^^^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:310:39
+   |
+LL |                     pipeline.push(algo.clone());
+   |                                       ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:310:35
+   |
+LL |                     pipeline.push(algo.clone());
+   |                                   ^^^^
+
+error: redundant clone
+  --> tests/ui/redundant_clone.rs:326:23
+   |
+LL |             out.push(s.clone());
+   |                       ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone.rs:326:22
+   |
+LL |             out.push(s.clone());
+   |                      ^
+
+error: aborting due to 18 previous errors
 

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -181,112 +181,88 @@ LL |     foo(&x.clone(), move || {
    |          ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:305:39
-   |
-LL |                     pipeline.push(algo.clone());
-   |                                       ^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:305:35
-   |
-LL |                     pipeline.push(algo.clone());
-   |                                   ^^^^
-
-error: redundant clone
-  --> tests/ui/redundant_clone.rs:310:39
-   |
-LL |                     pipeline.push(algo.clone());
-   |                                       ^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:310:35
-   |
-LL |                     pipeline.push(algo.clone());
-   |                                   ^^^^
-
-error: redundant clone
-  --> tests/ui/redundant_clone.rs:326:23
+  --> tests/ui/redundant_clone.rs:300:23
    |
 LL |             out.push(s.clone());
    |                       ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:326:22
+  --> tests/ui/redundant_clone.rs:300:22
    |
 LL |             out.push(s.clone());
    |                      ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:335:22
+  --> tests/ui/redundant_clone.rs:309:22
    |
 LL |             let t = s.clone();
    |                      ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:335:21
+  --> tests/ui/redundant_clone.rs:309:21
    |
 LL |             let t = s.clone();
    |                     ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:347:22
+  --> tests/ui/redundant_clone.rs:321:22
    |
 LL |             let t = s.clone();
    |                      ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:347:21
+  --> tests/ui/redundant_clone.rs:321:21
    |
 LL |             let t = s.clone();
    |                     ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:383:27
+  --> tests/ui/redundant_clone.rs:334:27
    |
 LL |                 out.push(s.clone());
    |                           ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:383:26
+  --> tests/ui/redundant_clone.rs:334:26
    |
 LL |                 out.push(s.clone());
    |                          ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:388:27
+  --> tests/ui/redundant_clone.rs:339:27
    |
 LL |                 out.push(s.clone());
    |                           ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:388:26
+  --> tests/ui/redundant_clone.rs:339:26
    |
 LL |                 out.push(s.clone());
    |                          ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:401:18
+  --> tests/ui/redundant_clone.rs:352:18
    |
 LL |             t = s.clone();
    |                  ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:401:17
+  --> tests/ui/redundant_clone.rs:352:17
    |
 LL |             t = s.clone();
    |                 ^
 
 error: redundant clone
-  --> tests/ui/redundant_clone.rs:411:18
+  --> tests/ui/redundant_clone.rs:362:18
    |
 LL |         let t = s.clone();
    |                  ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/redundant_clone.rs:411:17
+  --> tests/ui/redundant_clone.rs:362:17
    |
 LL |         let t = s.clone();
    |                 ^
 
-error: aborting due to 24 previous errors
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17495)*

Fixes rust-lang/rust-clippy#16096

`redundant_clone` missed every `clone()` in a loop body:

```rust
#![warn(clippy::redundant_clone)]
#![expect(dead_code)]

fn foo(){
    loop {
        let a = String::new();
        let _b = a.clone(); // not linted :(
    }
}
```

`visit_local_usage` returned `None` whenever `location.block` was in a cycle, and `redundant_clone` passes the clone's block.
`match` in the issue is a bit of a red-herring.
The arm ending in `return` linted only because it leaves the cycle.

The bailout here can't just be deleted, or `issue13900::regression` becomes an positive.
In rust-lang/rust-clippy#13900 `a`'s only read precedes `location` in the clone's own block, and `V::visit_place` hides it even though the cycle re-executes it.

What separates the two cases is where the local is declared.
One declared inside the body is `StorageDead`-ed before the back edge and `StorageLive`-d again next iteration, so it is a distinct variable each time round.
One declared outside is not...

`reachable_while_storage_live` walks forward from `location`, stops a path once every tracked local is `StorageDead`, and returns `None` only if `location.block` is reached again while one is still live.

`readonly_write_lock` and `used_exactly_once` pass `START_BLOCK`, where the old bailout was unreachable since `bb0` is never a branch target, therefore I don't think this specific issue exists there.
At least, I cannot come up with syntax that is not already caught by previous clippy.

changelog: [`redundant_clone`]: detect redundant clones inside loop bodies without aliases
