### PR TITLE
chore: kebab-case names for binaries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 bless = "test --config env.RUSTC_BLESS='1'"
 uitest = "test --test compile-test"
 uibless = "bless --test compile-test"
-dev = "run --package clippy_dev --bin clippy_dev --manifest-path clippy_dev/Cargo.toml --"
+dev = "run --package clippy-dev --bin clippy-dev --manifest-path clippy_dev/Cargo.toml --"
 lintcheck = "run --package lintcheck --bin lintcheck --manifest-path lintcheck/Cargo.toml  -- "
 collect-metadata = "test --test compile-test --config env.COLLECT_METADATA='1'"
 
@@ -19,7 +19,7 @@ profile-rustflags = true
 split-debuginfo = "unpacked"
 
 # Add back the containing directory of the packages we have to refer to using --manifest-path
-[profile.dev.package.clippy_dev]
+[profile.dev.package.clippy-dev]
 rustflags = ["--remap-path-prefix", "=clippy_dev"]
 [profile.dev.package.lintcheck]
 rustflags = ["--remap-path-prefix", "=lintcheck"]

--- a/.github/workflows/clippy_mq.yml
+++ b/.github/workflows/clippy_mq.yml
@@ -79,7 +79,7 @@ jobs:
       run: cargo test
       working-directory: rustc_tools_util
 
-    - name: Test clippy_dev
+    - name: Test clippy-dev
       run: cargo test
       working-directory: clippy_dev
 

--- a/.github/workflows/clippy_pr.yml
+++ b/.github/workflows/clippy_pr.yml
@@ -53,7 +53,7 @@ jobs:
       run: cargo test
       working-directory: rustc_tools_util
 
