### PR TITLE
perf: don't resolve columns in `four_forward_slashes`

### DIFF
--- a/clippy_lints/src/four_forward_slashes.rs
+++ b/clippy_lints/src/four_forward_slashes.rs
@@ -63,11 +63,17 @@ impl<'tcx> LateLintPass<'tcx> for FourForwardSlashes {
                 )
             })
             .fold(item.span.shrink_to_lo(), |span, attr| span.to(attr.span()));
-        let (Some(file), _, _, end_line, _) = sm.span_to_location_info(span) else {
+        // `lookup_line` binary searches the line table. Resolving a column instead walks
+        // the line from its start, which costs O(offset) per item, and a file that holds
+        // its whole content on one line — generated code printed from a `TokenStream`, or
+        // a minified source — makes that offset the item's position in the file.
+        let Ok(loc) = sm.lookup_line(span.hi()) else {
             return;
         };
+        // Lines count from 0 here, so `end_line` is already the line above the item.
+        let (file, end_line) = (loc.sf, loc.line);
         let mut bad_comments = vec![];
-        for line in (0..end_line.saturating_sub(1)).rev() {
+        for line in (0..end_line).rev() {
             let Some(contents) = file.get_line(line).map(|c| c.trim().to_owned()) else {
                 return;
             };


### PR DESCRIPTION

`four_forward_slashes` is quadratic on files that hold their content on a single line. A 32k-item single-line file takes 82s to lint; with this change it takes 0.9s.

## Cause

`check_item` starts with:

```rust
let (Some(file), _, _, end_line, _) = sm.span_to_location_info(span) else {
    return;
};
```

It binds the file and the end line, and discards the two column fields. Those columns are the expensive part:

```rust
// rustc_span::source_map::SourceMap
pub fn span_to_location_info(&self, sp: Span) -> (Option<Arc<SourceFile>>, usize, usize, usize, usize) {
    ...
    let lo = self.lookup_char_pos(sp.lo());
    let hi = self.lookup_char_pos(sp.hi());
    (Some(lo.file), lo.line, lo.col.to_usize() + 1, hi.line, hi.col.to_usize() + 1)
}

pub fn lookup_char_pos(&self, pos: BytePos) -> Loc {
    let sf = self.lookup_source_file(pos);
    let (line, col, col_display) = sf.lookup_file_pos_with_col_display(pos);
    Loc { file: sf, line, col, col_display }
}
```

```rust
// rustc_span::SourceFile
pub fn lookup_file_pos_with_col_display(&self, pos: BytePos) -> (usize, CharPos, usize) {
    ...
    let display_col = code.chars().take(col_or_chpos.0).map(|ch| char_width(ch)).sum();
    ...
}
```

That last line walks every character between the start of the line and the position, so it is O(distance from the line start). The lint pays it twice per item, for values it never reads.

When every item is on one line the distance is the item's offset in the file, and the sum over all items is quadratic in file size. The scan below never runs in that case: `end_line` is 1, so `(0..end_line.saturating_sub(1)).rev()` is empty. All of the time goes into columns that are computed and thrown away. A `perf` profile of such a run puts 98.5% of samples in `SourceMap::lookup_char_pos`.

## Fix

`SourceMap::lookup_line` binary searches the line table and returns the file and a 0-based line index, which is everything the lint uses.

`span_to_location_info` returns a 1-based line, `lookup_line` a 0-based index, so `(0..end_line.saturating_sub(1))` becomes `(0..end_line)` over the same lines. `span.hi()` matches the field the old code read.

## Measurements

Reproduction, N items on one line:

```python
N = 8000
items = [f'pub const K{i}: &str = "value number {i} with some padding text to add bytes";' for i in range(N)]
open("src/lib.rs", "w").write("pub mod m {{ {} }}".format(" ".join(items)))   # one line
# control: "\n".join(items)
```

Same bytes, same items, only the line structure differs: one line 5.55s, one item per line 0.28s.

Item count, single line, before and after this change, same driver path and same invocation:

| items | before | after |
| --- | --- | --- |
| 4000 | 1650 ms | 292 ms |
| 8000 | 5334 ms | 278 ms |
| 16000 | 20597 ms | 544 ms |
| 32000 | 82130 ms | 911 ms |

Before is 4x per doubling. After is linear.

Line length at a fixed 8000 items, before the change, padding the string literals:

| line length | time |
| --- | --- |
| 543 KB | 4728 ms |
| 863 KB | 7312 ms |
| 1503 KB | 12461 ms |
| 2783 KB | 22979 ms |

Linear in line length at fixed item count. Together the two series give O(items * line length).

Real-world case that led to this: a crate whose generated i18n bundle is one 11,258,133 character line. `cargo check` 30.6s, `cargo clippy` 786s, `cargo clippy` with this lint allowed 9.5s. In CI that single unit took 2634s of a 3407s job, and because it sits near the root of the dependency graph the machine ran one unit on one of 32 cores for 39 minutes.

## Testing

- full suite passes: 1860 UI tests, plus 194, 52 and the smaller suites, 0 failures
- no test fixture changed. `git status` after the run lists only `clippy_lints/src/four_forward_slashes.rs`, so the diagnostic and its machine-applicable suggestion are byte identical
- `cargo dev fmt --check` clean
- checked by hand that the lint still fires on `//// not a doc comment` with the same span and suggestion
- built and tested on nightly-2026-09-01, the version in `rust-toolchain.toml`

## LLM disclosure

<!-- EDIT THIS to match what you actually did. It is wrong to overstate the review. -->

An LLM (Claude) did the investigation and wrote the patch and this description. Specifically it: bisected the `suspicious` lint group to find which lint was responsible; read `four_forward_slashes.rs`, `rustc_span::source_map` and `rustc_span::SourceFile` to trace the cost to the discarded column values; wrote the one-line/many-line reproduction and the two scaling series; wrote the three-line code change and its comments; and wrote this PR description.

I directed the work, chose to fix it upstream rather than disable the lint locally, and reviewed the diff. The measurements were run on my machine: the before/after series comes from the same clippy checkout with the patch stashed and rebuilt for the control, and the full test suite and `cargo dev fmt --check` were run locally against nightly-2026-09-01.

changelog: [`four_forward_slashes`]: fix quadratic behaviour on files with very long lines
