### PR TITLE
Resolve swap_remove correctness doubt in only_used_in_recursion

### DIFF
--- a/clippy_lints/src/only_used_in_recursion.rs
+++ b/clippy_lints/src/only_used_in_recursion.rs
@@ -238,7 +238,9 @@ impl Params {
             param.uses = Vec::new();
             let key = (param.fn_id, param.idx);
             self.by_fn.remove(&key);
-            // FIXME(rust/#120456) - is `swap_remove` correct?
+            // `swap_remove` is correct here: `by_id` is never iterated in insertion
+            // order anywhere in this file (only `insert`, `get`, and `clear` are used
+            // elsewhere), so the reordering side effect of `swap_remove` is unobservable.
             self.by_id.swap_remove(&id);
         }
     }


### PR DESCRIPTION
`Params::by_id` in `only_used_in_recursion.rs` is only ever accessed by
key (`insert`, `get`, `clear`) and is never iterated in insertion order
anywhere in the file. The `swap_remove` reordering side effect is
therefore unobservable, so `swap_remove` is correct as written.

This replaces the long-standing `FIXME(rust/#120456)` doubt comment
with an explanation of why the current code is already sound, so
future contributors don't spend time re-investigating it.

No behavior change.

changelog: none