### PR TITLE
New lint/nonzero methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7566,6 +7566,7 @@ Released 2018-09-13
 [`unnecessary_map_or`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
 [`unnecessary_min_or_max`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_min_or_max
 [`unnecessary_mut_passed`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_mut_passed
+[`unnecessary_nonzero_get`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_nonzero_get
 [`unnecessary_operation`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_operation
 [`unnecessary_option_map_or_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_option_map_or_else
 [`unnecessary_owned_empty_strings`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_owned_empty_strings

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -787,6 +787,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::unnecessary_literal_bound::UNNECESSARY_LITERAL_BOUND_INFO,
     crate::unnecessary_map_on_constructor::UNNECESSARY_MAP_ON_CONSTRUCTOR_INFO,
     crate::unnecessary_mut_passed::UNNECESSARY_MUT_PASSED_INFO,
+    crate::unnecessary_nonzero_get::UNNECESSARY_NONZERO_GET_INFO,
     crate::unnecessary_owned_empty_strings::UNNECESSARY_OWNED_EMPTY_STRINGS_INFO,
     crate::unnecessary_self_imports::UNNECESSARY_SELF_IMPORTS_INFO,
     crate::unnecessary_semicolon::UNNECESSARY_SEMICOLON_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -382,6 +382,7 @@ mod unnecessary_box_returns;
 mod unnecessary_literal_bound;
 mod unnecessary_map_on_constructor;
 mod unnecessary_mut_passed;
+mod unnecessary_nonzero_get;
 mod unnecessary_owned_empty_strings;
 mod unnecessary_self_imports;
 mod unnecessary_semicolon;
@@ -871,6 +872,7 @@ rustc_lint::late_lint_methods!(
         RestWhenDestructuringStruct: rest_when_destructuring_struct::RestWhenDestructuringStruct = rest_when_destructuring_struct::RestWhenDestructuringStruct,
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
+        UnnecessaryNonzeroGet: unnecessary_nonzero_get::UnnecessaryNonzeroGet = unnecessary_nonzero_get::UnnecessaryNonzeroGet::new(conf),
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/unnecessary_nonzero_get.rs
+++ b/clippy_lints/src/unnecessary_nonzero_get.rs
@@ -1,0 +1,132 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::Msrv;
+use clippy_utils::{is_from_proc_macro, span_contains_comment, sym};
+use rustc_errors::Applicability;
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, Ty};
+use rustc_session::impl_lint_pass;
+use rustc_span::Symbol;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `NonZero::get` calls that are immediately followed by a method which
+    /// `NonZero` provides itself, with the same return type.
+    ///
+    /// ### Why is this bad?
+    /// The `get` call adds nothing but noise, as the method could be called on the
+    /// `NonZero` value directly.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # use std::num::NonZero;
+    /// # let nz = NonZero::new(1u32).unwrap();
+    /// let _ = nz.get().leading_zeros();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # use std::num::NonZero;
+    /// # let nz = NonZero::new(1u32).unwrap();
+    /// let _ = nz.leading_zeros();
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub UNNECESSARY_NONZERO_GET,
+    complexity,
+    "calling `NonZero::get` before a method `NonZero` provides itself"
+}
+
+impl_lint_pass!(UnnecessaryNonzeroGet => [UNNECESSARY_NONZERO_GET]);
+
+pub struct UnnecessaryNonzeroGet {
+    msrv: Msrv,
+}
+
+impl UnnecessaryNonzeroGet {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self { msrv: conf.msrv.into() }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for UnnecessaryNonzeroGet {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+        // `<recv>.get().<method>()`
+        if let ExprKind::MethodCall(method, get_call, [], _) = expr.kind
+            && let ExprKind::MethodCall(get, recv, [], get_span) = get_call.kind
+            && get.ident.name == sym::get
+            // Both calls must resolve to inherent methods. A trait method of the same name would
+            // resolve differently once the receiver becomes a `NonZero`, changing the meaning.
+            // Inherent impls can only be written for local types, so an inherent `get` on
+            // `NonZero` is necessarily `NonZero::get`.
+            && let Some(get_did) = cx.typeck_results().type_dependent_def_id(get_call.hir_id)
+            && cx.tcx.trait_of_assoc(get_did).is_none()
+            && let Some(method_did) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
+            && cx.tcx.trait_of_assoc(method_did).is_none()
+            // The `get` receiver is a `NonZero<_>`
+            && let nz_ty = cx.typeck_results().expr_ty_adjusted(recv).peel_refs()
+            && let ty::Adt(adt, _) = nz_ty.kind()
+            && cx.tcx.is_diagnostic_item(sym::NonZero, adt.did())
+            // ...which has an inherent method of the same name returning the very same type, so
+            // that dropping the `get` leaves the expression's type unchanged. Methods that return
+            // a `NonZero` where the primitive returns a plain integer (`bit_width`, `count_ones`)
+            // deliberately do not match: rewriting those would only move the `get`, not remove it.
+            && let ret_ty = cx.typeck_results().expr_ty(expr)
+            && has_matching_method(cx, adt.did(), nz_ty, method.ident.name, ret_ty, self.msrv)
+            // Removing `.get()` means editing the span between the receiver and the method call,
+            // which is only meaningful when both are written out in the same context.
+            && !expr.span.from_expansion()
+            && recv.span.eq_ctxt(expr.span)
+            && get_call.span.eq_ctxt(expr.span)
+            && recv.span.hi() <= get_call.span.hi()
+            && !is_from_proc_macro(cx, expr)
+        {
+            // Covers `.get()` including the dot and any whitespace before it
+            let removal_span = get_call.span.with_lo(recv.span.hi());
+            // Do not mark this machine-applicable: removing the span could also remove comments
+            // that appear between the receiver and `.get()`.
+            let applicability = if span_contains_comment(cx, removal_span) {
+                Applicability::MaybeIncorrect
+            } else {
+                Applicability::MachineApplicable
+            };
+            span_lint_and_then(
+                cx,
+                UNNECESSARY_NONZERO_GET,
+                get_span,
+                format!("unnecessary `get` before `{}`", method.ident.name),
+                |diag| {
+                    diag.span_suggestion_verbose(removal_span, "remove this", "", applicability);
+                },
+            );
+        }
+    }
+}
+
+/// Checks whether `nz_ty` has an inherent method `name` taking nothing but `self` and returning
+/// exactly `ret_ty`, which is stable under `msrv`.
+fn has_matching_method<'tcx>(
+    cx: &LateContext<'tcx>,
+    nonzero_did: DefId,
+    nz_ty: Ty<'tcx>,
+    name: Symbol,
+    ret_ty: Ty<'tcx>,
+    msrv: Msrv,
+) -> bool {
+    cx.tcx.inherent_impls(nonzero_did).iter().any(|&impl_did| {
+        // The integer methods live in concrete `impl NonZero<u32>`-style blocks, so their
+        // signatures need no instantiation. Restricting to the impl matching the receiver also
+        // keeps signed-only methods off unsigned `NonZero`s and vice versa.
+        cx.tcx.type_of(impl_did).instantiate_identity().skip_norm_wip() == nz_ty
+            && cx
+                .tcx
+                .associated_items(impl_did)
+                .filter_by_name_unhygienic(name)
+                .any(|item| {
+                    item.is_fn() && {
+                        let sig = cx.tcx.fn_sig(item.def_id).instantiate_identity().skip_binder();
+                        sig.inputs().len() == 1 && sig.output() == ret_ty && msrv.is_stable(cx, item.def_id)
+                    }
+                })
+    })
+}

--- a/tests/ui/unnecessary_nonzero_get.fixed
+++ b/tests/ui/unnecessary_nonzero_get.fixed
@@ -1,0 +1,152 @@
+#![warn(clippy::unnecessary_nonzero_get)]
+// the `msrv` functions below deliberately use items newer than their MSRV
+#![allow(clippy::incompatible_msrv)]
+
+use std::num::{NonZero, NonZeroI32, NonZeroU32};
+
+fn unsigned(nz: NonZero<u32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed(nz: NonZero<i32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_negative();
+    //~^ unnecessary_nonzero_get
+}
+
+fn unsigned_widths(a: NonZero<u8>, b: NonZero<u16>, c: NonZero<u64>, d: NonZero<u128>, e: NonZero<usize>) {
+    let _ = a.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = b.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = c.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = d.is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = e.ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed_widths(f: NonZero<i8>, g: NonZero<i16>, h: NonZero<i64>, i: NonZero<i128>, j: NonZero<isize>) {
+    let _ = f.is_negative();
+    //~^ unnecessary_nonzero_get
+    let _ = g.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = h.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = i.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = j.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn aliases_and_receivers(a: NonZeroU32, b: NonZeroI32, r: &NonZero<u32>) {
+    let _ = a.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = b.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = r.leading_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // more complex receiver expressions
+    let _ = NonZero::new(5u32).unwrap().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = (a).trailing_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // multi-line chain
+    let _ = a
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
+}
+
+fn no_lint(nz: NonZero<u32>, signed: NonZero<i32>, plain: u32) {
+    // `NonZero`'s version returns `NonZero<u32>` rather than `u32`, so the `get` would only move
+    // rather than disappear
+    let _ = nz.get().bit_width();
+    let _ = nz.get().count_ones();
+    let _ = nz.get().isqrt();
+    let _ = nz.get().checked_add(1);
+    let _ = nz.get().saturating_mul(2);
+    let _ = signed.get().abs();
+    let _ = signed.get().cast_unsigned();
+    let _ = signed.get().unsigned_abs();
+    let _ = signed.get().wrapping_neg();
+    let _ = signed.get().overflowing_neg();
+
+    // `highest_one`/`lowest_one` return `Option<u32>` on integers but `u32` on `NonZero`
+    let _ = nz.get().highest_one();
+    let _ = nz.get().lowest_one();
+
+    // no `NonZero` equivalent at all
+    let _ = nz.get().to_string();
+    let _ = nz.get().count_zeros();
+
+    // `i32::ilog2` exists but `NonZero<i32>::ilog2` does not, so the impls must not cross over
+    let _ = signed.get().ilog2();
+
+    // not a `NonZero` receiver
+    let _ = plain.leading_zeros();
+
+    // `get` is not immediately followed by the method
+    let x = nz.get();
+    let _ = x.leading_zeros();
+
+    // takes arguments
+    let _ = nz.get().rotate_left(2);
+
+    // a shadowing trait method must not be rewritten
+    let _ = nz.get().shadowed();
+}
+
+trait Shadowed {
+    fn shadowed(self) -> u32;
+}
+
+impl Shadowed for u32 {
+    fn shadowed(self) -> u32 {
+        self
+    }
+}
+
+impl Shadowed for NonZero<u32> {
+    fn shadowed(self) -> u32 {
+        0
+    }
+}
+
+// `NonZero::leading_zeros` was stabilized in 1.53.0
+#[clippy::msrv = "1.52"]
+fn below_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+}
+
+#[clippy::msrv = "1.53"]
+fn meets_msrv(nz: NonZero<u32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+// `NonZero::ilog2` was stabilized in 1.67.0, later than `leading_zeros`
+#[clippy::msrv = "1.66"]
+fn below_ilog2_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().ilog2();
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_nonzero_get.rs
+++ b/tests/ui/unnecessary_nonzero_get.rs
@@ -1,0 +1,153 @@
+#![warn(clippy::unnecessary_nonzero_get)]
+// the `msrv` functions below deliberately use items newer than their MSRV
+#![allow(clippy::incompatible_msrv)]
+
+use std::num::{NonZero, NonZeroI32, NonZeroU32};
+
+fn unsigned(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed(nz: NonZero<i32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_negative();
+    //~^ unnecessary_nonzero_get
+}
+
+fn unsigned_widths(a: NonZero<u8>, b: NonZero<u16>, c: NonZero<u64>, d: NonZero<u128>, e: NonZero<usize>) {
+    let _ = a.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = b.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = c.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = d.get().is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = e.get().ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed_widths(f: NonZero<i8>, g: NonZero<i16>, h: NonZero<i64>, i: NonZero<i128>, j: NonZero<isize>) {
+    let _ = f.get().is_negative();
+    //~^ unnecessary_nonzero_get
+    let _ = g.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = h.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = i.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = j.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn aliases_and_receivers(a: NonZeroU32, b: NonZeroI32, r: &NonZero<u32>) {
+    let _ = a.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = b.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = r.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // more complex receiver expressions
+    let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = (a).get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // multi-line chain
+    let _ = a
+        .get()
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
+}
+
+fn no_lint(nz: NonZero<u32>, signed: NonZero<i32>, plain: u32) {
+    // `NonZero`'s version returns `NonZero<u32>` rather than `u32`, so the `get` would only move
+    // rather than disappear
+    let _ = nz.get().bit_width();
+    let _ = nz.get().count_ones();
+    let _ = nz.get().isqrt();
+    let _ = nz.get().checked_add(1);
+    let _ = nz.get().saturating_mul(2);
+    let _ = signed.get().abs();
+    let _ = signed.get().cast_unsigned();
+    let _ = signed.get().unsigned_abs();
+    let _ = signed.get().wrapping_neg();
+    let _ = signed.get().overflowing_neg();
+
+    // `highest_one`/`lowest_one` return `Option<u32>` on integers but `u32` on `NonZero`
+    let _ = nz.get().highest_one();
+    let _ = nz.get().lowest_one();
+
+    // no `NonZero` equivalent at all
+    let _ = nz.get().to_string();
+    let _ = nz.get().count_zeros();
+
+    // `i32::ilog2` exists but `NonZero<i32>::ilog2` does not, so the impls must not cross over
+    let _ = signed.get().ilog2();
+
+    // not a `NonZero` receiver
+    let _ = plain.leading_zeros();
+
+    // `get` is not immediately followed by the method
+    let x = nz.get();
+    let _ = x.leading_zeros();
+
+    // takes arguments
+    let _ = nz.get().rotate_left(2);
+
+    // a shadowing trait method must not be rewritten
+    let _ = nz.get().shadowed();
+}
+
+trait Shadowed {
+    fn shadowed(self) -> u32;
+}
+
+impl Shadowed for u32 {
+    fn shadowed(self) -> u32 {
+        self
+    }
+}
+
+impl Shadowed for NonZero<u32> {
+    fn shadowed(self) -> u32 {
+        0
+    }
+}
+
+// `NonZero::leading_zeros` was stabilized in 1.53.0
+#[clippy::msrv = "1.52"]
+fn below_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+}
+
+#[clippy::msrv = "1.53"]
+fn meets_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+// `NonZero::ilog2` was stabilized in 1.67.0, later than `leading_zeros`
+#[clippy::msrv = "1.66"]
+fn below_ilog2_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().ilog2();
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_nonzero_get.stderr
+++ b/tests/ui/unnecessary_nonzero_get.stderr
@@ -1,0 +1,329 @@
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:8:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+   = note: `-D clippy::unnecessary-nonzero-get` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_nonzero_get)]`
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:10:16
+   |
+LL |     let _ = nz.get().trailing_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().trailing_zeros();
+LL +     let _ = nz.trailing_zeros();
+   |
+
+error: unnecessary `get` before `is_power_of_two`
+  --> tests/ui/unnecessary_nonzero_get.rs:12:16
+   |
+LL |     let _ = nz.get().is_power_of_two();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_power_of_two();
+LL +     let _ = nz.is_power_of_two();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:14:16
+   |
+LL |     let _ = nz.get().ilog2();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().ilog2();
+LL +     let _ = nz.ilog2();
+   |
+
+error: unnecessary `get` before `ilog10`
+  --> tests/ui/unnecessary_nonzero_get.rs:16:16
+   |
+LL |     let _ = nz.get().ilog10();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().ilog10();
+LL +     let _ = nz.ilog10();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:21:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:23:16
+   |
+LL |     let _ = nz.get().trailing_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().trailing_zeros();
+LL +     let _ = nz.trailing_zeros();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:25:16
+   |
+LL |     let _ = nz.get().is_positive();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_positive();
+LL +     let _ = nz.is_positive();
+   |
+
+error: unnecessary `get` before `is_negative`
+  --> tests/ui/unnecessary_nonzero_get.rs:27:16
+   |
+LL |     let _ = nz.get().is_negative();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_negative();
+LL +     let _ = nz.is_negative();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:32:15
+   |
+LL |     let _ = a.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a.get().leading_zeros();
+LL +     let _ = a.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:34:15
+   |
+LL |     let _ = b.get().trailing_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = b.get().trailing_zeros();
+LL +     let _ = b.trailing_zeros();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:36:15
+   |
+LL |     let _ = c.get().ilog2();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = c.get().ilog2();
+LL +     let _ = c.ilog2();
+   |
+
+error: unnecessary `get` before `is_power_of_two`
+  --> tests/ui/unnecessary_nonzero_get.rs:38:15
+   |
+LL |     let _ = d.get().is_power_of_two();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = d.get().is_power_of_two();
+LL +     let _ = d.is_power_of_two();
+   |
+
+error: unnecessary `get` before `ilog10`
+  --> tests/ui/unnecessary_nonzero_get.rs:40:15
+   |
+LL |     let _ = e.get().ilog10();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = e.get().ilog10();
+LL +     let _ = e.ilog10();
+   |
+
+error: unnecessary `get` before `is_negative`
+  --> tests/ui/unnecessary_nonzero_get.rs:45:15
+   |
+LL |     let _ = f.get().is_negative();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = f.get().is_negative();
+LL +     let _ = f.is_negative();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:47:15
+   |
+LL |     let _ = g.get().is_positive();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = g.get().is_positive();
+LL +     let _ = g.is_positive();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:49:15
+   |
+LL |     let _ = h.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = h.get().leading_zeros();
+LL +     let _ = h.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:51:15
+   |
+LL |     let _ = i.get().trailing_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = i.get().trailing_zeros();
+LL +     let _ = i.trailing_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:53:15
+   |
+LL |     let _ = j.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = j.get().leading_zeros();
+LL +     let _ = j.leading_zeros();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:58:15
+   |
+LL |     let _ = a.get().ilog2();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a.get().ilog2();
+LL +     let _ = a.ilog2();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:60:15
+   |
+LL |     let _ = b.get().is_positive();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = b.get().is_positive();
+LL +     let _ = b.is_positive();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:62:15
+   |
+LL |     let _ = r.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = r.get().leading_zeros();
+LL +     let _ = r.leading_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:66:41
+   |
+LL |     let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+   |                                         ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+LL +     let _ = NonZero::new(5u32).unwrap().leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:68:17
+   |
+LL |     let _ = (a).get().trailing_zeros();
+   |                 ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = (a).get().trailing_zeros();
+LL +     let _ = (a).trailing_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:73:10
+   |
+LL |         .get()
+   |          ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a
+LL -         .get()
+LL +     let _ = a
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:141:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:149:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: aborting due to 27 previous errors
+

--- a/tests/ui/unnecessary_nonzero_get_unfixable.rs
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.rs
@@ -8,6 +8,8 @@ fn main() {
     let nz = NonZero::new(1u32).unwrap();
 
     // This comment must not be removed by an automatic fix.
-    let _ = nz /* keep this comment */.get().leading_zeros();
-    //~^ unnecessary_nonzero_get
+    let _ = nz /* keep this comment */
+        .get()
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
 }

--- a/tests/ui/unnecessary_nonzero_get_unfixable.rs
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.rs
@@ -1,0 +1,13 @@
+//@no-rustfix: the suggestion would remove the comment before `.get()`
+
+#![warn(clippy::unnecessary_nonzero_get)]
+
+use std::num::NonZero;
+
+fn main() {
+    let nz = NonZero::new(1u32).unwrap();
+
+    // This comment must not be removed by an automatic fix.
+    let _ = nz /* keep this comment */.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}

--- a/tests/ui/unnecessary_nonzero_get_unfixable.stderr
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.stderr
@@ -1,0 +1,16 @@
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:11:40
+   |
+LL |     let _ = nz /* keep this comment */.get().leading_zeros();
+   |                                        ^^^^^
+   |
+   = note: `-D clippy::unnecessary-nonzero-get` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_nonzero_get)]`
+help: remove this
+   |
+LL -     let _ = nz /* keep this comment */.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/unnecessary_nonzero_get_unfixable.stderr
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.stderr
@@ -1,15 +1,16 @@
 error: unnecessary `get` before `leading_zeros`
-  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:11:40
+  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:12:10
    |
-LL |     let _ = nz /* keep this comment */.get().leading_zeros();
-   |                                        ^^^^^
+LL |         .get()
+   |          ^^^^^
    |
    = note: `-D clippy::unnecessary-nonzero-get` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_nonzero_get)]`
 help: remove this
    |
-LL -     let _ = nz /* keep this comment */.get().leading_zeros();
-LL +     let _ = nz.leading_zeros();
+LL -     let _ = nz /* keep this comment */
+LL -         .get()
+LL +     let _ = nz
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
changelog: [`unnecessary_nonzero_get`]: suggest calling methods directly on `NonZero` instead of through `get()`.
fixes rust-lang/rust-clippy#17483

This adds the `unnecessary_nonzero_get` complexity lint. It detects an inherent `NonZero::get()` immediately followed by an equivalent `NonZero` method, respects MSRV settings, and avoids changing trait-method resolution.

Suggestions are downgraded when comments occur in the removal span so rustfix cannot silently delete them. UI tests cover signed and unsigned types, aliases, references, MSRV boundaries, non-matching methods, and comment preservation.

This is the method-call layer of the stacked PR series; operator forms are intentionally deferred to a follow-up layer.

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests, including committed `.stderr` files
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Ran `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints