### PR TITLE
perf: check fn kind before the expansion walk in missing_const_for_thread_local

### DIFF
--- a/clippy_lints/src/missing_const_for_thread_local.rs
+++ b/clippy_lints/src/missing_const_for_thread_local.rs
@@ -60,10 +60,11 @@ fn is_thread_local_initializer(
     fn_kind: intravisit::FnKind<'_>,
     span: rustc_span::Span,
 ) -> Option<bool> {
-    let macro_def_id = span.source_callee()?.macro_def_id?;
     Some(
-        cx.tcx.is_diagnostic_item(sym::thread_local_macro, macro_def_id)
-            && matches!(fn_kind, intravisit::FnKind::ItemFn(..)),
+        matches!(fn_kind, intravisit::FnKind::ItemFn(..))
+            && cx
+                .tcx
+                .is_diagnostic_item(sym::thread_local_macro, span.source_callee()?.macro_def_id?),
     )
 }
 


### PR DESCRIPTION
| crate | change |
|---|---|
| syn 2.0.71 | -0.00% |
| serde 1.0.204 | -0.01% |
| wasmi 0.35.0 | **-0.46%** |
| regex 1.10.5 | +0.00% |
| ryu 1.0.18 | -0.00% |

changelog: none