### PR TITLE
Add a lint for combined equality assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ document.
 
 [b147b68...master](https://github.com/rust-lang/rust-clippy/compare/b147b68...master)
 
+### New Lints
+
+* Added [`assert_multiple`] to `nursery`
+
 ## Rust 1.97
 
 Current stable, released 2026-07-09
@@ -6753,6 +6757,7 @@ Released 2018-09-13
 [`as_ptr_cast_mut`]: https://rust-lang.github.io/rust-clippy/main/index.html#as_ptr_cast_mut
 [`as_underscore`]: https://rust-lang.github.io/rust-clippy/main/index.html#as_underscore
 [`assert_is_empty`]: https://rust-lang.github.io/rust-clippy/main/index.html#assert_is_empty
+[`assert_multiple`]: https://rust-lang.github.io/rust-clippy/main/index.html#assert_multiple
 [`assertions_on_constants`]: https://rust-lang.github.io/rust-clippy/main/index.html#assertions_on_constants
 [`assertions_on_result_states`]: https://rust-lang.github.io/rust-clippy/main/index.html#assertions_on_result_states
 [`assign_op_pattern`]: https://rust-lang.github.io/rust-clippy/main/index.html#assign_op_pattern

--- a/clippy_lints/src/assert_multiple.rs
+++ b/clippy_lints/src/assert_multiple.rs
@@ -1,0 +1,130 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::macros::{find_assert_args, root_macro_call_first_node};
+use clippy_utils::source::{snippet, snippet_indent};
+use clippy_utils::sym;
+use clippy_utils::ty::implements_trait;
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks assertions that combine two equality comparisons with `&&`.
+    ///
+    /// ### Why is this bad?
+    /// A combined assertion only reports that the whole condition failed. Separate assertions
+    /// identify which comparison failed and show the compared values.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # #[derive(Debug, PartialEq)]
+    /// # let expected_name = "name";
+    /// # let actual_name = "name";
+    /// # let expected_count = 1;
+    /// # let actual_count = 1;
+    /// assert!(actual_name == expected_name && actual_count == expected_count);
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// # #[derive(Debug, PartialEq)]
+    /// # let expected_name = "name";
+    /// # let actual_name = "name";
+    /// # let expected_count = 1;
+    /// # let actual_count = 1;
+    /// assert_eq!(actual_name, expected_name);
+    /// assert_eq!(actual_count, expected_count);
+    /// ```
+    #[clippy::version = "1.98.0"]
+    pub ASSERT_MULTIPLE,
+    nursery,
+    "asserting multiple equality comparisons in one assertion"
+}
+
+declare_lint_pass!(AssertMultiple => [ASSERT_MULTIPLE]);
+
+fn comparison<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<(BinOpKind, &'tcx Expr<'tcx>, &'tcx Expr<'tcx>)> {
+    let ExprKind::Binary(op, lhs, rhs) = expr.kind else {
+        return None;
+    };
+
+    matches!(op.node, BinOpKind::Eq | BinOpKind::Ne).then_some((op.node, lhs, rhs))
+}
+
+fn has_debug_impl(cx: &LateContext<'_>, expr: &Expr<'_>, debug_trait: rustc_hir::def_id::DefId) -> bool {
+    let ty = cx.typeck_results().expr_ty(expr);
+    !ty.is_raw_ptr() && implements_trait(cx, ty, debug_trait, &[])
+}
+
+fn assertion_suggestion(
+    cx: &LateContext<'_>,
+    assert_name: &str,
+    comparison: (BinOpKind, &Expr<'_>, &Expr<'_>),
+) -> String {
+    let (op, lhs, rhs) = comparison;
+    let suffix = match op {
+        BinOpKind::Eq => "_eq",
+        BinOpKind::Ne => "_ne",
+        _ => unreachable!(),
+    };
+    format!(
+        "{assert_name}{suffix}!({}, {})",
+        snippet(cx, lhs.span, ".."),
+        snippet(cx, rhs.span, ".."),
+    )
+}
+
+impl LateLintPass<'_> for AssertMultiple {
+    fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
+        let Some(macro_call) = root_macro_call_first_node(cx, expr) else {
+            return;
+        };
+        let assert_name = match cx.tcx.get_diagnostic_name(macro_call.def_id) {
+            Some(sym::assert_macro) => "assert",
+            Some(sym::debug_assert_macro) => "debug_assert",
+            _ => return,
+        };
+        let Some((condition, panic_call)) = find_assert_args(cx, expr, macro_call.expn) else {
+            return;
+        };
+        if !panic_call.is_default_message() || condition.span.from_expansion() {
+            return;
+        }
+        let ExprKind::Binary(op, lhs, rhs) = condition.kind else {
+            return;
+        };
+        if op.node != BinOpKind::And {
+            return;
+        }
+        let Some(lhs_comparison) = comparison(lhs) else {
+            return;
+        };
+        let Some(rhs_comparison) = comparison(rhs) else {
+            return;
+        };
+        let Some(debug_trait) = cx.tcx.get_diagnostic_item(sym::Debug) else {
+            return;
+        };
+        if ![lhs_comparison.1, lhs_comparison.2, rhs_comparison.1, rhs_comparison.2]
+            .into_iter()
+            .all(|expr| has_debug_impl(cx, expr, debug_trait))
+        {
+            return;
+        }
+
+        let indent = snippet_indent(cx, macro_call.span).unwrap_or_default();
+        let first = assertion_suggestion(cx, assert_name, lhs_comparison);
+        let second = assertion_suggestion(cx, assert_name, rhs_comparison);
+        let suggestion = format!("{first};\n{indent}{second}");
+        span_lint_and_sugg(
+            cx,
+            ASSERT_MULTIPLE,
+            macro_call.span,
+            "multiple equality comparisons combined into one assertion",
+            "split the comparisons into separate assertions",
+            suggestion,
+            Applicability::MaybeIncorrect,
+        );
+    }
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -12,6 +12,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::asm_syntax::INLINE_ASM_X86_ATT_SYNTAX_INFO,
     crate::asm_syntax::INLINE_ASM_X86_INTEL_SYNTAX_INFO,
     crate::assert_is_empty::ASSERT_IS_EMPTY_INFO,
