### PR TITLE
Add `test_without_assertions` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7617,6 +7617,7 @@ Released 2018-09-13
 [`temporary_assignment`]: https://rust-lang.github.io/rust-clippy/main/index.html#temporary_assignment
 [`temporary_cstring_as_ptr`]: https://rust-lang.github.io/rust-clippy/main/index.html#temporary_cstring_as_ptr
 [`test_attr_in_doctest`]: https://rust-lang.github.io/rust-clippy/main/index.html#test_attr_in_doctest
+[`test_without_assertions`]: https://rust-lang.github.io/rust-clippy/main/index.html#test_without_assertions
 [`tests_outside_test_module`]: https://rust-lang.github.io/rust-clippy/main/index.html#tests_outside_test_module
 [`thread_local_initializer_can_be_made_const`]: https://rust-lang.github.io/rust-clippy/main/index.html#thread_local_initializer_can_be_made_const
 [`to_digit_is_some`]: https://rust-lang.github.io/rust-clippy/main/index.html#to_digit_is_some

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -738,6 +738,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::swap_ptr_to_ref::SWAP_PTR_TO_REF_INFO,
     crate::tabs_in_doc_comments::TABS_IN_DOC_COMMENTS_INFO,
     crate::temporary_assignment::TEMPORARY_ASSIGNMENT_INFO,
+    crate::test_without_assertions::TEST_WITHOUT_ASSERTIONS_INFO,
     crate::tests_outside_test_module::TESTS_OUTSIDE_TEST_MODULE_INFO,
     crate::time_subtraction::MANUAL_INSTANT_ELAPSED_INFO,
     crate::time_subtraction::UNCHECKED_TIME_SUBTRACTION_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -359,6 +359,7 @@ mod swap;
 mod swap_ptr_to_ref;
 mod tabs_in_doc_comments;
 mod temporary_assignment;
+mod test_without_assertions;
 mod tests_outside_test_module;
 mod time_subtraction;
 mod to_digit_is_some;
