### PR TITLE
`missing_transmute_annotations`: handle pattern_types in suggestion

### DIFF
--- a/clippy_lints/src/transmute/missing_transmute_annotations.rs
+++ b/clippy_lints/src/transmute/missing_transmute_annotations.rs
@@ -83,6 +83,20 @@ pub(super) fn check<'tcx>(
             let from_ty_no_name = ty_cannot_be_named(from_ty);
             let to_ty_no_name = ty_cannot_be_named(to_ty);
             if from_ty_no_name || to_ty_no_name {
+                if cx.tcx.features().pattern_types()
+                    && let (Some(from_str), Some(to_str)) = (
+                        try_format_pat_ty(from_ty).or_else(|| (!from_ty_no_name).then_some(from_ty.to_string())),
+                        try_format_pat_ty(to_ty).or_else(|| (!to_ty_no_name).then_some(to_ty.to_string())),
+                    )
+                {
+                    diag.span_suggestion(
+                        span,
+                        "consider adding missing annotations",
+                        format!("{}::<{from_str}, {to_str}>", last.ident),
+                        Applicability::MaybeIncorrect,
+                    );
+                    return;
+                }
                 let to_name = match (from_ty_no_name, to_ty_no_name) {
                     (true, false) => maybe_name_by_expr(cx, arg.span, "the origin type"),
                     (false, true) => "the destination type".into(),
@@ -113,7 +127,7 @@ fn ty_cannot_be_named(ty: Ty<'_>) -> bool {
                 kind: ty::Opaque { .. } | ty::Inherent { .. },
                 ..
             }
-        )
+        ) | ty::Pat(..)
     )
 }
 
@@ -123,4 +137,13 @@ fn maybe_name_by_expr<'a>(cx: &LateContext<'_>, span: Span, default: &'a str) ->
     })
     .flatten()
     .unwrap_or(default.into())
+}
+
+/// Tries to render a `ty::Pat` type as a valid `pattern_type!(...)` macro invocation,
+fn try_format_pat_ty(ty: Ty<'_>) -> Option<String> {
+    let ty::Pat(base, pat) = ty.kind() else { return None };
+    if matches!(base.kind(), ty::Pat(..)) {
+        unreachable!("base of a ty::Pat cannot be a ty::Pat");
+    }
+    Some(format!("pattern_type!({base} is {pat:?})"))
 }

--- a/tests/ui/transmute_pattern_type.fixed
+++ b/tests/ui/transmute_pattern_type.fixed
@@ -10,7 +10,7 @@ use std::pat::pattern_type;
 // Only suggest if the pattern_type feature is active.
 fn pattern_type_transmute(val: u32) -> Option<pattern_type!(u32 is 1..)> {
     if let 1.. = val {
-        Some(unsafe { std::mem::transmute(val) })
+        Some(unsafe { std::mem::transmute::<u32, pattern_type!(u32 is 1..)>(val) })
         //~^ missing_transmute_annotations
     } else {
         None

--- a/tests/ui/transmute_pattern_type.rs
+++ b/tests/ui/transmute_pattern_type.rs
@@ -1,0 +1,23 @@
+//@no-rustfix
+#![feature(pattern_types, pattern_type_macro)]
+use std::pat::pattern_type;
+
+// rust-lang/rust's `niche_types.rs`-style pattern: transmuting into/out of a
+// pattern type was producing incorrect clippy suggestion to add a `(<type>) is <pattern>` instead
+// of `<pattern_type!(<type> is <pattern>)` argument which is not valid rust syntax.
+//
+// Now produces the correct syntax when suggesting.
+//
+// Only suggest if the pattern_type feature is active.
+fn pattern_type_transmute(val: u32) -> Option<pattern_type!(u32 is 1..)> {
+    if let 1.. = val {
+        Some(unsafe { std::mem::transmute(val) })
+        //~^ missing_transmute_annotations
+    } else {
+        None
+    }
+}
+
+fn pattern_type_transmute_back(val: pattern_type!(u32 is 1..)) -> u32 {
+    unsafe { std::mem::transmute(val) }
+}

--- a/tests/ui/transmute_pattern_type.stderr
+++ b/tests/ui/transmute_pattern_type.stderr
@@ -1,8 +1,8 @@
 error: transmute used without annotations
-  --> tests/ui/transmute_pattern_type.rs:10:33
+  --> tests/ui/transmute_pattern_type.rs:13:33
    |
 LL |         Some(unsafe { std::mem::transmute(val) })
-   |                                 ^^^^^^^^^ help: consider adding missing annotations: `transmute::<u32, (u32) is 1..>`
+   |                                 ^^^^^^^^^ help: consider adding missing annotations: `transmute::<u32, pattern_type!(u32 is 1..)>`
    |
    = note: `-D clippy::missing-transmute-annotations` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::missing_transmute_annotations)]`

--- a/tests/ui/transmute_pattern_type.stderr
+++ b/tests/ui/transmute_pattern_type.stderr
@@ -1,0 +1,11 @@
+error: transmute used without annotations
+  --> tests/ui/transmute_pattern_type.rs:10:33
+   |
+LL |         Some(unsafe { std::mem::transmute(val) })
+   |                                 ^^^^^^^^^ help: consider adding missing annotations: `transmute::<u32, (u32) is 1..>`
+   |
+   = note: `-D clippy::missing-transmute-annotations` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_transmute_annotations)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
`transmute_missing_annotations` does not suggest valid rust code for `pattern_types`. For instance, a range pattern_type like `pattern_type!(u8 is 1..)` gets suggested as `((u8) is 1..)`.


This PR addresses this issue.
It also gates the suggestion itself on the `pattern_type` feature being enabled to avoid suggesting code that cannot compile without it.

changelog:[`transmute_missing_annotations`]: handle pattern_types in suggestion
