### PR TITLE
fix(useless_conversion): ignore From::from in generated code

### DIFF
--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -3,7 +3,7 @@ use clippy_utils::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _, Maybe
 use clippy_utils::source::{snippet, snippet_with_context};
 use clippy_utils::sugg::{DiagExt as _, Sugg};
 use clippy_utils::ty::{is_copy, same_type_modulo_regions};
-use clippy_utils::{get_parent_expr, is_ty_alias, sym};
+use clippy_utils::{get_parent_expr, in_automatically_derived, is_ty_alias, sym};
 use rustc_errors::Applicability;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{BindingMode, Expr, ExprKind, HirId, LangItem, MatchSource, Mutability, Node, PatKind};
@@ -436,7 +436,10 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                             None,
                             hint,
                         );
-                    } else if name == sym::from_fn && same_type_modulo_regions(a, b) {
+                    } else if name == sym::from_fn
+                        && same_type_modulo_regions(a, b)
+                        && !in_automatically_derived(cx.tcx, e.hir_id)
+                    {
                         let mut app = Applicability::MachineApplicable;
                         let sugg = Sugg::hir_with_context(cx, arg, e.span.ctxt(), "<expr>", &mut app).maybe_paren();
                         let sugg_msg = format!("consider removing `{}()`", snippet(cx, path.span, "From::from"));

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -501,3 +501,43 @@ fn after_question_mark() -> Result<(), ()> {
     //~^ useless_conversion
     Ok(())
 }
+
+mod issue17083 {
+    trait FromU32: From<u32> {}
+
+    trait HasType {
+        type Type: FromU32;
+    }
+
+    trait HasNestedType {
+        type Type: HasType;
+    }
+
+    trait CanWrite
+    where
+        Self: HasNestedType,
+    {
+        fn write(output: &mut <<Self as HasNestedType>::Type as HasType>::Type);
+    }
+
+    enum Test<T> {
+        Add(T),
+    }
+
+    impl<T> HasNestedType for Test<T>
+    where
+        T: HasType,
+    {
+        type Type = T;
+    }
+
+    #[automatically_derived]
+    impl<T> CanWrite for Test<T>
+    where
+        T: HasType<Type = u32>,
+    {
+        fn write(output: &mut T::Type) {
+            *output = !T::Type::from(1u32);
+        }
+    }
+}

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -501,3 +501,43 @@ fn after_question_mark() -> Result<(), ()> {
     //~^ useless_conversion
     Ok(())
 }
+
+mod issue17083 {
+    trait FromU32: From<u32> {}
+
+    trait HasType {
+        type Type: FromU32;
+    }
+
+    trait HasNestedType {
+        type Type: HasType;
+    }
+
+    trait CanWrite
+    where
+        Self: HasNestedType,
+    {
+        fn write(output: &mut <<Self as HasNestedType>::Type as HasType>::Type);
+    }
+
+    enum Test<T> {
+        Add(T),
+    }
+
+    impl<T> HasNestedType for Test<T>
+    where
+        T: HasType,
+    {
+        type Type = T;
+    }
+
+    #[automatically_derived]
+    impl<T> CanWrite for Test<T>
+    where
+        T: HasType<Type = u32>,
+    {
+        fn write(output: &mut T::Type) {
+            *output = !T::Type::from(1u32);
+        }
+    }
+}


### PR DESCRIPTION
Fixes `useless_conversion` being triggered for `From::from(...)` in `#[automatically_derived]` code.

The lint now skips those cases and the UI test has been updated accordingly.

I used an LLM to help understand parts of the codebase and explore the approach. The final change was reviewed, understood and implemented by me.

changelog: [`useless_conversion`]: Don't lint `From::from` in automatically derived code

Fixes rust-lang/rust-clippy#17083