@@ -870,6 +871,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        TestWithoutAssertions: test_without_assertions::TestWithoutAssertions = test_without_assertions::TestWithoutAssertions,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/test_without_assertions.rs
+++ b/clippy_lints/src/test_without_assertions.rs
@@ -1,0 +1,86 @@
+use std::ops::ControlFlow;
+
+use clippy_utils::diagnostics::span_lint;
+use clippy_utils::is_test_function;
+use clippy_utils::visitors::for_each_expr_without_closures;
+use rustc_hir::intravisit::FnKind;
+use rustc_hir::{Body, ExprKind, FnDecl, find_attr};
+use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
+use rustc_span::Span;
+use rustc_span::def_id::LocalDefId;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for test functions without assertions or other potential failure sites.
+    ///
+    /// ### Why is this bad?
+    /// Such tests may pass without verifying any behavior. They can represent unfinished work or
+    /// forgotten stubs, giving a false sense of coverage.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #[test]
+    /// fn adds_numbers() {
+    ///     let _ = 1 + 1;
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// #[test]
+    /// fn adds_numbers() {
+    ///     assert_eq!(1 + 1, 2);
+    /// }
+    /// ```
+    ///
+    /// ### Known problems
+    ///
+    /// Calls and method calls are treated as potential failure sites without inspecting their
+    /// bodies. Therefore, tests that only call helpers which cannot fail are not linted.
+    #[clippy::version = "1.100.0"]
+    pub TEST_WITHOUT_ASSERTIONS,
+    suspicious,
+    "test function without assertions or other potential failure sites"
+}
+
+declare_lint_pass!(TestWithoutAssertions => [TEST_WITHOUT_ASSERTIONS]);
+
+impl LateLintPass<'_> for TestWithoutAssertions {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'_>,
+        kind: FnKind<'_>,
+        _: &FnDecl<'_>,
+        body: &Body<'_>,
+        span: Span,
+        fn_def_id: LocalDefId,
+    ) {
+        if matches!(kind, FnKind::ItemFn(..))
+            && let ExprKind::Block(block, _) = body.value.kind
+            && is_test_function(cx.tcx, fn_def_id)
+        {
+            let is_empty = block.stmts.is_empty() && block.expr.is_none();
+            let is_should_panic = find_attr!(cx.tcx, fn_def_id, ShouldPanic { .. });
+
+            if is_empty || (!is_should_panic && !has_potential_failure_site(body)) {
+                span_lint(
+                    cx,
+                    TEST_WITHOUT_ASSERTIONS,
+                    span,
+                    "test function without assertions or other potential failure sites",
+                );
+            }
+        }
+    }
+}
+
+fn has_potential_failure_site(body: &Body<'_>) -> bool {
+    for_each_expr_without_closures(body.value, |expr| {
+        if matches!(expr.kind, ExprKind::Call(..) | ExprKind::MethodCall(..)) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .is_some()
+}

--- a/tests/ui-toml/indexing_slicing/indexing_slicing.rs
+++ b/tests/ui-toml/indexing_slicing/indexing_slicing.rs
@@ -11,6 +11,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    #[expect(clippy::test_without_assertions)]
     #[test]
     fn test_fn() {
         let x = [1, 2, 3, 4];

--- a/tests/ui-toml/large_stack_frames_for_special_targets/large_stack_frames.rs
+++ b/tests/ui-toml/large_stack_frames_for_special_targets/large_stack_frames.rs
@@ -8,6 +8,7 @@
 #[cfg(test)]
 #[expect(clippy::large_stack_frames)]
 mod test {
+    #[expect(clippy::test_without_assertions)]
     #[test]
     fn main_test() {}
 }

--- a/tests/ui/crashes/used_underscore_binding_macro.rs
+++ b/tests/ui/crashes/used_underscore_binding_macro.rs
@@ -10,6 +10,7 @@ struct MacroAttributesTest {
     _foo: u32,
 }
 
+#[expect(clippy::test_without_assertions)]
 #[test]
 fn macro_attributes_test() {
     let _ = MacroAttributesTest { _foo: 0 };

--- a/tests/ui/dbg_macro/dbg_macro.fixed
+++ b/tests/ui/dbg_macro/dbg_macro.fixed
@@ -89,6 +89,7 @@ mod issue7274 {
     });
 }
 
+#[allow(clippy::test_without_assertions, reason = "the lint only triggers after rustfix")]
 #[test]
 pub fn issue8481() {
     1;

--- a/tests/ui/dbg_macro/dbg_macro.rs
+++ b/tests/ui/dbg_macro/dbg_macro.rs
@@ -89,6 +89,7 @@ mod issue7274 {
     });
 }
 
+#[allow(clippy::test_without_assertions, reason = "the lint only triggers after rustfix")]
 #[test]
 pub fn issue8481() {
     dbg!(1);

--- a/tests/ui/dbg_macro/dbg_macro.stderr
+++ b/tests/ui/dbg_macro/dbg_macro.stderr
@@ -171,7 +171,7 @@ LL +         2;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:94:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:95:5
    |
 LL |     dbg!(1);
    |     ^^^^^^^
@@ -183,7 +183,7 @@ LL +     1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:100:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:101:5
    |
 LL |     dbg!(1);
    |     ^^^^^^^
@@ -195,7 +195,7 @@ LL +     1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:107:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:108:9
    |
 LL |         dbg!(1);
    |         ^^^^^^^
@@ -207,7 +207,7 @@ LL +         1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:114:31
+  --> tests/ui/dbg_macro/dbg_macro.rs:115:31
    |
 LL |         println!("dbg: {:?}", dbg!(s));
    |                               ^^^^^^^
@@ -219,7 +219,7 @@ LL +         println!("dbg: {:?}", s);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:117:22
+  --> tests/ui/dbg_macro/dbg_macro.rs:118:22
    |
 LL |         print!("{}", dbg!(s));
    |                      ^^^^^^^
@@ -231,7 +231,7 @@ LL +         print!("{}", s);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:133:36
+  --> tests/ui/dbg_macro/dbg_macro.rs:134:36
    |
 LL |         takes_async_fn(async |val| dbg!(val));
    |                                    ^^^^^^^^^

--- a/tests/ui/disallowed_names.rs
+++ b/tests/ui/disallowed_names.rs
@@ -86,6 +86,7 @@ mod tests {
     }
 }
 
+#[expect(clippy::test_without_assertions)]
 #[test]
 fn test_with_disallowed_name() {
     let foo = 0;

--- a/tests/ui/four_forward_slashes.fixed
+++ b/tests/ui/four_forward_slashes.fixed
@@ -23,6 +23,7 @@ fn c() {}
 
 fn d() {}
 
+#[expect(clippy::test_without_assertions)]
 #[test]
 /// between attributes
 //~^ four_forward_slashes

--- a/tests/ui/four_forward_slashes.rs
+++ b/tests/ui/four_forward_slashes.rs
@@ -23,6 +23,7 @@ fn c() {}
 
 fn d() {}
 
+#[expect(clippy::test_without_assertions)]
 #[test]
 //// between attributes
 //~^ four_forward_slashes

--- a/tests/ui/four_forward_slashes.stderr
+++ b/tests/ui/four_forward_slashes.stderr
@@ -47,7 +47,7 @@ LL ~ /// two borked comments!
    |
 
 error: this item has comments with 4 forward slashes (`////`). These look like doc comments, but they aren't
-  --> tests/ui/four_forward_slashes.rs:27:1
+  --> tests/ui/four_forward_slashes.rs:28:1
    |
 LL | / //// between attributes
 LL | |
@@ -62,7 +62,7 @@ LL + /// between attributes
    |
 
 error: this item has comments with 4 forward slashes (`////`). These look like doc comments, but they aren't
-  --> tests/ui/four_forward_slashes.rs:31:1
+  --> tests/ui/four_forward_slashes.rs:32:1
    |
 LL | /     //// not very start of contents
 LL | |

--- a/tests/ui/ignore_without_reason.rs
+++ b/tests/ui/ignore_without_reason.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::ignore_without_reason)]
+#![expect(clippy::test_without_assertions)]
 
 fn main() {}
 

