### PR TITLE
Make needless_bool less aggressive for chained `if`s

### DIFF
--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -249,6 +249,21 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBool {
             && then_val != tail_val
             && wrapper_ctors_match(cx, then_func, tail_func)
         {
+            // If there is another `if _ { return ..; }` before the `if_expr`, don't lint. Replacing the last
+            // `if` won't decrease complexity, without refactoring the entire block.
+            if block.stmts.len() >= 2
+                && let [.., prev_stmt, _] = block.stmts
+                && let StmtKind::Semi(prev_if_expr) | StmtKind::Expr(prev_if_expr) = prev_stmt.kind
+                && let Some(higher::If {
+                    cond: _,
+                    then: prev_then,
+                    r#else: None,
+                }) = higher::If::hir(prev_if_expr)
+                && let ExprKind::Ret(Some(_)) = peel_blocks_with_stmt(prev_then).kind
+            {
+                return;
+            }
+
             let span = if_expr.span.to(tail.span);
             if span_contains_comment(cx, span) {
                 return;

--- a/tests/ui/needless_bool/early_return.fixed
+++ b/tests/ui/needless_bool/early_return.fixed
@@ -28,6 +28,18 @@ fn complex_condition(a: i32, b: i32) -> Result<bool, ()> {
     //~^^^^ needless_bool
 }
 
+fn multi_if_complex_previous_if(x: bool, y: bool) -> Result<bool, ()> {
+    if y {
+        let z = x && y;
+        if z {
+            return Ok(x);
+        }
+        return Ok(true);
+    }
+    Ok(x)
+    //~^^^^ needless_bool
+}
+
 // Do NOT lint: the two values are equal, and the condition might have side effects.
 fn same_value(x: bool) -> Result<bool, ()> {
     if x {
@@ -62,6 +74,29 @@ fn not_a_ctor(x: bool) -> bool {
         return make(true);
     }
     make(false)
+}
+
+// Do NOT lint: multiple if statements chained one after another.
+fn multi_if(x: bool, y: bool) -> Result<bool, ()> {
+    if y {
+        return Ok(true);
+    }
+    if x {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+// Do NOT lint: multiple if statements chained one after another, even if they have different return
+// values.
+fn multi_if_different_values(x: bool, y: bool) -> bool {
+    if y {
+        return false;
+    }
+    if x {
+        return true;
+    }
+    false
 }
 
 fn main() {}

--- a/tests/ui/needless_bool/early_return.rs
+++ b/tests/ui/needless_bool/early_return.rs
@@ -43,6 +43,21 @@ fn complex_condition(a: i32, b: i32) -> Result<bool, ()> {
     //~^^^^ needless_bool
 }
 
+fn multi_if_complex_previous_if(x: bool, y: bool) -> Result<bool, ()> {
+    if y {
+        let z = x && y;
+        if z {
+            return Ok(x);
+        }
+        return Ok(true);
+    }
+    if x {
+        return Ok(true);
+    }
+    Ok(false)
+    //~^^^^ needless_bool
+}
+
 // Do NOT lint: the two values are equal, and the condition might have side effects.
 fn same_value(x: bool) -> Result<bool, ()> {
     if x {
@@ -77,6 +92,29 @@ fn not_a_ctor(x: bool) -> bool {
         return make(true);
     }
     make(false)
+}
+
+// Do NOT lint: multiple if statements chained one after another.
+fn multi_if(x: bool, y: bool) -> Result<bool, ()> {
+    if y {
+        return Ok(true);
+    }
+    if x {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+// Do NOT lint: multiple if statements chained one after another, even if they have different return
+// values.
+fn multi_if_different_values(x: bool, y: bool) -> bool {
+    if y {
+        return false;
+    }
+    if x {
+        return true;
+    }
+    false
 }
 
 fn main() {}

--- a/tests/ui/needless_bool/early_return.stderr
+++ b/tests/ui/needless_bool/early_return.stderr
@@ -46,5 +46,14 @@ LL | |     }
 LL | |     Ok(true)
    | |____________^ help: you can reduce it to: `Ok(!(a < b && b > 0))`
 
-error: aborting due to 5 previous errors
+error: this `if` guard returns a bool literal and is followed by another
+  --> tests/ui/needless_bool/early_return.rs:54:5
+   |
+LL | /     if x {
+LL | |         return Ok(true);
+LL | |     }
+LL | |     Ok(false)
+   | |_____________^ help: you can reduce it to: `Ok(x)`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
In a function with multiple `if .. { return _; }`s with a trailing `!_` at the end, combining the last `if`+`!_` doesn't make the code less complex necessarily. It just moves the "problem" one up. Piping this through the entire `if` chain in the function either requires a non-trivial refactor or makes the code potentially less readable. Both are not acceptable for a complexity lint.

This adds a check to the lint that makes sure that there is no other `if` statement before the last collapsible `if` statement.

changelog: none 
(Will be synced together with the commit that introduces it, so no changelog entry required)
