### PR TITLE
feat: add `obfuscated_and_then` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7409,6 +7409,7 @@ Released 2018-09-13
 [`nonsensical_open_options`]: https://rust-lang.github.io/rust-clippy/main/index.html#nonsensical_open_options
 [`nonstandard_macro_braces`]: https://rust-lang.github.io/rust-clippy/main/index.html#nonstandard_macro_braces
 [`not_unsafe_ptr_arg_deref`]: https://rust-lang.github.io/rust-clippy/main/index.html#not_unsafe_ptr_arg_deref
+[`obfuscated_and_then`]: https://rust-lang.github.io/rust-clippy/main/index.html#obfuscated_and_then
 [`obfuscated_if_else`]: https://rust-lang.github.io/rust-clippy/main/index.html#obfuscated_if_else
 [`octal_escapes`]: https://rust-lang.github.io/rust-clippy/main/index.html#octal_escapes
 [`ok_expect`]: https://rust-lang.github.io/rust-clippy/main/index.html#ok_expect

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -456,6 +456,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::methods::NEW_RET_NO_SELF_INFO,
     crate::methods::NO_EFFECT_REPLACE_INFO,
     crate::methods::NONSENSICAL_OPEN_OPTIONS_INFO,
+    crate::methods::OBFUSCATED_AND_THEN_INFO,
     crate::methods::OBFUSCATED_IF_ELSE_INFO,
     crate::methods::OK_EXPECT_INFO,
     crate::methods::OPTION_AS_REF_CLONED_INFO,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -88,6 +88,7 @@ mod needless_option_as_deref;
 mod needless_option_take;
 mod new_ret_no_self;
 mod no_effect_replace;
+mod obfuscated_and_then;
 mod obfuscated_if_else;
 mod ok_expect;
 mod open_options;
@@ -2822,6 +2823,33 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for `.map_or_else(Err, f)` on a `Result` and `.map_or_else(|| None, f)` on an
+    /// `Option`.
+    ///
+    /// ### Why is this bad?
+    /// In these cases the "default closure" wraps the value unchanged, so the
+    /// call is the same as `.and_then(f)`, which is shorter and quicker to read.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// fn get(res: Result<Vec<i32>, String>) -> Result<i32, String> {
+    ///     res.map_or_else(Err, |mut v| v.pop().ok_or_else(|| "empty!".to_string()))
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// fn get(res: Result<Vec<i32>, String>) -> Result<i32, String> {
+    ///     res.and_then(|mut v| v.pop().ok_or_else(|| "empty!".to_string()))
+    /// }
+    /// ```
+    #[clippy::version = "1.100.0"]
+    pub OBFUSCATED_AND_THEN,
+    style,
+    "using `.map_or_else(Err, f)` / `.map_or_else(|| None, f)` instead of `.and_then(f)`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for unnecessary method chains that can be simplified into `if .. else ..`.
     ///
     /// ### Why is this bad?
