### PR TITLE
fix: don't produce malformed spans for macro-generated items

### DIFF
--- a/clippy_lints/src/empty_line_after.rs
+++ b/clippy_lints/src/empty_line_after.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::source::{SpanExt as _, snippet_indent};
+use clippy_utils::source::{SpanExt as _, snippet_indent, span_up_to_ident};
 use clippy_utils::tokenize_with_text;
 use itertools::Itertools as _;
 use rustc_ast::token::CommentKind;
@@ -126,7 +126,7 @@ impl ItemInfo {
             kind,
             name: ident.map(|ident| ident.name),
             span: match ident {
-                Some(ident) => span.with_hi(ident.span.hi()),
+                Some(ident) => span_up_to_ident(span, ident),
                 None => span.shrink_to_lo(),
             },
             mod_items,

--- a/clippy_lints/src/redundant_pub_crate.rs
+++ b/clippy_lints/src/redundant_pub_crate.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::source::span_up_to_ident;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Item, ItemKind, UseKind};
@@ -52,7 +53,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantPubCrate {
             let span = item
                 .kind
                 .ident()
-                .map_or(item.span, |ident| item.span.with_hi(ident.span.hi()));
+                .map_or(item.span, |ident| span_up_to_ident(item.span, ident));
             let descr = cx.tcx.def_kind(item.owner_id).descr(item.owner_id.to_def_id());
             span_lint_and_then(
                 cx,

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -13,7 +13,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::source_map::{SourceMap, original_sp};
 use rustc_span::{
-    BytePos, DUMMY_SP, DesugaringKind, Pos as _, RelativeBytePos, SourceFile, SourceFileAndLine, Span, SpanData,
+    BytePos, DUMMY_SP, DesugaringKind, Ident, Pos as _, RelativeBytePos, SourceFile, SourceFileAndLine, Span, SpanData,
     SyntaxContext, hygiene,
 };
 use std::borrow::Cow;
@@ -407,6 +407,21 @@ fn first_char_in_first_line<'sm>(sm: impl HasSourceMap<'sm>, span: Span) -> Opti
         snip.find(|c: char| !c.is_whitespace())
             .map(|pos| line_span.lo() + BytePos::from_usize(pos))
     })
+}
+
+/// Shortens `span` so that it ends where `ident`'s span ends, e.g. to make an item's span point
+/// at its `fn name` part rather than including the entire body.
+///
+/// Returns `span` unchanged when `ident`'s span isn't contained in it. This can happen for
+/// macro-generated items whose ident comes from a different location entirely (e.g. the macro call
+/// site, or another file); combining the two spans would produce a nonsensical span covering
+/// unrelated code.
+pub fn span_up_to_ident(span: Span, ident: Ident) -> Span {
+    if span.contains(ident.span) {
+        span.with_hi(ident.span.hi())
+    } else {
+        span
+    }
 }
 
 /// Extends the span to the beginning of the spans line, incl. whitespaces.

--- a/tests/ui/empty_line_after/outer_attribute.1.fixed
+++ b/tests/ui/empty_line_after/outer_attribute.1.fixed
@@ -115,4 +115,30 @@ mod issue_14980 {
     }
 }
 
+mod macro_ident_from_call_site {
+    fn before() {}
+
+    // The ident of a macro-generated item can come from the macro call site while the rest of
+    // the item comes from the macro definition. Combining the two produced a nonsensical span
+    // for the "the attribute applies to this item" label (same root cause as #14968).
+    //~v empty_line_after_outer_attr
+    crate::macro_ident_from_call_site::macros::mac! {
+        {
+            #[allow(dead_code)]
+            #[allow(unused)]
+        }
+        some_function_name
+    }
+
+    mod macros {
+        macro_rules! mac_impl {
+            ({$($attr:tt)*} $name:ident) => {
+                $($attr)*
+                fn $name() {}
+            };
+        }
+        pub(crate) use mac_impl as mac;
+    }
+}
+
 fn main() {}

--- a/tests/ui/empty_line_after/outer_attribute.2.fixed
+++ b/tests/ui/empty_line_after/outer_attribute.2.fixed
@@ -118,4 +118,30 @@ mod issue_14980 {
     }
 }
 
+mod macro_ident_from_call_site {
+    fn before() {}
+
+    // The ident of a macro-generated item can come from the macro call site while the rest of
+    // the item comes from the macro definition. Combining the two produced a nonsensical span
+    // for the "the attribute applies to this item" label (same root cause as #14968).
+    //~v empty_line_after_outer_attr
+    crate::macro_ident_from_call_site::macros::mac! {
+        {
+            #[allow(dead_code)]
+            #[allow(unused)]
+        }
+        some_function_name
+    }
+
+    mod macros {
+        macro_rules! mac_impl {
+            ({$($attr:tt)*} $name:ident) => {
+                $($attr)*
+                fn $name() {}
+            };
+        }
+        pub(crate) use mac_impl as mac;
+    }
+}
+
 fn main() {}

--- a/tests/ui/empty_line_after/outer_attribute.rs
+++ b/tests/ui/empty_line_after/outer_attribute.rs
@@ -127,4 +127,31 @@ mod issue_14980 {
     }
 }
 
+mod macro_ident_from_call_site {
+    fn before() {}
+
+    // The ident of a macro-generated item can come from the macro call site while the rest of
+    // the item comes from the macro definition. Combining the two produced a nonsensical span
+    // for the "the attribute applies to this item" label (same root cause as #14968).
+    //~v empty_line_after_outer_attr
+    crate::macro_ident_from_call_site::macros::mac! {
+        {
+            #[allow(dead_code)]
+
+            #[allow(unused)]
+        }
+        some_function_name
+    }
+
+    mod macros {
+        macro_rules! mac_impl {
+            ({$($attr:tt)*} $name:ident) => {
+                $($attr)*
+                fn $name() {}
+            };
+        }
+        pub(crate) use mac_impl as mac;
+    }
+}
+
 fn main() {}

