### PR TITLE
`unused_trait_names`: make the suggestion nicer

### DIFF
--- a/clippy_lints/src/unused_trait_names.rs
+++ b/clippy_lints/src/unused_trait_names.rs
@@ -1,8 +1,7 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_from_proc_macro;
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::source::snippet_opt;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Item, ItemKind, UseKind};
@@ -70,19 +69,33 @@ impl<'tcx> LateLintPass<'tcx> for UnusedTraitNames {
             && let module = cx.tcx.parent_module_from_def_id(item.owner_id.def_id)
             && cx.tcx.local_visibility(item.owner_id.def_id) == Visibility::Restricted(module)
             && let Some(last_segment) = path.segments.last()
-            && let Some(snip) = snippet_opt(cx, last_segment.ident.span)
             && self.msrv.meets(cx, msrvs::UNDERSCORE_IMPORTS)
             && !is_from_proc_macro(cx, &last_segment.ident)
         {
             let complete_span = last_segment.ident.span.to(ident.span);
-            span_lint_and_sugg(
+            span_lint_and_then(
                 cx,
                 UNUSED_TRAIT_NAMES,
                 complete_span,
                 "importing trait that is only used anonymously",
-                "use",
-                format!("{snip} as _"),
-                Applicability::MachineApplicable,
+                |diag| {
+                    // HACK: `ident.span` points at either the final segment of the import path,
+                    // or the `bar` in `as bar`. We thus compare it with `last_segment`'s span
+                    // in order to distinguish the two cases.
+                    let (span, sugg) = if ident.span == last_segment.ident.span {
+                        // `use foo::bar;` -- append an `as _`
+                        (ident.span.shrink_to_hi(), " as _")
+                    } else {
+                        // `use foo::bar as baz` -- replace `baz` with `_`
+                        (ident.span, "_")
+                    };
+                    diag.span_suggestion_verbose(
+                        span,
+                        "import the trait anonymously",
+                        sugg,
+                        Applicability::MachineApplicable,
+                    );
+                },
             );
         }
     }

--- a/tests/ui/unused_trait_names.stderr
+++ b/tests/ui/unused_trait_names.stderr
@@ -11,52 +11,93 @@ error: importing trait that is only used anonymously
   --> tests/ui/unused_trait_names.rs:11:19
    |
 LL |     use std::any::Any;
-   |                   ^^^ help: use: `Any as _`
+   |                   ^^^
    |
    = note: `-D clippy::unused-trait-names` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unused_trait_names)]`
+help: import the trait anonymously
+   |
+LL |     use std::any::Any as _;
+   |                       ++++
 
 error: importing trait that is only used anonymously
   --> tests/ui/unused_trait_names.rs:31:26
    |
 LL |     use std::any::{self, Any, TypeId};
-   |                          ^^^ help: use: `Any as _`
+   |                          ^^^
+   |
+help: import the trait anonymously
+   |
+LL |     use std::any::{self, Any as _, TypeId};
+   |                              ++++
 
 error: importing trait that is only used anonymously
   --> tests/ui/unused_trait_names.rs:44:19
    |
 LL |     use std::any::Any as MyAny;
-   |                   ^^^^^^^^^^^^ help: use: `Any as _`
+   |                   ^^^^^^^^^^^^
+   |
+help: import the trait anonymously
+   |
+LL -     use std::any::Any as MyAny;
+LL +     use std::any::Any as _;
+   |
 
 error: importing trait that is only used anonymously
   --> tests/ui/unused_trait_names.rs:51:20
    |
 LL |     use std::any::{Any as MyAny, TypeId as MyTypeId};
-   |                    ^^^^^^^^^^^^ help: use: `Any as _`
+   |                    ^^^^^^^^^^^^
+   |
+help: import the trait anonymously
+   |
+LL -     use std::any::{Any as MyAny, TypeId as MyTypeId};
+LL +     use std::any::{Any as _, TypeId as MyTypeId};
+   |
 
 error: importing trait that is only used anonymously
   --> tests/ui/unused_trait_names.rs:75:23
    |
 LL |         use std::any::Any;
-   |                       ^^^ help: use: `Any as _`
+   |                       ^^^
+   |
+help: import the trait anonymously
+   |
+LL |         use std::any::Any as _;
+   |                           ++++
 
 error: importing trait that is only used anonymously
   --> tests/ui/unused_trait_names.rs:117:19
    |
 LL |     use std::any::Any;
-   |                   ^^^ help: use: `Any as _`
+   |                   ^^^
+   |
+help: import the trait anonymously
+   |
+LL |     use std::any::Any as _;
+   |                       ++++
 
 error: importing trait that is only used anonymously
   --> tests/ui/unused_trait_names.rs:137:19
    |
 LL |     use std::any::Any;
-   |                   ^^^ help: use: `Any as _`
+   |                   ^^^
+   |
+help: import the trait anonymously
+   |
+LL |     use std::any::Any as _;
+   |                       ++++
 
 error: importing trait that is only used anonymously
   --> tests/ui/unused_trait_names.rs:197:34
    |
 LL |     use simple_trait::{MyStruct, MyTrait};
-   |                                  ^^^^^^^ help: use: `MyTrait as _`
+   |                                  ^^^^^^^
+   |
+help: import the trait anonymously
+   |
+LL |     use simple_trait::{MyStruct, MyTrait as _};
+   |                                          ++++
 
 error: aborting due to 9 previous errors
 


### PR DESCRIPTION
- make the message more descriptive
- reduce the diff
- make the suggestion verbose, so that the diff can be color-coded (and because it'd get formatted awkwardly otherwise)

changelog: none
(because the change is not that significant imo)