### PR TITLE
disable missing_transmute_annotations lint in local macros

### DIFF
--- a/clippy_lints/src/transmute/missing_transmute_annotations.rs
+++ b/clippy_lints/src/transmute/missing_transmute_annotations.rs
@@ -49,8 +49,7 @@ pub(super) fn check<'tcx>(
     expr_hir_id: HirId,
 ) -> bool {
     let last = path.segments.last().unwrap();
-    if last.ident.span.in_external_macro(cx.tcx.sess.source_map()) {
-        // If it comes from a non-local macro, we ignore it.
+    if last.ident.span.from_expansion() {
         return false;
     }
     let args = last.args;

--- a/tests/ui/missing_transmute_annotations.fixed
+++ b/tests/ui/missing_transmute_annotations.fixed
@@ -8,8 +8,8 @@ extern crate macro_rules;
 
 macro_rules! local_bad_transmute {
     ($e:expr) => {
-        std::mem::transmute::<[u16; 2], i32>($e)
-        //~^ missing_transmute_annotations
+        // Should not warn!
+        std::mem::transmute($e)
     };
 }
 

--- a/tests/ui/missing_transmute_annotations.rs
+++ b/tests/ui/missing_transmute_annotations.rs
@@ -8,8 +8,8 @@ extern crate macro_rules;
 
 macro_rules! local_bad_transmute {
     ($e:expr) => {
+        // Should not warn!
         std::mem::transmute($e)
-        //~^ missing_transmute_annotations
     };
 }
 

--- a/tests/ui/missing_transmute_annotations.stderr
+++ b/tests/ui/missing_transmute_annotations.stderr
@@ -38,17 +38,6 @@ LL |         bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:11:19
-   |
-LL |         std::mem::transmute($e)
-   |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
-...
-LL |         i = local_bad_transmute!([1u16, 2u16]);
-   |             ---------------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `local_bad_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: transmute used without annotations
   --> tests/ui/missing_transmute_annotations.rs:57:23
    |
 LL |         i = std::mem::transmute([0i16, 0i16]);
@@ -78,5 +67,5 @@ error: transmute used without annotations
 LL |         let x: _ = std::mem::transmute::<_, i32>([1u16, 2u16]);
    |                              ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
-error: aborting due to 12 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
As the name says, this disables the `missing_transmute_annotations` lint in local macros.

As discussed in https://github.com/rust-lang/rust/pull/161677 and https://github.com/rust-lang/rust-clippy/pull/17612,
this lint firing in local macros may be a generally bad idea:  the point of the lint is that in order to ensure that the safety invariant holds, the transmute source and destination should be explicitly fixed. 

In macros, the source or destination may very well be dynamic and dependent on the macro call, which means we cannot always promise safety.
Also, the lint may fire many times with different suggestions, one for each macro call which is very noisy. 

Because this is an alternative solution to it, this closes https://github.com/rust-lang/rust-clippy/pull/17612 

My thanks to @CommanderStorm 


changelog: [`missing_transmute_annotations`]: disable the lint in local macros
