### PR TITLE
cleanup: bump toml to 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ pulldown-cmark = { version = "0.11", default-features = false, features = ["html
 askama = { version = "0.16.0", default-features = false, features = ["alloc", "config", "derive"] }
 
 [dev-dependencies.toml]
-version = "0.9.7"
+version = "1.1"
 default-features = false
 # preserve_order keeps diagnostic output in file order
 features = ["parse", "preserve_order"]

--- a/clippy_config/Cargo.toml
+++ b/clippy_config/Cargo.toml
@@ -12,7 +12,7 @@ clippy_utils = { path = "../clippy_utils" }
 itertools = "0.15"
 
 [dependencies.toml]
-version = "0.9.7"
+version = "1.1"
 default-features = false
 # preserve_order keeps diagnostic output in file order
 features = ["parse", "preserve_order"]

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -25,7 +25,7 @@ semver = "1.0"
 url = "2.2"
 
 [dependencies.toml]
-version = "0.9.7"
+version = "1.1"
 default-features = false
 # preserve_order keeps diagnostic output in file order
 features = ["parse", "preserve_order"]

--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -22,6 +22,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
 strip-ansi-escapes = "0.2.0"
 tar = "0.4.45"
-toml = "0.9.7"
+toml = "1.1"
 ureq = { version = "2.2", features = ["json"] }
 walkdir = "2.3"


### PR DESCRIPTION
I had noticed we were getting toml 0.7 only for clippy at work, and a recent PR bumped it to 0.9. As far as I can tell everything works with 1.1, so let's catch all the way up.

changelog: none
