### PR TITLE
missing_transmute_annotations: add option to ignore in all expansions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7850,6 +7850,7 @@ Released 2018-09-13
 [`min-ident-chars-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#min-ident-chars-threshold
 [`missing-docs-allow-unused`]: https://doc.rust-lang.org/clippy/lint_configuration.html#missing-docs-allow-unused
 [`missing-docs-in-crate-items`]: https://doc.rust-lang.org/clippy/lint_configuration.html#missing-docs-in-crate-items
+[`missing-transmute-annotations-in-expansions`]: https://doc.rust-lang.org/clippy/lint_configuration.html#missing-transmute-annotations-in-expansions
 [`module-item-order-groupings`]: https://doc.rust-lang.org/clippy/lint_configuration.html#module-item-order-groupings
 [`module-items-ordered-within-groupings`]: https://doc.rust-lang.org/clippy/lint_configuration.html#module-items-ordered-within-groupings
 [`msrv`]: https://doc.rust-lang.org/clippy/lint_configuration.html#msrv

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -904,6 +904,16 @@ crate. For example, `pub(crate)` items.
 * [`missing_docs_in_private_items`](https://rust-lang.github.io/rust-clippy/main/index.html#missing_docs_in_private_items)
 
 
+## `missing-transmute-annotations-in-expansions`
+Whether to check for missing transmute annotations inside expansions. For example, macros.
+
+**Default Value:** `true`
+
+---
+**Affected lints:**
+* [`missing_transmute_annotations`](https://rust-lang.github.io/rust-clippy/main/index.html#missing_transmute_annotations)
+
+
 ## `module-item-order-groupings`
 The named groupings of different source item kinds within modules.
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -628,6 +628,9 @@ define_Conf! {
     /// crate. For example, `pub(crate)` items.
     #[lints(missing_docs_in_private_items)]
     missing_docs_in_crate_items("missing-docs-in-crate-items"): bool = false,
+    /// Whether to check for missing transmute annotations inside expansions. For example, macros.
+    #[lints(missing_transmute_annotations)]
+    missing_transmute_annotations_in_expansions("missing-transmute-annotations-in-expansions"): bool = true,
     /// The named groupings of different source item kinds within modules.
     #[lints(arbitrary_source_item_ordering)]
     module_item_order_groupings("module-item-order-groupings"): SourceItemOrderingModuleItemGroupings,

--- a/clippy_lints/src/transmute/missing_transmute_annotations.rs
+++ b/clippy_lints/src/transmute/missing_transmute_annotations.rs
@@ -46,12 +46,17 @@ pub(super) fn check<'tcx>(
     from_ty: Ty<'tcx>,
     to_ty: Ty<'tcx>,
     expr_hir_id: HirId,
+    annotations_in_expansions: bool,
 ) -> bool {
     let last = path.segments.last().unwrap();
-    if last.ident.span.in_external_macro(cx.tcx.sess.source_map()) {
-        // If it comes from a non-local macro, we ignore it.
+    if last.ident.span.from_expansion()
+        && (!annotations_in_expansions || last.ident.span.in_external_macro(cx.tcx.sess.source_map()))
+    {
+        // If it comes from an expansion and this lint is disabled there or it is a non-local macro, we
+        // ignore it.
         return false;
     }
+
     let args = last.args;
     let missing_generic = match args {
         Some(args) if !args.args.is_empty() => args.args.iter().any(|arg| matches!(arg, GenericArg::Infer(_))),

--- a/clippy_lints/src/transmute/mod.rs
+++ b/clippy_lints/src/transmute/mod.rs
@@ -490,10 +490,14 @@ impl_lint_pass!(Transmute => [
 
 pub struct Transmute {
     msrv: Msrv,
+    annotations_in_expansions: bool,
 }
 impl Transmute {
     pub fn new(conf: &'static Conf) -> Self {
-        Self { msrv: conf.msrv.into() }
+        Self {
+            msrv: conf.msrv.into(),
+            annotations_in_expansions: conf.missing_transmute_annotations_in_expansions,
+        }
     }
 
     /// When transmuting, a struct containing a single field works like the field.
@@ -555,7 +559,15 @@ impl<'tcx> LateLintPass<'tcx> for Transmute {
                 | transmuting_null::check(cx, e, arg, to_ty)
                 | transmute_null_to_fn::check(cx, e, arg, to_ty)
                 | transmute_ptr_to_ref::check(cx, e, from_field_ty, to_ty, from_field_expr.clone(), path, self.msrv)
-                | missing_transmute_annotations::check(cx, path, arg, from_ty, to_ty, e.hir_id)
+                | missing_transmute_annotations::check(
+                    cx,
+                    path,
+                    arg,
+                    from_ty,
+                    to_ty,
+                    e.hir_id,
+                    self.annotations_in_expansions,
+                )
                 | transmute_ref_to_ref::check(cx, e, from_ty, to_ty, arg, const_context)
                 | transmute_ptr_to_ptr::check(cx, e, from_field_ty, to_ty, from_field_expr, self.msrv)
                 | transmute_int_to_bool::check(cx, e, from_ty, to_ty, arg)

--- a/tests/ui-toml/missing_transmute_annotations_in_expansions/clippy.toml
+++ b/tests/ui-toml/missing_transmute_annotations_in_expansions/clippy.toml
@@ -1,0 +1,1 @@
+missing-transmute-annotations-in-expansions = false

--- a/tests/ui-toml/missing_transmute_annotations_in_expansions/disabled.fixed
+++ b/tests/ui-toml/missing_transmute_annotations_in_expansions/disabled.fixed
@@ -1,0 +1,18 @@
+#![warn(clippy::missing_transmute_annotations)]
+
+macro_rules! local_bad_transmute {
+    ($e:expr) => {
+        std::mem::transmute($e)
+        // when `in_expansions` is `true` (its default), there is a
+        // transmute_missing_annotations error expected here
+    };
+}
+
+fn main() {
+    unsafe {
+        let mut i: i32 = 0;
+        i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        //~^ missing_transmute_annotations
+        i = local_bad_transmute!([1u16, 2u16]);
+    }
+}

--- a/tests/ui-toml/missing_transmute_annotations_in_expansions/disabled.rs
+++ b/tests/ui-toml/missing_transmute_annotations_in_expansions/disabled.rs
@@ -1,0 +1,18 @@
+#![warn(clippy::missing_transmute_annotations)]
+
+macro_rules! local_bad_transmute {
+    ($e:expr) => {
+        std::mem::transmute($e)
+        // when `in_expansions` is `true` (its default), there is a
+        // transmute_missing_annotations error expected here
+    };
+}
+
+fn main() {
+    unsafe {
+        let mut i: i32 = 0;
+        i = std::mem::transmute([1u16, 2u16]);
+        //~^ missing_transmute_annotations
+        i = local_bad_transmute!([1u16, 2u16]);
+    }
+}

--- a/tests/ui-toml/missing_transmute_annotations_in_expansions/disabled.stderr
+++ b/tests/ui-toml/missing_transmute_annotations_in_expansions/disabled.stderr
@@ -1,0 +1,11 @@
+error: transmute used without annotations
+  --> tests/ui-toml/missing_transmute_annotations_in_expansions/disabled.rs:14:23
+   |
+LL |         i = std::mem::transmute([1u16, 2u16]);
+   |                       ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+   |
+   = note: `-D clippy::missing-transmute-annotations` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_transmute_annotations)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -74,6 +74,7 @@ LL | foobar = 42
            min-ident-chars-threshold
            missing-docs-allow-unused
            missing-docs-in-crate-items
+           missing-transmute-annotations-in-expansions
            module-item-order-groupings
            module-items-ordered-within-groupings
            msrv


### PR DESCRIPTION
Working on clippyfying rust-lang/rust we encounter many `missing_transmute_annotations` triggering inside local macros, this adds an option to disable the lint in all expanded code while preserving the original default behaviour of disabling the lint in external macros.
See: https://github.com/rust-lang/rust/pull/161593
Because this is an alternative solution to it, this closes https://github.com/rust-lang/rust-clippy/pull/17683

changelog:[`missing_transmute_annotations`]: add option do disable lint in expanded code