### PR TITLE
fix: missing_transmute_annotations should not contain fn name in suggestion

### DIFF
--- a/clippy_lints/src/transmute/missing_transmute_annotations.rs
+++ b/clippy_lints/src/transmute/missing_transmute_annotations.rs
@@ -5,6 +5,7 @@ use clippy_utils::source::SpanExt as _;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, GenericArg, HirId, LetStmt, Node, Path, TyKind};
 use rustc_lint::LateContext;
+use rustc_middle::ty::print::with_types_for_suggestion;
 use rustc_middle::ty::{self, Ty};
 use rustc_span::Span;
 
@@ -95,7 +96,7 @@ pub(super) fn check<'tcx>(
                 diag.span_suggestion(
                     span,
                     "consider adding missing annotations",
-                    format!("{}::<{from_ty}, {to_ty}>", last.ident),
+                    with_types_for_suggestion!(format!("{}::<{from_ty}, {to_ty}>", last.ident)),
                     Applicability::MaybeIncorrect,
                 );
             }

--- a/tests/ui/missing_transmute_annotations.fixed
+++ b/tests/ui/missing_transmute_annotations.fixed
@@ -9,7 +9,7 @@ extern crate macro_rules;
 macro_rules! local_bad_transmute {
     ($e:expr) => {
         std::mem::transmute::<[u16; 2], i32>($e)
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
     };
 }
 
@@ -36,18 +36,18 @@ unsafe fn foo2() -> i32 {
     unsafe {
         let mut i: i32 = 0;
         i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
         i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
         i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
         i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         let x: i32 = bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
         bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         i = local_bad_transmute!([1u16, 2u16]);
 
@@ -55,10 +55,10 @@ unsafe fn foo2() -> i32 {
         i = bad_transmute!([1u16, 2u16]);
 
         i = std::mem::transmute::<[i16; 2], i32>([0i16, 0i16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         i = std::mem::transmute::<Foo, i32>(Foo::A);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         i
     }
@@ -66,10 +66,10 @@ unsafe fn foo2() -> i32 {
 
 fn main() {
     let x: _ = unsafe { std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]) };
-    //~^ ERROR: transmute used without annotations
+    //~^ missing_transmute_annotations
     unsafe {
         let x: _ = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         // Should not warn.
         std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);

--- a/tests/ui/missing_transmute_annotations.fixed
+++ b/tests/ui/missing_transmute_annotations.fixed
@@ -64,6 +64,15 @@ unsafe fn foo2() -> i32 {
     }
 }
 
+#[expect(invalid_value)]
+// https://github.com/rust-lang/rust-clippy/issues/15839
+fn function_name_in_suggestion() {
+    trait T {}
+    struct S(*mut dyn T);
+    let _ = S(unsafe { std::mem::transmute::<(usize, usize), *mut dyn T>((0usize, 0usize)) });
+    //~^ missing_transmute_annotations
+}
+
 fn main() {
     let x: _ = unsafe { std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]) };
     //~^ missing_transmute_annotations

--- a/tests/ui/missing_transmute_annotations.rs
+++ b/tests/ui/missing_transmute_annotations.rs
@@ -9,7 +9,7 @@ extern crate macro_rules;
 macro_rules! local_bad_transmute {
     ($e:expr) => {
         std::mem::transmute($e)
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
     };
 }
 
@@ -36,18 +36,18 @@ unsafe fn foo2() -> i32 {
     unsafe {
         let mut i: i32 = 0;
         i = std::mem::transmute([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
         i = std::mem::transmute::<_, _>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
         i = std::mem::transmute::<_, i32>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
         i = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
         bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         i = local_bad_transmute!([1u16, 2u16]);
 
@@ -55,10 +55,10 @@ unsafe fn foo2() -> i32 {
         i = bad_transmute!([1u16, 2u16]);
 
         i = std::mem::transmute([0i16, 0i16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         i = std::mem::transmute(Foo::A);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         i
     }
@@ -66,10 +66,10 @@ unsafe fn foo2() -> i32 {
 
 fn main() {
     let x: _ = unsafe { std::mem::transmute::<_, i32>([1u16, 2u16]) };
-    //~^ ERROR: transmute used without annotations
+    //~^ missing_transmute_annotations
     unsafe {
         let x: _ = std::mem::transmute::<_, i32>([1u16, 2u16]);
-        //~^ ERROR: transmute used without annotations
+        //~^ missing_transmute_annotations
 
         // Should not warn.
         std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);

--- a/tests/ui/missing_transmute_annotations.rs
+++ b/tests/ui/missing_transmute_annotations.rs
@@ -64,6 +64,15 @@ unsafe fn foo2() -> i32 {
     }
 }
 
+#[expect(invalid_value)]
+// https://github.com/rust-lang/rust-clippy/issues/15839
+fn function_name_in_suggestion() {
+    trait T {}
+    struct S(*mut dyn T);
+    let _ = S(unsafe { std::mem::transmute((0usize, 0usize)) });
+    //~^ missing_transmute_annotations
+}
+
 fn main() {
     let x: _ = unsafe { std::mem::transmute::<_, i32>([1u16, 2u16]) };
     //~^ missing_transmute_annotations

--- a/tests/ui/missing_transmute_annotations.stderr
+++ b/tests/ui/missing_transmute_annotations.stderr
@@ -61,16 +61,22 @@ LL |         i = std::mem::transmute(Foo::A);
    |                       ^^^^^^^^^ help: consider adding missing annotations: `transmute::<Foo, i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:68:35
+  --> tests/ui/missing_transmute_annotations.rs:72:34
+   |
+LL |     let _ = S(unsafe { std::mem::transmute((0usize, 0usize)) });
+   |                                  ^^^^^^^^^ help: consider adding missing annotations: `transmute::<(usize, usize), *mut dyn T>`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:77:35
    |
 LL |     let x: _ = unsafe { std::mem::transmute::<_, i32>([1u16, 2u16]) };
    |                                   ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:71:30
+  --> tests/ui/missing_transmute_annotations.rs:80:30
    |
 LL |         let x: _ = std::mem::transmute::<_, i32>([1u16, 2u16]);
    |                              ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
fixes  rust-lang/rust-clippy#15839: `missing_transmute_annotations` containing fn name in suggestion (such as `main`) which fails to resolve


changelog:[`missing_transmute_annotations`]: remove function names from the suggestion
