### PR TITLE
approx_const.rs: fix typo (golden_ration -> golden_ratio)

### DIFF
--- a/tests/ui/approx_const.rs
+++ b/tests/ui/approx_const.rs
@@ -115,13 +115,13 @@ fn main() {
 
     let no_euler_gamma = 0.577;
 
-    let my_golden_ration = 1.618033988749895;
+    let my_golden_ratio = 1.618033988749895;
     //~^ approx_constant
 
-    let almost_golden_ration = 1.6180;
+    let almost_golden_ratio = 1.6180;
     //~^ approx_constant
 
-    let no_almost_golden_ration = 1.618;
+    let no_almost_golden_ratio = 1.618;
 
     // issue #15194
     #[allow(clippy::excessive_precision)]

--- a/tests/ui/approx_const.stderr
+++ b/tests/ui/approx_const.stderr
@@ -201,18 +201,18 @@ LL |     let almost_euler_gamma = 0.5772;
    = help: consider using the constant directly
 
 error: approximate value of `f{32, 64}::consts::GOLDEN_RATIO` found
-  --> tests/ui/approx_const.rs:118:28
+  --> tests/ui/approx_const.rs:118:27
    |
-LL |     let my_golden_ration = 1.618033988749895;
-   |                            ^^^^^^^^^^^^^^^^^
+LL |     let my_golden_ratio = 1.618033988749895;
+   |                           ^^^^^^^^^^^^^^^^^
    |
    = help: consider using the constant directly
 
 error: approximate value of `f{32, 64}::consts::GOLDEN_RATIO` found
-  --> tests/ui/approx_const.rs:121:32
+  --> tests/ui/approx_const.rs:121:31
    |
-LL |     let almost_golden_ration = 1.6180;
-   |                                ^^^^^^
+LL |     let almost_golden_ratio = 1.6180;
+   |                               ^^^^^^
    |
    = help: consider using the constant directly
 


### PR DESCRIPTION
changelog: none