### PR TITLE
`manual_option_as_slice`: ignore by-reference bindings

### DIFF
--- a/clippy_lints/src/manual_option_as_slice.rs
+++ b/clippy_lints/src/manual_option_as_slice.rs
@@ -5,8 +5,8 @@ use clippy_utils::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _};
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::{as_some_pattern, is_none_pattern, msrvs, peel_hir_expr_refs, sym};
 use rustc_errors::Applicability;
-use rustc_hir::{Arm, Expr, ExprKind, Pat, PatKind, QPath, is_range_literal};
-use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
+use rustc_hir::{Arm, ByRef, Expr, ExprKind, Pat, PatKind, QPath, is_range_literal};
+use rustc_lint::{LateContext, LateLintPass, LintContext as _, impl_lint_pass};
 use rustc_span::{Span, Symbol};
 
 declare_clippy_lint! {
@@ -66,9 +66,9 @@ impl LateLintPass<'_> for ManualOptionAsSlice {
             },
             ExprKind::If(cond, then, Some(other)) => {
                 if let ExprKind::Let(let_expr) = cond.kind
+                    && is_empty_slice(cx, other.peel_blocks())
                     && let Some(binding) = extract_ident_from_some_pat(cx, let_expr.pat)
                     && check_some_body(cx, binding, then)
-                    && is_empty_slice(cx, other.peel_blocks())
                 {
                     check_as_ref(cx, let_expr.init, span, self.msrv);
                 }
@@ -142,7 +142,13 @@ fn check_as_ref(cx: &LateContext<'_>, expr: &Expr<'_>, span: Span, msrv: Msrv) {
 
 fn extract_ident_from_some_pat(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<Symbol> {
     if let Some([binding]) = as_some_pattern(cx, pat)
-        && let PatKind::Binding(_mode, _hir_id, ident, _inner_pat) = binding.kind
+        && let PatKind::Binding(_, hir_id, ident, _inner_pat) = binding.kind
+        && matches!(
+            cx.typeck_results()
+                .extract_binding_mode(cx.sess(), hir_id, binding.span)
+                .0,
+            ByRef::No
+        )
     {
         Some(ident.name)
     } else {

--- a/tests/ui/manual_option_as_slice.fixed
+++ b/tests/ui/manual_option_as_slice.fixed
@@ -49,6 +49,15 @@ fn check(x: Option<u32>) {
     _ = x.as_ref().map_or(&[42][..], std::slice::from_ref);
     _ = x.as_ref().map_or_else(|| &[42][..1], std::slice::from_ref);
     _ = x.as_ref().map(|f| std::slice::from_ref(f)).unwrap_or_default();
+
+    let _: &[&u32] = match x.as_ref() {
+        Some(ref f) => std::slice::from_ref(f),
+        None => &[],
+    };
+    let _: &[&u32] = match x.as_ref() {
+        Some(ref mut f) => std::slice::from_ref(f),
+        None => &[],
+    };
 }
 
 #[clippy::msrv = "1.74"]

--- a/tests/ui/manual_option_as_slice.rs
+++ b/tests/ui/manual_option_as_slice.rs
@@ -59,6 +59,15 @@ fn check(x: Option<u32>) {
     _ = x.as_ref().map_or(&[42][..], std::slice::from_ref);
     _ = x.as_ref().map_or_else(|| &[42][..1], std::slice::from_ref);
     _ = x.as_ref().map(|f| std::slice::from_ref(f)).unwrap_or_default();
+
+    let _: &[&u32] = match x.as_ref() {
+        Some(ref f) => std::slice::from_ref(f),
+        None => &[],
+    };
+    let _: &[&u32] = match x.as_ref() {
+        Some(ref mut f) => std::slice::from_ref(f),
+        None => &[],
+    };
 }
 
 #[clippy::msrv = "1.74"]

--- a/tests/ui/manual_option_as_slice_2021.rs
+++ b/tests/ui/manual_option_as_slice_2021.rs
@@ -1,0 +1,20 @@
+//@ edition: 2021
+//@ check-pass
+
+#![warn(clippy::manual_option_as_slice)]
+
+fn check(x: Option<u32>) {
+    // Edition 2024 drops the `as_ref` temporary before the result of the `if let` is consumed.
+    _ = if let Some(ref f) = x.as_ref() {
+        std::slice::from_ref(f)
+    } else {
+        &[]
+    };
+    _ = if let Some(ref mut f) = x.as_ref() {
+        std::slice::from_ref(f)
+    } else {
+        &[]
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
changelog: [`manual_option_as_slice`]: avoid incorrect suggestions for by-reference `Some` bindings

`extract_ident_from_some_pat` previously ignored the effective binding mode of the inner `Some` pattern.

For `Some(ref value)` matched against `option.as_ref()`, `value` has an additional reference layer. As a result, `slice::from_ref(value)` can produce a `&[&T]`, while the suggested `option.as_slice()` produces a `&[T]`. Applying the machine-applicable suggestion can therefore cause a type error.

Check the binding mode computed by type checking and only lint by-value bindings. Add regression tests for `ref` and `ref mut` bindings.