### PR TITLE
fix(map_clone): avoid suggestions after type-changing coercions

### DIFF
--- a/clippy_lints/src/methods/map_clone.rs
+++ b/clippy_lints/src/methods/map_clone.rs
@@ -89,6 +89,7 @@ pub(super) fn check(cx: &LateContext<'_>, e: &hir::Expr<'_>, recv: &hir::Expr<'_
                             hir::ExprKind::Call(call, [arg]) => {
                                 if let hir::ExprKind::Path(qpath) = call.kind
                                     && ident_eq(name, arg)
+                                    && cx.typeck_results().expr_ty(arg) == cx.typeck_results().expr_ty_adjusted(arg)
                                 {
                                     handle_path(cx, call, &qpath, e, recv);
                                 }

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -68,6 +68,14 @@ fn main() {
         let _ = Some(RefCell::new(String::new()).borrow()).map(|s| s.clone());
     }
 
+    // Issue #17550
+    {
+        let string = String::new();
+        let input = [&string];
+        let _: Vec<String> = input.iter().map(|s: &&String| String::clone(s)).collect();
+        let _: Vec<String> = input.iter().map(|s: &&String| <String as Clone>::clone(s)).collect();
+    }
+
     let x = Some(String::new());
     let x = x.as_ref(); // We do this to prevent triggering the `useless_asref` lint.
     let y = x.cloned();

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -68,6 +68,14 @@ fn main() {
         let _ = Some(RefCell::new(String::new()).borrow()).map(|s| s.clone());
     }
 
+    // Issue #17550
+    {
+        let string = String::new();
+        let input = [&string];
+        let _: Vec<String> = input.iter().map(|s: &&String| String::clone(s)).collect();
+        let _: Vec<String> = input.iter().map(|s: &&String| <String as Clone>::clone(s)).collect();
+    }
+
     let x = Some(String::new());
     let x = x.as_ref(); // We do this to prevent triggering the `useless_asref` lint.
     let y = x.map(|x| String::clone(x));

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -38,55 +38,55 @@ LL |     let _ = std::env::args().map(|v| v.clone());
    |                             ^^^^^^^^^^^^^^^^^^^ help: remove the `map` call
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:73:13
+  --> tests/ui/map_clone.rs:81:13
    |
 LL |     let y = x.map(|x| String::clone(x));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `x.cloned()`
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:76:13
+  --> tests/ui/map_clone.rs:84:13
    |
 LL |     let y = x.map(Clone::clone);
    |             ^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `x.cloned()`
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:79:13
+  --> tests/ui/map_clone.rs:87:13
    |
 LL |     let y = x.map(String::clone);
    |             ^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `x.cloned()`
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:84:13
+  --> tests/ui/map_clone.rs:92:13
    |
 LL |     let y = x.map(|x| u32::clone(x));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `x.copied()`
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:87:13
+  --> tests/ui/map_clone.rs:95:13
    |
 LL |     let y = x.map(|x| Clone::clone(x));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `x.copied()`
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:98:13
+  --> tests/ui/map_clone.rs:106:13
    |
 LL |     let y = x.map(|x| String::clone(x));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `x.cloned()`
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:101:13
+  --> tests/ui/map_clone.rs:109:13
    |
 LL |     let y = x.map(|x| Clone::clone(x));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `x.cloned()`
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:106:13
+  --> tests/ui/map_clone.rs:114:13
    |
 LL |     let y = x.map(|x| u32::clone(x));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `x.copied()`
 
 error: you are explicitly cloning with `.map()`
-  --> tests/ui/map_clone.rs:109:13
+  --> tests/ui/map_clone.rs:117:13
    |
 LL |     let y = x.map(|x| Clone::clone(x));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `x.copied()`


### PR DESCRIPTION
`map_clone` incorrectly suggests `.cloned()` for calls such as:

```rust
input.iter().map(|s: &&String| String::clone(s))
```

Here, `String::clone` coerces `&&String` to `&String` and returns `String`, while `.cloned()` returns `&String`.

Only lint when argument adjustments preserve its type. This fixes the false positive while retaining valid `Option` and `Result` diagnostics. Tests cover `String::clone` and `<String as Clone>::clone`.

Fixes rust-lang/rust-clippy#17550

changelog: Fix [`map_clone`] false positive for clone calls using deref coercion