-    - name: Test clippy_dev
+    - name: Test clippy-dev
       run: cargo test
       working-directory: clippy_dev
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ For [`rust-analyzer`][ra_homepage] to work correctly make sure that in the `rust
 You should be able to see information on things like `Expr` or `EarlyContext` now if you hover them, also
 a lot more type hints.
 
-To have `rust-analyzer` also work in the `clippy_dev` and `lintcheck` crates, add the following configuration
+To have `rust-analyzer` also work in the `clippy-dev` and `lintcheck` crates, add the following configuration
 
 ```json
 {

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "clippy_dev"
+name = "clippy-dev"
 description = "Clippy developer tooling"
 version = "0.0.1"
 edition = "2024"

--- a/clippy_dev/src/setup/git_hook.rs
+++ b/clippy_dev/src/setup/git_hook.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 /// Rusts setup uses `git rev-parse --git-common-dir` to get the root directory of the repo.
 /// I've decided against this for the sake of simplicity and to make sure that it doesn't install
-/// the hook if `clippy_dev` would be used in the rust tree. The hook also references this tool
+/// the hook if `clippy-dev` would be used in the rust tree. The hook also references this tool
 /// for formatting and should therefore only be used in a normal clone of clippy
 const REPO_GIT_DIR: &str = ".git";
 const HOOK_SOURCE_FILE: &str = "util/etc/pre-commit.sh";
@@ -36,7 +36,7 @@ fn check_precondition(force_override: bool) -> bool {
     // Make sure that we can find the git repository
     let git_path = Path::new(REPO_GIT_DIR);
     if !git_path.exists() || !git_path.is_dir() {
-        eprintln!("error: clippy_dev was unable to find the `.git` directory");
+        eprintln!("error: clippy-dev was unable to find the `.git` directory");
         return false;
     }
 

--- a/clippy_dev/src/setup/intellij.rs
+++ b/clippy_dev/src/setup/intellij.rs
@@ -96,7 +96,7 @@ fn inject_deps_into_project(rustc_source_dir: &Path, project: &ClippyProjectInfo
     }
 }
 
-/// `clippy_dev` expects to be executed in the root directory of Clippy. This function
+/// `clippy-dev` expects to be executed in the root directory of Clippy. This function
 /// loads the given file or returns an error. Having it in this extra function ensures
 /// that the error message looks nice.
 fn read_project_file(file_path: &str) -> Result<String, ()> {

--- a/clippy_dummy/Cargo.toml
+++ b/clippy_dummy/Cargo.toml
@@ -12,5 +12,9 @@ license = "MIT OR Apache-2.0"
 keywords = ["clippy", "lint", "plugin"]
 categories = ["development-tools", "development-tools::cargo-plugins"]
 
+[[bin]]
+name = "clippy"
+path = "src/main.rs"
+
 [build-dependencies]
 term = "1"

--- a/clippy_test_deps/Cargo.lock
+++ b/clippy_test_deps/Cargo.lock
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "clippy_test_deps"
+name = "clippy-test-deps"
 version = "0.1.0"
 dependencies = [
  "futures",

--- a/clippy_test_deps/Cargo.toml
+++ b/clippy_test_deps/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "clippy_test_deps"
+name = "clippy-test-deps"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/ui-cargo/cargo_common_metadata/fail/Cargo.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail/Cargo.stderr
@@ -1,16 +1,16 @@
-error: package `cargo_common_metadata_fail` is missing `package.description` metadata
+error: package `cargo-common-metadata-fail` is missing `package.description` metadata
   |
   = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::cargo_common_metadata)]`
 
-error: package `cargo_common_metadata_fail` is missing `either package.license or package.license_file` metadata
+error: package `cargo-common-metadata-fail` is missing `either package.license or package.license_file` metadata
 
-error: package `cargo_common_metadata_fail` is missing `package.repository` metadata
+error: package `cargo-common-metadata-fail` is missing `package.repository` metadata
 
-error: package `cargo_common_metadata_fail` is missing `package.readme` metadata
+error: package `cargo-common-metadata-fail` is missing `package.readme` metadata
 
-error: package `cargo_common_metadata_fail` is missing `package.keywords` metadata
+error: package `cargo-common-metadata-fail` is missing `package.keywords` metadata
 
-error: package `cargo_common_metadata_fail` is missing `package.categories` metadata
+error: package `cargo-common-metadata-fail` is missing `package.categories` metadata
 
-error: could not compile `cargo_common_metadata_fail` (bin "cargo_common_metadata_fail") due to 6 previous errors
+error: could not compile `cargo-common-metadata-fail` (bin "cargo-common-metadata-fail") due to 6 previous errors

--- a/tests/ui-cargo/cargo_common_metadata/fail/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata_fail"
+name = "cargo-common-metadata-fail"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish/Cargo.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish/Cargo.stderr
@@ -1,16 +1,16 @@
-error: package `cargo_common_metadata_fail_publish` is missing `package.description` metadata
+error: package `cargo-common-metadata-fail-publish` is missing `package.description` metadata
   |
   = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::cargo_common_metadata)]`
 
-error: package `cargo_common_metadata_fail_publish` is missing `either package.license or package.license_file` metadata
+error: package `cargo-common-metadata-fail-publish` is missing `either package.license or package.license_file` metadata
 
-error: package `cargo_common_metadata_fail_publish` is missing `package.repository` metadata
+error: package `cargo-common-metadata-fail-publish` is missing `package.repository` metadata
 
-error: package `cargo_common_metadata_fail_publish` is missing `package.readme` metadata
+error: package `cargo-common-metadata-fail-publish` is missing `package.readme` metadata
 
-error: package `cargo_common_metadata_fail_publish` is missing `package.keywords` metadata
+error: package `cargo-common-metadata-fail-publish` is missing `package.keywords` metadata
 
-error: package `cargo_common_metadata_fail_publish` is missing `package.categories` metadata
+error: package `cargo-common-metadata-fail-publish` is missing `package.categories` metadata
 
-error: could not compile `cargo_common_metadata_fail_publish` (bin "cargo_common_metadata_fail_publish") due to 6 previous errors
+error: could not compile `cargo-common-metadata-fail-publish` (bin "cargo-common-metadata-fail-publish") due to 6 previous errors

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata_fail_publish"
+name = "cargo-common-metadata-fail-publish"
 version = "0.1.0"
 publish = ["some-registry-name"]
 

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish_true/Cargo.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish_true/Cargo.stderr
@@ -1,16 +1,16 @@
-error: package `cargo_common_metadata_fail_publish_true` is missing `package.description` metadata
+error: package `cargo-common-metadata-fail-publish-true` is missing `package.description` metadata
   |
   = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::cargo_common_metadata)]`
 
-error: package `cargo_common_metadata_fail_publish_true` is missing `either package.license or package.license_file` metadata
+error: package `cargo-common-metadata-fail-publish-true` is missing `either package.license or package.license_file` metadata
 
-error: package `cargo_common_metadata_fail_publish_true` is missing `package.repository` metadata
+error: package `cargo-common-metadata-fail-publish-true` is missing `package.repository` metadata
 
-error: package `cargo_common_metadata_fail_publish_true` is missing `package.readme` metadata
+error: package `cargo-common-metadata-fail-publish-true` is missing `package.readme` metadata
 
-error: package `cargo_common_metadata_fail_publish_true` is missing `package.keywords` metadata
+error: package `cargo-common-metadata-fail-publish-true` is missing `package.keywords` metadata
 
-error: package `cargo_common_metadata_fail_publish_true` is missing `package.categories` metadata
+error: package `cargo-common-metadata-fail-publish-true` is missing `package.categories` metadata
 
-error: could not compile `cargo_common_metadata_fail_publish_true` (bin "cargo_common_metadata_fail_publish_true") due to 6 previous errors
+error: could not compile `cargo-common-metadata-fail-publish-true` (bin "cargo-common-metadata-fail-publish-true") due to 6 previous errors

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish_true/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish_true/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata_fail_publish_true"
+name = "cargo-common-metadata-fail-publish-true"
 version = "0.1.0"
 publish = true
 

--- a/tests/ui-cargo/cargo_common_metadata/pass/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/pass/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata_pass"
+name = "cargo-common-metadata-pass"
 version = "0.1.0"
 publish = false
 description = "A test package for the cargo_common_metadata lint"

--- a/tests/ui-cargo/cargo_common_metadata/pass_publish_empty/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/pass_publish_empty/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata_pass_publish_empty"
+name = "cargo-common-metadata-pass-publish-empty"
 version = "0.1.0"
 publish = []
 

--- a/tests/ui-cargo/cargo_common_metadata/pass_publish_false/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/pass_publish_false/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata_pass_publish_false"
+name = "cargo-common-metadata-pass-publish-false"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/duplicate_mod/fail/Cargo.stderr
+++ b/tests/ui-cargo/duplicate_mod/fail/Cargo.stderr
@@ -50,4 +50,4 @@ error: file is loaded as a module multiple times: `src/from_other_module.rs`
    |
    = help: replace all but one `mod` item with `use` items
 
-error: could not compile `duplicate_mod` (bin "duplicate_mod") due to 4 previous errors
+error: could not compile `duplicate-mod` (bin "duplicate-mod") due to 4 previous errors

--- a/tests/ui-cargo/duplicate_mod/fail/Cargo.toml
+++ b/tests/ui-cargo/duplicate_mod/fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "duplicate_mod"
+name = "duplicate-mod"
 edition = "2021"
 publish = false
 version = "0.1.0"

--- a/tests/ui-cargo/feature_name/fail/Cargo.stderr
+++ b/tests/ui-cargo/feature_name/fail/Cargo.stderr
@@ -42,4 +42,4 @@ error: the "with_" prefix in the feature name "with_owo" is redundant
   |
   = help: consider renaming the feature to "owo"
 
-error: could not compile `feature_name` (bin "feature_name") due to 10 previous errors
+error: could not compile `feature-name` (bin "feature-name") due to 10 previous errors

--- a/tests/ui-cargo/feature_name/fail/Cargo.toml
+++ b/tests/ui-cargo/feature_name/fail/Cargo.toml
@@ -2,7 +2,7 @@
 # Content that triggers the lint goes here
 
 [package]
-name = "feature_name"
+name = "feature-name"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/feature_name/pass/Cargo.toml
+++ b/tests/ui-cargo/feature_name/pass/Cargo.toml
@@ -2,7 +2,7 @@
 # This file should not trigger the lint
 
 [package]
-name = "feature_name"
+name = "feature-name"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/multiple_config_files/no_warn/Cargo.toml
+++ b/tests/ui-cargo/multiple_config_files/no_warn/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "no_warn"
+name = "no-warn"
 version = "0.1.0"
 edition = "2021"
 publish = false

--- a/tests/ui-cargo/multiple_crate_versions/12176_allow_duplicate_crates/Cargo.toml
+++ b/tests/ui-cargo/multiple_crate_versions/12176_allow_duplicate_crates/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "multiple_crate_versions"
+name = "multiple-crate-versions"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/multiple_crate_versions/5041_allow_dev_build/Cargo.toml
+++ b/tests/ui-cargo/multiple_crate_versions/5041_allow_dev_build/Cargo.toml
@@ -1,7 +1,7 @@
 # Should not lint for dev or build dependencies. See issue 5041.
 
 [package]
-name = "multiple_crate_versions"
+name = "multiple-crate-versions"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/multiple_crate_versions/fail/Cargo.lock
+++ b/tests/ui-cargo/multiple_crate_versions/fail/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiple_crate_versions"
+name = "multiple-crate-versions"
 version = "0.1.0"
 dependencies = [
  "ansi_term",

--- a/tests/ui-cargo/multiple_crate_versions/fail/Cargo.stderr
+++ b/tests/ui-cargo/multiple_crate_versions/fail/Cargo.stderr
@@ -3,4 +3,4 @@ error: multiple versions for dependency `winapi`: 0.2.8, 0.3.9
   = note: `-D clippy::multiple-crate-versions` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::multiple_crate_versions)]`
 
