### PR TITLE
fix: avoid double_must_use in macro-generated code

### DIFF
--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -139,7 +139,7 @@ fn check_needless_must_use(
     attrs: &[Attribute],
     sig: &FnSig<'_>,
 ) {
-    if item_span.in_external_macro(cx.sess().source_map()) {
+    if item_span.in_external_macro(cx.sess().source_map()) || attr_span.from_expansion() {
         return;
     }
     if returns_unit(decl) {

--- a/tests/ui/auxiliary/proc_macro_attr.rs
+++ b/tests/ui/auxiliary/proc_macro_attr.rs
@@ -42,9 +42,29 @@ pub fn fake_async_trait(_args: TokenStream, input: TokenStream) -> TokenStream {
     TokenStream::from(quote!(#item))
 }
 
-fn add_must_use(attrs: &mut Vec<Attribute>, sig: &mut Signature) {
-    sig.asyncness = None;
+fn add_must_use_attr(attrs: &mut Vec<Attribute>) {
     attrs.push(parse_quote!(#[must_use]));
+}
+
+fn desugar_async(attrs: &mut Vec<Attribute>, sig: &mut Signature) {
+    sig.asyncness = None;
+    add_must_use_attr(attrs);
+}
+
+#[proc_macro_attribute]
+pub fn add_must_use(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut item = parse_macro_input!(input as Item);
+
+    match &mut item {
+        Item::Fn(item) => add_must_use_attr(&mut item.attrs),
+        Item::Struct(item) => add_must_use_attr(&mut item.attrs),
+        Item::Union(item) => add_must_use_attr(&mut item.attrs),
+        Item::Enum(item) => add_must_use_attr(&mut item.attrs),
+        Item::Trait(item) => add_must_use_attr(&mut item.attrs),
+        _ => {},
+    }
+
+    TokenStream::from(quote!(#item))
 }
 
 #[proc_macro_attribute]
@@ -52,18 +72,18 @@ pub fn add_must_use_to_async(_args: TokenStream, input: TokenStream) -> TokenStr
     let mut item = parse_macro_input!(input as Item);
 
     match &mut item {
-        Item::Fn(item) => add_must_use(&mut item.attrs, &mut item.sig),
+        Item::Fn(item) => desugar_async(&mut item.attrs, &mut item.sig),
         Item::Trait(item) => {
             for trait_item in &mut item.items {
                 if let TraitItem::Fn(method) = trait_item {
-                    add_must_use(&mut method.attrs, &mut method.sig);
+                    desugar_async(&mut method.attrs, &mut method.sig);
                 }
             }
         },
         Item::Impl(item) => {
             for impl_item in &mut item.items {
                 if let ImplItem::Fn(method) = impl_item {
-                    add_must_use(&mut method.attrs, &mut method.sig);
+                    desugar_async(&mut method.attrs, &mut method.sig);
                 }
             }
         },

--- a/tests/ui/auxiliary/proc_macro_attr.rs
+++ b/tests/ui/auxiliary/proc_macro_attr.rs
@@ -10,8 +10,8 @@ use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 use syn::token::Star;
 use syn::{
-    FnArg, ImplItem, ItemFn, ItemImpl, ItemStruct, ItemTrait, Lifetime, Pat, PatIdent, PatType, Signature, TraitItem,
-    Type, Visibility, parse_macro_input, parse_quote,
+    Attribute, FnArg, ImplItem, Item, ItemFn, ItemImpl, ItemStruct, ItemTrait, Lifetime, Pat, PatIdent, PatType,
+    Signature, TraitItem, Type, Visibility, parse_macro_input, parse_quote,
 };
 
 #[proc_macro_attribute]
@@ -39,6 +39,37 @@ pub fn fake_async_trait(_args: TokenStream, input: TokenStream) -> TokenStream {
             }
         }
     }
+    TokenStream::from(quote!(#item))
+}
+
+fn add_must_use(attrs: &mut Vec<Attribute>, sig: &mut Signature) {
+    sig.asyncness = None;
+    attrs.push(parse_quote!(#[must_use]));
+}
+
+#[proc_macro_attribute]
+pub fn add_must_use_to_async(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut item = parse_macro_input!(input as Item);
+
+    match &mut item {
+        Item::Fn(item) => add_must_use(&mut item.attrs, &mut item.sig),
+        Item::Trait(item) => {
+            for trait_item in &mut item.items {
+                if let TraitItem::Fn(method) = trait_item {
+                    add_must_use(&mut method.attrs, &mut method.sig);
+                }
+            }
+        },
+        Item::Impl(item) => {
+            for impl_item in &mut item.items {
+                if let ImplItem::Fn(method) = impl_item {
+                    add_must_use(&mut method.attrs, &mut method.sig);
+                }
+            }
+        },
+        _ => {},
+    }
+
     TokenStream::from(quote!(#item))
 }
 

--- a/tests/ui/double_must_use_proc_macro.rs
+++ b/tests/ui/double_must_use_proc_macro.rs
@@ -1,9 +1,11 @@
 //@aux-build:proc_macro_attr.rs
+//@no-rustfix
 #![warn(clippy::double_must_use, clippy::must_use_unit)]
+#![allow(dead_code)]
 
 extern crate proc_macro_attr;
 
-use proc_macro_attr::{add_must_use_to_async, dummy};
+use proc_macro_attr::{add_must_use, add_must_use_to_async, dummy};
 
 #[add_must_use_to_async]
 async fn function() -> Result<(), ()> {
@@ -25,6 +27,53 @@ impl Struct {
     async fn method(&self) -> Result<(), ()> {
         Ok(())
     }
+}
+
+#[add_must_use]
+struct MustUseStruct;
+
+#[add_must_use]
+union MustUseUnion {
+    field: u32,
+}
+
+#[add_must_use]
+enum MustUseEnum {
+    Variant,
+}
+
+#[add_must_use]
+trait MustUseTrait {}
+
+impl MustUseTrait for u32 {}
+
+#[add_must_use]
+fn macro_must_use() -> Result<(), ()> {
+    Ok(())
+}
+
+#[must_use]
+fn returns_must_use_struct() -> MustUseStruct {
+    //~^ double_must_use
+    MustUseStruct
+}
+
+#[must_use]
+fn returns_must_use_union() -> MustUseUnion {
+    //~^ double_must_use
+    MustUseUnion { field: 0 }
+}
+
+#[must_use]
+fn returns_must_use_enum() -> MustUseEnum {
+    //~^ double_must_use
+    MustUseEnum::Variant
+}
+
+#[must_use]
+fn returns_must_use_trait() -> impl MustUseTrait {
+    //~^ double_must_use
+    0u32
 }
 
 #[dummy]

--- a/tests/ui/double_must_use_proc_macro.rs
+++ b/tests/ui/double_must_use_proc_macro.rs
@@ -1,0 +1,38 @@
+//@aux-build:proc_macro_attr.rs
+#![warn(clippy::double_must_use, clippy::must_use_unit)]
+
+extern crate proc_macro_attr;
+
+use proc_macro_attr::{add_must_use_to_async, dummy};
+
+#[add_must_use_to_async]
+async fn function() -> Result<(), ()> {
+    Ok(())
+}
+
+#[add_must_use_to_async]
+async fn unit_function() {}
+
+#[add_must_use_to_async]
+trait AsyncTrait {
+    async fn method(&self) -> Result<(), ()>;
+}
+
+struct Struct;
+
+#[add_must_use_to_async]
+impl Struct {
+    async fn method(&self) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+#[dummy]
+#[must_use]
+#[inline]
+fn user_must_use() -> Result<(), ()> {
+    //~^ double_must_use
+    Ok(())
+}
+
+fn main() {}

--- a/tests/ui/double_must_use_proc_macro.stderr
+++ b/tests/ui/double_must_use_proc_macro.stderr
@@ -1,17 +1,62 @@
 error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
-  --> tests/ui/double_must_use_proc_macro.rs:33:1
+  --> tests/ui/double_must_use_proc_macro.rs:56:1
+   |
+LL | #[must_use]
+   | ----------- help: remove the attribute
+LL | fn returns_must_use_struct() -> MustUseStruct {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: alternatively, you may add an explicit reason to the `must_use` attribute
+   = note: `-D clippy::double-must-use` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::double_must_use)]`
+
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
+  --> tests/ui/double_must_use_proc_macro.rs:62:1
+   |
+LL | #[must_use]
+   | ----------- help: remove the attribute
+LL | fn returns_must_use_union() -> MustUseUnion {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: alternatively, you may add an explicit reason to the `must_use` attribute
+
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
+  --> tests/ui/double_must_use_proc_macro.rs:68:1
+   |
+LL | #[must_use]
+   | ----------- help: remove the attribute
+LL | fn returns_must_use_enum() -> MustUseEnum {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: alternatively, you may add an explicit reason to the `must_use` attribute
+
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
+  --> tests/ui/double_must_use_proc_macro.rs:74:1
+   |
+LL | #[must_use]
+   | ----------- help: remove the attribute
+LL | fn returns_must_use_trait() -> impl MustUseTrait {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the return type is implementer of `MustUseTrait`
+  --> tests/ui/double_must_use_proc_macro.rs:74:32
+   |
+LL | fn returns_must_use_trait() -> impl MustUseTrait {
+   |                                ^^^^^^^^^^^^^^^^^
+   = note: alternatively, you may add an explicit reason to the `must_use` attribute
+
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
+  --> tests/ui/double_must_use_proc_macro.rs:82:1
    |
 LL | fn user_must_use() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove `must_use`
-  --> tests/ui/double_must_use_proc_macro.rs:31:1
+  --> tests/ui/double_must_use_proc_macro.rs:80:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
    = note: alternatively, you may add an explicit reason to the `must_use` attribute
-   = note: `-D clippy::double-must-use` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::double_must_use)]`
 
-error: aborting due to 1 previous error
+error: aborting due to 5 previous errors
 

--- a/tests/ui/double_must_use_proc_macro.stderr
+++ b/tests/ui/double_must_use_proc_macro.stderr
@@ -1,0 +1,17 @@
+error: this function has a `#[must_use]` attribute with no message, but returns a type already considered as `#[must_use]`
+  --> tests/ui/double_must_use_proc_macro.rs:33:1
+   |
+LL | fn user_must_use() -> Result<(), ()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove `must_use`
+  --> tests/ui/double_must_use_proc_macro.rs:31:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^
+   = note: alternatively, you may add an explicit reason to the `must_use` attribute
+   = note: `-D clippy::double-must-use` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::double_must_use)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17529

`double_must_use` and `must_use_unit` now ignore `#[must_use]` attributes generated by macro expansion, while continuing to lint user-written attributes passed through procedural macros.

changelog: [`double_must_use`]: Fixed false positives from macro-generated `#[must_use]` attributes.