### PR TITLE
perf: bail early in `too_many_lines` lint if rule is not enabled.

### DIFF
--- a/clippy_lints/src/functions/too_many_lines.rs
+++ b/clippy_lints/src/functions/too_many_lines.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint;
+use clippy_utils::is_lint_allowed;
 use clippy_utils::source::SpanExt as _;
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
@@ -16,6 +17,10 @@ pub(super) fn check_fn(
     def_id: LocalDefId,
     too_many_lines_threshold: u64,
 ) {
+    if is_lint_allowed(cx, TOO_MANY_LINES, cx.tcx.local_def_id_to_hir_id(def_id)) {
+        return;
+    }
+
     // Closures must be contained in a parent body, which will be checked for `too_many_lines`.
     // Don't check closures for `too_many_lines` to avoid duplicated lints.
     if matches!(kind, FnKind::Closure) || (span.from_expansion() && span.in_external_macro(cx.sess().source_map())) {

--- a/clippy_lints/src/functions/too_many_lines.rs
+++ b/clippy_lints/src/functions/too_many_lines.rs
@@ -17,13 +17,13 @@ pub(super) fn check_fn(
     def_id: LocalDefId,
     too_many_lines_threshold: u64,
 ) {
-    if is_lint_allowed(cx, TOO_MANY_LINES, cx.tcx.local_def_id_to_hir_id(def_id)) {
-        return;
-    }
-
     // Closures must be contained in a parent body, which will be checked for `too_many_lines`.
     // Don't check closures for `too_many_lines` to avoid duplicated lints.
     if matches!(kind, FnKind::Closure) || (span.from_expansion() && span.in_external_macro(cx.sess().source_map())) {
+        return;
+    }
+
+    if is_lint_allowed(cx, TOO_MANY_LINES, cx.tcx.local_def_id_to_hir_id(def_id)) {
         return;
     }
 


### PR DESCRIPTION
If the rule isn't enabled (which is the default behavior), there's no reason to scan the lines in the given function and count them. This avoids extra work for most users.

changelog: none