### PR TITLE
excessive_nesting: Move excessive_nesting from complexity to pedantic

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -716,7 +716,7 @@ The maximum size of an enum's variant to avoid box suggestion
 ## `excessive-nesting-threshold`
 The maximum amount of nesting a block can reside in
 
-**Default Value:** `6`
+**Default Value:** `8`
 
 ---
 **Affected lints:**

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -716,7 +716,7 @@ The maximum size of an enum's variant to avoid box suggestion
 ## `excessive-nesting-threshold`
 The maximum amount of nesting a block can reside in
 
-**Default Value:** `0`
+**Default Value:** `6`
 
 ---
 **Affected lints:**

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -567,7 +567,7 @@ define_Conf! {
     enum_variant_size_threshold("enum-variant-size-threshold"): u64 = 200,
     /// The maximum amount of nesting a block can reside in
     #[lints(excessive_nesting)]
-    excessive_nesting_threshold("excessive-nesting-threshold"): u64 = 0,
+    excessive_nesting_threshold("excessive-nesting-threshold"): u64 = 6,
     /// The maximum byte size a `Future` can have, before it triggers the `clippy::large_futures` lint
     #[lints(large_futures)]
     future_size_threshold("future-size-threshold"): u64 = 16 * 1024,

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -567,7 +567,7 @@ define_Conf! {
     enum_variant_size_threshold("enum-variant-size-threshold"): u64 = 200,
     /// The maximum amount of nesting a block can reside in
     #[lints(excessive_nesting)]
-    excessive_nesting_threshold("excessive-nesting-threshold"): u64 = 6,
+    excessive_nesting_threshold("excessive-nesting-threshold"): u64 = 8,
     /// The maximum byte size a `Future` can have, before it triggers the `clippy::large_futures` lint
     #[lints(large_futures)]
     future_size_threshold("future-size-threshold"): u64 = 16 * 1024,

--- a/clippy_lints/src/excessive_nesting.rs
+++ b/clippy_lints/src/excessive_nesting.rs
@@ -12,7 +12,7 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for blocks which are nested beyond a certain threshold.
     ///
-    /// Note: Even though this lint is warn-by-default, it will only trigger if a maximum nesting level is defined in the clippy.toml file.
+    /// The default maximum nesting level is 6 and can be customized in the clippy.toml file.
     ///
     /// ### Why is this bad?
     /// It can severely hinder readability.
@@ -58,7 +58,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.72.0"]
     pub EXCESSIVE_NESTING,
-    complexity,
+    pedantic,
     "checks for blocks nested beyond a certain threshold"
 }
 

--- a/clippy_lints/src/excessive_nesting.rs
+++ b/clippy_lints/src/excessive_nesting.rs
@@ -12,7 +12,7 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for blocks which are nested beyond a certain threshold.
     ///
-    /// The default maximum nesting level is 6 and can be customized in the clippy.toml file.
+    /// The default maximum nesting level is 8 and can be customized in the clippy.toml file.
     ///
     /// ### Why is this bad?
     /// It can severely hinder readability.

--- a/tests/ui/excessive_nesting.rs
+++ b/tests/ui/excessive_nesting.rs
@@ -1,0 +1,87 @@
+#![warn(clippy::pedantic)]
+#![allow(clippy::let_and_return)]
+
+fn main() {
+    // This should trigger at level 7
+    let a = {
+        let b = {
+            let c = {
+                let d = {
+                    let e = {
+                        let f = { 42 };
+                        //~^ excessive_nesting
+                        f
+                    };
+                    e
+                };
+                d
+            };
+            c
+        };
+        b
+    };
+
+    // This should trigger at level 7
+    let x = {
+        let y = {
+            let z = {
+                let w = {
+                    let v = {
+                        let u = {
+                            //~^ excessive_nesting
+                            let t = { 42 };
+                            t
+                        };
+                        u
+                    };
+                    v
+                };
+                w
+            };
+            z
+        };
+        y
+    };
+}
+
+struct A;
+
+impl A {
+    fn test() {
+        // This should trigger at level 7
+        struct B;
+        impl B {
+            fn test() {
+                struct C;
+                impl C {
+                    fn test() {
+                        if true {
+                            //~^ excessive_nesting
+                            let x = { 1 };
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+trait TestTrait {
+    fn test() {
+        // This should trigger at level 7
+        struct B;
+        impl B {
+            fn test() {
+                struct C;
+                impl C {
+                    fn test() {
+                        if true {
+                            //~^ excessive_nesting
+                            let x = { 1 };
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/ui/excessive_nesting.rs
+++ b/tests/ui/excessive_nesting.rs
@@ -2,14 +2,13 @@
 #![allow(clippy::let_and_return)]
 
 fn main() {
-    // This should trigger at level 7
+    // This should not trigger
     let a = {
         let b = {
             let c = {
                 let d = {
                     let e = {
                         let f = { 42 };
-                        //~^ excessive_nesting
                         f
                     };
                     e
@@ -21,15 +20,18 @@ fn main() {
         b
     };
 
-    // This should trigger at level 7
+    // This should trigger at level 9
     let x = {
         let y = {
             let z = {
                 let w = {
                     let v = {
                         let u = {
-                            //~^ excessive_nesting
-                            let t = { 42 };
+                            let t = {
+                                let s = { 42 };
+                                //~^ excessive_nesting
+                                s
+                            };
                             t
                         };
                         u
@@ -48,16 +50,18 @@ struct A;
 
 impl A {
     fn test() {
-        // This should trigger at level 7
+        // This should trigger at level 9
         struct B;
         impl B {
             fn test() {
                 struct C;
                 impl C {
                     fn test() {
-                        if true {
-                            //~^ excessive_nesting
-                            let x = { 1 };
+                        {
+                            if true {
+                                let x = { 1 };
+                                //~^ excessive_nesting
+                            }
                         }
                     }
                 }
@@ -68,16 +72,18 @@ impl A {
 
 trait TestTrait {
     fn test() {
-        // This should trigger at level 7
+        // This should trigger at level 9
         struct B;
         impl B {
             fn test() {
                 struct C;
                 impl C {
                     fn test() {
-                        if true {
-                            //~^ excessive_nesting
-                            let x = { 1 };
+                        {
+                            if true {
+                                let x = { 1 };
+                                //~^ excessive_nesting
+                            }
                         }
                     }
                 }

--- a/tests/ui/excessive_nesting.stderr
+++ b/tests/ui/excessive_nesting.stderr
@@ -1,0 +1,49 @@
+error: this block is too nested
+  --> tests/ui/excessive_nesting.rs:13:33
+   |
+LL |                         let f = { 42 };
+   |                                 ^^^^^^
+   |
+   = help: try refactoring your code to minimize nesting
+   = note: `-D clippy::excessive-nesting` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::excessive_nesting)]`
+
+error: this block is too nested
+  --> tests/ui/excessive_nesting.rs:32:33
+   |
+LL |                           let u = {
+   |  _________________________________^
+LL | |
+LL | |                             let t = { 42 };
+LL | |                             t
+LL | |                         };
+   | |_________________________^
+   |
+   = help: try refactoring your code to minimize nesting
+
+error: this block is too nested
+  --> tests/ui/excessive_nesting.rs:60:33
+   |
+LL |                           if true {
+   |  _________________________________^
+LL | |
+LL | |                             let x = { 1 };
+LL | |                         }
+   | |_________________________^
+   |
+   = help: try refactoring your code to minimize nesting
+
+error: this block is too nested
+  --> tests/ui/excessive_nesting.rs:80:33
+   |
+LL |                           if true {
+   |  _________________________________^
+LL | |
+LL | |                             let x = { 1 };
+LL | |                         }
+   | |_________________________^
+   |
+   = help: try refactoring your code to minimize nesting
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/excessive_nesting.stderr
+++ b/tests/ui/excessive_nesting.stderr
@@ -1,5 +1,5 @@
 error: this block is too nested
-  --> tests/ui/excessive_nesting.rs:13:33
+  --> tests/ui/excessive_nesting.rs:11:33
    |
 LL |                         let f = { 42 };
    |                                 ^^^^^^
@@ -9,7 +9,7 @@ LL |                         let f = { 42 };
    = help: to override `-D warnings` add `#[allow(clippy::excessive_nesting)]`
 
 error: this block is too nested
-  --> tests/ui/excessive_nesting.rs:32:33
+  --> tests/ui/excessive_nesting.rs:30:33
    |
 LL |                           let u = {
    |  _________________________________^
@@ -22,7 +22,7 @@ LL | |                         };
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> tests/ui/excessive_nesting.rs:60:33
+  --> tests/ui/excessive_nesting.rs:58:33
    |
 LL |                           if true {
    |  _________________________________^
@@ -34,7 +34,7 @@ LL | |                         }
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> tests/ui/excessive_nesting.rs:80:33
+  --> tests/ui/excessive_nesting.rs:78:33
    |
 LL |                           if true {
    |  _________________________________^

--- a/tests/ui/excessive_nesting.stderr
+++ b/tests/ui/excessive_nesting.stderr
@@ -1,49 +1,28 @@
 error: this block is too nested
-  --> tests/ui/excessive_nesting.rs:11:33
+  --> tests/ui/excessive_nesting.rs:31:41
    |
-LL |                         let f = { 42 };
-   |                                 ^^^^^^
+LL | ...                   let s = { 42 };
+   |                               ^^^^^^
    |
    = help: try refactoring your code to minimize nesting
    = note: `-D clippy::excessive-nesting` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::excessive_nesting)]`
 
 error: this block is too nested
-  --> tests/ui/excessive_nesting.rs:30:33
+  --> tests/ui/excessive_nesting.rs:62:41
    |
-LL |                           let u = {
-   |  _________________________________^
-LL | |
-LL | |                             let t = { 42 };
-LL | |                             t
-LL | |                         };
-   | |_________________________^
+LL | ...                   let x = { 1 };
+   |                               ^^^^^
    |
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> tests/ui/excessive_nesting.rs:58:33
+  --> tests/ui/excessive_nesting.rs:84:41
    |
-LL |                           if true {
-   |  _________________________________^
-LL | |
-LL | |                             let x = { 1 };
-LL | |                         }
-   | |_________________________^
+LL | ...                   let x = { 1 };
+   |                               ^^^^^
    |
    = help: try refactoring your code to minimize nesting
 
-error: this block is too nested
-  --> tests/ui/excessive_nesting.rs:78:33
-   |
-LL |                           if true {
-   |  _________________________________^
-LL | |
-LL | |                             let x = { 1 };
-LL | |                         }
-   | |_________________________^
-   |
-   = help: try refactoring your code to minimize nesting
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust-clippy/issues/14923

- Move excessive_nesting to pedantic
- Set default value 6 and update line doc comment
- Add UI test

```
changelog: [`excessive_nesting`]: Move it from the `complexity` group to `pedantic`
```


<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_CONCERN-ISSUE_START -->

> [!CAUTION]
> # Concerns (1 active)
>
> - [Too many hits](https://github.com/rust-lang/rust-clippy/pull/17509#issuecomment-5201715254)
>
> *Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/concern.html) for details.*

<!-- TRIAGEBOT_CONCERN-ISSUE_END -->
<!-- TRIAGEBOT_END -->