### PR TITLE
Respect renamed dependencies when resolving configured paths

### DIFF
--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -197,47 +197,51 @@ pub fn lookup_path(tcx: TyCtxt<'_>, ns: PathNS, path: &[Symbol]) -> Vec<DefId> {
     out
 }
 
-/// Finds the crates called `name`, may be multiple due to multiple major versions.
-pub fn find_crates(tcx: TyCtxt<'_>, name: Symbol) -> &'static [DefId] {
-    static BY_NAME: OnceLock<FxHashMap<Symbol, Vec<DefId>>> = OnceLock::new();
-    let map = BY_NAME.get_or_init(|| {
-        let mut map = FxHashMap::default();
-        map.insert(tcx.crate_name(LOCAL_CRATE), vec![LOCAL_CRATE.as_def_id()]);
-        for &num in tcx.crates(()) {
-            map.entry(tcx.crate_name(num)).or_default().push(num.as_def_id());
-        }
+fn collect_crates_by_name(tcx: TyCtxt<'_>) -> FxHashMap<Symbol, Vec<DefId>> {
+    let mut map = FxHashMap::default();
+    map.insert(tcx.crate_name(LOCAL_CRATE), vec![LOCAL_CRATE.as_def_id()]);
+    for &num in tcx.crates(()) {
+        map.entry(tcx.crate_name(num)).or_default().push(num.as_def_id());
+    }
 
-        let mut extern_names_by_path: FxHashMap<&Path, Vec<Symbol>> = FxHashMap::default();
-        for (name, entry) in tcx.sess.opts.externs.iter().filter(|(_, entry)| entry.add_prelude) {
-            let Some(files) = entry.files() else {
+    // Match prelude-visible `--extern` aliases to loaded crates by source path. An alias replaces a
+    // colliding canonical name to mirror path resolution in source code.
+    let mut extern_names_by_path: FxHashMap<&Path, Vec<Symbol>> = FxHashMap::default();
+    for (name, entry) in tcx.sess.opts.externs.iter().filter(|(_, entry)| entry.add_prelude) {
+        let Some(files) = entry.files() else {
+            continue;
+        };
+        for file in files {
+            extern_names_by_path
+                .entry(file.canonicalized())
+                .or_default()
+                .push(Symbol::intern(name));
+        }
+    }
+    let mut matched_extern_names = FxHashSet::default();
+    for &num in tcx.crates(()) {
+        for path in tcx.used_crate_source(num).paths() {
+            let Some(names) = extern_names_by_path.get(path.as_path()) else {
                 continue;
             };
-            for file in files {
-                extern_names_by_path
-                    .entry(file.canonicalized())
-                    .or_default()
-                    .push(Symbol::intern(name));
-            }
-        }
-        let mut matched_extern_names = FxHashSet::default();
-        for &num in tcx.crates(()) {
-            for path in tcx.used_crate_source(num).paths() {
-                let Some(names) = extern_names_by_path.get(path.as_path()) else {
-                    continue;
-                };
-                for &name in names {
-                    if matched_extern_names.insert(name) {
-                        map.remove(&name);
-                    }
-                    let def_ids = map.entry(name).or_default();
-                    if !def_ids.contains(&num.as_def_id()) {
-                        def_ids.push(num.as_def_id());
-                    }
+            for &name in names {
+                if matched_extern_names.insert(name) {
+                    map.remove(&name);
+                }
+                let def_ids = map.entry(name).or_default();
+                if !def_ids.contains(&num.as_def_id()) {
+                    def_ids.push(num.as_def_id());
                 }
             }
         }
-        map
-    });
+    }
+    map
+}
+
+/// Finds the crates called `name`, may be multiple due to multiple major versions.
+pub fn find_crates(tcx: TyCtxt<'_>, name: Symbol) -> &'static [DefId] {
+    static BY_NAME: OnceLock<FxHashMap<Symbol, Vec<DefId>>> = OnceLock::new();
+    let map = BY_NAME.get_or_init(|| collect_crates_by_name(tcx));
     match map.get(&name) {
         Some(def_ids) => def_ids,
         None => &[],

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -7,7 +7,7 @@
 use crate::res::MaybeQPath;
 use crate::sym;
 use rustc_ast::Mutability;
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::def::Namespace::{MacroNS, TypeNS, ValueNS};
 use rustc_hir::def::{DefKind, Namespace, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
@@ -17,6 +17,7 @@ use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::layout::HasTyCtxt;
 use rustc_middle::ty::{FloatTy, IntTy, Ty, TyCtxt, UintTy};
 use rustc_span::{Ident, STDLIB_STABLE_CRATES, Symbol};
+use std::path::Path;
 use std::sync::OnceLock;
 
 /// Specifies whether to resolve a path in the [`TypeNS`], [`ValueNS`], [`MacroNS`] or in an
@@ -204,6 +205,36 @@ pub fn find_crates(tcx: TyCtxt<'_>, name: Symbol) -> &'static [DefId] {
         map.insert(tcx.crate_name(LOCAL_CRATE), vec![LOCAL_CRATE.as_def_id()]);
         for &num in tcx.crates(()) {
             map.entry(tcx.crate_name(num)).or_default().push(num.as_def_id());
+        }
+
+        let mut extern_names_by_path: FxHashMap<&Path, Vec<Symbol>> = FxHashMap::default();
+        for (name, entry) in tcx.sess.opts.externs.iter().filter(|(_, entry)| entry.add_prelude) {
+            let Some(files) = entry.files() else {
+                continue;
+            };
+            for file in files {
+                extern_names_by_path
+                    .entry(file.canonicalized())
+                    .or_default()
+                    .push(Symbol::intern(name));
+            }
+        }
+        let mut matched_extern_names = FxHashSet::default();
+        for &num in tcx.crates(()) {
+            for path in tcx.used_crate_source(num).paths() {
+                let Some(names) = extern_names_by_path.get(path.as_path()) else {
+                    continue;
+                };
+                for &name in names {
+                    if matched_extern_names.insert(name) {
+                        map.remove(&name);
+                    }
+                    let def_ids = map.entry(name).or_default();
+                    if !def_ids.contains(&num.as_def_id()) {
+                        def_ids.push(num.as_def_id());
+                    }
+                }
+            }
         }
         map
     });

--- a/tests/ui-cargo/disallowed_paths_renamed_dependency/Cargo.stderr
+++ b/tests/ui-cargo/disallowed_paths_renamed_dependency/Cargo.stderr
@@ -1,0 +1,16 @@
+error: use of a disallowed method `renamed_dependency::forbidden_by_alias`
+ --> src/main.rs:4:5
+  |
+4 |     renamed_dependency::forbidden_by_alias();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `-D clippy::disallowed-methods` implied by `-D warnings`
+  = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
+
+error: use of a disallowed method `actual_dependency::forbidden_by_package_name`
+ --> src/main.rs:5:5
+  |
+5 |     renamed_dependency::forbidden_by_package_name();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: could not compile `disallowed_paths_renamed_dependency` (bin "disallowed_paths_renamed_dependency") due to 2 previous errors

--- a/tests/ui-cargo/disallowed_paths_renamed_dependency/Cargo.toml
+++ b/tests/ui-cargo/disallowed_paths_renamed_dependency/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "disallowed_paths_renamed_dependency"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+renamed_dependency = { package = "actual_dependency", path = "actual_dependency" }
+other_dependency = { package = "renamed_dependency", path = "renamed_dependency" }

--- a/tests/ui-cargo/disallowed_paths_renamed_dependency/actual_dependency/Cargo.toml
+++ b/tests/ui-cargo/disallowed_paths_renamed_dependency/actual_dependency/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "actual_dependency"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+path = "lib.rs"

--- a/tests/ui-cargo/disallowed_paths_renamed_dependency/actual_dependency/lib.rs
+++ b/tests/ui-cargo/disallowed_paths_renamed_dependency/actual_dependency/lib.rs
@@ -1,0 +1,2 @@
+pub fn forbidden_by_alias() {}
+pub fn forbidden_by_package_name() {}

--- a/tests/ui-cargo/disallowed_paths_renamed_dependency/clippy.toml
+++ b/tests/ui-cargo/disallowed_paths_renamed_dependency/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-methods = [
+    { path = "renamed_dependency::forbidden_by_alias", allow-invalid = true },
+    { path = "actual_dependency::forbidden_by_package_name", allow-invalid = true },
+    { path = "renamed_dependency::allowed", allow-invalid = true },
+]

--- a/tests/ui-cargo/disallowed_paths_renamed_dependency/renamed_dependency/Cargo.toml
+++ b/tests/ui-cargo/disallowed_paths_renamed_dependency/renamed_dependency/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "renamed_dependency"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+path = "lib.rs"

--- a/tests/ui-cargo/disallowed_paths_renamed_dependency/renamed_dependency/lib.rs
+++ b/tests/ui-cargo/disallowed_paths_renamed_dependency/renamed_dependency/lib.rs
@@ -1,0 +1,1 @@
+pub fn allowed() {}

--- a/tests/ui-cargo/disallowed_paths_renamed_dependency/src/main.rs
+++ b/tests/ui-cargo/disallowed_paths_renamed_dependency/src/main.rs
@@ -1,0 +1,7 @@
+#![warn(clippy::disallowed_methods)]
+
+fn main() {
+    renamed_dependency::forbidden_by_alias();
+    renamed_dependency::forbidden_by_package_name();
+    other_dependency::allowed();
+}


### PR DESCRIPTION

Clippy's shared path resolver indexed external crates by their canonical metadata names. This meant that a path configured with the source-visible name of a renamed Cargo dependency could not resolve, even though that was the only name available in the crate's source code.

This keeps canonical-name lookup intact and also indexes prelude-visible `--extern` aliases by matching their canonical source paths to loaded crates. A source-visible alias takes precedence if it collides with another crate's canonical name, matching how paths resolve in source code. The shared fix applies to `disallowed-methods`, `disallowed-types`, and other configuration features that use the same path resolver.

The UI-Cargo regression covers alias resolution, canonical-name compatibility, and a collision with another crate's canonical name.

Fixes rust-lang/rust-clippy#17585

changelog: [`disallowed_methods`, `disallowed_types`]: resolve configured paths through renamed Cargo dependencies

## Testing

- `TESTNAME=disallowed_paths_renamed_dependency cargo uitest`
- `cargo test`
- `cargo dev fmt --check`