### PR TITLE
Use `is_from_proc_macro` instead of using snippet

### DIFF
--- a/clippy_lints/src/excessive_nesting.rs
+++ b/clippy_lints/src/excessive_nesting.rs
@@ -1,6 +1,6 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_help;
-use clippy_utils::source::snippet;
+use clippy_utils::is_from_proc_macro;
 use rustc_ast::node_id::NodeSet;
 use rustc_ast::visit::{Visitor, walk_block, walk_item};
 use rustc_ast::{Block, Crate, Inline, Item, ItemKind, ModKind, NodeId};
@@ -143,10 +143,7 @@ impl Visitor<'_> for NestingVisitor<'_, '_> {
             return;
         }
 
-        // TODO: This should be rewritten using `LateLintPass` so we can use `is_from_proc_macro` instead,
-        // but for now, this is fine.
-        let snippet = snippet(self.cx, block.span, "{}").trim().to_owned();
-        if !snippet.starts_with('{') || !snippet.ends_with('}') {
+        if is_from_proc_macro(self.cx, block) {
             return;
         }
 

--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -13,19 +13,17 @@
 //! if the span is not from a `macro_rules` based macro.
 
 use rustc_abi::ExternAbi;
-use rustc_ast as ast;
-use rustc_ast::AttrStyle;
 use rustc_ast::ast::{
     AttrKind, Attribute, BindingMode, GenericArgs, IntTy, LitIntType, LitKind, StrStyle, TraitObjectSyntax, UintTy,
 };
 use rustc_ast::token::CommentKind;
+use rustc_ast::{self as ast, AttrStyle, Block, BlockCheckMode};
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{
-    Block, BlockCheckMode, Body, BoundConstness, BoundPolarity, Closure, Destination, Expr, ExprKind, FieldDef,
-    FnHeader, FnRetTy, HirId, Impl, ImplItem, ImplItemImplKind, ImplItemKind, IsAuto, Item, ItemKind, Lit, LoopSource,
-    MatchSource, MutTy, Node, PatExpr, PatExprKind, PatKind, Path, PolyTraitRef, QPath, Safety, TraitBoundModifiers,
-    TraitImplHeader, TraitItem, TraitItemKind, TraitRef, Ty, TyKind, UnOp, UnsafeSource, Variant, VariantData,
-    YieldSource,
+    Body, BoundConstness, BoundPolarity, Closure, Destination, Expr, ExprKind, FieldDef, FnHeader, FnRetTy, HirId,
+    Impl, ImplItem, ImplItemImplKind, ImplItemKind, IsAuto, Item, ItemKind, Lit, LoopSource, MatchSource, MutTy, Node,
+    PatExpr, PatExprKind, PatKind, Path, PolyTraitRef, QPath, Safety, TraitBoundModifiers, TraitImplHeader, TraitItem,
+    TraitItemKind, TraitRef, Ty, TyKind, UnOp, UnsafeSource, Variant, VariantData, YieldSource,
 };
 use rustc_lint::{EarlyContext, LateContext, LintContext};
 use rustc_middle::ty::TyCtxt;
@@ -209,8 +207,8 @@ fn expr_search_pat(tcx: TyCtxt<'_>, e: &Expr<'_>) -> (Pat, Pat) {
                 expr_search_pat_inner(tcx, tcx.hir_body(body).value, outer_span).1,
             ),
             ExprKind::Block(
-                Block {
-                    rules: BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided),
+                rustc_hir::Block {
+                    rules: rustc_hir::BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided),
                     ..
                 },
                 None,
@@ -293,6 +291,17 @@ fn item_search_pat(item: &Item<'_>) -> (Pat, Pat) {
         (start_pat, end_pat)
     } else {
         (Pat::Str("pub"), end_pat)
+    }
+}
+
+fn block_search_pat(block: &Block) -> (Pat, Pat) {
+    if matches!(
+        block.rules,
+        BlockCheckMode::Unsafe(rustc_ast::UnsafeSource::UserProvided)
+    ) {
+        (Pat::Str("unsafe"), Pat::Str("}"))
+    } else {
+        (Pat::Str("{"), Pat::Str("}"))
     }
 }
 
@@ -718,6 +727,7 @@ impl_with_search_pat!((cx: LateContext<'tcx>, self: rustc_hir::Pat<'_>) => pat_s
 
 impl_with_search_pat!((_cx: EarlyContext<'tcx>, self: Attribute) => attr_search_pat(self));
 impl_with_search_pat!((_cx: EarlyContext<'tcx>, self: ast::Ty) => ast_ty_search_pat(self));
+impl_with_search_pat!((_cx: EarlyContext<'tcx>, self: Block) => block_search_pat(self));
 
 impl<'cx> WithSearchPat<'cx> for (&FnKind<'cx>, &Body<'cx>, HirId, Span) {
     type Context = LateContext<'cx>;

--- a/tests/ui-toml/excessive_nesting/excessive_nesting.rs
+++ b/tests/ui-toml/excessive_nesting/excessive_nesting.rs
@@ -222,6 +222,9 @@ fn main() {
             }
         }
     }
+
+    let _ = unsafe {{{{{{{{{{{ todo!() }}}}}}}}}}};
+    //~^ excessive_nesting
 }
 
 async fn b() -> u32 {

--- a/tests/ui-toml/excessive_nesting/excessive_nesting.stderr
+++ b/tests/ui-toml/excessive_nesting/excessive_nesting.stderr
@@ -300,7 +300,15 @@ LL | |                 }
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> tests/ui-toml/excessive_nesting/excessive_nesting.rs:228:28
+  --> tests/ui-toml/excessive_nesting/excessive_nesting.rs:226:23
+   |
+LL |     let _ = unsafe {{{{{{{{{{{ todo!() }}}}}}}}}}};
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try refactoring your code to minimize nesting
+
+error: this block is too nested
+  --> tests/ui-toml/excessive_nesting/excessive_nesting.rs:231:28
    |
 LL |     async fn c() -> u32 {{{{{{{0}}}}}}}
    |                            ^^^^^^^^^
@@ -308,12 +316,12 @@ LL |     async fn c() -> u32 {{{{{{{0}}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> tests/ui-toml/excessive_nesting/excessive_nesting.rs:235:8
+  --> tests/ui-toml/excessive_nesting/excessive_nesting.rs:238:8
    |
 LL |     {{{{b().await}}}};
    |        ^^^^^^^^^^^
    |
    = help: try refactoring your code to minimize nesting
 
-error: aborting due to 37 previous errors
+error: aborting due to 38 previous errors
 


### PR DESCRIPTION
changelog: [`excessive_nesting`]: lint unsafe blocks.
