### PR TITLE
fix: check expr.span for external macro in redundant_field_names

### DIFF
--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -50,6 +50,7 @@ impl EarlyLintPass for RedundantFieldNames {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         if let ExprKind::Struct(ref se) = expr.kind
             && self.msrv.meets(msrvs::FIELD_INIT_SHORTHAND)
+            && !expr.span.in_external_macro(cx.sess().source_map())
         {
             for field in &se.fields {
                 if !field.is_shorthand
@@ -58,7 +59,6 @@ impl EarlyLintPass for RedundantFieldNames {
                     && segment.args.is_none()
                     && segment.ident == field.ident
                     && field.span.eq_ctxt(field.ident.span)
-                    && !field.span.in_external_macro(cx.sess().source_map())
                 {
                     span_lint_and_sugg(
                         cx,


### PR DESCRIPTION
## Summary

Fixes rust-lang/rust-clippy#17525

PR rust-lang/rust-clippy#17294 changed the external macro check from `expr.span.in_external_macro` to `field.span.in_external_macro`. This caused false positives on code generated by derive macros like `thiserror::Error`.

## Root Cause

When a derive macro expands code:
- `expr.span` points to the `#[derive(...)]` line (correctly identified as external macro)
- `field.span`s point to the original struct definition (NOT identified as external macro)

So `field.span.in_external_macro` returns false even though the code is generated by a macro.

## Fix

Reverted to checking `expr.span.in_external_macro` before the field loop. This correctly skips linting on all derived code.

## Testing

All existing tests pass:
```
cargo test --test compile-test -- redundant_field_names
tests/ui/redundant_field_names.rs ... ok
tests/ui/redundant_field_names.fixed ... ok
```