--- a/tests/ui/empty_line_after/outer_attribute.stderr
+++ b/tests/ui/empty_line_after/outer_attribute.stderr
@@ -122,5 +122,17 @@ LL |       enum Aligned {
    |
    = help: if the empty line is unintentional, remove it
 
-error: aborting due to 10 previous errors
+error: empty line after outer attribute
+  --> tests/ui/empty_line_after/outer_attribute.rs:139:13
+   |
+LL | /             #[allow(dead_code)]
+LL | |
+   | |_^
+...
+LL |                   fn $name() {}
+   |                   ------------- the attribute applies to this function
+   |
+   = help: if the empty line is unintentional, remove it
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/redundant_pub_crate.fixed
+++ b/tests/ui/redundant_pub_crate.fixed
@@ -154,4 +154,23 @@ proc_macros::external! {
     }
 }
 
+// Regression test for <https://github.com/rust-lang/rust-clippy/issues/14968>: the ident of a
+// macro-generated item can come from the macro call site while the rest of the item comes from the
+// macro definition. Combining the two produced a nonsensical span crashing the diagnostic emitter.
+mod issue_14968 {
+    mod inner {
+        crate::issue_14968::macros::mac!(some_function_name);
+    }
+
+    mod macros {
+        macro_rules! mac_impl {
+            ($name:ident) => {
+                pub fn $name() {}
+                //~^ redundant_pub_crate
+            };
+        }
+        pub(crate) use mac_impl as mac;
+    }
+}
+
 fn main() {}

--- a/tests/ui/redundant_pub_crate.rs
+++ b/tests/ui/redundant_pub_crate.rs
@@ -154,4 +154,23 @@ proc_macros::external! {
     }
 }
 
+// Regression test for <https://github.com/rust-lang/rust-clippy/issues/14968>: the ident of a
+// macro-generated item can come from the macro call site while the rest of the item comes from the
+// macro definition. Combining the two produced a nonsensical span crashing the diagnostic emitter.
+mod issue_14968 {
+    mod inner {
+        crate::issue_14968::macros::mac!(some_function_name);
+    }
+
+    mod macros {
+        macro_rules! mac_impl {
+            ($name:ident) => {
+                pub(crate) fn $name() {}
+                //~^ redundant_pub_crate
+            };
+        }
+        pub(crate) use mac_impl as mac;
+    }
+}
+
 fn main() {}

--- a/tests/ui/redundant_pub_crate.stderr
+++ b/tests/ui/redundant_pub_crate.stderr
@@ -145,5 +145,18 @@ LL |     pub(crate) use m5_1::{*};
    |     |
    |     help: consider using: `pub`
 
-error: aborting due to 18 previous errors
+error: pub(crate) function inside private module
+  --> tests/ui/redundant_pub_crate.rs:168:17
+   |
+LL |         crate::issue_14968::macros::mac!(some_function_name);
+   |         ---------------------------------------------------- in this macro invocation
+...
+LL |                 pub(crate) fn $name() {}
+   |                 ----------^^^^^^^^^^^^^^
+   |                 |
+   |                 help: consider using: `pub`
+   |
+   = note: this error originates in the macro `crate::issue_14968::macros::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#14968

When an item is generated by a macro, its ident's span can come from a
different location than the rest of the item — typically the ident is a
macro argument (so its span points at the call site) while the item's other
tokens come from the macro definition. In that case
`item.span.with_hi(ident.span.hi())` combines positions from two unrelated
locations, and since `Span::new` silently swaps inverted bounds, the result
is a span stretching across arbitrary unrelated code. On the toolchain from
the issue report this crashed the diagnostic emitter; on current toolchains
it renders as garbage, e.g. on master:

```
warning: pub(crate) function inside private module
  |
 6 |       crate::macros::mac!(some_function_name);
  |  _____--------------------------------------^
  | |     |
  | |     in this macro invocation
 7 | | }
...
12 | |             pub(crate) fn $name() {}
  | |            ^---------- help: consider using: `pub`
  | |____________|
```

`empty_line_after_outer_attr`/`empty_line_after_doc_comments` had the same
pattern for the "the attribute applies to this item" label, reachable when
user-written attributes are passed through a local macro.

The fix only truncates the item span to the ident when the ident's span is
actually contained in it, extracted into a shared
`clippy_utils::source::span_up_to_ident` helper. I checked the remaining
ident-splice sites (`module_style`, `empty_with_brackets`,
`no_mangle_with_rust_abi`, and several expression-internal ones): they all
guard with `from_expansion()` checks or operate on same-node spans, so they
can't hit this.

Note on the ICE itself: the panic site from the issue's backtrace
(`HumanEmitter::render_source_line`) was removed when the human emitter was
replaced by the `annotate-snippets` renderer. I confirmed empirically (by
building pre-fix Clippy against the debug-assertions "alt" CI toolchain for
the same commit as the pinned nightly) that the ICE no longer triggers on
current rustc — the malformed span is the surviving defect and is what the
UI tests pin.

changelog: [`redundant_pub_crate`], [`empty_line_after_outer_attr`], [`empty_line_after_doc_comments`]: fix nonsensical spans in diagnostics for macro-generated items, which could crash the diagnostic emitter