### PR TITLE
Fix `--explain` lint lookup being case-mismatched

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -423,7 +423,7 @@ use rustc_middle::ty::TyCtxt;
 use utils::attr_collector::AttrStorage;
 
 pub fn explain(name: &str) -> i32 {
-    let target = format!("clippy::{name}");
+    let target = format!("clippy::{}", name.to_ascii_uppercase());
     if let Some(info) = declared_lints::LINTS.iter().find(|info| info.lint.name == target) {
         println!("{}", sanitize_explanation(info.explanation));
         // Check if the lint has configuration

--- a/tests/explain.rs
+++ b/tests/explain.rs
@@ -1,0 +1,44 @@
+//! Checks `--explain` against the forms of a lint name a user may actually type.
+//!
+//! `src/main.rs` lowercases the argument, strips a `clippy::` prefix and replaces
+//! `-` with `_` before `clippy_lints::explain` looks the name up in its uppercase
+//! form. Calling `explain` directly would leave that conversion untested.
+//!
+//! This test is a no-op if run as part of the compiler test suite
+//! and will always succeed.
+
+use std::process::{Command, Stdio};
+use test_utils::{CARGO_CLIPPY_PATH, IS_RUSTC_TEST_SUITE};
+
+mod test_utils;
+
+#[test]
+fn explain() {
+    if IS_RUSTC_TEST_SUITE {
+        return;
+    }
+
+    let running = [
+        ("allow-attributes", true),
+        ("clippy::allow_attributes", true),
+        ("TOPLEVEL_REF_ARG", true),
+        ("CLIPPY::TOPLEVEL_REF_ARG", true),
+        ("not_a_lint", false),
+    ]
+    .map(|(arg, found)| {
+        let child = Command::new(&*CARGO_CLIPPY_PATH)
+            .args(["--explain", arg])
+            .stdout(Stdio::null())
+            .spawn()
+            .unwrap();
+        (arg, found, child)
+    });
+
+    for (arg, found, mut child) in running {
+        assert_eq!(
+            child.wait().unwrap().success(),
+            found,
+            "unexpected result for `--explain {arg}`"
+        );
+    }
+}


### PR DESCRIPTION
`cargo clippy --explain <lint>` prints `unknown lint` for every lint on beta and nightly.

`src/main.rs` lowercases the argument, but `Lint::name` is uppercase (`clippy::ALLOW_ATTRIBUTES`), so the lookup in `explain` never matches. The `to_ascii_uppercase` that reconciled the two was dropped in c97f7ebf9 ("Rewrite of the config parsing code"), and this restores that line verbatim. `beta` and `master` carry the commit, stable 0.1.98 does not, which is why `--explain` still works there.

The lowercase rebinding below the lookup is deliberately left alone. `mdconf.retain(...)` keys on that form, so removing it would silently drop every configuration section.

The tests are new because `--explain` had no coverage at all, which is how this went unreported for three weeks.

`cargo test --features internal` passes here apart from the 16 `tests/ui-internal` cases, which fail the same way on an unmodified master checkout, so they look local to my Windows setup.

rust-lang/rust-clippy#17573 moves this code and inherits the same mismatch, so whichever lands second needs a small rebase.

fixes rust-lang/rust-clippy#17620

changelog: Fix `cargo clippy --explain <lint>` reporting `unknown lint` for every lint
