### PR TITLE
Avoid `manual_assert_eq` for byte slice-like types

### DIFF
--- a/clippy_lints/src/manual_assert_eq.rs
+++ b/clippy_lints/src/manual_assert_eq.rs
@@ -18,6 +18,12 @@ declare_clippy_lint! {
     /// `assert_{eq,ne}!` and `debug_assert_{eq,ne}!` achieves the same goal, and provides some
     /// additional debug information
     ///
+    /// ### Known problems
+    /// This lint cannot determine how large the `Debug` output of the compared values will be.
+    /// To avoid producing excessively large assertion output, it ignores comparisons involving
+    /// byte-slice-like types. These include byte slices and types that dereference to a byte slice
+    /// or implement `AsRef<[u8]>` without also implementing `AsRef<str>`.
+    ///
     /// ### Example
     /// ```no_run
     /// assert!(2 * 2 == 4);

--- a/clippy_lints/src/manual_assert_eq.rs
+++ b/clippy_lints/src/manual_assert_eq.rs
@@ -2,11 +2,12 @@ use clippy_utils::consts::ConstEvalCtxt;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::macros::{PanicCall, find_assert_args, root_macro_call_first_node};
 use clippy_utils::source::walk_span_to_context;
-use clippy_utils::ty::implements_trait;
+use clippy_utils::ty::{deref_chain, implements_trait};
 use clippy_utils::{is_in_const_context, sym};
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext as _};
+use rustc_middle::ty::{self, Ty};
 use rustc_session::declare_lint_pass;
 
 declare_clippy_lint! {
@@ -82,6 +83,9 @@ impl LateLintPass<'_> for ManualAssertEq {
             // Printing raw pointers isn't very useful
             && !lhs_ty.is_raw_ptr()
             && !rhs_ty.is_raw_ptr()
+            // Byte buffers can be large and their debug output is rarely useful
+            && !is_byte_slice_like(cx, lhs_ty)
+            && !is_byte_slice_like(cx, rhs_ty)
             // The output of `(debug_)assert_eq` isn't very useful when one of the sides is a constant value
             && if eq_kind == EqKind::Ne {
                    let ecx = ConstEvalCtxt::new(cx);
@@ -119,4 +123,32 @@ impl LateLintPass<'_> for ManualAssertEq {
             );
         }
     }
+}
+
+fn is_byte_slice_like<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    let byte_slice = Ty::new_slice(cx.tcx, cx.tcx.types.u8);
+    let ty = ty.peel_refs();
+
+    if ty == byte_slice {
+        return true;
+    }
+    if matches!(ty.kind(), ty::Adt(..))
+        && cx.tcx.get_diagnostic_item(sym::AsRef).is_some_and(|trait_id| {
+            implements_trait(cx, ty, trait_id, &[byte_slice.into()])
+                && !implements_trait(cx, ty, trait_id, &[cx.tcx.types.str_.into()])
+        })
+    {
+        return true;
+    }
+
+    for (depth, ty) in deref_chain(cx, ty).enumerate().skip(1) {
+        if !cx.tcx.recursion_limit().value_within_limit(depth) {
+            return false;
+        }
+        if ty == byte_slice {
+            return true;
+        }
+    }
+
+    false
 }

--- a/tests/ui/manual_assert_eq.fixed
+++ b/tests/ui/manual_assert_eq.fixed
@@ -85,6 +85,98 @@ fn main() {
         assert!(nd == id);
     }
 
