### PR TITLE
Introduce LLM policy in PR template, book and CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,12 +32,15 @@ order to get feedback.
 
 ---
 
-Please read our [LLM policy] before opening a PR,
+Please read our [LLM policy] before opening a PR.
 If you used an LLM to generate any part of this PR, including the PR description,
 please disclose that according to our [guidelines][disclosure guidelines].
 LLM contributions are not banned, but are held to a higher standard of review and correctness.
 
 [LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
+<!-- TODO: Once the new LLM usage policy is deployed, change the LLM policy link into ours.
+[LLM policy]: https://doc.rust-lang.org/stable/clippy/development/development/llm-usage.html-->
+
 [disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines
 
 Delete this line and everything above before opening your PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,16 @@ checked during review or continuous integration.
 Note that you can skip the above if you are just opening a WIP PR in
 order to get feedback.
 
+---
+
+Please read our [LLM policy] before opening a PR,
+If you used an LLM to generate any part of this PR, including the PR description,
+please disclose that according to our [guidelines][disclosure guidelines].
+LLM contributions are not banned, but are held to a higher standard of review and correctness.
+
+[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
+[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines
+
 Delete this line and everything above before opening your PR.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,13 @@ changelog: Something 3
 
 [changelog]: CHANGELOG.md
 
+## LLM policy
+
+Clippy adopts the same [LLM usage policy] as `rust-lang/rust`.
+You can consult the [LLM usage chapter] in the Clippy book to see
+what that means, how it applies.
+
+
 ## License
 
 All code in this repository is under the [Apache-2.0] or the [MIT] license.
@@ -265,3 +272,5 @@ All code in this repository is under the [Apache-2.0] or the [MIT] license.
 
 [Apache-2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [MIT]: https://opensource.org/licenses/MIT
+[LLM usage policy]: https://forge.rust-lang.org/policies/llm-usage.html
+[LLM usage chapter]: https://doc.rust-lang.org/stable/clippy/development/infrastructure/book.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,4 +273,4 @@ All code in this repository is under the [Apache-2.0] or the [MIT] license.
 [Apache-2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [MIT]: https://opensource.org/licenses/MIT
 [LLM usage policy]: https://forge.rust-lang.org/policies/llm-usage.html
-[LLM usage chapter]: https://doc.rust-lang.org/stable/clippy/development/infrastructure/book.html
+[LLM usage chapter]: https://doc.rust-lang.org/nightly/clippy/development/llm_usage.html

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -24,6 +24,7 @@
     - [Method Checking](development/method_checking.md)
     - [Macro Expansions](development/macro_expansions.md)
     - [Common Tools](development/common_tools_writing_lints.md)
+    - [LLM usage](development/llm_usage.md)
     - [Infrastructure](development/infrastructure/README.md)
         - [Syncing changes between Clippy and rust-lang/rust](development/infrastructure/sync.md)
         - [Backporting Changes](development/infrastructure/backport.md)

--- a/book/src/development/basics.md
+++ b/book/src/development/basics.md
@@ -12,7 +12,7 @@ codebase take a look at [Adding Lints] or [Common Tools].
   - [Building and Testing](#building-and-testing)
   - [`cargo dev`](#cargo-dev)
   - [lintcheck](#lintcheck)
-  - [PR](#pr)
+  - [PR](#on-prs)
   - [Common Abbreviations](#common-abbreviations)
   - [Install from source](#install-from-source)
 

--- a/book/src/development/basics.md
+++ b/book/src/development/basics.md
@@ -117,10 +117,13 @@ Refer to the tools [README] for more details.
 
 [README]: https://github.com/rust-lang/rust-clippy/blob/master/lintcheck/README.md
 
-## PR
+## On PRs
 
 We follow a rustc no merge-commit policy. See
 <https://rustc-dev-guide.rust-lang.org/contributing.html#opening-a-pr>.
+
+Before opening your pull request, know that we follow an LLM policy. See
+<https://doc.rust-lang.org/stable/clippy/development/llm_usage.html>
 
 ## Common Abbreviations
 

--- a/book/src/development/basics.md
+++ b/book/src/development/basics.md
@@ -122,8 +122,8 @@ Refer to the tools [README] for more details.
 We follow a rustc no merge-commit policy. See
 <https://rustc-dev-guide.rust-lang.org/contributing.html#opening-a-pr>.
 
-Before opening your pull request, know that we follow an LLM policy. See
-<https://doc.rust-lang.org/stable/clippy/development/llm_usage.html>
+Before opening your pull request, know that we follow an LLM policy.
+See [LLM policy](llm_usage.md)
 
 ## Common Abbreviations
 

--- a/book/src/development/llm_usage.md
+++ b/book/src/development/llm_usage.md
@@ -18,8 +18,8 @@ When reading the policy in the context of Clippy:
 * The Clippy team will over time more precisely define what we mean by "critical" areas.
   We expect to adopt whatever tooling `rust-lang/rust` adopts to specify this more precisely.
 * When in doubt,
-  the Clippy team will provide any and all Clippy-specific interpretations of the policy,
-  until such time as the policy itself is updated to encompass Clippy.
+  the Clippy team will provide any and all Clippy-specific interpretations of the policy, until
+  the policy itself is updated to include Clippy.
 
 For suggestions about how to use LLMs *well*,
 and how to review LLM-created PRs,

--- a/book/src/development/llm_usage.md
+++ b/book/src/development/llm_usage.md
@@ -1,0 +1,29 @@
+# LLM Usage
+
+Clippy follows the same [LLM usage policy] as `rust-lang/rust`.
+Please read it before using LLM assistance
+when participating in `rust-lang/rust-clippy`.
+
+For clarity,
+this includes any updates to this policy made subsequent to Clippy's adoption of it;
+it is our intention to remain aligned with the current policy on an ongoing basis.
+
+When reading the policy in the context of Clippy:
+
+* Read `rust-lang/rust` as `rust-lang/rust-clippy`.
+* Read the ratifying teams as the Clippy team.
+* Read "diagnostics" as generally encompassing Clippy's user-facing output.
+* Ignore parts that do not apply to Clippy,
+  such as those specific to the compiler or the language.
+* The Clippy team will over time more precisely define what we mean by "critical" areas.
+  We expect to adopt whatever tooling `rust-lang/rust` adopts to specify this more precisely.
+* When in doubt,
+  the Clippy team will provide any and all Clippy-specific interpretations of the policy,
+  until such time as the policy itself is updated to encompass Clipy.
+
+For suggestions about how to use LLMs *well*,
+and how to review LLM-created PRs,
+see [the rustc-dev-guide][llm-guidance].
+
+[LLM usage policy]: https://forge.rust-lang.org/policies/llm-usage.html
+[llm-guidance]: https://rustc-dev-guide.rust-lang.org/llm-guidance.html

--- a/book/src/development/llm_usage.md
+++ b/book/src/development/llm_usage.md
@@ -19,7 +19,7 @@ When reading the policy in the context of Clippy:
   We expect to adopt whatever tooling `rust-lang/rust` adopts to specify this more precisely.
 * When in doubt,
   the Clippy team will provide any and all Clippy-specific interpretations of the policy,
-  until such time as the policy itself is updated to encompass Clipy.
+  until such time as the policy itself is updated to encompass Clippy.
 
 For suggestions about how to use LLMs *well*,
 and how to review LLM-created PRs,


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17641)*

Adopting the LLM policy from `rust-lang/rust`, really similar to https://github.com/rust-lang/cargo/pull/17330 but _Clippier_

@rust-lang/clippy @rust-lang/clippy-contributors 

changelog:Adopt the upstream `rust-lang/rust` LLM policy
r? @flip1995 