### PR TITLE
manual_pop_if: lint when the popped value is discarded

### DIFF
--- a/clippy_lints/src/manual_pop_if.rs
+++ b/clippy_lints/src/manual_pop_if.rs
@@ -394,10 +394,8 @@ fn check_map_unwrap_or_pattern<'tcx>(
     None
 }
 
-/// Checks for a `collection.<pop_method>()` call.
-/// Returns the collection expression and the span of the call.
-/// The result must be unwrapped with `.unwrap()`, `.expect(..)` or `.unwrap_unchecked()`.
-/// It can also be discarded with `collection.pop()` or `let _ = collection.pop()`.
+/// Checks for a `collection.<pop_method>()` call and returns the collection
+/// expression and the span of the call.
 /// If the call is the only statement in the block, the result is marked as
 /// suggestable (we can provide an automatic fix).
 fn check_pop<'tcx>(
@@ -446,16 +444,11 @@ fn check_pop<'tcx>(
         }
     };
 
-    // Matches a statement that pops and throws the value away.
-    // That is `collection.pop()` or `let _ = collection.pop()`.
-    // This is exactly what `pop_if` does.
-    //
-    // A pop in value position is not matched.
-    // Unlike `.unwrap()`, it does not claim that the collection is non-empty.
-    //
-    // A pop with a type annotation is not matched either.
-    // The suggestion replaces the whole statement.
-    // The annotation may be the only thing pinning down the element type.
+    // Matches a statement that pops and throws the value away, which is exactly what
+    // `pop_if` does. A pop in value position is not matched, as unlike `.unwrap()` it
+    // does not claim that the collection is non-empty. A pop with a type annotation is
+    // not matched either, as the annotation may be the only thing pinning down the
+    // element type.
     let as_discarded_pop = |stmt: &Stmt<'tcx>| -> Option<(&'tcx Expr<'tcx>, Span)> {
         match stmt.kind {
             StmtKind::Semi(stmt_expr) if !stmt_expr.span.from_expansion() => as_pop(stmt_expr),
@@ -475,9 +468,8 @@ fn check_pop<'tcx>(
     if let [stmt] = block.stmts
         && block.expr.is_none()
     {
-        // `stmt_lo` is where the replaced code starts.
-        // The suggestion replaces the whole statement.
-        // For `let _ = collection.pop()` that includes the `let _ =` part.
+        // `stmt_lo` is where the replaced code starts. The suggestion replaces the whole
+        // statement, so for `let _ = collection.pop()` that includes the `let _ =` part.
         let pop = if let StmtKind::Semi(stmt_expr) | StmtKind::Expr(stmt_expr) = stmt.kind
             && !stmt_expr.span.from_expansion()
             && let Some((collection_expr, span)) = as_pop_unwrap(peel_unsafe(stmt_expr))
@@ -505,8 +497,8 @@ fn check_pop<'tcx>(
         }
     });
 
-    // Otherwise look for a discarded pop among the statements of the block.
-    // Only the statements are checked, not every expression.
+    // Otherwise look for a discarded pop among the statements of the block. Only the
+    // statements are checked, not every expression.
     pop_unwrap.or_else(|| {
         block
             .stmts

--- a/clippy_lints/src/manual_pop_if.rs
+++ b/clippy_lints/src/manual_pop_if.rs
@@ -394,10 +394,10 @@ fn check_map_unwrap_or_pattern<'tcx>(
     None
 }
 
-/// Checks for a `collection.<pop_method>()` call whose result is either unwrapped
-/// (`.unwrap()`, `.expect(..)` or `.unwrap_unchecked()`) or discarded
-/// (`collection.pop();` or `let _ = collection.pop();`), and returns the collection
-/// expression and the span of the call.
+/// Checks for a `collection.<pop_method>()` call.
+/// Returns the collection expression and the span of the call.
+/// The result must be unwrapped with `.unwrap()`, `.expect(..)` or `.unwrap_unchecked()`.
+/// It can also be discarded with `collection.pop()` or `let _ = collection.pop()`.
 /// If the call is the only statement in the block, the result is marked as
 /// suggestable (we can provide an automatic fix).
 fn check_pop<'tcx>(
@@ -446,13 +446,16 @@ fn check_pop<'tcx>(
         }
     };
 
-    // A statement that pops and throws the value away: `collection.pop();` or
-    // `let _ = collection.pop();`. Unlike a bare `collection.pop()` in value position,
-    // this is exactly what `pop_if` does, so it is worth linting on its own.
+    // Matches a statement that pops and throws the value away.
+    // That is `collection.pop()` or `let _ = collection.pop()`.
+    // This is exactly what `pop_if` does.
     //
-    // An annotated `let _: Option<i32> = collection.pop();` is left alone: the whole
-    // statement is replaced by the suggestion, and the annotation may be what pins down
-    // the element type of the collection.
+    // A pop in value position is not matched.
+    // Unlike `.unwrap()`, it does not claim that the collection is non-empty.
+    //
+    // A pop with a type annotation is not matched either.
+    // The suggestion replaces the whole statement.
+    // The annotation may be the only thing pinning down the element type.
     let as_discarded_pop = |stmt: &Stmt<'tcx>| -> Option<(&'tcx Expr<'tcx>, Span)> {
         match stmt.kind {
             StmtKind::Semi(stmt_expr) if !stmt_expr.span.from_expansion() => as_pop(stmt_expr),
@@ -467,31 +470,30 @@ fn check_pop<'tcx>(
         }
     };
 
