### PR TITLE
chore: fix lint `cargo::manual_readme`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "clippy"
 version = "0.1.100"
 description = "A bunch of helpful lints to avoid common pitfalls in Rust"
 repository = "https://github.com/rust-lang/rust-clippy"
-readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["clippy", "lint", "plugin"]
 categories = ["development-tools", "development-tools::cargo-plugins"]

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -3,7 +3,6 @@ name = "clippy_lints"
 version = "0.1.100"
 description = "A bunch of helpful lints to avoid common pitfalls in Rust"
 repository = "https://github.com/rust-lang/rust-clippy"
-readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["clippy", "lint", "plugin"]
 edition = "2024"

--- a/clippy_utils/Cargo.toml
+++ b/clippy_utils/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.100"
 edition = "2024"
 description = "Helpful tools for writing lints, provided as they are used in Clippy"
 repository = "https://github.com/rust-lang/rust-clippy"
-readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["clippy", "lint", "utils"]
 categories = ["development-tools"]

--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -2,7 +2,6 @@
 name = "lintcheck"
 version = "0.0.1"
 description = "tool to monitor impact of changes in Clippy's lints on a part of the ecosystem"
-readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/rust-clippy"
 categories = ["development-tools"]

--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -3,7 +3,6 @@ name = "rustc_tools_util"
 version = "0.4.2"
 description = "small helper to generate version information for git packages"
 repository = "https://github.com/rust-lang/rust-clippy"
-readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["rustc", "tool", "git", "version", "hash"]
 categories = ["development-tools"]


### PR DESCRIPTION
See
<https://triage.rust-lang.org/gha-logs/rust-lang/rust/98030530980#L2026-08-26T03:05:00.5382785Z-L2026-08-26T03:05:00.5404907Z>

This was found in https://github.com/rust-lang/rust/pull/161789

changelog: none
