### PR TITLE
fix imprecise flops lint in const contexts

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic/mod.rs
+++ b/clippy_lints/src/floating_point_arithmetic/mod.rs
@@ -1,7 +1,9 @@
+use clippy_config::Conf;
+use clippy_utils::msrvs::Msrv;
 use clippy_utils::res::{MaybeDef as _, MaybeTypeckRes as _};
-use clippy_utils::{is_in_const_context, is_no_std_crate, sym};
+use clippy_utils::{is_in_const_context, is_no_std_crate, msrvs, sym};
 use rustc_hir::{Expr, ExprKind};
-use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
+use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
 
 mod custom_abs;
 mod expm1;
@@ -102,12 +104,26 @@ declare_clippy_lint! {
     "usage of sub-optimal floating point operations"
 }
 
-declare_lint_pass!(FloatingPointArithmetic => [IMPRECISE_FLOPS, SUBOPTIMAL_FLOPS]);
+impl_lint_pass!(FloatingPointArithmetic => [IMPRECISE_FLOPS, SUBOPTIMAL_FLOPS]);
+
+pub struct FloatingPointArithmetic {
+    msrv: Msrv,
+}
+
+impl FloatingPointArithmetic {
+    pub fn new(conf: &Conf) -> Self {
+        Self { msrv: conf.msrv.into() }
+    }
+}
 
 impl<'tcx> LateLintPass<'tcx> for FloatingPointArithmetic {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        // All of these operations are currently not const and are in std.
         if is_in_const_context(cx) {
+            // `mul_add` became const-stable in Rust 1.94. Other operations in
+            // this lint are still not available in const contexts.
+            if self.msrv.meets(cx, msrvs::CONST_FLOAT_MUL_ADD) {
+                mul_add::check(cx, expr);
+            }
             return;
         }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -692,7 +692,7 @@ rustc_lint::late_lint_methods!(
         ToDigitIsSome: to_digit_is_some::ToDigitIsSome = to_digit_is_some::ToDigitIsSome::new(conf),
         LargeStackArrays: large_stack_arrays::LargeStackArrays = large_stack_arrays::LargeStackArrays::new(conf),
         LargeConstArrays: large_const_arrays::LargeConstArrays = large_const_arrays::LargeConstArrays::new(conf),
-        FloatingPointArithmetic: floating_point_arithmetic::FloatingPointArithmetic = floating_point_arithmetic::FloatingPointArithmetic,
+        FloatingPointArithmetic: floating_point_arithmetic::FloatingPointArithmetic = floating_point_arithmetic::FloatingPointArithmetic::new(conf),
         AsConversions: as_conversions::AsConversions = as_conversions::AsConversions,
         LetUnderscore: let_underscore::LetUnderscore = let_underscore::LetUnderscore,
         ExcessiveBools: excessive_bools::ExcessiveBools = excessive_bools::ExcessiveBools::new(conf),

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -26,7 +26,7 @@ macro_rules! msrv_aliases {
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
     1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
-    1,94,0 { EULER_GAMMA, GOLDEN_RATIO }
+    1,94,0 { CONST_FLOAT_MUL_ADD, EULER_GAMMA, GOLDEN_RATIO }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }
     1,91,0 { DURATION_FROM_MINUTES_HOURS }
     1,89,0 { NONNULL_FROM_MUT }

--- a/tests/ui/floating_point_mul_add.fixed
+++ b/tests/ui/floating_point_mul_add.fixed
@@ -1,6 +1,7 @@
 #![warn(clippy::suboptimal_flops)]
 
 /// Allow suboptimal_ops in constant context
+#[clippy::msrv = "1.93"]
 pub const fn in_const_context() {
     let a: f64 = 1234.567;
     let b: f64 = 45.67834;
@@ -8,6 +9,18 @@ pub const fn in_const_context() {
 
     let _ = a * b + c;
     let _ = c + a * b;
+}
+
+#[clippy::msrv = "1.94"]
+const fn in_const_context_with_mul_add() {
+    let a: f64 = 1234.567;
+    let b: f64 = 45.67834;
+    let c: f64 = 0.0004;
+
+    let _ = a.mul_add(b, c);
+    //~^ suboptimal_flops
+    let _ = a.mul_add(b, c);
+    //~^ suboptimal_flops
 }
 
 fn main() {

--- a/tests/ui/floating_point_mul_add.rs
+++ b/tests/ui/floating_point_mul_add.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::suboptimal_flops)]
 
 /// Allow suboptimal_ops in constant context
+#[clippy::msrv = "1.93"]
 pub const fn in_const_context() {
     let a: f64 = 1234.567;
     let b: f64 = 45.67834;
@@ -8,6 +9,18 @@ pub const fn in_const_context() {
 
     let _ = a * b + c;
     let _ = c + a * b;
+}
+
+#[clippy::msrv = "1.94"]
+const fn in_const_context_with_mul_add() {
+    let a: f64 = 1234.567;
+    let b: f64 = 45.67834;
+    let c: f64 = 0.0004;
+
+    let _ = a * b + c;
+    //~^ suboptimal_flops
+    let _ = c + a * b;
+    //~^ suboptimal_flops
 }
 
 fn main() {

--- a/tests/ui/floating_point_mul_add.stderr
+++ b/tests/ui/floating_point_mul_add.stderr
@@ -1,5 +1,5 @@
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:19:13
+  --> tests/ui/floating_point_mul_add.rs:20:13
    |
 LL |     let _ = a * b + c;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
@@ -9,121 +9,115 @@ LL |     let _ = a * b + c;
    = help: to override `-D warnings` add `#[allow(clippy::suboptimal_flops)]`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:21:13
-   |
-LL |     let _ = a * b - c;
-   |             ^^^^^^^^^ help: consider using: `a.mul_add(b, -c)`
-
-error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:23:13
+  --> tests/ui/floating_point_mul_add.rs:22:13
    |
 LL |     let _ = c + a * b;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:25:13
+  --> tests/ui/floating_point_mul_add.rs:32:13
+   |
+LL |     let _ = a * b + c;
+   |             ^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:34:13
+   |
+LL |     let _ = a * b - c;
+   |             ^^^^^^^^^ help: consider using: `a.mul_add(b, -c)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:36:13
+   |
+LL |     let _ = c + a * b;
+   |             ^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:38:13
    |
 LL |     let _ = c - a * b;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(-b, c)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:27:13
+  --> tests/ui/floating_point_mul_add.rs:40:13
    |
 LL |     let _ = a + 2.0 * 4.0;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4.0, a)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:29:13
+  --> tests/ui/floating_point_mul_add.rs:42:13
    |
 LL |     let _ = a + 2. * 4.;
    |             ^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4., a)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:32:13
+  --> tests/ui/floating_point_mul_add.rs:45:13
    |
 LL |     let _ = (a * b) + c;
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:34:13
+  --> tests/ui/floating_point_mul_add.rs:47:13
    |
 LL |     let _ = c + (a * b);
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:36:13
+  --> tests/ui/floating_point_mul_add.rs:49:13
    |
 LL |     let _ = a * b * c + d;
    |             ^^^^^^^^^^^^^ help: consider using: `(a * b).mul_add(c, d)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:39:13
+  --> tests/ui/floating_point_mul_add.rs:52:13
    |
 LL |     let _ = a.mul_add(b, c) * a.mul_add(b, c) + a.mul_add(b, c) + c;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `a.mul_add(b, c).mul_add(a.mul_add(b, c), a.mul_add(b, c))`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:41:13
+  --> tests/ui/floating_point_mul_add.rs:54:13
    |
 LL |     let _ = 1234.567_f64 * 45.67834_f64 + 0.0004_f64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1234.567_f64.mul_add(45.67834_f64, 0.0004_f64)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:44:13
+  --> tests/ui/floating_point_mul_add.rs:57:13
    |
 LL |     let _ = (a * a + b).sqrt();
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(a, b)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:48:13
+  --> tests/ui/floating_point_mul_add.rs:61:13
    |
 LL |     let _ = a - (b * u as f64);
    |             ^^^^^^^^^^^^^^^^^^ help: consider using: `b.mul_add(-(u as f64), a)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:75:13
+  --> tests/ui/floating_point_mul_add.rs:88:13
    |
 LL |     let _ = x * 2.0 + 0.5;
    |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 2.0, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:79:13
+  --> tests/ui/floating_point_mul_add.rs:92:13
    |
 LL |     let _ = 0.5 + x * 2.0;
    |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 2.0, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:81:13
+  --> tests/ui/floating_point_mul_add.rs:94:13
    |
 LL |     let _ = 0.5 + x * 1.2;
    |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:83:13
+  --> tests/ui/floating_point_mul_add.rs:96:13
    |
 LL |     let _ = 1.2 + x * 1.2;
    |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 1.2)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:87:13
-   |
-LL |     let _ = 0.5 + x * 1.2;
-   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
-
-error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:91:13
-   |
-LL |     let _ = 0.5 + x * 1.2;
-   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
-
-error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:95:13
-   |
-LL |     let _ = 0.5 + x * 1.2;
-   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
-
-error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:99:13
+  --> tests/ui/floating_point_mul_add.rs:100:13
    |
 LL |     let _ = 0.5 + x * 1.2;
    |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
@@ -131,104 +125,122 @@ LL |     let _ = 0.5 + x * 1.2;
 error: multiply and add expressions may be calculated more efficiently and accurately
   --> tests/ui/floating_point_mul_add.rs:104:13
    |
-LL |     let _ = 0.5 + f() * 1.2;
-   |             ^^^^^^^^^^^^^^^ help: consider using: `f64::mul_add(f(), 1.2, 0.5)`
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:107:13
+  --> tests/ui/floating_point_mul_add.rs:108:13
    |
 LL |     let _ = 0.5 + x * 1.2;
    |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:113:13
+  --> tests/ui/floating_point_mul_add.rs:112:13
+   |
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:117:13
+   |
+LL |     let _ = 0.5 + f() * 1.2;
+   |             ^^^^^^^^^^^^^^^ help: consider using: `f64::mul_add(f(), 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:120:13
+   |
+LL |     let _ = 0.5 + x * 1.2;
+   |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(x, 1.2, 0.5)`
+
+error: multiply and add expressions may be calculated more efficiently and accurately
+  --> tests/ui/floating_point_mul_add.rs:126:13
    |
 LL |     let _ = 0.5 + z * 1.2;
    |             ^^^^^^^^^^^^^ help: consider using: `f64::mul_add(z, 1.2, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:116:13
+  --> tests/ui/floating_point_mul_add.rs:129:13
    |
 LL |     let _ = 0.5 + 2.0 * x;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(x, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:118:13
+  --> tests/ui/floating_point_mul_add.rs:131:13
    |
 LL |     let _ = 2.0 * x + 0.5;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(x, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:121:13
+  --> tests/ui/floating_point_mul_add.rs:134:13
    |
 LL |     let _ = x + 2.0 * 4.0;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4.0, x)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:125:13
+  --> tests/ui/floating_point_mul_add.rs:138:13
    |
 LL |     let _ = y * 2.0 + 0.5;
    |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(2.0, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:127:13
+  --> tests/ui/floating_point_mul_add.rs:140:13
    |
 LL |     let _ = 1.0 * 2.0 + 0.5;
    |             ^^^^^^^^^^^^^^^ help: consider using: `1.0f64.mul_add(2.0, 0.5)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:136:5
+  --> tests/ui/floating_point_mul_add.rs:149:5
    |
 LL |     a += b * c;
    |     ^^^^^^^^^^ help: consider using: `a = b.mul_add(c, a)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:139:5
+  --> tests/ui/floating_point_mul_add.rs:152:5
    |
 LL |     a -= b * c;
    |     ^^^^^^^^^^ help: consider using: `a = b.mul_add(-c, a)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:148:13
+  --> tests/ui/floating_point_mul_add.rs:161:13
    |
 LL |     let _ = 1.0 - y * 0.3;
    |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(-0.3, 1.0)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:153:13
+  --> tests/ui/floating_point_mul_add.rs:166:13
    |
 LL |     let _ = 1.0 - y * 0.3;
    |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(-0.3, 1.0)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:158:13
+  --> tests/ui/floating_point_mul_add.rs:171:13
    |
 LL |     let _ = 1.0 - y * 0.3;
    |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(-0.3, 1.0)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:164:13
+  --> tests/ui/floating_point_mul_add.rs:177:13
    |
 LL |     let _ = 1.0 - y * 0.3;
    |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(-0.3, 1.0)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:170:13
+  --> tests/ui/floating_point_mul_add.rs:183:13
    |
 LL |     let _ = x + y * z;
    |             ^^^^^^^^^ help: consider using: `f32::mul_add(y, z, x)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:172:13
+  --> tests/ui/floating_point_mul_add.rs:185:13
    |
 LL |     let _ = y * z + x;
    |             ^^^^^^^^^ help: consider using: `f32::mul_add(y, z, x)`
 
 error: multiply and add expressions may be calculated more efficiently and accurately
-  --> tests/ui/floating_point_mul_add.rs:176:13
+  --> tests/ui/floating_point_mul_add.rs:189:13
    |
 LL |     let _ = y + a * z;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(z, y)`
 
-error: aborting due to 38 previous errors
+error: aborting due to 40 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17606

The floating-point arithmetic lints currently skip all expressions in const contexts. `f32::mul_add` and `f64::mul_add` became const-stable in Rust 1.94, so `suboptimal_flops` should also check these expressions when the configured MSRV permits it.

This change:

- keeps the existing behavior for operations that are not const-stable;
- runs the `mul_add` check in const contexts when the configured MSRV is at least 1.94;
- adds regression tests for the MSRV 1.93 and 1.94 boundary.

Tests:

- `cargo dev fmt --check`
- `TESTNAME=floating_point_mul_add.rs cargo test --features internal --test compile-test`
- `cargo test --features internal`

Development note: an LLM was used privately to help inspect the existing code and review feedback. The patch was checked against the surrounding Clippy implementation and validated with the tests listed above.

changelog: [`suboptimal_flops`]: lint [`mul_add`] opportunities in const contexts