-    // Returns the pop call of a statement, along with the position the replaced code
-    // starts at (which is the start of the statement itself, as e.g. the `let _ =` of a
-    // discarded pop is replaced as well).
-    let as_pop_stmt = |stmt: &Stmt<'tcx>| -> Option<(&'tcx Expr<'tcx>, Span, BytePos)> {
-        if let StmtKind::Semi(stmt_expr) | StmtKind::Expr(stmt_expr) = stmt.kind
+    // Check for single statement with the pop (not in a macro or other expression)
+    // and that there are no comments or other text before or after the pop call.
+    if let [stmt] = block.stmts
+        && block.expr.is_none()
+    {
+        // `stmt_lo` is where the replaced code starts.
+        // The suggestion replaces the whole statement.
+        // For `let _ = collection.pop()` that includes the `let _ =` part.
+        let pop = if let StmtKind::Semi(stmt_expr) | StmtKind::Expr(stmt_expr) = stmt.kind
             && !stmt_expr.span.from_expansion()
             && let Some((collection_expr, span)) = as_pop_unwrap(peel_unsafe(stmt_expr))
         {
             Some((collection_expr, span, stmt_expr.span.lo()))
         } else {
             as_discarded_pop(stmt).map(|(collection_expr, span)| (collection_expr, span, stmt.span.lo()))
-        }
-    };
+        };
 
-    // Check for single statement with the pop (not in a macro or other expression)
-    // and that there are no comments or other text before or after the pop call.
-    if let [stmt] = block.stmts
-        && block.expr.is_none()
-        && let Some((collection_expr, span, stmt_lo)) = as_pop_stmt(stmt)
-    {
-        let span_before = block.span.with_lo(block.span.lo() + BytePos(1)).with_hi(stmt_lo);
-        let span_after = stmt.span.shrink_to_hi().with_hi(block.span.hi() - BytePos(1));
-        let suggestable = !span_contains_non_whitespace(cx, span_before, false)
-            && !span_contains_non_whitespace(cx, span_after, false);
-        return Some((collection_expr, span, suggestable));
+        if let Some((collection_expr, span, stmt_lo)) = pop {
+            let span_before = block.span.with_lo(block.span.lo() + BytePos(1)).with_hi(stmt_lo);
+            let span_after = stmt.span.shrink_to_hi().with_hi(block.span.hi() - BytePos(1));
+            let suggestable = !span_contains_non_whitespace(cx, span_before, false)
+                && !span_contains_non_whitespace(cx, span_after, false);
+            return Some((collection_expr, span, suggestable));
+        }
     }
 
     // Check if the pop unwrap is present at all
@@ -503,9 +505,8 @@ fn check_pop<'tcx>(
         }
     });
 
