### PR TITLE
perf: resolve the callee before the expansion walk in VecArgs::hir

### DIFF
--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -369,9 +369,14 @@ impl<'a> VecArgs<'a> {
     pub fn hir(cx: &LateContext<'_>, expr: &'a Expr<'_>) -> Option<VecArgs<'a>> {
         if let ExprKind::Call(fun, args) = expr.kind
             && let ExprKind::Path(ref qpath) = fun.kind
-            && is_expn_of(fun.span, sym::vec).is_some()
             && let Some(fun_def_id) = cx.qpath_res(qpath, fun.hir_id).opt_def_id()
             && let Some(name) = cx.tcx.get_diagnostic_name(fun_def_id)
+            && matches!(
+                name,
+                sym::vec_from_elem | sym::box_assume_init_into_vec_unsafe | sym::vec_new
+            )
+            // Do the cheap checks first, since `is_expn_of` walks the whole expansion chain.
+            && is_expn_of(fun.span, sym::vec).is_some()
         {
             return match (name, args) {
                 (sym::vec_from_elem, [elem, size]) => {


### PR DESCRIPTION
| crate | change |
|---|---|
| syn 2.0.71 | -0.00% |
| serde 1.0.204 | -0.03% |
| wasmi 0.35.0 | **-0.34%** |
| regex 1.10.5 | -0.00% |
| ryu 1.0.18 | +0.00% |

changelog: none