### PR TITLE
fix(byte_char_slices): suggest a copy when the borrow is mutable

### DIFF
--- a/clippy_lints/src/byte_char_slices.rs
+++ b/clippy_lints/src/byte_char_slices.rs
@@ -62,6 +62,11 @@ impl<'tcx> LateLintPass<'tcx> for ByteCharSlice {
                     });
                     if !has_ref && !cx.typeck_results().expr_ty_adjusted(expr).is_array_slice() {
                         sugg = sugg.deref();
+                        if is_mut_borrowed(cx, expr) {
+                            // A byte string literal is immutable, so a mutable borrow has to
+                            // point at a copy of it: `&mut { *b"ab" }`.
+                            sugg = sugg.blockify();
+                        }
                     }
 
                     diag.span_suggestion(expr.span, "try", sugg, app);
@@ -69,6 +74,12 @@ impl<'tcx> LateLintPass<'tcx> for ByteCharSlice {
             );
         }
     }
+}
+
+/// Checks whether `expr` is the operand of a mutable borrow.
+fn is_mut_borrowed<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
+    get_parent_expr(cx, expr)
+        .is_some_and(|parent| matches!(parent.kind, ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, _)))
 }
 
 /// Checks whether the slice is that of byte chars, and if so, builds a byte-string out of it

--- a/tests/ui/byte_char_slices.fixed
+++ b/tests/ui/byte_char_slices.fixed
@@ -49,3 +49,17 @@ fn issue16759(bytes: [u32; 3]) {
     takes_array_ref_ref(&b"ab");
     //~^ byte_char_slices
 }
+
+fn takes_mut_array_ref(_: &mut [u8; 2]) {}
+
+fn issue17627() {
+    // a byte string literal is immutable, so a mutable borrow has to point at a copy of it
+    let mutable = &mut { *b"ab" };
+    //~^ byte_char_slices
+    takes_mut_array_ref(&mut { *b"ab" });
+    //~^ byte_char_slices
+    unsafe {
+        let _ = std::str::from_utf8_unchecked_mut(&mut { *b"clippy" });
+        //~^ byte_char_slices
+    }
+}

--- a/tests/ui/byte_char_slices.rs
+++ b/tests/ui/byte_char_slices.rs
@@ -49,3 +49,17 @@ fn issue16759(bytes: [u32; 3]) {
     takes_array_ref_ref(&&[b'a', b'b']);
     //~^ byte_char_slices
 }
+
+fn takes_mut_array_ref(_: &mut [u8; 2]) {}
+
+fn issue17627() {
+    // a byte string literal is immutable, so a mutable borrow has to point at a copy of it
+    let mutable = &mut [b'a', b'b'];
+    //~^ byte_char_slices
+    takes_mut_array_ref(&mut [b'a', b'b']);
+    //~^ byte_char_slices
+    unsafe {
+        let _ = std::str::from_utf8_unchecked_mut(&mut [b'c', b'l', b'i', b'p', b'p', b'y']);
+        //~^ byte_char_slices
+    }
+}

--- a/tests/ui/byte_char_slices.stderr
+++ b/tests/ui/byte_char_slices.stderr
@@ -55,5 +55,23 @@ error: can be more succinctly written as a byte str
 LL |     takes_array_ref_ref(&&[b'a', b'b']);
    |                          ^^^^^^^^^^^^^ help: try: `b"ab"`
 
-error: aborting due to 9 previous errors
+error: can be more succinctly written as a byte str
+  --> tests/ui/byte_char_slices.rs:57:24
+   |
+LL |     let mutable = &mut [b'a', b'b'];
+   |                        ^^^^^^^^^^^^ help: try: `{ *b"ab" }`
+
+error: can be more succinctly written as a byte str
+  --> tests/ui/byte_char_slices.rs:59:30
+   |
+LL |     takes_mut_array_ref(&mut [b'a', b'b']);
+   |                              ^^^^^^^^^^^^ help: try: `{ *b"ab" }`
+
+error: can be more succinctly written as a byte str
+  --> tests/ui/byte_char_slices.rs:62:56
+   |
+LL |         let _ = std::str::from_utf8_unchecked_mut(&mut [b'c', b'l', b'i', b'p', b'p', b'y']);
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `{ *b"clippy" }`
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17627

`is_byte_char_slices` bails out on an array literal whose parent expression is a shared borrow, so that the parent gets linted instead and the suggestion replaces the whole `&[b'a', b'b']`. A mutable borrow does not match that check, so the array itself is linted and the suggestion is applied inside the borrow:

```rust
std::str::from_utf8_unchecked_mut(&mut [b'c', b'l', b'i', b'p', b'p', b'y']);
//                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `*b"clippy"`
```

Applying that gives `&mut *b"clippy"`, which does not compile: a byte string literal is immutable, so its pointee cannot be borrowed mutably.

Per the review, the suggestion is now wrapped in a block when the array is mutably borrowed, so the fix is `&mut { *b"clippy" }`. The block copies the literal into a temporary, which can be borrowed mutably, and that keeps the semantics of the array literal it replaces.

changelog: Fix [`byte_char_slices`] suggestion that did not compile behind a mutable borrow
