### PR TITLE
prevent checking `redundant_field_names` lint on `Derive`d code

### DIFF
--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -49,6 +49,9 @@ impl RedundantFieldNames {
 
 impl EarlyLintPass for RedundantFieldNames {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        if expr.span.in_external_macro(cx.sess().source_map()) {
+            return;
+        }
         if let ExprKind::Struct(ref se) = expr.kind
             && self.msrv.meets(msrvs::FIELD_INIT_SHORTHAND)
         {

--- a/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/tests/ui/auxiliary/proc_macro_derive.rs
@@ -243,3 +243,21 @@ pub fn derive_double_parens(_: TokenStream) -> TokenStream {
         }
     }
 }
+
+// This must construct the redundant fields using the input struct's
+// identifiers, so that the fields' spans are from outside this macro to be a
+// reasonable approximation of real use.
+#[proc_macro_derive(ConstructStructWithRedundantFields)]
+pub fn derive_construct_struct_with_redundant_fields(input: TokenStream) -> TokenStream {
+    let syn::ItemStruct { fields, ident, .. } = syn::parse_macro_input!(input);
+
+    let field_names: Vec<_> = fields.iter().map(|f| f.ident.as_ref().expect("named field")).collect();
+    let field_types: Vec<_> = fields.iter().map(|f| &f.ty).collect();
+
+    quote::quote! {
+        pub fn construct_struct_with_redundant_fields(#(#field_names: #field_types),*) -> #ident {
+            #ident { #(#field_names: #field_names),* }
+        }
+    }
+    .into()
+}

--- a/tests/ui/redundant_field_names.fixed
+++ b/tests/ui/redundant_field_names.fixed
@@ -1,4 +1,5 @@
 //@aux-build:proc_macros.rs
+//@aux-build:proc_macro_derive.rs
 #![warn(clippy::redundant_field_names)]
 #![expect(clippy::no_effect)]
 
@@ -82,6 +83,12 @@ fn main() {
         };
     }
     internal!(v);
+
+    // Derive-generated code should not be linted.
+    #[derive(proc_macro_derive::ConstructStructWithRedundantFields)]
+    struct DerivedS {
+        v: usize,
+    }
 }
 
 fn issue_3476() {

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -1,4 +1,5 @@
 //@aux-build:proc_macros.rs
+//@aux-build:proc_macro_derive.rs
 #![warn(clippy::redundant_field_names)]
 #![expect(clippy::no_effect)]
 
@@ -82,6 +83,12 @@ fn main() {
         };
     }
     internal!(v);
+
+    // Derive-generated code should not be linted.
+    #[derive(proc_macro_derive::ConstructStructWithRedundantFields)]
+    struct DerivedS {
+        v: usize,
+    }
 }
 
 fn issue_3476() {

--- a/tests/ui/redundant_field_names.stderr
+++ b/tests/ui/redundant_field_names.stderr
@@ -1,5 +1,5 @@
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:33:9
+  --> tests/ui/redundant_field_names.rs:34:9
    |
 LL |         gender: gender,
    |         ^^^^^^^^^^^^^^ help: replace it with: `gender`
@@ -8,43 +8,43 @@ LL |         gender: gender,
    = help: to override `-D warnings` add `#[allow(clippy::redundant_field_names)]`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:35:9
+  --> tests/ui/redundant_field_names.rs:36:9
    |
 LL |         age: age,
    |         ^^^^^^^^ help: replace it with: `age`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:56:25
+  --> tests/ui/redundant_field_names.rs:57:25
    |
 LL |     let _ = RangeFrom { start: start };
    |                         ^^^^^^^^^^^^ help: replace it with: `start`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:58:23
+  --> tests/ui/redundant_field_names.rs:59:23
    |
 LL |     let _ = RangeTo { end: end };
    |                       ^^^^^^^^ help: replace it with: `end`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:60:21
+  --> tests/ui/redundant_field_names.rs:61:21
    |
 LL |     let _ = Range { start: start, end: end };
    |                     ^^^^^^^^^^^^ help: replace it with: `start`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:60:35
+  --> tests/ui/redundant_field_names.rs:61:35
    |
 LL |     let _ = Range { start: start, end: end };
    |                                   ^^^^^^^^ help: replace it with: `end`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:64:32
+  --> tests/ui/redundant_field_names.rs:65:32
    |
 LL |     let _ = RangeToInclusive { end: end };
    |                                ^^^^^^^^ help: replace it with: `end`
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:77:25
+  --> tests/ui/redundant_field_names.rs:78:25
    |
 LL |             let _ = S { v: v };
    |                         ^^^^ help: replace it with: `v`
@@ -55,7 +55,7 @@ LL |     internal!(v);
    = note: this error originates in the macro `internal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: redundant field names in struct initialization
-  --> tests/ui/redundant_field_names.rs:106:25
+  --> tests/ui/redundant_field_names.rs:113:25
    |
 LL |     let _ = RangeFrom { start: start };
    |                         ^^^^^^^^^^^^ help: replace it with: `start`


### PR DESCRIPTION
This check was removed in rust-lang/rust-clippy#17294 and replaced with a later per-field check, however the `field`'s `span`s can (maybe always do?) point back to the fields in the original struct declaration for struct expressions in derived code. This was causing this lint to warn on derive-generated code.

I wrote a more complete explanation here: https://github.com/rust-lang/rust-clippy/issues/17525#issuecomment-5272744010

changelog: [`redundant_field_names`]: don't check derived expressions

Fixes: rust-lang/rust-clippy#17525