### PR TITLE
regex_creation_in_loops: check MIR loop structure

### DIFF
--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use clippy_utils::consts::{ConstEvalCtxt, Constant};
 use clippy_utils::diagnostics::{span_lint, span_lint_and_help};
+use clippy_utils::mir::{block_in_cycle, enclosing_mir, function_call_basic_block};
 use clippy_utils::paths;
 use clippy_utils::paths::PathLookup;
 use clippy_utils::res::MaybeQPath as _;
@@ -144,6 +145,9 @@ impl<'tcx> LateLintPass<'tcx> for Regex {
             if let Some(&(loop_item_id, loop_span)) = self.loop_stack.last()
                 && loop_item_id == fun.hir_id.owner
                 && (matches!(arg.kind, ExprKind::Lit(_)) || const_str(cx, arg).is_some())
+                && let Some(mir_body) = enclosing_mir(cx.tcx, fun.hir_id)
+                && let Some(mir_fun) = function_call_basic_block(mir_body, fun)
+                && block_in_cycle(mir_body, mir_fun)
             {
                 span_lint_and_help(
                     cx,

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -290,3 +290,17 @@ fn is_local_assignment(mir: &Body<'_>, local: Local, location: Location) -> bool
         },
     }
 }
+
+/// Returns the basic block that is terminated with this function call.
+pub fn function_call_basic_block(body: &Body<'_>, fun: &Expr<'_>) -> Option<BasicBlock> {
+    body.basic_blocks.iter_enumerated().find_map(|(block, data)| {
+        if let Some(terminator) = data.terminator.as_ref()
+            && let TerminatorKind::Call { fn_span, .. } = terminator.kind
+            && fn_span.lo() == fun.span.lo()
+        {
+            Some(block)
+        } else {
+            None
+        }
+    })
+}

--- a/tests/ui/regex.rs
+++ b/tests/ui/regex.rs
@@ -1,6 +1,6 @@
 //@require-annotations-for-level: WARN
 #![warn(clippy::invalid_regex, clippy::regex_creation_in_loops, clippy::trivial_regex)]
-#![expect(clippy::needless_borrows_for_generic_args)]
+#![expect(clippy::needless_borrows_for_generic_args, clippy::never_loop)]
 
 extern crate regex;
 
@@ -143,6 +143,112 @@ fn regex_creation_in_loops() {
 
     for i in 0..10 {
         let dependant_regex = Regex::new(&format!("{i}"));
+    }
+
+    // https://github.com/rust-lang/rust-clippy/issues/15484
+
+    fn issue_15484_break_noloop() {
+        loop {
+            let nested_regex = Regex::new("a.b.1");
+            break;
+        }
+    }
+
+    fn issue_15484_break_doublenest() {
+        loop {
+            loop {
+                let nested_regex = Regex::new("a.b.2");
+                //~^ ERROR: compiling a regex in a loop
+                break;
+            }
+        }
+    }
+
+    fn issue_15484_break_doublenest_print() {
+        loop {
+            println!("foo");
+            loop {
+                let nested_regex = Regex::new("a.b.2");
+                //~^ ERROR: compiling a regex in a loop
+                break;
+            }
+        }
+    }
+
+    fn issue_15484_break_doublenest_fncall() {
+        loop {
+            regex_creation_in_loops();
+            loop {
+                let nested_regex = Regex::new("a.b.2");
+                //~^ ERROR: compiling a regex in a loop
+                break;
+            }
+        }
+    }
+
+    // neither loop loops, so no lint
+    fn issue_15484_break_noloop_doublenest() {
+        'outer: loop {
+            loop {
+                let nested_regex = Regex::new("a.b.3");
+                break 'outer;
+            }
+        }
+    }
+
+    // neither loop loops, so no lint
+    fn issue_15484_panic_noloop_doublenest() {
+        loop {
+            loop {
+                let nested_regex = Regex::new("a.b.4");
+                panic!();
+            }
+        }
+    }
+
+    // the outer loop doesn't loop, but the inner loop does
+    fn issue_15484_panic_doublenest() {
+        loop {
+            loop {
+                let nested_regex = Regex::new("a.b.5");
+                //~^ ERROR: compiling a regex in a loop
+            }
+            panic!();
+        }
+    }
+
+    fn issue_15484_continue_doublenest() {
+        loop {
+            loop {
+                let nested_regex = Regex::new("a.b.6");
+                //~^ ERROR: compiling a regex in a loop
+                continue;
+            }
+        }
+    }
+
+    fn issue_15484_continue_outer_doublenest() {
+        'outer: loop {
+            regex_creation_in_loops();
+            loop {
+                let nested_regex = Regex::new("a.b.6");
+                //~^ ERROR: compiling a regex in a loop
+                continue 'outer;
+            }
+        }
+    }
+
+    fn issue_15484_if() {
+        loop {
+            if true {
+                let nested_regex = Regex::new("a.b.6");
+                //~^ ERROR: compiling a regex in a loop
+                if true {
+                    continue;
+                }
+                break;
+            }
+        }
     }
 }
 

