### PR TITLE
add new lint: [`missing_panic_message`]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7320,6 +7320,7 @@ Released 2018-09-13
 [`missing_errors_doc`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_errors_doc
 [`missing_fields_in_debug`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_fields_in_debug
 [`missing_inline_in_public_items`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_inline_in_public_items
+[`missing_panic_message`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_panic_message
 [`missing_panics_doc`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_panics_doc
 [`missing_safety_doc`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_safety_doc
 [`missing_spin_loop`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_spin_loop

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -548,6 +548,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::missing_enforced_import_rename::MISSING_ENFORCED_IMPORT_RENAMES_INFO,
     crate::missing_fields_in_debug::MISSING_FIELDS_IN_DEBUG_INFO,
     crate::missing_inline::MISSING_INLINE_IN_PUBLIC_ITEMS_INFO,
+    crate::missing_panic_message::MISSING_PANIC_MESSAGE_INFO,
     crate::missing_trait_methods::MISSING_TRAIT_METHODS_INFO,
     crate::mixed_read_write_in_expression::DIVERGING_SUB_EXPRESSION_INFO,
     crate::mixed_read_write_in_expression::MIXED_READ_WRITE_IN_EXPRESSION_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -244,6 +244,7 @@ mod missing_doc;
 mod missing_enforced_import_rename;
 mod missing_fields_in_debug;
 mod missing_inline;
+mod missing_panic_message;
 mod missing_trait_methods;
 mod mixed_read_write_in_expression;
 mod module_style;
@@ -870,6 +871,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        MissingPanicMessage: missing_panic_message::MissingPanicMessage = missing_panic_message::MissingPanicMessage,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/missing_panic_message.rs
+++ b/clippy_lints/src/missing_panic_message.rs
@@ -1,0 +1,95 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::macros::{PanicCall, root_macro_call_first_node};
+use clippy_utils::res::MaybeDef as _;
+use clippy_utils::{peel_blocks_with_stmt, sym};
+use rustc_hir::Expr;
+use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
+use rustc_span::hygiene::MacroKind;
+use rustc_span::symbol::Symbol;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks if `panic!`, `todo!`, `unimplemented!`, and `unreachable!`
+    /// have a custom panic message.
+    ///
+    /// ### Why restrict this?
+    /// Custom messages make code more readable and debugging easier.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// # use std::panic::panic_any;
+    /// panic!();
+    /// todo!();
+    /// unimplemented!();
+    /// unreachable!();
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// # use std::panic::panic_any;
+    /// panic!("why this is bad");
+    /// todo!("what to do");
+    /// unimplemented!("why this is intentionally unimplemented");
+    /// unreachable!("why this is unreachable");
+    /// ```
+    #[clippy::version = "1.100.0"]
+    pub MISSING_PANIC_MESSAGE,
+    restriction,
+    "panic without a useful message"
+}
+
+declare_lint_pass!(MissingPanicMessage => [MISSING_PANIC_MESSAGE]);
+
+impl<'tcx> LateLintPass<'tcx> for MissingPanicMessage {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if let Some(macro_call) = root_macro_call_first_node(cx, expr)
+            && macro_call.kind == MacroKind::Bang
+            && let Some(kind) = macro_call.def_id.opt_diag_name(cx).and_then(PanicMacroKind::new)
+            && PanicCall::parse(peel_blocks_with_stmt(expr)).is_some_and(|panic_call| panic_call.is_default_message())
+        {
+            span_lint_and_help(cx, MISSING_PANIC_MESSAGE, expr.span, kind.message(), None, kind.help());
+        }
+    }
+}
+
+enum PanicMacroKind {
+    Panic,
+    Todo,
+    Unimplemented,
+    Unreachable,
+}
+
+impl PanicMacroKind {
+    fn new(name: Symbol) -> Option<Self> {
+        match name {
+            sym::core_panic_macro
+            | sym::std_panic_macro
+            | sym::core_panic_2015_macro
+            | sym::std_panic_2015_macro
+            | sym::core_panic_2021_macro => Some(Self::Panic),
+            sym::todo_macro => Some(Self::Todo),
+            sym::unimplemented_macro => Some(Self::Unimplemented),
+            sym::unreachable_macro => Some(Self::Unreachable),
+            _ => None,
+        }
+    }
+
+    fn message(&self) -> String {
+        let kind = match self {
+            PanicMacroKind::Panic => "panic!",
+            PanicMacroKind::Todo => "todo!",
+            PanicMacroKind::Unimplemented => "unimplemented!",
+            PanicMacroKind::Unreachable => "unreachable!",
+        };
+        format!("using `{kind}` macro without a custom message")
+    }
+
+    fn help(&self) -> String {
+        let help = match self {
+            PanicMacroKind::Panic => "why this is bad",
+            PanicMacroKind::Todo => "what to do",
+            PanicMacroKind::Unimplemented => "why this is intentionally unimplemented",
+            PanicMacroKind::Unreachable => "why this is unreachable",
+        };
+        format!("consider describing {help}")
+    }
+}

--- a/tests/ui/missing_panic_message.edition2015.stderr
+++ b/tests/ui/missing_panic_message.edition2015.stderr
@@ -1,0 +1,100 @@
+error: using `panic!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:10:5
+   |
+LL |     panic!();
+   |     ^^^^^^^^
+   |
+   = help: consider describing why this is bad
+   = note: `-D clippy::missing-panic-message` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_panic_message)]`
+
+error: using `todo!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:11:5
+   |
+LL |     todo!();
+   |     ^^^^^^^
+   |
+   = help: consider describing what to do
+
+error: using `unimplemented!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:12:5
+   |
+LL |     unimplemented!();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is intentionally unimplemented
+
+error: using `unreachable!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:13:5
+   |
+LL |     unreachable!();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is unreachable
+
+error: using `panic!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:34:5
+   |
+LL |     std::panic!();
+   |     ^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is bad
+
+error: using `panic!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:35:5
+   |
+LL |     core::panic!();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is bad
+
+error: using `todo!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:37:5
+   |
+LL |     std::todo!();
+   |     ^^^^^^^^^^^^
+   |
+   = help: consider describing what to do
+
+error: using `todo!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:38:5
+   |
+LL |     core::prelude::v1::todo!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing what to do
+
+error: using `unimplemented!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:40:5
+   |
+LL |     unimplemented!();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is intentionally unimplemented
+
+error: using `unimplemented!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:41:5
+   |
+LL |     core::prelude::v1::unimplemented!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is intentionally unimplemented
+
+error: using `unreachable!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:43:5
+   |
+LL |     unreachable!();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is unreachable
+
+error: using `unreachable!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:44:5
+   |
+LL |     core::prelude::v1::unreachable!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is unreachable
+
+error: aborting due to 12 previous errors
+

--- a/tests/ui/missing_panic_message.edition2021.stderr
+++ b/tests/ui/missing_panic_message.edition2021.stderr
@@ -1,0 +1,100 @@
+error: using `panic!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:10:5
+   |
+LL |     panic!();
+   |     ^^^^^^^^
+   |
+   = help: consider describing why this is bad
+   = note: `-D clippy::missing-panic-message` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_panic_message)]`
+
+error: using `todo!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:11:5
+   |
+LL |     todo!();
+   |     ^^^^^^^
+   |
+   = help: consider describing what to do
+
+error: using `unimplemented!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:12:5
+   |
+LL |     unimplemented!();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is intentionally unimplemented
+
+error: using `unreachable!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:13:5
+   |
+LL |     unreachable!();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is unreachable
+
+error: using `panic!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:34:5
+   |
+LL |     std::panic!();
+   |     ^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is bad
+
+error: using `panic!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:35:5
+   |
+LL |     core::panic!();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is bad
+
+error: using `todo!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:37:5
+   |
+LL |     std::todo!();
+   |     ^^^^^^^^^^^^
+   |
+   = help: consider describing what to do
+
+error: using `todo!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:38:5
+   |
+LL |     core::prelude::v1::todo!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing what to do
+
+error: using `unimplemented!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:40:5
+   |
+LL |     unimplemented!();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is intentionally unimplemented
+
+error: using `unimplemented!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:41:5
+   |
+LL |     core::prelude::v1::unimplemented!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is intentionally unimplemented
+
+error: using `unreachable!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:43:5
+   |
+LL |     unreachable!();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is unreachable
+
+error: using `unreachable!` macro without a custom message
+  --> tests/ui/missing_panic_message.rs:44:5
+   |
+LL |     core::prelude::v1::unreachable!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider describing why this is unreachable
+
+error: aborting due to 12 previous errors
+

--- a/tests/ui/missing_panic_message.rs
+++ b/tests/ui/missing_panic_message.rs
@@ -1,0 +1,45 @@
+//@revisions: edition2015 edition2021
+//@[edition2015] edition:2015
+//@[edition2021] edition:2021
+#![warn(clippy::missing_panic_message)]
+
+use std::hint::black_box;
+use std::panic::panic_any;
+
+fn main() {
+    panic!(); //~ missing_panic_message
+    todo!(); //~ missing_panic_message
+    unimplemented!(); //~ missing_panic_message
+    unreachable!(); //~ missing_panic_message
+
+    panic!("r");
+    todo!("u");
+    unimplemented!("s");
+    unreachable!("t");
+
+    let _ = vec![0];
+
+    macro_rules! ignore_me {
+        () => {{
+            panic!();
+            todo!();
+            unimplemented!();
+            unreachable!();
+        }};
+    }
+    ignore_me!();
+}
+
+fn qualified_macros() {
+    std::panic!(); //~ missing_panic_message
+    core::panic!(); //~ missing_panic_message
+
+    std::todo!(); //~ missing_panic_message
+    core::prelude::v1::todo!(); //~ missing_panic_message
+
+    unimplemented!(); //~ missing_panic_message
+    core::prelude::v1::unimplemented!(); //~ missing_panic_message
+
+    unreachable!(); //~ missing_panic_message
+    core::prelude::v1::unreachable!(); //~ missing_panic_message
+}


### PR DESCRIPTION
Resolves https://github.com/rust-lang/rust-clippy/issues/14843

```
changelog: new lint: [`missing_panic_message`]
```

<details>
<summary>LLM disclosure: I used LLM to refine my English</summary>

- In `clippy_lints/src/missing_panic_message.rs`: check -> assess
```
/// ### Known problems
/// This lint cannot assess the quality of the custom messages.
```
- In `tests/ui/missing_panic_message.rs`: originally "The two lints do not conflict but are overlapped. Considering lint coverage, it is better that both of them catch this pattern"
```
#[expect(
    clippy::unit_arg,
    reason = "These two lints overlap without conflicting. Keeping both active provides better overall coverage."
)]
```

</details>