### PR TITLE
perf: check first_node_in_macro before the root macro walk in useless_format

### DIFF
--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -58,8 +58,11 @@ impl<'tcx> LateLintPass<'tcx> for UselessFormat {
         // HIR nodes inside `format!`'s own expansion (its outer block's tail, its nested
         // `format_args!`), which would otherwise also pass `first_node_in_macro` and cause the
         // lint to fire multiple times per call.
-        if let Some(macro_call) = matching_root_macro_call(cx, expr.span, sym::format_macro)
-            && first_node_in_macro(cx, expr).is_some_and(|p_expn| p_expn != macro_call.expn)
+        //
+        // `first_node_in_macro` is checked first because it is cheaper.
+        if let Some(p_expn) = first_node_in_macro(cx, expr)
+            && let Some(macro_call) = matching_root_macro_call(cx, expr.span, sym::format_macro)
+            && p_expn != macro_call.expn
             && let Some(format_args) = self.format_args.get(cx, expr, macro_call.expn)
         {
             let mut applicability = Applicability::MachineApplicable;


### PR DESCRIPTION
| crate | change |
|---|---|
| syn 2.0.71 | -0.13% |
| serde 1.0.204 | -0.24% |
| wasmi 0.35.0 | **-5.04%** |
| regex 1.10.5 | -0.06% |
| ryu 1.0.18 | -0.09% |

changelog: none

