### PR TITLE
New lint: `doc_attr_ordering` doc comments and attributes precede other attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6867,6 +6867,7 @@ Released 2018-09-13
 [`disallowed_type`]: https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_type
 [`disallowed_types`]: https://rust-lang.github.io/rust-clippy/main/index.html#disallowed_types
 [`diverging_sub_expression`]: https://rust-lang.github.io/rust-clippy/main/index.html#diverging_sub_expression
+[`doc_attr_ordering`]: https://rust-lang.github.io/rust-clippy/main/index.html#doc_attr_ordering
 [`doc_broken_link`]: https://rust-lang.github.io/rust-clippy/main/index.html#doc_broken_link
 [`doc_comment_double_space_linebreaks`]: https://rust-lang.github.io/rust-clippy/main/index.html#doc_comment_double_space_linebreaks
 [`doc_include_without_cfg`]: https://rust-lang.github.io/rust-clippy/main/index.html#doc_include_without_cfg

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -120,26 +120,25 @@ enum DevCommand {
     Bless,
     /// Runs the dogfood test
     Dogfood {
-        #[arg(long)]
         /// Apply the suggestions when possible
+        #[arg(long)]
         fix: bool,
-        #[arg(long, requires = "fix")]
         /// Fix code even if the working directory has changes
+        #[arg(long, requires = "fix")]
         allow_dirty: bool,
-        #[arg(long, requires = "fix")]
         /// Fix code even if the working directory has staged changes
-        allow_staged: bool,
         #[arg(long, requires = "fix")]
+        allow_staged: bool,
         /// Fix code even if a VCS was not detected
+        #[arg(long, requires = "fix")]
         allow_no_vcs: bool,
     },
     /// Run rustfmt on all projects and tests
     Fmt {
-        #[arg(long)]
         /// Use the rustfmt --check option
+        #[arg(long)]
         check: bool,
     },
-    #[command(name = "update_lints")]
     /// Updates lint registration and information from the source code
     ///
     /// Makes sure that: {n}
@@ -148,24 +147,26 @@ enum DevCommand {
     /// * all lint groups include the correct lints {n}
     /// * lint modules in `clippy_lints/*` are visible in `src/lib.rs` via `pub mod` {n}
     /// * all lints are registered in the lint store
+    #[command(name = "update_lints")]
     UpdateLints {
-        #[arg(long)]
         /// Checks that `cargo dev update_lints` has been run. Used on CI.
+        #[arg(long)]
         check: bool,
     },
-    #[command(name = "new_lint")]
     /// Create a new lint and run `cargo dev update_lints`
+    #[command(name = "new_lint")]
     NewLint {
-        #[arg(short, long, conflicts_with = "type", default_value = "late")]
         /// Specify whether the lint runs during the early or late pass
+        #[arg(short, long, conflicts_with = "type", default_value = "late")]
         pass: new_lint::Pass,
+        /// Name of the new lint in snake case, ex: `fn_too_long`
         #[arg(
             short,
             long,
             value_parser = lint_name,
         )]
-        /// Name of the new lint in snake case, ex: `fn_too_long`
         name: String,
+        /// What category the lint belongs to
         #[arg(
             short,
             long,
@@ -182,13 +183,12 @@ enum DevCommand {
             ],
             default_value = "nursery",
         )]
-        /// What category the lint belongs to
         category: String,
-        #[arg(long)]
         /// What directory the lint belongs in
-        r#type: Option<String>,
         #[arg(long)]
+        r#type: Option<String>,
         /// Add MSRV config code to the lint
+        #[arg(long)]
         msrv: bool,
     },
     /// Support for setting up your personal development environment
