### PR TITLE
fix(std_instead_of_core): don't suggest a path that does not resolve

### DIFF
--- a/clippy_lints/src/std_instead_of_core.rs
+++ b/clippy_lints/src/std_instead_of_core.rs
@@ -2,13 +2,14 @@ use clippy_config::Conf;
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use clippy_utils::is_from_proc_macro;
 use clippy_utils::msrvs::Msrv;
+use clippy_utils::paths::{PathNS, lookup_path};
 use rustc_errors::Applicability;
-use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def::{DefKind, Namespace, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Block, Body, HirId, Path, PathSegment, StabilityLevel, StableSince};
 use rustc_lint::{LateContext, LateLintPass, Lint, LintContext as _, impl_lint_pass};
 use rustc_span::symbol::kw;
-use rustc_span::{Span, sym};
+use rustc_span::{Span, Symbol, sym};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -148,6 +149,14 @@ impl<'tcx> LateLintPass<'tcx> for StdReexports {
                 },
             };
 
+            // Only the crate name is replaced, so the rest of the path has to name the same item in
+            // the target crate. `std::collections::Bound` for instance reaches `core::ops::Bound`
+            // through a legacy re-export, and `core::collections` does not exist.
+            if !resolves_in(cx, path, def_kind, def_id, replace_with) {
+                self.lint_if_finish(cx, first_segment.ident.span, LintPoint::Conflict);
+                return;
+            }
+
             self.lint_if_finish(
                 cx,
                 first_segment.ident.span,
@@ -216,6 +225,31 @@ fn emit_lints(cx: &LateContext<'_>, lint_points: Option<(Span, Vec<LintPoint>)>)
             format!("consider importing the item from `{replace_with}`"),
         );
     }
+}
+
+/// Checks whether `path` still resolves to `def_id` once its crate name is replaced with
+/// `replace_with`.
+///
+/// [`lookup_path`] is expensive, so this is only called once a path is about to be linted.
+fn resolves_in(cx: &LateContext<'_>, path: &Path<'_>, def_kind: DefKind, def_id: DefId, replace_with: &str) -> bool {
+    let ns = match def_kind.ns() {
+        Some(Namespace::TypeNS) => PathNS::Type,
+        Some(Namespace::ValueNS) => PathNS::Value,
+        Some(Namespace::MacroNS) => PathNS::Macro,
+        None => PathNS::Arbitrary,
+    };
+
+    let mut segments = Vec::with_capacity(path.segments.len());
+    segments.push(Symbol::intern(replace_with));
+    segments.extend(
+        path.segments
+            .iter()
+            .skip_while(|segment| segment.ident.name == kw::PathRoot)
+            .skip(1)
+            .map(|segment| segment.ident.name),
+    );
+
+    lookup_path(cx.tcx, ns, &segments).contains(&def_id)
 }
 
 /// Returns the first named segment of a [`Path`].

--- a/tests/ui/std_instead_of_core.fixed
+++ b/tests/ui/std_instead_of_core.fixed
@@ -115,3 +115,9 @@ fn issue13158_msrv_1_80(_: &dyn std::error::Error) {}
 #[clippy::msrv = "1.81"]
 fn issue13158_msrv_1_81(_: &dyn core::error::Error) {}
 //~^ std_instead_of_core
+
+fn issue17602() {
+    // `Bound` is defined in `core::ops` and only reachable from `std::collections` through a
+    // legacy re-export, so replacing `std` with `core` would name a module that does not exist.
+    use std::collections::Bound;
+}

--- a/tests/ui/std_instead_of_core.fixed
+++ b/tests/ui/std_instead_of_core.fixed
@@ -120,4 +120,12 @@ fn issue17602() {
     // `Bound` is defined in `core::ops` and only reachable from `std::collections` through a
     // legacy re-export, so replacing `std` with `core` would name a module that does not exist.
     use std::collections::Bound;
+    use std::collections::Bound::{Excluded, Included};
+
+    // The very same items are still linted through the path they are actually defined at, both
+    // as a type and as a value.
+    use core::ops::Bound as OpsBound;
+    //~^ std_instead_of_core
+    use core::ops::Bound::Unbounded;
+    //~^ std_instead_of_core
 }

--- a/tests/ui/std_instead_of_core.rs
+++ b/tests/ui/std_instead_of_core.rs
@@ -120,4 +120,12 @@ fn issue17602() {
     // `Bound` is defined in `core::ops` and only reachable from `std::collections` through a
     // legacy re-export, so replacing `std` with `core` would name a module that does not exist.
     use std::collections::Bound;
+    use std::collections::Bound::{Excluded, Included};
+
+    // The very same items are still linted through the path they are actually defined at, both
+    // as a type and as a value.
+    use std::ops::Bound as OpsBound;
+    //~^ std_instead_of_core
+    use std::ops::Bound::Unbounded;
+    //~^ std_instead_of_core
 }

--- a/tests/ui/std_instead_of_core.rs
+++ b/tests/ui/std_instead_of_core.rs
@@ -115,3 +115,9 @@ fn issue13158_msrv_1_80(_: &dyn std::error::Error) {}
 #[clippy::msrv = "1.81"]
 fn issue13158_msrv_1_81(_: &dyn std::error::Error) {}
 //~^ std_instead_of_core
+
+fn issue17602() {
+    // `Bound` is defined in `core::ops` and only reachable from `std::collections` through a
+    // legacy re-export, so replacing `std` with `core` would name a module that does not exist.
+    use std::collections::Bound;
+}

--- a/tests/ui/std_instead_of_core.stderr
+++ b/tests/ui/std_instead_of_core.stderr
@@ -109,5 +109,17 @@ error: used import from `std` instead of `core`
 LL | fn issue13158_msrv_1_81(_: &dyn std::error::Error) {}
    |                                 ^^^ help: consider importing the item from `core`: `core`
 
-error: aborting due to 17 previous errors
+error: used import from `std` instead of `core`
+  --> tests/ui/std_instead_of_core.rs:127:9
+   |
+LL |     use std::ops::Bound as OpsBound;
+   |         ^^^ help: consider importing the item from `core`: `core`
+
+error: used import from `std` instead of `core`
+  --> tests/ui/std_instead_of_core.rs:129:9
+   |
+LL |     use std::ops::Bound::Unbounded;
+   |         ^^^ help: consider importing the item from `core`: `core`
+
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17602

`check_path` decides that an item is available in the target crate by looking at where it is defined (`cx.tcx.crate_name(def_id.krate)`), but the suggestion only replaces the crate name and leaves the rest of the path alone. The two do not always agree: `std::collections::Bound` reaches `core::ops::Bound` through a legacy re-export, so the item really is in `core` while `core::collections` does not exist.

```rust
#![no_std]
extern crate std;
use std::collections::Bound::{Excluded, Included};
```

```
help: consider importing the item from `core`: `core`
```

`cargo clippy --fix` applies that and leaves the crate unable to compile with ``cannot find `collections` in `core` ``.

The path is now resolved with the crate name replaced, and is only linted when it still resolves to the same item. Resolving is done through `lookup_path`, which is documented as expensive, so the check runs only once a path has passed every other condition and is about to be linted.

An unresolvable path is recorded as `LintPoint::Conflict` rather than skipped, so that a group of imports sharing one crate name does not get a `MachineApplicable` suggestion when one of its members cannot be replaced:

```rust
use std::{collections::Bound, fmt::Debug};
```

still reports `Debug`, but as a help message instead of a suggestion to rewrite `std`, which would have broken `Bound`.

changelog: Fix [`std_instead_of_core`] suggesting a path that does not resolve
