### PR TITLE
[cast_possible_truncation]: fix try_from suggestion expanding macros

### DIFF
--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -184,16 +184,18 @@ fn offer_suggestion(
     diag: &mut Diag<'_, ()>,
 ) {
     let cast_to_snip = snippet(cx, cast_to_span, "..");
+    let mut applicability = Applicability::Unspecified;
+    let sugg = Sugg::hir_with_context(cx, cast_expr, expr.span.ctxt(), "..", &mut applicability);
     let suggestion = if cast_to_snip == "_" {
-        format!("{}.try_into()", Sugg::hir(cx, cast_expr, "..").maybe_paren())
+        format!("{}.try_into()", sugg.maybe_paren())
     } else {
-        format!("{cast_to_snip}::try_from({})", Sugg::hir(cx, cast_expr, ".."))
+        format!("{cast_to_snip}::try_from({sugg})")
     };
 
     diag.span_suggestion_verbose(
         expr.span,
         "... or use `try_from` and handle the error accordingly",
         suggestion,
-        Applicability::Unspecified,
+        applicability,
     );
 }

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -592,3 +592,13 @@ fn issue16045() {
         Ok(())
     }
 }
+
+fn issue_17501() {
+    macro_rules! cast_from_macro {
+        () => {
+            5_i64
+        };
+    }
+    let _ = cast_from_macro!() as i32;
+    //~^ cast_possible_truncation
+}

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -770,5 +770,18 @@ error: casting `u8` to `i8` may wrap around the value
 LL |         _ = val? as i8;
    |             ^^^^^^^^^^ help: if this is intentional, use `cast_signed()` instead: `val?.cast_signed()`
 
-error: aborting due to 95 previous errors
+error: casting `i64` to `i32` may truncate the value
+  --> tests/ui/cast.rs:602:13
+   |
+LL |     let _ = cast_from_macro!() as i32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL -     let _ = cast_from_macro!() as i32;
+LL +     let _ = i32::try_from(cast_from_macro!());
+   |
+
+error: aborting due to 96 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17501

changelog: [`cast_possible_truncation`]: fix `try_from` suggestion expanding macros instead of showing the macro call
