### PR TITLE
Suggest `hypot` for `x.mul_add(x, y * y).sqrt()`

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic/hypot.rs
+++ b/clippy_lints/src/floating_point_arithmetic/hypot.rs
@@ -66,8 +66,11 @@ pub(super) fn detect(cx: &LateContext<'_>, receiver: &Expr<'_>, app: &mut Applic
     }
 
     // Check if expression is of the form x.mul_add(x, y * y)
+    // Note: the enclosing `.sqrt()` is already stripped off, the dispatch happens in
+    // `floating_point_arithmetic/mod.rs`
     if let ExprKind::MethodCall(PathSegment { ident: method, .. }, self_arg, [arg1, arg2], _) = receiver.kind
         && method.name == sym::mul_add
+        && cx.typeck_results().expr_ty(self_arg).is_floating_point()
         && eq_expr_value(cx, ctxt, self_arg, arg1)
         && let ExprKind::Binary(
             Spanned {

--- a/clippy_lints/src/floating_point_arithmetic/hypot.rs
+++ b/clippy_lints/src/floating_point_arithmetic/hypot.rs
@@ -11,6 +11,8 @@ use rustc_span::Spanned;
 use super::IMPRECISE_FLOPS;
 
 pub(super) fn detect(cx: &LateContext<'_>, receiver: &Expr<'_>, app: &mut Applicability) -> Option<String> {
+    let ctxt = receiver.span.ctxt();
+
     if let ExprKind::Binary(
         Spanned {
             node: BinOpKind::Add, ..
@@ -19,7 +21,6 @@ pub(super) fn detect(cx: &LateContext<'_>, receiver: &Expr<'_>, app: &mut Applic
         add_rhs,
     ) = receiver.kind
     {
-        let ctxt = receiver.span.ctxt();
         // check if expression of the form x * x + y * y
         if let ExprKind::Binary(
             Spanned {
@@ -62,6 +63,26 @@ pub(super) fn detect(cx: &LateContext<'_>, receiver: &Expr<'_>, app: &mut Applic
                 Sugg::hir_with_applicability(cx, rargs_0, "_", app)
             ));
         }
+    }
+
+    // Check if expression is of the form x.mul_add(x, y * y)
+    if let ExprKind::MethodCall(PathSegment { ident: method, .. }, self_arg, [arg1, arg2], _) = receiver.kind
+        && method.name == sym::mul_add
+        && eq_expr_value(cx, ctxt, self_arg, arg1)
+        && let ExprKind::Binary(
+            Spanned {
+                node: BinOpKind::Mul, ..
+            },
+            mul_lhs,
+            mul_rhs,
+        ) = arg2.kind
+        && eq_expr_value(cx, ctxt, mul_lhs, mul_rhs)
+    {
+        return Some(format!(
+            "{}.hypot({})",
+            Sugg::hir_with_applicability(cx, self_arg, "_", app).maybe_paren(),
+            Sugg::hir_with_applicability(cx, mul_lhs, "_", app)
+        ));
     }
 
     None

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -437,6 +437,7 @@ generate! {
     module_name_repetitions,
     msrv,
     msrvs,
+    mul_add,
     mut_ptr,
     mutex,
     needless_return,

--- a/tests/ui/floating_point_hypot.fixed
+++ b/tests/ui/floating_point_hypot.fixed
@@ -1,5 +1,13 @@
 #![warn(clippy::imprecise_flops)]
 
+#[derive(Clone, Copy, Debug)]
+struct CustomMulAdd;
+impl CustomMulAdd {
+    fn mul_add(self, _a: CustomMulAdd, _b: f32) -> f32 {
+        42.0
+    }
+}
+
 macro_rules! m {
     () => {
         std::hint::black_box(1f32)
@@ -9,6 +17,8 @@ macro_rules! m {
 fn main() {
     let x = 3f32;
     let y = 4f32;
+    let custom_mul_add = CustomMulAdd;
+
     let _ = x.hypot(y);
     //~^ imprecise_flops
     let _ = (x + 1f32).hypot(y);
@@ -17,8 +27,12 @@ fn main() {
     //~^ imprecise_flops
     let _ = x.hypot(y);
     //~^ imprecise_flops
+
     // Cases where the lint shouldn't be applied
     let _ = (x * 4f32 + y * y).sqrt();
     let _ = x.mul_add(x, y * y);
     let _ = m!().mul_add(m!(), y * y).sqrt();
+    // Should not lint: `self_arg` is not a floating point type,
+    // even though the call's return type is.
+    let _ = custom_mul_add.mul_add(custom_mul_add, y * y).sqrt();
 }

--- a/tests/ui/floating_point_hypot.fixed
+++ b/tests/ui/floating_point_hypot.fixed
@@ -1,5 +1,11 @@
 #![warn(clippy::imprecise_flops)]
 
+macro_rules! m {
+    () => {
+        std::hint::black_box(1f32)
+    };
+}
+
 fn main() {
     let x = 3f32;
     let y = 4f32;
@@ -9,8 +15,10 @@ fn main() {
     //~^ imprecise_flops
     let _ = x.hypot(y);
     //~^ imprecise_flops
+    let _ = x.hypot(y);
+    //~^ imprecise_flops
     // Cases where the lint shouldn't be applied
-    // TODO: linting this adds some complexity, but could be done
-    let _ = x.mul_add(x, y * y).sqrt();
     let _ = (x * 4f32 + y * y).sqrt();
+    let _ = x.mul_add(x, y * y);
+    let _ = m!().mul_add(m!(), y * y).sqrt();
 }

--- a/tests/ui/floating_point_hypot.rs
+++ b/tests/ui/floating_point_hypot.rs
@@ -1,5 +1,11 @@
 #![warn(clippy::imprecise_flops)]
 
+macro_rules! m {
+    () => {
+        std::hint::black_box(1f32)
+    };
+}
+
 fn main() {
     let x = 3f32;
     let y = 4f32;
@@ -9,8 +15,10 @@ fn main() {
     //~^ imprecise_flops
     let _ = (x.powi(2) + y.powi(2)).sqrt();
     //~^ imprecise_flops
-    // Cases where the lint shouldn't be applied
-    // TODO: linting this adds some complexity, but could be done
     let _ = x.mul_add(x, y * y).sqrt();
+    //~^ imprecise_flops
+    // Cases where the lint shouldn't be applied
     let _ = (x * 4f32 + y * y).sqrt();
+    let _ = x.mul_add(x, y * y);
+    let _ = m!().mul_add(m!(), y * y).sqrt();
 }

--- a/tests/ui/floating_point_hypot.rs
+++ b/tests/ui/floating_point_hypot.rs
@@ -1,5 +1,13 @@
 #![warn(clippy::imprecise_flops)]
 
+#[derive(Clone, Copy, Debug)]
+struct CustomMulAdd;
+impl CustomMulAdd {
+    fn mul_add(self, _a: CustomMulAdd, _b: f32) -> f32 {
+        42.0
+    }
+}
+
 macro_rules! m {
     () => {
         std::hint::black_box(1f32)
@@ -9,6 +17,8 @@ macro_rules! m {
 fn main() {
     let x = 3f32;
     let y = 4f32;
+    let custom_mul_add = CustomMulAdd;
+
     let _ = (x * x + y * y).sqrt();
     //~^ imprecise_flops
     let _ = ((x + 1f32) * (x + 1f32) + y * y).sqrt();
@@ -17,8 +27,12 @@ fn main() {
     //~^ imprecise_flops
     let _ = x.mul_add(x, y * y).sqrt();
     //~^ imprecise_flops
+
     // Cases where the lint shouldn't be applied
     let _ = (x * 4f32 + y * y).sqrt();
     let _ = x.mul_add(x, y * y);
     let _ = m!().mul_add(m!(), y * y).sqrt();
+    // Should not lint: `self_arg` is not a floating point type,
+    // even though the call's return type is.
+    let _ = custom_mul_add.mul_add(custom_mul_add, y * y).sqrt();
 }

--- a/tests/ui/floating_point_hypot.stderr
+++ b/tests/ui/floating_point_hypot.stderr
@@ -1,5 +1,5 @@
 error: hypotenuse can be computed more accurately
-  --> tests/ui/floating_point_hypot.rs:12:13
+  --> tests/ui/floating_point_hypot.rs:22:13
    |
 LL |     let _ = (x * x + y * y).sqrt();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
@@ -8,19 +8,19 @@ LL |     let _ = (x * x + y * y).sqrt();
    = help: to override `-D warnings` add `#[allow(clippy::imprecise_flops)]`
 
 error: hypotenuse can be computed more accurately
-  --> tests/ui/floating_point_hypot.rs:14:13
+  --> tests/ui/floating_point_hypot.rs:24:13
    |
 LL |     let _ = ((x + 1f32) * (x + 1f32) + y * y).sqrt();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(x + 1f32).hypot(y)`
 
 error: hypotenuse can be computed more accurately
-  --> tests/ui/floating_point_hypot.rs:16:13
+  --> tests/ui/floating_point_hypot.rs:26:13
    |
 LL |     let _ = (x.powi(2) + y.powi(2)).sqrt();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
 
 error: hypotenuse can be computed more accurately
-  --> tests/ui/floating_point_hypot.rs:18:13
+  --> tests/ui/floating_point_hypot.rs:28:13
    |
 LL |     let _ = x.mul_add(x, y * y).sqrt();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`

--- a/tests/ui/floating_point_hypot.stderr
+++ b/tests/ui/floating_point_hypot.stderr
@@ -1,5 +1,5 @@
 error: hypotenuse can be computed more accurately
-  --> tests/ui/floating_point_hypot.rs:6:13
+  --> tests/ui/floating_point_hypot.rs:12:13
    |
 LL |     let _ = (x * x + y * y).sqrt();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
@@ -8,16 +8,22 @@ LL |     let _ = (x * x + y * y).sqrt();
    = help: to override `-D warnings` add `#[allow(clippy::imprecise_flops)]`
 
 error: hypotenuse can be computed more accurately
-  --> tests/ui/floating_point_hypot.rs:8:13
+  --> tests/ui/floating_point_hypot.rs:14:13
    |
 LL |     let _ = ((x + 1f32) * (x + 1f32) + y * y).sqrt();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(x + 1f32).hypot(y)`
 
 error: hypotenuse can be computed more accurately
-  --> tests/ui/floating_point_hypot.rs:10:13
+  --> tests/ui/floating_point_hypot.rs:16:13
    |
 LL |     let _ = (x.powi(2) + y.powi(2)).sqrt();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
 
-error: aborting due to 3 previous errors
+error: hypotenuse can be computed more accurately
+  --> tests/ui/floating_point_hypot.rs:18:13
+   |
+LL |     let _ = x.mul_add(x, y * y).sqrt();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
changelog: [`imprecise_flops`]: also suggest `hypot` for the form `x.mul_add(x, y * y).sqrt()`
