### PR TITLE
Fix `missing_const_for_thread_local` false positive on targets without native `#[thread_local]`

### DIFF
--- a/clippy_lints/src/missing_const_for_thread_local.rs
+++ b/clippy_lints/src/missing_const_for_thread_local.rs
@@ -122,6 +122,11 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForThreadLocal {
             && let ExprKind::Block(block, _) = body.value.kind
             && let Some(unpeeled) = block.expr
             && let ret_expr = peel_blocks(unpeeled)
+            // The initializer is already a `const` block: there is nothing to suggest.
+            // On targets without `#[thread_local]` (e.g. x86_64-pc-windows-gnu), the
+            // generated init fn is not a `const fn` even for `const` initializers,
+            // so the `is_const_fn` check above does not cover this case.
+            && !matches!(ret_expr.kind, ExprKind::ConstBlock(_))
             // A common pattern around threadlocal! is to make the value unreachable
             // to force an initialization before usage
             // https://github.com/rust-lang/rust-clippy/issues/12637

--- a/tests/ui/missing_const_for_thread_local.fixed
+++ b/tests/ui/missing_const_for_thread_local.fixed
@@ -69,6 +69,14 @@ fn issue_12637() {
     println!("{}", STATE_12637_UNREACHABLE.get());
 }
 
+fn issue_17566() {
+    // On targets without native `#[thread_local]`, a `const` initializer expands to a
+    // non-`const` init fn, which used to slip past the `is_const_fn` guard and lint here.
+    thread_local! {
+        static STATE_17566: Cell<Option<u8>> = const { Cell::new(None) };
+    }
+}
+
 #[clippy::msrv = "1.58"]
 fn f() {
     thread_local! {

--- a/tests/ui/missing_const_for_thread_local.rs
+++ b/tests/ui/missing_const_for_thread_local.rs
@@ -69,6 +69,14 @@ fn issue_12637() {
     println!("{}", STATE_12637_UNREACHABLE.get());
 }
 
+fn issue_17566() {
+    // On targets without native `#[thread_local]`, a `const` initializer expands to a
+    // non-`const` init fn, which used to slip past the `is_const_fn` guard and lint here.
+    thread_local! {
+        static STATE_17566: Cell<Option<u8>> = const { Cell::new(None) };
+    }
+}
+
 #[clippy::msrv = "1.58"]
 fn f() {
     thread_local! {


### PR DESCRIPTION
On targets with no native `#[thread_local]`, such as `x86_64-pc-windows-gnu`, a `const` thread-local initializer expands into an ordinary non-`const` init function. The lint checks whether that generated function is `const` and skips if it is. On these targets it no longer is, so the check stops skipping and the lint fires on initializers that are already `const`, pointing at the whole `thread_local!` block.

The fix skips when the initializer expression is a const block. If the initializer is already `const` there is nothing to suggest, on any target. I left the existing `is_const_fn` check in place because it still does its job where the generated function is `const`.

`tests/ui/missing_const_for_thread_local.rs` and `.fixed` gain `fn issue_17566()` carrying the reproducer from the issue, asserting the lint stays quiet.

Verified locally on `x86_64-pc-windows-gnu` with the pinned nightly. Reverting the guard makes `tests/ui/missing_const_for_thread_local.rs` fail, with the lint firing 9 times on already-`const` initializers; restoring it makes both the `.rs` and `.fixed` cases pass. Full suite: 1841 passed, 1 failed, 7 ignored. The one failure is a `.stderr` mismatch in `suspicious_else_formatting`, which I have not attributed.

An earlier version of this description said I could not run the suite here because rustup binaries were blocked. That was wrong; the results above are from this machine.

LLM usage, per the Rust policy: developed with AI assistance (Claude), which I should have disclosed when I opened this. What I verified myself is the revert-and-rerun above.

fixes rust-lang/rust-clippy#17566

changelog: [`missing_const_for_thread_local`]: fix false positive on targets without native `#[thread_local]` where the initializer is already `const`