@@ -197,14 +197,14 @@ enum DevCommand {
     Remove(RemoveCommand),
     /// Launch a local 'ALL the Clippy Lints' website in a browser
     Serve {
-        #[arg(short, long, default_value = "8000")]
         /// Local port for the http server
+        #[arg(short, long, default_value = "8000")]
         port: u16,
-        #[arg(long)]
         /// Which lint's page to load initially (optional)
+        #[arg(long)]
         lint: Option<String>,
     },
-    #[expect(clippy::doc_markdown)]
+    #[expect(clippy::doc_markdown, clippy::doc_attr_ordering)]
     /// Manually run clippy on a file or package
     ///
     /// ## Examples
@@ -231,14 +231,14 @@ enum DevCommand {
         /// Pass extra arguments to cargo/clippy-driver
         args: Vec<String>,
     },
-    #[command(name = "rename_lint")]
     /// Rename a lint
+    #[command(name = "rename_lint")]
     RenameLint {
         /// The name of the lint to rename
         #[arg(value_parser = lint_name)]
         old_name: String,
-        #[arg(value_parser = lint_name)]
         /// The new name of the lint
+        #[arg(value_parser = lint_name)]
         new_name: String,
     },
     /// Deprecate the given lint
@@ -246,8 +246,8 @@ enum DevCommand {
         /// The name of the lint to deprecate
         #[arg(value_parser = lint_name)]
         name: String,
-        #[arg(long, short)]
         /// The reason for deprecation
+        #[arg(long, short)]
         reason: String,
     },
     /// Sync between the rust repo and the Clippy repo
@@ -275,20 +275,20 @@ struct SetupCommand {
 enum SetupSubcommand {
     /// Alter dependencies so Intellij Rust can find rustc internals
     Intellij {
-        #[arg(long)]
         /// Remove the dependencies added with 'cargo dev setup intellij'
+        #[arg(long)]
         remove: bool,
-        #[arg(long, short, conflicts_with = "remove")]
         /// The path to a rustc repo that will be used for setting the dependencies
+        #[arg(long, short, conflicts_with = "remove")]
         repo_path: String,
     },
     /// Add a pre-commit git hook that formats your code to make it look pretty
     GitHook {
-        #[arg(long)]
         /// Remove the pre-commit hook added with 'cargo dev setup git-hook'
+        #[arg(long)]
         remove: bool,
-        #[arg(long, short)]
         /// Forces the override of an existing git pre-commit hook
+        #[arg(long, short)]
         force_override: bool,
     },
     /// Install a rustup toolchain pointing to the local clippy build
@@ -297,30 +297,30 @@ enum SetupSubcommand {
     /// `target/.../{clippy-driver,cargo-clippy}`, rebuilds of the project will be reflected in the
     /// created toolchain unless `--standalone` is passed
     Toolchain {
-        #[arg(long, short)]
         /// Create a standalone toolchain by copying the clippy binaries instead
         /// of symlinking them
         ///
         /// Use this for example to create a toolchain, make a small change and then make another
         /// toolchain with a different name in order to easily compare the two
+        #[arg(long, short)]
         standalone: bool,
-        #[arg(long, short)]
         /// Override an existing toolchain
-        force: bool,
         #[arg(long, short)]
+        force: bool,
         /// Point to --release clippy binary
+        #[arg(long, short)]
         release: bool,
-        #[arg(long, short, default_value = "clippy")]
         /// Name of the toolchain
+        #[arg(long, short, default_value = "clippy")]
         name: String,
     },
     /// Add several tasks to vscode for formatting, validation and testing
     VscodeTasks {
-        #[arg(long)]
         /// Remove the tasks added with 'cargo dev setup vscode-tasks'
+        #[arg(long)]
         remove: bool,
-        #[arg(long, short)]
         /// Forces the override of existing vscode tasks
+        #[arg(long, short)]
         force_override: bool,
     },
 }
@@ -349,8 +349,8 @@ struct SyncCommand {
 
 #[derive(Subcommand)]
 enum SyncSubcommand {
-    #[command(name = "update_nightly")]
     /// Update nightly version in `rust-toolchain.toml` and `clippy_utils`
+    #[command(name = "update_nightly")]
     UpdateNightly,
 }
 
@@ -362,7 +362,7 @@ struct ReleaseCommand {
 
 #[derive(Subcommand)]
 enum ReleaseSubcommand {
-    #[command(name = "bump_version")]
     /// Bump the version in the Cargo.toml files
+    #[command(name = "bump_version")]
     BumpVersion,
 }

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -136,6 +136,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::doc::TEST_ATTR_IN_DOCTEST_INFO,
     crate::doc::TOO_LONG_FIRST_DOC_PARAGRAPH_INFO,
     crate::doc::UNNECESSARY_SAFETY_DOC_INFO,
+    crate::doc_attr_ordering::DOC_ATTR_ORDERING_INFO,
     crate::double_parens::DOUBLE_PARENS_INFO,
     crate::drop_forget_ref::DROP_NON_DROP_INFO,
     crate::drop_forget_ref::FORGET_NON_DROP_INFO,

--- a/clippy_lints/src/doc/doc_paragraphs_missing_punctuation.rs
+++ b/clippy_lints/src/doc/doc_paragraphs_missing_punctuation.rs
@@ -43,8 +43,8 @@ pub fn check(cx: &LateContext<'_>, doc: &str, fragments: Fragments<'_>) {
     }
 }
 
-#[must_use]
 /// If punctuation is missing, returns the offset where new punctuation should be inserted.
+#[must_use]
 fn is_missing_punctuation(doc_string: &str) -> Vec<MissingPunctuation> {
     // The colon is not exactly a terminal punctuation mark, but this is required for paragraphs that
     // introduce a table or a list for example.

--- a/clippy_lints/src/doc_attr_ordering.rs
+++ b/clippy_lints/src/doc_attr_ordering.rs
@@ -1,0 +1,113 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_ast::ast::{AttrId, AttrKind, AttrStyle, Attribute, SyntheticAttr};
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::impl_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Ensures that doc comments and attributes appear before other attributes.
+    ///
+    /// ### Why is this bad?
+    /// Documentation can be lengthy, which can cause relevant attributes to
+    /// be separated from the code they affect by a significant distance.
+    /// That can make it easy to miss critical attributes.
+    ///
+    /// This lint presently applies only to outer attributes ("`#[...`"),
+    /// not inner attributes ("`#![...`"). Inner attributes, which appear at the
+    /// top of modules/files, have less reason to be strictly ordered.
+    /// In future, this lint might be updated to check inner attributes.
+    ///
+    /// ### Why does this miss some cases?
+    /// Some attributes are not visible to this lint, including `#[derive...]`,
+    /// any `#[cfg_attr(pred, ...)]` where the predicate evaluates to false,
+    /// and any other attributes that the compiler removes before this lint runs.
+    ///
+    /// This lint accepts `#[cfg_attr(..., doc = "")]` mixed with documentation.
+    /// This pattern is therefore allowed in documentation.  For example, this
+    /// can ensure that doc tests are ignored for disabled features.
+    ///
+    /// ### Why this cannot be fixed automatically
+    /// Some attributes, such as proc macros, might depend on specific ordering,
+    /// such that changing their order attributes could affect program behavior.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #[test]
+    /// /// Documentation should precede other attributes.
+    /// fn check() {}
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// /// Documentation should precede other attributes.
+    /// #[test]
+    /// fn check() {}
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub DOC_ATTR_ORDERING,
+    pedantic,
+    "doc attribute ordering"
+}
+
+impl_lint_pass!(DocAttrOrdering => [DOC_ATTR_ORDERING]);
+
+#[derive(Default)]
+pub struct DocAttrOrdering {
+    /// Statements share their attributes with the node they wrap, so
+    /// `check_attributes` is run twice. The two visits are adjacent,
+    /// so remembering the last scan is enough to avoid duplicates.
+    last: Option<AttrId>,
+}
+
+impl DocAttrOrdering {
+    fn needs_checking(&mut self, attrs: &[Attribute]) -> bool {
+        if attrs.is_empty() {
+            false
+        } else {
+            let id = attrs.first().map(|a| a.id);
+            if self.last == id {
+                false
+            } else {
+                self.last = id;
+                true
+            }
+        }
+    }
+}
+
+impl EarlyLintPass for DocAttrOrdering {
+    fn check_attributes(&mut self, cx: &EarlyContext<'_>, attrs: &[Attribute]) {
+        if self.needs_checking(attrs) {
+            let mut first_non_doc = None;
+            for attr in attrs {
+                if attr.style != AttrStyle::Outer {
+                    continue;
+                }
+                if let AttrKind::Synthetic(ref synth) = attr.kind
+                    && matches!(**synth, SyntheticAttr::CfgAttrTrace(..))
+                {
+                    // Skip `cfg_attr` so that `#[cfg_attr(..., doc = "...")]` is accepted.
+                    // Any enabled attribute(s) that are produced will be checked separately.
+                    continue;
+                }
+
+                if attr.doc_str().is_some() {
+                    if first_non_doc.is_none() {
+                        continue;
+                    }
+                    span_lint_and_help(
+                        cx,
+                        DOC_ATTR_ORDERING,
+                        attr.span,
+                        "doc comments and attributes should precede other attributes",
+                        first_non_doc,
+                        "place any doc comments and attributes before this attribute",
+                    );
+                    return;
+                }
+                if first_non_doc.is_none() {
+                    first_non_doc = Some(attr.span);
+                }
+            }
+        }
+    }
+}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -112,6 +112,7 @@ mod disallowed_names;
 mod disallowed_script_idents;
 mod disallowed_types;
 mod doc;
+mod doc_attr_ordering;
 mod double_parens;
 mod drop_forget_ref;
 mod duplicate_mod;
@@ -542,6 +543,7 @@ rustc_lint::early_lint_methods!(
         EmptyLineAfter: empty_line_after::EmptyLineAfter = empty_line_after::EmptyLineAfter::new(),
         InlineTraitBounds: inline_trait_bounds::InlineTraitBounds = inline_trait_bounds::InlineTraitBounds::default(),
         DefinitionInModuleRoot: definition_in_module_root::DefinitionInModuleRoot = definition_in_module_root::DefinitionInModuleRoot::default(),
+        DocAttrOrdering: doc_attr_ordering::DocAttrOrdering = doc_attr_ordering::DocAttrOrdering::default(),
         // add early passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_utils/src/attrs.rs
+++ b/clippy_utils/src/attrs.rs
@@ -145,8 +145,8 @@ impl Drop for LimitStack {
 
 #[expect(missing_docs, reason = "they're all trivial...")]
 impl LimitStack {
-    #[must_use]
     /// Initialize the stack starting with a default value, which usually comes from configuration
+    #[must_use]
     pub fn new(limit: u64) -> Self {
         Self {
             default: limit,

--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -68,8 +68,8 @@ pub struct If<'hir> {
 }
 
 impl<'hir> If<'hir> {
-    #[inline]
     /// Parses an `if` expression without `let`
+    #[inline]
     pub const fn hir(expr: &Expr<'hir>) -> Option<Self> {
         if let ExprKind::If(cond, then, r#else) = expr.kind
             && !has_let_expr(cond)
@@ -191,8 +191,8 @@ pub struct IfOrIfLet<'hir> {
 }
 
 impl<'hir> IfOrIfLet<'hir> {
-    #[inline]
     /// Parses an `if` or `if let` expression
+    #[inline]
     pub const fn hir(expr: &Expr<'hir>) -> Option<Self> {
         if let ExprKind::If(cond, then, r#else) = expr.kind {
             Some(Self { cond, then, r#else })
@@ -406,8 +406,8 @@ pub struct While<'hir> {
 }
 
 impl<'hir> While<'hir> {
-    #[inline]
     /// Parses a desugared `while` loop
+    #[inline]
     pub const fn hir(expr: &Expr<'hir>) -> Option<Self> {
         if let ExprKind::Loop(
             Block {
@@ -450,8 +450,8 @@ pub struct WhileLet<'hir> {
 }
 
 impl<'hir> WhileLet<'hir> {
-    #[inline]
     /// Parses a desugared `while let` loop
+    #[inline]
     pub const fn hir(expr: &Expr<'hir>) -> Option<Self> {
         if let ExprKind::Loop(
             &Block {

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1648,15 +1648,15 @@ pub fn int_bits(tcx: TyCtxt<'_>, ity: IntTy) -> u64 {
     Integer::from_int_ty(&tcx, ity).size().bits()
 }
 
-#[expect(clippy::cast_possible_wrap)]
 /// Turn a constant int byte representation into an i128
+#[expect(clippy::cast_possible_wrap)]
 pub fn sext(tcx: TyCtxt<'_>, u: u128, ity: IntTy) -> i128 {
     let amt = 128 - int_bits(tcx, ity);
     ((u as i128) << amt) >> amt
 }
 
-#[expect(clippy::cast_sign_loss)]
 /// clip unused bytes
+#[expect(clippy::cast_sign_loss)]
 pub fn unsext(tcx: TyCtxt<'_>, u: i128, ity: IntTy) -> u128 {
     let amt = 128 - int_bits(tcx, ity);
     ((u as u128) << amt) >> amt

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -3,6 +3,9 @@
 #![expect(clippy::module_name_repetitions)]
 
 use core::ops::ControlFlow;
+use std::collections::hash_map::Entry;
+use std::{debug_assert_matches, iter, mem};
+
 use itertools::Itertools as _;
 use rustc_abi::{BackendRepr, FieldsShape, VariantIdx, Variants};
 use rustc_ast::ast::Mutability;
@@ -32,8 +35,6 @@ use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _;
 use rustc_trait_selection::traits::query::normalize::QueryNormalizeExt as _;
 use rustc_trait_selection::traits::{Obligation, ObligationCause};
-use std::collections::hash_map::Entry;
-use std::{debug_assert_matches, iter, mem};
 
 use crate::paths::{PathNS, lookup_path_str};
 use crate::res::{MaybeDef as _, MaybeQPath as _};
@@ -1114,8 +1115,8 @@ pub fn approx_ty_size<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> u64 {
     }
 }
 
-#[cfg(debug_assertions)]
 /// Asserts that the given arguments match the generic parameters of the given item.
+#[cfg(debug_assertions)]
 fn assert_generic_args_match<'tcx>(tcx: TyCtxt<'tcx>, did: DefId, args: &[GenericArg<'tcx>]) {
     use itertools::Itertools as _;
     let g = tcx.generics_of(did);

--- a/tests/ui/doc_attr_ordering.rs
+++ b/tests/ui/doc_attr_ordering.rs
@@ -1,0 +1,78 @@
+#![warn(clippy::doc_attr_ordering)]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[repr(u8)]
+/// Type
+//~^ doc_attr_ordering
+enum DocAttrOrdering {
+    Variant,
+}
+
+#[must_use]
+/// Function
+//~^ doc_attr_ordering
+fn doc_attr_ordering() -> bool {
+    #[allow(unused_doc_comments)]
+    /// Statement
+    //~^ doc_attr_ordering
+    true
+}
+
+#[proc_macro]
+/// Proc macro
+//~^ doc_attr_ordering
+pub fn proc_macro_fn(t: TokenStream) -> TokenStream {
+    t
+}
+
+/// Documentation that...
+#[must_use]
+/// ...wraps other attributes
+//~^ doc_attr_ordering
+struct OtherInterspersed;
+
+#[must_use]
+/// Documentation in between other attributes
+//~^ doc_attr_ordering
+#[repr(u8)]
+enum DocInterspersed {
+    Variant,
+}
+
+/// Documentation
+#[doc = concat!("can include", " doc attributes")]
+/// and continue afterwards safely
+#[repr(u8)]
+enum DocAttrInterspersed {
+    Variant,
+}
+
+/// Using `cfg_attr`  
+#[cfg_attr(true, doc = "interspersed with doc comments")]
+/// counts as a doc comment
+struct CfgAttrDoc;
+
+mod nested {
+    #![allow(dead_code)]
+    //! Module/outer attributes are not checked.
+}
+
+#[allow(dead_code)]
+/// Only outer attributes are checked
+//~^ doc_attr_ordering
+mod inner_outer {
+    #![allow(clippy::mixed_attributes_style)]
+    //! ...even when the inner is present.
+}
+
+#[derive(Default)]
+/// A `derive` macro is erased during macro expansion,
+/// so this will not be flagged.
+struct DerivedException;
+
+#[cfg_attr(false, derive(Default))]
+/// A disabled `cfg_attr` is not caught because it is erased.
+struct DisabledCfgAttr;

--- a/tests/ui/doc_attr_ordering.stderr
+++ b/tests/ui/doc_attr_ordering.stderr
@@ -1,0 +1,88 @@
+error: doc comments and attributes should precede other attributes
+  --> tests/ui/doc_attr_ordering.rs:8:1
+   |
+LL | /// Type
+   | ^^^^^^^^
+   |
+help: place any doc comments and attributes before this attribute
+  --> tests/ui/doc_attr_ordering.rs:7:1
+   |
+LL | #[repr(u8)]
+   | ^^^^^^^^^^^
+   = note: `-D clippy::doc-attr-ordering` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::doc_attr_ordering)]`
+
+error: doc comments and attributes should precede other attributes
+  --> tests/ui/doc_attr_ordering.rs:15:1
+   |
+LL | /// Function
+   | ^^^^^^^^^^^^
+   |
+help: place any doc comments and attributes before this attribute
+  --> tests/ui/doc_attr_ordering.rs:14:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^
+
+error: doc comments and attributes should precede other attributes
+  --> tests/ui/doc_attr_ordering.rs:19:5
+   |
+LL |     /// Statement
+   |     ^^^^^^^^^^^^^
+   |
+help: place any doc comments and attributes before this attribute
+  --> tests/ui/doc_attr_ordering.rs:18:5
+   |
+LL |     #[allow(unused_doc_comments)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: doc comments and attributes should precede other attributes
+  --> tests/ui/doc_attr_ordering.rs:25:1
+   |
+LL | /// Proc macro
+   | ^^^^^^^^^^^^^^
+   |
+help: place any doc comments and attributes before this attribute
+  --> tests/ui/doc_attr_ordering.rs:24:1
+   |
+LL | #[proc_macro]
+   | ^^^^^^^^^^^^^
+
+error: doc comments and attributes should precede other attributes
+  --> tests/ui/doc_attr_ordering.rs:33:1
+   |
+LL | /// ...wraps other attributes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: place any doc comments and attributes before this attribute
+  --> tests/ui/doc_attr_ordering.rs:32:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^
+
+error: doc comments and attributes should precede other attributes
+  --> tests/ui/doc_attr_ordering.rs:38:1
+   |
+LL | /// Documentation in between other attributes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: place any doc comments and attributes before this attribute
+  --> tests/ui/doc_attr_ordering.rs:37:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^
+
+error: doc comments and attributes should precede other attributes
+  --> tests/ui/doc_attr_ordering.rs:64:1
+   |
+LL | /// Only outer attributes are checked
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: place any doc comments and attributes before this attribute
+  --> tests/ui/doc_attr_ordering.rs:63:1
+   |
+LL | #[allow(dead_code)]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17535)*

This lint checks that doc comments and attributes precede other attributes.

Because doc comments can be long, important attributes above them can be hidden when viewing the documented code.  This is a styling change that was considered for inclusion in `rustfmt`, but was not possible due to the potential for attribute ordering to be relevant.  A clippy lint is a perfect way to implement this sort of control, as it is opt-in and it can be disabled on an as-needed basis.

This version only checks *outer* attributes (`#[foo]`) and not inner attributes (`#![foo]`).  The reasoning above applies most strongly to outer attributes; inner attributes have less need to be placed near the code that follows. The documentation indicates inner attributes could be covered in future.

The issue recommends that this be configurable, but it seems better to be opinionated in this case, so I opted not to include that feature.  That might be a way to manage inner attributes in future.

A few small gotchas that are worth noting:

* The compiler eats `#[derive(...)]` before this lint can see the attributes.  Unlike `#[cfg_attr(...)]`, the attribute is not replaced with an `AttrKind::Synthetic` tombstone.  That means that this will fail to catch when the derive attributes appear before this lint.  The code around pre-early lints strongly suggested that new lints would not be tolerated there, so I've opted not to push things.

* That `#[cfg_attr]` synthetic tombstone is ignored.  Otherwise, any use of doc attributes with `#[cfg_attr(..., doc = "..."]`, which is a fairly common pattern, would trigger this lint.  The lint ignores `#[cfg_attr]` to allow that. If a different attribute is wrapped, that attribute will be identified as a real attribute, but only if the predicate on the `cfg_attr` is true; conditions that are removed will be invisible.

I've added mentions of these to the documentation.

The changes for dogfooding were interesting.  On the one hand, this makes the inconsistency in style very apparent.  On the other hand, the inverse ordering might be justified in some of these cases, particularly where the attribute applies to the comment itself.  There was one instance of `#[expect(clippy::doc_markdown)]` where I added an override for this new lint.  I can see why reasonable people might reach a different conclusion about this or the other instances where attributes are reordered.  The attributes on the `--category` flag are worth drawing some attention to, for instance.

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

changelog: [`doc_attr_ordering`]: Check that doc comments and attributes precede other attributes

fixes rust-lang/rust-clippy#14691