### PR TITLE
fix(match_like_matches_macro): invalid or-pattern suggestions

### DIFF
--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -145,10 +145,7 @@ pub(super) fn check_match<'tcx>(
 
         for arm in arms_without_last {
             let pat = arm.pat;
-            if pat.span.from_expansion() {
-                return false;
-            }
-            if has_at_binding(pat) {
+            if has_at_binding_or_macro_expansion(pat) {
                 return false;
             }
             if !is_lint_allowed(cx, REDUNDANT_PATTERN_MATCHING, pat.hir_id) && is_some_wild(pat.kind) {
@@ -252,18 +249,18 @@ fn is_some_wild(pat_kind: PatKind<'_>) -> bool {
     }
 }
 
-/// Bails on `@` bindings.
-fn has_at_binding(pat: &Pat<'_>) -> bool {
-    let mut found_at_binding = false;
+/// Bails on `@` bindings or macro expansions.
+fn has_at_binding_or_macro_expansion(pat: &Pat<'_>) -> bool {
+    let mut found = false;
 
     pat.walk_short(|p| {
-        if matches!(p.kind, PatKind::Binding(_, _, _, Some(_))) {
-            found_at_binding = true;
+        if matches!(p.kind, PatKind::Binding(_, _, _, Some(_))) || p.span.from_expansion() {
+            found = true;
             return false;
         }
         true
     });
-    found_at_binding
+    found
 }
 
 /// Replace bindings in a pattern's snippet with `_`, so multiple arms with

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -5,7 +5,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::higher::has_let_expr;
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use clippy_utils::{is_lint_allowed, is_wild, span_contains_comment};
-use rustc_ast::LitKind;
+use rustc_ast::{ByRef, LitKind};
 use rustc_errors::Applicability;
 use rustc_hir::{Arm, BorrowKind, Expr, ExprKind, Pat, PatKind, QPath};
 use rustc_lint::LateContext;
@@ -272,9 +272,17 @@ fn replace_bindings_with_wildcard(arm_pat: &Pat<'_>, mut s: String) -> String {
     let mut binding_spans: Vec<Span> = Vec::new();
     let mut binding_spans_with_struct: Vec<(Span, String)> = Vec::new();
 
+    // skip replacement when there is a `ref` to a binding.
+    let mut has_ref_binding = false;
+
     arm_pat.walk_always(|p| {
-        if let PatKind::Binding(_, _, ident, _) = p.kind {
+        if let PatKind::Binding(binding_mode, _, ident, _) = p.kind {
             binding_spans.push(ident.span);
+
+            // `ref` and `ref mut` won't be replaced with `_`
+            if let ByRef::Yes(..) = binding_mode.0 {
+                has_ref_binding = true;
+            }
         }
         if let PatKind::Struct(_, pat_fields, _) = p.kind {
             for field in pat_fields {
@@ -285,17 +293,19 @@ fn replace_bindings_with_wildcard(arm_pat: &Pat<'_>, mut s: String) -> String {
         }
     });
 
-    if binding_spans_with_struct.is_empty() {
-        for span in binding_spans.iter().rev() {
-            let start = (span.lo() - arm_pat.span.lo()).0 as usize;
-            let end = (span.hi() - arm_pat.span.lo()).0 as usize;
-            s.replace_range(start..end, "_");
-        }
-    } else {
-        for (span, replacement) in binding_spans_with_struct.iter().rev() {
-            let start = (span.lo() - arm_pat.span.lo()).0 as usize;
-            let end = (span.hi() - arm_pat.span.lo()).0 as usize;
-            s.replace_range(start..end, replacement);
+    if !has_ref_binding {
+        if binding_spans_with_struct.is_empty() {
+            for span in binding_spans.iter().rev() {
+                let start = (span.lo() - arm_pat.span.lo()).0 as usize;
+                let end = (span.hi() - arm_pat.span.lo()).0 as usize;
+                s.replace_range(start..end, "_");
+            }
+        } else {
+            for (span, replacement) in binding_spans_with_struct.iter().rev() {
+                let start = (span.lo() - arm_pat.span.lo()).0 as usize;
+                let end = (span.hi() - arm_pat.span.lo()).0 as usize;
+                s.replace_range(start..end, replacement);
+            }
         }
     }
 

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -157,7 +157,24 @@ pub(super) fn check_match<'tcx>(
             use itertools::Itertools as _;
             arms_without_last
                 .iter()
-                .map(|arm| snippet_with_applicability(cx, arm.pat.span, "..", &mut applicability))
+                .map(|arm| {
+                    let mut s = snippet_with_applicability(cx, arm.pat.span, "..", &mut applicability).into_owned();
+
+                    if !middle_arms.is_empty() {
+                        // Only erase bindings when actually merging multiple arms into an or-pattern (#17503)
+                        arm.pat.walk_always(|p| {
+                            if let PatKind::Binding(..) = p.kind {
+                                s = s.replacen(
+                                    &*snippet_with_applicability(cx, p.span, "_", &mut applicability),
+                                    "_",
+                                    1,
+                                );
+                            }
+                        });
+                    }
+
+                    s
+                })
                 .join(" | ")
         };
         let pat_and_guard = if let Some(g) = first_arm.guard {

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -5,7 +5,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::higher::has_let_expr;
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use clippy_utils::{is_lint_allowed, is_wild, span_contains_comment};
-use rustc_ast::{ByRef, LitKind};
+use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::{Arm, BorrowKind, Expr, ExprKind, Pat, PatKind, QPath};
 use rustc_lint::LateContext;
@@ -169,7 +169,7 @@ pub(super) fn check_match<'tcx>(
                     // rust requires every match arm to have the same bindings
                     // we thus need to change bindings to `_` for this suggestion to compile
                     if !middle_arms.is_empty() {
-                        s = replace_bindings_with_wildcard(arm.pat, s);
+                        s = replace_bindings_with_wildcard(arm, s);
                     }
 
                     s
@@ -268,47 +268,38 @@ fn has_at_binding(pat: &Pat<'_>) -> bool {
 
 /// Replace bindings in a pattern's snippet with `_`, so multiple arms with
 /// different binding names can be merged into a single `matches!` pattern.
-fn replace_bindings_with_wildcard(arm_pat: &Pat<'_>, mut s: String) -> String {
+fn replace_bindings_with_wildcard(arm: &Arm<'_>, mut s: String) -> String {
     let mut replacements: Vec<(Span, String)> = Vec::new();
+    // record the span of the struct field, so we can skip it when replacing bindings
+    let mut struct_field_spans: Vec<Span> = Vec::new();
 
-    // skip replacement when there is a `ref` to a binding.
-    let mut has_binding_modifier = false;
-
-    arm_pat.walk_always(|p| {
-        if let PatKind::Binding(binding_mode, _, ident, _) = p.kind {
-            // `ref` and `ref mut` won't be replaced with `_`
-            if let ByRef::Yes(..) = binding_mode.0 {
-                has_binding_modifier = true;
-            }
-
-            // `mut` won't be replaced with `_`
-            if binding_mode.1.is_mut() {
-                has_binding_modifier = true;
-            }
-
-            // make sure that we don't replace the same binding twice
-            if !replacements.iter().any(|(span, _)| *span == ident.span) {
-                replacements.push((ident.span, "_".to_owned()));
-            }
-        }
-
+    arm.pat.walk_always(|p| {
         if let PatKind::Struct(_, pat_fields, _) = p.kind {
             for field in pat_fields {
                 if field.is_shorthand {
+                    // we need to replace shorthand cases specially like `var: _` rather than `_`
                     replacements.push((field.span, format!("{}: _", field.ident)));
+                    struct_field_spans.push(field.span);
                 }
             }
         }
+
+        if let PatKind::Binding(_, _, _, _) = p.kind {
+            // skip the shorthand spans
+            if struct_field_spans.contains(&p.span) {
+                return;
+            }
+
+            replacements.push((p.span, "_".to_owned()));
+        }
     });
 
-    if !has_binding_modifier {
-        // sort replacements by span so that the replacements are applied in the correct order.
-        replacements.sort_by_key(|(span, _)| span.lo());
-        for (span, replacement) in replacements.iter().rev() {
-            let start = (span.lo() - arm_pat.span.lo()).0 as usize;
-            let end = (span.hi() - arm_pat.span.lo()).0 as usize;
-            s.replace_range(start..end, replacement);
-        }
+    // sort replacements by span so that the replacements are applied in the correct order.
+    replacements.sort_by_key(|(span, _)| span.lo());
+    for (span, replacement) in replacements.iter().rev() {
+        let start = (span.lo() - arm.pat.span.lo()).0 as usize;
+        let end = (span.hi() - arm.pat.span.lo()).0 as usize;
+        s.replace_range(start..end, replacement);
     }
 
     s

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -10,7 +10,7 @@ use rustc_errors::Applicability;
 use rustc_hir::{Arm, BorrowKind, Expr, ExprKind, Pat, PatKind, QPath};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
-use rustc_span::Spanned;
+use rustc_span::{Span, Spanned};
 
 use super::MATCH_LIKE_MATCHES_MACRO;
 
@@ -157,7 +157,29 @@ pub(super) fn check_match<'tcx>(
             use itertools::Itertools as _;
             arms_without_last
                 .iter()
-                .map(|arm| snippet_with_applicability(cx, arm.pat.span, "..", &mut applicability))
+                .map(|arm| {
+                    let mut s = snippet_with_applicability(cx, arm.pat.span, "..", &mut applicability).into_owned();
+
+                    // Only erase bindings when actually merging multiple arms into an or-pattern (#17503)
+                    if !middle_arms.is_empty() {
+                        let mut binding_spans: Vec<Span> = Vec::new();
+
+                        arm.pat.walk_always(|p| {
+                            if let PatKind::Binding(_, _, ident, _) = p.kind {
+                                binding_spans.push(ident.span);
+                            }
+                        });
+
+                        for span in binding_spans.iter().rev() {
+                            let start = (span.lo() - arm.pat.span.lo()).0 as usize;
+                            let end = (span.hi() - arm.pat.span.lo()).0 as usize;
+
+                            s.replace_range(start..end, "_");
+                        }
+                    }
+
+                    s
+                })
                 .join(" | ")
         };
         let pat_and_guard = if let Some(g) = first_arm.guard {

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -269,8 +269,7 @@ fn has_at_binding(pat: &Pat<'_>) -> bool {
 /// Replace bindings in a pattern's snippet with `_`, so multiple arms with
 /// different binding names can be merged into a single `matches!` pattern.
 fn replace_bindings_with_wildcard(arm_pat: &Pat<'_>, mut s: String) -> String {
-    let mut binding_spans: Vec<Span> = Vec::new();
-    let mut binding_spans_with_struct: Vec<(Span, String)> = Vec::new();
+    let mut replacements: Vec<(Span, String)> = Vec::new();
 
     // skip replacement when there is a `ref` to a binding.
     let mut has_binding_modifier = false;
@@ -287,30 +286,28 @@ fn replace_bindings_with_wildcard(arm_pat: &Pat<'_>, mut s: String) -> String {
                 has_binding_modifier = true;
             }
 
-            binding_spans.push(ident.span);
+            // make sure that we don't replace the same binding twice
+            if !replacements.iter().any(|(span, _)| *span == ident.span) {
+                replacements.push((ident.span, "_".to_owned()));
+            }
         }
+
         if let PatKind::Struct(_, pat_fields, _) = p.kind {
             for field in pat_fields {
                 if field.is_shorthand {
-                    binding_spans_with_struct.push((field.span, format!("{}: _", field.ident)));
+                    replacements.push((field.span, format!("{}: _", field.ident)));
                 }
             }
         }
     });
 
     if !has_binding_modifier {
-        if binding_spans_with_struct.is_empty() {
-            for span in binding_spans.iter().rev() {
-                let start = (span.lo() - arm_pat.span.lo()).0 as usize;
-                let end = (span.hi() - arm_pat.span.lo()).0 as usize;
-                s.replace_range(start..end, "_");
-            }
-        } else {
-            for (span, replacement) in binding_spans_with_struct.iter().rev() {
-                let start = (span.lo() - arm_pat.span.lo()).0 as usize;
-                let end = (span.hi() - arm_pat.span.lo()).0 as usize;
-                s.replace_range(start..end, replacement);
-            }
+        // sort replacements by span so that the replacements are applied in the correct order.
+        replacements.sort_by_key(|(span, _)| span.lo());
+        for (span, replacement) in replacements.iter().rev() {
+            let start = (span.lo() - arm_pat.span.lo()).0 as usize;
+            let end = (span.hi() - arm_pat.span.lo()).0 as usize;
+            s.replace_range(start..end, replacement);
         }
     }
 

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -163,18 +163,36 @@ pub(super) fn check_match<'tcx>(
                     // Only erase bindings when actually merging multiple arms into an or-pattern (#17503)
                     if !middle_arms.is_empty() {
                         let mut binding_spans: Vec<Span> = Vec::new();
+                        let mut binding_spans_with_struct: Vec<(Span, String)> = Vec::new();
 
                         arm.pat.walk_always(|p| {
                             if let PatKind::Binding(_, _, ident, _) = p.kind {
                                 binding_spans.push(ident.span);
                             }
+
+                            if let PatKind::Struct(_, pat_fields, _) = p.kind {
+                                for field in pat_fields {
+                                    if field.is_shorthand {
+                                        binding_spans_with_struct.push((field.span, format!("{}: _", field.ident)));
+                                    }
+                                }
+                            }
                         });
 
-                        for span in binding_spans.iter().rev() {
-                            let start = (span.lo() - arm.pat.span.lo()).0 as usize;
-                            let end = (span.hi() - arm.pat.span.lo()).0 as usize;
+                        if binding_spans_with_struct.is_empty() {
+                            for span in binding_spans.iter().rev() {
+                                let start = (span.lo() - arm.pat.span.lo()).0 as usize;
+                                let end = (span.hi() - arm.pat.span.lo()).0 as usize;
 
-                            s.replace_range(start..end, "_");
+                                s.replace_range(start..end, "_");
+                            }
+                        } else {
+                            for (span, replacement) in binding_spans_with_struct.iter().rev() {
+                                let start = (span.lo() - arm.pat.span.lo()).0 as usize;
+                                let end = (span.hi() - arm.pat.span.lo()).0 as usize;
+
+                                s.replace_range(start..end, replacement);
+                            }
                         }
                     }
 

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -160,7 +160,8 @@ pub(super) fn check_match<'tcx>(
                 .map(|arm| {
                     let mut s = snippet_with_applicability(cx, arm.pat.span, "..", &mut applicability).into_owned();
 
-                    // Only erase bindings when actually merging multiple arms into an or-pattern (#17503)
+                    // rust requires every match arm to have the same bindings
+                    // we thus need to change bindings to `_` for this suggestion to compile
                     if !middle_arms.is_empty() {
                         let mut binding_spans: Vec<Span> = Vec::new();
                         let mut binding_spans_with_struct: Vec<(Span, String)> = Vec::new();

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -284,11 +284,12 @@ fn is_some_wild(pat_kind: PatKind<'_>) -> bool {
 fn has_at_binding(pat: &Pat<'_>) -> bool {
     let mut found_at_binding = false;
 
-    pat.walk_always(|p| {
+    pat.walk_short(|p| {
         if matches!(p.kind, PatKind::Binding(_, _, _, Some(_))) {
             found_at_binding = true;
+            return false;
         }
+        true
     });
-
     found_at_binding
 }

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -148,6 +148,9 @@ pub(super) fn check_match<'tcx>(
             if has_at_binding(pat) {
                 return false;
             }
+            if arm.pat.span.from_expansion() {
+                return false;
+            }
             if !is_lint_allowed(cx, REDUNDANT_PATTERN_MATCHING, pat.hir_id) && is_some_wild(pat.kind) {
                 return false;
             }

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -145,10 +145,10 @@ pub(super) fn check_match<'tcx>(
 
         for arm in arms_without_last {
             let pat = arm.pat;
-            if has_at_binding(pat) {
+            if pat.span.from_expansion() {
                 return false;
             }
-            if arm.pat.span.from_expansion() {
+            if has_at_binding(pat) {
                 return false;
             }
             if !is_lint_allowed(cx, REDUNDANT_PATTERN_MATCHING, pat.hir_id) && is_some_wild(pat.kind) {
@@ -169,38 +169,7 @@ pub(super) fn check_match<'tcx>(
                     // rust requires every match arm to have the same bindings
                     // we thus need to change bindings to `_` for this suggestion to compile
                     if !middle_arms.is_empty() {
-                        let mut binding_spans: Vec<Span> = Vec::new();
-                        let mut binding_spans_with_struct: Vec<(Span, String)> = Vec::new();
-
-                        arm.pat.walk_always(|p| {
-                            if let PatKind::Binding(_, _, ident, _) = p.kind {
-                                binding_spans.push(ident.span);
-                            }
-
-                            if let PatKind::Struct(_, pat_fields, _) = p.kind {
-                                for field in pat_fields {
-                                    if field.is_shorthand {
-                                        binding_spans_with_struct.push((field.span, format!("{}: _", field.ident)));
-                                    }
-                                }
-                            }
-                        });
-
-                        if binding_spans_with_struct.is_empty() {
-                            for span in binding_spans.iter().rev() {
-                                let start = (span.lo() - arm.pat.span.lo()).0 as usize;
-                                let end = (span.hi() - arm.pat.span.lo()).0 as usize;
-
-                                s.replace_range(start..end, "_");
-                            }
-                        } else {
-                            for (span, replacement) in binding_spans_with_struct.iter().rev() {
-                                let start = (span.lo() - arm.pat.span.lo()).0 as usize;
-                                let end = (span.hi() - arm.pat.span.lo()).0 as usize;
-
-                                s.replace_range(start..end, replacement);
-                            }
-                        }
+                        s = replace_bindings_with_wildcard(arm.pat, s);
                     }
 
                     s
@@ -295,4 +264,40 @@ fn has_at_binding(pat: &Pat<'_>) -> bool {
         true
     });
     found_at_binding
+}
+
+/// Replace bindings in a pattern's snippet with `_`, so multiple arms with
+/// different binding names can be merged into a single `matches!` pattern.
+fn replace_bindings_with_wildcard(arm_pat: &Pat<'_>, mut s: String) -> String {
+    let mut binding_spans: Vec<Span> = Vec::new();
+    let mut binding_spans_with_struct: Vec<(Span, String)> = Vec::new();
+
+    arm_pat.walk_always(|p| {
+        if let PatKind::Binding(_, _, ident, _) = p.kind {
+            binding_spans.push(ident.span);
+        }
+        if let PatKind::Struct(_, pat_fields, _) = p.kind {
+            for field in pat_fields {
+                if field.is_shorthand {
+                    binding_spans_with_struct.push((field.span, format!("{}: _", field.ident)));
+                }
+            }
+        }
+    });
+
+    if binding_spans_with_struct.is_empty() {
+        for span in binding_spans.iter().rev() {
+            let start = (span.lo() - arm_pat.span.lo()).0 as usize;
+            let end = (span.hi() - arm_pat.span.lo()).0 as usize;
+            s.replace_range(start..end, "_");
+        }
+    } else {
+        for (span, replacement) in binding_spans_with_struct.iter().rev() {
+            let start = (span.lo() - arm_pat.span.lo()).0 as usize;
+            let end = (span.hi() - arm_pat.span.lo()).0 as usize;
+            s.replace_range(start..end, replacement);
+        }
+    }
+
+    s
 }

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -273,16 +273,21 @@ fn replace_bindings_with_wildcard(arm_pat: &Pat<'_>, mut s: String) -> String {
     let mut binding_spans_with_struct: Vec<(Span, String)> = Vec::new();
 
     // skip replacement when there is a `ref` to a binding.
-    let mut has_ref_binding = false;
+    let mut has_binding_modifier = false;
 
     arm_pat.walk_always(|p| {
         if let PatKind::Binding(binding_mode, _, ident, _) = p.kind {
-            binding_spans.push(ident.span);
-
             // `ref` and `ref mut` won't be replaced with `_`
             if let ByRef::Yes(..) = binding_mode.0 {
-                has_ref_binding = true;
+                has_binding_modifier = true;
             }
+
+            // `mut` won't be replaced with `_`
+            if binding_mode.1.is_mut() {
+                has_binding_modifier = true;
+            }
+
+            binding_spans.push(ident.span);
         }
         if let PatKind::Struct(_, pat_fields, _) = p.kind {
             for field in pat_fields {
@@ -293,7 +298,7 @@ fn replace_bindings_with_wildcard(arm_pat: &Pat<'_>, mut s: String) -> String {
         }
     });
 
-    if !has_ref_binding {
+    if !has_binding_modifier {
         if binding_spans_with_struct.is_empty() {
             for span in binding_spans.iter().rev() {
                 let start = (span.lo() - arm_pat.span.lo()).0 as usize;

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -145,6 +145,9 @@ pub(super) fn check_match<'tcx>(
 
         for arm in arms_without_last {
             let pat = arm.pat;
+            if has_at_binding(pat) {
+                return false;
+            }
             if !is_lint_allowed(cx, REDUNDANT_PATTERN_MATCHING, pat.hir_id) && is_some_wild(pat.kind) {
                 return false;
             }
@@ -275,4 +278,17 @@ fn is_some_wild(pat_kind: PatKind<'_>) -> bool {
         },
         _ => false,
     }
+}
+
+/// Bails on `@` bindings.
+fn has_at_binding(pat: &Pat<'_>) -> bool {
+    let mut found_at_binding = false;
+
+    pat.walk_always(|p| {
+        if matches!(p.kind, PatKind::Binding(_, _, _, Some(_))) {
+            found_at_binding = true;
+        }
+    });
+
+    found_at_binding
 }

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -10,7 +10,7 @@ use rustc_errors::Applicability;
 use rustc_hir::{Arm, BorrowKind, Expr, ExprKind, Pat, PatKind, QPath};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
-use rustc_span::Spanned;
+use rustc_span::{Span, Spanned};
 
 use super::MATCH_LIKE_MATCHES_MACRO;
 
@@ -160,17 +160,22 @@ pub(super) fn check_match<'tcx>(
                 .map(|arm| {
                     let mut s = snippet_with_applicability(cx, arm.pat.span, "..", &mut applicability).into_owned();
 
+                    // Only erase bindings when actually merging multiple arms into an or-pattern (#17503)
                     if !middle_arms.is_empty() {
-                        // Only erase bindings when actually merging multiple arms into an or-pattern (#17503)
+                        let mut binding_spans: Vec<Span> = Vec::new();
+
                         arm.pat.walk_always(|p| {
-                            if let PatKind::Binding(..) = p.kind {
-                                s = s.replacen(
-                                    &*snippet_with_applicability(cx, p.span, "_", &mut applicability),
-                                    "_",
-                                    1,
-                                );
+                            if let PatKind::Binding(_, _, ident, _) = p.kind {
+                                binding_spans.push(ident.span);
                             }
                         });
+
+                        for span in binding_spans.iter().rev() {
+                            let start = (span.lo() - arm.pat.span.lo()).0 as usize;
+                            let end = (span.hi() - arm.pat.span.lo()).0 as usize;
+
+                            s.replace_range(start..end, "_");
+                        }
                     }
 
                     s

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -478,12 +478,25 @@ mod issue17503 {
             Some($name)
         };
     }
+    enum FromExpansion {
+        A(Option<u8>),
+        B(Option<u8>),
+    }
 
     // ok
     fn from_expansion(v: Option<u8>) -> bool {
         match v {
             mk_pat!(a) => true,
             mk_pat!(b) => true,
+            _ => false,
+        }
+    }
+
+    // ok
+    fn from_expansion2(v: FromExpansion) -> bool {
+        match v {
+            FromExpansion::A(mk_pat!(a)) => true,
+            FromExpansion::B(mk_pat!(b)) => true,
             _ => false,
         }
     }

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -273,6 +273,11 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn different_binding_names_2(match_type: MatchType) -> bool {
+        matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+        //~^^^^^ match_like_matches_macro
+    }
+
     enum MatchType2 {
         A,
         B,
@@ -281,6 +286,69 @@ mod issue17503 {
 
     fn matches2(match_type2: MatchType2) -> bool {
         matches!(match_type2, MatchType2::A | MatchType2::B)
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn tuple_binding_names(v: (Option<u8>, Option<u8>)) -> bool {
+        matches!(v, (Some(_), _) | (_, Some(_)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    // FIXME: Erasing bindings in struct shorthand patterns (`Foo { a, .. }`)
+    // requires rewriting them as `Foo { a: _, .. }`. Replacing only the binding
+    // span currently produces invalid syntax (`Foo { _, .. }`).
+    // ```rs
+    // struct TestBindingNames {
+    //     a: u8,
+    //     b: u8,
+    // }
+    // fn struct_binding_names(x: TestBindingNames) -> bool {
+    //     match x {
+    //         TestBindingNames { a, .. } => true,
+    //         TestBindingNames { b, .. } => true,
+    //         _ => false,
+    //     }
+    // }
+    // ```
+
+    enum NestedTupleInEnum {
+        A((u8, u8)),
+        B((u8, u8)),
+    }
+
+    fn nested_tuple(e: NestedTupleInEnum) -> bool {
+        matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_, _)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    enum Inner {
+        X(u8),
+    }
+
+    enum Outer {
+        A(Inner),
+        B(Inner),
+    }
+
+    fn nested_enum(o: Outer) -> bool {
+        matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    // FIXME: Handle `@` bindings when removing bindings from suggestions.
+    // Replacing only the binding span creates invalid patterns like `_ @ 0`.
+    // ```rs
+    // fn at_binding(v: Option<u8>) -> bool {
+    //     match v {
+    //         Some(x @ 0) => true,
+    //         Some(y @ 1) => true,
+    //         _ => false,
+    //     }
+    // }
+    // ```
+
+    fn slice_binding(v: &[u8]) -> bool {
+        matches!(v, [_, ..] | [_, _])
         //~^^^^^ match_like_matches_macro
     }
 }

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -342,6 +342,70 @@ mod issue17503 {
         //~^^^^^^ match_like_matches_macro
     }
 
+    struct MixedBindingNames {
+        a: u8,
+        b: u8,
+    }
+    fn mixed_binding_names(x: MixedBindingNames, y: Option<u8>) -> bool {
+        matches!((x, y), (MixedBindingNames { a: _, .. }, Some(_)) | (MixedBindingNames { b: _, .. }, Some(_)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct MixedNested {
+        a: Option<u8>,
+        b: u8,
+    }
+    fn mixed_nested(x: MixedNested) -> bool {
+        matches!(x, MixedNested { a: Some(_), b: _ } | MixedNested { a: Some(_), b: _ })
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct MixedFields {
+        a: u8,
+        b: u8,
+    }
+    fn mixed_fields(x: MixedFields) -> bool {
+        matches!(x, MixedFields { a: _, b: 1 } | MixedFields { a: 2, b: _ })
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct InnerStruct {
+        x: u8,
+    }
+    struct OuterStruct {
+        inner: InnerStruct,
+        y: u8,
+    }
+    fn nested_struct(x: OuterStruct) -> bool {
+        matches!(x, OuterStruct {
+                inner: InnerStruct { x: _, .. },
+                y: _,
+            } | OuterStruct {
+                inner: InnerStruct { x: _, .. },
+                y: _,
+            })
+        //~^^^^^^^^^^^ match_like_matches_macro
+    }
+    fn nested_struct_shorthand(x: OuterStruct) -> bool {
+        matches!(x, OuterStruct {
+                inner: InnerStruct { x: _, .. },
+                y: _,
+            } | OuterStruct {
+                inner: InnerStruct { x: _, .. },
+                y: _,
+            })
+        //~^^^^^^^^^^^ match_like_matches_macro
+    }
+
+    struct AdjacentShorthand {
+        a: u8,
+        b: u8,
+    }
+    fn adjacent_shorthand_fields(x: AdjacentShorthand) -> bool {
+        matches!(x, AdjacentShorthand { a: _, b: _ } | AdjacentShorthand { a: 1, b: 2 })
+        //~^^^^^ match_like_matches_macro
+    }
+
     enum NestedTupleInEnum {
         A((u8, u8)),
         B((u8, u8)),
@@ -393,5 +457,18 @@ mod issue17503 {
             mk_pat!(b) => true,
             _ => false,
         }
+    }
+
+    struct Data {
+        x: u8,
+    }
+    enum Kind {
+        A(Data),
+        B(Data),
+    }
+    // Test all of above cases in one function.
+    fn everything(v: (Kind, Option<u8>)) -> bool {
+        matches!(v, (Kind::A(Data { x: _, .. }), Some(_)) | (Kind::B(Data { x: _, .. }), Some(_)))
+        //~^^^^^ match_like_matches_macro
     }
 }

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -345,4 +345,19 @@ mod issue17503 {
         matches!(v, [_, ..] | [_, _])
         //~^^^^^ match_like_matches_macro
     }
+
+    macro_rules! mk_pat {
+        ($name:ident) => {
+            Some($name)
+        };
+    }
+
+    // ok
+    fn from_expansion(v: Option<u8>) -> bool {
+        match v {
+            mk_pat!(a) => true,
+            mk_pat!(b) => true,
+            _ => false,
+        }
+    }
 }

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -273,6 +273,11 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn different_binding_names_2(match_type: MatchType) -> bool {
+        matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+        //~^^^^^ match_like_matches_macro
+    }
+
     enum MatchType2 {
         A,
         B,
@@ -281,6 +286,68 @@ mod issue17503 {
 
     fn matches2(match_type2: MatchType2) -> bool {
         matches!(match_type2, MatchType2::A | MatchType2::B)
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn tuple_binding_names(v: (Option<u8>, Option<u8>)) -> bool {
+        matches!(v, (Some(_), _) | (_, Some(_)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    // FIXME: Erasing bindings in struct shorthand patterns (`Foo { a, .. }`)
+    // requires rewriting them as `Foo { a: _, .. }`. Replacing only the binding
+    // span currently produces invalid syntax (`Foo { _, .. }`).
+    // ```rs
+    // struct TestBindingNames {
+    //     a: u8,
+    //     b: u8,
+    // }
+    // fn struct_binding_names(x: TestBindingNames) -> bool {
+    //     match x {
+    //         TestBindingNames { a, .. } => true,
+    //         TestBindingNames { b, .. } => true,
+    //         _ => false,
+    //     }
+    // }
+    // ```
+
+    enum NestedTupleInEnum {
+        A((u8, u8)),
+        B((u8, u8)),
+    }
+
+    fn nested_tuple(e: NestedTupleInEnum) -> bool {
+        matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_, _)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    enum Inner {
+        X(u8),
+    }
+
+    enum Outer {
+        A(Inner),
+        B(Inner),
+    }
+
+    fn nested_enum(o: Outer) -> bool {
+        matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    // FIXME: Avoid invalid suggestions for `@` bindings.
+    // ```rs
+    // fn at_binding(v: Option<u8>) -> bool {
+    //     match v {
+    //         Some(x @ 0) => true,
+    //         Some(y @ 1) => true,
+    //         _ => false,
+    //     }
+    // }
+    // ```
+
+    fn slice_binding(v: &[u8]) -> bool {
+        matches!(v, [_, ..] | [_, _])
         //~^^^^^ match_like_matches_macro
     }
 }

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -335,8 +335,7 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
-    // FIXME: Handle `@` bindings when removing bindings from suggestions.
-    // Replacing only the binding span creates invalid patterns like `_ @ 0`.
+    // FIXME: Avoid invalid suggestions for `@` bindings.
     // ```rs
     // fn at_binding(v: Option<u8>) -> bool {
     //     match v {

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::match_like_matches_macro)]
-#![allow(irrefutable_let_patterns, clippy::redundant_guards)]
+#![allow(
+    irrefutable_let_patterns,
+    clippy::redundant_guards,
+    clippy::unneeded_wildcard_pattern
+)]
 #![expect(clippy::needless_borrowed_reference)]
 
 fn main() {
@@ -294,22 +298,24 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
-    // FIXME: Erasing bindings in struct shorthand patterns (`Foo { a, .. }`)
-    // requires rewriting them as `Foo { a: _, .. }`. Replacing only the binding
-    // span currently produces invalid syntax (`Foo { _, .. }`).
-    // ```rs
-    // struct TestBindingNames {
-    //     a: u8,
-    //     b: u8,
-    // }
-    // fn struct_binding_names(x: TestBindingNames) -> bool {
-    //     match x {
-    //         TestBindingNames { a, .. } => true,
-    //         TestBindingNames { b, .. } => true,
-    //         _ => false,
-    //     }
-    // }
-    // ```
+    struct TestBindingNames {
+        a: u8,
+        b: u8,
+    }
+    fn struct_binding_names(x: TestBindingNames) -> bool {
+        matches!(x, TestBindingNames { a: _, .. } | TestBindingNames { b: _, .. })
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct TestBindingNames2 {
+        a: u8,
+        b: u8,
+        c: u8,
+    }
+    fn struct_binding_names2(x: TestBindingNames2) -> bool {
+        matches!(x, TestBindingNames2 { a: _, b: 1, .. } | TestBindingNames2 { a: _, b: 2, .. } | TestBindingNames2 { a: 3, b: 4, .. })
+        //~^^^^^^ match_like_matches_macro
+    }
 
     enum NestedTupleInEnum {
         A((u8, u8)),

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -290,27 +290,42 @@ mod issue17503 {
     }
 
     fn ref_binding_names(v: (Option<u8>, Option<u8>)) -> bool {
-        matches!(v, (Some(ref x), Some(1)) | (Some(ref x), Some(2)))
+        matches!(v, (Some(_), Some(1)) | (Some(_), Some(2)))
         //~^^^^^ match_like_matches_macro
     }
 
     fn ref_binding_names2(v1: Option<u8>, v2: Option<u8>) -> bool {
-        matches!((v1, v2), (Some(ref x), Some(1)) | (Some(ref x), Some(2)))
+        matches!((v1, v2), (Some(_), Some(1)) | (Some(_), Some(2)))
         //~^^^^^ match_like_matches_macro
     }
 
+    fn ref_binding_names_three_arms(v: (Option<u8>, u8)) -> bool {
+        matches!(v, (Some(_), 1) | (Some(_), 2) | (Some(_), 3))
+        //~^^^^^^ match_like_matches_macro
+    }
+
+    fn ref_binding_var_is_not_used(v: (Option<u8>, u8)) -> bool {
+        matches!(v, (Some(_), 1) | (Some(_), 2))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn ref_binding_multi_arm_var_is_not_used(v: (Option<u8>, u8)) -> bool {
+        matches!(v, (Some(_), 1) | (Some(_), 2) | (Some(_), 3))
+        //~^^^^^^ match_like_matches_macro
+    }
+
     fn ref_mut_binding_names(v: (&mut Option<u8>, &mut Option<u8>)) -> bool {
-        matches!(v, (&mut Some(ref mut x), &mut Some(1)) | (&mut Some(ref mut x), &mut Some(2)))
+        matches!(v, (&mut Some(_), &mut Some(1)) | (&mut Some(_), &mut Some(2)))
         //~^^^^^ match_like_matches_macro
     }
 
     fn ref_mut_binding_names2(v1: &mut Option<u8>, v2: &mut Option<u8>) -> bool {
-        matches!((v1, v2), (&mut Some(ref mut x), &mut Some(1)) | (&mut Some(ref mut x), &mut Some(2)))
+        matches!((v1, v2), (&mut Some(_), &mut Some(1)) | (&mut Some(_), &mut Some(2)))
         //~^^^^^ match_like_matches_macro
     }
 
     fn mut_binding(v: (Option<u8>, Option<u8>)) -> bool {
-        matches!(v, (Some(mut x), Some(1)) | (Some(mut x), Some(2)))
+        matches!(v, (Some(_), Some(1)) | (Some(_), Some(2)))
         //~^^^^^ match_like_matches_macro
     }
 
@@ -319,7 +334,11 @@ mod issue17503 {
         y: u8,
     }
     fn struct_ref_binding(v: StructRefBinding) -> bool {
-        matches!(v, StructRefBinding { ref x, y: 1 } | StructRefBinding { ref x, y: 2 })
+        matches!(v, StructRefBinding { x: _, y: 1 } | StructRefBinding { x: _, y: 2 })
+        //~^^^^^ match_like_matches_macro
+    }
+    fn struct_ref_binding2(v: StructRefBinding) -> bool {
+        matches!(v, StructRefBinding { x: _, y: 1 } | StructRefBinding { x: _, y: 2 })
         //~^^^^^ match_like_matches_macro
     }
 
@@ -393,6 +412,16 @@ mod issue17503 {
             } | OuterStruct {
                 inner: InnerStruct { x: _, .. },
                 y: _,
+            })
+        //~^^^^^^^^^^^ match_like_matches_macro
+    }
+    fn nested_struct_ref_shorthand(v: OuterStruct) -> bool {
+        matches!(v, OuterStruct {
+                inner: InnerStruct { x: _ },
+                y: 1,
+            } | OuterStruct {
+                inner: InnerStruct { x: _ },
+                y: 2,
             })
         //~^^^^^^^^^^^ match_like_matches_macro
     }

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -264,7 +264,9 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
-    fn match_check_pass(match_type: MatchType) -> bool {
+    // TODO: This can be transformed into `matches!(match_type, MatchType::A(_) | MatchType::C)`,
+    // but is currently not linted because the middle arm returns a different boolean value.
+    fn match_check_todo(match_type: MatchType) -> bool {
         match match_type {
             MatchType::A(_str1) => true,
             MatchType::B(_str1, _str2) => false,
@@ -279,17 +281,6 @@ mod issue17503 {
 
     fn different_binding_names_2(match_type: MatchType) -> bool {
         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
-        //~^^^^^ match_like_matches_macro
-    }
-
-    enum MatchType2 {
-        A,
-        B,
-        C,
-    }
-
-    fn matches2(match_type2: MatchType2) -> bool {
-        matches!(match_type2, MatchType2::A | MatchType2::B)
         //~^^^^^ match_like_matches_macro
     }
 
@@ -341,16 +332,14 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
-    // FIXME: Avoid invalid suggestions for `@` bindings.
-    // ```rs
-    // fn at_binding(v: Option<u8>) -> bool {
-    //     match v {
-    //         Some(x @ 0) => true,
-    //         Some(y @ 1) => true,
-    //         _ => false,
-    //     }
-    // }
-    // ```
+    // Bail on at bindings, so this one won't be linted.
+    fn at_binding(v: Option<u8>) -> bool {
+        match v {
+            Some(x @ 0) => true,
+            Some(y @ 1) => true,
+            _ => false,
+        }
+    }
 
     fn slice_binding(v: &[u8]) -> bool {
         matches!(v, [_, ..] | [_, _])

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -247,3 +247,40 @@ fn issue16015<T: 'static, U: 'static>() -> bool {
     matches!(typeid!(U), _)
     //~^ match_like_matches_macro
 }
+
+mod issue17503 {
+    enum MatchType {
+        A(String),
+        B(String, String),
+        C,
+    }
+
+    fn matches(match_type: MatchType) -> bool {
+        matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn match_check_pass(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(_str1) => true,
+            MatchType::B(_str1, _str2) => false,
+            MatchType::C => true,
+        }
+    }
+
+    fn different_binding_names(match_type: MatchType) -> bool {
+        matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    enum MatchType2 {
+        A,
+        B,
+        C,
+    }
+
+    fn matches2(match_type2: MatchType2) -> bool {
+        matches!(match_type2, MatchType2::A | MatchType2::B)
+        //~^^^^^ match_like_matches_macro
+    }
+}

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -260,6 +260,19 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn match_check_pass(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(_str1) => true,
+            MatchType::B(_str1, _str2) => false,
+            MatchType::C => true,
+        }
+    }
+
+    fn different_binding_names(match_type: MatchType) -> bool {
+        matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+        //~^^^^^ match_like_matches_macro
+    }
+
     enum MatchType2 {
         A,
         B,

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -247,3 +247,27 @@ fn issue16015<T: 'static, U: 'static>() -> bool {
     matches!(typeid!(U), _)
     //~^ match_like_matches_macro
 }
+
+mod issue17503 {
+    enum MatchType {
+        A(String),
+        B(String, String),
+        C,
+    }
+
+    fn matches(match_type: MatchType) -> bool {
+        matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    enum MatchType2 {
+        A,
+        B,
+        C,
+    }
+
+    fn matches2(match_type2: MatchType2) -> bool {
+        matches!(match_type2, MatchType2::A | MatchType2::B)
+        //~^^^^^ match_like_matches_macro
+    }
+}

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -309,6 +309,20 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn mut_binding(v: (Option<u8>, Option<u8>)) -> bool {
+        matches!(v, (Some(mut x), Some(1)) | (Some(mut x), Some(2)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct StructRefBinding {
+        x: Option<u8>,
+        y: u8,
+    }
+    fn struct_ref_binding(v: StructRefBinding) -> bool {
+        matches!(v, StructRefBinding { ref x, y: 1 } | StructRefBinding { ref x, y: 2 })
+        //~^^^^^ match_like_matches_macro
+    }
+
     struct TestBindingNames {
         a: u8,
         b: u8,

--- a/tests/ui/match_like_matches_macro.fixed
+++ b/tests/ui/match_like_matches_macro.fixed
@@ -289,6 +289,26 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn ref_binding_names(v: (Option<u8>, Option<u8>)) -> bool {
+        matches!(v, (Some(ref x), Some(1)) | (Some(ref x), Some(2)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn ref_binding_names2(v1: Option<u8>, v2: Option<u8>) -> bool {
+        matches!((v1, v2), (Some(ref x), Some(1)) | (Some(ref x), Some(2)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn ref_mut_binding_names(v: (&mut Option<u8>, &mut Option<u8>)) -> bool {
+        matches!(v, (&mut Some(ref mut x), &mut Some(1)) | (&mut Some(ref mut x), &mut Some(2)))
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn ref_mut_binding_names2(v1: &mut Option<u8>, v2: &mut Option<u8>) -> bool {
+        matches!((v1, v2), (&mut Some(ref mut x), &mut Some(1)) | (&mut Some(ref mut x), &mut Some(2)))
+        //~^^^^^ match_like_matches_macro
+    }
+
     struct TestBindingNames {
         a: u8,
         b: u8,

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -635,12 +635,25 @@ mod issue17503 {
             Some($name)
         };
     }
+    enum FromExpansion {
+        A(Option<u8>),
+        B(Option<u8>),
+    }
 
     // ok
     fn from_expansion(v: Option<u8>) -> bool {
         match v {
             mk_pat!(a) => true,
             mk_pat!(b) => true,
+            _ => false,
+        }
+    }
+
+    // ok
+    fn from_expansion2(v: FromExpansion) -> bool {
+        match v {
+            FromExpansion::A(mk_pat!(a)) => true,
+            FromExpansion::B(mk_pat!(b)) => true,
             _ => false,
         }
     }

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -331,6 +331,15 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn different_binding_names_2(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(r#match) => true,
+            MatchType::B(very_long_name_in_snake_case, __very_strange_name__) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
     enum MatchType2 {
         A,
         B,
@@ -341,6 +350,84 @@ mod issue17503 {
         match match_type2 {
             MatchType2::A => true,
             MatchType2::B => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn tuple_binding_names(v: (Option<u8>, Option<u8>)) -> bool {
+        match v {
+            (Some(left), _) => true,
+            (_, Some(right)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    // FIXME: Erasing bindings in struct shorthand patterns (`Foo { a, .. }`)
+    // requires rewriting them as `Foo { a: _, .. }`. Replacing only the binding
+    // span currently produces invalid syntax (`Foo { _, .. }`).
+    // ```rs
+    // struct TestBindingNames {
+    //     a: u8,
+    //     b: u8,
+    // }
+    // fn struct_binding_names(x: TestBindingNames) -> bool {
+    //     match x {
+    //         TestBindingNames { a, .. } => true,
+    //         TestBindingNames { b, .. } => true,
+    //         _ => false,
+    //     }
+    // }
+    // ```
+
+    enum NestedTupleInEnum {
+        A((u8, u8)),
+        B((u8, u8)),
+    }
+
+    fn nested_tuple(e: NestedTupleInEnum) -> bool {
+        match e {
+            NestedTupleInEnum::A((x, y)) => true,
+            NestedTupleInEnum::B((a, b)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    enum Inner {
+        X(u8),
+    }
+
+    enum Outer {
+        A(Inner),
+        B(Inner),
+    }
+
+    fn nested_enum(o: Outer) -> bool {
+        match o {
+            Outer::A(Inner::X(x)) => true,
+            Outer::B(Inner::X(y)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    // FIXME: Avoid invalid suggestions for `@` bindings.
+    // ```rs
+    // fn at_binding(v: Option<u8>) -> bool {
+    //     match v {
+    //         Some(x @ 0) => true,
+    //         Some(y @ 1) => true,
+    //         _ => false,
+    //     }
+    // }
+    // ```
+
+    fn slice_binding(v: &[u8]) -> bool {
+        match v {
+            [first, ..] => true,
+            [_, last] => true,
             _ => false,
         }
         //~^^^^^ match_like_matches_macro

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -297,3 +297,52 @@ fn issue16015<T: 'static, U: 'static>() -> bool {
     if let _ = typeid!(U) { true } else { false }
     //~^ match_like_matches_macro
 }
+
+mod issue17503 {
+    enum MatchType {
+        A(String),
+        B(String, String),
+        C,
+    }
+
+    fn matches(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(_str1) => true,
+            MatchType::B(_str1, _str2) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn match_check_pass(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(_str1) => true,
+            MatchType::B(_str1, _str2) => false,
+            MatchType::C => true,
+        }
+    }
+
+    fn different_binding_names(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(a) => true,
+            MatchType::B(b, c) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    enum MatchType2 {
+        A,
+        B,
+        C,
+    }
+
+    fn matches2(match_type2: MatchType2) -> bool {
+        match match_type2 {
+            MatchType2::A => true,
+            MatchType2::B => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+}

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -297,3 +297,35 @@ fn issue16015<T: 'static, U: 'static>() -> bool {
     if let _ = typeid!(U) { true } else { false }
     //~^ match_like_matches_macro
 }
+
+mod issue17503 {
+    enum MatchType {
+        A(String),
+        B(String, String),
+        C,
+    }
+
+    fn matches(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(_str1) => true,
+            MatchType::B(_str1, _str2) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    enum MatchType2 {
+        A,
+        B,
+        C,
+    }
+
+    fn matches2(match_type2: MatchType2) -> bool {
+        match match_type2 {
+            MatchType2::A => true,
+            MatchType2::B => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+}

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -373,6 +373,35 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn ref_binding_names_three_arms(v: (Option<u8>, u8)) -> bool {
+        match v {
+            (Some(ref x), 1) => true,
+            (Some(ref x), 2) => true,
+            (Some(ref x), 3) => true,
+            _ => false,
+        }
+        //~^^^^^^ match_like_matches_macro
+    }
+
+    fn ref_binding_var_is_not_used(v: (Option<u8>, u8)) -> bool {
+        match v {
+            (Some(ref x), 1) => true,
+            (Some(ref y), 2) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn ref_binding_multi_arm_var_is_not_used(v: (Option<u8>, u8)) -> bool {
+        match v {
+            (Some(ref x), 1) => true,
+            (Some(ref x), 2) => true,
+            (Some(ref z), 3) => true,
+            _ => false,
+        }
+        //~^^^^^^ match_like_matches_macro
+    }
+
     fn ref_mut_binding_names(v: (&mut Option<u8>, &mut Option<u8>)) -> bool {
         match v {
             (&mut Some(ref mut x), &mut Some(1)) => true,
@@ -408,6 +437,14 @@ mod issue17503 {
         match v {
             StructRefBinding { ref x, y: 1 } => true,
             StructRefBinding { ref x, y: 2 } => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+    fn struct_ref_binding2(v: StructRefBinding) -> bool {
+        match v {
+            StructRefBinding { x: ref a, y: 1 } => true,
+            StructRefBinding { x: ref b, y: 2 } => true,
             _ => false,
         }
         //~^^^^^ match_like_matches_macro
@@ -510,6 +547,20 @@ mod issue17503 {
             OuterStruct {
                 inner: InnerStruct { x, .. },
                 y,
+            } => true,
+            _ => false,
+        }
+        //~^^^^^^^^^^^ match_like_matches_macro
+    }
+    fn nested_struct_ref_shorthand(v: OuterStruct) -> bool {
+        match v {
+            OuterStruct {
+                inner: InnerStruct { ref x },
+                y: 1,
+            } => true,
+            OuterStruct {
+                inner: InnerStruct { ref x },
+                y: 2,
             } => true,
             _ => false,
         }

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -314,6 +314,23 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn match_check_pass(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(_str1) => true,
+            MatchType::B(_str1, _str2) => false,
+            MatchType::C => true,
+        }
+    }
+
+    fn different_binding_names(match_type: MatchType) -> bool {
+        match match_type {
+            MatchType::A(a) => true,
+            MatchType::B(b, c) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
     enum MatchType2 {
         A,
         B,

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -391,6 +391,28 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn mut_binding(v: (Option<u8>, Option<u8>)) -> bool {
+        match v {
+            (Some(mut x), Some(1)) => true,
+            (Some(mut x), Some(2)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct StructRefBinding {
+        x: Option<u8>,
+        y: u8,
+    }
+    fn struct_ref_binding(v: StructRefBinding) -> bool {
+        match v {
+            StructRefBinding { ref x, y: 1 } => true,
+            StructRefBinding { ref x, y: 2 } => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
     struct TestBindingNames {
         a: u8,
         b: u8,

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -318,7 +318,9 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
-    fn match_check_pass(match_type: MatchType) -> bool {
+    // TODO: This can be transformed into `matches!(match_type, MatchType::A(_) | MatchType::C)`,
+    // but is currently not linted because the middle arm returns a different boolean value.
+    fn match_check_todo(match_type: MatchType) -> bool {
         match match_type {
             MatchType::A(_str1) => true,
             MatchType::B(_str1, _str2) => false,
@@ -339,21 +341,6 @@ mod issue17503 {
         match match_type {
             MatchType::A(r#match) => true,
             MatchType::B(very_long_name_in_snake_case, __very_strange_name__) => true,
-            _ => false,
-        }
-        //~^^^^^ match_like_matches_macro
-    }
-
-    enum MatchType2 {
-        A,
-        B,
-        C,
-    }
-
-    fn matches2(match_type2: MatchType2) -> bool {
-        match match_type2 {
-            MatchType2::A => true,
-            MatchType2::B => true,
             _ => false,
         }
         //~^^^^^ match_like_matches_macro
@@ -428,16 +415,14 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
-    // FIXME: Avoid invalid suggestions for `@` bindings.
-    // ```rs
-    // fn at_binding(v: Option<u8>) -> bool {
-    //     match v {
-    //         Some(x @ 0) => true,
-    //         Some(y @ 1) => true,
-    //         _ => false,
-    //     }
-    // }
-    // ```
+    // Bail on at bindings, so this one won't be linted.
+    fn at_binding(v: Option<u8>) -> bool {
+        match v {
+            Some(x @ 0) => true,
+            Some(y @ 1) => true,
+            _ => false,
+        }
+    }
 
     fn slice_binding(v: &[u8]) -> bool {
         match v {

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -355,6 +355,42 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
+    fn ref_binding_names(v: (Option<u8>, Option<u8>)) -> bool {
+        match v {
+            (Some(ref x), Some(1)) => true,
+            (Some(ref x), Some(2)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn ref_binding_names2(v1: Option<u8>, v2: Option<u8>) -> bool {
+        match (v1, v2) {
+            (Some(ref x), Some(1)) => true,
+            (Some(ref x), Some(2)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn ref_mut_binding_names(v: (&mut Option<u8>, &mut Option<u8>)) -> bool {
+        match v {
+            (&mut Some(ref mut x), &mut Some(1)) => true,
+            (&mut Some(ref mut x), &mut Some(2)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    fn ref_mut_binding_names2(v1: &mut Option<u8>, v2: &mut Option<u8>) -> bool {
+        match (v1, v2) {
+            (&mut Some(ref mut x), &mut Some(1)) => true,
+            (&mut Some(ref mut x), &mut Some(2)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
     struct TestBindingNames {
         a: u8,
         b: u8,

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::match_like_matches_macro)]
-#![allow(irrefutable_let_patterns, clippy::redundant_guards)]
+#![allow(
+    irrefutable_let_patterns,
+    clippy::redundant_guards,
+    clippy::unneeded_wildcard_pattern
+)]
 #![expect(clippy::needless_borrowed_reference)]
 
 fn main() {
@@ -364,22 +368,33 @@ mod issue17503 {
         //~^^^^^ match_like_matches_macro
     }
 
-    // FIXME: Erasing bindings in struct shorthand patterns (`Foo { a, .. }`)
-    // requires rewriting them as `Foo { a: _, .. }`. Replacing only the binding
-    // span currently produces invalid syntax (`Foo { _, .. }`).
-    // ```rs
-    // struct TestBindingNames {
-    //     a: u8,
-    //     b: u8,
-    // }
-    // fn struct_binding_names(x: TestBindingNames) -> bool {
-    //     match x {
-    //         TestBindingNames { a, .. } => true,
-    //         TestBindingNames { b, .. } => true,
-    //         _ => false,
-    //     }
-    // }
-    // ```
+    struct TestBindingNames {
+        a: u8,
+        b: u8,
+    }
+    fn struct_binding_names(x: TestBindingNames) -> bool {
+        match x {
+            TestBindingNames { a, .. } => true,
+            TestBindingNames { b, .. } => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct TestBindingNames2 {
+        a: u8,
+        b: u8,
+        c: u8,
+    }
+    fn struct_binding_names2(x: TestBindingNames2) -> bool {
+        match x {
+            TestBindingNames2 { a, b: 1, .. } => true,
+            TestBindingNames2 { a, b: 2, .. } => true,
+            TestBindingNames2 { a: 3, b: 4, .. } => true,
+            _ => false,
+        }
+        //~^^^^^^ match_like_matches_macro
+    }
 
     enum NestedTupleInEnum {
         A((u8, u8)),

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -432,4 +432,19 @@ mod issue17503 {
         }
         //~^^^^^ match_like_matches_macro
     }
+
+    macro_rules! mk_pat {
+        ($name:ident) => {
+            Some($name)
+        };
+    }
+
+    // ok
+    fn from_expansion(v: Option<u8>) -> bool {
+        match v {
+            mk_pat!(a) => true,
+            mk_pat!(b) => true,
+            _ => false,
+        }
+    }
 }

--- a/tests/ui/match_like_matches_macro.rs
+++ b/tests/ui/match_like_matches_macro.rs
@@ -441,6 +441,94 @@ mod issue17503 {
         //~^^^^^^ match_like_matches_macro
     }
 
+    struct MixedBindingNames {
+        a: u8,
+        b: u8,
+    }
+    fn mixed_binding_names(x: MixedBindingNames, y: Option<u8>) -> bool {
+        match (x, y) {
+            (MixedBindingNames { a, .. }, Some(x)) => true,
+            (MixedBindingNames { b, .. }, Some(y)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct MixedNested {
+        a: Option<u8>,
+        b: u8,
+    }
+    fn mixed_nested(x: MixedNested) -> bool {
+        match x {
+            MixedNested { a: Some(x), b } => true,
+            MixedNested { a: Some(y), b: c } => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct MixedFields {
+        a: u8,
+        b: u8,
+    }
+    fn mixed_fields(x: MixedFields) -> bool {
+        match x {
+            MixedFields { a, b: 1 } => true,
+            MixedFields { a: 2, b } => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
+    struct InnerStruct {
+        x: u8,
+    }
+    struct OuterStruct {
+        inner: InnerStruct,
+        y: u8,
+    }
+    fn nested_struct(x: OuterStruct) -> bool {
+        match x {
+            OuterStruct {
+                inner: InnerStruct { x, .. },
+                y: w,
+            } => true,
+            OuterStruct {
+                inner: InnerStruct { x: z, .. },
+                y: w,
+            } => true,
+            _ => false,
+        }
+        //~^^^^^^^^^^^ match_like_matches_macro
+    }
+    fn nested_struct_shorthand(x: OuterStruct) -> bool {
+        match x {
+            OuterStruct {
+                inner: InnerStruct { x, .. },
+                y,
+            } => true,
+            OuterStruct {
+                inner: InnerStruct { x, .. },
+                y,
+            } => true,
+            _ => false,
+        }
+        //~^^^^^^^^^^^ match_like_matches_macro
+    }
+
+    struct AdjacentShorthand {
+        a: u8,
+        b: u8,
+    }
+    fn adjacent_shorthand_fields(x: AdjacentShorthand) -> bool {
+        match x {
+            AdjacentShorthand { a, b } => true,
+            AdjacentShorthand { a: 1, b: 2 } => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
+    }
+
     enum NestedTupleInEnum {
         A((u8, u8)),
         B((u8, u8)),
@@ -504,5 +592,22 @@ mod issue17503 {
             mk_pat!(b) => true,
             _ => false,
         }
+    }
+
+    struct Data {
+        x: u8,
+    }
+    enum Kind {
+        A(Data),
+        B(Data),
+    }
+    // Test all of above cases in one function.
+    fn everything(v: (Kind, Option<u8>)) -> bool {
+        match v {
+            (Kind::A(Data { x, .. }), Some(y)) => true,
+            (Kind::B(Data { x: z, .. }), Some(w)) => true,
+            _ => false,
+        }
+        //~^^^^^ match_like_matches_macro
     }
 }

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -855,7 +855,7 @@ LL +         matches!(v, [_, ..] | [_, _])
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:657:9
+  --> tests/ui/match_like_matches_macro.rs:670:9
    |
 LL | /         match v {
 LL | |             (Kind::A(Data { x, .. }), Some(y)) => true,

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -340,7 +340,27 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:324:9
+  --> tests/ui/match_like_matches_macro.rs:326:9
+   |
+LL | /         match match_type {
+LL | |             MatchType::A(a) => true,
+LL | |             MatchType::B(b, c) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match match_type {
+LL -             MatchType::A(a) => true,
+LL -             MatchType::B(b, c) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:341:9
    |
 LL | /         match match_type2 {
 LL | |             MatchType2::A => true,
@@ -359,5 +379,5 @@ LL -         }
 LL +         matches!(match_type2, MatchType2::A | MatchType2::B)
    |
 
-error: aborting due to 19 previous errors
+error: aborting due to 20 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -416,7 +416,7 @@ LL -             (Some(ref x), Some(1)) => true,
 LL -             (Some(ref x), Some(2)) => true,
 LL -             _ => false,
 LL -         }
-LL +         matches!(v, (Some(ref x), Some(1)) | (Some(ref x), Some(2)))
+LL +         matches!(v, (Some(_), Some(1)) | (Some(_), Some(2)))
    |
 
 error: match expression looks like `matches!` macro
@@ -436,11 +436,75 @@ LL -             (Some(ref x), Some(1)) => true,
 LL -             (Some(ref x), Some(2)) => true,
 LL -             _ => false,
 LL -         }
-LL +         matches!((v1, v2), (Some(ref x), Some(1)) | (Some(ref x), Some(2)))
+LL +         matches!((v1, v2), (Some(_), Some(1)) | (Some(_), Some(2)))
    |
 
 error: match expression looks like `matches!` macro
   --> tests/ui/match_like_matches_macro.rs:377:9
+   |
+LL | /         match v {
+LL | |             (Some(ref x), 1) => true,
+LL | |             (Some(ref x), 2) => true,
+LL | |             (Some(ref x), 3) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (Some(ref x), 1) => true,
+LL -             (Some(ref x), 2) => true,
+LL -             (Some(ref x), 3) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (Some(_), 1) | (Some(_), 2) | (Some(_), 3))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:387:9
+   |
+LL | /         match v {
+LL | |             (Some(ref x), 1) => true,
+LL | |             (Some(ref y), 2) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (Some(ref x), 1) => true,
+LL -             (Some(ref y), 2) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (Some(_), 1) | (Some(_), 2))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:396:9
+   |
+LL | /         match v {
+LL | |             (Some(ref x), 1) => true,
+LL | |             (Some(ref x), 2) => true,
+LL | |             (Some(ref z), 3) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (Some(ref x), 1) => true,
+LL -             (Some(ref x), 2) => true,
+LL -             (Some(ref z), 3) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (Some(_), 1) | (Some(_), 2) | (Some(_), 3))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:406:9
    |
 LL | /         match v {
 LL | |             (&mut Some(ref mut x), &mut Some(1)) => true,
@@ -456,11 +520,11 @@ LL -             (&mut Some(ref mut x), &mut Some(1)) => true,
 LL -             (&mut Some(ref mut x), &mut Some(2)) => true,
 LL -             _ => false,
 LL -         }
-LL +         matches!(v, (&mut Some(ref mut x), &mut Some(1)) | (&mut Some(ref mut x), &mut Some(2)))
+LL +         matches!(v, (&mut Some(_), &mut Some(1)) | (&mut Some(_), &mut Some(2)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:386:9
+  --> tests/ui/match_like_matches_macro.rs:415:9
    |
 LL | /         match (v1, v2) {
 LL | |             (&mut Some(ref mut x), &mut Some(1)) => true,
@@ -476,11 +540,11 @@ LL -             (&mut Some(ref mut x), &mut Some(1)) => true,
 LL -             (&mut Some(ref mut x), &mut Some(2)) => true,
 LL -             _ => false,
 LL -         }
-LL +         matches!((v1, v2), (&mut Some(ref mut x), &mut Some(1)) | (&mut Some(ref mut x), &mut Some(2)))
+LL +         matches!((v1, v2), (&mut Some(_), &mut Some(1)) | (&mut Some(_), &mut Some(2)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:395:9
+  --> tests/ui/match_like_matches_macro.rs:424:9
    |
 LL | /         match v {
 LL | |             (Some(mut x), Some(1)) => true,
@@ -496,11 +560,11 @@ LL -             (Some(mut x), Some(1)) => true,
 LL -             (Some(mut x), Some(2)) => true,
 LL -             _ => false,
 LL -         }
-LL +         matches!(v, (Some(mut x), Some(1)) | (Some(mut x), Some(2)))
+LL +         matches!(v, (Some(_), Some(1)) | (Some(_), Some(2)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:408:9
+  --> tests/ui/match_like_matches_macro.rs:437:9
    |
 LL | /         match v {
 LL | |             StructRefBinding { ref x, y: 1 } => true,
@@ -516,11 +580,31 @@ LL -             StructRefBinding { ref x, y: 1 } => true,
 LL -             StructRefBinding { ref x, y: 2 } => true,
 LL -             _ => false,
 LL -         }
-LL +         matches!(v, StructRefBinding { ref x, y: 1 } | StructRefBinding { ref x, y: 2 })
+LL +         matches!(v, StructRefBinding { x: _, y: 1 } | StructRefBinding { x: _, y: 2 })
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:421:9
+  --> tests/ui/match_like_matches_macro.rs:445:9
+   |
+LL | /         match v {
+LL | |             StructRefBinding { x: ref a, y: 1 } => true,
+LL | |             StructRefBinding { x: ref b, y: 2 } => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             StructRefBinding { x: ref a, y: 1 } => true,
+LL -             StructRefBinding { x: ref b, y: 2 } => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, StructRefBinding { x: _, y: 1 } | StructRefBinding { x: _, y: 2 })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:458:9
    |
 LL | /         match x {
 LL | |             TestBindingNames { a, .. } => true,
@@ -540,7 +624,7 @@ LL +         matches!(x, TestBindingNames { a: _, .. } | TestBindingNames { b: _
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:435:9
+  --> tests/ui/match_like_matches_macro.rs:472:9
    |
 LL | /         match x {
 LL | |             TestBindingNames2 { a, b: 1, .. } => true,
@@ -562,7 +646,7 @@ LL +         matches!(x, TestBindingNames2 { a: _, b: 1, .. } | TestBindingNames
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:449:9
+  --> tests/ui/match_like_matches_macro.rs:486:9
    |
 LL | /         match (x, y) {
 LL | |             (MixedBindingNames { a, .. }, Some(x)) => true,
@@ -582,7 +666,7 @@ LL +         matches!((x, y), (MixedBindingNames { a: _, .. }, Some(_)) | (Mixed
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:462:9
+  --> tests/ui/match_like_matches_macro.rs:499:9
    |
 LL | /         match x {
 LL | |             MixedNested { a: Some(x), b } => true,
@@ -602,7 +686,7 @@ LL +         matches!(x, MixedNested { a: Some(_), b: _ } | MixedNested { a: Som
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:475:9
+  --> tests/ui/match_like_matches_macro.rs:512:9
    |
 LL | /         match x {
 LL | |             MixedFields { a, b: 1 } => true,
@@ -622,7 +706,7 @@ LL +         matches!(x, MixedFields { a: _, b: 1 } | MixedFields { a: 2, b: _ }
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:491:9
+  --> tests/ui/match_like_matches_macro.rs:528:9
    |
 LL | /         match x {
 LL | |             OuterStruct {
@@ -645,7 +729,7 @@ LL +             })
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:505:9
+  --> tests/ui/match_like_matches_macro.rs:542:9
    |
 LL | /         match x {
 LL | |             OuterStruct {
@@ -668,7 +752,30 @@ LL +             })
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:524:9
+  --> tests/ui/match_like_matches_macro.rs:556:9
+   |
+LL | /         match v {
+LL | |             OuterStruct {
+LL | |                 inner: InnerStruct { ref x },
+LL | |                 y: 1,
+...  |
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL ~         matches!(v, OuterStruct {
+LL +                 inner: InnerStruct { x: _ },
+LL +                 y: 1,
+LL +             } | OuterStruct {
+LL +                 inner: InnerStruct { x: _ },
+LL +                 y: 2,
+LL +             })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:575:9
    |
 LL | /         match x {
 LL | |             AdjacentShorthand { a, b } => true,
@@ -688,7 +795,7 @@ LL +         matches!(x, AdjacentShorthand { a: _, b: _ } | AdjacentShorthand { 
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:538:9
+  --> tests/ui/match_like_matches_macro.rs:589:9
    |
 LL | /         match e {
 LL | |             NestedTupleInEnum::A((x, y)) => true,
@@ -708,7 +815,7 @@ LL +         matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_,
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:556:9
+  --> tests/ui/match_like_matches_macro.rs:607:9
    |
 LL | /         match o {
 LL | |             Outer::A(Inner::X(x)) => true,
@@ -728,7 +835,7 @@ LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:574:9
+  --> tests/ui/match_like_matches_macro.rs:625:9
    |
 LL | /         match v {
 LL | |             [first, ..] => true,
@@ -748,7 +855,7 @@ LL +         matches!(v, [_, ..] | [_, _])
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:606:9
+  --> tests/ui/match_like_matches_macro.rs:657:9
    |
 LL | /         match v {
 LL | |             (Kind::A(Data { x, .. }), Some(y)) => true,
@@ -767,5 +874,5 @@ LL -         }
 LL +         matches!(v, (Kind::A(Data { x: _, .. }), Some(_)) | (Kind::B(Data { x: _, .. }), Some(_)))
    |
 
-error: aborting due to 39 previous errors
+error: aborting due to 44 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -360,7 +360,27 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:341:9
+  --> tests/ui/match_like_matches_macro.rs:335:9
+   |
+LL | /         match match_type {
+LL | |             MatchType::A(r#match) => true,
+LL | |             MatchType::B(very_long_name_in_snake_case, __very_strange_name__) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match match_type {
+LL -             MatchType::A(r#match) => true,
+LL -             MatchType::B(very_long_name_in_snake_case, __very_strange_name__) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:350:9
    |
 LL | /         match match_type2 {
 LL | |             MatchType2::A => true,
@@ -379,5 +399,85 @@ LL -         }
 LL +         matches!(match_type2, MatchType2::A | MatchType2::B)
    |
 
-error: aborting due to 20 previous errors
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:359:9
+   |
+LL | /         match v {
+LL | |             (Some(left), _) => true,
+LL | |             (_, Some(right)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (Some(left), _) => true,
+LL -             (_, Some(right)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (Some(_), _) | (_, Some(_)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:390:9
+   |
+LL | /         match e {
+LL | |             NestedTupleInEnum::A((x, y)) => true,
+LL | |             NestedTupleInEnum::B((a, b)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match e {
+LL -             NestedTupleInEnum::A((x, y)) => true,
+LL -             NestedTupleInEnum::B((a, b)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_, _)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:408:9
+   |
+LL | /         match o {
+LL | |             Outer::A(Inner::X(x)) => true,
+LL | |             Outer::B(Inner::X(y)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match o {
+LL -             Outer::A(Inner::X(x)) => true,
+LL -             Outer::B(Inner::X(y)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:428:9
+   |
+LL | /         match v {
+LL | |             [first, ..] => true,
+LL | |             [_, last] => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             [first, ..] => true,
+LL -             [_, last] => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, [_, ..] | [_, _])
+   |
+
+error: aborting due to 25 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -400,7 +400,87 @@ LL +         matches!(v, (Some(_), _) | (_, Some(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:363:9
+  --> tests/ui/match_like_matches_macro.rs:359:9
+   |
+LL | /         match v {
+LL | |             (Some(ref x), Some(1)) => true,
+LL | |             (Some(ref x), Some(2)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (Some(ref x), Some(1)) => true,
+LL -             (Some(ref x), Some(2)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (Some(ref x), Some(1)) | (Some(ref x), Some(2)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:368:9
+   |
+LL | /         match (v1, v2) {
+LL | |             (Some(ref x), Some(1)) => true,
+LL | |             (Some(ref x), Some(2)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match (v1, v2) {
+LL -             (Some(ref x), Some(1)) => true,
+LL -             (Some(ref x), Some(2)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!((v1, v2), (Some(ref x), Some(1)) | (Some(ref x), Some(2)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:377:9
+   |
+LL | /         match v {
+LL | |             (&mut Some(ref mut x), &mut Some(1)) => true,
+LL | |             (&mut Some(ref mut x), &mut Some(2)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (&mut Some(ref mut x), &mut Some(1)) => true,
+LL -             (&mut Some(ref mut x), &mut Some(2)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (&mut Some(ref mut x), &mut Some(1)) | (&mut Some(ref mut x), &mut Some(2)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:386:9
+   |
+LL | /         match (v1, v2) {
+LL | |             (&mut Some(ref mut x), &mut Some(1)) => true,
+LL | |             (&mut Some(ref mut x), &mut Some(2)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match (v1, v2) {
+LL -             (&mut Some(ref mut x), &mut Some(1)) => true,
+LL -             (&mut Some(ref mut x), &mut Some(2)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!((v1, v2), (&mut Some(ref mut x), &mut Some(1)) | (&mut Some(ref mut x), &mut Some(2)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:399:9
    |
 LL | /         match x {
 LL | |             TestBindingNames { a, .. } => true,
@@ -420,7 +500,7 @@ LL +         matches!(x, TestBindingNames { a: _, .. } | TestBindingNames { b: _
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:377:9
+  --> tests/ui/match_like_matches_macro.rs:413:9
    |
 LL | /         match x {
 LL | |             TestBindingNames2 { a, b: 1, .. } => true,
@@ -442,7 +522,7 @@ LL +         matches!(x, TestBindingNames2 { a: _, b: 1, .. } | TestBindingNames
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:392:9
+  --> tests/ui/match_like_matches_macro.rs:428:9
    |
 LL | /         match e {
 LL | |             NestedTupleInEnum::A((x, y)) => true,
@@ -462,7 +542,7 @@ LL +         matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_,
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:410:9
+  --> tests/ui/match_like_matches_macro.rs:446:9
    |
 LL | /         match o {
 LL | |             Outer::A(Inner::X(x)) => true,
@@ -482,7 +562,7 @@ LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:428:9
+  --> tests/ui/match_like_matches_macro.rs:464:9
    |
 LL | /         match v {
 LL | |             [first, ..] => true,
@@ -501,5 +581,5 @@ LL -         }
 LL +         matches!(v, [_, ..] | [_, _])
    |
 
-error: aborting due to 26 previous errors
+error: aborting due to 30 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -360,7 +360,27 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:341:9
+  --> tests/ui/match_like_matches_macro.rs:335:9
+   |
+LL | /         match match_type {
+LL | |             MatchType::A(r#match) => true,
+LL | |             MatchType::B(very_long_name_in_snake_case, __very_strange_name__) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match match_type {
+LL -             MatchType::A(r#match) => true,
+LL -             MatchType::B(very_long_name_in_snake_case, __very_strange_name__) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:350:9
    |
 LL | /         match match_type2 {
 LL | |             MatchType2::A => true,
@@ -379,5 +399,85 @@ LL -         }
 LL +         matches!(match_type2, MatchType2::A | MatchType2::B)
    |
 
-error: aborting due to 20 previous errors
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:359:9
+   |
+LL | /         match v {
+LL | |             (Some(left), _) => true,
+LL | |             (_, Some(right)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (Some(left), _) => true,
+LL -             (_, Some(right)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (Some(_), _) | (_, Some(_)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:390:9
+   |
+LL | /         match e {
+LL | |             NestedTupleInEnum::A((x, y)) => true,
+LL | |             NestedTupleInEnum::B((a, b)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match e {
+LL -             NestedTupleInEnum::A((x, y)) => true,
+LL -             NestedTupleInEnum::B((a, b)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_, _)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:408:9
+   |
+LL | /         match o {
+LL | |             Outer::A(Inner::X(x)) => true,
+LL | |             Outer::B(Inner::X(y)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match o {
+LL -             Outer::A(Inner::X(x)) => true,
+LL -             Outer::B(Inner::X(y)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:429:9
+   |
+LL | /         match v {
+LL | |             [first, ..] => true,
+LL | |             [_, last] => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             [first, ..] => true,
+LL -             [_, last] => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, [_, ..] | [_, _])
+   |
+
+error: aborting due to 25 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -340,7 +340,7 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:330:9
+  --> tests/ui/match_like_matches_macro.rs:332:9
    |
 LL | /         match match_type {
 LL | |             MatchType::A(a) => true,
@@ -360,7 +360,7 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:339:9
+  --> tests/ui/match_like_matches_macro.rs:341:9
    |
 LL | /         match match_type {
 LL | |             MatchType::A(r#match) => true,
@@ -380,27 +380,7 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:354:9
-   |
-LL | /         match match_type2 {
-LL | |             MatchType2::A => true,
-LL | |             MatchType2::B => true,
-LL | |             _ => false,
-LL | |         }
-   | |_________^
-   |
-help: use `matches!` directly
-   |
-LL -         match match_type2 {
-LL -             MatchType2::A => true,
-LL -             MatchType2::B => true,
-LL -             _ => false,
-LL -         }
-LL +         matches!(match_type2, MatchType2::A | MatchType2::B)
-   |
-
-error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:363:9
+  --> tests/ui/match_like_matches_macro.rs:350:9
    |
 LL | /         match v {
 LL | |             (Some(left), _) => true,
@@ -420,7 +400,7 @@ LL +         matches!(v, (Some(_), _) | (_, Some(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:376:9
+  --> tests/ui/match_like_matches_macro.rs:363:9
    |
 LL | /         match x {
 LL | |             TestBindingNames { a, .. } => true,
@@ -440,7 +420,7 @@ LL +         matches!(x, TestBindingNames { a: _, .. } | TestBindingNames { b: _
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:390:9
+  --> tests/ui/match_like_matches_macro.rs:377:9
    |
 LL | /         match x {
 LL | |             TestBindingNames2 { a, b: 1, .. } => true,
@@ -462,7 +442,7 @@ LL +         matches!(x, TestBindingNames2 { a: _, b: 1, .. } | TestBindingNames
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:405:9
+  --> tests/ui/match_like_matches_macro.rs:392:9
    |
 LL | /         match e {
 LL | |             NestedTupleInEnum::A((x, y)) => true,
@@ -482,7 +462,7 @@ LL +         matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_,
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:423:9
+  --> tests/ui/match_like_matches_macro.rs:410:9
    |
 LL | /         match o {
 LL | |             Outer::A(Inner::X(x)) => true,
@@ -502,7 +482,7 @@ LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:443:9
+  --> tests/ui/match_like_matches_macro.rs:428:9
    |
 LL | /         match v {
 LL | |             [first, ..] => true,
@@ -521,5 +501,5 @@ LL -         }
 LL +         matches!(v, [_, ..] | [_, _])
    |
 
-error: aborting due to 27 previous errors
+error: aborting due to 26 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -319,5 +319,65 @@ LL -     if let _ = typeid!(U) { true } else { false }
 LL +     matches!(typeid!(U), _)
    |
 
-error: aborting due to 17 previous errors
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:309:9
+   |
+LL | /         match match_type {
+LL | |             MatchType::A(_str1) => true,
+LL | |             MatchType::B(_str1, _str2) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match match_type {
+LL -             MatchType::A(_str1) => true,
+LL -             MatchType::B(_str1, _str2) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:326:9
+   |
+LL | /         match match_type {
+LL | |             MatchType::A(a) => true,
+LL | |             MatchType::B(b, c) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match match_type {
+LL -             MatchType::A(a) => true,
+LL -             MatchType::B(b, c) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:341:9
+   |
+LL | /         match match_type2 {
+LL | |             MatchType2::A => true,
+LL | |             MatchType2::B => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match match_type2 {
+LL -             MatchType2::A => true,
+LL -             MatchType2::B => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(match_type2, MatchType2::A | MatchType2::B)
+   |
+
+error: aborting due to 20 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -480,7 +480,47 @@ LL +         matches!((v1, v2), (&mut Some(ref mut x), &mut Some(1)) | (&mut Som
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:399:9
+  --> tests/ui/match_like_matches_macro.rs:395:9
+   |
+LL | /         match v {
+LL | |             (Some(mut x), Some(1)) => true,
+LL | |             (Some(mut x), Some(2)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (Some(mut x), Some(1)) => true,
+LL -             (Some(mut x), Some(2)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (Some(mut x), Some(1)) | (Some(mut x), Some(2)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:408:9
+   |
+LL | /         match v {
+LL | |             StructRefBinding { ref x, y: 1 } => true,
+LL | |             StructRefBinding { ref x, y: 2 } => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             StructRefBinding { ref x, y: 1 } => true,
+LL -             StructRefBinding { ref x, y: 2 } => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, StructRefBinding { ref x, y: 1 } | StructRefBinding { ref x, y: 2 })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:421:9
    |
 LL | /         match x {
 LL | |             TestBindingNames { a, .. } => true,
@@ -500,7 +540,7 @@ LL +         matches!(x, TestBindingNames { a: _, .. } | TestBindingNames { b: _
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:413:9
+  --> tests/ui/match_like_matches_macro.rs:435:9
    |
 LL | /         match x {
 LL | |             TestBindingNames2 { a, b: 1, .. } => true,
@@ -522,7 +562,7 @@ LL +         matches!(x, TestBindingNames2 { a: _, b: 1, .. } | TestBindingNames
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:428:9
+  --> tests/ui/match_like_matches_macro.rs:450:9
    |
 LL | /         match e {
 LL | |             NestedTupleInEnum::A((x, y)) => true,
@@ -542,7 +582,7 @@ LL +         matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_,
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:446:9
+  --> tests/ui/match_like_matches_macro.rs:468:9
    |
 LL | /         match o {
 LL | |             Outer::A(Inner::X(x)) => true,
@@ -562,7 +602,7 @@ LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:464:9
+  --> tests/ui/match_like_matches_macro.rs:486:9
    |
 LL | /         match v {
 LL | |             [first, ..] => true,
@@ -581,5 +621,5 @@ LL -         }
 LL +         matches!(v, [_, ..] | [_, _])
    |
 
-error: aborting due to 30 previous errors
+error: aborting due to 32 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -319,5 +319,45 @@ LL -     if let _ = typeid!(U) { true } else { false }
 LL +     matches!(typeid!(U), _)
    |
 
-error: aborting due to 17 previous errors
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:309:9
+   |
+LL | /         match match_type {
+LL | |             MatchType::A(_str1) => true,
+LL | |             MatchType::B(_str1, _str2) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match match_type {
+LL -             MatchType::A(_str1) => true,
+LL -             MatchType::B(_str1, _str2) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:324:9
+   |
+LL | /         match match_type2 {
+LL | |             MatchType2::A => true,
+LL | |             MatchType2::B => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match match_type2 {
+LL -             MatchType2::A => true,
+LL -             MatchType2::B => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(match_type2, MatchType2::A | MatchType2::B)
+   |
+
+error: aborting due to 19 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -1,5 +1,5 @@
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:9:14
+  --> tests/ui/match_like_matches_macro.rs:13:14
    |
 LL |       let _y = match x {
    |  ______________^
@@ -20,7 +20,7 @@ LL +     let _y = matches!(x, Some(0));
    |
 
 error: redundant pattern matching
-  --> tests/ui/match_like_matches_macro.rs:16:14
+  --> tests/ui/match_like_matches_macro.rs:20:14
    |
 LL |       let _w = match x {
    |  ______________^
@@ -41,7 +41,7 @@ LL +     let _w = x.is_some();
    |
 
 error: redundant pattern matching
-  --> tests/ui/match_like_matches_macro.rs:23:14
+  --> tests/ui/match_like_matches_macro.rs:27:14
    |
 LL |       let _z = match x {
    |  ______________^
@@ -60,7 +60,7 @@ LL +     let _z = x.is_none();
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:30:15
+  --> tests/ui/match_like_matches_macro.rs:34:15
    |
 LL |       let _zz = match x {
    |  _______________^
@@ -79,7 +79,7 @@ LL +     let _zz = !matches!(x, Some(r) if r == 0);
    |
 
 error: `if let .. else` expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:37:16
+  --> tests/ui/match_like_matches_macro.rs:41:16
    |
 LL |     let _zzz = if let Some(5) = x { true } else { false };
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -91,7 +91,7 @@ LL +     let _zzz = matches!(x, Some(5));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:62:20
+  --> tests/ui/match_like_matches_macro.rs:66:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -112,7 +112,7 @@ LL +         let _ans = matches!(x, E::A(_) | E::B(_));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:73:20
+  --> tests/ui/match_like_matches_macro.rs:77:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -136,7 +136,7 @@ LL +         let _ans = matches!(x, E::A(_) | E::B(_));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:84:20
+  --> tests/ui/match_like_matches_macro.rs:88:20
    |
 LL |           let _ans = match x {
    |  ____________________^
@@ -157,7 +157,7 @@ LL +         let _ans = !matches!(x, E::B(_) | E::C);
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:145:18
+  --> tests/ui/match_like_matches_macro.rs:149:18
    |
 LL |           let _z = match &z {
    |  __________________^
@@ -176,7 +176,7 @@ LL +         let _z = matches!(z, Some(3));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:155:18
+  --> tests/ui/match_like_matches_macro.rs:159:18
    |
 LL |           let _z = match &z {
    |  __________________^
@@ -195,7 +195,7 @@ LL +         let _z = matches!(&z, Some(3));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:173:21
+  --> tests/ui/match_like_matches_macro.rs:177:21
    |
 LL |               let _ = match &z {
    |  _____________________^
@@ -214,7 +214,7 @@ LL +             let _ = matches!(&z, AnEnum::X);
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:188:20
+  --> tests/ui/match_like_matches_macro.rs:192:20
    |
 LL |           let _res = match &val {
    |  ____________________^
@@ -233,7 +233,7 @@ LL +         let _res = matches!(&val, &Some(ref _a));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:201:20
+  --> tests/ui/match_like_matches_macro.rs:205:20
    |
 LL |           let _res = match &val {
    |  ____________________^
@@ -252,7 +252,7 @@ LL +         let _res = matches!(&val, &Some(ref _a));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:260:14
+  --> tests/ui/match_like_matches_macro.rs:264:14
    |
 LL |       let _y = match Some(5) {
    |  ______________^
@@ -271,7 +271,7 @@ LL +     let _y = matches!(Some(5), Some(0));
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:270:13
+  --> tests/ui/match_like_matches_macro.rs:274:13
    |
 LL |       let _ = match opt {
    |  _____________^
@@ -290,7 +290,7 @@ LL +     let _ = matches!(opt, Some(first) if (if let Some(second) = first { tru
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:291:5
+  --> tests/ui/match_like_matches_macro.rs:295:5
    |
 LL | /     match typeid!(T) {
 LL | |         _ => true,
@@ -308,7 +308,7 @@ LL +     matches!(typeid!(T), _);
    |
 
 error: `if let .. else` expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:297:5
+  --> tests/ui/match_like_matches_macro.rs:301:5
    |
 LL |     if let _ = typeid!(U) { true } else { false }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -320,7 +320,7 @@ LL +     matches!(typeid!(U), _)
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:309:9
+  --> tests/ui/match_like_matches_macro.rs:313:9
    |
 LL | /         match match_type {
 LL | |             MatchType::A(_str1) => true,
@@ -340,7 +340,7 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:326:9
+  --> tests/ui/match_like_matches_macro.rs:330:9
    |
 LL | /         match match_type {
 LL | |             MatchType::A(a) => true,
@@ -360,7 +360,7 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:335:9
+  --> tests/ui/match_like_matches_macro.rs:339:9
    |
 LL | /         match match_type {
 LL | |             MatchType::A(r#match) => true,
@@ -380,7 +380,7 @@ LL +         matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:350:9
+  --> tests/ui/match_like_matches_macro.rs:354:9
    |
 LL | /         match match_type2 {
 LL | |             MatchType2::A => true,
@@ -400,7 +400,7 @@ LL +         matches!(match_type2, MatchType2::A | MatchType2::B)
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:359:9
+  --> tests/ui/match_like_matches_macro.rs:363:9
    |
 LL | /         match v {
 LL | |             (Some(left), _) => true,
@@ -420,7 +420,49 @@ LL +         matches!(v, (Some(_), _) | (_, Some(_)))
    |
 
 error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:376:9
+   |
+LL | /         match x {
+LL | |             TestBindingNames { a, .. } => true,
+LL | |             TestBindingNames { b, .. } => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match x {
+LL -             TestBindingNames { a, .. } => true,
+LL -             TestBindingNames { b, .. } => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(x, TestBindingNames { a: _, .. } | TestBindingNames { b: _, .. })
+   |
+
+error: match expression looks like `matches!` macro
   --> tests/ui/match_like_matches_macro.rs:390:9
+   |
+LL | /         match x {
+LL | |             TestBindingNames2 { a, b: 1, .. } => true,
+LL | |             TestBindingNames2 { a, b: 2, .. } => true,
+LL | |             TestBindingNames2 { a: 3, b: 4, .. } => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match x {
+LL -             TestBindingNames2 { a, b: 1, .. } => true,
+LL -             TestBindingNames2 { a, b: 2, .. } => true,
+LL -             TestBindingNames2 { a: 3, b: 4, .. } => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(x, TestBindingNames2 { a: _, b: 1, .. } | TestBindingNames2 { a: _, b: 2, .. } | TestBindingNames2 { a: 3, b: 4, .. })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:405:9
    |
 LL | /         match e {
 LL | |             NestedTupleInEnum::A((x, y)) => true,
@@ -440,7 +482,7 @@ LL +         matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_,
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:408:9
+  --> tests/ui/match_like_matches_macro.rs:423:9
    |
 LL | /         match o {
 LL | |             Outer::A(Inner::X(x)) => true,
@@ -460,7 +502,7 @@ LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:428:9
+  --> tests/ui/match_like_matches_macro.rs:443:9
    |
 LL | /         match v {
 LL | |             [first, ..] => true,
@@ -479,5 +521,5 @@ LL -         }
 LL +         matches!(v, [_, ..] | [_, _])
    |
 
-error: aborting due to 25 previous errors
+error: aborting due to 27 previous errors
 

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -460,7 +460,7 @@ LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:429:9
+  --> tests/ui/match_like_matches_macro.rs:428:9
    |
 LL | /         match v {
 LL | |             [first, ..] => true,

--- a/tests/ui/match_like_matches_macro.stderr
+++ b/tests/ui/match_like_matches_macro.stderr
@@ -562,7 +562,133 @@ LL +         matches!(x, TestBindingNames2 { a: _, b: 1, .. } | TestBindingNames
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:450:9
+  --> tests/ui/match_like_matches_macro.rs:449:9
+   |
+LL | /         match (x, y) {
+LL | |             (MixedBindingNames { a, .. }, Some(x)) => true,
+LL | |             (MixedBindingNames { b, .. }, Some(y)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match (x, y) {
+LL -             (MixedBindingNames { a, .. }, Some(x)) => true,
+LL -             (MixedBindingNames { b, .. }, Some(y)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!((x, y), (MixedBindingNames { a: _, .. }, Some(_)) | (MixedBindingNames { b: _, .. }, Some(_)))
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:462:9
+   |
+LL | /         match x {
+LL | |             MixedNested { a: Some(x), b } => true,
+LL | |             MixedNested { a: Some(y), b: c } => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match x {
+LL -             MixedNested { a: Some(x), b } => true,
+LL -             MixedNested { a: Some(y), b: c } => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(x, MixedNested { a: Some(_), b: _ } | MixedNested { a: Some(_), b: _ })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:475:9
+   |
+LL | /         match x {
+LL | |             MixedFields { a, b: 1 } => true,
+LL | |             MixedFields { a: 2, b } => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match x {
+LL -             MixedFields { a, b: 1 } => true,
+LL -             MixedFields { a: 2, b } => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(x, MixedFields { a: _, b: 1 } | MixedFields { a: 2, b: _ })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:491:9
+   |
+LL | /         match x {
+LL | |             OuterStruct {
+LL | |                 inner: InnerStruct { x, .. },
+LL | |                 y: w,
+...  |
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL ~         matches!(x, OuterStruct {
+LL +                 inner: InnerStruct { x: _, .. },
+LL +                 y: _,
+LL +             } | OuterStruct {
+LL +                 inner: InnerStruct { x: _, .. },
+LL +                 y: _,
+LL +             })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:505:9
+   |
+LL | /         match x {
+LL | |             OuterStruct {
+LL | |                 inner: InnerStruct { x, .. },
+LL | |                 y,
+...  |
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL ~         matches!(x, OuterStruct {
+LL +                 inner: InnerStruct { x: _, .. },
+LL +                 y: _,
+LL +             } | OuterStruct {
+LL +                 inner: InnerStruct { x: _, .. },
+LL +                 y: _,
+LL +             })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:524:9
+   |
+LL | /         match x {
+LL | |             AdjacentShorthand { a, b } => true,
+LL | |             AdjacentShorthand { a: 1, b: 2 } => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match x {
+LL -             AdjacentShorthand { a, b } => true,
+LL -             AdjacentShorthand { a: 1, b: 2 } => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(x, AdjacentShorthand { a: _, b: _ } | AdjacentShorthand { a: 1, b: 2 })
+   |
+
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:538:9
    |
 LL | /         match e {
 LL | |             NestedTupleInEnum::A((x, y)) => true,
@@ -582,7 +708,7 @@ LL +         matches!(e, NestedTupleInEnum::A((_, _)) | NestedTupleInEnum::B((_,
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:468:9
+  --> tests/ui/match_like_matches_macro.rs:556:9
    |
 LL | /         match o {
 LL | |             Outer::A(Inner::X(x)) => true,
@@ -602,7 +728,7 @@ LL +         matches!(o, Outer::A(Inner::X(_)) | Outer::B(Inner::X(_)))
    |
 
 error: match expression looks like `matches!` macro
-  --> tests/ui/match_like_matches_macro.rs:486:9
+  --> tests/ui/match_like_matches_macro.rs:574:9
    |
 LL | /         match v {
 LL | |             [first, ..] => true,
@@ -621,5 +747,25 @@ LL -         }
 LL +         matches!(v, [_, ..] | [_, _])
    |
 
-error: aborting due to 32 previous errors
+error: match expression looks like `matches!` macro
+  --> tests/ui/match_like_matches_macro.rs:606:9
+   |
+LL | /         match v {
+LL | |             (Kind::A(Data { x, .. }), Some(y)) => true,
+LL | |             (Kind::B(Data { x: z, .. }), Some(w)) => true,
+LL | |             _ => false,
+LL | |         }
+   | |_________^
+   |
+help: use `matches!` directly
+   |
+LL -         match v {
+LL -             (Kind::A(Data { x, .. }), Some(y)) => true,
+LL -             (Kind::B(Data { x: z, .. }), Some(w)) => true,
+LL -             _ => false,
+LL -         }
+LL +         matches!(v, (Kind::A(Data { x: _, .. }), Some(_)) | (Kind::B(Data { x: _, .. }), Some(_)))
+   |
+
+error: aborting due to 39 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17505)*

changelog: [`match_like_matches_macro`]: avoid invalid bindings in suggestions

Fixes: rust-lang/rust-clippy#17503

This PR replaces unused variable bindings with `_` when generating suggestions for combined match arms. Previously, the lint could generate an uncompilable suggestion like:

```rs
matches!(match_type, MatchType::A(_str1) | MatchType::B(_str1, _str2))
```

After fix, the lint now generate compilable suggestions like:
```rs
matches!(match_type, MatchType::A(_) | MatchType::B(_, _))
```

The replacement is only applied when multiple arms are merged into an `Or` pattern, so single-arm suggestions keep their existing behavior.

### Notes
- `@` bindings now cause the lint to bail rather than generate an uncompilable suggestion.
- It seems like a false-negative exists on cases like `middle arm != first arm` which is not handled by this issue.
