### PR TITLE
Rewrite `cargo-clippy`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -419,9 +419,10 @@ use clippy_utils::macros::FormatArgsStorage;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_lint::is_lint_pass_required;
 use rustc_middle::ty::TyCtxt;
+use std::process::ExitCode;
 use utils::attr_collector::AttrStorage;
 
-pub fn explain(name: &str) -> i32 {
+pub fn explain(name: &str) -> ExitCode {
     let target = format!("clippy::{name}");
     if let Some(info) = declared_lints::LINTS.iter().find(|info| info.lint.name == target) {
         println!("{}", sanitize_explanation(info.explanation));
@@ -435,10 +436,10 @@ pub fn explain(name: &str) -> i32 {
                 println!("{conf}");
             }
         }
-        0
+        ExitCode::SUCCESS
     } else {
         println!("unknown lint: {name}");
-        1
+        ExitCode::FAILURE
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,153 +1,167 @@
-// We need this feature as it changes `dylib` linking behavior and allows us to link to
-// `rustc_driver`.
 #![feature(rustc_private)]
 // warn on lints, that are included in `rust-lang/rust`s bootstrap
 #![warn(rust_2018_idioms, unused_lifetimes)]
 
+#[expect(unused_extern_crates, reason = "needed to link to rustc_driver")]
 extern crate rustc_driver;
 
 use std::env;
 use std::io::Write as _;
 use std::path::PathBuf;
-use std::process::{self, Command, exit};
+use std::process::{self, Command, ExitCode};
 
-fn show_help() {
-    if writeln!(&mut anstream::stdout().lock(), "{}", help_message()).is_err() {
-        exit(rustc_driver::EXIT_FAILURE);
+fn main() -> ExitCode {
+    let args = match Args::parse(env::args()) {
+        Ok(args) => args,
+        Err(e) => {
+            e.print();
+            return ExitCode::FAILURE;
+        },
+    };
+
+    if args.help {
+        return match anstream::stdout().write_all(HELP_MSG.as_bytes()) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(_) => ExitCode::FAILURE,
+        };
     }
-}
-
-fn show_version() {
-    let version_info = rustc_tools_util::get_version_info!();
-    if writeln!(&mut anstream::stdout().lock(), "{version_info}").is_err() {
-        exit(rustc_driver::EXIT_FAILURE);
+    if args.version {
+        return match writeln!(anstream::stdout(), "{}", rustc_tools_util::get_version_info!()) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(_) => ExitCode::FAILURE,
+        };
     }
-}
-
-pub fn main() {
-    // Check for version and help flags even when invoked as 'cargo-clippy'
-    if env::args().any(|a| a == "--help" || a == "-h") {
-        show_help();
-        return;
-    }
-
-    if env::args().any(|a| a == "--version" || a == "-V") {
-        show_version();
-        return;
-    }
-
-    if let Some(pos) = env::args().position(|a| a == "--explain") {
-        if let Some(mut lint) = env::args().nth(pos + 1) {
-            lint.make_ascii_lowercase();
-            process::exit(clippy_lints::explain(
-                &lint.strip_prefix("clippy::").unwrap_or(&lint).replace('-', "_"),
-            ));
-        }
-        show_help();
-        return;
+    if let Some(lint) = &args.explain {
+        return clippy_lints::explain(lint);
     }
 
-    if let Err(code) = process(env::args().skip(2)) {
-        process::exit(code);
-    }
-}
-
-struct ClippyCmd {
-    cargo_subcommand: &'static str,
-    args: Vec<String>,
-    clippy_args: Vec<String>,
-}
-
-impl ClippyCmd {
-    fn new<I>(mut old_args: I) -> Self
-    where
-        I: Iterator<Item = String>,
-    {
-        let mut cargo_subcommand = "check";
-        let mut args = vec![];
-        let mut clippy_args: Vec<String> = vec![];
-
-        for arg in old_args.by_ref() {
-            match arg.as_str() {
-                "--fix" => {
-                    cargo_subcommand = "fix";
-                    continue;
-                },
-                "--no-deps" => {
-                    clippy_args.push("--no-deps".into());
-                    continue;
-                },
-                "--" => break,
-                _ => {},
-            }
-
-            args.push(arg);
-        }
-
-        clippy_args.append(&mut (old_args.collect()));
-        if cargo_subcommand == "fix" && !clippy_args.iter().any(|arg| arg == "--no-deps") {
-            clippy_args.push("--no-deps".into());
-        }
-
-        Self {
-            cargo_subcommand,
-            args,
-            clippy_args,
-        }
-    }
-
-    fn path() -> PathBuf {
-        let mut path = env::current_exe()
-            .expect("current executable path invalid")
-            .with_file_name("clippy-driver");
-
-        if cfg!(windows) {
-            path.set_extension("exe");
-        }
-
-        path
-    }
-
-    fn into_std_cmd(self) -> Command {
-        let mut cmd = Command::new(env::var("CARGO").unwrap_or_else(|_| "cargo".into()));
-        let clippy_args: String = self
-            .clippy_args
-            .iter()
-            .fold(String::new(), |s, arg| s + arg + "__CLIPPY_HACKERY__");
-
-        cmd.env("RUSTC_WORKSPACE_WRAPPER", Self::path())
-            .env("CLIPPY_ARGS", clippy_args)
-            .arg(self.cargo_subcommand)
-            .args(&self.args);
-
-        cmd
-    }
-}
-
-fn process<I>(old_args: I) -> Result<(), i32>
-where
-    I: Iterator<Item = String>,
-{
-    let cmd = ClippyCmd::new(old_args);
-
-    let mut cmd = cmd.into_std_cmd();
-
-    let exit_status = cmd
+    if let Some(code) = Command::new(env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+        .env("RUSTC_WORKSPACE_WRAPPER", driver_path())
+        .env("CLIPPY_ARGS", &args.clippy_args)
+        .arg(if args.fix { "fix" } else { "check" })
+        .args(&args.cargo_args)
         .spawn()
         .expect("could not run cargo")
         .wait()
-        .expect("failed to wait for cargo?");
+        .expect("failed to wait for cargo?")
+        .code()
+    {
+        process::exit(code);
+    }
+    // Cargo exited due to a signal
+    ExitCode::from(u8::MAX)
+}
 
-    if exit_status.success() {
-        Ok(())
-    } else {
-        Err(exit_status.code().unwrap_or(-1))
+#[expect(clippy::struct_field_names)]
+struct Args {
+    /// The arguments to forward to cargo.
+    cargo_args: Vec<String>,
+    /// Arguments to pass through to `clippy-driver`. Arguments are separated by
+    // "__CLIPPY_HACKERY__" and passed via. an environment variable.
+    clippy_args: String,
+    /// Whether to stop and print info for the specified lint.
+    explain: Option<String>,
+    /// Whether to stop and print help info.
+    help: bool,
+    /// Whether to stop and print version info.
+    version: bool,
+    /// Whether to run in fix mode.
+    fix: bool,
+}
+impl Args {
+    fn parse(mut args: impl Iterator<Item = String>) -> Result<Self, ArgError> {
+        let mut parsed = Args {
+            cargo_args: Vec::new(),
+            clippy_args: String::new(),
+            explain: None,
+            help: false,
+            version: false,
+            fix: false,
+        };
+        let mut no_deps = false;
+
+        // Cargo forwards to sub-commands as `cargo sub-command args`.
+        // Special case handling help and version in case this is called directly,
+        // but otherwise ignore the second argument.
+        match args.nth(1) {
+            Some(x) => match &*x {
+                "-h" | "--help" => parsed.help = true,
+                "-V" | "--version" => parsed.version = true,
+                // FIXME(@Jarcho): Handle all arguments here without breaking too many existing callers.
+                _ => {},
+            },
+            None => return Ok(parsed),
+        }
+        while let Some(arg) = args.next() {
+            match &*arg {
+                "-h" | "--help" => parsed.help = true,
+                "-V" | "--version" => parsed.version = true,
+                "--explain" if parsed.explain.is_some() => return Err(ArgError::MultipleExplain),
+                "--explain" => {
+                    if let Some(mut arg) = args.next()
+                        && !arg.starts_with('-')
+                    {
+                        arg.make_ascii_lowercase();
+                        parsed.explain = Some(arg.strip_prefix("clippy::").unwrap_or(&*arg).replace('-', "_"));
+                    } else {
+                        return Err(ArgError::NoExplainArg);
+                    }
+                },
+                "--fix" => parsed.fix = true,
+                "--no-deps" => {
+                    no_deps = true;
+                    parsed.clippy_args.push_str("--no-deps__CLIPPY_HACKERY__");
+                },
+                "--" => {
+                    for arg in args {
+                        no_deps |= arg == "--no-deps";
+                        parsed.clippy_args.extend([&*arg, "__CLIPPY_HACKERY__"]);
+                    }
+                    break;
+                },
+                _ => parsed.cargo_args.push(arg),
+            }
+        }
+        if parsed.fix && !no_deps {
+            parsed.clippy_args.push_str("--no-deps__CLIPPY_HACKERY__");
+        }
+        Ok(parsed)
     }
 }
 
-#[must_use]
-pub fn help_message() -> &'static str {
-    color_print::cstr!(
+/// Gets the driver path relative to the current cargo-clippy.
+fn driver_path() -> PathBuf {
+    const DRIVER_NAME: &str = if cfg!(windows) {
+        "clippy-driver.exe"
+    } else {
+        "clippy-driver"
+    };
+
+    let mut path = env::current_exe().expect("current executable path invalid");
+    path.set_file_name(DRIVER_NAME);
+    path
+}
+
+#[derive(Debug)]
+enum ArgError {
+    MultipleExplain,
+    NoExplainArg,
+}
+impl ArgError {
+    fn print(&self) {
+        let msg = match self {
+            Self::MultipleExplain => "multiple `--explain` arguments",
+            Self::NoExplainArg => "missing value for `--explain`",
+        };
+        let mut dst = anstream::stderr().lock();
+        let _ = dst
+            .write_all(color_print::cstr!("<bold,red>error</>: ").as_bytes())
+            .and_then(|()| dst.write_all(msg.as_bytes()))
+            .and_then(|()| dst.write_all(HELP_USAGE.as_bytes()));
+    }
+}
+
+const HELP_MSG: &str = color_print::cstr!(
 "Checks a package to catch common mistakes and improve your Rust code.
 
 <green,bold>Usage</>:
@@ -180,40 +194,42 @@ You can use tool lints to allow or deny lints from your code, e.g.:
     <cyan,bold>--frozen</>                Require Cargo.lock and cache are up to date
     <cyan,bold>--locked</>                Require Cargo.lock is up to date
     <cyan,bold>--offline</>               Run without accessing the network
-")
-}
+
+");
+const HELP_USAGE: &str = {
+    let mut i = 0usize;
+    while HELP_MSG.as_bytes()[i] != b'\n' {
+        i += 1;
+    }
+    HELP_MSG.split_at(i).1 // include leading line ends
+};
+
 #[cfg(test)]
 mod tests {
-    use super::ClippyCmd;
+    use super::Args;
 
-    #[test]
-    fn fix() {
-        let args = "cargo clippy --fix".split_whitespace().map(ToString::to_string);
-        let cmd = ClippyCmd::new(args);
-        assert_eq!("fix", cmd.cargo_subcommand);
-        assert!(!cmd.args.iter().any(|arg| arg.ends_with("unstable-options")));
+    fn parse(args: &[&str]) -> Args {
+        Args::parse(args.iter().copied().map(String::from)).unwrap()
+    }
+    fn clippy_args(args: &Args) -> impl Iterator<Item = &str> {
+        args.clippy_args.split("__CLIPPY_HACKERY__")
     }
 
     #[test]
     fn fix_implies_no_deps() {
-        let args = "cargo clippy --fix".split_whitespace().map(ToString::to_string);
-        let cmd = ClippyCmd::new(args);
-        assert!(cmd.clippy_args.iter().any(|arg| arg == "--no-deps"));
+        let args = parse(&["cargo", "clippy", "--fix"]);
+        assert!(clippy_args(&args).any(|arg| arg == "--no-deps"));
     }
 
     #[test]
     fn no_deps_not_duplicated_with_fix() {
-        let args = "cargo clippy --fix -- --no-deps"
-            .split_whitespace()
-            .map(ToString::to_string);
-        let cmd = ClippyCmd::new(args);
-        assert_eq!(cmd.clippy_args.iter().filter(|arg| *arg == "--no-deps").count(), 1);
+        let args = parse(&["cargo", "clippy", "--fix", "--no-deps"]);
+        assert_eq!(clippy_args(&args).filter(|&arg| arg == "--no-deps").count(), 1);
     }
 
     #[test]
-    fn check() {
-        let args = "cargo clippy".split_whitespace().map(ToString::to_string);
-        let cmd = ClippyCmd::new(args);
-        assert_eq!("check", cmd.cargo_subcommand);
+    fn no_deps_not_duplicated_with_fix_extra() {
+        let args = parse(&["cargo", "clippy", "--fix", "--", "--no-deps"]);
+        assert_eq!(clippy_args(&args).filter(|&arg| arg == "--no-deps").count(), 1);
     }
 }


### PR DESCRIPTION
Not at all necessary rewrite, but it fixes a couple of weird things.
* `-h`, `-V` and `--explain` are no longer parsed if they occur after the `--` argument. Doesn't really make a difference in practice, but this matches how other programs with argument forwarding work.
* `--explain` actually prints an error message when there's no argument.
* `--explain` gives an error when it appears multiple times instead of only printing the first. Alternatively we could just print all lints.

This also doesn't walk the argument list four times. Not a big deal since the argument list is usually short and running cargo isn't exactly fast in the first place.

changelog: none