+    // Don't lint: byte buffers can contain too much data for useful debug output
+    {
+        use std::borrow::Cow;
+        use std::ops::Deref;
+        use std::rc::Rc;
+        use std::sync::Arc;
+
+        #[derive(Debug, PartialEq)]
+        struct ByteBuf(Vec<u8>);
+
+        impl Deref for ByteBuf {
+            type Target = [u8];
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        let vec = vec![1_u8];
+        assert!(vec == vec![1]);
+
+        let slice: &[u8] = &[1];
+        let expected_slice: &[u8] = &[1];
+        assert!(slice == expected_slice);
+
+        let boxed: Box<[u8]> = Box::new([1]);
+        assert!(boxed == Box::new([1]));
+
+        let cow: Cow<'_, [u8]> = Cow::Borrowed(&[1]);
+        assert!(cow == Cow::Borrowed(&[1]));
+
+        let rc: Rc<[u8]> = Rc::new([1]);
+        assert!(rc == Rc::new([1]));
+
+        let arc: Arc<[u8]> = Arc::new([1]);
+        assert!(arc == Arc::new([1]));
+
+        let custom = ByteBuf(vec![1]);
+        assert!(custom == ByteBuf(vec![1]));
+
+        #[derive(Debug, PartialEq)]
+        struct InnerPiece([u8; 1024]);
+
+        #[derive(Debug, PartialEq)]
+        struct Piece(InnerPiece);
+
+        impl Deref for Piece {
+            type Target = InnerPiece;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl AsRef<[u8]> for Piece {
+            fn as_ref(&self) -> &[u8] {
+                &self.0.0
+            }
+        }
+
+        let piece = Piece(InnerPiece([0; 1024]));
+        assert!(piece == Piece(InnerPiece([0; 1024])));
+
+        #[derive(Debug, PartialEq)]
+        struct Grow<T>(std::marker::PhantomData<T>);
+
+        impl<T> Deref for Grow<T> {
+            type Target = Grow<(T,)>;
+
+            fn deref(&self) -> &Self::Target {
+                unreachable!()
+            }
+        }
+
+        assert_eq!(Grow::<u8>(std::marker::PhantomData), Grow(std::marker::PhantomData));
+        //~^ manual_assert_eq
+
+        #[derive(Debug, PartialEq)]
+        struct SelfDerefer;
+
+        impl Deref for SelfDerefer {
+            type Target = Self;
+
+            fn deref(&self) -> &Self::Target {
+                self
+            }
+        }
+
+        assert_eq!(SelfDerefer, SelfDerefer);
+        //~^ manual_assert_eq
+    }
+
     // Don't lint: in const context
     const {
         assert!(5 == 2 + 3);

--- a/tests/ui/manual_assert_eq.rs
+++ b/tests/ui/manual_assert_eq.rs
@@ -85,6 +85,98 @@ fn main() {
         assert!(nd == id);
     }
 
+    // Don't lint: byte buffers can contain too much data for useful debug output
+    {
+        use std::borrow::Cow;
+        use std::ops::Deref;
+        use std::rc::Rc;
+        use std::sync::Arc;
+
+        #[derive(Debug, PartialEq)]
+        struct ByteBuf(Vec<u8>);
+
+        impl Deref for ByteBuf {
+            type Target = [u8];
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        let vec = vec![1_u8];
+        assert!(vec == vec![1]);
+
+        let slice: &[u8] = &[1];
+        let expected_slice: &[u8] = &[1];
+        assert!(slice == expected_slice);
+
+        let boxed: Box<[u8]> = Box::new([1]);
+        assert!(boxed == Box::new([1]));
+
+        let cow: Cow<'_, [u8]> = Cow::Borrowed(&[1]);
+        assert!(cow == Cow::Borrowed(&[1]));
+
+        let rc: Rc<[u8]> = Rc::new([1]);
+        assert!(rc == Rc::new([1]));
+
+        let arc: Arc<[u8]> = Arc::new([1]);
+        assert!(arc == Arc::new([1]));
+
+        let custom = ByteBuf(vec![1]);
+        assert!(custom == ByteBuf(vec![1]));
+
+        #[derive(Debug, PartialEq)]
+        struct InnerPiece([u8; 1024]);
+
+        #[derive(Debug, PartialEq)]
+        struct Piece(InnerPiece);
+
+        impl Deref for Piece {
+            type Target = InnerPiece;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl AsRef<[u8]> for Piece {
+            fn as_ref(&self) -> &[u8] {
+                &self.0.0
+            }
+        }
+
+        let piece = Piece(InnerPiece([0; 1024]));
+        assert!(piece == Piece(InnerPiece([0; 1024])));
+
+        #[derive(Debug, PartialEq)]
+        struct Grow<T>(std::marker::PhantomData<T>);
+
+        impl<T> Deref for Grow<T> {
+            type Target = Grow<(T,)>;
+
+            fn deref(&self) -> &Self::Target {
+                unreachable!()
+            }
+        }
+
+        assert!(Grow::<u8>(std::marker::PhantomData) == Grow(std::marker::PhantomData));
+        //~^ manual_assert_eq
+
+        #[derive(Debug, PartialEq)]
+        struct SelfDerefer;
+
+        impl Deref for SelfDerefer {
+            type Target = Self;
+
+            fn deref(&self) -> &Self::Target {
+                self
+            }
+        }
+
+        assert!(SelfDerefer == SelfDerefer);
+        //~^ manual_assert_eq
+    }
+
     // Don't lint: in const context
     const {
         assert!(5 == 2 + 3);

--- a/tests/ui/manual_assert_eq.stderr
+++ b/tests/ui/manual_assert_eq.stderr
@@ -84,5 +84,29 @@ LL -     assert!(vec![1] == vec![1, 2, 3]);
 LL +     assert_eq!(vec![1], vec![1, 2, 3]);
    |
 
-error: aborting due to 7 previous errors
+error: used `assert!` with an equality comparison
+  --> tests/ui/manual_assert_eq.rs:162:9
+   |
+LL |         assert!(Grow::<u8>(std::marker::PhantomData) == Grow(std::marker::PhantomData));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert_eq!(..)`
+   |
+LL -         assert!(Grow::<u8>(std::marker::PhantomData) == Grow(std::marker::PhantomData));
+LL +         assert_eq!(Grow::<u8>(std::marker::PhantomData), Grow(std::marker::PhantomData));
+   |
+
+error: used `assert!` with an equality comparison
+  --> tests/ui/manual_assert_eq.rs:176:9
+   |
+LL |         assert!(SelfDerefer == SelfDerefer);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert_eq!(..)`
+   |
+LL -         assert!(SelfDerefer == SelfDerefer);
+LL +         assert_eq!(SelfDerefer, SelfDerefer);
+   |
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
`manual_assert_eq` can produce very large and unhelpful debug output when either operand is a byte buffer. This change skips the lint when an operand's dereference chain reaches `[u8]` or its type implements `AsRef<[u8]>`. Types that also implement `AsRef<str>` remain linted, preserving the current behavior for `String`.

The dereference traversal respects the compiler recursion limit so that pathological `Deref` implementations cannot make linting hang or overflow.

The existing UI test covers direct slices, standard byte-buffer wrappers, custom `Deref` and `AsRef<[u8]>` types, pathological dereference chains, and the existing non-byte and string diagnostics.

Fixes rust-lang/rust-clippy#17524

changelog: [`manual_assert_eq`]: avoid linting comparisons involving byte slice-like types

## Testing

- `cargo fmt --all -- --check`
- `TESTNAME=manual_assert_eq cargo uitest`
- `cargo test`