-error: could not compile `multiple_crate_versions` (bin "multiple_crate_versions") due to 1 previous error
+error: could not compile `multiple-crate-versions` (bin "multiple-crate-versions") due to 1 previous error

--- a/tests/ui-cargo/multiple_crate_versions/fail/Cargo.toml
+++ b/tests/ui-cargo/multiple_crate_versions/fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "multiple_crate_versions"
+name = "multiple-crate-versions"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/multiple_crate_versions/pass/Cargo.toml
+++ b/tests/ui-cargo/multiple_crate_versions/pass/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "multiple_crate_versions"
+name = "multiple-crate-versions"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/multiple_inherent_impl/config_fail/Cargo.stderr
+++ b/tests/ui-cargo/multiple_inherent_impl/config_fail/Cargo.stderr
@@ -6,4 +6,4 @@ error: expected one of: `crate`, `file`, `module`
   |
   = note: possible values: `crate`, `file`, `module`
 
-error: could not compile `config_fail` (bin "config_fail") due to 1 previous error
+error: could not compile `config-fail` (bin "config-fail") due to 1 previous error

--- a/tests/ui-cargo/multiple_inherent_impl/config_fail/Cargo.toml
+++ b/tests/ui-cargo/multiple_inherent_impl/config_fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "config_fail"
+name = "config-fail"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/tests/ui-cargo/multiple_inherent_impl/crate_fail/Cargo.stderr
+++ b/tests/ui-cargo/multiple_inherent_impl/crate_fail/Cargo.stderr
@@ -54,4 +54,4 @@ note: first implementation here
  6 | | }
    | |_^
 
