### PR TITLE
fix: skip `redundant_field_names` lint on macro-generated code

### DIFF
--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -60,6 +60,7 @@ impl EarlyLintPass for RedundantFieldNames {
                     && segment.ident == field.ident
                     && field.span.eq_ctxt(field.ident.span)
                     && !field.span.in_external_macro(cx.sess().source_map())
+                    && !field.span.from_expansion()
                 {
                     span_lint_and_sugg(
                         cx,

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -75,7 +75,6 @@ fn main() {
     macro_rules! internal {
         ($i:ident) => {
             let _ = S { v: v };
-            //~^ redundant_field_names
             let _ = S { $i: v };
             let _ = S { v: $i };
             let _ = S { $i: $i };

--- a/tests/ui/redundant_field_names.stderr
+++ b/tests/ui/redundant_field_names.stderr
@@ -44,21 +44,10 @@ LL |     let _ = RangeToInclusive { end: end };
    |                                ^^^^^^^^ help: replace it with: `end`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:77:25
-   |
-LL |             let _ = S { v: v };
-   |                         ^^^^ help: replace it with: `v`
-...
-LL |     internal!(v);
-   |     ------------ in this macro invocation
-   |
-   = note: this error originates in the macro `internal` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: redundant field names in struct initialization
   --> tests/ui/redundant_field_names.rs:106:25
    |
 LL |     let _ = RangeFrom { start: start };
    |                         ^^^^^^^^^^^^ help: replace it with: `start`
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17525

`redundant_field_names` was firing on code generated by proc-macro derives (e.g., `thiserror::Error`), where the user cannot control the generated expansion. This adds a `!field.span.from_expansion()` guard to skip linting any code from macro expansions, including proc-macro derive output.

## Changes
- `clippy_lints/src/redundant_field_names.rs`: added `&& !field.span.from_expansion()` check
- `tests/ui/redundant_field_names.rs`: removed `internal!` macro lint expectation (now skipped by `from_expansion()` check)
- `tests/ui/redundant_field_names.stderr`: updated expected error count from 9 to 8