### PR TITLE
fix(filter_map_bool_then): don't lint on conflicting captures

### DIFF
--- a/clippy_lints/src/methods/filter_map_bool_then.rs
+++ b/clippy_lints/src/methods/filter_map_bool_then.rs
@@ -44,6 +44,9 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg: &
             .filter(|adj| matches!(adj.kind, Adjust::Deref(_)))
             .count()
         && let Some(param_snippet) = param.span.get_text(cx)
+        // Splitting the closure is the only thing this lint has to offer, and here it cannot be
+        // done at all, not even by hand.
+        && !has_conflicting_captures(cx, &param, recv, then_body)
     {
         let mut applicability = Applicability::MachineApplicable;
         let (filter, _) = snippet_with_context(cx, recv.span, expr.span.ctxt(), "..", &mut applicability);
@@ -55,7 +58,9 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg: &
             call_span,
             "usage of `bool::then` in `filter_map`",
             |diag| {
-                if can_filter_and_then_move_to_closure(cx, &param, recv, then_body) {
+                if contains_return(recv) {
+                    diag.help("consider using `filter` then `map` instead");
+                } else {
                     diag.span_suggestion(
                         call_span,
                         "use `filter` then `map` instead",
@@ -65,8 +70,6 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg: &
                         ),
                         applicability,
                     );
-                } else {
-                    diag.help("consider using `filter` then `map` instead");
                 }
             },
         );
@@ -85,32 +88,28 @@ fn find_bindings_from_pat(pat: &Pat<'_>) -> FxHashSet<HirId> {
     bindings
 }
 
-/// Returns true if we can take a closure parameter and have it in both the `filter` function and
-/// the`map` function. This is not the case if:
+/// Returns true if splitting the closure would leave the same binding borrowed by both halves,
+/// with at least one of them needing it mutably.
 ///