-error: could not compile `crate_fail` (bin "crate_fail") due to 3 previous errors
+error: could not compile `crate-fail` (bin "crate-fail") due to 3 previous errors

--- a/tests/ui-cargo/multiple_inherent_impl/crate_fail/Cargo.toml
+++ b/tests/ui-cargo/multiple_inherent_impl/crate_fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "crate_fail"
+name = "crate-fail"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/tests/ui-cargo/multiple_inherent_impl/file_fail/Cargo.stderr
+++ b/tests/ui-cargo/multiple_inherent_impl/file_fail/Cargo.stderr
@@ -55,4 +55,4 @@ note: first implementation here
 12 | |     }
    | |_____^
 
-error: could not compile `file_fail` (bin "file_fail") due to 3 previous errors
+error: could not compile `file-fail` (bin "file-fail") due to 3 previous errors

--- a/tests/ui-cargo/multiple_inherent_impl/file_fail/Cargo.toml
+++ b/tests/ui-cargo/multiple_inherent_impl/file_fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "file_fail"
+name = "file-fail"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/tests/ui-cargo/multiple_inherent_impl/module_fail/Cargo.stderr
+++ b/tests/ui-cargo/multiple_inherent_impl/module_fail/Cargo.stderr
@@ -38,4 +38,4 @@ note: first implementation here
 10 | | }
    | |_^
 
