### PR TITLE
fix: Also add main in the deployment, do not let it go away

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -49,6 +49,8 @@ if [[ -n $TAG_NAME ]]; then
   git add "$TAG_NAME"
   # Update the symlink
   git add stable
+  # Add main with master
+  git add main
   # Update the index.html file
   git add index.html
   git commit -m "Add documentation for ${TAG_NAME} release: ${SHA}"

--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -41,10 +41,6 @@ git status
 if [[ -n $TAG_NAME ]]; then
   # track files, so that the following check works
   git add --intent-to-add "$TAG_NAME"
-  if git diff --exit-code --quiet -- $TAG_NAME/; then
-    echo "No changes to the output on this push; exiting."
-    exit 0
-  fi
   # Add the new dir
   git add "$TAG_NAME"
   # Update the symlink
@@ -53,6 +49,10 @@ if [[ -n $TAG_NAME ]]; then
   git add main
   # Update the index.html file
   git add index.html
+  if git diff --exit-code --quiet -- $TAG_NAME/; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+  fi
   git commit -m "Add documentation for ${TAG_NAME} release: ${SHA}"
 elif [[ $BETA = "true" ]]; then
   if git diff --exit-code --quiet -- beta/; then


### PR DESCRIPTION
cc @Kobzol, fix from rust-lang/rust-clippy#17541, which did not `git add main` into the final output (and seems that the script did not add `out` itself, but everything manually)

changelog: none
