### PR TITLE
test: document default_trait_access suggestion as unfixable

### DIFF
--- a/clippy_lints/src/default.rs
+++ b/clippy_lints/src/default.rs
@@ -102,7 +102,8 @@ impl<'tcx> LateLintPass<'tcx> for Default {
                 format!("calling `{replacement}` is more clear than this expression"),
                 "try",
                 replacement,
-                Applicability::Unspecified, // First resolve the TODO above
+                // The trimmed path may not be in scope, so the suggestion cannot be machine-applicable.
+                Applicability::Unspecified,
             );
         }
     }

--- a/tests/ui/default_trait_access_unfixable.rs
+++ b/tests/ui/default_trait_access_unfixable.rs
@@ -1,0 +1,7 @@
+//@no-rustfix: the trimmed replacement path may not be in scope
+#![warn(clippy::default_trait_access)]
+
+fn main() {
+    let _: std::time::Duration = Default::default();
+    //~^ default_trait_access
+}

--- a/tests/ui/default_trait_access_unfixable.stderr
+++ b/tests/ui/default_trait_access_unfixable.stderr
@@ -1,0 +1,11 @@
+error: calling `Duration::default()` is more clear than this expression
+  --> tests/ui/default_trait_access_unfixable.rs:5:34
+   |
+LL |     let _: std::time::Duration = Default::default();
+   |                                  ^^^^^^^^^^^^^^^^^^ help: try: `Duration::default()`
+   |
+   = note: `-D clippy::default-trait-access` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::default_trait_access)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
changelog: none

The original machine-applicability change is unsafe because `with_forced_trimmed_paths` can produce a replacement path that is not in scope. For example, `std::time::Duration` is rendered as `Duration`.

This revision:
- keeps the suggestion at `Applicability::Unspecified`
- documents the path-trimming limitation next to the applicability
- adds a `default_trait_access_unfixable.rs` regression test

## Validation
- `TESTNAME=default_trait_access_unfixable cargo uibless`
- `TESTNAME=default_trait_access_unfixable cargo uitest`
- `cargo fmt --check`