-error: could not compile `module_fail` (bin "module_fail") due to 2 previous errors
+error: could not compile `module-fail` (bin "module-fail") due to 2 previous errors

--- a/tests/ui-cargo/multiple_inherent_impl/module_fail/Cargo.toml
+++ b/tests/ui-cargo/multiple_inherent_impl/module_fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module_fail"
+name = "module-fail"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/tests/ui-cargo/undocumented_unsafe_blocks/fail/Cargo.stderr
+++ b/tests/ui-cargo/undocumented_unsafe_blocks/fail/Cargo.stderr
@@ -23,4 +23,4 @@ help: consider removing the safety comment
 4 | // SAFETY: ...
   |    ^^^^^^^
 
-error: could not compile `undocumented_unsafe_blocks` (bin "undocumented_unsafe_blocks") due to 2 previous errors
+error: could not compile `undocumented-unsafe-blocks` (bin "undocumented-unsafe-blocks") due to 2 previous errors

--- a/tests/ui-cargo/undocumented_unsafe_blocks/fail/Cargo.toml
+++ b/tests/ui-cargo/undocumented_unsafe_blocks/fail/Cargo.toml
@@ -3,7 +3,7 @@
 # will set it up here.
 
 [package]
-name = "undocumented_unsafe_blocks"
+name = "undocumented-unsafe-blocks"
 edition = "2024"
 publish = false
 version = "0.1.0"

--- a/tests/ui-cargo/wildcard_dependencies/fail/Cargo.stderr
+++ b/tests/ui-cargo/wildcard_dependencies/fail/Cargo.stderr
@@ -3,4 +3,4 @@ error: wildcard dependency for `regex`
   = note: `-D clippy::wildcard-dependencies` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::wildcard_dependencies)]`
 
-error: could not compile `wildcard_dependencies` (bin "wildcard_dependencies") due to 1 previous error
+error: could not compile `wildcard-dependencies` (bin "wildcard-dependencies") due to 1 previous error

--- a/tests/ui-cargo/wildcard_dependencies/fail/Cargo.toml
+++ b/tests/ui-cargo/wildcard_dependencies/fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wildcard_dependencies"
+name = "wildcard-dependencies"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/wildcard_dependencies/pass/Cargo.toml
+++ b/tests/ui-cargo/wildcard_dependencies/pass/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wildcard_dependencies"
+name = "wildcard-dependencies"
 version = "0.1.0"
 publish = false
 

--- a/tests/workspace_test/Cargo.toml
+++ b/tests/workspace_test/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "workspace_test"
+name = "workspace-test"
 version = "0.1.0"
 edition = "2018"
 


### PR DESCRIPTION
These commits follow the lint `cargo::non_kebab_case_bins`
https://doc.rust-lang.org/nightly/cargo/reference/lints.html#non_kebab_case_bins

The failure was found in <https://github.com/rust-lang/rust/pull/161789#issuecomment-5420221553> when syncing Cargo submodule.

* `clippy_dev` `package.name` got renamed to `clippy-dev`.
  * Expect no actual developer workflow changes as people usually run `cargo dev` via `.cargo/config.toml` alias.
  * ‼️ One caveat of this is that the next subtree sync need to also update the name in rust-lang/rust's Cargo.lock
* `clippy_dummy`, because it is published already, rename its bin name directly as `clippy`. This is a dummy package so it doesn't matter that much, as we are unlikely to publish new versions.
* Test snapshots and test binary names are also converted to dashes. They are less controversial than above as being completely internal.

changelog: none
