### PR TITLE
fix(redundant_field_names): skip external macros

### DIFF
--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -51,6 +51,7 @@ impl EarlyLintPass for RedundantFieldNames {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         if let ExprKind::Struct(ref se) = expr.kind
             && self.msrv.meets(msrvs::FIELD_INIT_SHORTHAND)
+            && !expr.span.in_external_macro(cx.sess().source_map())
         {
             for field in &se.fields {
                 if !field.is_shorthand

--- a/tests/ui/redundant_field_names_proc_macro.rs
+++ b/tests/ui/redundant_field_names_proc_macro.rs
@@ -1,0 +1,19 @@
+//@aux-build:proc_macros.rs
+//@check-pass
+#![warn(clippy::redundant_field_names)]
+
+#[macro_use]
+extern crate proc_macros;
+
+struct S {
+    field: usize,
+}
+
+fn main() {
+    let field = 1;
+
+    // Proc macros may preserve the input span for generated fields.
+    external! {
+        let _ = S { $(field: field) };
+    }
+}


### PR DESCRIPTION
changelog: [`redundant_field_names`]: avoid false positives in proc-macro-generated struct initializers

Fixes rust-lang/rust-clippy#17525

The lint now checks the enclosing struct expression's expansion context in addition to each field span. This covers proc macros that preserve a user-provided span on generated fields.

Tested with:

- `TESTNAME=redundant_field_names cargo uitest`
- `cargo dev fmt --check`