--- a/tests/ui/regex.stderr
+++ b/tests/ui/regex.stderr
@@ -245,5 +245,89 @@ help: move the regex construction outside this loop
 LL |         for _ in 0..10 {
    |         ^^^^^^^^^^^^^^
 
-error: aborting due to 28 previous errors
+error: compiling a regex in a loop
+  --> tests/ui/regex.rs:160:36
+   |
+LL |                 let nested_regex = Regex::new("a.b.2");
+   |                                    ^^^^^^^^^^
+   |
+help: move the regex construction outside this loop
+  --> tests/ui/regex.rs:159:13
+   |
+LL |             loop {
+   |             ^^^^
+
+error: compiling a regex in a loop
+  --> tests/ui/regex.rs:171:36
+   |
+LL |                 let nested_regex = Regex::new("a.b.2");
+   |                                    ^^^^^^^^^^
+   |
+help: move the regex construction outside this loop
+  --> tests/ui/regex.rs:170:13
+   |
+LL |             loop {
+   |             ^^^^
+
+error: compiling a regex in a loop
+  --> tests/ui/regex.rs:182:36
+   |
+LL |                 let nested_regex = Regex::new("a.b.2");
+   |                                    ^^^^^^^^^^
+   |
+help: move the regex construction outside this loop
+  --> tests/ui/regex.rs:181:13
+   |
+LL |             loop {
+   |             ^^^^
+
+error: compiling a regex in a loop
+  --> tests/ui/regex.rs:213:36
+   |
+LL |                 let nested_regex = Regex::new("a.b.5");
+   |                                    ^^^^^^^^^^
+   |
+help: move the regex construction outside this loop
+  --> tests/ui/regex.rs:212:13
+   |
+LL |             loop {
+   |             ^^^^
+
+error: compiling a regex in a loop
+  --> tests/ui/regex.rs:223:36
+   |
+LL |                 let nested_regex = Regex::new("a.b.6");
+   |                                    ^^^^^^^^^^
+   |
+help: move the regex construction outside this loop
+  --> tests/ui/regex.rs:222:13
+   |
+LL |             loop {
+   |             ^^^^
+
+error: compiling a regex in a loop
+  --> tests/ui/regex.rs:234:36
+   |
+LL |                 let nested_regex = Regex::new("a.b.6");
+   |                                    ^^^^^^^^^^
+   |
+help: move the regex construction outside this loop
+  --> tests/ui/regex.rs:233:13
+   |
+LL |             loop {
+   |             ^^^^
+
+error: compiling a regex in a loop
+  --> tests/ui/regex.rs:244:36
+   |
+LL |                 let nested_regex = Regex::new("a.b.6");
+   |                                    ^^^^^^^^^^
+   |
+help: move the regex construction outside this loop
+  --> tests/ui/regex.rs:242:9
+   |
+LL |         loop {
+   |         ^^^^
+
+error: aborting due to 35 previous errors
 


### PR DESCRIPTION
changelog: [`regex_creation_in_loops`]: do not warn if the regex code path breaks out of the loop

Fixes https://github.com/rust-lang/rust-clippy/issues/15484