+    crate::assert_multiple::ASSERT_MULTIPLE_INFO,
     crate::assertions_on_constants::ASSERTIONS_ON_CONSTANTS_INFO,
     crate::assertions_on_result_states::ASSERTIONS_ON_RESULT_STATES_INFO,
     crate::assigning_clones::ASSIGNING_CLONES_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -66,6 +66,7 @@ mod arc_with_non_send_sync;
 mod as_conversions;
 mod asm_syntax;
 mod assert_is_empty;
+mod assert_multiple;
 mod assertions_on_constants;
 mod assertions_on_result_states;
 mod assigning_clones;
@@ -869,6 +870,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        AssertMultiple: assert_multiple::AssertMultiple = assert_multiple::AssertMultiple,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/tests/ui/assert_multiple.rs
+++ b/tests/ui/assert_multiple.rs
@@ -1,0 +1,28 @@
+#![warn(clippy::assert_multiple)]
+
+fn main() {
+    let expected_name = "name";
+    let actual_name = "name";
+    let expected_count = 1;
+    let actual_count = 1;
+
+    assert!(actual_name == expected_name && actual_count == expected_count);
+    //~^ assert_multiple
+    debug_assert!(actual_name != expected_name && actual_count != expected_count);
+    //~^ assert_multiple
+
+    // Do not lint comparisons whose values cannot be shown by `assert_eq!`.
+    #[derive(PartialEq)]
+    struct NotDebug;
+    let left_one = NotDebug;
+    let right_one = NotDebug;
+    let left_two = NotDebug;
+    let right_two = NotDebug;
+    assert!(left_one == right_one && left_two == right_two);
+
+    // Keep custom messages intact rather than duplicating them.
+    assert!(
+        actual_name == expected_name && actual_count == expected_count,
+        "context"
+    );
+}

--- a/tests/ui/assert_multiple.stderr
+++ b/tests/ui/assert_multiple.stderr
@@ -25,3 +25,5 @@ LL ~     debug_assert_ne!(actual_count, expected_count);
    |
 
 error: aborting due to 2 previous errors
+
+

--- a/tests/ui/assert_multiple.stderr
+++ b/tests/ui/assert_multiple.stderr
@@ -10,6 +10,7 @@ help: split the comparisons into separate assertions
    |
 LL ~     assert_eq!(actual_name, expected_name);
 LL ~     assert_eq!(actual_count, expected_count);
+   |
 
 error: multiple equality comparisons combined into one assertion
   --> tests/ui/assert_multiple.rs:11:5
@@ -21,5 +22,6 @@ help: split the comparisons into separate assertions
    |
 LL ~     debug_assert_ne!(actual_name, expected_name);
 LL ~     debug_assert_ne!(actual_count, expected_count);
+   |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/assert_multiple.stderr
+++ b/tests/ui/assert_multiple.stderr
@@ -1,0 +1,25 @@
+error: multiple equality comparisons combined into one assertion
+  --> tests/ui/assert_multiple.rs:9:5
+   |
+LL |     assert!(actual_name == expected_name && actual_count == expected_count);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::assert-multiple` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::assert_multiple)]`
+help: split the comparisons into separate assertions
+   |
+LL ~     assert_eq!(actual_name, expected_name);
+LL ~     assert_eq!(actual_count, expected_count);
+
+error: multiple equality comparisons combined into one assertion
+  --> tests/ui/assert_multiple.rs:11:5
+   |
+LL |     debug_assert!(actual_name != expected_name && actual_count != expected_count);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: split the comparisons into separate assertions
+   |
+LL ~     debug_assert_ne!(actual_name, expected_name);
+LL ~     debug_assert_ne!(actual_count, expected_count);
+
+error: aborting due to 2 previous errors


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#1810

changelog: [`assert_multiple`]: Add a lint for assertions with multiple equality comparisons

### Summary
- add the nursery `assert_multiple` lint for `assert!` and `debug_assert!` calls combining two equality comparisons with `&&`
- suggest separate `assert_eq!`/`assert_ne!` calls when all operands implement `Debug`
- skip custom assertion messages and non-Debug operands to avoid changing output or producing invalid suggestions
- add UI coverage and register the lint in the generated lint list

### Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- Clippy UI compilation was not available locally because this checkout lacks the `rustc-dev` compiler components; upstream CI is required for compiler and UI validation.

Prepared with AI assistance; I reviewed the implementation and validation output.