### PR TITLE
Don't fire `manual_contains` when both sides use the slice element

### DIFF
--- a/clippy_lints/src/methods/manual_contains.rs
+++ b/clippy_lints/src/methods/manual_contains.rs
@@ -3,6 +3,7 @@ use clippy_utils::eager_or_lazy::switch_to_eager_eval;
 use clippy_utils::peel_hir_pat_refs;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::sugg::Sugg;
+use clippy_utils::usage::local_used_in;
 use rustc_ast::UnOp;
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
@@ -80,7 +81,7 @@ fn try_get_eligible_arg<'tcx>(
             }
         },
         _ => {
-            if switch_to_eager_eval(cx, expr) {
+            if switch_to_eager_eval(cx, expr) && !local_used_in(cx, closure_arg_id, expr) {
                 Some((get_snippet(expr, true), expr))
             } else {
                 None

--- a/tests/ui/manual_contains.fixed
+++ b/tests/ui/manual_contains.fixed
@@ -50,6 +50,15 @@ fn should_lint() {
     let values = &vec[..];
     let _ = values.contains(&(4 + 1));
     //~^ manual_contains
+
+    // Eager bitwise expressions still lint when they do not mention the element.
+    let mask = 0x0f_u8;
+    let other = 0x03_u8;
+    let values: [u8; 6] = [3, 14, 15, 92, 6, 5];
+    let _ = values.contains(&(mask & other));
+    //~^ manual_contains
+    let _ = values.contains(&(mask | other));
+    //~^ manual_contains
 }
 
 fn should_not_lint() {
@@ -85,6 +94,14 @@ fn should_not_lint() {
     };
     let _ = values.iter().any(|&v| v == count());
     let _ = values.iter().any(|&v| v == v * 2);
+
+    // Don't fire when both sides use the slice element. #17563
+    let mask = 0x0f_u8;
+    let values: &[u8] = &[1, 2, 3];
+    let _ = values.iter().any(|&i| i & mask == i);
+    let _ = values.iter().any(|&i| i == i & mask);
+    let _ = values.iter().any(|&i| i == !i);
+    let _ = values.iter().any(|i| *i == *i & mask);
 }
 
 fn foo(values: &[u8]) -> bool {

--- a/tests/ui/manual_contains.rs
+++ b/tests/ui/manual_contains.rs
@@ -50,6 +50,15 @@ fn should_lint() {
     let values = &vec[..];
     let _ = values.iter().any(|&v| v == 4 + 1);
     //~^ manual_contains
+
+    // Eager bitwise expressions still lint when they do not mention the element.
+    let mask = 0x0f_u8;
+    let other = 0x03_u8;
+    let values: [u8; 6] = [3, 14, 15, 92, 6, 5];
+    let _ = values.iter().any(|&v| v == mask & other);
+    //~^ manual_contains
+    let _ = values.iter().any(|&v| mask | other == v);
+    //~^ manual_contains
 }
 
 fn should_not_lint() {
@@ -85,6 +94,14 @@ fn should_not_lint() {
     };
     let _ = values.iter().any(|&v| v == count());
     let _ = values.iter().any(|&v| v == v * 2);
+
+    // Don't fire when both sides use the slice element. #17563
+    let mask = 0x0f_u8;
+    let values: &[u8] = &[1, 2, 3];
+    let _ = values.iter().any(|&i| i & mask == i);
+    let _ = values.iter().any(|&i| i == i & mask);
+    let _ = values.iter().any(|&i| i == !i);
+    let _ = values.iter().any(|i| *i == *i & mask);
 }
 
 fn foo(values: &[u8]) -> bool {

--- a/tests/ui/manual_contains.stderr
+++ b/tests/ui/manual_contains.stderr
@@ -62,16 +62,28 @@ LL |     let _ = values.iter().any(|&v| v == 4 + 1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `values.contains(&(4 + 1))`
 
 error: using `contains()` instead of `iter().any()` is more efficient
-  --> tests/ui/manual_contains.rs:91:5
+  --> tests/ui/manual_contains.rs:58:13
+   |
+LL |     let _ = values.iter().any(|&v| v == mask & other);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `values.contains(&(mask & other))`
+
+error: using `contains()` instead of `iter().any()` is more efficient
+  --> tests/ui/manual_contains.rs:60:13
+   |
+LL |     let _ = values.iter().any(|&v| mask | other == v);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `values.contains(&(mask | other))`
+
+error: using `contains()` instead of `iter().any()` is more efficient
+  --> tests/ui/manual_contains.rs:108:5
    |
 LL |     values.iter().any(|&v| v == 10)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `values.contains(&10)`
 
 error: using `contains()` instead of `iter().any()` is more efficient
-  --> tests/ui/manual_contains.rs:96:5
+  --> tests/ui/manual_contains.rs:113:5
    |
 LL |     values.iter().any(|&v| v == 10)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `values.contains(&10)`
 
-error: aborting due to 12 previous errors
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17563

changelog: [`manual_contains`]: Don't fire when both sides use the slice element