### PR TITLE
Added a new lint path_comparison_to_empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7444,6 +7444,7 @@ Released 2018-09-13
 [`partialeq_ne_impl`]: https://rust-lang.github.io/rust-clippy/main/index.html#partialeq_ne_impl
 [`partialeq_to_none`]: https://rust-lang.github.io/rust-clippy/main/index.html#partialeq_to_none
 [`path_buf_push_overwrite`]: https://rust-lang.github.io/rust-clippy/main/index.html#path_buf_push_overwrite
+[`path_comparison_to_empty`]: https://rust-lang.github.io/rust-clippy/main/index.html#path_comparison_to_empty
 [`path_ends_with_ext`]: https://rust-lang.github.io/rust-clippy/main/index.html#path_ends_with_ext
 [`pathbuf_init_then_push`]: https://rust-lang.github.io/rust-clippy/main/index.html#pathbuf_init_then_push
 [`pattern_type_mismatch`]: https://rust-lang.github.io/rust-clippy/main/index.html#pattern_type_mismatch

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -999,6 +999,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`nonnull_unchecked_on_box_ptr`](https://rust-lang.github.io/rust-clippy/main/index.html#nonnull_unchecked_on_box_ptr)
 * [`option_as_ref_deref`](https://rust-lang.github.io/rust-clippy/main/index.html#option_as_ref_deref)
 * [`or_fun_call`](https://rust-lang.github.io/rust-clippy/main/index.html#or_fun_call)
+* [`path_comparison_to_empty`](https://rust-lang.github.io/rust-clippy/main/index.html#path_comparison_to_empty)
 * [`ptr_as_ptr`](https://rust-lang.github.io/rust-clippy/main/index.html#ptr_as_ptr)
 * [`question_mark`](https://rust-lang.github.io/rust-clippy/main/index.html#question_mark)
 * [`redundant_field_names`](https://rust-lang.github.io/rust-clippy/main/index.html#redundant_field_names)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -705,6 +705,7 @@ define_Conf! {
         nonnull_unchecked_on_box_ptr,
         option_as_ref_deref,
         or_fun_call,
+        path_comparison_to_empty,
         ptr_as_ptr,
         question_mark,
         redundant_field_names,

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -647,6 +647,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::partialeq_to_none::PARTIALEQ_TO_NONE_INFO,
     crate::pass_by_ref_or_value::LARGE_TYPES_PASSED_BY_VALUE_INFO,
     crate::pass_by_ref_or_value::TRIVIALLY_COPY_PASS_BY_REF_INFO,
+    crate::path_comparison_to_empty::PATH_COMPARISON_TO_EMPTY_INFO,
     crate::pathbuf_init_then_push::PATHBUF_INIT_THEN_PUSH_INFO,
     crate::pattern_type_mismatch::PATTERN_TYPE_MISMATCH_INFO,
     crate::permissions_set_readonly_false::PERMISSIONS_SET_READONLY_FALSE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -296,6 +296,7 @@ mod partial_pub_fields;
 mod partialeq_ne_impl;
 mod partialeq_to_none;
 mod pass_by_ref_or_value;
+mod path_comparison_to_empty;
 mod pathbuf_init_then_push;
 mod pattern_type_mismatch;
 mod permissions_set_readonly_false;
@@ -870,6 +871,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        PathComparisonToEmpty: path_comparison_to_empty::PathComparisonToEmpty = path_comparison_to_empty::PathComparisonToEmpty::new(conf),
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/path_comparison_to_empty.rs
+++ b/clippy_lints/src/path_comparison_to_empty.rs
@@ -16,12 +16,14 @@ declare_clippy_lint! {
     /// using `is_empty()` is more performant
     /// ### Example
     /// ```no_run
+    /// # use std::path::{Path};
     /// if path == Path::new("") {
     ///         return Ok(());
     /// }
     /// ```
     /// Use instead:
     /// ```no_run
+    ///  # use std::path::{Path};
     /// if path.is_empty() {
     ///        return Ok(());
     /// }

--- a/clippy_lints/src/path_comparison_to_empty.rs
+++ b/clippy_lints/src/path_comparison_to_empty.rs
@@ -17,16 +17,14 @@ declare_clippy_lint! {
     /// ### Example
     /// ```no_run
     /// # use std::path::{Path};
-    /// if path == Path::new("") {
-    ///         return Ok(());
-    /// }
+    /// let path = Path::new("123");
+    /// let _ = path == Path::new("");
     /// ```
     /// Use instead:
     /// ```no_run
     ///  # use std::path::{Path};
-    /// if path.is_empty() {
-    ///        return Ok(());
-    /// }
+    /// let path = Path::new("123");
+    /// let _ = path.is_empty();
     /// ```
     #[clippy::version = "1.100.0"]
     pub PATH_COMPARISON_TO_EMPTY,

--- a/clippy_lints/src/path_comparison_to_empty.rs
+++ b/clippy_lints/src/path_comparison_to_empty.rs
@@ -11,9 +11,9 @@ use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for comparing a `Path` or `PathBuf` to `Path::new("")` or `PathBuf()` and suggests to use `.is_empty()` instead
+    /// Checks for comparing a `Path` or `PathBuf` to `Path::new("")` or `PathBuf::new()` and suggests to use `.is_empty()` instead
     /// ### Why is this bad?
-    /// using `is_empty()` is more performant
+    /// using `is_empty()` is clearer
     /// ### Example
     /// ```no_run
     /// # use std::path::{Path};
@@ -73,7 +73,7 @@ impl LateLintPass<'_> for PathComparisonToEmpty {
                 cx,
                 PATH_COMPARISON_TO_EMPTY,
                 expr.span,
-                "path comparison to new empty initialized path",
+                "comparing a path against an empty path",
                 format!("using `{negation_sign}is_empty` is clearer and more explicit"),
                 format!(
                     "{negation_sign}{}.is_empty()",
@@ -86,25 +86,18 @@ impl LateLintPass<'_> for PathComparisonToEmpty {
 }
 
 fn is_path_new_empty_args(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    // PathBuf has no args, Path has "" as args
     if let ExprKind::Call(func, args) = expr.kind
         && let ExprKind::Path(ref qpath) = func.kind
         && let Some(def_id) = cx.qpath_res(qpath, func.hir_id).opt_def_id()
-        && let Some(impl_ty) = def_id.assoc_parent(cx).opt_impl_ty(cx)
         && cx.tcx.item_name(def_id) == sym::new
-        && (impl_ty.skip_binder().is_diag_item(cx, sym::Path) || impl_ty.skip_binder().is_diag_item(cx, sym::PathBuf))
+        && let Some(impl_ty) = def_id.assoc_parent(cx).opt_impl_ty(cx)
     {
-        // PathBuf::new() check for no args
-        if args.is_empty() && impl_ty.skip_binder().is_diag_item(cx, sym::PathBuf) {
-            return true;
-        }
-
-        // Path::new("") check for empty String as arg
-        if let [arg] = args
-            && (impl_ty.skip_binder().is_diag_item(cx, sym::Path))
-        {
-            return is_empty_string(arg);
-        }
+        // `PathBuf::new()` takes no args, `Path::new("")` takes one empty string literal.
+        return match impl_ty.skip_binder().opt_diag_name(cx) {
+            Some(sym::PathBuf) => args.is_empty(),
+            Some(sym::Path) => matches!(args, [arg] if is_empty_string(arg)),
+            _ => false,
+        };
     }
     false
 }

--- a/clippy_lints/src/path_comparison_to_empty.rs
+++ b/clippy_lints/src/path_comparison_to_empty.rs
@@ -61,7 +61,7 @@ impl LateLintPass<'_> for PathComparisonToEmpty {
             let cmp_expr = if right_path_new_empty_string { left } else { right };
             let cmp_ty = cx.typeck_results().expr_ty(cmp_expr).peel_refs();
 
-            if !(cmp_ty.is_diag_item(cx, sym::Path) || cmp_ty.is_diag_item(cx, sym::PathBuf)) {
+            if !matches!(cmp_ty.opt_diag_name(cx), Some(sym::Path | sym::PathBuf)) {
                 return;
             }
 

--- a/clippy_lints/src/path_comparison_to_empty.rs
+++ b/clippy_lints/src/path_comparison_to_empty.rs
@@ -1,0 +1,120 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::res::MaybeDef as _;
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::sym;
+use rustc_ast::LitKind;
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for comparing a `Path` or `PathBuf` to `Path::new("")` or `PathBuf()` and suggests to use `.is_empty()` instead
+    /// ### Why is this bad?
+    /// using `is_empty()` is more performant
+    /// ### Example
+    /// ```no_run
+    /// if path == Path::new("") {
+    ///         return Ok(());
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// if path.is_empty() {
+    ///        return Ok(());
+    /// }
+    /// ```
+    #[clippy::version = "1.100.0"]
+    pub PATH_COMPARISON_TO_EMPTY,
+    style,
+    "checking comparison `path == Path::new(\"\")` when `.is_empty()` could be used instead"
+}
+
+impl_lint_pass!(PathComparisonToEmpty => [PATH_COMPARISON_TO_EMPTY]);
+
+pub struct PathComparisonToEmpty {
+    msrv: Msrv,
+}
+
+impl PathComparisonToEmpty {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self { msrv: conf.msrv.into() }
+    }
+}
+
+impl LateLintPass<'_> for PathComparisonToEmpty {
+    fn check_expr(&mut self, cx: &LateContext<'_>, expr: &'_ Expr<'_>) {
+        if let ExprKind::Binary(op, left, right) = expr.kind
+            && (op.node == BinOpKind::Eq || op.node == BinOpKind::Ne)
+            && self.msrv.meets(cx, msrvs::PATH_IS_EMPTY)
+        {
+            let left_path_new_empty_string = is_path_new_empty_args(cx, left);
+            let right_path_new_empty_string = is_path_new_empty_args(cx, right);
+
+            // in case of `Path::new("") == Path::new("")` the lint doesn't make much sense
+            if !(left_path_new_empty_string ^ right_path_new_empty_string) {
+                return;
+            }
+
+            let cmp_expr = if right_path_new_empty_string { left } else { right };
+            let cmp_ty = cx.typeck_results().expr_ty(cmp_expr).peel_refs();
+
+            if !(cmp_ty.is_diag_item(cx, sym::Path) || cmp_ty.is_diag_item(cx, sym::PathBuf)) {
+                return;
+            }
+
+            let is_non_equal = op.node == BinOpKind::Ne;
+            let negation_sign = if is_non_equal { "!" } else { "" };
+            let mut applicability = Applicability::MachineApplicable;
+
+            span_lint_and_sugg(
+                cx,
+                PATH_COMPARISON_TO_EMPTY,
+                expr.span,
+                "path comparison to new empty initialized path",
+                format!("using `{negation_sign}is_empty` is clearer and more explicit"),
+                format!(
+                    "{negation_sign}{}.is_empty()",
+                    snippet_with_context(cx, cmp_expr.span, expr.span.ctxt(), "_", &mut applicability).0,
+                ),
+                applicability,
+            );
+        }
+    }
+}
+
+fn is_path_new_empty_args(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    // PathBuf has no args, Path has "" as args
+    if let ExprKind::Call(func, args) = expr.kind
+        && let ExprKind::Path(ref qpath) = func.kind
+        && let Some(def_id) = cx.qpath_res(qpath, func.hir_id).opt_def_id()
+        && let Some(impl_ty) = def_id.assoc_parent(cx).opt_impl_ty(cx)
+        && cx.tcx.item_name(def_id) == sym::new
+        && (impl_ty.skip_binder().is_diag_item(cx, sym::Path) || impl_ty.skip_binder().is_diag_item(cx, sym::PathBuf))
+    {
+        // PathBuf::new() check for no args
+        if args.is_empty() && impl_ty.skip_binder().is_diag_item(cx, sym::PathBuf) {
+            return true;
+        }
+
+        // Path::new("") check for empty String as arg
+        if let [arg] = args
+            && (impl_ty.skip_binder().is_diag_item(cx, sym::Path))
+        {
+            return is_empty_string(arg);
+        }
+    }
+    false
+}
+
+fn is_empty_string(expr: &Expr<'_>) -> bool {
+    if let ExprKind::Lit(lit) = expr.kind
+        && let LitKind::Str(lit, _) = lit.node
+    {
+        let lit = lit.as_str();
+        return lit.is_empty();
+    }
+    false
+}

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -25,6 +25,7 @@ macro_rules! msrv_aliases {
 
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
+    1,98,0 { PATH_IS_EMPTY }
     1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
     1,94,0 { EULER_GAMMA, GOLDEN_RATIO }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }

--- a/tests/ui/path_comparison_to_empty.fixed
+++ b/tests/ui/path_comparison_to_empty.fixed
@@ -1,0 +1,65 @@
+#![warn(clippy::path_comparison_to_empty)]
+#![allow(unused, clippy::needless_ifs)]
+
+use std::path::{Path, PathBuf};
+
+#[clippy::msrv = "1.97"]
+fn msrv_1_97() {
+    let s_97 = Path::new("a");
+    let _ = s_97 == Path::new("");
+}
+
+#[clippy::msrv = "1.98"]
+fn msrv_1_98() {
+    let s_98 = Path::new("a");
+    let _ = s_98.is_empty();
+    //~^ path_comparison_to_empty
+}
+
+fn main() {
+    let p = Path::new("abcd");
+    let r = Path::new("abcde");
+    let s = Path::new("");
+
+    let _ = p == s;
+    let _ = r == s;
+
+    let _ = s.is_empty();
+    //~^ path_comparison_to_empty
+    let _ = !s.is_empty();
+    //~^ path_comparison_to_empty
+    let _ = s.is_empty();
+    //~^ path_comparison_to_empty
+    let _ = Path::new("") == Path::new("");
+
+    let _ = r.is_empty();
+    //~^ path_comparison_to_empty
+
+    let _ = s == Path::new("1234");
+    let _ = Path::new("2234") == s;
+    let _ = Path::new("");
+
+    if s.is_empty() {
+        //~^ path_comparison_to_empty
+    }
+    if !p.is_empty() {
+        //~^ path_comparison_to_empty
+    }
+    if !s.is_empty() {
+        //~^ path_comparison_to_empty
+    }
+    if s.is_empty() && p == Path::new("abcd") {
+        //~^ path_comparison_to_empty
+    }
+
+    if Some("123") == Path::new("").to_str() {}
+
+    if Path::new("").to_str().unwrap() == "" {}
+
+    let mut b = PathBuf::new();
+
+    let _ = s.is_empty();
+    //~^ path_comparison_to_empty
+    let _ = b.is_empty();
+    //~^ path_comparison_to_empty
+}

--- a/tests/ui/path_comparison_to_empty.rs
+++ b/tests/ui/path_comparison_to_empty.rs
@@ -1,0 +1,65 @@
+#![warn(clippy::path_comparison_to_empty)]
+#![allow(unused, clippy::needless_ifs)]
+
+use std::path::{Path, PathBuf};
+
+#[clippy::msrv = "1.97"]
+fn msrv_1_97() {
+    let s_97 = Path::new("a");
+    let _ = s_97 == Path::new("");
+}
+
+#[clippy::msrv = "1.98"]
+fn msrv_1_98() {
+    let s_98 = Path::new("a");
+    let _ = s_98 == Path::new("");
+    //~^ path_comparison_to_empty
+}
+
+fn main() {
+    let p = Path::new("abcd");
+    let r = Path::new("abcde");
+    let s = Path::new("");
+
+    let _ = p == s;
+    let _ = r == s;
+
+    let _ = s == Path::new("");
+    //~^ path_comparison_to_empty
+    let _ = s != Path::new("");
+    //~^ path_comparison_to_empty
+    let _ = Path::new("") == s;
+    //~^ path_comparison_to_empty
+    let _ = Path::new("") == Path::new("");
+
+    let _ = std::path::Path::new("") == r;
+    //~^ path_comparison_to_empty
+
+    let _ = s == Path::new("1234");
+    let _ = Path::new("2234") == s;
+    let _ = Path::new("");
+
+    if s == Path::new("") {
+        //~^ path_comparison_to_empty
+    }
+    if p != Path::new("") {
+        //~^ path_comparison_to_empty
+    }
+    if !(s == Path::new("")) {
+        //~^ path_comparison_to_empty
+    }
+    if s == Path::new("") && p == Path::new("abcd") {
+        //~^ path_comparison_to_empty
+    }
+
+    if Some("123") == Path::new("").to_str() {}
+
+    if Path::new("").to_str().unwrap() == "" {}
+
+    let mut b = PathBuf::new();
+
+    let _ = s == PathBuf::new();
+    //~^ path_comparison_to_empty
+    let _ = b == PathBuf::new();
+    //~^ path_comparison_to_empty
+}

--- a/tests/ui/path_comparison_to_empty.stderr
+++ b/tests/ui/path_comparison_to_empty.stderr
@@ -1,0 +1,71 @@
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:15:13
+   |
+LL |     let _ = s_98 == Path::new("");
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `s_98.is_empty()`
+   |
+   = note: `-D clippy::path-comparison-to-empty` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::path_comparison_to_empty)]`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:27:13
+   |
+LL |     let _ = s == Path::new("");
+   |             ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `s.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:29:13
+   |
+LL |     let _ = s != Path::new("");
+   |             ^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!s.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:31:13
+   |
+LL |     let _ = Path::new("") == s;
+   |             ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `s.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:35:13
+   |
+LL |     let _ = std::path::Path::new("") == r;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `r.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:42:8
+   |
+LL |     if s == Path::new("") {
+   |        ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `s.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:45:8
+   |
+LL |     if p != Path::new("") {
+   |        ^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!p.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:48:9
+   |
+LL |     if !(s == Path::new("")) {
+   |         ^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `s.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:51:8
+   |
+LL |     if s == Path::new("") && p == Path::new("abcd") {
+   |        ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `s.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:61:13
+   |
+LL |     let _ = s == PathBuf::new();
+   |             ^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `s.is_empty()`
+
+error: path comparison to new empty initialized path
+  --> tests/ui/path_comparison_to_empty.rs:63:13
+   |
+LL |     let _ = b == PathBuf::new();
+   |             ^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `b.is_empty()`
+
+error: aborting due to 11 previous errors
+


### PR DESCRIPTION

---

changelog: [`path_comparison_to_empty`] Added a new lint `path_comparison_to_empty`, which checks for comparing a path to `Path::new("")` or `PathBuf::new()` and suggests to use `is_empty`

fixes: rust-lang/rust-clippy#17615