-    // Otherwise, look for a discarded pop among the statements of the block. This is
-    // deliberately not a full expression walk: a `collection.pop()` in value position
-    // carries none of the "the collection is not empty" intent that `.unwrap()` does.
+    // Otherwise look for a discarded pop among the statements of the block.
+    // Only the statements are checked, not every expression.
     pop_unwrap.or_else(|| {
         block
             .stmts

--- a/clippy_lints/src/manual_pop_if.rs
+++ b/clippy_lints/src/manual_pop_if.rs
@@ -8,7 +8,7 @@ use clippy_utils::{eq_expr_value, is_else_clause, is_lang_item_or_ctor, span_con
 use rustc_ast::LitKind;
 use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::attrs::lang_items::LangItem;
-use rustc_hir::{BlockCheckMode, Expr, ExprKind, PatKind, StmtKind, UnsafeSource};
+use rustc_hir::{BlockCheckMode, Expr, ExprKind, PatKind, Stmt, StmtKind, UnsafeSource};
 use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{BytePos, Span, Symbol};
@@ -41,6 +41,9 @@ declare_clippy_lint! {
     /// if deque.front().is_some_and(|x| *x > 5) {
     ///     deque.pop_front().unwrap();
     /// }
+    /// if vec.last().is_some_and(|x| *x > 9) {
+    ///     vec.pop();
+    /// }
     /// ```
     /// Use instead:
     /// ```no_run
@@ -50,6 +53,7 @@ declare_clippy_lint! {
     /// vec.pop_if(|x| *x > 5);
     /// deque.pop_back_if(|x| *x > 5);
     /// deque.pop_front_if(|x| *x > 5);
+    /// vec.pop_if(|x| *x > 9);
     /// ```
     #[clippy::version = "1.96.0"]
     pub MANUAL_POP_IF,
@@ -211,7 +215,7 @@ fn check_is_some_and_pattern<'tcx>(
         && kind.is_diag_item(cx, collection_expr)
         && let ExprKind::Closure(closure) = closure_arg.kind
         && let body = cx.tcx.hir_body(closure.body)
-        && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
+        && let Some((pop_collection, pop_span, suggestable)) = check_pop(cx, then_block, pop_method)
         && eq_expr_value(cx, if_expr_span.ctxt(), collection_expr, pop_collection)
         && let Some(param) = body.params.first()
         && let Some(ident) = param.pat.simple_ident()
@@ -273,7 +277,7 @@ fn check_if_let_pattern<'tcx>(
 
             if let ExprKind::If(inner_cond, inner_then, None) = inner_if.kind
                 && is_local_used(cx, inner_cond, binding_id)
-                && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, inner_then, pop_method)
+                && let Some((pop_collection, pop_span, suggestable)) = check_pop(cx, inner_then, pop_method)
                 && eq_expr_value(cx, if_expr_span.ctxt(), collection_expr, pop_collection)
             {
                 return Some(ManualPopIfPattern {
@@ -326,7 +330,7 @@ fn check_let_chain_pattern<'tcx>(
             && path.ident.name == peek_method
             && kind.is_diag_item(cx, collection_expr)
             && is_local_used(cx, right, binding_id)
-            && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
+            && let Some((pop_collection, pop_span, suggestable)) = check_pop(cx, then_block, pop_method)
             && eq_expr_value(cx, if_expr_span.ctxt(), collection_expr, pop_collection)
         {
             return Some(ManualPopIfPattern {
@@ -371,7 +375,7 @@ fn check_map_unwrap_or_pattern<'tcx>(
         && let ExprKind::Closure(closure) = closure_arg.kind
         && let body = cx.tcx.hir_body(closure.body)
         && cx.typeck_results().expr_ty(body.value).is_bool()
-        && let Some((pop_collection, pop_span, suggestable)) = check_pop_unwrap(cx, then_block, pop_method)
+        && let Some((pop_collection, pop_span, suggestable)) = check_pop(cx, then_block, pop_method)
         && eq_expr_value(cx, if_expr_span.ctxt(), collection_expr, pop_collection)
         && let Some(param) = body.params.first()
         && let Some(ident) = param.pat.simple_ident()
@@ -390,11 +394,13 @@ fn check_map_unwrap_or_pattern<'tcx>(
     None
 }
 
-/// Checks for `collection.<pop_method>().unwrap()` or `collection.<pop_method>().expect(..)`
-/// and returns the collection expression and the span of the pop+unwrap call.
-/// If the pop+unwrap is the only statement in the block, the result is marked as
+/// Checks for a `collection.<pop_method>()` call whose result is either unwrapped
+/// (`.unwrap()`, `.expect(..)` or `.unwrap_unchecked()`) or discarded
+/// (`collection.pop();` or `let _ = collection.pop();`), and returns the collection
+/// expression and the span of the call.
+/// If the call is the only statement in the block, the result is marked as
 /// suggestable (we can provide an automatic fix).
-fn check_pop_unwrap<'tcx>(
+fn check_pop<'tcx>(
     cx: &LateContext<'tcx>,
     expr: &'tcx Expr<'_>,
     pop_method: Symbol,
@@ -403,14 +409,23 @@ fn check_pop_unwrap<'tcx>(
         return None;
     };
 
+    let as_pop = |expr: &Expr<'tcx>| -> Option<(&'tcx Expr<'tcx>, Span)> {
+        if let ExprKind::MethodCall(pop_path, collection_expr, [], _) = expr.kind
+            && pop_path.ident.name == pop_method
+        {
+            Some((collection_expr, expr.span))
+        } else {
+            None
+        }
+    };
+
     let as_pop_unwrap = |expr: &Expr<'tcx>| -> Option<(&'tcx Expr<'tcx>, Span)> {
         if let ExprKind::MethodCall(unwrap_path, receiver, _, _) = expr.kind
             && matches!(
                 unwrap_path.ident.name,
                 sym::unwrap | sym::unwrap_unchecked | sym::expect
             )
-            && let ExprKind::MethodCall(pop_path, collection_expr, [], _) = receiver.kind
-            && pop_path.ident.name == pop_method
+            && let Some((collection_expr, _)) = as_pop(receiver)
         {
             Some((collection_expr, expr.span))
         } else {
@@ -431,18 +446,48 @@ fn check_pop_unwrap<'tcx>(
         }
     };
 
-    // Check for single statement with the pop unwrap (not in a macro or other expression)
+    // A statement that pops and throws the value away: `collection.pop();` or
+    // `let _ = collection.pop();`. Unlike a bare `collection.pop()` in value position,
+    // this is exactly what `pop_if` does, so it is worth linting on its own.
+    //
+    // An annotated `let _: Option<i32> = collection.pop();` is left alone: the whole
+    // statement is replaced by the suggestion, and the annotation may be what pins down
+    // the element type of the collection.
+    let as_discarded_pop = |stmt: &Stmt<'tcx>| -> Option<(&'tcx Expr<'tcx>, Span)> {
+        match stmt.kind {
+            StmtKind::Semi(stmt_expr) if !stmt_expr.span.from_expansion() => as_pop(stmt_expr),
+            StmtKind::Let(let_stmt)
+                if matches!(let_stmt.pat.kind, PatKind::Wild)
+                    && let_stmt.ty.is_none()
+                    && !stmt.span.from_expansion() =>
+            {
+                let_stmt.init.and_then(&as_pop)
+            },
+            _ => None,
+        }
+    };
+
+    // Returns the pop call of a statement, along with the position the replaced code
+    // starts at (which is the start of the statement itself, as e.g. the `let _ =` of a
+    // discarded pop is replaced as well).
+    let as_pop_stmt = |stmt: &Stmt<'tcx>| -> Option<(&'tcx Expr<'tcx>, Span, BytePos)> {
+        if let StmtKind::Semi(stmt_expr) | StmtKind::Expr(stmt_expr) = stmt.kind
+            && !stmt_expr.span.from_expansion()
+            && let Some((collection_expr, span)) = as_pop_unwrap(peel_unsafe(stmt_expr))
+        {
+            Some((collection_expr, span, stmt_expr.span.lo()))
+        } else {
+            as_discarded_pop(stmt).map(|(collection_expr, span)| (collection_expr, span, stmt.span.lo()))
+        }
+    };
+
+    // Check for single statement with the pop (not in a macro or other expression)
     // and that there are no comments or other text before or after the pop call.
     if let [stmt] = block.stmts
         && block.expr.is_none()
-        && let StmtKind::Semi(stmt_expr) | StmtKind::Expr(stmt_expr) = &stmt.kind
-        && !stmt_expr.span.from_expansion()
-        && let Some((collection_expr, span)) = as_pop_unwrap(peel_unsafe(stmt_expr))
+        && let Some((collection_expr, span, stmt_lo)) = as_pop_stmt(stmt)
     {
-        let span_before = block
-            .span
-            .with_lo(block.span.lo() + BytePos(1))
-            .with_hi(stmt_expr.span.lo());
+        let span_before = block.span.with_lo(block.span.lo() + BytePos(1)).with_hi(stmt_lo);
         let span_after = stmt.span.shrink_to_hi().with_hi(block.span.hi() - BytePos(1));
         let suggestable = !span_contains_non_whitespace(cx, span_before, false)
             && !span_contains_non_whitespace(cx, span_after, false);
@@ -450,12 +495,22 @@ fn check_pop_unwrap<'tcx>(
     }
 
     // Check if the pop unwrap is present at all
-    for_each_expr_without_closures(block, |expr| {
+    let pop_unwrap = for_each_expr_without_closures(block, |expr| {
         if let Some((collection_expr, span)) = as_pop_unwrap(expr) {
             ControlFlow::Break((collection_expr, span, false))
         } else {
             ControlFlow::Continue(())
         }
+    });
+
+    // Otherwise, look for a discarded pop among the statements of the block. This is
+    // deliberately not a full expression walk: a `collection.pop()` in value position
+    // carries none of the "the collection is not empty" intent that `.unwrap()` does.
+    pop_unwrap.or_else(|| {
+        block
+            .stmts
+            .iter()
+            .find_map(|stmt| as_discarded_pop(stmt).map(|(collection_expr, span)| (collection_expr, span, false)))
     })
 }
 

--- a/tests/ui/manual_pop_if.fixed
+++ b/tests/ui/manual_pop_if.fixed
@@ -38,6 +38,22 @@ fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut
 
     //~v manual_pop_if
     heap.pop_if(|x| *x > 2);
+
+    // The popped value is discarded, which is exactly what `pop_if` does
+    //~v manual_pop_if
+    vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    deque.pop_back_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    deque.pop_front_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    heap.pop_if(|x| *x > 2);
 }
 
 fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
@@ -47,10 +63,37 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
         vec2.pop().unwrap();
     }
 
+    // Do not lint, different vectors
+    if vec.last().is_some_and(|x| *x > 2) {
+        vec2.pop();
+    }
+
+    // Do not lint, the popped value is bound and used, so it is not discarded
+    if vec.last().is_some_and(|x| *x > 2) {
+        let popped = vec.pop();
+        println!("{popped:?}");
+    }
+
+    // Do not lint, dropping the `let` would drop a type annotation that may be what
+    // pins down the element type of the collection
+    if vec.last().is_some_and(|x| *x > 2) {
+        let _: Option<i32> = vec.pop();
+    }
+
+    // Do not lint, `pop` is in value position and carries no "not empty" intent
+    if vec.last().is_some_and(|x| *x > 2) {
+        while vec.pop().is_some() {}
+    }
+
     // Do not lint, non-Vec type
     let mut fake_vec: FakeVec<i32> = FakeVec(PhantomData);
     if fake_vec.last().is_some_and(|x| *x > 2) {
         fake_vec.pop().unwrap();
+    }
+
+    // Do not lint, non-Vec type
+    if fake_vec.last().is_some_and(|x| *x > 2) {
+        fake_vec.pop();
     }
 
     // Do not lint, else block
@@ -67,6 +110,18 @@ fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap
 
     //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    deque.pop_back_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    deque.pop_front_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    heap.pop_if(|x| *x > 2);
 
     //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
@@ -125,6 +180,14 @@ fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut h
     deque.pop_front_if(|x| *x > 2);
 
     heap.pop_if(|x| *x > 2);
+
+    vec.pop_if(|x| *x > 2);
+
+    deque.pop_back_if(|x| *x > 2);
+
+    deque.pop_front_if(|x| *x > 2);
+
+    heap.pop_if(|x| *x > 2);
 }
 
 fn let_chain_pattern_negative(mut vec: Vec<i32>) {
@@ -159,6 +222,18 @@ fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, m
 
     //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    vec.pop_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    deque.pop_back_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    deque.pop_front_if(|x| *x > 2);
+
+    //~v manual_pop_if
+    heap.pop_if(|x| *x > 2);
 
     //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
@@ -214,6 +289,10 @@ fn handle_macro_in_closure(mut vec: Vec<Vec<i32>>) {
 fn msrv_too_low_vec(mut vec: Vec<i32>) {
     if vec.last().is_some_and(|x| *x > 2) {
         vec.pop().unwrap();
+    }
+
+    if vec.last().is_some_and(|x| *x > 2) {
+        vec.pop();
     }
 }
 

--- a/tests/ui/manual_pop_if.fixed
+++ b/tests/ui/manual_pop_if.fixed
@@ -39,7 +39,7 @@ fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut
     //~v manual_pop_if
     heap.pop_if(|x| *x > 2);
 
-    // The popped value is discarded, which is exactly what `pop_if` does
+    // The popped value is discarded, which is what `pop_if` does
     //~v manual_pop_if
     vec.pop_if(|x| *x > 2);
 
@@ -68,19 +68,18 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
         vec2.pop();
     }
 
-    // Do not lint, the popped value is bound and used, so it is not discarded
+    // Do not lint, the popped value is bound and used
     if vec.last().is_some_and(|x| *x > 2) {
         let popped = vec.pop();
         println!("{popped:?}");
     }
 
-    // Do not lint, dropping the `let` would drop a type annotation that may be what
-    // pins down the element type of the collection
+    // Do not lint, the type annotation may pin down the element type
     if vec.last().is_some_and(|x| *x > 2) {
         let _: Option<i32> = vec.pop();
     }
 
-    // Do not lint, `pop` is in value position and carries no "not empty" intent
+    // Do not lint, the pop is in value position
     if vec.last().is_some_and(|x| *x > 2) {
         while vec.pop().is_some() {}
     }

--- a/tests/ui/manual_pop_if.rs
+++ b/tests/ui/manual_pop_if.rs
@@ -50,6 +50,32 @@ fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut
     if heap.peek().is_some_and(|x| *x > 2) {
         heap.pop().unwrap();
     }
+
+    // The popped value is discarded, which is exactly what `pop_if` does
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        vec.pop();
+    }
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        let _ = vec.pop();
+    }
+
+    //~v manual_pop_if
+    if deque.back().is_some_and(|x| *x > 2) {
+        deque.pop_back();
+    }
+
+    //~v manual_pop_if
+    if deque.front().is_some_and(|x| *x > 2) {
+        deque.pop_front();
+    }
+
+    //~v manual_pop_if
+    if heap.peek().is_some_and(|x| *x > 2) {
+        heap.pop();
+    }
 }
 
 fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
