### PR TITLE
chore(cargo-dev): read target dir envs and try to use hardlinking

### DIFF
--- a/clippy_dev/src/setup/toolchain.rs
+++ b/clippy_dev/src/setup/toolchain.rs
@@ -1,6 +1,6 @@
 use crate::utils::{cargo_cmd, run_exit_on_err};
 use std::env::consts::EXE_SUFFIX;
-use std::env::current_dir;
+use std::env::{current_dir, var_os};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -67,8 +67,10 @@ fn install_bin(bin: &str, dest: &Path, standalone: bool, release: bool) {
     let profile = if release { "release" } else { "debug" };
     let file_name = format!("{bin}{EXE_SUFFIX}");
 
-    let mut src = current_dir().unwrap();
-    src.extend(["target", profile, &file_name]);
+    let mut src = var_os("CARGO_BUILD_TARGET_DIR")
+        .or_else(|| var_os("CARGO_TARGET_DIR"))
+        .map_or_else(|| current_dir().unwrap().join("target"), PathBuf::from);
+    src.extend([profile, &file_name]);
 
     let mut dest = dest.to_path_buf();
     dest.extend(["bin", &file_name]);

--- a/clippy_dev/src/setup/toolchain.rs
+++ b/clippy_dev/src/setup/toolchain.rs
@@ -76,7 +76,9 @@ fn install_bin(bin: &str, dest: &Path, standalone: bool, release: bool) {
     dest.extend(["bin", &file_name]);
 
     if standalone {
-        fs::copy(src, dest).unwrap();
+        fs::hard_link(&src, &dest)
+            .or_else(|_| fs::copy(src, dest).map(|_| ()))
+            .unwrap();
     } else {
         symlink(src, dest).unwrap();
     }


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none

---

Two independent commits for `cargo dev setup toolchain`, I pasted their descriptions below to make it easier to review.

- fix(cargo-dev): read target dir from env if present in toolchain install

   I set a per-project `CARGO_TARGET_DIR` to `~/.cache/...` so that I can
   simply `rm -rf ~/.cache/target-dirs` when I want to clean them up all at
   once, which made `cargo dev setup toolchain` produce an install with broken
   symlinks (or failed copies with `--standalone`).

   The fully correct way would likely be to use `cargo metadata` but I don't
   think it's necessary to introduce JSON parsing in `cargo dev` here since
   there is already a committed `.cargo/config.toml` that sets the target dir
   to `"target"` so the only ways to do a user-specific override are via the
   env vars or `--target-dir` and that second one cannot be passed to `cargo
   dev setup toolchain`.

- nit(cargo-dev): try to hard-link in `setup toolchain`
   
   When `--standalone` is passed, we try to hard-link first to save some
   space, falling back to copying on failure (which can notably happens when
   `src` and `dest` are on different filesystems).
   
---

Sorry if I missed any guidelines on internal-only improvements, I only saw the note about the changelog in the PR description.