### PR TITLE
Respect inline allows in needless_pass_by_value

### DIFF
--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::res::{MaybeDef as _, MaybeResPath as _};
 use clippy_utils::source::{SpanExt as _, snippet};
 use clippy_utils::ty::{implements_trait, implements_trait_with_env_from_iter, is_copy};
@@ -295,9 +295,10 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                     );
                 };
 
-                span_lint_and_then(
+                span_lint_hir_and_then(
                     cx,
                     NEEDLESS_PASS_BY_VALUE,
+                    arg.hir_id,
                     input.span,
                     "this argument is passed by value, but not consumed in the function body",
                     sugg,

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -217,6 +217,8 @@ fn non_option_either(x: Opt<String>) {
     dbg!(&x);
 }
 
+fn issue_17664(#[allow(clippy::needless_pass_by_value)] sr: String) {}
+
 fn main() {
     // This should not cause an ICE either
     // https://github.com/rust-lang/rust-clippy/issues/3144


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17664

Make `needless_pass_by_value` emit diagnostics using the `HirId` of the function argument. This ensures inline `#[allow(clippy::needless_pass_by_value)]` attributes on arguments suppress the corresponding diagnostic.

Added a UI regression test for an allowed `String` argument.

changelog: [`needless_pass_by_value`]: Respect inline `#[allow]` attributes on function arguments.