### PR TITLE
Build docs into the `main` directory

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -4,6 +4,7 @@ set -ex
 
 echo "Removing the current docs for master"
 rm -rf out/master/ || exit 0
+rm -rf out/main/ || exit 0
 
 echo "Making the docs for master"
 mkdir out/master/
@@ -11,6 +12,9 @@ cp util/gh-pages/index.html out/master
 cp util/gh-pages/theme.js out/master
 cp util/gh-pages/script.js out/master
 cp util/gh-pages/style.css out/master
+
+echo "Copying the docs into the main directory"
+cp -Tr out/master/ out/main/
 
 if [[ -n $TAG_NAME ]]; then
   echo "Save the doc for the current tag ($TAG_NAME) and point stable/ to it"


### PR DESCRIPTION
This is in preparation for renaming the default branch to `main` (https://rust-lang.zulipchat.com/#narrow/channel/257328-t-clippy/topic/Renaming.20the.20Clippy.27s.20default.20branch.20to.20main/with/615804918).

It should build the docs into both the `master` and `main` directories. After we confirm that this works, and that https://rust-lang.github.io/rust-clippy/main is available, we can modify Clippy to start generating links that will point to `main`, instead of `master`.

changelog: none