### PR TITLE
fix(cargo_common_metadata): stop checking `package.readme`

### DIFF
--- a/clippy_lints/src/cargo/common_metadata.rs
+++ b/clippy_lints/src/cargo/common_metadata.rs
@@ -22,10 +22,6 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata, ignore_publish: b
                 missing_warning(cx, package, "package.repository");
             }
 
-            if is_empty_str(package.readme.as_ref()) {
-                missing_warning(cx, package, "package.readme");
-            }
-
             if is_empty_vec(package.keywords.as_ref()) {
                 missing_warning(cx, package, "package.keywords");
             }

--- a/clippy_lints/src/cargo/mod.rs
+++ b/clippy_lints/src/cargo/mod.rs
@@ -15,7 +15,7 @@ use rustc_span::DUMMY_SP;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks to see if all common metadata is defined in
+    /// Checks to see if common metadata is defined in
     /// `Cargo.toml`. See: <https://rust-lang.github.io/api-guidelines/documentation.html#cargotoml-includes-all-common-metadata-c-metadata>
     ///
     /// ### Why is this bad?
@@ -29,7 +29,6 @@ declare_clippy_lint! {
     /// name = "clippy"
     /// version = "0.0.212"
     /// repository = "https://github.com/rust-lang/rust-clippy"
-    /// readme = "README.md"
     /// license = "MIT OR Apache-2.0"
     /// keywords = ["clippy", "lint", "plugin"]
     /// categories = ["development-tools", "development-tools::cargo-plugins"]
@@ -44,7 +43,6 @@ declare_clippy_lint! {
     /// version = "0.0.212"
     /// description = "A bunch of helpful lints to avoid common pitfalls in Rust"
     /// repository = "https://github.com/rust-lang/rust-clippy"
-    /// readme = "README.md"
     /// license = "MIT OR Apache-2.0"
     /// keywords = ["clippy", "lint", "plugin"]
     /// categories = ["development-tools", "development-tools::cargo-plugins"]

--- a/tests/ui-cargo/cargo_common_metadata/fail/Cargo.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail/Cargo.stderr
@@ -7,10 +7,8 @@ error: package `cargo-common-metadata-fail` is missing `either package.license o
 
 error: package `cargo-common-metadata-fail` is missing `package.repository` metadata
 
-error: package `cargo-common-metadata-fail` is missing `package.readme` metadata
-
 error: package `cargo-common-metadata-fail` is missing `package.keywords` metadata
 
 error: package `cargo-common-metadata-fail` is missing `package.categories` metadata
 
-error: could not compile `cargo-common-metadata-fail` (bin "cargo-common-metadata-fail") due to 6 previous errors
+error: could not compile `cargo-common-metadata-fail` (bin "cargo-common-metadata-fail") due to 5 previous errors

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish/Cargo.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish/Cargo.stderr
@@ -7,10 +7,8 @@ error: package `cargo-common-metadata-fail-publish` is missing `either package.l
 
 error: package `cargo-common-metadata-fail-publish` is missing `package.repository` metadata
 
-error: package `cargo-common-metadata-fail-publish` is missing `package.readme` metadata
-
 error: package `cargo-common-metadata-fail-publish` is missing `package.keywords` metadata
 
 error: package `cargo-common-metadata-fail-publish` is missing `package.categories` metadata
 
-error: could not compile `cargo-common-metadata-fail-publish` (bin "cargo-common-metadata-fail-publish") due to 6 previous errors
+error: could not compile `cargo-common-metadata-fail-publish` (bin "cargo-common-metadata-fail-publish") due to 5 previous errors

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish_true/Cargo.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish_true/Cargo.stderr
@@ -7,10 +7,8 @@ error: package `cargo-common-metadata-fail-publish-true` is missing `either pack
 
 error: package `cargo-common-metadata-fail-publish-true` is missing `package.repository` metadata
 
-error: package `cargo-common-metadata-fail-publish-true` is missing `package.readme` metadata
-
 error: package `cargo-common-metadata-fail-publish-true` is missing `package.keywords` metadata
 
 error: package `cargo-common-metadata-fail-publish-true` is missing `package.categories` metadata
 
-error: could not compile `cargo-common-metadata-fail-publish-true` (bin "cargo-common-metadata-fail-publish-true") due to 6 previous errors
+error: could not compile `cargo-common-metadata-fail-publish-true` (bin "cargo-common-metadata-fail-publish-true") due to 5 previous errors

--- a/tests/ui-cargo/cargo_common_metadata/pass/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/pass/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 publish = false
 description = "A test package for the cargo_common_metadata lint"
 repository = "https://github.com/someone/cargo_common_metadata"
-readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["metadata", "lint", "clippy"]
 categories = ["development-tools::testing"]


### PR DESCRIPTION
Cargo infers standard README filenames,
and the new cargo lint `cargo::manual_readme` warns when the field is redundantly set.

We simply just remove the check,
as most of the cargo lints in clippy will slowly be deprecated and migrated to cargo.

See

* https://doc.rust-lang.org/nightly/cargo/reference/lints.html#manual_readme
* Fixes rust-lang/rust-clippy#17635

changelog: [`cargo_common_metadata`]: No longer checks for `package.readme` metadata field


My friend's cat
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d6102160-3e0e-405e-b3c4-40137ded8191" />