@@ -59,10 +85,37 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
         vec2.pop().unwrap();
     }
 
+    // Do not lint, different vectors
+    if vec.last().is_some_and(|x| *x > 2) {
+        vec2.pop();
+    }
+
+    // Do not lint, the popped value is bound and used, so it is not discarded
+    if vec.last().is_some_and(|x| *x > 2) {
+        let popped = vec.pop();
+        println!("{popped:?}");
+    }
+
+    // Do not lint, dropping the `let` would drop a type annotation that may be what
+    // pins down the element type of the collection
+    if vec.last().is_some_and(|x| *x > 2) {
+        let _: Option<i32> = vec.pop();
+    }
+
+    // Do not lint, `pop` is in value position and carries no "not empty" intent
+    if vec.last().is_some_and(|x| *x > 2) {
+        while vec.pop().is_some() {}
+    }
+
     // Do not lint, non-Vec type
     let mut fake_vec: FakeVec<i32> = FakeVec(PhantomData);
     if fake_vec.last().is_some_and(|x| *x > 2) {
         fake_vec.pop().unwrap();
+    }
+
+    // Do not lint, non-Vec type
+    if fake_vec.last().is_some_and(|x| *x > 2) {
+        fake_vec.pop();
     }
 
     // Do not lint, else block
@@ -113,6 +166,34 @@ fn if_let_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut heap
     if let Some(x) = heap.peek() {
         if *x > 2 {
             heap.pop().unwrap();
+        }
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last() {
+        if *x > 2 {
+            vec.pop();
+        }
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = deque.back() {
+        if *x > 2 {
+            deque.pop_back();
+        }
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = deque.front() {
+        if *x > 2 {
+            deque.pop_front();
+        }
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = heap.peek() {
+        if *x > 2 {
+            heap.pop();
         }
     }
 }
@@ -185,6 +266,30 @@ fn let_chain_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut h
     {
         heap.pop().unwrap();
     }
+
+    if let Some(x) = vec.last() //~ manual_pop_if
+        && *x > 2
+    {
+        vec.pop();
+    }
+
+    if let Some(x) = deque.back() //~ manual_pop_if
+        && *x > 2
+    {
+        deque.pop_back();
+    }
+
+    if let Some(x) = deque.front() //~ manual_pop_if
+        && *x > 2
+    {
+        deque.pop_front();
+    }
+
+    if let Some(x) = heap.peek() //~ manual_pop_if
+        && *x > 2
+    {
+        heap.pop();
+    }
 }
 
 fn let_chain_pattern_negative(mut vec: Vec<i32>) {
@@ -243,6 +348,26 @@ fn map_unwrap_or_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, m
     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
         heap.pop().unwrap();
     }
+
+    //~v manual_pop_if
+    if vec.last().map(|x| *x > 2).unwrap_or(false) {
+        vec.pop();
+    }
+
+    //~v manual_pop_if
+    if deque.back().map(|x| *x > 2).unwrap_or(false) {
+        deque.pop_back();
+    }
+
+    //~v manual_pop_if
+    if deque.front().map(|x| *x > 2).unwrap_or(false) {
+        deque.pop_front();
+    }
+
+    //~v manual_pop_if
+    if heap.peek().map(|x| *x > 2).unwrap_or(false) {
+        heap.pop();
+    }
 }
 
 fn map_unwrap_or_pattern_negative(mut vec: Vec<i32>) {
@@ -288,6 +413,10 @@ fn handle_macro_in_closure(mut vec: Vec<Vec<i32>>) {
 fn msrv_too_low_vec(mut vec: Vec<i32>) {
     if vec.last().is_some_and(|x| *x > 2) {
         vec.pop().unwrap();
+    }
+
+    if vec.last().is_some_and(|x| *x > 2) {
+        vec.pop();
     }
 }
 

--- a/tests/ui/manual_pop_if.rs
+++ b/tests/ui/manual_pop_if.rs
@@ -51,7 +51,7 @@ fn is_some_and_pattern_positive(mut vec: Vec<i32>, mut deque: VecDeque<i32>, mut
         heap.pop().unwrap();
     }
 
-    // The popped value is discarded, which is exactly what `pop_if` does
+    // The popped value is discarded, which is what `pop_if` does
     //~v manual_pop_if
     if vec.last().is_some_and(|x| *x > 2) {
         vec.pop();
@@ -90,19 +90,18 @@ fn is_some_and_pattern_negative(mut vec: Vec<i32>, mut deque: VecDeque<i32>) {
         vec2.pop();
     }
 
-    // Do not lint, the popped value is bound and used, so it is not discarded
+    // Do not lint, the popped value is bound and used
     if vec.last().is_some_and(|x| *x > 2) {
         let popped = vec.pop();
         println!("{popped:?}");
     }
 
-    // Do not lint, dropping the `let` would drop a type annotation that may be what
-    // pins down the element type of the collection
+    // Do not lint, the type annotation may pin down the element type
     if vec.last().is_some_and(|x| *x > 2) {
         let _: Option<i32> = vec.pop();
     }
 
-    // Do not lint, `pop` is in value position and carries no "not empty" intent
+    // Do not lint, the pop is in value position
     if vec.last().is_some_and(|x| *x > 2) {
         while vec.pop().is_some() {}
     }

--- a/tests/ui/manual_pop_if.stderr
+++ b/tests/ui/manual_pop_if.stderr
@@ -97,7 +97,87 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:78:5
+  --> tests/ui/manual_pop_if.rs:56:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop();
+   |         ^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().is_some_and(|x| *x > 2) {
+LL -         vec.pop();
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:61:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _ = vec.pop();
+   |                 ^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().is_some_and(|x| *x > 2) {
+LL -         let _ = vec.pop();
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `VecDeque::pop_back_if`
+  --> tests/ui/manual_pop_if.rs:66:5
+   |
+LL |     if deque.back().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_back();
+   |         ^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.back().is_some_and(|x| *x > 2) {
+LL -         deque.pop_back();
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
+
+error: manual implementation of `VecDeque::pop_front_if`
+  --> tests/ui/manual_pop_if.rs:71:5
+   |
+LL |     if deque.front().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_front();
+   |         ^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.front().is_some_and(|x| *x > 2) {
+LL -         deque.pop_front();
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
+
+error: manual implementation of `BinaryHeap::pop_if`
+  --> tests/ui/manual_pop_if.rs:76:5
+   |
+LL |     if heap.peek().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         heap.pop();
+   |         ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if heap.peek().is_some_and(|x| *x > 2) {
+LL -         heap.pop();
+LL -     }
+LL +     heap.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:131:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,7 +197,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:85:5
+  --> tests/ui/manual_pop_if.rs:138:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,7 +217,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:92:5
+  --> tests/ui/manual_pop_if.rs:145:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +237,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:99:5
+  --> tests/ui/manual_pop_if.rs:152:5
    |
 LL |     if let Some(x) = deque.back() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -177,7 +257,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:106:5
+  --> tests/ui/manual_pop_if.rs:159:5
    |
 LL |     if let Some(x) = deque.front() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +277,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:113:5
+  --> tests/ui/manual_pop_if.rs:166:5
    |
 LL |     if let Some(x) = heap.peek() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +297,87 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:153:5
+  --> tests/ui/manual_pop_if.rs:173:5
+   |
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             vec.pop();
+   |             ^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = vec.last() {
+LL -         if *x > 2 {
+LL -             vec.pop();
+LL -         }
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `VecDeque::pop_back_if`
+  --> tests/ui/manual_pop_if.rs:180:5
+   |
+LL |     if let Some(x) = deque.back() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             deque.pop_back();
+   |             ^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = deque.back() {
+LL -         if *x > 2 {
+LL -             deque.pop_back();
+LL -         }
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
+
+error: manual implementation of `VecDeque::pop_front_if`
+  --> tests/ui/manual_pop_if.rs:187:5
+   |
+LL |     if let Some(x) = deque.front() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             deque.pop_front();
+   |             ^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = deque.front() {
+LL -         if *x > 2 {
+LL -             deque.pop_front();
+LL -         }
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
+
+error: manual implementation of `BinaryHeap::pop_if`
+  --> tests/ui/manual_pop_if.rs:194:5
+   |
+LL |     if let Some(x) = heap.peek() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             heap.pop();
+   |             ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = heap.peek() {
+LL -         if *x > 2 {
+LL -             heap.pop();
+LL -         }
+LL -     }
+LL +     heap.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:234:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -237,7 +397,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:159:5
+  --> tests/ui/manual_pop_if.rs:240:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -257,7 +417,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:165:5
+  --> tests/ui/manual_pop_if.rs:246:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -277,7 +437,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:171:5
+  --> tests/ui/manual_pop_if.rs:252:5
    |
 LL | /     if let Some(x) = deque.back()
 LL | |         && *x > 2
@@ -297,7 +457,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:177:5
+  --> tests/ui/manual_pop_if.rs:258:5
    |
 LL | /     if let Some(x) = deque.front()
 LL | |         && *x > 2
@@ -317,7 +477,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:183:5
+  --> tests/ui/manual_pop_if.rs:264:5
    |
 LL | /     if let Some(x) = heap.peek()
 LL | |         && *x > 2
@@ -337,7 +497,87 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:218:5
+  --> tests/ui/manual_pop_if.rs:270:5
+   |
+LL | /     if let Some(x) = vec.last()
+LL | |         && *x > 2
+   | |_________________^
+LL |       {
+LL |           vec.pop();
+   |           ^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = vec.last()
+LL -         && *x > 2
+LL -     {
+LL -         vec.pop();
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `VecDeque::pop_back_if`
+  --> tests/ui/manual_pop_if.rs:276:5
+   |
+LL | /     if let Some(x) = deque.back()
+LL | |         && *x > 2
+   | |_________________^
+LL |       {
+LL |           deque.pop_back();
+   |           ^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = deque.back()
+LL -         && *x > 2
+LL -     {
+LL -         deque.pop_back();
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
+
+error: manual implementation of `VecDeque::pop_front_if`
+  --> tests/ui/manual_pop_if.rs:282:5
+   |
+LL | /     if let Some(x) = deque.front()
+LL | |         && *x > 2
+   | |_________________^
+LL |       {
+LL |           deque.pop_front();
+   |           ^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = deque.front()
+LL -         && *x > 2
+LL -     {
+LL -         deque.pop_front();
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
+
+error: manual implementation of `BinaryHeap::pop_if`
+  --> tests/ui/manual_pop_if.rs:288:5
+   |
+LL | /     if let Some(x) = heap.peek()
+LL | |         && *x > 2
+   | |_________________^
+LL |       {
+LL |           heap.pop();
+   |           ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if let Some(x) = heap.peek()
+LL -         && *x > 2
+LL -     {
+LL -         heap.pop();
+LL -     }
+LL +     heap.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:323:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -353,7 +593,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:223:5
+  --> tests/ui/manual_pop_if.rs:328:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -369,7 +609,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:228:5
+  --> tests/ui/manual_pop_if.rs:333:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -385,7 +625,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:233:5
+  --> tests/ui/manual_pop_if.rs:338:5
    |
 LL |     if deque.back().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -401,7 +641,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:238:5
+  --> tests/ui/manual_pop_if.rs:343:5
    |
 LL |     if deque.front().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -417,7 +657,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:243:5
+  --> tests/ui/manual_pop_if.rs:348:5
    |
 LL |     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -433,7 +673,71 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:282:5
+  --> tests/ui/manual_pop_if.rs:353:5
+   |
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop();
+   |         ^^^^^^^^^
+   |
+help: try
+   |
+LL -     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+LL -         vec.pop();
+LL -     }
+LL +     vec.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `VecDeque::pop_back_if`
+  --> tests/ui/manual_pop_if.rs:358:5
+   |
+LL |     if deque.back().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_back();
+   |         ^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.back().map(|x| *x > 2).unwrap_or(false) {
+LL -         deque.pop_back();
+LL -     }
+LL +     deque.pop_back_if(|x| *x > 2);
+   |
+
+error: manual implementation of `VecDeque::pop_front_if`
+  --> tests/ui/manual_pop_if.rs:363:5
+   |
+LL |     if deque.front().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         deque.pop_front();
+   |         ^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if deque.front().map(|x| *x > 2).unwrap_or(false) {
+LL -         deque.pop_front();
+LL -     }
+LL +     deque.pop_front_if(|x| *x > 2);
+   |
+
+error: manual implementation of `BinaryHeap::pop_if`
+  --> tests/ui/manual_pop_if.rs:368:5
+   |
+LL |     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         heap.pop();
+   |         ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
+LL -         heap.pop();
+LL -     }
+LL +     heap.pop_if(|x| *x > 2);
+   |
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if.rs:407:5
    |
 LL |     if vec.last().is_some_and(|e| *e == vec![1]) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -449,7 +753,7 @@ LL +     vec.pop_if(|e| *e == vec![1]);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:308:5
+  --> tests/ui/manual_pop_if.rs:437:5
    |
 LL |     if vec.last().is_some_and(|x| *x > 2) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -465,7 +769,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:316:5
+  --> tests/ui/manual_pop_if.rs:445:5
    |
 LL |     if deque.back().is_some_and(|x| *x > 2) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -481,7 +785,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:321:5
+  --> tests/ui/manual_pop_if.rs:450:5
    |
 LL |     if deque.front().is_some_and(|x| *x > 2) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -496,5 +800,5 @@ LL -     }
 LL +     deque.pop_front_if(|x| *x > 2);
    |
 
-error: aborting due to 28 previous errors
+error: aborting due to 45 previous errors
 

--- a/tests/ui/manual_pop_if.stderr
+++ b/tests/ui/manual_pop_if.stderr
@@ -177,7 +177,7 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:131:5
+  --> tests/ui/manual_pop_if.rs:130:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:138:5
+  --> tests/ui/manual_pop_if.rs:137:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +217,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:145:5
+  --> tests/ui/manual_pop_if.rs:144:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +237,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:152:5
+  --> tests/ui/manual_pop_if.rs:151:5
    |
 LL |     if let Some(x) = deque.back() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -257,7 +257,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:159:5
+  --> tests/ui/manual_pop_if.rs:158:5
    |
 LL |     if let Some(x) = deque.front() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,7 +277,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:166:5
+  --> tests/ui/manual_pop_if.rs:165:5
    |
 LL |     if let Some(x) = heap.peek() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -297,7 +297,7 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:173:5
+  --> tests/ui/manual_pop_if.rs:172:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -317,7 +317,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:180:5
+  --> tests/ui/manual_pop_if.rs:179:5
    |
 LL |     if let Some(x) = deque.back() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -337,7 +337,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:187:5
+  --> tests/ui/manual_pop_if.rs:186:5
    |
 LL |     if let Some(x) = deque.front() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -357,7 +357,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:194:5
+  --> tests/ui/manual_pop_if.rs:193:5
    |
 LL |     if let Some(x) = heap.peek() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -377,7 +377,7 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:234:5
+  --> tests/ui/manual_pop_if.rs:233:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -397,7 +397,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:240:5
+  --> tests/ui/manual_pop_if.rs:239:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -417,7 +417,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:246:5
+  --> tests/ui/manual_pop_if.rs:245:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -437,7 +437,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:252:5
+  --> tests/ui/manual_pop_if.rs:251:5
    |
 LL | /     if let Some(x) = deque.back()
 LL | |         && *x > 2
@@ -457,7 +457,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:258:5
+  --> tests/ui/manual_pop_if.rs:257:5
    |
 LL | /     if let Some(x) = deque.front()
 LL | |         && *x > 2
@@ -477,7 +477,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:264:5
+  --> tests/ui/manual_pop_if.rs:263:5
    |
 LL | /     if let Some(x) = heap.peek()
 LL | |         && *x > 2
@@ -497,7 +497,7 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:270:5
+  --> tests/ui/manual_pop_if.rs:269:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -517,7 +517,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:276:5
+  --> tests/ui/manual_pop_if.rs:275:5
    |
 LL | /     if let Some(x) = deque.back()
 LL | |         && *x > 2
@@ -537,7 +537,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:282:5
+  --> tests/ui/manual_pop_if.rs:281:5
    |
 LL | /     if let Some(x) = deque.front()
 LL | |         && *x > 2
@@ -557,7 +557,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:288:5
+  --> tests/ui/manual_pop_if.rs:287:5
    |
 LL | /     if let Some(x) = heap.peek()
 LL | |         && *x > 2
@@ -577,7 +577,7 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:323:5
+  --> tests/ui/manual_pop_if.rs:322:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -593,7 +593,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:328:5
+  --> tests/ui/manual_pop_if.rs:327:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -609,7 +609,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:333:5
+  --> tests/ui/manual_pop_if.rs:332:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -625,7 +625,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:338:5
+  --> tests/ui/manual_pop_if.rs:337:5
    |
 LL |     if deque.back().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -641,7 +641,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:343:5
+  --> tests/ui/manual_pop_if.rs:342:5
    |
 LL |     if deque.front().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -657,7 +657,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:348:5
+  --> tests/ui/manual_pop_if.rs:347:5
    |
 LL |     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -673,7 +673,7 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:353:5
+  --> tests/ui/manual_pop_if.rs:352:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -689,7 +689,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:358:5
+  --> tests/ui/manual_pop_if.rs:357:5
    |
 LL |     if deque.back().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -705,7 +705,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:363:5
+  --> tests/ui/manual_pop_if.rs:362:5
    |
 LL |     if deque.front().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -721,7 +721,7 @@ LL +     deque.pop_front_if(|x| *x > 2);
    |
 
 error: manual implementation of `BinaryHeap::pop_if`
-  --> tests/ui/manual_pop_if.rs:368:5
+  --> tests/ui/manual_pop_if.rs:367:5
    |
 LL |     if heap.peek().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -737,7 +737,7 @@ LL +     heap.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:407:5
+  --> tests/ui/manual_pop_if.rs:406:5
    |
 LL |     if vec.last().is_some_and(|e| *e == vec![1]) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -753,7 +753,7 @@ LL +     vec.pop_if(|e| *e == vec![1]);
    |
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if.rs:437:5
+  --> tests/ui/manual_pop_if.rs:436:5
    |
 LL |     if vec.last().is_some_and(|x| *x > 2) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -769,7 +769,7 @@ LL +     vec.pop_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_back_if`
-  --> tests/ui/manual_pop_if.rs:445:5
+  --> tests/ui/manual_pop_if.rs:444:5
    |
 LL |     if deque.back().is_some_and(|x| *x > 2) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -785,7 +785,7 @@ LL +     deque.pop_back_if(|x| *x > 2);
    |
 
 error: manual implementation of `VecDeque::pop_front_if`
-  --> tests/ui/manual_pop_if.rs:450:5
+  --> tests/ui/manual_pop_if.rs:449:5
    |
 LL |     if deque.front().is_some_and(|x| *x > 2) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/manual_pop_if_unfixable.rs
+++ b/tests/ui/manual_pop_if_unfixable.rs
@@ -36,6 +36,54 @@ fn is_some_and_pattern(mut vec: Vec<i32>) {
     }
 }
 
+fn discarded_pop(mut vec: Vec<i32>) {
+    if false {
+        // something
+    } else if vec.last().is_some_and(|x| *x > 2) {
+        vec.pop();
+    }
+    //~^^^ manual_pop_if
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        println!("Popping");
+        vec.pop();
+    }
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        // a comment before the pop
+        vec.pop();
+    }
+
+    //~v manual_pop_if
+    if vec.last().is_some_and(|x| *x > 2) {
+        vec.pop();
+        // a comment after the pop
+    }
+
+    //~v manual_pop_if
+    if let Some(x) = vec.last() {
+        if *x > 2 {
+            // a comment before the pop
+            vec.pop();
+        }
+    }
+
+    if let Some(x) = vec.last() //~ manual_pop_if
+        && *x > 2
+    {
+        // a comment before the pop
+        vec.pop();
+    }
+
+    //~v manual_pop_if
+    if vec.last().map(|x| *x > 2).unwrap_or(false) {
+        // a comment before the pop
+        vec.pop();
+    }
+}
+
 fn if_let_pattern(mut vec: Vec<i32>) {
     //~v manual_pop_if
     if let Some(x) = vec.last() {

--- a/tests/ui/manual_pop_if_unfixable.stderr
+++ b/tests/ui/manual_pop_if_unfixable.stderr
@@ -52,7 +52,85 @@ LL |         vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:41:5
+  --> tests/ui/manual_pop_if_unfixable.rs:42:12
+   |
+LL |     } else if vec.last().is_some_and(|x| *x > 2) {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop();
+   |         ^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:48:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         println!("Popping");
+LL |         vec.pop();
+   |         ^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:54:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         // a comment before the pop
+LL |         vec.pop();
+   |         ^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:60:5
+   |
+LL |     if vec.last().is_some_and(|x| *x > 2) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         vec.pop();
+   |         ^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:66:5
+   |
+LL |     if let Some(x) = vec.last() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         if *x > 2 {
+   |         ^^^^^^^^^
+LL |             // a comment before the pop
+LL |             vec.pop();
+   |             ^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:73:5
+   |
+LL | /     if let Some(x) = vec.last()
+LL | |         && *x > 2
+   | |_________________^
+...
+LL |           vec.pop();
+   |           ^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:81:5
+   |
+LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         // a comment before the pop
+LL |         vec.pop();
+   |         ^^^^^^^^^
+   |
+   = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
+
+error: manual implementation of `Vec::pop_if`
+  --> tests/ui/manual_pop_if_unfixable.rs:89:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +142,7 @@ LL |             let val = vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:49:5
+  --> tests/ui/manual_pop_if_unfixable.rs:97:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,7 +154,7 @@ LL |             println!("Popped: {}", vec.pop().unwrap());
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:56:5
+  --> tests/ui/manual_pop_if_unfixable.rs:104:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +167,7 @@ LL |             vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:64:5
+  --> tests/ui/manual_pop_if_unfixable.rs:112:5
    |
 LL |     if let Some(x) = vec.last() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -101,7 +179,7 @@ LL |             vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:74:5
+  --> tests/ui/manual_pop_if_unfixable.rs:122:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -113,7 +191,7 @@ LL |           let val = vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:82:5
+  --> tests/ui/manual_pop_if_unfixable.rs:130:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -125,7 +203,7 @@ LL |           println!("Popped: {}", vec.pop().unwrap());
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:89:5
+  --> tests/ui/manual_pop_if_unfixable.rs:137:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -137,7 +215,7 @@ LL |           vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:97:5
+  --> tests/ui/manual_pop_if_unfixable.rs:145:5
    |
 LL | /     if let Some(x) = vec.last()
 LL | |         && *x > 2
@@ -149,7 +227,7 @@ LL |           vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:107:5
+  --> tests/ui/manual_pop_if_unfixable.rs:155:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,7 +237,7 @@ LL |         let val = vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:113:5
+  --> tests/ui/manual_pop_if_unfixable.rs:161:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +247,7 @@ LL |         println!("Popped: {}", vec.pop().unwrap());
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:118:5
+  --> tests/ui/manual_pop_if_unfixable.rs:166:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -180,7 +258,7 @@ LL |         vec.pop().unwrap();
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
 error: manual implementation of `Vec::pop_if`
-  --> tests/ui/manual_pop_if_unfixable.rs:124:5
+  --> tests/ui/manual_pop_if_unfixable.rs:172:5
    |
 LL |     if vec.last().map(|x| *x > 2).unwrap_or(false) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -189,5 +267,5 @@ LL |         vec.pop().unwrap();
    |
    = help: try refactoring the code using `vec.pop_if(|x| *x > 2);`
 
-error: aborting due to 17 previous errors
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
changelog: [`manual_pop_if`]: also lint when the popped value is discarded, e.g. `vec.pop();`

`if vec.last().is_some_and(|x| *x > 5) { vec.pop(); }` is exactly `vec.pop_if(|x| *x > 5);`, but the lint only fired when the popped value was unwrapped. Accept a pop whose value is thrown away as well, both as a plain `collection.pop();` statement and as `let _ = collection.pop();`.

A discarded pop is only recognised in statement position. Unlike `.unwrap()`, a `collection.pop()` in value position carries no assertion that the collection is non-empty, so walking every expression for one would be a large false-positive surface for no benefit.

An annotated `let _: Option<i32> = collection.pop();` is left alone too: the suggestion replaces the whole statement, and the annotation may be the only thing pinning down the element type of the collection.
