### PR TITLE
Refer to Zulip channel with its new name #t-clippy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ something. We appreciate any sort of contributions, and don't want a wall of rul
 
 Clippy welcomes contributions from everyone. There are many ways to contribute to Clippy and the following document
 explains how you can contribute and how to get started.  If you have any questions about contributing or need help with
-anything, feel free to ask questions on issues or visit the `#clippy` on [Zulip].
+anything, feel free to ask questions on issues or visit the `#t-clippy` on [Zulip].
 
 All contributors are expected to follow the [Rust Code of Conduct].
 
@@ -24,7 +24,7 @@ All contributors are expected to follow the [Rust Code of Conduct].
   - [Contributions](#contributions)
   - [License](#license)
 
-[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/clippy
+[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/t-clippy
 [Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
 
 ## The Clippy book

--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -801,4 +801,4 @@ don't hesitate to ask on [Zulip] or in the issue/PR.
 [nightly_docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/
 [ast]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/ast/index.html
 [ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/sty/index.html
-[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/clippy
+[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/t-clippy

--- a/book/src/development/infrastructure/sync.md
+++ b/book/src/development/infrastructure/sync.md
@@ -92,7 +92,7 @@ to be run inside the `rust` directory):
    accelerate the process ping the `@rust-lang/clippy` team in your PR and/or
    ask them in the [Zulip] stream.)
 
-[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/clippy
+[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/t-clippy
 [`rust-lang/rust`]: https://github.com/rust-lang/rust
 
 ## Performing the sync from Clippy to [`rust-lang/rust`]


### PR DESCRIPTION
Fixes problem [reported in Zulip](https://rust-lang.zulipchat.com/#narrow/channel/257328-t-clippy/topic/The.20clippy.20channel.20link.20for.20zulip.20doesn.27t.20seem.20to.20work/with/618159412).

r? @Manishearth

changelog: none