-/// - The `filter` would contain an early return,
-/// - `filter` and `then` contain captures, and any of those are &mut
-fn can_filter_and_then_move_to_closure<'tcx>(
+/// The two closures are alive at the same time once they are arguments to `filter` and `map`, so
+/// the borrow checker rejects that. There is no way to write the split by hand either, which is
+/// all this lint has to say, so it stays quiet instead.
+fn has_conflicting_captures<'tcx>(
     cx: &LateContext<'tcx>,
     param: &Param<'tcx>,
     filter: &'tcx Expr<'tcx>,
     then: &'tcx Expr<'tcx>,
 ) -> bool {
-    if contains_return(filter) {
+    let (Some(filter_captures), Some(then_captures)) =
+        (can_move_expr_to_closure(cx, filter), can_move_expr_to_closure(cx, then))
+    else {
         return false;
-    }
-
-    let Some(filter_captures) = can_move_expr_to_closure(cx, filter) else {
-        return true;
-    };
-    let Some(then_captures) = can_move_expr_to_closure(cx, then) else {
-        return true;
     };
 
     let param_bindings = find_bindings_from_pat(param.pat);
-    filter_captures.iter().all(|(hir_id, filter_cap)| {
-        param_bindings.contains(hir_id)
-            || !then_captures
+    filter_captures.iter().any(|(hir_id, filter_cap)| {
+        !param_bindings.contains(hir_id)
+            && then_captures
                 .get(hir_id)
                 .is_some_and(|then_cap| matches!(*filter_cap | *then_cap, CaptureKind::Ref(Mutability::Mut)))
     })

--- a/tests/ui/filter_map_bool_then.fixed
+++ b/tests/ui/filter_map_bool_then.fixed
@@ -109,3 +109,30 @@ fn issue15047() {
         .filter(|&(t, s, i)| matches!(t, MyEnum::A if s.starts_with("bar"))).map(|(t, s, i)| foo!(x));
     //~^ filter_map_bool_then
 }
+
+// The predicate and the body of `then` both reach the same binding, and one of them needs it
+// mutably, so the two halves cannot live in a `filter` and a `map` at the same time.
+mod no_lint_on_conflicting_captures {
+    fn issue11617() {
+        let mut x: Vec<usize> = vec![0; 10];
+        let _ = (0..x.len()).zip(x.clone().iter()).filter_map(|(i, v)| {
+            (x[i] != *v).then(|| {
+                x[i] = i;
+                i
+            })
+        });
+    }
+
+    fn issue17629() {
+        let mut last = None;
+        let _: Vec<u32> = [1, 2, 2, 3]
+            .into_iter()
+            .filter_map(|val| {
+                (last != Some(val)).then(|| {
+                    last = Some(val);
+                    val
+                })
+            })
+            .collect();
+    }
+}

--- a/tests/ui/filter_map_bool_then.rs
+++ b/tests/ui/filter_map_bool_then.rs
@@ -109,3 +109,30 @@ fn issue15047() {
         .filter_map(|(t, s, i)| matches!(t, MyEnum::A if s.starts_with("bar")).then(|| foo!(x)));
     //~^ filter_map_bool_then
 }
+
+// The predicate and the body of `then` both reach the same binding, and one of them needs it
+// mutably, so the two halves cannot live in a `filter` and a `map` at the same time.
+mod no_lint_on_conflicting_captures {
+    fn issue11617() {
+        let mut x: Vec<usize> = vec![0; 10];
+        let _ = (0..x.len()).zip(x.clone().iter()).filter_map(|(i, v)| {
+            (x[i] != *v).then(|| {
+                x[i] = i;
+                i
+            })
+        });
+    }
+
+    fn issue17629() {
+        let mut last = None;
+        let _: Vec<u32> = [1, 2, 2, 3]
+            .into_iter()
+            .filter_map(|val| {
+                (last != Some(val)).then(|| {
+                    last = Some(val);
+                    val
+                })
+            })
+            .collect();
+    }
+}

--- a/tests/ui/filter_map_bool_then_unfixable.rs
+++ b/tests/ui/filter_map_bool_then_unfixable.rs
@@ -1,17 +1,6 @@
 #![expect(clippy::question_mark)]
 #![warn(clippy::filter_map_bool_then)]
 
-fn issue11617() {
-    let mut x: Vec<usize> = vec![0; 10];
-    let _ = (0..x.len()).zip(x.clone().iter()).filter_map(|(i, v)| {
-        //~^ filter_map_bool_then
-        (x[i] != *v).then(|| {
-            x[i] = i;
-            i
-        })
-    });
-}
-
 mod issue14368 {
 
     fn do_something(_: ()) -> bool {

--- a/tests/ui/filter_map_bool_then_unfixable.stderr
+++ b/tests/ui/filter_map_bool_then_unfixable.stderr
@@ -1,30 +1,15 @@
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then_unfixable.rs:6:48
+  --> tests/ui/filter_map_bool_then_unfixable.rs:11:26
    |
-LL |       let _ = (0..x.len()).zip(x.clone().iter()).filter_map(|(i, v)| {
-   |  ________________________________________________^
-LL | |
-LL | |         (x[i] != *v).then(|| {
-LL | |             x[i] = i;
-LL | |             i
-LL | |         })
-LL | |     });
-   | |______^
+LL |         let _ = x.iter().filter_map(|&x| x?.then(|| do_something(())));
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using `filter` then `map` instead
    = note: `-D clippy::filter-map-bool-then` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::filter_map_bool_then)]`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then_unfixable.rs:22:26
-   |
-LL |         let _ = x.iter().filter_map(|&x| x?.then(|| do_something(())));
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using `filter` then `map` instead
-
-error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then_unfixable.rs:26:14
+  --> tests/ui/filter_map_bool_then_unfixable.rs:15:14
    |
 LL |             .filter_map(|&x| if let Some(x) = x { x } else { return None }.then(|| do_something(())));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +17,7 @@ LL |             .filter_map(|&x| if let Some(x) = x { x } else { return None }.
    = help: consider using `filter` then `map` instead
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then_unfixable.rs:28:26
+  --> tests/ui/filter_map_bool_then_unfixable.rs:17:26
    |
 LL |           let _ = x.iter().filter_map(|&x| {
    |  __________________________^
@@ -47,7 +32,7 @@ LL | |         });
    = help: consider using `filter` then `map` instead
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then_unfixable.rs:46:26
+  --> tests/ui/filter_map_bool_then_unfixable.rs:35:26
    |
 LL |           let _ = x.iter().filter_map(|&x| {
    |  __________________________^
@@ -61,5 +46,5 @@ LL | |         });
    |
    = help: consider using `filter` then `map` instead
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17629

```rust
let mut last = None;
let dedup: Vec<u32> = [1, 2, 2, 3]
    .into_iter()
    .filter_map(|val| {
        (last != Some(val)).then(|| {
            last = Some(val);
            val
        })
    })
    .collect();
```

Split that and `filter` needs `&last` for the comparison while `map` needs
`&mut last` for the assignment. Both closures are passed to the iterator
before either runs, so E0502. The lint tells you to split it.

`can_filter_and_then_move_to_closure` (rust-lang/rust-clippy#14061) already works this out, it was
just only used to decide whether to attach a suggestion. The lint still fired,
you got the `help:` line, and there was nothing you could do with it. Moved
the call into the let chain instead.

Split that function in two while I was in there. It was checking early returns
and captures in one place and only the capture half should silence the lint.
Early returns behave the same as before.

`issue11617` is the same thing, so it comes out of the unfixable test file.

changelog: [`filter_map_bool_then`]: don't lint when the predicate and `then` have conflicting captures
