### PR TITLE
fix: fix false positives on duplicated_attributes

### DIFF
--- a/clippy_lints/src/attrs/duplicated_attributes.rs
+++ b/clippy_lints/src/attrs/duplicated_attributes.rs
@@ -1,6 +1,6 @@
 use super::DUPLICATED_ATTRIBUTES;
+use super::utils::is_lint_level;
 use clippy_utils::diagnostics::span_lint_and_then;
-use itertools::Itertools as _;
 use rustc_ast::{Attribute, MetaItem};
 use rustc_ast_pretty::pprust::path_to_string;
 use rustc_data_structures::fx::FxHashMap;
@@ -8,74 +8,69 @@ use rustc_lint::EarlyContext;
 use rustc_span::{Span, Symbol, sym};
 use std::collections::hash_map::Entry;
 
+#[derive(Clone, Copy)]
+enum Context {
+    /// The meta item is an entire attribute.
+    Attribute,
+    /// The meta item is an argument of the lint level attribute `level`,
+    /// e.g. a lint name or `reason = "..."`.
+    LintName { level: Symbol },
+}
+
 fn emit_if_duplicated(
     cx: &EarlyContext<'_>,
-    attr: &MetaItem,
-    attr_paths: &mut FxHashMap<String, Span>,
+    meta: &MetaItem,
+    seen: &mut FxHashMap<String, Span>,
     complete_path: String,
 ) {
-    match attr_paths.entry(complete_path) {
+    match seen.entry(complete_path) {
         Entry::Vacant(v) => {
-            v.insert(attr.span);
+            v.insert(meta.span);
         },
         Entry::Occupied(o) => {
-            span_lint_and_then(cx, DUPLICATED_ATTRIBUTES, attr.span, "duplicated attribute", |diag| {
+            span_lint_and_then(cx, DUPLICATED_ATTRIBUTES, meta.span, "duplicated attribute", |diag| {
                 diag.span_note(*o.get(), "first defined here");
-                diag.span_help(attr.span, "remove this attribute");
+                diag.span_help(meta.span, "remove this attribute");
             });
         },
     }
 }
 
-fn check_duplicated_attr(
-    cx: &EarlyContext<'_>,
-    attr: &MetaItem,
-    attr_paths: &mut FxHashMap<String, Span>,
-    parent: &mut Vec<Symbol>,
-) {
-    if attr.span.from_expansion() {
+fn check_duplicated_attr(cx: &EarlyContext<'_>, meta: &MetaItem, seen: &mut FxHashMap<String, Span>, ctx: Context) {
+    if meta.span.from_expansion() {
         return;
     }
-    let attr_path = if let Some(ident) = attr.ident() {
-        ident.name
-    } else {
-        Symbol::intern(&path_to_string(&attr.path))
-    };
-    if let Some(ident) = attr.ident() {
-        let name = ident.name;
-        if name == sym::doc || name == sym::rustc_on_unimplemented || name == sym::reason {
-            // FIXME: Would be nice to handle `cfg_attr` as well. Only problem is to check that cfg
-            // conditions are the same.
-            // `#[rustc_on_unimplemented]` contains duplicated subattributes, that's expected.
-            return;
-        }
-    }
-    if let Some(value) = attr.value_str() {
-        emit_if_duplicated(
-            cx,
-            attr,
-            attr_paths,
-            format!("{}:{attr_path}={value}", parent.iter().join(":")),
-        );
-    } else if let Some(sub_attrs) = attr.meta_item_list() {
-        parent.push(attr_path);
-        for sub_attr in sub_attrs {
-            if let Some(meta) = sub_attr.meta_item() {
-                check_duplicated_attr(cx, meta, attr_paths, parent);
+    match ctx {
+        Context::Attribute => {
+            // Only attributes whose semantics are known here are checked, currently these
+            // are the lint level attributes, whose arguments are independent lint names.
+            if let Some(ident) = meta.ident()
+                && is_lint_level(ident.name)
+                && let Some(items) = meta.meta_item_list()
+            {
+                for item in items {
+                    if let Some(item) = item.meta_item() {
+                        check_duplicated_attr(cx, item, seen, Context::LintName { level: ident.name });
+                    }
+                }
             }
-        }
-        parent.pop();
-    } else {
-        emit_if_duplicated(cx, attr, attr_paths, format!("{}:{attr_path}", parent.iter().join(":")));
+        },
+        Context::LintName { level } => {
+            // Multiple lint level attributes may share the same `reason`
+            if meta.has_name(sym::reason) {
+                return;
+            }
+            emit_if_duplicated(cx, meta, seen, format!("{level}:{}", path_to_string(&meta.path)));
+        },
     }
 }
 
 pub fn check(cx: &EarlyContext<'_>, attrs: &[Attribute]) {
-    let mut attr_paths = FxHashMap::default();
+    let mut seen = FxHashMap::default();
 
     for attr in attrs {
         if let Some(meta) = attr.meta() {
-            check_duplicated_attr(cx, &meta, &mut attr_paths, &mut Vec::new());
+            check_duplicated_attr(cx, &meta, &mut seen, Context::Attribute);
         }
     }
 }

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -186,9 +186,12 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for attributes that appear two or more times.
     ///
+    /// Only lint-level attributes are checked, as other attributes'
+    /// (e.g. proc-macro attributes) repetition can have a meaning.
+    ///
     /// ### Why is this bad?
-    /// Repeating an attribute on the same item (or globally on the same crate)
-    /// is unnecessary and doesn't have an effect.
+    /// Naming a lint repeatedly on the same item (or globally on the same
+    /// crate) is unnecessary and doesn't have an effect.
     ///
     /// ### Example
     /// ```no_run

--- a/tests/ui/auxiliary/proc_macro_attr.rs
+++ b/tests/ui/auxiliary/proc_macro_attr.rs
@@ -239,3 +239,8 @@ pub fn duplicated_attr(_attr: TokenStream, input: TokenStream) -> TokenStream {
     }
     .into()
 }
+
+#[proc_macro_derive(DerivedAttrs, attributes(attr))]
+pub fn derived_attrs(_input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/tests/ui/duplicated_attributes.rs
+++ b/tests/ui/duplicated_attributes.rs
@@ -31,4 +31,33 @@ fn babar() {}
 #[allow(exported_private_dependencies, reason = "library for internal use only")]
 fn duplicate_reason() {}
 
+#[allow(dead_code)]
+#[allow(dead_code, unused_variables)] //~ duplicated_attributes
+fn overlapping_lint_lists() {}
+
+// https://github.com/rust-lang/rust-clippy/issues/13238
+#[derive(proc_macro_attr::DerivedAttrs)]
+#[attr(
+    status(code = 400, description = "bad request"),
+    status(code = 400, description = "also bad request")
+)] // Should not warn!
+enum ErrorResponse {
+    A,
+    B,
+}
+
+// Even though these two are identical, only the proc-macro knows
+// if repeating its helper attribute is meaningful, so don't warn.
+#[derive(proc_macro_attr::DerivedAttrs)]
+#[attr(status(code = 400))]
+#[attr(status(code = 400))] // Should not warn!
+struct IdenticalInvocations {
+    field: u8,
+}
+
+// Attributes expanded from an enabled cfg_attr are checked like regular ones.
+#[allow(dead_code)]
+#[cfg_attr(all(), allow(dead_code))] //~ duplicated_attributes
+fn through_cfg_attr() {}
+
 fn main() {}

--- a/tests/ui/duplicated_attributes.stderr
+++ b/tests/ui/duplicated_attributes.stderr
@@ -51,5 +51,39 @@ help: remove this attribute
 LL | #[allow(dead_code)]
    |         ^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: duplicated attribute
+  --> tests/ui/duplicated_attributes.rs:35:9
+   |
+LL | #[allow(dead_code, unused_variables)]
+   |         ^^^^^^^^^
+   |
+note: first defined here
+  --> tests/ui/duplicated_attributes.rs:34:9
+   |
+LL | #[allow(dead_code)]
+   |         ^^^^^^^^^
+help: remove this attribute
+  --> tests/ui/duplicated_attributes.rs:35:9
+   |
+LL | #[allow(dead_code, unused_variables)]
+   |         ^^^^^^^^^
+
+error: duplicated attribute
+  --> tests/ui/duplicated_attributes.rs:60:25
+   |
+LL | #[cfg_attr(all(), allow(dead_code))]
+   |                         ^^^^^^^^^
+   |
+note: first defined here
+  --> tests/ui/duplicated_attributes.rs:59:9
+   |
+LL | #[allow(dead_code)]
+   |         ^^^^^^^^^
+help: remove this attribute
+  --> tests/ui/duplicated_attributes.rs:60:25
+   |
+LL | #[cfg_attr(all(), allow(dead_code))]
+   |                         ^^^^^^^^^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/13238 and https://github.com/rust-lang/rust-clippy/issues/12923

Previously, PR https://github.com/rust-lang/rust-clippy/issues/13355 (partly) addressed similar issues, @kpreid identified the cause, I hope this fix matches the intention outlined there.

changelog: Limit duplicated_attribute to lint-level attributes to reduce false positives and overlaps with rustc
