### PR TITLE
New lint/nonzero operators and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7566,6 +7566,7 @@ Released 2018-09-13
 [`unnecessary_map_or`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
 [`unnecessary_min_or_max`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_min_or_max
 [`unnecessary_mut_passed`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_mut_passed
+[`unnecessary_nonzero_get`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_nonzero_get
 [`unnecessary_operation`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_operation
 [`unnecessary_option_map_or_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_option_map_or_else
 [`unnecessary_owned_empty_strings`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_owned_empty_strings

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -787,6 +787,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::unnecessary_literal_bound::UNNECESSARY_LITERAL_BOUND_INFO,
     crate::unnecessary_map_on_constructor::UNNECESSARY_MAP_ON_CONSTRUCTOR_INFO,
     crate::unnecessary_mut_passed::UNNECESSARY_MUT_PASSED_INFO,
+    crate::unnecessary_nonzero_get::UNNECESSARY_NONZERO_GET_INFO,
     crate::unnecessary_owned_empty_strings::UNNECESSARY_OWNED_EMPTY_STRINGS_INFO,
     crate::unnecessary_self_imports::UNNECESSARY_SELF_IMPORTS_INFO,
     crate::unnecessary_semicolon::UNNECESSARY_SEMICOLON_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -382,6 +382,7 @@ mod unnecessary_box_returns;
 mod unnecessary_literal_bound;
 mod unnecessary_map_on_constructor;
 mod unnecessary_mut_passed;
+mod unnecessary_nonzero_get;
 mod unnecessary_owned_empty_strings;
 mod unnecessary_self_imports;
 mod unnecessary_semicolon;
@@ -871,6 +872,7 @@ rustc_lint::late_lint_methods!(
         RestWhenDestructuringStruct: rest_when_destructuring_struct::RestWhenDestructuringStruct = rest_when_destructuring_struct::RestWhenDestructuringStruct,
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
+        UnnecessaryNonzeroGet: unnecessary_nonzero_get::UnnecessaryNonzeroGet = unnecessary_nonzero_get::UnnecessaryNonzeroGet::new(conf),
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/unnecessary_nonzero_get.rs
+++ b/clippy_lints/src/unnecessary_nonzero_get.rs
@@ -1,0 +1,132 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::Msrv;
+use clippy_utils::{is_from_proc_macro, span_contains_comment, sym};
+use rustc_errors::Applicability;
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, Ty};
+use rustc_session::impl_lint_pass;
+use rustc_span::Symbol;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `NonZero::get` calls that are immediately followed by a method which
+    /// `NonZero` provides itself, with the same return type.
+    ///
+    /// ### Why is this bad?
+    /// The `get` call adds nothing but noise, as the method could be called on the
+    /// `NonZero` value directly.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # use std::num::NonZero;
+    /// # let nz = NonZero::new(1u32).unwrap();
+    /// let _ = nz.get().leading_zeros();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # use std::num::NonZero;
+    /// # let nz = NonZero::new(1u32).unwrap();
+    /// let _ = nz.leading_zeros();
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub UNNECESSARY_NONZERO_GET,
+    complexity,
+    "calling `NonZero::get` before a method `NonZero` provides itself"
+}
+
+impl_lint_pass!(UnnecessaryNonzeroGet => [UNNECESSARY_NONZERO_GET]);
+
+pub struct UnnecessaryNonzeroGet {
+    msrv: Msrv,
+}
+
+impl UnnecessaryNonzeroGet {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self { msrv: conf.msrv.into() }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for UnnecessaryNonzeroGet {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+        // `<recv>.get().<method>()`
+        if let ExprKind::MethodCall(method, get_call, [], _) = expr.kind
+            && let ExprKind::MethodCall(get, recv, [], get_span) = get_call.kind
+            && get.ident.name == sym::get
+            // Both calls must resolve to inherent methods. A trait method of the same name would
+            // resolve differently once the receiver becomes a `NonZero`, changing the meaning.
+            // Inherent impls can only be written for local types, so an inherent `get` on
+            // `NonZero` is necessarily `NonZero::get`.
+            && let Some(get_did) = cx.typeck_results().type_dependent_def_id(get_call.hir_id)
+            && cx.tcx.trait_of_assoc(get_did).is_none()
+            && let Some(method_did) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
+            && cx.tcx.trait_of_assoc(method_did).is_none()
+            // The `get` receiver is a `NonZero<_>`
+            && let nz_ty = cx.typeck_results().expr_ty_adjusted(recv).peel_refs()
+            && let ty::Adt(adt, _) = nz_ty.kind()
+            && cx.tcx.is_diagnostic_item(sym::NonZero, adt.did())
+            // ...which has an inherent method of the same name returning the very same type, so
+            // that dropping the `get` leaves the expression's type unchanged. Methods that return
+            // a `NonZero` where the primitive returns a plain integer (`bit_width`, `count_ones`)
+            // deliberately do not match: rewriting those would only move the `get`, not remove it.
+            && let ret_ty = cx.typeck_results().expr_ty(expr)
+            && has_matching_method(cx, adt.did(), nz_ty, method.ident.name, ret_ty, self.msrv)
+            // Removing `.get()` means editing the span between the receiver and the method call,
+            // which is only meaningful when both are written out in the same context.
+            && !expr.span.from_expansion()
+            && recv.span.eq_ctxt(expr.span)
+            && get_call.span.eq_ctxt(expr.span)
+            && recv.span.hi() <= get_call.span.hi()
+            && !is_from_proc_macro(cx, expr)
+        {
+            // Covers `.get()` including the dot and any whitespace before it
+            let removal_span = get_call.span.with_lo(recv.span.hi());
+            // Do not mark this machine-applicable: removing the span could also remove comments
+            // that appear between the receiver and `.get()`.
+            let applicability = if span_contains_comment(cx, removal_span) {
+                Applicability::MaybeIncorrect
+            } else {
+                Applicability::MachineApplicable
+            };
+            span_lint_and_then(
+                cx,
+                UNNECESSARY_NONZERO_GET,
+                get_span,
+                format!("unnecessary `get` before `{}`", method.ident.name),
+                |diag| {
+                    diag.span_suggestion_verbose(removal_span, "remove this", "", applicability);
+                },
+            );
+        }
+    }
+}
+
+/// Checks whether `nz_ty` has an inherent method `name` taking nothing but `self` and returning
+/// exactly `ret_ty`, which is stable under `msrv`.
+fn has_matching_method<'tcx>(
+    cx: &LateContext<'tcx>,
+    nonzero_did: DefId,
+    nz_ty: Ty<'tcx>,
+    name: Symbol,
+    ret_ty: Ty<'tcx>,
+    msrv: Msrv,
+) -> bool {
+    cx.tcx.inherent_impls(nonzero_did).iter().any(|&impl_did| {
+        // The integer methods live in concrete `impl NonZero<u32>`-style blocks, so their
+        // signatures need no instantiation. Restricting to the impl matching the receiver also
+        // keeps signed-only methods off unsigned `NonZero`s and vice versa.
+        cx.tcx.type_of(impl_did).instantiate_identity().skip_norm_wip() == nz_ty
+            && cx
+                .tcx
+                .associated_items(impl_did)
+                .filter_by_name_unhygienic(name)
+                .any(|item| {
+                    item.is_fn() && {
+                        let sig = cx.tcx.fn_sig(item.def_id).instantiate_identity().skip_binder();
+                        sig.inputs().len() == 1 && sig.output() == ret_ty && msrv.is_stable(cx, item.def_id)
+                    }
+                })
+    })
+}

--- a/clippy_lints/src/unnecessary_nonzero_get.rs
+++ b/clippy_lints/src/unnecessary_nonzero_get.rs
@@ -1,0 +1,232 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::Msrv;
+use clippy_utils::ty::implements_trait;
+use clippy_utils::{binop_traits, is_from_proc_macro, span_contains_comment, sym};
+use rustc_errors::Applicability;
+use rustc_hir::def_id::DefId;
+use rustc_hir::{AssignOpKind, BinOpKind, Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, Ty};
+use rustc_session::impl_lint_pass;
+use rustc_span::{Span, Symbol};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `NonZero::get` calls that are immediately followed by a method or operator
+    /// which `NonZero` provides itself, with the same return type.
+    ///
+    /// ### Why is this bad?
+    /// The `get` call adds nothing but noise, as the method could be called on the
+    /// `NonZero` value directly.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # use std::num::NonZero;
+    /// # let nz = NonZero::new(1u32).unwrap();
+    /// let _ = nz.get().leading_zeros();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # use std::num::NonZero;
+    /// # let nz = NonZero::new(1u32).unwrap();
+    /// let _ = nz.leading_zeros();
+    /// ```
+    ///
+    /// The lint also handles division and remainder operators:
+    /// ```no_run
+    /// # use std::num::NonZero;
+    /// # let nz = NonZero::new(2u32).unwrap();
+    /// let _ = 4 / nz.get();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # use std::num::NonZero;
+    /// # let nz = NonZero::new(2u32).unwrap();
+    /// let _ = 4 / nz;
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub UNNECESSARY_NONZERO_GET,
+    complexity,
+    "unnecessary `NonZero::get` call"
+}
+
+impl_lint_pass!(UnnecessaryNonzeroGet => [UNNECESSARY_NONZERO_GET]);
+
+pub struct UnnecessaryNonzeroGet {
+    msrv: Msrv,
+}
+
+impl UnnecessaryNonzeroGet {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self { msrv: conf.msrv.into() }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for UnnecessaryNonzeroGet {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+        match expr.kind {
+            // `<recv>.get().<method>()`
+            ExprKind::MethodCall(method, get_call, [], _)
+                if let Some((recv, nz_ty, nonzero_did, get_span)) = nonzero_get(cx, get_call)
+                    // The outer call must resolve to an inherent method. A trait method of the same
+                    // name could resolve differently once the receiver becomes a `NonZero`.
+                    && let Some(method_did) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
+                    && cx.tcx.trait_of_assoc(method_did).is_none()
+                    // Dropping `get` must leave the expression's type unchanged. Methods whose
+                    // `NonZero` version returns a `NonZero` deliberately do not match.
+                    && let ret_ty = cx.typeck_results().expr_ty(expr)
+                    && has_matching_method(cx, nonzero_did, nz_ty, method.ident.name, ret_ty, self.msrv) =>
+            {
+                emit_unnecessary_get(cx, expr, get_call, recv, get_span, method.ident.name.as_str());
+            },
+
+            // `<lhs> / <recv>.get()` and `<lhs> % <recv>.get()`
+            ExprKind::Binary(op, lhs, get_call)
+                if matches!(op.node, BinOpKind::Div | BinOpKind::Rem)
+                    && let Some((recv, nz_ty, _, get_span)) = nonzero_get(cx, get_call)
+                    && let Some((trait_lang_item, _)) = binop_traits(op.node)
+                    && let Some(trait_id) = cx.tcx.lang_items().get(trait_lang_item)
+                    && has_nonzero_operator(cx, lhs, recv, nz_ty, trait_id, self.msrv) =>
+            {
+                emit_unnecessary_get(cx, expr, get_call, recv, get_span, op.node.as_str());
+            },
+
+            // `<lhs> /= <recv>.get()` and `<lhs> %= <recv>.get()`
+            ExprKind::AssignOp(op, lhs, get_call)
+                if matches!(op.node, AssignOpKind::DivAssign | AssignOpKind::RemAssign)
+                    && let Some((recv, nz_ty, _, get_span)) = nonzero_get(cx, get_call)
+                    && let Some((_, trait_lang_item)) = binop_traits(op.node.into())
+                    && let Some(trait_id) = cx.tcx.lang_items().get(trait_lang_item)
+                    && has_nonzero_operator(cx, lhs, recv, nz_ty, trait_id, self.msrv) =>
+            {
+                emit_unnecessary_get(cx, expr, get_call, recv, get_span, op.node.as_str());
+            },
+
+            _ => {},
+        }
+    }
+}
+
+/// Returns the receiver, its `NonZero` type and definition, and the `get` identifier span when
+/// `expr` is an inherent `NonZero::get()` call.
+fn nonzero_get<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+) -> Option<(&'tcx Expr<'tcx>, Ty<'tcx>, DefId, Span)> {
+    let ExprKind::MethodCall(get, recv, [], get_span) = expr.kind else {
+        return None;
+    };
+    if get.ident.name != sym::get {
+        return None;
+    }
+    let get_did = cx.typeck_results().type_dependent_def_id(expr.hir_id)?;
+    if cx.tcx.trait_of_assoc(get_did).is_some() {
+        return None;
+    }
+    let nz_ty = cx.typeck_results().expr_ty_adjusted(recv);
+    let ty::Adt(adt, _) = nz_ty.kind() else {
+        return None;
+    };
+    if !cx.tcx.is_diagnostic_item(sym::NonZero, adt.did()) {
+        return None;
+    }
+
+    Some((recv, nz_ty, adt.did(), get_span))
+}
+
+fn emit_unnecessary_get<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &Expr<'tcx>,
+    get_call: &Expr<'tcx>,
+    recv: &Expr<'tcx>,
+    get_span: Span,
+    operation: &str,
+) {
+    // Removing `.get()` means editing the span between the receiver and the surrounding
+    // expression, which is only meaningful when both are written out in the same context.
+    if expr.span.from_expansion()
+        || !recv.span.eq_ctxt(expr.span)
+        || !get_call.span.eq_ctxt(expr.span)
+        || is_from_proc_macro(cx, expr)
+    {
+        return;
+    }
+
+    span_lint_and_then(
+        cx,
+        UNNECESSARY_NONZERO_GET,
+        get_span,
+        format!("unnecessary `get` before `{operation}`"),
+        |diag| {
+            // Covers `.get()` including the dot and any whitespace before it.
+            let removal_span = get_call.span.with_lo(recv.span.hi());
+            let applicability = if span_contains_comment(cx, removal_span) {
+                Applicability::MaybeIncorrect
+            } else {
+                Applicability::MachineApplicable
+            };
+            diag.span_suggestion_verbose(removal_span, "remove this", "", applicability);
+        },
+    );
+}
+
+/// Checks whether replacing the right-hand primitive operand with its `NonZero` receiver resolves
+/// to an unsigned standard-library operator implementation that is usable under `msrv`. In a
+/// `const` context that means const-stable, which the `NonZero` operator implementations are not.
+fn has_nonzero_operator<'tcx>(
+    cx: &LateContext<'tcx>,
+    lhs: &'tcx Expr<'tcx>,
+    recv: &'tcx Expr<'tcx>,
+    nz_ty: Ty<'tcx>,
+    trait_id: DefId,
+    msrv: Msrv,
+) -> bool {
+    let lhs_ty = cx.typeck_results().expr_ty(lhs);
+    let ty::Adt(_, args) = nz_ty.kind() else {
+        return false;
+    };
+    let inner_ty = args.type_at(0);
+
+    // Primitive operators forward some reference operands, whereas the `NonZero` implementations
+    // do not. Require the exact written operand types so the replacement is guaranteed to resolve.
+    lhs_ty == inner_ty
+        && cx.typeck_results().expr_ty(recv) == nz_ty
+        && matches!(lhs_ty.kind(), ty::Uint(_))
+        && implements_trait(cx, lhs_ty, trait_id, &[nz_ty.into()])
+        && cx.tcx.non_blanket_impls_for_ty(trait_id, lhs_ty).any(|impl_id| {
+            let trait_ref = cx.tcx.impl_trait_ref(impl_id).instantiate_identity().skip_norm_wip();
+            trait_ref.args.type_at(1) == nz_ty && msrv.is_stable_or_const_stable(cx, impl_id)
+        })
+}
+
+/// Checks whether `nz_ty` has an inherent method `name` taking nothing but `self` and returning
+/// exactly `ret_ty`, which is usable under `msrv` (const-stable when in a `const` context, stable
+/// otherwise).
+fn has_matching_method<'tcx>(
+    cx: &LateContext<'tcx>,
+    nonzero_did: DefId,
+    nz_ty: Ty<'tcx>,
+    name: Symbol,
+    ret_ty: Ty<'tcx>,
+    msrv: Msrv,
+) -> bool {
+    cx.tcx.inherent_impls(nonzero_did).iter().any(|&impl_did| {
+        // The integer methods live in concrete `impl NonZero<u32>`-style blocks, so their
+        // signatures need no instantiation. Restricting to the impl matching the receiver also
+        // keeps signed-only methods off unsigned `NonZero`s and vice versa.
+        cx.tcx.type_of(impl_did).instantiate_identity().skip_norm_wip() == nz_ty
+            && cx
+                .tcx
+                .associated_items(impl_did)
+                .filter_by_name_unhygienic(name)
+                .any(|item| {
+                    item.is_fn() && {
+                        let sig = cx.tcx.fn_sig(item.def_id).instantiate_identity().skip_binder();
+                        sig.inputs().len() == 1
+                            && sig.output() == ret_ty
+                            && msrv.is_stable_or_const_stable(cx, item.def_id)
+                    }
+                })
+    })
+}

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -1,11 +1,12 @@
-use crate::sym;
+use crate::{is_in_const_context, sym};
 use rustc_ast::Attribute;
 use rustc_ast::attr::AttributeExt;
 use rustc_attr_parsing::parse_version;
 use rustc_data_structures::smallvec::SmallVec;
 use rustc_hir::attrs::RustcVersion;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{HirId, StabilityLevel, StableSince};
+use rustc_hir::{Constness, HirId, StabilityLevel, StableSince};
 use rustc_lint::LateContext;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
@@ -157,8 +158,46 @@ impl Msrv {
     }
 
     pub fn is_stable(self, cx: &LateContext<'_>, def_id: DefId) -> bool {
-        cx.tcx.lookup_stability(def_id).is_none_or(|stability| {
-            if let StabilityLevel::Stable { since, .. } = stability.level {
+        self.stability_met(cx, cx.tcx.lookup_stability(def_id).map(|stability| stability.level))
+    }
+
+    /// Checks whether `def_id` is `const` and const-stable since a version met by the MSRV.
+    ///
+    /// `def_id` must identify a function-like definition or an impl.
+    ///
+    /// Nothing in the crate being linted carries a const-stability attribute, so `const` fns and
+    /// impls defined there are treated as meeting any MSRV, mirroring
+    /// [`is_stable`](Self::is_stable).
+    pub fn is_const_stable(self, cx: &LateContext<'_>, def_id: DefId) -> bool {
+        let constness = match cx.tcx.def_kind(def_id) {
+            // The constness of a trait impl is not encoded in crate metadata, where `constness`
+            // would decode as its default of `Const`. It is only available from the impl header.
+            DefKind::Impl { of_trait: true } => cx.tcx.impl_trait_header(def_id).constness,
+            _ => cx.tcx.constness(def_id),
+        };
+
+        matches!(constness, Constness::Const { .. })
+            && self.stability_met(
+                cx,
+                cx.tcx.lookup_const_stability(def_id).map(|stability| stability.level),
+            )
+    }
+
+    /// Checks the stability relevant to where we are: const-stability inside a `const` context,
+    /// regular stability everywhere else.
+    ///
+    /// Like [`is_in_const_context`], this requires the `LateContext` to have an enclosing body.
+    pub fn is_stable_or_const_stable(self, cx: &LateContext<'_>, def_id: DefId) -> bool {
+        if is_in_const_context(cx) {
+            self.is_const_stable(cx, def_id)
+        } else {
+            self.is_stable(cx, def_id)
+        }
+    }
+
+    fn stability_met(self, cx: &LateContext<'_>, level: Option<StabilityLevel>) -> bool {
+        level.is_none_or(|level| {
+            if let StabilityLevel::Stable { since, .. } = level {
                 let version = match since {
                     StableSince::Version(version) => version,
                     StableSince::Current => RustcVersion::CURRENT,

--- a/tests/ui/non_zero_suggestions.fixed
+++ b/tests/ui/non_zero_suggestions.fixed
@@ -1,4 +1,6 @@
 #![warn(clippy::non_zero_suggestions)]
+#![allow(clippy::unnecessary_nonzero_get)]
+
 use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
 
 fn main() {

--- a/tests/ui/non_zero_suggestions.rs
+++ b/tests/ui/non_zero_suggestions.rs
@@ -1,4 +1,6 @@
 #![warn(clippy::non_zero_suggestions)]
+#![allow(clippy::unnecessary_nonzero_get)]
+
 use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
 
 fn main() {

--- a/tests/ui/non_zero_suggestions.stderr
+++ b/tests/ui/non_zero_suggestions.stderr
@@ -1,5 +1,5 @@
 error: consider using `NonZeroU64::from()` for more efficient and type-safe conversion
-  --> tests/ui/non_zero_suggestions.rs:9:18
+  --> tests/ui/non_zero_suggestions.rs:11:18
    |
 LL |     let r1 = x / u64::from(y.get());
    |                  ^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU64::from(y)`
@@ -8,31 +8,31 @@ LL |     let r1 = x / u64::from(y.get());
    = help: to override `-D warnings` add `#[allow(clippy::non_zero_suggestions)]`
 
 error: consider using `NonZeroU64::from()` for more efficient and type-safe conversion
-  --> tests/ui/non_zero_suggestions.rs:12:18
+  --> tests/ui/non_zero_suggestions.rs:14:18
    |
 LL |     let r2 = x % u64::from(y.get());
    |                  ^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU64::from(y)`
 
 error: consider using `NonZeroU32::from()` for more efficient and type-safe conversion
-  --> tests/ui/non_zero_suggestions.rs:18:18
+  --> tests/ui/non_zero_suggestions.rs:20:18
    |
 LL |     let r3 = a / u32::from(b.get());
    |                  ^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU32::from(b)`
 
 error: consider using `NonZeroU64::from()` for more efficient and type-safe conversion
-  --> tests/ui/non_zero_suggestions.rs:21:13
+  --> tests/ui/non_zero_suggestions.rs:23:13
    |
 LL |     let x = u64::from(NonZeroU32::new(5).unwrap().get());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU64::from(NonZeroU32::new(5).unwrap())`
 
 error: consider using `NonZeroU64::from()` for more efficient and type-safe conversion
-  --> tests/ui/non_zero_suggestions.rs:58:9
+  --> tests/ui/non_zero_suggestions.rs:60:9
    |
 LL |     x / u64::from(y.get())
    |         ^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU64::from(y)`
 
 error: consider using `NonZeroU64::from()` for more efficient and type-safe conversion
-  --> tests/ui/non_zero_suggestions.rs:68:22
+  --> tests/ui/non_zero_suggestions.rs:70:22
    |
 LL |         self.value / u64::from(divisor.get())
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `NonZeroU64::from(divisor)`

--- a/tests/ui/unnecessary_nonzero_get.fixed
+++ b/tests/ui/unnecessary_nonzero_get.fixed
@@ -1,0 +1,152 @@
+#![warn(clippy::unnecessary_nonzero_get)]
+// the `msrv` functions below deliberately use items newer than their MSRV
+#![allow(clippy::incompatible_msrv)]
+
+use std::num::{NonZero, NonZeroI32, NonZeroU32};
+
+fn unsigned(nz: NonZero<u32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed(nz: NonZero<i32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_negative();
+    //~^ unnecessary_nonzero_get
+}
+
+fn unsigned_widths(a: NonZero<u8>, b: NonZero<u16>, c: NonZero<u64>, d: NonZero<u128>, e: NonZero<usize>) {
+    let _ = a.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = b.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = c.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = d.is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = e.ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed_widths(f: NonZero<i8>, g: NonZero<i16>, h: NonZero<i64>, i: NonZero<i128>, j: NonZero<isize>) {
+    let _ = f.is_negative();
+    //~^ unnecessary_nonzero_get
+    let _ = g.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = h.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = i.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = j.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn aliases_and_receivers(a: NonZeroU32, b: NonZeroI32, r: &NonZero<u32>) {
+    let _ = a.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = b.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = r.leading_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // more complex receiver expressions
+    let _ = NonZero::new(5u32).unwrap().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = (a).trailing_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // multi-line chain
+    let _ = a
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
+}
+
+fn no_lint(nz: NonZero<u32>, signed: NonZero<i32>, plain: u32) {
+    // `NonZero`'s version returns `NonZero<u32>` rather than `u32`, so the `get` would only move
+    // rather than disappear
+    let _ = nz.get().bit_width();
+    let _ = nz.get().count_ones();
+    let _ = nz.get().isqrt();
+    let _ = nz.get().checked_add(1);
+    let _ = nz.get().saturating_mul(2);
+    let _ = signed.get().abs();
+    let _ = signed.get().cast_unsigned();
+    let _ = signed.get().unsigned_abs();
+    let _ = signed.get().wrapping_neg();
+    let _ = signed.get().overflowing_neg();
+
+    // `highest_one`/`lowest_one` return `Option<u32>` on integers but `u32` on `NonZero`
+    let _ = nz.get().highest_one();
+    let _ = nz.get().lowest_one();
+
+    // no `NonZero` equivalent at all
+    let _ = nz.get().to_string();
+    let _ = nz.get().count_zeros();
+
+    // `i32::ilog2` exists but `NonZero<i32>::ilog2` does not, so the impls must not cross over
+    let _ = signed.get().ilog2();
+
+    // not a `NonZero` receiver
+    let _ = plain.leading_zeros();
+
+    // `get` is not immediately followed by the method
+    let x = nz.get();
+    let _ = x.leading_zeros();
+
+    // takes arguments
+    let _ = nz.get().rotate_left(2);
+
+    // a shadowing trait method must not be rewritten
+    let _ = nz.get().shadowed();
+}
+
+trait Shadowed {
+    fn shadowed(self) -> u32;
+}
+
+impl Shadowed for u32 {
+    fn shadowed(self) -> u32 {
+        self
+    }
+}
+
+impl Shadowed for NonZero<u32> {
+    fn shadowed(self) -> u32 {
+        0
+    }
+}
+
+// `NonZero::leading_zeros` was stabilized in 1.53.0
+#[clippy::msrv = "1.52"]
+fn below_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+}
+
+#[clippy::msrv = "1.53"]
+fn meets_msrv(nz: NonZero<u32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+// `NonZero::ilog2` was stabilized in 1.67.0, later than `leading_zeros`
+#[clippy::msrv = "1.66"]
+fn below_ilog2_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().ilog2();
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_nonzero_get.fixed
+++ b/tests/ui/unnecessary_nonzero_get.fixed
@@ -1,0 +1,257 @@
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::unnecessary_nonzero_get)]
+// the `msrv` functions below deliberately use items newer than their MSRV
+#![allow(clippy::incompatible_msrv)]
+
+extern crate proc_macros;
+
+use proc_macros::with_span;
+use std::num::{NonZero, NonZeroI32, NonZeroU32};
+
+fn unsigned(nz: NonZero<u32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed(nz: NonZero<i32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.is_negative();
+    //~^ unnecessary_nonzero_get
+}
+
+fn unsigned_widths(a: NonZero<u8>, b: NonZero<u16>, c: NonZero<u64>, d: NonZero<u128>, e: NonZero<usize>) {
+    let _ = a.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = b.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = c.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = d.is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = e.ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed_widths(f: NonZero<i8>, g: NonZero<i16>, h: NonZero<i64>, i: NonZero<i128>, j: NonZero<isize>) {
+    let _ = f.is_negative();
+    //~^ unnecessary_nonzero_get
+    let _ = g.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = h.leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = i.trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = j.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn aliases_and_receivers(a: NonZeroU32, b: NonZeroI32, r: &NonZero<u32>) {
+    let _ = a.ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = b.is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = r.leading_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // more complex receiver expressions
+    let _ = NonZero::new(5u32).unwrap().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = (a).trailing_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // multi-line chain
+    let _ = a
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
+}
+
+fn operators(mut value: u32, other: u32, nz: NonZero<u32>) {
+    let _ = other / nz;
+    //~^ unnecessary_nonzero_get
+    let _ = other % nz;
+    //~^ unnecessary_nonzero_get
+    value /= nz;
+    //~^ unnecessary_nonzero_get
+    value %= nz;
+    //~^ unnecessary_nonzero_get
+}
+
+// The `NonZero` operator implementations carry `#[rustc_const_unstable(feature = "const_ops")]`,
+// so they are not usable in a `const` context even though `Div`/`Rem` themselves are stable.
+const fn const_operators(mut value: u32, nz: NonZero<u32>) -> u32 {
+    value /= nz.get();
+    value / nz.get()
+}
+
+// `NonZero::leading_zeros` is const-stable since 1.53.0, so the `get` can go even in a `const fn`.
+const fn const_methods(nz: NonZero<u32>) -> u32 {
+    nz.leading_zeros()
+    //~^ unnecessary_nonzero_get
+}
+
+fn no_lint(nz: NonZero<u32>, signed: NonZero<i32>, plain: u32) {
+    // `NonZero`'s version returns `NonZero<u32>` rather than `u32`, so the `get` would only move
+    // rather than disappear
+    let _ = nz.get().bit_width();
+    let _ = nz.get().count_ones();
+    let _ = nz.get().isqrt();
+    let _ = nz.get().checked_add(1);
+    let _ = nz.get().saturating_mul(2);
+    let _ = signed.get().abs();
+    let _ = signed.get().cast_unsigned();
+    let _ = signed.get().unsigned_abs();
+    let _ = signed.get().wrapping_neg();
+    let _ = signed.get().overflowing_neg();
+
+    // `highest_one`/`lowest_one` return `Option<u32>` on integers but `u32` on `NonZero`
+    let _ = nz.get().highest_one();
+    let _ = nz.get().lowest_one();
+
+    // no `NonZero` equivalent at all
+    let _ = nz.get().to_string();
+    let _ = nz.get().count_zeros();
+
+    // `i32::ilog2` exists but `NonZero<i32>::ilog2` does not, so the impls must not cross over
+    let _ = signed.get().ilog2();
+
+    // The `NonZero` division and remainder implementations are unsigned-only.
+    let signed_value = signed.get();
+    let _ = signed_value / signed.get();
+    let _ = signed_value % signed.get();
+
+    // Primitive operators forward references, but the `NonZero` operators do not.
+    let value_ref = &plain;
+    let _ = value_ref / nz.get();
+    let _ = value_ref % nz.get();
+
+    let nz_ref = &nz;
+    let _ = plain / nz_ref.get();
+    let _ = plain % nz_ref.get();
+
+    // not a `NonZero` receiver
+    let _ = plain.leading_zeros();
+
+    // `get` is not immediately followed by the method
+    let x = nz.get();
+    let _ = x.leading_zeros();
+
+    // takes arguments
+    let _ = nz.get().rotate_left(2);
+
+    // a shadowing trait method must not be rewritten
+    let _ = nz.get().shadowed();
+}
+
+trait Shadowed {
+    fn shadowed(self) -> u32;
+}
+
+impl Shadowed for u32 {
+    fn shadowed(self) -> u32 {
+        self
+    }
+}
+
+impl Shadowed for NonZero<u32> {
+    fn shadowed(self) -> u32 {
+        0
+    }
+}
+
+// `NonZero::leading_zeros` was stabilized in 1.53.0
+#[clippy::msrv = "1.52"]
+fn below_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+}
+
+#[clippy::msrv = "1.53"]
+fn meets_msrv(nz: NonZero<u32>) {
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+// `NonZero::ilog2` was stabilized in 1.67.0, later than `leading_zeros`
+#[clippy::msrv = "1.66"]
+fn below_ilog2_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().ilog2();
+    let _ = nz.leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+// `Div<NonZero<_>>` and `Rem<NonZero<_>>` were stabilized in 1.51.0
+#[clippy::msrv = "1.50"]
+fn below_nonzero_div_msrv(value: u32, nz: NonZero<u32>) {
+    let _ = value / nz.get();
+    let _ = value % nz.get();
+}
+
+#[clippy::msrv = "1.51"]
+fn meets_nonzero_div_msrv(value: u32, nz: NonZero<u32>) {
+    let _ = value / nz;
+    //~^ unnecessary_nonzero_get
+    let _ = value % nz;
+    //~^ unnecessary_nonzero_get
+}
+
+// `DivAssign<NonZero<_>>` and `RemAssign<NonZero<_>>` were stabilized in 1.79.0
+#[clippy::msrv = "1.78"]
+fn below_nonzero_div_assign_msrv(mut value: u32, nz: NonZero<u32>) {
+    value /= nz.get();
+    value %= nz.get();
+}
+
+#[clippy::msrv = "1.79"]
+fn meets_nonzero_div_assign_msrv(mut value: u32, nz: NonZero<u32>) {
+    value /= nz;
+    //~^ unnecessary_nonzero_get
+    value %= nz;
+    //~^ unnecessary_nonzero_get
+}
+
+// The whole expression is written in the macro, so the suggestion would point at code the caller
+// cannot edit.
+macro_rules! leading_zeros_of_five {
+    () => {{
+        let nz = NonZero::new(5u32).unwrap();
+        nz.get().leading_zeros()
+    }};
+}
+
+// Only the receiver comes from the macro, so the removal span would start in the expansion and end
+// at the call site.
+macro_rules! five {
+    () => {
+        NonZero::new(5u32).unwrap()
+    };
+}
+
+// Only `.get()` comes from the macro: the receiver is a macro argument and keeps its call site
+// span.
+macro_rules! get_of {
+    ($nz:expr) => {
+        $nz.get()
+    };
+}
+
+fn from_macros(nz: NonZero<u32>) {
+    let _ = leading_zeros_of_five!();
+    let _ = five!().get().leading_zeros();
+    let _ = get_of!(nz).leading_zeros();
+    let _ = with_span!(span nz.get().leading_zeros());
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_nonzero_get.rs
+++ b/tests/ui/unnecessary_nonzero_get.rs
@@ -1,0 +1,153 @@
+#![warn(clippy::unnecessary_nonzero_get)]
+// the `msrv` functions below deliberately use items newer than their MSRV
+#![allow(clippy::incompatible_msrv)]
+
+use std::num::{NonZero, NonZeroI32, NonZeroU32};
+
+fn unsigned(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed(nz: NonZero<i32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_negative();
+    //~^ unnecessary_nonzero_get
+}
+
+fn unsigned_widths(a: NonZero<u8>, b: NonZero<u16>, c: NonZero<u64>, d: NonZero<u128>, e: NonZero<usize>) {
+    let _ = a.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = b.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = c.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = d.get().is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = e.get().ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed_widths(f: NonZero<i8>, g: NonZero<i16>, h: NonZero<i64>, i: NonZero<i128>, j: NonZero<isize>) {
+    let _ = f.get().is_negative();
+    //~^ unnecessary_nonzero_get
+    let _ = g.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = h.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = i.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = j.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn aliases_and_receivers(a: NonZeroU32, b: NonZeroI32, r: &NonZero<u32>) {
+    let _ = a.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = b.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = r.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // more complex receiver expressions
+    let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = (a).get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // multi-line chain
+    let _ = a
+        .get()
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
+}
+
+fn no_lint(nz: NonZero<u32>, signed: NonZero<i32>, plain: u32) {
+    // `NonZero`'s version returns `NonZero<u32>` rather than `u32`, so the `get` would only move
+    // rather than disappear
+    let _ = nz.get().bit_width();
+    let _ = nz.get().count_ones();
+    let _ = nz.get().isqrt();
+    let _ = nz.get().checked_add(1);
+    let _ = nz.get().saturating_mul(2);
+    let _ = signed.get().abs();
+    let _ = signed.get().cast_unsigned();
+    let _ = signed.get().unsigned_abs();
+    let _ = signed.get().wrapping_neg();
+    let _ = signed.get().overflowing_neg();
+
+    // `highest_one`/`lowest_one` return `Option<u32>` on integers but `u32` on `NonZero`
+    let _ = nz.get().highest_one();
+    let _ = nz.get().lowest_one();
+
+    // no `NonZero` equivalent at all
+    let _ = nz.get().to_string();
+    let _ = nz.get().count_zeros();
+
+    // `i32::ilog2` exists but `NonZero<i32>::ilog2` does not, so the impls must not cross over
+    let _ = signed.get().ilog2();
+
+    // not a `NonZero` receiver
+    let _ = plain.leading_zeros();
+
+    // `get` is not immediately followed by the method
+    let x = nz.get();
+    let _ = x.leading_zeros();
+
+    // takes arguments
+    let _ = nz.get().rotate_left(2);
+
+    // a shadowing trait method must not be rewritten
+    let _ = nz.get().shadowed();
+}
+
+trait Shadowed {
+    fn shadowed(self) -> u32;
+}
+
+impl Shadowed for u32 {
+    fn shadowed(self) -> u32 {
+        self
+    }
+}
+
+impl Shadowed for NonZero<u32> {
+    fn shadowed(self) -> u32 {
+        0
+    }
+}
+
+// `NonZero::leading_zeros` was stabilized in 1.53.0
+#[clippy::msrv = "1.52"]
+fn below_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+}
+
+#[clippy::msrv = "1.53"]
+fn meets_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+// `NonZero::ilog2` was stabilized in 1.67.0, later than `leading_zeros`
+#[clippy::msrv = "1.66"]
+fn below_ilog2_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().ilog2();
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_nonzero_get.rs
+++ b/tests/ui/unnecessary_nonzero_get.rs
@@ -1,0 +1,258 @@
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::unnecessary_nonzero_get)]
+// the `msrv` functions below deliberately use items newer than their MSRV
+#![allow(clippy::incompatible_msrv)]
+
+extern crate proc_macros;
+
+use proc_macros::with_span;
+use std::num::{NonZero, NonZeroI32, NonZeroU32};
+
+fn unsigned(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed(nz: NonZero<i32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = nz.get().is_negative();
+    //~^ unnecessary_nonzero_get
+}
+
+fn unsigned_widths(a: NonZero<u8>, b: NonZero<u16>, c: NonZero<u64>, d: NonZero<u128>, e: NonZero<usize>) {
+    let _ = a.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = b.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = c.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = d.get().is_power_of_two();
+    //~^ unnecessary_nonzero_get
+    let _ = e.get().ilog10();
+    //~^ unnecessary_nonzero_get
+}
+
+fn signed_widths(f: NonZero<i8>, g: NonZero<i16>, h: NonZero<i64>, i: NonZero<i128>, j: NonZero<isize>) {
+    let _ = f.get().is_negative();
+    //~^ unnecessary_nonzero_get
+    let _ = g.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = h.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = i.get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = j.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+fn aliases_and_receivers(a: NonZeroU32, b: NonZeroI32, r: &NonZero<u32>) {
+    let _ = a.get().ilog2();
+    //~^ unnecessary_nonzero_get
+    let _ = b.get().is_positive();
+    //~^ unnecessary_nonzero_get
+    let _ = r.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // more complex receiver expressions
+    let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+    let _ = (a).get().trailing_zeros();
+    //~^ unnecessary_nonzero_get
+
+    // multi-line chain
+    let _ = a
+        .get()
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
+}
+
+fn operators(mut value: u32, other: u32, nz: NonZero<u32>) {
+    let _ = other / nz.get();
+    //~^ unnecessary_nonzero_get
+    let _ = other % nz.get();
+    //~^ unnecessary_nonzero_get
+    value /= nz.get();
+    //~^ unnecessary_nonzero_get
+    value %= nz.get();
+    //~^ unnecessary_nonzero_get
+}
+
+// The `NonZero` operator implementations carry `#[rustc_const_unstable(feature = "const_ops")]`,
+// so they are not usable in a `const` context even though `Div`/`Rem` themselves are stable.
+const fn const_operators(mut value: u32, nz: NonZero<u32>) -> u32 {
+    value /= nz.get();
+    value / nz.get()
+}
+
+// `NonZero::leading_zeros` is const-stable since 1.53.0, so the `get` can go even in a `const fn`.
+const fn const_methods(nz: NonZero<u32>) -> u32 {
+    nz.get().leading_zeros()
+    //~^ unnecessary_nonzero_get
+}
+
+fn no_lint(nz: NonZero<u32>, signed: NonZero<i32>, plain: u32) {
+    // `NonZero`'s version returns `NonZero<u32>` rather than `u32`, so the `get` would only move
+    // rather than disappear
+    let _ = nz.get().bit_width();
+    let _ = nz.get().count_ones();
+    let _ = nz.get().isqrt();
+    let _ = nz.get().checked_add(1);
+    let _ = nz.get().saturating_mul(2);
+    let _ = signed.get().abs();
+    let _ = signed.get().cast_unsigned();
+    let _ = signed.get().unsigned_abs();
+    let _ = signed.get().wrapping_neg();
+    let _ = signed.get().overflowing_neg();
+
+    // `highest_one`/`lowest_one` return `Option<u32>` on integers but `u32` on `NonZero`
+    let _ = nz.get().highest_one();
+    let _ = nz.get().lowest_one();
+
+    // no `NonZero` equivalent at all
+    let _ = nz.get().to_string();
+    let _ = nz.get().count_zeros();
+
+    // `i32::ilog2` exists but `NonZero<i32>::ilog2` does not, so the impls must not cross over
+    let _ = signed.get().ilog2();
+
+    // The `NonZero` division and remainder implementations are unsigned-only.
+    let signed_value = signed.get();
+    let _ = signed_value / signed.get();
+    let _ = signed_value % signed.get();
+
+    // Primitive operators forward references, but the `NonZero` operators do not.
+    let value_ref = &plain;
+    let _ = value_ref / nz.get();
+    let _ = value_ref % nz.get();
+
+    let nz_ref = &nz;
+    let _ = plain / nz_ref.get();
+    let _ = plain % nz_ref.get();
+
+    // not a `NonZero` receiver
+    let _ = plain.leading_zeros();
+
+    // `get` is not immediately followed by the method
+    let x = nz.get();
+    let _ = x.leading_zeros();
+
+    // takes arguments
+    let _ = nz.get().rotate_left(2);
+
+    // a shadowing trait method must not be rewritten
+    let _ = nz.get().shadowed();
+}
+
+trait Shadowed {
+    fn shadowed(self) -> u32;
+}
+
+impl Shadowed for u32 {
+    fn shadowed(self) -> u32 {
+        self
+    }
+}
+
+impl Shadowed for NonZero<u32> {
+    fn shadowed(self) -> u32 {
+        0
+    }
+}
+
+// `NonZero::leading_zeros` was stabilized in 1.53.0
+#[clippy::msrv = "1.52"]
+fn below_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+}
+
+#[clippy::msrv = "1.53"]
+fn meets_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+// `NonZero::ilog2` was stabilized in 1.67.0, later than `leading_zeros`
+#[clippy::msrv = "1.66"]
+fn below_ilog2_msrv(nz: NonZero<u32>) {
+    let _ = nz.get().ilog2();
+    let _ = nz.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}
+
+// `Div<NonZero<_>>` and `Rem<NonZero<_>>` were stabilized in 1.51.0
+#[clippy::msrv = "1.50"]
+fn below_nonzero_div_msrv(value: u32, nz: NonZero<u32>) {
+    let _ = value / nz.get();
+    let _ = value % nz.get();
+}
+
+#[clippy::msrv = "1.51"]
+fn meets_nonzero_div_msrv(value: u32, nz: NonZero<u32>) {
+    let _ = value / nz.get();
+    //~^ unnecessary_nonzero_get
+    let _ = value % nz.get();
+    //~^ unnecessary_nonzero_get
+}
+
+// `DivAssign<NonZero<_>>` and `RemAssign<NonZero<_>>` were stabilized in 1.79.0
+#[clippy::msrv = "1.78"]
+fn below_nonzero_div_assign_msrv(mut value: u32, nz: NonZero<u32>) {
+    value /= nz.get();
+    value %= nz.get();
+}
+
+#[clippy::msrv = "1.79"]
+fn meets_nonzero_div_assign_msrv(mut value: u32, nz: NonZero<u32>) {
+    value /= nz.get();
+    //~^ unnecessary_nonzero_get
+    value %= nz.get();
+    //~^ unnecessary_nonzero_get
+}
+
+// The whole expression is written in the macro, so the suggestion would point at code the caller
+// cannot edit.
+macro_rules! leading_zeros_of_five {
+    () => {{
+        let nz = NonZero::new(5u32).unwrap();
+        nz.get().leading_zeros()
+    }};
+}
+
+// Only the receiver comes from the macro, so the removal span would start in the expansion and end
+// at the call site.
+macro_rules! five {
+    () => {
+        NonZero::new(5u32).unwrap()
+    };
+}
+
+// Only `.get()` comes from the macro: the receiver is a macro argument and keeps its call site
+// span.
+macro_rules! get_of {
+    ($nz:expr) => {
+        $nz.get()
+    };
+}
+
+fn from_macros(nz: NonZero<u32>) {
+    let _ = leading_zeros_of_five!();
+    let _ = five!().get().leading_zeros();
+    let _ = get_of!(nz).leading_zeros();
+    let _ = with_span!(span nz.get().leading_zeros());
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_nonzero_get.stderr
+++ b/tests/ui/unnecessary_nonzero_get.stderr
@@ -1,0 +1,329 @@
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:8:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+   = note: `-D clippy::unnecessary-nonzero-get` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_nonzero_get)]`
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:10:16
+   |
+LL |     let _ = nz.get().trailing_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().trailing_zeros();
+LL +     let _ = nz.trailing_zeros();
+   |
+
+error: unnecessary `get` before `is_power_of_two`
+  --> tests/ui/unnecessary_nonzero_get.rs:12:16
+   |
+LL |     let _ = nz.get().is_power_of_two();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_power_of_two();
+LL +     let _ = nz.is_power_of_two();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:14:16
+   |
+LL |     let _ = nz.get().ilog2();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().ilog2();
+LL +     let _ = nz.ilog2();
+   |
+
+error: unnecessary `get` before `ilog10`
+  --> tests/ui/unnecessary_nonzero_get.rs:16:16
+   |
+LL |     let _ = nz.get().ilog10();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().ilog10();
+LL +     let _ = nz.ilog10();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:21:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:23:16
+   |
+LL |     let _ = nz.get().trailing_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().trailing_zeros();
+LL +     let _ = nz.trailing_zeros();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:25:16
+   |
+LL |     let _ = nz.get().is_positive();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_positive();
+LL +     let _ = nz.is_positive();
+   |
+
+error: unnecessary `get` before `is_negative`
+  --> tests/ui/unnecessary_nonzero_get.rs:27:16
+   |
+LL |     let _ = nz.get().is_negative();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_negative();
+LL +     let _ = nz.is_negative();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:32:15
+   |
+LL |     let _ = a.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a.get().leading_zeros();
+LL +     let _ = a.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:34:15
+   |
+LL |     let _ = b.get().trailing_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = b.get().trailing_zeros();
+LL +     let _ = b.trailing_zeros();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:36:15
+   |
+LL |     let _ = c.get().ilog2();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = c.get().ilog2();
+LL +     let _ = c.ilog2();
+   |
+
+error: unnecessary `get` before `is_power_of_two`
+  --> tests/ui/unnecessary_nonzero_get.rs:38:15
+   |
+LL |     let _ = d.get().is_power_of_two();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = d.get().is_power_of_two();
+LL +     let _ = d.is_power_of_two();
+   |
+
+error: unnecessary `get` before `ilog10`
+  --> tests/ui/unnecessary_nonzero_get.rs:40:15
+   |
+LL |     let _ = e.get().ilog10();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = e.get().ilog10();
+LL +     let _ = e.ilog10();
+   |
+
+error: unnecessary `get` before `is_negative`
+  --> tests/ui/unnecessary_nonzero_get.rs:45:15
+   |
+LL |     let _ = f.get().is_negative();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = f.get().is_negative();
+LL +     let _ = f.is_negative();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:47:15
+   |
+LL |     let _ = g.get().is_positive();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = g.get().is_positive();
+LL +     let _ = g.is_positive();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:49:15
+   |
+LL |     let _ = h.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = h.get().leading_zeros();
+LL +     let _ = h.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:51:15
+   |
+LL |     let _ = i.get().trailing_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = i.get().trailing_zeros();
+LL +     let _ = i.trailing_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:53:15
+   |
+LL |     let _ = j.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = j.get().leading_zeros();
+LL +     let _ = j.leading_zeros();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:58:15
+   |
+LL |     let _ = a.get().ilog2();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a.get().ilog2();
+LL +     let _ = a.ilog2();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:60:15
+   |
+LL |     let _ = b.get().is_positive();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = b.get().is_positive();
+LL +     let _ = b.is_positive();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:62:15
+   |
+LL |     let _ = r.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = r.get().leading_zeros();
+LL +     let _ = r.leading_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:66:41
+   |
+LL |     let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+   |                                         ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+LL +     let _ = NonZero::new(5u32).unwrap().leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:68:17
+   |
+LL |     let _ = (a).get().trailing_zeros();
+   |                 ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = (a).get().trailing_zeros();
+LL +     let _ = (a).trailing_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:73:10
+   |
+LL |         .get()
+   |          ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a
+LL -         .get()
+LL +     let _ = a
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:141:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:149:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: aborting due to 27 previous errors
+

--- a/tests/ui/unnecessary_nonzero_get.stderr
+++ b/tests/ui/unnecessary_nonzero_get.stderr
@@ -1,0 +1,437 @@
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:13:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+   = note: `-D clippy::unnecessary-nonzero-get` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_nonzero_get)]`
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:15:16
+   |
+LL |     let _ = nz.get().trailing_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().trailing_zeros();
+LL +     let _ = nz.trailing_zeros();
+   |
+
+error: unnecessary `get` before `is_power_of_two`
+  --> tests/ui/unnecessary_nonzero_get.rs:17:16
+   |
+LL |     let _ = nz.get().is_power_of_two();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_power_of_two();
+LL +     let _ = nz.is_power_of_two();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:19:16
+   |
+LL |     let _ = nz.get().ilog2();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().ilog2();
+LL +     let _ = nz.ilog2();
+   |
+
+error: unnecessary `get` before `ilog10`
+  --> tests/ui/unnecessary_nonzero_get.rs:21:16
+   |
+LL |     let _ = nz.get().ilog10();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().ilog10();
+LL +     let _ = nz.ilog10();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:26:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:28:16
+   |
+LL |     let _ = nz.get().trailing_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().trailing_zeros();
+LL +     let _ = nz.trailing_zeros();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:30:16
+   |
+LL |     let _ = nz.get().is_positive();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_positive();
+LL +     let _ = nz.is_positive();
+   |
+
+error: unnecessary `get` before `is_negative`
+  --> tests/ui/unnecessary_nonzero_get.rs:32:16
+   |
+LL |     let _ = nz.get().is_negative();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().is_negative();
+LL +     let _ = nz.is_negative();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:37:15
+   |
+LL |     let _ = a.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a.get().leading_zeros();
+LL +     let _ = a.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:39:15
+   |
+LL |     let _ = b.get().trailing_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = b.get().trailing_zeros();
+LL +     let _ = b.trailing_zeros();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:41:15
+   |
+LL |     let _ = c.get().ilog2();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = c.get().ilog2();
+LL +     let _ = c.ilog2();
+   |
+
+error: unnecessary `get` before `is_power_of_two`
+  --> tests/ui/unnecessary_nonzero_get.rs:43:15
+   |
+LL |     let _ = d.get().is_power_of_two();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = d.get().is_power_of_two();
+LL +     let _ = d.is_power_of_two();
+   |
+
+error: unnecessary `get` before `ilog10`
+  --> tests/ui/unnecessary_nonzero_get.rs:45:15
+   |
+LL |     let _ = e.get().ilog10();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = e.get().ilog10();
+LL +     let _ = e.ilog10();
+   |
+
+error: unnecessary `get` before `is_negative`
+  --> tests/ui/unnecessary_nonzero_get.rs:50:15
+   |
+LL |     let _ = f.get().is_negative();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = f.get().is_negative();
+LL +     let _ = f.is_negative();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:52:15
+   |
+LL |     let _ = g.get().is_positive();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = g.get().is_positive();
+LL +     let _ = g.is_positive();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:54:15
+   |
+LL |     let _ = h.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = h.get().leading_zeros();
+LL +     let _ = h.leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:56:15
+   |
+LL |     let _ = i.get().trailing_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = i.get().trailing_zeros();
+LL +     let _ = i.trailing_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:58:15
+   |
+LL |     let _ = j.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = j.get().leading_zeros();
+LL +     let _ = j.leading_zeros();
+   |
+
+error: unnecessary `get` before `ilog2`
+  --> tests/ui/unnecessary_nonzero_get.rs:63:15
+   |
+LL |     let _ = a.get().ilog2();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a.get().ilog2();
+LL +     let _ = a.ilog2();
+   |
+
+error: unnecessary `get` before `is_positive`
+  --> tests/ui/unnecessary_nonzero_get.rs:65:15
+   |
+LL |     let _ = b.get().is_positive();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = b.get().is_positive();
+LL +     let _ = b.is_positive();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:67:15
+   |
+LL |     let _ = r.get().leading_zeros();
+   |               ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = r.get().leading_zeros();
+LL +     let _ = r.leading_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:71:41
+   |
+LL |     let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+   |                                         ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = NonZero::new(5u32).unwrap().get().leading_zeros();
+LL +     let _ = NonZero::new(5u32).unwrap().leading_zeros();
+   |
+
+error: unnecessary `get` before `trailing_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:73:17
+   |
+LL |     let _ = (a).get().trailing_zeros();
+   |                 ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = (a).get().trailing_zeros();
+LL +     let _ = (a).trailing_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:78:10
+   |
+LL |         .get()
+   |          ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = a
+LL -         .get()
+LL +     let _ = a
+   |
+
+error: unnecessary `get` before `/`
+  --> tests/ui/unnecessary_nonzero_get.rs:84:24
+   |
+LL |     let _ = other / nz.get();
+   |                        ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = other / nz.get();
+LL +     let _ = other / nz;
+   |
+
+error: unnecessary `get` before `%`
+  --> tests/ui/unnecessary_nonzero_get.rs:86:24
+   |
+LL |     let _ = other % nz.get();
+   |                        ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = other % nz.get();
+LL +     let _ = other % nz;
+   |
+
+error: unnecessary `get` before `/=`
+  --> tests/ui/unnecessary_nonzero_get.rs:88:17
+   |
+LL |     value /= nz.get();
+   |                 ^^^^^
+   |
+help: remove this
+   |
+LL -     value /= nz.get();
+LL +     value /= nz;
+   |
+
+error: unnecessary `get` before `%=`
+  --> tests/ui/unnecessary_nonzero_get.rs:90:17
+   |
+LL |     value %= nz.get();
+   |                 ^^^^^
+   |
+help: remove this
+   |
+LL -     value %= nz.get();
+LL +     value %= nz;
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:103:8
+   |
+LL |     nz.get().leading_zeros()
+   |        ^^^^^
+   |
+help: remove this
+   |
+LL -     nz.get().leading_zeros()
+LL +     nz.leading_zeros()
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:184:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get.rs:192:16
+   |
+LL |     let _ = nz.get().leading_zeros();
+   |                ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = nz.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: unnecessary `get` before `/`
+  --> tests/ui/unnecessary_nonzero_get.rs:205:24
+   |
+LL |     let _ = value / nz.get();
+   |                        ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = value / nz.get();
+LL +     let _ = value / nz;
+   |
+
+error: unnecessary `get` before `%`
+  --> tests/ui/unnecessary_nonzero_get.rs:207:24
+   |
+LL |     let _ = value % nz.get();
+   |                        ^^^^^
+   |
+help: remove this
+   |
+LL -     let _ = value % nz.get();
+LL +     let _ = value % nz;
+   |
+
+error: unnecessary `get` before `/=`
+  --> tests/ui/unnecessary_nonzero_get.rs:220:17
+   |
+LL |     value /= nz.get();
+   |                 ^^^^^
+   |
+help: remove this
+   |
+LL -     value /= nz.get();
+LL +     value /= nz;
+   |
+
+error: unnecessary `get` before `%=`
+  --> tests/ui/unnecessary_nonzero_get.rs:222:17
+   |
+LL |     value %= nz.get();
+   |                 ^^^^^
+   |
+help: remove this
+   |
+LL -     value %= nz.get();
+LL +     value %= nz;
+   |
+
+error: aborting due to 36 previous errors
+

--- a/tests/ui/unnecessary_nonzero_get_unfixable.rs
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.rs
@@ -8,6 +8,8 @@ fn main() {
     let nz = NonZero::new(1u32).unwrap();
 
     // This comment must not be removed by an automatic fix.
-    let _ = nz /* keep this comment */.get().leading_zeros();
-    //~^ unnecessary_nonzero_get
+    let _ = nz /* keep this comment */
+        .get()
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
 }

--- a/tests/ui/unnecessary_nonzero_get_unfixable.rs
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.rs
@@ -1,0 +1,13 @@
+//@no-rustfix: the suggestion would remove the comment before `.get()`
+
+#![warn(clippy::unnecessary_nonzero_get)]
+
+use std::num::NonZero;
+
+fn main() {
+    let nz = NonZero::new(1u32).unwrap();
+
+    // This comment must not be removed by an automatic fix.
+    let _ = nz /* keep this comment */.get().leading_zeros();
+    //~^ unnecessary_nonzero_get
+}

--- a/tests/ui/unnecessary_nonzero_get_unfixable.rs
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.rs
@@ -1,0 +1,26 @@
+//@no-rustfix: the suggestion would remove the comment before `.get()`
+
+#![warn(clippy::unnecessary_nonzero_get)]
+
+use std::num::NonZero;
+
+fn main() {
+    let nz = NonZero::new(1u32).unwrap();
+    let mut value = 10u32;
+
+    // This comment must not be removed by an automatic fix.
+    let _ = nz /* keep this comment */
+        .get()
+        //~^ unnecessary_nonzero_get
+        .leading_zeros();
+
+    // The operator suggestions share the same removal span, so they must preserve comments too.
+    let _ = value
+        / nz /* keep this comment */
+            .get();
+    //~^ unnecessary_nonzero_get
+
+    value %= nz /* keep this comment */
+        .get();
+    //~^ unnecessary_nonzero_get
+}

--- a/tests/ui/unnecessary_nonzero_get_unfixable.stderr
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.stderr
@@ -1,0 +1,16 @@
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:11:40
+   |
+LL |     let _ = nz /* keep this comment */.get().leading_zeros();
+   |                                        ^^^^^
+   |
+   = note: `-D clippy::unnecessary-nonzero-get` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_nonzero_get)]`
+help: remove this
+   |
+LL -     let _ = nz /* keep this comment */.get().leading_zeros();
+LL +     let _ = nz.leading_zeros();
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/unnecessary_nonzero_get_unfixable.stderr
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.stderr
@@ -1,15 +1,16 @@
 error: unnecessary `get` before `leading_zeros`
-  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:11:40
+  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:12:10
    |
-LL |     let _ = nz /* keep this comment */.get().leading_zeros();
-   |                                        ^^^^^
+LL |         .get()
+   |          ^^^^^
    |
    = note: `-D clippy::unnecessary-nonzero-get` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_nonzero_get)]`
 help: remove this
    |
-LL -     let _ = nz /* keep this comment */.get().leading_zeros();
-LL +     let _ = nz.leading_zeros();
+LL -     let _ = nz /* keep this comment */
+LL -         .get()
+LL +     let _ = nz
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/unnecessary_nonzero_get_unfixable.stderr
+++ b/tests/ui/unnecessary_nonzero_get_unfixable.stderr
@@ -1,0 +1,43 @@
+error: unnecessary `get` before `leading_zeros`
+  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:13:10
+   |
+LL |         .get()
+   |          ^^^^^
+   |
+   = note: `-D clippy::unnecessary-nonzero-get` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_nonzero_get)]`
+help: remove this
+   |
+LL -     let _ = nz /* keep this comment */
+LL -         .get()
+LL +     let _ = nz
+   |
+
+error: unnecessary `get` before `/`
+  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:20:14
+   |
+LL |             .get();
+   |              ^^^^^
+   |
+help: remove this
+   |
+LL -         / nz /* keep this comment */
+LL -             .get();
+LL +         / nz;
+   |
+
+error: unnecessary `get` before `%=`
+  --> tests/ui/unnecessary_nonzero_get_unfixable.rs:24:10
+   |
+LL |         .get();
+   |          ^^^^^
+   |
+help: remove this
+   |
+LL -     value %= nz /* keep this comment */
+LL -         .get();
+LL +     value %= nz;
+   |
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17499)*

Adds `unnecessary_nonzero_get`, a `complexity` lint that drops `NonZero::get()` when the following method or operator is available on `NonZero` itself with the same return type.

```rust
let _ = nz.get().leading_zeros();  // -> nz.leading_zeros()
let _ = x / nz.get();              // -> x / nz
```

Methods only match when the `NonZero` version returns the same type. Cases like `bit_width` and `count_ones` return `NonZero`, so rewriting those would move the `get` instead of removing it, and they are skipped.

Operators cover `/`, `%`, `/=` and `%=`. Three constraints keep the suggestion sound:

- unsigned only, since `core` generates `Div`/`Rem` for `NonZero` from the unsigned arm only
- not in const contexts, since the impls are `#[rustc_const_unstable]`
- exact operand types, since primitive operators forward references but the `NonZero` impls do not

MSRV is read from the impl or method rather than hardcoded.

fixes rust-lang/rust-clippy#17483

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

changelog: new lint: [`unnecessary_nonzero_get`]
