### PR TITLE
fix(pattern_type_mismatch): honor match arm expectations

### DIFF
--- a/clippy_lints/src/pattern_type_mismatch.rs
+++ b/clippy_lints/src/pattern_type_mismatch.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_hir::{
     Body, Expr, ExprKind, FnDecl, LetExpr, LocalSource, Mutability, Pat, PatKind, Stmt, StmtKind, intravisit,
 };
@@ -138,10 +138,10 @@ enum DerefPossible {
 fn apply_lint(cx: &LateContext<'_>, pat: &Pat<'_>, deref_possible: DerefPossible) -> bool {
     let maybe_mismatch = find_first_mismatch(cx, pat);
     if let Some((span, mutability, level)) = maybe_mismatch {
-        #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
-        span_lint_and_then(
+        span_lint_hir_and_then(
             cx,
             PATTERN_TYPE_MISMATCH,
+            pat.hir_id,
             span,
             "type of pattern does not match the expression type",
             |diag| {

--- a/tests/ui/pattern_type_mismatch/expect_match_arm.rs
+++ b/tests/ui/pattern_type_mismatch/expect_match_arm.rs
@@ -1,0 +1,42 @@
+//@check-pass
+#![warn(clippy::pattern_type_mismatch)]
+#![allow(clippy::match_like_matches_macro)]
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+enum Expr {
+    Boolean(Box<bool>),
+    Number(Box<i64>),
+    Boxed(Box<Expr>),
+    Other(String),
+}
+
+impl Expr {
+    fn is_scalar(&self) -> bool {
+        match self {
+            &Expr::Boolean(_) | &Expr::Number(_) => true,
+            #[expect(
+                clippy::pattern_type_mismatch,
+                reason = "Conflicts with clippy::needless_borrowed_references"
+            )]
+            Expr::Boxed(inner) => inner.is_scalar(),
+            _ => false,
+        }
+    }
+
+    fn is_other(&self) -> bool {
+        #[expect(clippy::pattern_type_mismatch, reason = "Works on overall match")]
+        match self {
+            #[expect(unused_variables, reason = "Expect works on match arms")]
+            Expr::Other(s) => true,
+            _ => false,
+        }
+    }
+}
+
+fn main() {
+    assert!(Expr::Boolean(Box::new(true)).is_scalar());
+    assert!(Expr::Number(Box::new(5)).is_scalar());
+    assert!(Expr::Boxed(Box::new(Expr::Boolean(Box::new(true)))).is_scalar());
+    assert!(!Expr::Other(String::new()).is_scalar());
+    assert!(Expr::Other(String::new()).is_other());
+}


### PR DESCRIPTION
## Summary

Fix rust-lang/rust-clippy#17494 by emitting `pattern_type_mismatch` with the affected pattern's HIR ID. This lets `#[expect(clippy::pattern_type_mismatch)]` attached to an individual match arm suppress the diagnostic, while preserving the existing diagnostic span and behavior for other patterns.

A regression test covers both an expectation on one match arm and an expectation on the complete match expression.

## Testing

- `rustfmt --check clippy_lints/src/pattern_type_mismatch.rs`
- `cargo test --test compile-test -- pattern_type_mismatch` *(blocked locally because the Homebrew Rust installation does not include the `rustc-dev` component required to build Clippy)*

## Changelog

changelog: Fix `pattern_type_mismatch` expectations on individual match arms.

## AI disclosure

This draft was prepared with OpenAI Codex assistance; no human-review or passing-test claim is being made yet.