### PR TITLE
Fix  suggestions for borrowed fields

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -39,6 +39,7 @@ extern crate rustc_lint;
 extern crate rustc_middle;
 extern crate rustc_parse_format;
 extern crate rustc_resolve;
+extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_structures;
 extern crate rustc_target;

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -106,17 +106,17 @@ enum UnwrappableKind {
 }
 
 impl UnwrappableKind {
-    fn success_variant_pattern(self) -> &'static str {
+    fn success_variant_pattern(self, binding_prefix: &str) -> String {
         match self {
-            UnwrappableKind::Option => "Some(<item>)",
-            UnwrappableKind::Result => "Ok(<item>)",
+            UnwrappableKind::Option => format!("Some({binding_prefix}<item>)"),
+            UnwrappableKind::Result => format!("Ok({binding_prefix}<item>)"),
         }
     }
 
-    fn error_variant_pattern(self) -> &'static str {
+    fn error_variant_pattern(self, binding_prefix: &str) -> String {
         match self {
-            UnwrappableKind::Option => "None",
-            UnwrappableKind::Result => "Err(<item>)",
+            UnwrappableKind::Option => "None".to_string(),
+            UnwrappableKind::Result => format!("Err({binding_prefix}<item>)"),
         }
     }
 }
@@ -465,20 +465,26 @@ impl<'tcx> Visitor<'tcx> for UnwrappableVariablesVisitor<'_, 'tcx> {
                         ),
                         |diag| {
                             if unwrappable.is_entire_condition {
+                                // For field access, borrowing the scrutinee (`&self.field`) can keep the borrow alive
+                                // after the `if` under legacy borrow checking, conflicting with a later mutation
+                                // (#16182). A `ref` or `ref mut` binding instead
+                                // borrows only the matched field value.
+                                let (binding_prefix, borrow_prefix) = match (as_ref_kind, &unwrappable.local) {
+                                    (Some(AsRefKind::AsRef), Local::WithFieldAccess { .. }) => ("ref ", ""),
+                                    (Some(AsRefKind::AsMut), Local::WithFieldAccess { .. }) => ("ref mut ", ""),
+                                    (Some(AsRefKind::AsRef), _) => ("", "&"),
+                                    (Some(AsRefKind::AsMut), _) => ("", "&mut "),
+                                    (None, _) => ("", ""),
+                                };
                                 diag.span_suggestion(
                                     unwrappable.check.span.with_lo(unwrappable.if_expr.span.lo()),
                                     "try",
                                     format!(
                                         "if let {suggested_pattern} = {borrow_prefix}{unwrappable_variable_str}",
                                         suggested_pattern = if call_to_unwrap {
-                                            unwrappable.kind.success_variant_pattern()
+                                            unwrappable.kind.success_variant_pattern(binding_prefix)
                                         } else {
-                                            unwrappable.kind.error_variant_pattern()
-                                        },
-                                        borrow_prefix = match as_ref_kind {
-                                            Some(AsRefKind::AsRef) => "&",
-                                            Some(AsRefKind::AsMut) => "&mut ",
-                                            None => "",
+                                            unwrappable.kind.error_variant_pattern(binding_prefix)
                                         },
                                     ),
                                     // We don't track how the unwrapped value is used inside the

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -18,6 +18,7 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::hir::place::ProjectionKind;
 use rustc_middle::mir::FakeReadCause;
 use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_session::config::Polonius;
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Span, Symbol};
 
@@ -465,15 +466,22 @@ impl<'tcx> Visitor<'tcx> for UnwrappableVariablesVisitor<'_, 'tcx> {
                         ),
                         |diag| {
                             if unwrappable.is_entire_condition {
-                                // For field access, borrowing the scrutinee (`&self.field`) can keep the borrow alive
-                                // after the `if` under legacy borrow checking, conflicting with a later mutation
-                                // (#16182). A `ref` or `ref mut` binding instead
-                                // borrows only the matched field value.
-                                let (binding_prefix, borrow_prefix) = match (as_ref_kind, &unwrappable.local) {
-                                    (Some(AsRefKind::AsRef), Local::WithFieldAccess { .. }) => ("ref ", ""),
-                                    (Some(AsRefKind::AsMut), Local::WithFieldAccess { .. }) => ("ref mut ", ""),
-                                    (Some(AsRefKind::AsRef), _) => ("", "&"),
-                                    (Some(AsRefKind::AsMut), _) => ("", "&mut "),
+                                // For field access, borrowing the scrutinee (`&self.field`) evaluates the
+                                // borrow before the match, which under NLL can keep it alive after the `if`
+                                // and conflict with a later mutation (#16182). A `ref` or `ref mut` binding
+                                // instead borrows only the matched field value, which both borrow checkers
+                                // accept. Polonius does not have that limitation, so it keeps the more
+                                // idiomatic match ergonomics form. This special case can be dropped once
+                                // polonius is enabled everywhere.
+                                let polonius_enabled =
+                                    !matches!(self.cx.tcx.sess.opts.unstable_opts.polonius, Polonius::Off);
+                                let use_ref_binding =
+                                    !polonius_enabled && matches!(unwrappable.local, Local::WithFieldAccess { .. });
+                                let (binding_prefix, borrow_prefix) = match (as_ref_kind, use_ref_binding) {
+                                    (Some(AsRefKind::AsRef), true) => ("ref ", ""),
+                                    (Some(AsRefKind::AsMut), true) => ("ref mut ", ""),
+                                    (Some(AsRefKind::AsRef), false) => ("", "&"),
+                                    (Some(AsRefKind::AsMut), false) => ("", "&mut "),
                                     (None, _) => ("", ""),
                                 };
                                 diag.span_suggestion(

--- a/tests/ui/checked_unwrap/simple_conditionals.rs
+++ b/tests/ui/checked_unwrap/simple_conditionals.rs
@@ -473,7 +473,7 @@ fn issue15321() {
         topt.0.unwrap();
         //~^ unnecessary_unwrap
     }
-    // This is fine though, as `if let Some(ref o) = topt.0` won't (partially) move `topt`
+    // This is fine though, as `if let Some(o) = &topt.0` won't (partially) move `topt`
     if topt.0.is_some() {
         borrow_toption(&topt);
         topt.0.as_ref().unwrap();
@@ -548,21 +548,21 @@ mod issue16182 {
         }
 
         fn suggested_option_ref(&mut self) -> &String {
-            if let Some(ref value) = self.option {
+            if let Some(value) = &self.option {
                 return value;
             }
             self.option.insert(String::new())
         }
 
         fn suggested_option_mut(&mut self) -> &mut String {
-            if let Some(ref mut value) = self.option {
+            if let Some(value) = &mut self.option {
                 return value;
             }
             self.option.insert(String::new())
         }
 
         fn suggested_result_ok(&mut self) -> &String {
-            if let Ok(ref value) = self.result {
+            if let Ok(value) = &self.result {
                 return value;
             }
             self.result = Ok(String::new());
@@ -573,7 +573,7 @@ mod issue16182 {
         }
 
         fn suggested_result_err(&mut self) -> &String {
-            if let Err(ref error) = self.result {
+            if let Err(error) = &self.result {
                 return error;
             }
             self.result = Err(String::new());

--- a/tests/ui/checked_unwrap/simple_conditionals.rs
+++ b/tests/ui/checked_unwrap/simple_conditionals.rs
@@ -408,6 +408,14 @@ fn issue15321() {
         sopt2.option.option.unwrap()
         //~^ panicking_unwrap
     };
+    // Lint nested field accesses through `as_ref()` as well
+    let _res = if sopt2.option.option.is_some() {
+        sopt2.option.option.as_ref().unwrap()
+        //~^ unnecessary_unwrap
+    } else {
+        sopt2.option.option.as_ref().unwrap()
+        //~^ panicking_unwrap
+    };
     // Lint: an unrelated outer field was mutated -- don't get confused by `Soption2.other` having the
     // same `FieldIdx` of 1 as `Soption.option`
     let _res = if sopt2.option.option.is_some() {
@@ -465,7 +473,7 @@ fn issue15321() {
         topt.0.unwrap();
         //~^ unnecessary_unwrap
     }
-    // This is fine though, as `if let Some(o) = &topt.0` won't (partially) move `topt`
+    // This is fine though, as `if let Some(ref o) = topt.0` won't (partially) move `topt`
     if topt.0.is_some() {
         borrow_toption(&topt);
         topt.0.as_ref().unwrap();
@@ -487,6 +495,91 @@ mod issue16188 {
             if self.value.is_none() {
                 self.value = Some(10);
                 print_value(self.value.unwrap());
+            }
+        }
+    }
+}
+
+mod issue16182 {
+    struct Wrapper {
+        option: Option<String>,
+        result: Result<String, String>,
+    }
+
+    impl Wrapper {
+        fn option_ref(&mut self) -> &String {
+            if self.option.is_some() {
+                return self.option.as_ref().unwrap();
+                //~^ unnecessary_unwrap
+            }
+            self.option.insert(String::new())
+        }
+
+        fn option_mut(&mut self) -> &mut String {
+            if self.option.is_some() {
+                return self.option.as_mut().unwrap();
+                //~^ unnecessary_unwrap
+            }
+            self.option.insert(String::new())
+        }
+
+        fn result_ok(&mut self) -> &String {
+            if self.result.is_ok() {
+                return self.result.as_ref().unwrap();
+                //~^ unnecessary_unwrap
+            }
+            self.result = Ok(String::new());
+            match &self.result {
+                Ok(value) => value,
+                Err(_) => unreachable!(),
+            }
+        }
+
+        fn result_err(&mut self) -> &String {
+            if self.result.is_err() {
+                return self.result.as_ref().unwrap_err();
+                //~^ unnecessary_unwrap
+            }
+            self.result = Err(String::new());
+            match &self.result {
+                Ok(_) => unreachable!(),
+                Err(error) => error,
+            }
+        }
+
+        fn suggested_option_ref(&mut self) -> &String {
+            if let Some(ref value) = self.option {
+                return value;
+            }
+            self.option.insert(String::new())
+        }
+
+        fn suggested_option_mut(&mut self) -> &mut String {
+            if let Some(ref mut value) = self.option {
+                return value;
+            }
+            self.option.insert(String::new())
+        }
+
+        fn suggested_result_ok(&mut self) -> &String {
+            if let Ok(ref value) = self.result {
+                return value;
+            }
+            self.result = Ok(String::new());
+            match &self.result {
+                Ok(value) => value,
+                Err(_) => unreachable!(),
+            }
+        }
+
+        fn suggested_result_err(&mut self) -> &String {
+            if let Err(ref error) = self.result {
+                return error;
+            }
+            self.result = Err(String::new());
+            match &self.result {
+                Ok(_) => unreachable!(),
+                Err(error) => error,
             }
         }
     }

--- a/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -451,7 +451,24 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `sopt2.option.option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:415:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:413:9
+   |
+LL |     let _res = if sopt2.option.option.is_some() {
+   |                -------------------------------- help: try: `if let Some(ref <item>) = sopt2.option.option`
+LL |         sopt2.option.option.as_ref().unwrap()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: this call to `unwrap()` will always panic
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:416:9
+   |
+LL |     let _res = if sopt2.option.option.is_some() {
+   |                   ----------------------------- because of this check
+...
+LL |         sopt2.option.option.as_ref().unwrap()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: called `unwrap` on `sopt2.option.option` after checking its variant with `is_some`
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:423:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                -------------------------------- help: try: `if let Some(<item>) = sopt2.option.option`
@@ -460,7 +477,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:419:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:427:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                   ----------------------------- because of this check
@@ -469,7 +486,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `sopt2.option.option` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:425:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:433:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                -------------------------------- help: try: `if let Some(<item>) = sopt2.option.option`
@@ -478,7 +495,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `unwrap()` will always panic
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:429:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:437:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
    |                   ----------------------------- because of this check
@@ -487,7 +504,7 @@ LL |         sopt2.option.option.unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `topt.0` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:465:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:473:9
    |
 LL |     if topt.0.is_some() {
    |     ------------------- help: try: `if let Some(<item>) = topt.0`
@@ -496,13 +513,45 @@ LL |         topt.0.unwrap();
    |         ^^^^^^^^^^^^^^^
 
 error: called `unwrap` on `topt.0` after checking its variant with `is_some`
-  --> tests/ui/checked_unwrap/simple_conditionals.rs:471:9
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:479:9
    |
 LL |     if topt.0.is_some() {
-   |     ------------------- help: try: `if let Some(<item>) = &topt.0`
+   |     ------------------- help: try: `if let Some(ref <item>) = topt.0`
 LL |         borrow_toption(&topt);
 LL |         topt.0.as_ref().unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 57 previous errors
+error: called `unwrap` on `self.option` after checking its variant with `is_some`
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:512:24
+   |
+LL |             if self.option.is_some() {
+   |             ------------------------ help: try: `if let Some(ref <item>) = self.option`
+LL |                 return self.option.as_ref().unwrap();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: called `unwrap` on `self.option` after checking its variant with `is_some`
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:520:24
+   |
+LL |             if self.option.is_some() {
+   |             ------------------------ help: try: `if let Some(ref mut <item>) = self.option`
+LL |                 return self.option.as_mut().unwrap();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: called `unwrap` on `self.result` after checking its variant with `is_ok`
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:528:24
+   |
+LL |             if self.result.is_ok() {
+   |             ---------------------- help: try: `if let Ok(ref <item>) = self.result`
+LL |                 return self.result.as_ref().unwrap();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: called `unwrap_err` on `self.result` after checking its variant with `is_err`
+  --> tests/ui/checked_unwrap/simple_conditionals.rs:540:24
+   |
+LL |             if self.result.is_err() {
+   |             ----------------------- help: try: `if let Err(ref <item>) = self.result`
+LL |                 return self.result.as_ref().unwrap_err();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 63 previous errors
 

--- a/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -454,7 +454,7 @@ error: called `unwrap` on `sopt2.option.option` after checking its variant with 
   --> tests/ui/checked_unwrap/simple_conditionals.rs:413:9
    |
 LL |     let _res = if sopt2.option.option.is_some() {
-   |                -------------------------------- help: try: `if let Some(ref <item>) = sopt2.option.option`
+   |                -------------------------------- help: try: `if let Some(<item>) = &sopt2.option.option`
 LL |         sopt2.option.option.as_ref().unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -516,7 +516,7 @@ error: called `unwrap` on `topt.0` after checking its variant with `is_some`
   --> tests/ui/checked_unwrap/simple_conditionals.rs:479:9
    |
 LL |     if topt.0.is_some() {
-   |     ------------------- help: try: `if let Some(ref <item>) = topt.0`
+   |     ------------------- help: try: `if let Some(<item>) = &topt.0`
 LL |         borrow_toption(&topt);
 LL |         topt.0.as_ref().unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -525,7 +525,7 @@ error: called `unwrap` on `self.option` after checking its variant with `is_some
   --> tests/ui/checked_unwrap/simple_conditionals.rs:512:24
    |
 LL |             if self.option.is_some() {
-   |             ------------------------ help: try: `if let Some(ref <item>) = self.option`
+   |             ------------------------ help: try: `if let Some(<item>) = &self.option`
 LL |                 return self.option.as_ref().unwrap();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -533,7 +533,7 @@ error: called `unwrap` on `self.option` after checking its variant with `is_some
   --> tests/ui/checked_unwrap/simple_conditionals.rs:520:24
    |
 LL |             if self.option.is_some() {
-   |             ------------------------ help: try: `if let Some(ref mut <item>) = self.option`
+   |             ------------------------ help: try: `if let Some(<item>) = &mut self.option`
 LL |                 return self.option.as_mut().unwrap();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -541,7 +541,7 @@ error: called `unwrap` on `self.result` after checking its variant with `is_ok`
   --> tests/ui/checked_unwrap/simple_conditionals.rs:528:24
    |
 LL |             if self.result.is_ok() {
-   |             ---------------------- help: try: `if let Ok(ref <item>) = self.result`
+   |             ---------------------- help: try: `if let Ok(<item>) = &self.result`
 LL |                 return self.result.as_ref().unwrap();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -549,7 +549,7 @@ error: called `unwrap_err` on `self.result` after checking its variant with `is_
   --> tests/ui/checked_unwrap/simple_conditionals.rs:540:24
    |
 LL |             if self.result.is_err() {
-   |             ----------------------- help: try: `if let Err(ref <item>) = self.result`
+   |             ----------------------- help: try: `if let Err(<item>) = &self.result`
 LL |                 return self.result.as_ref().unwrap_err();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/checked_unwrap/simple_conditionals_polonius_off.rs
+++ b/tests/ui/checked_unwrap/simple_conditionals_polonius_off.rs
@@ -1,0 +1,95 @@
+//@compile-flags: -Zpolonius=off
+//@no-rustfix: has placeholders
+#![warn(clippy::unnecessary_unwrap)]
+
+// Borrowing the scrutinee (`&self.field`) evaluates the borrow before the match, so under NLL it
+// can stay live past the `if` and conflict with a later mutation (#16182). With polonius disabled
+// the suggestion therefore falls back to a `ref`/`ref mut` binding, which borrows only the matched
+// field value. See `simple_conditionals.rs` for the polonius-enabled suggestions.
+
+mod issue16182 {
+    struct Wrapper {
+        option: Option<String>,
+        result: Result<String, String>,
+    }
+
+    impl Wrapper {
+        fn option_ref(&mut self) -> &String {
+            if self.option.is_some() {
+                return self.option.as_ref().unwrap();
+                //~^ unnecessary_unwrap
+            }
+            self.option.insert(String::new())
+        }
+
+        fn option_mut(&mut self) -> &mut String {
+            if self.option.is_some() {
+                return self.option.as_mut().unwrap();
+                //~^ unnecessary_unwrap
+            }
+            self.option.insert(String::new())
+        }
+
+        fn result_ok(&mut self) -> &String {
+            if self.result.is_ok() {
+                return self.result.as_ref().unwrap();
+                //~^ unnecessary_unwrap
+            }
+            self.result = Ok(String::new());
+            match &self.result {
+                Ok(value) => value,
+                Err(_) => unreachable!(),
+            }
+        }
+
+        fn result_err(&mut self) -> &String {
+            if self.result.is_err() {
+                return self.result.as_ref().unwrap_err();
+                //~^ unnecessary_unwrap
+            }
+            self.result = Err(String::new());
+            match &self.result {
+                Ok(_) => unreachable!(),
+                Err(error) => error,
+            }
+        }
+
+        fn suggested_option_ref(&mut self) -> &String {
+            if let Some(ref value) = self.option {
+                return value;
+            }
+            self.option.insert(String::new())
+        }
+
+        fn suggested_option_mut(&mut self) -> &mut String {
+            if let Some(ref mut value) = self.option {
+                return value;
+            }
+            self.option.insert(String::new())
+        }
+
+        fn suggested_result_ok(&mut self) -> &String {
+            if let Ok(ref value) = self.result {
+                return value;
+            }
+            self.result = Ok(String::new());
+            match &self.result {
+                Ok(value) => value,
+                Err(_) => unreachable!(),
+            }
+        }
+
+        fn suggested_result_err(&mut self) -> &String {
+            if let Err(ref error) = self.result {
+                return error;
+            }
+            self.result = Err(String::new());
+            match &self.result {
+                Ok(_) => unreachable!(),
+                Err(error) => error,
+            }
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/checked_unwrap/simple_conditionals_polonius_off.stderr
+++ b/tests/ui/checked_unwrap/simple_conditionals_polonius_off.stderr
@@ -1,0 +1,37 @@
+error: called `unwrap` on `self.option` after checking its variant with `is_some`
+  --> tests/ui/checked_unwrap/simple_conditionals_polonius_off.rs:19:24
+   |
+LL |             if self.option.is_some() {
+   |             ------------------------ help: try: `if let Some(ref <item>) = self.option`
+LL |                 return self.option.as_ref().unwrap();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::unnecessary-unwrap` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_unwrap)]`
+
+error: called `unwrap` on `self.option` after checking its variant with `is_some`
+  --> tests/ui/checked_unwrap/simple_conditionals_polonius_off.rs:27:24
+   |
+LL |             if self.option.is_some() {
+   |             ------------------------ help: try: `if let Some(ref mut <item>) = self.option`
+LL |                 return self.option.as_mut().unwrap();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: called `unwrap` on `self.result` after checking its variant with `is_ok`
+  --> tests/ui/checked_unwrap/simple_conditionals_polonius_off.rs:35:24
+   |
+LL |             if self.result.is_ok() {
+   |             ---------------------- help: try: `if let Ok(ref <item>) = self.result`
+LL |                 return self.result.as_ref().unwrap();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: called `unwrap_err` on `self.result` after checking its variant with `is_err`
+  --> tests/ui/checked_unwrap/simple_conditionals_polonius_off.rs:47:24
+   |
+LL |             if self.result.is_err() {
+   |             ----------------------- help: try: `if let Err(ref <item>) = self.result`
+LL |                 return self.result.as_ref().unwrap_err();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#16182.

`unnecessary_unwrap` suggests borrowing the scrutinee when it fires on a field access checked with `is_some()`/`is_ok()` and unwrapped through `as_ref()`/`as_mut()`:

```rust
if let Some(<item>) = &self.option
```

Evaluating that scrutinee borrows `self.option` before matching. Under the legacy borrow checker, the borrow can remain live after the `if` and conflict with a later mutation of `self.option`, producing E0502.

Current nightly’s default Polonius mode accepts the old form, while `-Zpolonius=off` reproduces the reported error. The equivalent `ref` form works with both borrow checkers, so field accesses now get:

```rust
if let Some(ref <item>) = self.option
```

Plain locals retain the existing `&` and `&mut` suggestions. The conflicting `&mut Option<_>` or `&mut Result<_, _>` parameter shape is not linted because its checked receiver type is a reference rather than the `Option` or `Result` ADT.

The UI tests cover shared and mutable `Option` access, both `Result` variants, tuple fields, and multi-level field access.

changelog: Fix [`unnecessary_unwrap`]: use `ref` bindings when suggesting `if let` for borrowed fields