--- a/tests/ui/ignore_without_reason.stderr
+++ b/tests/ui/ignore_without_reason.stderr
@@ -1,5 +1,5 @@
 error: `#[ignore]` without reason
-  --> tests/ui/ignore_without_reason.rs:13:1
+  --> tests/ui/ignore_without_reason.rs:14:1
    |
 LL | #[ignore]
    | ^^^^^^^^^

--- a/tests/ui/items_after_test_module/after_proc_macros.rs
+++ b/tests/ui/items_after_test_module/after_proc_macros.rs
@@ -8,5 +8,6 @@ proc_macros::with_span! {
     mod tests {}
 }
 
+#[expect(clippy::test_without_assertions)]
 #[test]
 fn f() {}

--- a/tests/ui/items_after_test_module/in_submodule.rs
+++ b/tests/ui/items_after_test_module/in_submodule.rs
@@ -4,6 +4,7 @@ mod submodule;
 
 #[cfg(test)]
 mod tests {
+    #[expect(clippy::test_without_assertions)]
     #[test]
     fn t() {}
 }

--- a/tests/ui/items_after_test_module/multiple_modules.rs
+++ b/tests/ui/items_after_test_module/multiple_modules.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+#![expect(clippy::test_without_assertions)]
 
 #[cfg(test)]
 mod tests {

--- a/tests/ui/items_after_test_module/root_module.fixed
+++ b/tests/ui/items_after_test_module/root_module.fixed
@@ -17,6 +17,7 @@ macro_rules! should_lint {
 #[cfg(test)]
 mod tests {
     //~^ items_after_test_module
+    #[expect(clippy::test_without_assertions)]
     #[test]
     fn hi() {}
 }

--- a/tests/ui/items_after_test_module/root_module.rs
+++ b/tests/ui/items_after_test_module/root_module.rs
@@ -10,6 +10,7 @@ fn should_not_lint() {}
 #[cfg(test)]
 mod tests {
     //~^ items_after_test_module
+    #[expect(clippy::test_without_assertions)]
     #[test]
     fn hi() {}
 }

--- a/tests/ui/redundant_test_prefix.fixed
+++ b/tests/ui/redundant_test_prefix.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::redundant_test_prefix)]
+#![expect(clippy::test_without_assertions)]
 
 fn main() {
     // Normal function, no redundant prefix.

--- a/tests/ui/redundant_test_prefix.rs
+++ b/tests/ui/redundant_test_prefix.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::redundant_test_prefix)]
+#![expect(clippy::test_without_assertions)]
 
 fn main() {
     // Normal function, no redundant prefix.

--- a/tests/ui/redundant_test_prefix.stderr
+++ b/tests/ui/redundant_test_prefix.stderr
@@ -1,5 +1,5 @@
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:16:4
+  --> tests/ui/redundant_test_prefix.rs:17:4
    |
 LL | fn test_f3() {
    |    ^^^^^^^ help: consider removing the `test_` prefix: `f3`
@@ -8,109 +8,109 @@ LL | fn test_f3() {
    = help: to override `-D warnings` add `#[allow(clippy::redundant_test_prefix)]`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:25:4
+  --> tests/ui/redundant_test_prefix.rs:26:4
    |
 LL | fn test_f4() {
    |    ^^^^^^^ help: consider removing the `test_` prefix: `f4`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:38:4
+  --> tests/ui/redundant_test_prefix.rs:39:4
    |
 LL | fn test_f6() {
    |    ^^^^^^^ help: consider removing the `test_` prefix: `f6`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:53:8
+  --> tests/ui/redundant_test_prefix.rs:54:8
    |
 LL |     fn test_foo() {
    |        ^^^^^^^^ help: consider removing the `test_` prefix: `foo`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:58:8
+  --> tests/ui/redundant_test_prefix.rs:59:8
    |
 LL |     fn test_foo_with_call() {
    |        ^^^^^^^^^^^^^^^^^^ help: consider removing the `test_` prefix: `foo_with_call`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:65:8
+  --> tests/ui/redundant_test_prefix.rs:66:8
    |
 LL |     fn test_f1() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f1`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:70:8
+  --> tests/ui/redundant_test_prefix.rs:71:8
    |
 LL |     fn test_f2() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f2`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:75:8
+  --> tests/ui/redundant_test_prefix.rs:76:8
    |
 LL |     fn test_f3() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f3`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:80:8
+  --> tests/ui/redundant_test_prefix.rs:81:8
    |
 LL |     fn test_f4() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f4`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:85:8
+  --> tests/ui/redundant_test_prefix.rs:86:8
    |
 LL |     fn test_f5() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f5`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:90:8
+  --> tests/ui/redundant_test_prefix.rs:91:8
    |
 LL |     fn test_f6() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f6`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:99:8
+  --> tests/ui/redundant_test_prefix.rs:100:8
    |
 LL |     fn test_foo() {
    |        ^^^^^^^^ help: consider removing the `test_` prefix: `foo`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:104:8
+  --> tests/ui/redundant_test_prefix.rs:105:8
    |
 LL |     fn test_foo_with_call() {
    |        ^^^^^^^^^^^^^^^^^^ help: consider removing the `test_` prefix: `foo_with_call`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:111:8
+  --> tests/ui/redundant_test_prefix.rs:112:8
    |
 LL |     fn test_f1() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f1`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:116:8
+  --> tests/ui/redundant_test_prefix.rs:117:8
    |
 LL |     fn test_f2() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f2`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:121:8
+  --> tests/ui/redundant_test_prefix.rs:122:8
    |
 LL |     fn test_f3() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f3`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:126:8
+  --> tests/ui/redundant_test_prefix.rs:127:8
    |
 LL |     fn test_f4() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f4`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:131:8
+  --> tests/ui/redundant_test_prefix.rs:132:8
    |
 LL |     fn test_f5() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f5`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix.rs:136:8
+  --> tests/ui/redundant_test_prefix.rs:137:8
    |
 LL |     fn test_f6() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f6`

--- a/tests/ui/redundant_test_prefix_unfixable.rs
+++ b/tests/ui/redundant_test_prefix_unfixable.rs
@@ -1,6 +1,7 @@
 //@no-rustfix: name conflicts
 
 #![warn(clippy::redundant_test_prefix)]
+#![expect(clippy::test_without_assertions)]
 
 fn main() {
     // Normal function, no redundant prefix.

--- a/tests/ui/redundant_test_prefix_unfixable.stderr
+++ b/tests/ui/redundant_test_prefix_unfixable.stderr
@@ -1,5 +1,5 @@
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:18:4
+  --> tests/ui/redundant_test_prefix_unfixable.rs:19:4
    |
 LL | fn test_f3() {
    |    ^^^^^^^ help: consider removing the `test_` prefix: `f3`
@@ -8,13 +8,13 @@ LL | fn test_f3() {
    = help: to override `-D warnings` add `#[allow(clippy::redundant_test_prefix)]`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:27:4
+  --> tests/ui/redundant_test_prefix_unfixable.rs:28:4
    |
 LL | fn test_f4() {
    |    ^^^^^^^ help: consider removing the `test_` prefix: `f4`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:38:4
+  --> tests/ui/redundant_test_prefix_unfixable.rs:39:4
    |
 LL | fn test_f5() {
    |    ^^^^^^^
@@ -26,7 +26,7 @@ LL + fn f5_works() {
    |
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:52:4
+  --> tests/ui/redundant_test_prefix_unfixable.rs:53:4
    |
 LL | fn test_f6() {
    |    ^^^^^^^
@@ -38,13 +38,13 @@ LL + fn f6_works() {
    |
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:64:4
+  --> tests/ui/redundant_test_prefix_unfixable.rs:65:4
    |
 LL | fn test_f8() {
    |    ^^^^^^^ help: consider removing the `test_` prefix: `f8`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:87:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:88:8
    |
 LL |     fn test_f() {
    |        ^^^^^^
@@ -56,61 +56,61 @@ LL +     fn f_works() {
    |
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:100:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:101:8
    |
 LL |     fn test_m3_2() {
    |        ^^^^^^^^^ help: consider removing the `test_` prefix: `m3_2`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:113:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:114:8
    |
 LL |     fn test_foo() {
    |        ^^^^^^^^ help: consider removing the `test_` prefix: `foo`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:118:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:119:8
    |
 LL |     fn test_foo_with_call() {
    |        ^^^^^^^^^^^^^^^^^^ help: consider removing the `test_` prefix: `foo_with_call`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:125:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:126:8
    |
 LL |     fn test_f1() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f1`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:130:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:131:8
    |
 LL |     fn test_f2() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f2`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:135:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:136:8
    |
 LL |     fn test_f3() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f3`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:140:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:141:8
    |
 LL |     fn test_f4() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f4`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:145:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:146:8
    |
 LL |     fn test_f5() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f5`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:150:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:151:8
    |
 LL |     fn test_f6() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f6`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:155:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:156:8
    |
 LL |     fn test_1() {
    |        ^^^^^^
@@ -118,7 +118,7 @@ LL |     fn test_1() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:162:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:163:8
    |
 LL |     fn test_const() {
    |        ^^^^^^^^^^
@@ -126,7 +126,7 @@ LL |     fn test_const() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:169:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:170:8
    |
 LL |     fn test_async() {
    |        ^^^^^^^^^^
@@ -134,7 +134,7 @@ LL |     fn test_async() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:176:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:177:8
    |
 LL |     fn test_yield() {
    |        ^^^^^^^^^^
@@ -142,7 +142,7 @@ LL |     fn test_yield() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:183:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:184:8
    |
 LL |     fn test_() {
    |        ^^^^^
@@ -150,55 +150,55 @@ LL |     fn test_() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:194:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:195:8
    |
 LL |     fn test_foo() {
    |        ^^^^^^^^ help: consider removing the `test_` prefix: `foo`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:199:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:200:8
    |
 LL |     fn test_foo_with_call() {
    |        ^^^^^^^^^^^^^^^^^^ help: consider removing the `test_` prefix: `foo_with_call`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:206:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:207:8
    |
 LL |     fn test_f1() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f1`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:211:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:212:8
    |
 LL |     fn test_f2() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f2`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:216:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:217:8
    |
 LL |     fn test_f3() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f3`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:221:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:222:8
    |
 LL |     fn test_f4() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f4`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:226:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:227:8
    |
 LL |     fn test_f5() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f5`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:231:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:232:8
    |
 LL |     fn test_f6() {
    |        ^^^^^^^ help: consider removing the `test_` prefix: `f6`
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:236:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:237:8
    |
 LL |     fn test_1() {
    |        ^^^^^^
@@ -206,7 +206,7 @@ LL |     fn test_1() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:243:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:244:8
    |
 LL |     fn test_const() {
    |        ^^^^^^^^^^
@@ -214,7 +214,7 @@ LL |     fn test_const() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:250:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:251:8
    |
 LL |     fn test_async() {
    |        ^^^^^^^^^^
@@ -222,7 +222,7 @@ LL |     fn test_async() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:257:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:258:8
    |
 LL |     fn test_yield() {
    |        ^^^^^^^^^^
@@ -230,7 +230,7 @@ LL |     fn test_yield() {
    = help: consider function renaming (just removing `test_` prefix will produce invalid function name)
 
 error: redundant `test_` prefix in test function name
-  --> tests/ui/redundant_test_prefix_unfixable.rs:264:8
+  --> tests/ui/redundant_test_prefix_unfixable.rs:265:8
    |
 LL |     fn test_() {
    |        ^^^^^

--- a/tests/ui/should_panic_without_expect.rs
+++ b/tests/ui/should_panic_without_expect.rs
@@ -1,5 +1,6 @@
 //@no-rustfix
 #![deny(clippy::should_panic_without_expect)]
+#![expect(clippy::test_without_assertions)]
 
 #[test]
 #[should_panic]

--- a/tests/ui/should_panic_without_expect.stderr
+++ b/tests/ui/should_panic_without_expect.stderr
@@ -1,5 +1,5 @@
 error: #[should_panic] attribute without a reason
-  --> tests/ui/should_panic_without_expect.rs:5:1
+  --> tests/ui/should_panic_without_expect.rs:6:1
    |
 LL | #[should_panic]
    | ^^^^^^^^^^^^^^^ help: consider specifying the expected panic: `#[should_panic(expected = /* panic message */)]`

--- a/tests/ui/single_call_fn.rs
+++ b/tests/ui/single_call_fn.rs
@@ -69,6 +69,7 @@ fn e() {
     b();
 }
 
+#[expect(clippy::test_without_assertions)]
 #[test]
 fn k() {}
 

--- a/tests/ui/single_call_fn.stderr
+++ b/tests/ui/single_call_fn.stderr
@@ -54,25 +54,25 @@ LL |     a();
    |     ^
 
 error: this function is only used once
-  --> tests/ui/single_call_fn.rs:92:5
+  --> tests/ui/single_call_fn.rs:93:5
    |
 LL |     fn default() {}
    |     ^^^^^^^^^^^^^^^
    |
 note: used here
-  --> tests/ui/single_call_fn.rs:109:5
+  --> tests/ui/single_call_fn.rs:110:5
    |
 LL |     T::default();
    |     ^^^^^^^^^^
 
 error: this function is only used once
-  --> tests/ui/single_call_fn.rs:106:9
+  --> tests/ui/single_call_fn.rs:107:9
    |
 LL |         fn foo() {}
    |         ^^^^^^^^^^^
    |
 note: used here
-  --> tests/ui/single_call_fn.rs:110:5
+  --> tests/ui/single_call_fn.rs:111:5
    |
 LL |     S::foo();
    |     ^^^^^^

--- a/tests/ui/test_without_assertions.rs
+++ b/tests/ui/test_without_assertions.rs
@@ -1,0 +1,94 @@
+#![warn(clippy::test_without_assertions)]
+
+mod main {
+    use std::{assert_matches, debug_assert_matches};
+
+    #[test]
+    fn empty() {}
+    //~^ test_without_assertions
+
+    #[test]
+    fn empty_with_comment() {
+        // This is still an empty body.
+    }
+    //~^^^ test_without_assertions
+
+    fn ordinary_empty_function() {}
+
+    #[test]
+    fn no_failure_site() {
+        let _ = 1 + 1;
+    }
+    //~^^^ test_without_assertions
+
+    #[expect(clippy::unused_unit)]
+    #[test]
+    fn only_returns_unit() {
+        ()
+    }
+    //~^^^ test_without_assertions
+
+    #[test]
+    #[should_panic]
+    fn empty_should_panic() {}
+    //~^ test_without_assertions
+
+    #[test]
+    #[should_panic(expected = "intentional")]
+    fn should_panic_with_expected_message() {
+        let _ = 1 + 1;
+    }
+
+    #[test]
+    #[should_panic]
+    fn should_panic_without_visible_panic() {
+        let _ = 1 + 1;
+    }
+
+    #[test]
+    fn calls_helper() {
+        // False negative: calls are treated as potential failure sites without inspecting their bodies.
+        helper();
+    }
+
+    #[test]
+    fn explicit_panic() {
+        panic!("intentional")
+    }
+
+    #[test]
+    fn assert_equal() {
+        assert_eq!(1 + 1, 2);
+    }
+
+    #[test]
+    fn assert_not_equal() {
+        assert_ne!(1 + 1, 3);
+    }
+
+    #[test]
+    fn assertion() {
+        let val = 1 + 1;
+        assert!(val == 2);
+    }
+
+    #[test]
+    fn debug_assertion() {
+        let val = 1 + 1;
+        debug_assert!(val == 2);
+    }
+
+    #[test]
+    fn assertion_matches() {
+        let val: Result<i32, &str> = Ok(42);
+        assert_matches!(val, Ok(42));
+    }
+
+    #[test]
+    fn debug_assertion_matches() {
+        let val = Some(42);
+        debug_assert_matches!(val, Some(n) if n > 0);
+    }
+
+    fn helper() {}
+}

--- a/tests/ui/test_without_assertions.stderr
+++ b/tests/ui/test_without_assertions.stderr
@@ -1,0 +1,41 @@
+error: test function without assertions or other potential failure sites
+  --> tests/ui/test_without_assertions.rs:7:5
+   |
+LL |     fn empty() {}
+   |     ^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::test-without-assertions` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::test_without_assertions)]`
+
+error: test function without assertions or other potential failure sites
+  --> tests/ui/test_without_assertions.rs:11:5
+   |
+LL | /     fn empty_with_comment() {
+LL | |         // This is still an empty body.
+LL | |     }
+   | |_____^
+
+error: test function without assertions or other potential failure sites
+  --> tests/ui/test_without_assertions.rs:19:5
+   |
+LL | /     fn no_failure_site() {
+LL | |         let _ = 1 + 1;
+LL | |     }
+   | |_____^
+
+error: test function without assertions or other potential failure sites
+  --> tests/ui/test_without_assertions.rs:26:5
+   |
+LL | /     fn only_returns_unit() {
+LL | |         ()
+LL | |     }
+   | |_____^
+
+error: test function without assertions or other potential failure sites
+  --> tests/ui/test_without_assertions.rs:33:5
+   |
+LL |     fn empty_should_panic() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/tests_outside_test_module.rs
+++ b/tests/ui/tests_outside_test_module.rs
@@ -1,5 +1,6 @@
 //@require-annotations-for-level: WARN
 #![warn(clippy::tests_outside_test_module)]
+#![expect(clippy::test_without_assertions)]
 
 fn main() {
     // test code goes here

--- a/tests/ui/tests_outside_test_module.stderr
+++ b/tests/ui/tests_outside_test_module.stderr
@@ -1,5 +1,5 @@
 error: this function marked with `#[test]` is outside a `#[cfg(test)]` module
-  --> tests/ui/tests_outside_test_module.rs:10:1
+  --> tests/ui/tests_outside_test_module.rs:11:1
    |
 LL | fn my_test() {}
    | ^^^^^^^^^^^^^^^

--- a/tests/ui/trailing_empty_array.rs
+++ b/tests/ui/trailing_empty_array.rs
@@ -200,6 +200,7 @@ mod tests {
         age: u8,
     }
 
+    #[expect(clippy::test_without_assertions)]
     #[test]
     fn oldest_empty_is_none() {
         struct Michael {

--- a/tests/ui/unicode.fixed
+++ b/tests/ui/unicode.fixed
@@ -1,3 +1,5 @@
+#![expect(clippy::test_without_assertions)]
+
 fn zero() {
     #![warn(clippy::invisible_characters)]
 

--- a/tests/ui/unicode.rs
+++ b/tests/ui/unicode.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::test_without_assertions)]
+
 fn zero() {
     #![warn(clippy::invisible_characters)]
 

--- a/tests/ui/unicode.stderr
+++ b/tests/ui/unicode.stderr
@@ -1,5 +1,5 @@
 error: invisible character detected
-  --> tests/ui/unicode.rs:4:12
+  --> tests/ui/unicode.rs:6:12
    |
 LL |     print!("Here >​< is a ZWS, and ​another");
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider replacing the string with: `"Here >\u{200B}< is a ZWS, and \u{200B}another"`
@@ -8,19 +8,19 @@ LL |     print!("Here >​< is a ZWS, and ​another");
    = help: to override `-D warnings` add `#[allow(clippy::invisible_characters)]`
 
 error: invisible character detected
-  --> tests/ui/unicode.rs:7:12
+  --> tests/ui/unicode.rs:9:12
    |
 LL |     print!("Here >­< is a SHY, and ­another");
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider replacing the string with: `"Here >\u{AD}< is a SHY, and \u{AD}another"`
 
 error: invisible character detected
-  --> tests/ui/unicode.rs:10:12
+  --> tests/ui/unicode.rs:12:12
    |
 LL |     print!("Here >⁠< is a WJ, and ⁠another");
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider replacing the string with: `"Here >\u{2060}< is a WJ, and \u{2060}another"`
 
 error: non-NFC Unicode sequence detected
-  --> tests/ui/unicode.rs:18:12
+  --> tests/ui/unicode.rs:20:12
    |
 LL |     print!("̀àh?");
    |            ^^^^^ help: consider replacing the string with: `"̀àh?"`
@@ -29,7 +29,7 @@ LL |     print!("̀àh?");
    = help: to override `-D warnings` add `#[allow(clippy::unicode_not_nfc)]`
 
 error: literal non-ASCII character detected
-  --> tests/ui/unicode.rs:27:16
+  --> tests/ui/unicode.rs:29:16
    |
 LL |         print!("Üben!");
    |                ^^^^^^^ help: consider replacing the string with: `"\u{dc}ben!"`
@@ -38,25 +38,25 @@ LL |         print!("Üben!");
    = help: to override `-D warnings` add `#[allow(clippy::non_ascii_literal)]`
 
 error: literal non-ASCII character detected
-  --> tests/ui/unicode.rs:34:36
+  --> tests/ui/unicode.rs:36:36
    |
 LL |         const _EMPTY_BLOCK: char = '▱';
    |                                    ^^^ help: consider replacing the string with: `'\u{25b1}'`
 
 error: literal non-ASCII character detected
-  --> tests/ui/unicode.rs:36:35
+  --> tests/ui/unicode.rs:38:35
    |
 LL |         const _FULL_BLOCK: char = '▰';
    |                                   ^^^ help: consider replacing the string with: `'\u{25b0}'`
 
 error: literal non-ASCII character detected
-  --> tests/ui/unicode.rs:55:21
+  --> tests/ui/unicode.rs:57:21
    |
 LL |             let _ = "悲しいかな、ここに日本語を書くことはできない。";
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider replacing the string with: `"\u{60b2}\u{3057}\u{3044}\u{304b}\u{306a}\u{3001}\u{3053}\u{3053}\u{306b}\u{65e5}\u{672c}\u{8a9e}\u{3092}\u{66f8}\u{304f}\u{3053}\u{3068}\u{306f}\u{3067}\u{304d}\u{306a}\u{3044}\u{3002}"`
 
 error: literal non-ASCII character detected
-  --> tests/ui/unicode.rs:91:9
+  --> tests/ui/unicode.rs:93:9
    |
 LL |         with_location!("héllo");
    |         ^^^^^^^^^^^^^^^^^^^^^^^ help: consider replacing the string with: `with_location!("h\u{e9}llo")`


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17626)*

Fixes rust-lang/rust-clippy#17488

Tests without assertions or other potential failure sites can pass without verifying behavior. This adds `test_without_assertions`, a suspicious lint that detects these tests, including empty test bodies.

changelog: [`test_without_assertions`]: add a suspicious lint for tests without assertions or other potential failure sites

- [x] Followed lint naming conventions
- [x] Added passing UI tests, including the `.stderr` file
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Ran `cargo dev fmt`