@@ -5044,6 +5072,7 @@ impl_lint_pass!(Methods => [
     NEW_RET_NO_SELF,
     NONSENSICAL_OPEN_OPTIONS,
     NO_EFFECT_REPLACE,
+    OBFUSCATED_AND_THEN,
     OBFUSCATED_IF_ELSE,
     OK_EXPECT,
     OPTION_AS_REF_CLONED,
@@ -5672,6 +5701,7 @@ impl Methods {
                 (sym::map_or_else, [def, map]) => {
                     result_map_or_else_none::check(cx, expr, recv, def, map);
                     unnecessary_map_or_else::check(cx, expr, recv, def, map, call_span);
+                    obfuscated_and_then::check(cx, expr, recv, def, map, call_span);
                     unnecessary_map_or::check_map_or_else(cx, expr, recv, def, map);
                 },
                 (sym::next, []) => {

--- a/clippy_lints/src/methods/obfuscated_and_then.rs
+++ b/clippy_lints/src/methods/obfuscated_and_then.rs
@@ -1,0 +1,82 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::res::{MaybeDef as _, MaybeQPath as _, MaybeResPath as _};
+use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::{is_none_expr, peel_blocks};
+use rustc_errors::Applicability;
+use rustc_hir::attrs::LangItem;
+use rustc_hir::attrs::LangItem::OptionNone;
+use rustc_hir::attrs::lang_items::LangItem::ResultErr;
+use rustc_hir::{Expr, ExprKind, PatKind};
+use rustc_lint::LateContext;
+use rustc_span::Span;
+use rustc_span::symbol::sym;
+
+use super::OBFUSCATED_AND_THEN;
+
+/// lint use of
+/// - `res.map_or_else(Err, f)` for `Result`s
+/// - `opt.map_or_else(|| None, f)` for `Option`s
+///
+/// which are both equivalent to `_.and_then(f)`.
+pub(super) fn check(
+    cx: &LateContext<'_>,
+    expr: &Expr<'_>,
+    recv: &Expr<'_>,
+    def_arg: &Expr<'_>,
+    map_arg: &Expr<'_>,
+    call_span: Span,
+) {
+    if expr.span.from_expansion() {
+        return;
+    }
+
+    let ty = cx.typeck_results().expr_ty(recv);
+    let msg = if ty.is_diag_item(cx, sym::Result) && is_wrapping_closure(cx, def_arg, ResultErr) {
+        "`map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`"
+    } else if ty.is_diag_item(cx, sym::Option) && is_wrapping_closure(cx, def_arg, OptionNone) {
+        "`map_or_else(|| None, ..)` on an `Option` can be replaced with `and_then`"
+    } else {
+        return;
+    };
+
+    span_lint_and_then(cx, OBFUSCATED_AND_THEN, expr.span, msg, |diag| {
+        let mut applicability = Applicability::MachineApplicable;
+        let map_snippet = snippet_with_applicability(cx, map_arg.span, "..", &mut applicability);
+        diag.span_suggestion_verbose(
+            call_span,
+            "use `and_then` instead",
+            format!("and_then({map_snippet})"),
+            applicability,
+        );
+    });
+}
+
+fn is_wrapping_closure(cx: &LateContext<'_>, arg: &Expr<'_>, expected_item: LangItem) -> bool {
+    // direct constructor/path: `Err`, `Some`, `None` etc.
+    if arg.res(cx).ctor_parent(cx).is_lang_item(cx, expected_item) {
+        return true;
+    }
+
+    // closure cases
+    if let ExprKind::Closure(closure) = arg.kind {
+        let body = cx.tcx.hir_body(closure.body);
+        let body_val = peel_blocks(body.value);
+
+        // special-case `|| None` when expected_ctor is OptionNone
+        if expected_item == OptionNone && body.params.is_empty() && is_none_expr(cx, body_val) {
+            return true;
+        }
+
+        // single-param closures like `|x| Err(x)`
+        if let [param] = body.params
+            && let PatKind::Binding(_, param_id, ..) = param.pat.kind
+            && let ExprKind::Call(callee, [call_arg]) = body_val.kind
+            && callee.res(cx).ctor_parent(cx).is_lang_item(cx, expected_item)
+            && call_arg.res_local_id() == Some(param_id)
+        {
+            return true;
+        }
+    }
+
+    false
+}

--- a/clippy_lints/src/methods/obfuscated_and_then.rs
+++ b/clippy_lints/src/methods/obfuscated_and_then.rs
@@ -31,13 +31,14 @@ pub(super) fn check(
     }
 
     let ty = cx.typeck_results().expr_ty(recv);
-    let msg = if ty.is_diag_item(cx, sym::Result) && is_wrapping_closure(cx, def_arg, ResultErr) {
-        "`map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`"
-    } else if ty.is_diag_item(cx, sym::Option) && is_wrapping_closure(cx, def_arg, OptionNone) {
-        "`map_or_else(|| None, ..)` on an `Option` can be replaced with `and_then`"
-    } else {
-        return;
+
+    let argument = match ty.opt_diag_name(cx) {
+        Some(sym::Result) if is_wrapping_closure(cx, def_arg, ResultErr) => "Err",
+        Some(sym::Option) if is_wrapping_closure(cx, def_arg, OptionNone) => "|| None",
+        _ => return,
     };
+
+    let msg = format!("`map_or_else({argument}, ..)` can be replaced with `and_then`");
 
     span_lint_and_then(cx, OBFUSCATED_AND_THEN, expr.span, msg, |diag| {
         let mut applicability = Applicability::MachineApplicable;

--- a/tests/ui/obfuscated_and_then.fixed
+++ b/tests/ui/obfuscated_and_then.fixed
@@ -69,4 +69,21 @@ fn main() {
 
     // `unwrap_or_else`-style use with a real default value
     let _: usize = opt.clone().map_or_else(|| 0, |v| v.len());
+
+    shadowed_err_is_not_linted();
+}
+
+fn shadowed_err_is_not_linted() {
+    #[expect(non_snake_case)]
+    fn Err<T, E>(e: E) -> Result<T, E> {
+        Result::Err(e)
+    }
+
+    let res: Result<Vec<i32>, String> = Ok(vec![1, 2, 3]);
+
+    // `Err` as a path
+    let _: Result<i32, String> = res.clone().map_or_else(Err, |v| pop(v));
+
+    // closure `|e| Err(e)`
+    let _: Result<i32, String> = res.clone().map_or_else(|e| Err(e), |v| pop(v));
 }

--- a/tests/ui/obfuscated_and_then.fixed
+++ b/tests/ui/obfuscated_and_then.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::obfuscated_and_then)]
-#![allow(clippy::unnecessary_literal_unwrap, clippy::redundant_closure)]
+#![expect(clippy::redundant_closure)]
 
 fn pop(mut v: Vec<i32>) -> Result<i32, String> {
     v.pop().ok_or_else(|| "empty list!".to_string())

--- a/tests/ui/obfuscated_and_then.fixed
+++ b/tests/ui/obfuscated_and_then.fixed
@@ -1,0 +1,72 @@
+#![warn(clippy::obfuscated_and_then)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::redundant_closure)]
+
+fn pop(mut v: Vec<i32>) -> Result<i32, String> {
+    v.pop().ok_or_else(|| "empty list!".to_string())
+}
+
+fn first(v: Vec<i32>) -> Option<i32> {
+    v.into_iter().next()
+}
+
+fn main() {
+    let res: Result<Vec<i32>, String> = Ok(vec![1, 2, 3]);
+
+    // `Err` as a path
+    let _: Result<i32, String> = res.clone().and_then(|v| pop(v));
+    //~^ obfuscated_and_then
+
+    // closure `|e| Err(e)`
+    let _: Result<i32, String> = res.clone().and_then(|v| pop(v));
+    //~^ obfuscated_and_then
+
+    // map arg is a path
+    let _: Result<i32, String> = res.clone().and_then(pop);
+    //~^ obfuscated_and_then
+
+    // multi-line
+    let _: Result<i32, String> = res
+        .clone()
+        .and_then(|mut v| v.pop().ok_or_else(|| "empty list!".to_string()));
+    //~^^^ obfuscated_and_then
+
+    let opt: Option<Vec<i32>> = Some(vec![1, 2, 3]);
+
+    let _: Option<i32> = opt.clone().and_then(|v| first(v));
+    //~^ obfuscated_and_then
+
+    let _: Option<i32> = opt.clone().and_then(first);
+    //~^ obfuscated_and_then
+
+    //
+    // Should not lint
+    //
+
+    // default arm does more than forward the error / return `None`
+    let _: Result<i32, String> = res.clone().map_or_else(|e| Err(format!("{e}!")), |v| pop(v));
+    let _: Result<i32, String> = res.clone().map_or_else(|_| Ok(0), |v| pop(v));
+    let _: Option<i32> = opt.clone().map_or_else(|| Some(0), |v| first(v));
+    let _: Option<i32> = opt.clone().map_or_else(
+        || {
+            println!("empty");
+            None
+        },
+        |v| first(v),
+    );
+
+    // default arm forwards the error but also runs a side effect
+    let _: Result<i32, String> = res.clone().map_or_else(
+        |e| {
+            eprintln!("{e}");
+            Err(e)
+        },
+        |v| pop(v),
+    );
+
+    // already using `and_then`
+    let _: Result<i32, String> = res.clone().and_then(|v| pop(v));
+    let _: Option<i32> = opt.clone().and_then(|v| first(v));
+
+    // `unwrap_or_else`-style use with a real default value
+    let _: usize = opt.clone().map_or_else(|| 0, |v| v.len());
+}

--- a/tests/ui/obfuscated_and_then.rs
+++ b/tests/ui/obfuscated_and_then.rs
@@ -1,0 +1,72 @@
+#![warn(clippy::obfuscated_and_then)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::redundant_closure)]
+
+fn pop(mut v: Vec<i32>) -> Result<i32, String> {
+    v.pop().ok_or_else(|| "empty list!".to_string())
+}
+
+fn first(v: Vec<i32>) -> Option<i32> {
+    v.into_iter().next()
+}
+
+fn main() {
+    let res: Result<Vec<i32>, String> = Ok(vec![1, 2, 3]);
+
+    // `Err` as a path
+    let _: Result<i32, String> = res.clone().map_or_else(Err, |v| pop(v));
+    //~^ obfuscated_and_then
+
+    // closure `|e| Err(e)`
+    let _: Result<i32, String> = res.clone().map_or_else(|e| Err(e), |v| pop(v));
+    //~^ obfuscated_and_then
+
+    // map arg is a path
+    let _: Result<i32, String> = res.clone().map_or_else(Err, pop);
+    //~^ obfuscated_and_then
+
+    // multi-line
+    let _: Result<i32, String> = res
+        .clone()
+        .map_or_else(Err, |mut v| v.pop().ok_or_else(|| "empty list!".to_string()));
+    //~^^^ obfuscated_and_then
+
+    let opt: Option<Vec<i32>> = Some(vec![1, 2, 3]);
+
+    let _: Option<i32> = opt.clone().map_or_else(|| None, |v| first(v));
+    //~^ obfuscated_and_then
+
+    let _: Option<i32> = opt.clone().map_or_else(|| None, first);
+    //~^ obfuscated_and_then
+
+    //
+    // Should not lint
+    //
+
+    // default arm does more than forward the error / return `None`
+    let _: Result<i32, String> = res.clone().map_or_else(|e| Err(format!("{e}!")), |v| pop(v));
+    let _: Result<i32, String> = res.clone().map_or_else(|_| Ok(0), |v| pop(v));
+    let _: Option<i32> = opt.clone().map_or_else(|| Some(0), |v| first(v));
+    let _: Option<i32> = opt.clone().map_or_else(
+        || {
+            println!("empty");
+            None
+        },
+        |v| first(v),
+    );
+
+    // default arm forwards the error but also runs a side effect
+    let _: Result<i32, String> = res.clone().map_or_else(
+        |e| {
+            eprintln!("{e}");
+            Err(e)
+        },
+        |v| pop(v),
+    );
+
+    // already using `and_then`
+    let _: Result<i32, String> = res.clone().and_then(|v| pop(v));
+    let _: Option<i32> = opt.clone().and_then(|v| first(v));
+
+    // `unwrap_or_else`-style use with a real default value
+    let _: usize = opt.clone().map_or_else(|| 0, |v| v.len());
+}

--- a/tests/ui/obfuscated_and_then.rs
+++ b/tests/ui/obfuscated_and_then.rs
@@ -69,4 +69,21 @@ fn main() {
 
     // `unwrap_or_else`-style use with a real default value
     let _: usize = opt.clone().map_or_else(|| 0, |v| v.len());
+
+    shadowed_err_is_not_linted();
+}
+
+fn shadowed_err_is_not_linted() {
+    #[expect(non_snake_case)]
+    fn Err<T, E>(e: E) -> Result<T, E> {
+        Result::Err(e)
+    }
+
+    let res: Result<Vec<i32>, String> = Ok(vec![1, 2, 3]);
+
+    // `Err` as a path
+    let _: Result<i32, String> = res.clone().map_or_else(Err, |v| pop(v));
+
+    // closure `|e| Err(e)`
+    let _: Result<i32, String> = res.clone().map_or_else(|e| Err(e), |v| pop(v));
 }

--- a/tests/ui/obfuscated_and_then.rs
+++ b/tests/ui/obfuscated_and_then.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::obfuscated_and_then)]
-#![allow(clippy::unnecessary_literal_unwrap, clippy::redundant_closure)]
+#![expect(clippy::redundant_closure)]
 
 fn pop(mut v: Vec<i32>) -> Result<i32, String> {
     v.pop().ok_or_else(|| "empty list!".to_string())

--- a/tests/ui/obfuscated_and_then.stderr
+++ b/tests/ui/obfuscated_and_then.stderr
@@ -1,0 +1,79 @@
+error: `map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`
+  --> tests/ui/obfuscated_and_then.rs:16:34
+   |
+LL |     let _: Result<i32, String> = res.clone().map_or_else(Err, |v| pop(v));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::obfuscated-and-then` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::obfuscated_and_then)]`
+help: use `and_then` instead
+   |
+LL -     let _: Result<i32, String> = res.clone().map_or_else(Err, |v| pop(v));
+LL +     let _: Result<i32, String> = res.clone().and_then(|v| pop(v));
+   |
+
+error: `map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`
+  --> tests/ui/obfuscated_and_then.rs:20:34
+   |
+LL |     let _: Result<i32, String> = res.clone().map_or_else(|e| Err(e), |v| pop(v));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `and_then` instead
+   |
+LL -     let _: Result<i32, String> = res.clone().map_or_else(|e| Err(e), |v| pop(v));
+LL +     let _: Result<i32, String> = res.clone().and_then(|v| pop(v));
+   |
+
+error: `map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`
+  --> tests/ui/obfuscated_and_then.rs:24:34
+   |
+LL |     let _: Result<i32, String> = res.clone().map_or_else(Err, pop);
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `and_then` instead
+   |
+LL -     let _: Result<i32, String> = res.clone().map_or_else(Err, pop);
+LL +     let _: Result<i32, String> = res.clone().and_then(pop);
+   |
+
+error: `map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`
+  --> tests/ui/obfuscated_and_then.rs:28:34
+   |
+LL |       let _: Result<i32, String> = res
+   |  __________________________________^
+LL | |         .clone()
+LL | |         .map_or_else(Err, |mut v| v.pop().ok_or_else(|| "empty list!".to_string()));
+   | |___________________________________________________________________________________^
+   |
+help: use `and_then` instead
+   |
+LL -         .map_or_else(Err, |mut v| v.pop().ok_or_else(|| "empty list!".to_string()));
+LL +         .and_then(|mut v| v.pop().ok_or_else(|| "empty list!".to_string()));
+   |
+
+error: `map_or_else(|| None, ..)` on an `Option` can be replaced with `and_then`
+  --> tests/ui/obfuscated_and_then.rs:35:26
+   |
+LL |     let _: Option<i32> = opt.clone().map_or_else(|| None, |v| first(v));
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `and_then` instead
+   |
+LL -     let _: Option<i32> = opt.clone().map_or_else(|| None, |v| first(v));
+LL +     let _: Option<i32> = opt.clone().and_then(|v| first(v));
+   |
+
+error: `map_or_else(|| None, ..)` on an `Option` can be replaced with `and_then`
+  --> tests/ui/obfuscated_and_then.rs:38:26
+   |
+LL |     let _: Option<i32> = opt.clone().map_or_else(|| None, first);
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `and_then` instead
+   |
+LL -     let _: Option<i32> = opt.clone().map_or_else(|| None, first);
+LL +     let _: Option<i32> = opt.clone().and_then(first);
+   |
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/obfuscated_and_then.stderr
+++ b/tests/ui/obfuscated_and_then.stderr
@@ -1,4 +1,4 @@
-error: `map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`
+error: `map_or_else(Err, ..)` can be replaced with `and_then`
   --> tests/ui/obfuscated_and_then.rs:16:34
    |
 LL |     let _: Result<i32, String> = res.clone().map_or_else(Err, |v| pop(v));
@@ -12,7 +12,7 @@ LL -     let _: Result<i32, String> = res.clone().map_or_else(Err, |v| pop(v));
 LL +     let _: Result<i32, String> = res.clone().and_then(|v| pop(v));
    |
 
-error: `map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`
+error: `map_or_else(Err, ..)` can be replaced with `and_then`
   --> tests/ui/obfuscated_and_then.rs:20:34
    |
 LL |     let _: Result<i32, String> = res.clone().map_or_else(|e| Err(e), |v| pop(v));
@@ -24,7 +24,7 @@ LL -     let _: Result<i32, String> = res.clone().map_or_else(|e| Err(e), |v| po
 LL +     let _: Result<i32, String> = res.clone().and_then(|v| pop(v));
    |
 
-error: `map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`
+error: `map_or_else(Err, ..)` can be replaced with `and_then`
   --> tests/ui/obfuscated_and_then.rs:24:34
    |
 LL |     let _: Result<i32, String> = res.clone().map_or_else(Err, pop);
@@ -36,7 +36,7 @@ LL -     let _: Result<i32, String> = res.clone().map_or_else(Err, pop);
 LL +     let _: Result<i32, String> = res.clone().and_then(pop);
    |
 
-error: `map_or_else(Err, ..)` on a `Result` can be replaced with `and_then`
+error: `map_or_else(Err, ..)` can be replaced with `and_then`
   --> tests/ui/obfuscated_and_then.rs:28:34
    |
 LL |       let _: Result<i32, String> = res
@@ -51,7 +51,7 @@ LL -         .map_or_else(Err, |mut v| v.pop().ok_or_else(|| "empty list!".to_st
 LL +         .and_then(|mut v| v.pop().ok_or_else(|| "empty list!".to_string()));
    |
 
-error: `map_or_else(|| None, ..)` on an `Option` can be replaced with `and_then`
+error: `map_or_else(|| None, ..)` can be replaced with `and_then`
   --> tests/ui/obfuscated_and_then.rs:35:26
    |
 LL |     let _: Option<i32> = opt.clone().map_or_else(|| None, |v| first(v));
@@ -63,7 +63,7 @@ LL -     let _: Option<i32> = opt.clone().map_or_else(|| None, |v| first(v));
 LL +     let _: Option<i32> = opt.clone().and_then(|v| first(v));
    |
 
-error: `map_or_else(|| None, ..)` on an `Option` can be replaced with `and_then`
+error: `map_or_else(|| None, ..)` can be replaced with `and_then`
   --> tests/ui/obfuscated_and_then.rs:38:26
    |
 LL |     let _: Option<i32> = opt.clone().map_or_else(|| None, first);


### PR DESCRIPTION
changelog: add `obfuscated_and_then` lint (fixes rust-lang/rust-clippy#17322).

# What does it do?

it checks for code like this: 
```rust
fn get(res: Result<Vec<i32>, String>) -> Result<i32, String> {
     res.map_or_else(Err, |mut v| v.pop().ok_or_else(|| "empty!".to_string()))
 }
```

and suggests this replacement 

```rust
fn get(res: Result<Vec<i32>, String>) -> Result<i32, String> {
    res.and_then(|mut v| v.pop().ok_or_else(|| "empty!".to_string()))
}
```

works for both options and result!

---

**note**: i tested it on the gnu toolchain instead of msvc (`nightly-2026-09-01-x86_64-pc-windows-gnu`)