### PR TITLE
Allow floating point (in-)equality comparisons to literals in `assert_eq!` and `assert_ne!` macros

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,6 @@ root = true
 [*]
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 [*]
 end_of_line = lf
 charset = utf-8
+trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4

--- a/clippy_lints/src/operators/float_cmp.rs
+++ b/clippy_lints/src/operators/float_cmp.rs
@@ -21,7 +21,7 @@ pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
         let ecx = ConstEvalCtxt::new(cx);
         let ctxt = macro_call.span.ctxt();
 
-        let has_const = is_float_const(&ecx, lhs, ctxt) || is_float_const(&ecx, rhs, ctxt);
+        let has_const = is_disallowed_float_const(&ecx, lhs, ctxt) || is_disallowed_float_const(&ecx, rhs, ctxt);
         if !has_const {
             return;
         }
@@ -37,9 +37,9 @@ pub(crate) fn check_assert<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
     }
 }
 
-fn is_float_const(ecx: &ConstEvalCtxt<'_>, expr: &Expr<'_>, ctxt: SyntaxContext) -> bool {
+fn is_disallowed_float_const(ecx: &ConstEvalCtxt<'_>, expr: &Expr<'_>, ctxt: SyntaxContext) -> bool {
     match ecx.eval_with_source(expr, ctxt) {
-        Some((c, s)) if !is_allowed(&c) => !s.is_local(),
+        Some((c, _)) => !is_allowed(&c),
         _ => false,
     }
 }

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -442,7 +442,7 @@ pub fn lit_to_mir_constant(lit: &LitKind, ty: Option<Ty<'_>>) -> Constant {
 }
 
 /// The source of a constant value.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum ConstantSource {
     /// The value is determined solely from the expression.
     Local,

--- a/tests/ui/float_cmp.rs
+++ b/tests/ui/float_cmp.rs
@@ -135,4 +135,33 @@ fn main() {
     // the comparison should also look through references
     &0.0 == &ZERO;
     &&&&0.0 == &&&&ZERO;
+
+    // `assert_eq` and `assert_ne` are not covered by `float_cmp`.
+    // Instead, they are covered by `float_cmp_const`.
+    let a = twice(0.0);
+    let b = twice(1.0);
+    assert_eq!(a, 0.0);
+    assert_ne!(b, 0.0);
+    assert_eq!(0.0, a);
+    assert_ne!(0.0, b);
+
+    assert_eq!(a, 2.0);
+    assert_ne!(b, 3.0);
+    assert_eq!(4.0, a);
+    assert_ne!(5.0, b);
+
+    // However, comparisons are covered.
+    assert!(a == 0.0);
+    assert!(b == 0.0);
+    assert!(0.0 == a);
+    assert!(0.0 == b);
+
+    assert!(a != 2.0);
+    //~^ float_cmp
+    assert!(b != 3.0);
+    //~^ float_cmp
+    assert!(4.0 != a);
+    //~^ float_cmp
+    assert!(5.0 != b);
+    //~^ float_cmp
 }

--- a/tests/ui/float_cmp.stderr
+++ b/tests/ui/float_cmp.stderr
@@ -37,5 +37,29 @@ error: strict comparison of `f32` or `f64`
 LL |     a1[0] == a2[0];
    |     ^^^^^^^^^^^^^^ help: consider comparing them within some margin of error: `(a1[0] - a2[0]).abs() < error_margin`
 
-error: aborting due to 6 previous errors
+error: strict comparison of `f32` or `f64`
+  --> tests/ui/float_cmp.rs:159:13
+   |
+LL |     assert!(a != 2.0);
+   |             ^^^^^^^^ help: consider comparing them within some margin of error: `(a - 2.0).abs() > error_margin`
+
+error: strict comparison of `f32` or `f64`
+  --> tests/ui/float_cmp.rs:161:13
+   |
+LL |     assert!(b != 3.0);
+   |             ^^^^^^^^ help: consider comparing them within some margin of error: `(b - 3.0).abs() > error_margin`
+
+error: strict comparison of `f32` or `f64`
+  --> tests/ui/float_cmp.rs:163:13
+   |
+LL |     assert!(4.0 != a);
+   |             ^^^^^^^^ help: consider comparing them within some margin of error: `(4.0 - a).abs() > error_margin`
+
+error: strict comparison of `f32` or `f64`
+  --> tests/ui/float_cmp.rs:165:13
+   |
+LL |     assert!(5.0 != b);
+   |             ^^^^^^^^ help: consider comparing them within some margin of error: `(5.0 - b).abs() > error_margin`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/float_cmp_const.rs
+++ b/tests/ui/float_cmp_const.rs
@@ -1,7 +1,7 @@
 //@no-rustfix: suggestions have an error margin placeholder
 #![warn(clippy::float_cmp_const)]
 #![expect(clippy::float_cmp)]
-#![allow(clippy::no_effect, clippy::unnecessary_operation)]
+#![allow(clippy::no_effect, clippy::redundant_closure_call, clippy::unnecessary_operation)]
 
 const ONE: f32 = 1.0;
 const TWO: f32 = 2.0;
@@ -77,5 +77,22 @@ fn main() {
 
     // has errors
     NON_ZERO_ARRAY == NON_ZERO_ARRAY2;
+    //~^ float_cmp_const
+
+    // `assert_eq` and `assert_ne` are covered by `float_cmp_const` as long as neither value is zero.
+    let a = (|| 0.0)();
+    let b = (|| 1.0)();
+    assert_eq!(a, 0.0);
+    assert_ne!(b, 0.0);
+    assert_eq!(0.0, a);
+    assert_ne!(0.0, b);
+
+    assert_eq!(a, 2.0);
+    //~^ float_cmp_const
+    assert_ne!(b, 3.0);
+    //~^ float_cmp_const
+    assert_eq!(4.0, a);
+    //~^ float_cmp_const
+    assert_ne!(5.0, b);
     //~^ float_cmp_const
 }

--- a/tests/ui/float_cmp_const.stderr
+++ b/tests/ui/float_cmp_const.stderr
@@ -67,5 +67,29 @@ error: strict comparison of `f32` or `f64` constant arrays
 LL |     NON_ZERO_ARRAY == NON_ZERO_ARRAY2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 11 previous errors
+error: strict comparison of `f32` or `f64` constant
+  --> tests/ui/float_cmp_const.rs:90:5
+   |
+LL |     assert_eq!(a, 2.0);
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: strict comparison of `f32` or `f64` constant
+  --> tests/ui/float_cmp_const.rs:92:5
+   |
+LL |     assert_ne!(b, 3.0);
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: strict comparison of `f32` or `f64` constant
+  --> tests/ui/float_cmp_const.rs:94:5
+   |
+LL |     assert_eq!(4.0, a);
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: strict comparison of `f32` or `f64` constant
+  --> tests/ui/float_cmp_const.rs:96:5
+   |
+LL |     assert_ne!(5.0, b);
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
changelog: [`float_cmp_const`] Check for floating-point (in-)equality comparisons to constants in `assert_eq!` and `assert_ne!` macros.

Fixes rust-lang/rust-clippy#17570 