### PR TITLE
Update allowed unauthenticated `D-Confusing` labels in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,6 +1,6 @@
 [relabel]
 allow-unauthenticated = [
-    "A-*", "C-*", "E-*", "I-*", "L-*", "P-*", "S-*", "T-*",
+    "A-*", "C-*", "D-*", "E-*", "I-*", "L-*", "P-*", "S-*", "T-*",
     "good first issue", "beta-nominated"
 ]
 


### PR DESCRIPTION
Because I don't think this makes sense. only D-Confusing is in there... So why not allow unauth?

CC @Gri-ffin

Motivation: https://github.com/rust-lang/rust-clippy/issues/17264

changelog: none