### PR TITLE
Improve `map_unwrap_or` lint to support `map(f).unwrap_or_default()`

### DIFF
--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -841,8 +841,7 @@ impl SourceItemOrderingWithinModuleItemGroupings {
                         .map(|(x, _)| &**x)
                         .collect::<Vec<_>>();
                     let suggestion = find_closest_match(&grouping.node, &names)
-                        .map(|s| format!(" perhaps you meant `{s}`?"))
-                        .unwrap_or_default();
+                        .map_or_default(|s| format!(" perhaps you meant `{s}`?"));
                     let names = names.iter().map(|s| format!("`{s}`")).join(", ");
                     sess.dcx().span_err(grouping.span, format!(
                         "unknown ordering group: `{}` was not specified in `module-items-ordered-within-groupings`,{suggestion} expected one of: {names}",

--- a/clippy_lints/src/attrs/utils.rs
+++ b/clippy_lints/src/attrs/utils.rs
@@ -53,7 +53,7 @@ pub(super) fn extract_clippy_lint(lint: &MetaItemInner) -> Option<Symbol> {
 /// Returns the lint namespace, if any, as well as the lint name. (`None`, `None`) means
 /// the lint had less than 1 or more than 2 segments.
 pub(super) fn namespace_and_lint(lint: &MetaItemInner) -> (Option<Symbol>, Option<Symbol>) {
-    match lint.meta_item().map(|m| m.path.segments.as_slice()).unwrap_or_default() {
+    match lint.meta_item().map_or_default(|m| m.path.segments.as_slice()) {
         [name] => (None, Some(name.ident.name)),
         [namespace, name] => (Some(namespace.ident.name), Some(name.ident.name)),
         _ => (None, None),

--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -380,8 +380,7 @@ impl<'tcx> LateLintPass<'tcx> for Dereferencing<'tcx> {
                                     && let Some(trait_id) = cx.tcx.trait_of_assoc(fn_id)
                                     && let arg_ty = cx.tcx.erase_and_anonymize_regions(adjusted_ty)
                                     && let ty::Ref(_, sub_ty, _) = *arg_ty.kind()
-                                    && let args =
-                                        typeck.node_args_opt(hir_id).map(|args| &args[1..]).unwrap_or_default()
+                                    && let args = typeck.node_args_opt(hir_id).map_or_default(|args| &args[1..])
                                     && let impl_ty = if cx
                                         .tcx
                                         .fn_sig(fn_id)

--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -104,7 +104,7 @@ fn check_struct<'tcx>(
     if let TyKind::Path(QPath::Resolved(_, p)) = self_ty.kind
         && let Some(PathSegment { args, .. }) = p.segments.last()
     {
-        let args = args.map(|a| a.args).unwrap_or_default();
+        let args = args.map_or_default(|a| a.args);
 
         // ty_args contains the generic parameters of the type declaration, while args contains the
         // arguments used at instantiation time. If both len are not equal, it means that some

--- a/clippy_lints/src/loops/while_let_loop.rs
+++ b/clippy_lints/src/loops/while_let_loop.rs
@@ -110,9 +110,7 @@ fn could_be_while_let<'tcx>(
         && let Some(pat_str) = snippet_opt(cx, pat.span)
         && let Some(init_str) = snippet_opt(cx, peel_blocks(inner_expr).span)
     {
-        let ty_str = ty
-            .map(|ty| format!(": {}", snippet(cx, ty.span, "_")))
-            .unwrap_or_default();
+        let ty_str = ty.map_or_default(|ty| format!(": {}", snippet(cx, ty.span, "_")));
         format!(
             "\n{indent}    let {pat_str}{ty_str} = {init_str};\n{indent}    ..\n{indent}",
             indent = snippet_indent(cx, expr.span).unwrap_or_default(),

--- a/clippy_lints/src/methods/map_unwrap_or_default.rs
+++ b/clippy_lints/src/methods/map_unwrap_or_default.rs
@@ -1,0 +1,57 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::res::MaybeDef as _;
+use clippy_utils::sym;
+use rustc_errors::Applicability;
+use rustc_hir::Expr;
+use rustc_lint::LateContext;
+use rustc_span::Span;
+
+use crate::methods::MAP_UNWRAP_OR;
+
+/// Lints usage of `map(f).unwrap_or_default()`, where the return type of `f` is not `bool`.
+/// When `f` returns a `bool` value, the `manual_is_variant_and` lint is more useful.
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    recv: &'tcx Expr<'tcx>,
+    map_recv: &'tcx Expr<'tcx>,
+    map_method_span: Span,
+    msrv: Msrv,
+) {
+    if !msrv.meets(cx, msrvs::MAP_OR_DEFAULT) {
+        return;
+    }
+
+    // Consider `Option` and `Result`.
+    let Some(ty @ (sym::Option | sym::Result)) =
+        cx.typeck_results().expr_ty(map_recv).peel_refs().opt_diag_name(&cx.tcx)
+    else {
+        return;
+    };
+
+    // Ignore `Option<bool>` or `Result<bool>`
+    // `manual_is_variant_and` lint is more useful in these cases.
+    if cx.typeck_results().expr_ty(expr).is_bool() {
+        return;
+    }
+
+    // Suggest autofix
+    let ty = if ty == sym::Option { "an `Option`" } else { "a `Result`" };
+    span_lint_and_then(
+        cx,
+        MAP_UNWRAP_OR,
+        expr.span,
+        format!("called `map(_).unwrap_or_default()` on {ty} value"),
+        |diag| {
+            diag.multipart_suggestion(
+                "use instead",
+                vec![
+                    (recv.span.shrink_to_hi().with_hi(expr.span.hi()), String::new()),
+                    (map_method_span, String::from("map_or_default")),
+                ],
+                Applicability::MachineApplicable,
+            );
+        },
+    );
+}

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -78,6 +78,7 @@ mod map_flatten;
 mod map_identity;
 mod map_or_identity;
 mod map_unwrap_or;
+mod map_unwrap_or_default;
 mod map_unwrap_or_else;
 mod map_with_unused_argument_over_ranges;
 mod mut_mutex_lock;
@@ -2440,12 +2441,12 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for usage of `option.map(_).unwrap_or(_)` or `option.map(_).unwrap_or_else(_)` or
-    /// `result.map(_).unwrap_or_else(_)`.
+    /// Checks the usage of `map(_).unwrap_or(_)`, `map(_).unwrap_or_default()`
+    /// or `map(_).unwrap_or_else(_)` for `Option` and `Result` types.
     ///
     /// ### Why is this bad?
     /// Readability, these can be written more concisely (resp.) as
-    /// `option.map_or(_, _)`, `option.map_or_else(_, _)` and `result.map_or_else(_, _)`.
+    /// `map_or(_, _)`, `map_or_default(_)` or `map_or_else(_, _)`.
     ///
     /// ### Known problems
     /// The order of the arguments is not in execution order
@@ -2457,6 +2458,7 @@ declare_clippy_lint! {
     /// # fn some_function(foo: ()) -> usize { 1 }
     /// option.map(|a| a + 1).unwrap_or(0);
     /// option.map(|a| a > 10).unwrap_or(false);
+    /// result.map(|a| vec![a]).unwrap_or_default();
     /// result.map(|a| a + 1).unwrap_or_else(some_function);
     /// ```
     ///
@@ -2467,12 +2469,13 @@ declare_clippy_lint! {
     /// # fn some_function(foo: ()) -> usize { 1 }
     /// option.map_or(0, |a| a + 1);
     /// option.is_some_and(|a| a > 10);
+    /// result.map_or_default(|a| vec![a]);
     /// result.map_or_else(some_function, |a| a + 1);
     /// ```
     #[clippy::version = "1.45.0"]
     pub MAP_UNWRAP_OR,
     pedantic,
-    "using `.map(f).unwrap_or(a)` or `.map(f).unwrap_or_else(func)`, which are more succinctly expressed as `map_or(a, f)` or `map_or_else(a, f)`"
+    "using `.map(f).unwrap_or(a)`, `map(f).unwrap_or_default()` or `.map(f).unwrap_or_else(func)`, which are more succinctly expressed as `map_or(a, f)`, `map_or_default(f)` or `map_or_else(a, f)`"
 }
 
 declare_clippy_lint! {
@@ -5897,6 +5900,7 @@ impl Methods {
                         },
                         Some((sym::map, m_recv, [arg], span, _)) => {
                             manual_is_variant_and::check_map_unwrap_or_default(cx, expr, m_recv, arg, span, self.msrv);
+                            map_unwrap_or_default::check(cx, expr, recv, m_recv, span, self.msrv);
                         },
                         Some((then_method @ (sym::then | sym::then_some), t_recv, [t_arg], _, _)) => {
                             obfuscated_if_else::check(

--- a/clippy_lints/src/useless_vec.rs
+++ b/clippy_lints/src/useless_vec.rs
@@ -288,9 +288,7 @@ impl SuggestedType {
         let maybe_args = maybe_args.as_deref().unwrap_or_default();
         let maybe_len = len_span
             .map(|sp| sp.get_text(cx).expect("spans are always crate-local"))
-            .map(|st| format!("; {st}"))
-            .unwrap_or_default();
-
+            .map_or_default(|st| format!("; {st}"));
         match self {
             Self::SliceRef(Mutability::Mut) => format!("&mut [{maybe_args}{maybe_len}]"),
             Self::SliceRef(Mutability::Not) => format!("&[{maybe_args}{maybe_len}]"),

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -25,6 +25,7 @@ macro_rules! msrv_aliases {
 
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
+    1,98,0 { MAP_OR_DEFAULT }
     1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
     1,94,0 { EULER_GAMMA, GOLDEN_RATIO }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -155,17 +155,15 @@ impl TestContext {
         let mut config = Config {
             output_conflict_handling: error_on_output_conflict,
             // Pre-fill filters with TESTNAME; will be later extended with `self.args`.
-            filter_files: env::var("TESTNAME")
-                .map(|filters| {
-                    filters
-                        .split(',')
-                        // Make sure that if TESTNAME is empty we produce the empty list here,
-                        // not a list containing an empty string.
-                        .filter(|s| !s.is_empty())
-                        .map(str::to_string)
-                        .collect()
-                })
-                .unwrap_or_default(),
+            filter_files: env::var("TESTNAME").map_or_default(|filters| {
+                filters
+                    .split(',')
+                    // Make sure that if TESTNAME is empty we produce the empty list here,
+                    // not a list containing an empty string.
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            }),
             target: None,
             bless_command: Some(if IS_RUSTC_TEST_SUITE {
                 "./x test src/tools/clippy --bless".into()

--- a/tests/ui/map_unwrap_or_fixable.fixed
+++ b/tests/ui/map_unwrap_or_fixable.fixed
@@ -82,3 +82,47 @@ fn issue15713() {
     println!("{}", x.map_or_else(|_| 3, |y| y + 1));
     //~^ map_unwrap_or
 }
+
+// Support `map(_).unwrap_or_default()` pattern
+mod pr17644 {
+    macro_rules! identity {
+        // Inner bracket is necessary to detect macro expansion
+        ( $e:expr ) => {{ $e }};
+    }
+
+    #[clippy::msrv = "1.98"]
+    mod unwrap_or_default {
+        fn option(opt: Option<i32>) {
+            let _ = opt.map_or_default(|x| x * x); //~ map_unwrap_or
+            let _ = opt.map_or_default(|x| vec![x]); //~ map_unwrap_or
+            let _ = identity!(opt.map_or_default(|x| x + 1)); //~ map_unwrap_or
+            let _ = identity!(opt.map(|x| x + 1)).unwrap_or_default();
+            let _ = identity!(opt).map(|x| x + 1).unwrap_or_default();
+        }
+        fn result(res: Result<i32, ()>) {
+            let _ = res.map_or_default(|x| x * x); //~ map_unwrap_or
+            let _ = res.map_or_default(|x| vec![x]); //~ map_unwrap_or
+            let _ = identity!(res.map_or_default(|x| x + 1)); //~ map_unwrap_or
+            let _ = identity!(res.map(|x| x + 1)).unwrap_or_default();
+            let _ = identity!(res).map(|x| x + 1).unwrap_or_default();
+        }
+    }
+
+    #[clippy::msrv = "1.97"]
+    mod unwrap_or_default_before_msrv {
+        fn option(opt: Option<i32>) {
+            let _ = opt.map(|x| x * x).unwrap_or_default();
+            let _ = opt.map(|x| vec![x]).unwrap_or_default();
+            let _ = identity!(opt.map(|x| x + 1).unwrap_or_default());
+            let _ = identity!(opt.map(|x| x + 1)).unwrap_or_default();
+            let _ = identity!(opt).map(|x| x + 1).unwrap_or_default();
+        }
+        fn result(res: Result<i32, ()>) {
+            let _ = res.map(|x| x * x).unwrap_or_default();
+            let _ = res.map(|x| vec![x]).unwrap_or_default();
+            let _ = identity!(res.map(|x| x + 1).unwrap_or_default());
+            let _ = identity!(res.map(|x| x + 1)).unwrap_or_default();
+            let _ = identity!(res).map(|x| x + 1).unwrap_or_default();
+        }
+    }
+}

--- a/tests/ui/map_unwrap_or_fixable.rs
+++ b/tests/ui/map_unwrap_or_fixable.rs
@@ -88,3 +88,47 @@ fn issue15713() {
     println!("{}", x.map(|y| y + 1).unwrap_or_else(|_| 3));
     //~^ map_unwrap_or
 }
+
+// Support `map(_).unwrap_or_default()` pattern
+mod pr17644 {
+    macro_rules! identity {
+        // Inner bracket is necessary to detect macro expansion
+        ( $e:expr ) => {{ $e }};
+    }
+
+    #[clippy::msrv = "1.98"]
+    mod unwrap_or_default {
+        fn option(opt: Option<i32>) {
+            let _ = opt.map(|x| x * x).unwrap_or_default(); //~ map_unwrap_or
+            let _ = opt.map(|x| vec![x]).unwrap_or_default(); //~ map_unwrap_or
+            let _ = identity!(opt.map(|x| x + 1).unwrap_or_default()); //~ map_unwrap_or
+            let _ = identity!(opt.map(|x| x + 1)).unwrap_or_default();
+            let _ = identity!(opt).map(|x| x + 1).unwrap_or_default();
+        }
+        fn result(res: Result<i32, ()>) {
+            let _ = res.map(|x| x * x).unwrap_or_default(); //~ map_unwrap_or
+            let _ = res.map(|x| vec![x]).unwrap_or_default(); //~ map_unwrap_or
+            let _ = identity!(res.map(|x| x + 1).unwrap_or_default()); //~ map_unwrap_or
+            let _ = identity!(res.map(|x| x + 1)).unwrap_or_default();
+            let _ = identity!(res).map(|x| x + 1).unwrap_or_default();
+        }
+    }
+
+    #[clippy::msrv = "1.97"]
+    mod unwrap_or_default_before_msrv {
+        fn option(opt: Option<i32>) {
+            let _ = opt.map(|x| x * x).unwrap_or_default();
+            let _ = opt.map(|x| vec![x]).unwrap_or_default();
+            let _ = identity!(opt.map(|x| x + 1).unwrap_or_default());
+            let _ = identity!(opt.map(|x| x + 1)).unwrap_or_default();
+            let _ = identity!(opt).map(|x| x + 1).unwrap_or_default();
+        }
+        fn result(res: Result<i32, ()>) {
+            let _ = res.map(|x| x * x).unwrap_or_default();
+            let _ = res.map(|x| vec![x]).unwrap_or_default();
+            let _ = identity!(res.map(|x| x + 1).unwrap_or_default());
+            let _ = identity!(res.map(|x| x + 1)).unwrap_or_default();
+            let _ = identity!(res).map(|x| x + 1).unwrap_or_default();
+        }
+    }
+}

--- a/tests/ui/map_unwrap_or_fixable.stderr
+++ b/tests/ui/map_unwrap_or_fixable.stderr
@@ -103,5 +103,77 @@ error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
 LL |     println!("{}", x.map(|y| y + 1).unwrap_or_else(|_| 3));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.map_or_else(|_| 3, |y| y + 1)`
 
-error: aborting due to 11 previous errors
+error: called `map(_).unwrap_or_default()` on an `Option` value
+  --> tests/ui/map_unwrap_or_fixable.rs:102:21
+   |
+LL |             let _ = opt.map(|x| x * x).unwrap_or_default();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use instead
+   |
+LL -             let _ = opt.map(|x| x * x).unwrap_or_default();
+LL +             let _ = opt.map_or_default(|x| x * x);
+   |
+
+error: called `map(_).unwrap_or_default()` on an `Option` value
+  --> tests/ui/map_unwrap_or_fixable.rs:103:21
+   |
+LL |             let _ = opt.map(|x| vec![x]).unwrap_or_default();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use instead
+   |
+LL -             let _ = opt.map(|x| vec![x]).unwrap_or_default();
+LL +             let _ = opt.map_or_default(|x| vec![x]);
+   |
+
+error: called `map(_).unwrap_or_default()` on an `Option` value
+  --> tests/ui/map_unwrap_or_fixable.rs:104:31
+   |
+LL |             let _ = identity!(opt.map(|x| x + 1).unwrap_or_default());
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use instead
+   |
+LL -             let _ = identity!(opt.map(|x| x + 1).unwrap_or_default());
+LL +             let _ = identity!(opt.map_or_default(|x| x + 1));
+   |
+
+error: called `map(_).unwrap_or_default()` on a `Result` value
+  --> tests/ui/map_unwrap_or_fixable.rs:109:21
+   |
+LL |             let _ = res.map(|x| x * x).unwrap_or_default();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use instead
+   |
+LL -             let _ = res.map(|x| x * x).unwrap_or_default();
+LL +             let _ = res.map_or_default(|x| x * x);
+   |
+
+error: called `map(_).unwrap_or_default()` on a `Result` value
+  --> tests/ui/map_unwrap_or_fixable.rs:110:21
+   |
+LL |             let _ = res.map(|x| vec![x]).unwrap_or_default();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use instead
+   |
+LL -             let _ = res.map(|x| vec![x]).unwrap_or_default();
+LL +             let _ = res.map_or_default(|x| vec![x]);
+   |
+
+error: called `map(_).unwrap_or_default()` on a `Result` value
+  --> tests/ui/map_unwrap_or_fixable.rs:111:31
+   |
+LL |             let _ = identity!(res.map(|x| x + 1).unwrap_or_default());
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use instead
+   |
+LL -             let _ = identity!(res.map(|x| x + 1).unwrap_or_default());
+LL +             let _ = identity!(res.map_or_default(|x| x + 1));
+   |
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/17644)*

`Option::map_or_default`/`Result::map_or_default` was stabilized in Rust 1.98.0, so the `map_unwrap_or` lint should also cover `map(f).unwrap_or_default()`, suggesting `map_or_default(f)` instead.

changelog: [`map_unwrap_or`]: extend to support `map(f).unwrap_or_default()`