### PR TITLE
Add missing_fused_iterator pedantic lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7319,6 +7319,7 @@ Released 2018-09-13
 [`missing_enforced_import_renames`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_enforced_import_renames
 [`missing_errors_doc`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_errors_doc
 [`missing_fields_in_debug`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_fields_in_debug
+[`missing_fused_iterator`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_fused_iterator
 [`missing_inline_in_public_items`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_inline_in_public_items
 [`missing_panics_doc`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_panics_doc
 [`missing_safety_doc`]: https://rust-lang.github.io/rust-clippy/main/index.html#missing_safety_doc

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -547,6 +547,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::missing_doc::MISSING_DOCS_IN_PRIVATE_ITEMS_INFO,
     crate::missing_enforced_import_rename::MISSING_ENFORCED_IMPORT_RENAMES_INFO,
     crate::missing_fields_in_debug::MISSING_FIELDS_IN_DEBUG_INFO,
+    crate::missing_fused_iterator::MISSING_FUSED_ITERATOR_INFO,
     crate::missing_inline::MISSING_INLINE_IN_PUBLIC_ITEMS_INFO,
     crate::missing_trait_methods::MISSING_TRAIT_METHODS_INFO,
     crate::mixed_read_write_in_expression::DIVERGING_SUB_EXPRESSION_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -243,6 +243,7 @@ mod missing_const_for_thread_local;
 mod missing_doc;
 mod missing_enforced_import_rename;
 mod missing_fields_in_debug;
+mod missing_fused_iterator;
 mod missing_inline;
 mod missing_trait_methods;
 mod mixed_read_write_in_expression;
@@ -870,6 +871,7 @@ rustc_lint::late_lint_methods!(
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
         NeedlessNonzeroGet: needless_nonzero_get::NeedlessNonzeroGet = needless_nonzero_get::NeedlessNonzeroGet::new(conf),
+        MissingFusedIterator: missing_fused_iterator::MissingFusedIterator = missing_fused_iterator::MissingFusedIterator::new(conf),
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/missing_fused_iterator.rs
+++ b/clippy_lints/src/missing_fused_iterator.rs
@@ -1,5 +1,5 @@
 use clippy_config::Conf;
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_lint_allowed;
 use clippy_utils::macros::span_is_local;
 use clippy_utils::msrvs::Msrv;
@@ -52,6 +52,11 @@ declare_clippy_lint! {
     /// Clippy cannot prove that an iterator remains exhausted after returning `None`. In
     /// addition, any positive or negative `FusedIterator` implementation for the type suppresses
     /// this lint, even if its generic bounds do not match every `Iterator` implementation.
+    ///
+    /// An iterator which is deliberately not fused is best documented with
+    /// `#[allow(clippy::missing_fused_iterator)]` and a comment saying why. A negative
+    /// implementation, `impl !std::iter::FusedIterator for Empty {}`, also suppresses this lint,
+    /// but negative implementations are unstable and only available on nightly.
     #[clippy::version = "1.100.0"]
     pub MISSING_FUSED_ITERATOR,
     pedantic,
@@ -72,53 +77,56 @@ impl MissingFusedIterator {
 
 impl<'tcx> LateLintPass<'tcx> for MissingFusedIterator {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'_>) {
-        if !matches!(
+        if matches!(
             item.kind,
             ItemKind::Struct(..) | ItemKind::Enum(..) | ItemKind::Union(..)
-        ) || !span_is_local(item.span)
-            || !cx.effective_visibilities.is_reachable(item.owner_id.def_id)
-            || is_lint_allowed(cx, MISSING_FUSED_ITERATOR, item.hir_id())
+        ) && span_is_local(item.span)
+            && cx.effective_visibilities.is_reachable(item.owner_id.def_id)
+            && !is_lint_allowed(cx, MISSING_FUSED_ITERATOR, item.hir_id())
+            && let Some(iterator_trait) = cx.tcx.lang_items().iterator_trait()
+            && let Some(fused_iterator_trait) = cx.tcx.lang_items().fused_iterator_trait()
+            && self.msrv.is_stable(cx, fused_iterator_trait)
+            && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip()
+            && cx
+                .tcx
+                .non_blanket_impls_for_ty(iterator_trait, ty)
+                .any(|impl_id| cx.tcx.impl_polarity(impl_id) == ty::ImplPolarity::Positive)
+            // Any implementation, including a conditional or negative one, indicates that the
+            // `FusedIterator` status of this nominal type has been considered explicitly.
+            && cx
+                .tcx
+                .non_blanket_impls_for_ty(fused_iterator_trait, ty)
+                .next()
+                .is_none()
         {
-            return;
-        }
+            // Point at the `Iterator` implementation which made this type an iterator. It may live
+            // far away from the type definition, even in another file.
+            let iterator_impl_span = cx
+                .tcx
+                .non_blanket_impls_for_ty(iterator_trait, ty)
+                .filter(|&impl_id| cx.tcx.impl_polarity(impl_id) == ty::ImplPolarity::Positive)
+                .filter_map(|impl_id| impl_id.as_local())
+                .map(|impl_id| cx.tcx.def_span(impl_id))
+                .filter(|&span| span_is_local(span))
+                .min_by_key(|span| span.lo());
 
-        let Some(iterator_trait) = cx.tcx.lang_items().iterator_trait() else {
-            return;
-        };
-        let Some(fused_iterator_trait) = cx.tcx.lang_items().fused_iterator_trait() else {
-            return;
-        };
-        if !self.msrv.is_stable(cx, fused_iterator_trait) {
-            return;
+            span_lint_and_then(
+                cx,
+                MISSING_FUSED_ITERATOR,
+                item.span,
+                "this publicly reachable type implements `Iterator` but not `FusedIterator`",
+                |diag| {
+                    let help = "if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`";
+                    if let Some(iterator_impl_span) = iterator_impl_span {
+                        diag.span_help(iterator_impl_span, help);
+                    } else {
+                        diag.help(help);
+                    }
+                    diag.help(
+                        "otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused",
+                    );
+                },
+            );
         }
-
-        let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip();
-        if !cx
-            .tcx
-            .non_blanket_impls_for_ty(iterator_trait, ty)
-            .any(|impl_id| cx.tcx.impl_polarity(impl_id) == ty::ImplPolarity::Positive)
-        {
-            return;
-        }
-
-        // Any implementation, including a conditional or negative one, indicates that the
-        // `FusedIterator` status of this nominal type has been considered explicitly.
-        if cx
-            .tcx
-            .non_blanket_impls_for_ty(fused_iterator_trait, ty)
-            .next()
-            .is_some()
-        {
-            return;
-        }
-
-        span_lint_and_help(
-            cx,
-            MISSING_FUSED_ITERATOR,
-            item.span,
-            "this publicly reachable type implements `Iterator` but not `FusedIterator`",
-            None,
-            "if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`",
-        );
     }
 }

--- a/clippy_lints/src/missing_fused_iterator.rs
+++ b/clippy_lints/src/missing_fused_iterator.rs
@@ -1,0 +1,124 @@
+use clippy_config::Conf;
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::is_lint_allowed;
+use clippy_utils::macros::span_is_local;
+use clippy_utils::msrvs::Msrv;
+use rustc_hir::{Item, ItemKind};
+use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
+use rustc_middle::ty;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for publicly reachable iterator types which do not implement
+    /// [`FusedIterator`](https://doc.rust-lang.org/std/iter/trait.FusedIterator.html).
+    ///
+    /// ### Why is this bad?
+    /// Implementing `FusedIterator` is a public guarantee that an iterator will keep returning
+    /// `None` after it is exhausted. It also allows
+    /// [`Iterator::fuse`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.fuse)
+    /// to optimize its wrapper into a no-op with no performance penalty.
+    ///
+    /// Not every iterator is fused. This lint should be allowed for iterators which may resume
+    /// yielding items after returning `None`.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// pub struct Empty;
+    ///
+    /// impl Iterator for Empty {
+    ///     type Item = ();
+    ///
+    ///     fn next(&mut self) -> Option<Self::Item> {
+    ///         None
+    ///     }
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// pub struct Empty;
+    ///
+    /// impl Iterator for Empty {
+    ///     type Item = ();
+    ///
+    ///     fn next(&mut self) -> Option<Self::Item> {
+    ///         None
+    ///     }
+    /// }
+    ///
+    /// impl std::iter::FusedIterator for Empty {}
+    /// ```
+    ///
+    /// ### Known problems
+    /// Clippy cannot prove that an iterator remains exhausted after returning `None`. In
+    /// addition, any positive or negative `FusedIterator` implementation for the type suppresses
+    /// this lint, even if its generic bounds do not match every `Iterator` implementation.
+    #[clippy::version = "1.100.0"]
+    pub MISSING_FUSED_ITERATOR,
+    pedantic,
+    "a publicly reachable iterator type does not implement `FusedIterator`"
+}
+
+impl_lint_pass!(MissingFusedIterator => [MISSING_FUSED_ITERATOR]);
+
+pub struct MissingFusedIterator {
+    msrv: Msrv,
+}
+
+impl MissingFusedIterator {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self { msrv: conf.msrv.into() }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for MissingFusedIterator {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'_>) {
+        if !matches!(
+            item.kind,
+            ItemKind::Struct(..) | ItemKind::Enum(..) | ItemKind::Union(..)
+        ) || !span_is_local(item.span)
+            || !cx.effective_visibilities.is_reachable(item.owner_id.def_id)
+            || is_lint_allowed(cx, MISSING_FUSED_ITERATOR, item.hir_id())
+        {
+            return;
+        }
+
+        let Some(iterator_trait) = cx.tcx.lang_items().iterator_trait() else {
+            return;
+        };
+        let Some(fused_iterator_trait) = cx.tcx.lang_items().fused_iterator_trait() else {
+            return;
+        };
+        if !self.msrv.is_stable(cx, fused_iterator_trait) {
+            return;
+        }
+
+        let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip();
+        if !cx
+            .tcx
+            .non_blanket_impls_for_ty(iterator_trait, ty)
+            .any(|impl_id| cx.tcx.impl_polarity(impl_id) == ty::ImplPolarity::Positive)
+        {
+            return;
+        }
+
+        // Any implementation, including a conditional or negative one, indicates that the
+        // `FusedIterator` status of this nominal type has been considered explicitly.
+        if cx
+            .tcx
+            .non_blanket_impls_for_ty(fused_iterator_trait, ty)
+            .next()
+            .is_some()
+        {
+            return;
+        }
+
+        span_lint_and_help(
+            cx,
+            MISSING_FUSED_ITERATOR,
+            item.span,
+            "this publicly reachable type implements `Iterator` but not `FusedIterator`",
+            None,
+            "if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`",
+        );
+    }
+}

--- a/clippy_lints/src/missing_fused_iterator.rs
+++ b/clippy_lints/src/missing_fused_iterator.rs
@@ -1,12 +1,17 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::is_lint_allowed;
 use clippy_utils::macros::span_is_local;
-use clippy_utils::msrvs::Msrv;
-use rustc_hir::def_id::DefId;
-use rustc_hir::{Item, ItemKind};
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::source::{reindent_multiline, snippet, snippet_opt};
+use clippy_utils::std_or_core;
+use clippy_utils::sugg::DiagExt as _;
+use rustc_ast::ImplPolarity;
+use rustc_errors::Applicability;
+use rustc_hir::attrs::{AttributeKind, LangItem};
+use rustc_hir::{Attribute, Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
-use rustc_middle::ty;
+use rustc_span::Span;
+use std::fmt::Write as _;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -19,7 +24,7 @@ declare_clippy_lint! {
     /// [`Iterator::fuse`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.fuse)
     /// to optimize its wrapper into a no-op with no performance penalty.
     ///
-    /// Not every iterator is fused. This lint should be allowed for iterators which may resume
+    /// Not every iterator is fused. This lint should be suppressed for iterators which may resume
     /// yielding items after returning `None`.
     ///
     /// ### Example
@@ -54,10 +59,12 @@ declare_clippy_lint! {
     /// addition, any positive or negative `FusedIterator` implementation for the type suppresses
     /// this lint, even if its generic bounds do not match every `Iterator` implementation.
     ///
-    /// An iterator which is deliberately not fused is best documented with
-    /// `#[allow(clippy::missing_fused_iterator)]` and a comment saying why. A negative
-    /// implementation, `impl !std::iter::FusedIterator for Empty {}`, also suppresses this lint,
-    /// but negative implementations are unstable and only available on nightly.
+    /// An iterator which is deliberately not fused is best documented by putting
+    /// `#[expect(clippy::missing_fused_iterator, reason = "...")]` on its `Iterator`
+    /// implementation, or `#[allow(clippy::missing_fused_iterator)]` with a comment saying why
+    /// if the MSRV is below 1.81. A negative implementation,
+    /// `impl !std::iter::FusedIterator for Empty {}`, also suppresses this lint, but negative
+    /// implementations are unstable and only available on nightly.
     #[clippy::version = "1.100.0"]
     pub MISSING_FUSED_ITERATOR,
     pedantic,
@@ -78,56 +85,122 @@ impl MissingFusedIterator {
 
 impl<'tcx> LateLintPass<'tcx> for MissingFusedIterator {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'_>) {
-        if matches!(
-            item.kind,
-            ItemKind::Struct(..) | ItemKind::Enum(..) | ItemKind::Union(..)
-        ) && span_is_local(item.span)
-            && cx.effective_visibilities.is_reachable(item.owner_id.def_id)
-            && !is_lint_allowed(cx, MISSING_FUSED_ITERATOR, item.hir_id())
-            && let Some(iterator_trait) = cx.tcx.lang_items().iterator_trait()
+        if let ItemKind::Impl(impl_) = item.kind
+            && let Some(of_trait) = impl_.of_trait
+            && of_trait.polarity == ImplPolarity::Positive
+            && let Some(trait_id) = of_trait.trait_ref.trait_def_id()
+            && cx.tcx.is_lang_item(trait_id, LangItem::Iterator)
+            && span_is_local(item.span)
+            && let self_ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip()
+            // Only the nominal type itself counts, not e.g. `impl Iterator for &Foo`.
+            && let Some(adt) = self_ty.ty_adt_def()
+            && let Some(adt_local_id) = adt.did().as_local()
+            && cx.effective_visibilities.is_reachable(adt_local_id)
             && let Some(fused_iterator_trait) = cx.tcx.lang_items().fused_iterator_trait()
             && self.msrv.is_stable(cx, fused_iterator_trait)
-            && let ty = cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip()
-            && cx
-                .tcx
-                .non_blanket_impls_for_ty(iterator_trait, ty)
-                .any(|impl_id| cx.tcx.impl_polarity(impl_id) == ty::ImplPolarity::Positive)
             // Any implementation, including a conditional or negative one, indicates that the
             // `FusedIterator` status of this nominal type has been considered explicitly.
             && cx
                 .tcx
-                .non_blanket_impls_for_ty(fused_iterator_trait, ty)
+                .non_blanket_impls_for_ty(fused_iterator_trait, self_ty)
                 .next()
                 .is_none()
+            && let Some(std_or_core) = std_or_core(cx)
         {
-            // Point at the `Iterator` implementation which made this type an iterator. It may live
-            // far away from the type definition, even in another file.
-            let iterator_impl_span = cx
-                .tcx
-                .non_blanket_impls_for_ty(iterator_trait, ty)
-                .filter(|&impl_id| cx.tcx.impl_polarity(impl_id) == ty::ImplPolarity::Positive)
-                .filter_map(DefId::as_local)
-                .map(|impl_id| cx.tcx.def_span(impl_id))
-                .filter(|&span| span_is_local(span))
-                .min_by_key(|span| span.lo());
+            let impl_span = cx.tcx.def_span(item.owner_id);
+            let self_ty_snip = if item.span.from_expansion() {
+                self_ty.to_string()
+            } else {
+                snippet(cx, impl_.self_ty.span, "..").into_owned()
+            };
 
             span_lint_and_then(
                 cx,
                 MISSING_FUSED_ITERATOR,
-                item.span,
-                "this publicly reachable type implements `Iterator` but not `FusedIterator`",
+                impl_span,
+                "publicly reachable type with `Iterator` implementation does not implement `FusedIterator`",
                 |diag| {
-                    let help = "if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`";
-                    if let Some(iterator_impl_span) = iterator_impl_span {
-                        diag.span_help(iterator_impl_span, help);
-                    } else {
-                        diag.help(help);
-                    }
-                    diag.help(
-                        "otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused",
+                    diag.span_label(impl_span, "missing `FusedIterator` implementation");
+                    diag.note(
+                        "public iterators that keep returning `None` once exhausted should implement `FusedIterator` \
+                         so that `Iterator::fuse` can become a no-op",
                     );
+
+                    let suppress_attr = if self.msrv.meets(cx, msrvs::LINT_REASONS_STABILIZATION) {
+                        "#[expect(clippy::missing_fused_iterator, reason = \"<why this iterator can yield again after returning `None`>\")]"
+                    } else {
+                        "#[allow(clippy::missing_fused_iterator)] // <why this iterator can yield again after returning `None`>"
+                    };
+                    let implement_msg = format!("implement `FusedIterator` for `{self_ty_snip}`");
+                    let suppress_msg = "if this iterator is intentionally not fused, suppress the lint";
+
+                    let conditional_attrs = if item.span.from_expansion() {
+                        None
+                    } else {
+                        conditional_attrs(cx, item)
+                    };
+                    if let Some(mut new_impl) = conditional_attrs {
+                        let generics = snippet(cx, impl_.generics.span, "");
+                        let _ = write!(
+                            new_impl,
+                            "impl{generics} {std_or_core}::iter::FusedIterator for {self_ty_snip}"
+                        );
+                        if impl_.generics.has_where_clause_predicates {
+                            let where_clause = snippet(cx, impl_.generics.where_clause_span, "");
+                            new_impl.push('\n');
+                            new_impl.push_str(&reindent_multiline(&where_clause, true, Some(4)));
+                            new_impl.push('\n');
+                        } else {
+                            new_impl.push(' ');
+                        }
+                        new_impl.push_str("{}");
+                        diag.suggest_append_item(
+                            cx,
+                            item.span,
+                            &implement_msg,
+                            &new_impl,
+                            Applicability::MaybeIncorrect,
+                        );
+                        diag.suggest_item_with_attr(
+                            cx,
+                            impl_span,
+                            suppress_msg,
+                            suppress_attr,
+                            Applicability::HasPlaceholders,
+                        );
+                    } else {
+                        diag.help(implement_msg);
+                        diag.help(format!("{suppress_msg} with `{suppress_attr}`"));
+                    }
                 },
             );
         }
     }
+}
+
+fn conditional_attrs(cx: &LateContext<'_>, item: &Item<'_>) -> Option<String> {
+    let spans: Vec<Span> = cx
+        .tcx
+        .hir_attrs(item.hir_id())
+        .iter()
+        .filter_map(|attr| match attr {
+            Attribute::Parsed(AttributeKind::CfgTrace(cfgs) | AttributeKind::CfgAttrTrace(cfgs)) => Some(cfgs),
+            _ => None,
+        })
+        .flat_map(|cfgs| cfgs.iter().map(|&(_, span)| span))
+        .collect();
+    let mut outermost: Vec<Span> = spans
+        .iter()
+        .copied()
+        .filter(|&span| !spans.iter().any(|&other| other != span && other.contains(span)))
+        .collect();
+    outermost.sort_by_key(|span| span.lo());
+    outermost.dedup();
+
+    let mut attrs = String::new();
+    for span in outermost {
+        attrs.push_str(&snippet_opt(cx, span)?);
+        attrs.push('\n');
+    }
+    Some(attrs)
 }

--- a/clippy_lints/src/missing_fused_iterator.rs
+++ b/clippy_lints/src/missing_fused_iterator.rs
@@ -3,6 +3,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_lint_allowed;
 use clippy_utils::macros::span_is_local;
 use clippy_utils::msrvs::Msrv;
+use rustc_hir::def_id::DefId;
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
 use rustc_middle::ty;
@@ -105,7 +106,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingFusedIterator {
                 .tcx
                 .non_blanket_impls_for_ty(iterator_trait, ty)
                 .filter(|&impl_id| cx.tcx.impl_polarity(impl_id) == ty::ImplPolarity::Positive)
-                .filter_map(|impl_id| impl_id.as_local())
+                .filter_map(DefId::as_local)
                 .map(|impl_id| cx.tcx.def_span(impl_id))
                 .filter(|&span| span_is_local(span))
                 .min_by_key(|span| span.lo());

--- a/tests/ui/missing_fused_iterator.rs
+++ b/tests/ui/missing_fused_iterator.rs
@@ -1,79 +1,89 @@
 //@no-rustfix
 //@aux-build:proc_macros.rs
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 #![feature(negative_impls)]
 #![warn(clippy::missing_fused_iterator)]
 
 extern crate proc_macros;
 
-use std::iter::{FusedIterator as RenamedFusedIterator, Iterator as RenamedIterator};
-
-pub struct PublicStruct;
-//~^ missing_fused_iterator
-
-impl Iterator for PublicStruct {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-pub enum PublicEnum {
+pub mod public_struct {
+    pub struct PublicStruct;
     //~^ missing_fused_iterator
-    Empty,
-}
 
-impl Iterator for PublicEnum {
-    type Item = ();
+    impl Iterator for PublicStruct {
+        type Item = ();
 
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
 }
 
-pub union PublicUnion {
+pub mod public_enum {
+    pub enum PublicEnum {
+        //~^ missing_fused_iterator
+        Empty,
+    }
+
+    impl Iterator for PublicEnum {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+}
+
+pub mod public_union {
+    pub union PublicUnion {
+        //~^ missing_fused_iterator
+        value: u8,
+    }
+
+    impl Iterator for PublicUnion {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+}
+
+pub mod public_generic {
+    pub struct PublicGeneric<T>(T);
     //~^ missing_fused_iterator
-    value: u8,
-}
 
-impl Iterator for PublicUnion {
-    type Item = ();
+    impl<T> Iterator for PublicGeneric<T> {
+        type Item = T;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
 }
 
-pub struct PublicGeneric<T>(T);
-//~^ missing_fused_iterator
+pub mod private_type {
+    struct Private;
 
-impl<T> Iterator for PublicGeneric<T> {
-    type Item = T;
+    impl Iterator for Private {
+        type Item = ();
 
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
 }
 
-struct Private;
+pub mod crate_visible_type {
+    pub(crate) struct CrateVisible;
 
-impl Iterator for Private {
-    type Item = ();
+    impl Iterator for CrateVisible {
+        type Item = ();
 
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-pub(crate) struct CrateVisible;
-
-impl Iterator for CrateVisible {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
 }
 
@@ -121,99 +131,117 @@ pub fn returned() -> visibility::Returned {
     visibility::returned()
 }
 
-pub struct AlreadyFused;
+pub mod already_fused {
+    pub struct AlreadyFused;
 
-impl Iterator for AlreadyFused {
-    type Item = ();
+    impl Iterator for AlreadyFused {
+        type Item = ();
 
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl std::iter::FusedIterator for AlreadyFused {}
+}
+
+pub mod conditionally_fused {
+    pub struct ConditionallyFused<T>(T);
+
+    impl<T> Iterator for ConditionallyFused<T> {
+        type Item = T;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    // Deliberately does not cover every `T` for which the `Iterator` implementation applies. Any
+    // implementation for the nominal type is enough to suppress the lint.
+    impl<T: Clone> std::iter::FusedIterator for ConditionallyFused<T> {}
+}
+
+pub mod explicitly_not_fused {
+    pub struct ExplicitlyNotFused;
+
+    impl Iterator for ExplicitlyNotFused {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    // An explicit negative implementation documents that this type is intentionally not fused.
+    impl !std::iter::FusedIterator for ExplicitlyNotFused {}
+}
+
+pub mod explicitly_not_an_iterator {
+    pub struct ExplicitlyNotAnIterator;
+
+    // Negative `Iterator` implementations must not satisfy the positive-implementation check.
+    impl !Iterator for ExplicitlyNotAnIterator {}
+}
+
+pub mod doc_hidden {
+    #[doc(hidden)]
+    pub struct DocHidden;
+    //~^ missing_fused_iterator
+
+    impl Iterator for DocHidden {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
 }
 
-impl std::iter::FusedIterator for AlreadyFused {}
+pub mod iterator_by_reference {
+    pub struct IteratorByReference;
 
-pub struct ConditionallyFused<T>(T);
+    // The declared nominal type does not itself implement `Iterator`.
+    impl Iterator for &IteratorByReference {
+        type Item = ();
 
-impl<T> Iterator for ConditionallyFused<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
 }
 
-// Deliberately does not cover every `T` for which the `Iterator` implementation applies. Any
-// implementation for the nominal type is enough to suppress the lint.
-impl<T: Clone> std::iter::FusedIterator for ConditionallyFused<T> {}
+pub mod opaque {
+    struct OpaqueIterator;
 
-pub struct ExplicitlyNotFused;
+    impl Iterator for OpaqueIterator {
+        type Item = ();
 
-impl Iterator for ExplicitlyNotFused {
-    type Item = ();
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+    // `FusedIterator` would need to be part of this opaque return bound to be exposed publicly.
+    pub fn opaque_iterator() -> impl Iterator<Item = ()> {
+        OpaqueIterator
     }
 }
 
-// An explicit negative implementation documents that this type is intentionally not fused.
-impl !std::iter::FusedIterator for ExplicitlyNotFused {}
+pub mod renamed_traits {
+    use std::iter::{FusedIterator as RenamedFusedIterator, Iterator as RenamedIterator};
 
-pub struct ExplicitlyNotAnIterator;
+    pub struct RenamedTraits;
 
-// Negative `Iterator` implementations must not satisfy the positive-implementation check.
-impl !Iterator for ExplicitlyNotAnIterator {}
+    impl RenamedIterator for RenamedTraits {
+        type Item = ();
 
-#[doc(hidden)]
-pub struct DocHidden;
-//~^ missing_fused_iterator
-
-impl Iterator for DocHidden {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
+
+    impl RenamedFusedIterator for RenamedTraits {}
 }
-
-pub struct IteratorByReference;
-
-// The declared nominal type does not itself implement `Iterator`.
-impl Iterator for &IteratorByReference {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-struct OpaqueIterator;
-
-impl Iterator for OpaqueIterator {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-// `FusedIterator` would need to be part of this opaque return bound to be exposed publicly.
-pub fn opaque_iterator() -> impl Iterator<Item = ()> {
-    OpaqueIterator
-}
-
-pub struct RenamedTraits;
-
-impl RenamedIterator for RenamedTraits {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-impl RenamedFusedIterator for RenamedTraits {}
 
 mod shadow_iterator {
     pub trait Iterator {}
@@ -244,27 +272,55 @@ mod shadow_fused_iterator {
 
 pub use shadow_fused_iterator::RealIterator;
 
-macro_rules! local_iterator {
-    ($name:ident) => {
-        pub struct $name;
-        //~^ missing_fused_iterator
+pub mod local_macro {
+    macro_rules! local_iterator {
+        ($name:ident) => {
+            pub struct $name;
+            //~^ missing_fused_iterator
 
-        impl Iterator for $name {
+            impl Iterator for $name {
+                type Item = ();
+
+                fn next(&mut self) -> Option<Self::Item> {
+                    None
+                }
+            }
+        };
+    }
+
+    local_iterator!(LocalMacroIterator);
+}
+
+pub mod external_macro {
+    proc_macros::external! {
+        pub struct ExternalMacroIterator;
+
+        impl Iterator for ExternalMacroIterator {
             type Item = ();
 
             fn next(&mut self) -> Option<Self::Item> {
                 None
             }
         }
-    };
+    }
 }
 
-local_iterator!(LocalMacroIterator);
+pub mod lint_levels {
+    #[allow(clippy::missing_fused_iterator)]
+    pub struct Allowed;
 
-proc_macros::external! {
-    pub struct ExternalMacroIterator;
+    impl Iterator for Allowed {
+        type Item = ();
 
-    impl Iterator for ExternalMacroIterator {
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    #[expect(clippy::missing_fused_iterator)]
+    pub struct Expected;
+
+    impl Iterator for Expected {
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -273,48 +329,28 @@ proc_macros::external! {
     }
 }
 
-#[allow(clippy::missing_fused_iterator)]
-pub struct Allowed;
+pub mod msrv {
+    #[clippy::msrv = "1.25"]
+    pub struct BeforeMsrv;
 
-impl Iterator for Allowed {
-    type Item = ();
+    impl Iterator for BeforeMsrv {
+        type Item = ();
 
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
-}
 
-#[expect(clippy::missing_fused_iterator)]
-pub struct Expected;
+    #[clippy::msrv = "1.26"]
+    pub struct AtMsrv;
+    //~^ missing_fused_iterator
 
-impl Iterator for Expected {
-    type Item = ();
+    impl Iterator for AtMsrv {
+        type Item = ();
 
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-#[clippy::msrv = "1.25"]
-pub struct BeforeMsrv;
-
-impl Iterator for BeforeMsrv {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-#[clippy::msrv = "1.26"]
-pub struct AtMsrv;
-//~^ missing_fused_iterator
-
-impl Iterator for AtMsrv {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
     }
 }
 

--- a/tests/ui/missing_fused_iterator.rs
+++ b/tests/ui/missing_fused_iterator.rs
@@ -395,7 +395,7 @@ pub mod bounded_generic {
     //~v missing_fused_iterator
     impl<T: Clone> Iterator for Bounded<T>
     where
-        T: Default,
+        T: Default, // needed for the default value
         T: Copy,
     {
         type Item = T;

--- a/tests/ui/missing_fused_iterator.rs
+++ b/tests/ui/missing_fused_iterator.rs
@@ -9,9 +9,9 @@ extern crate proc_macros;
 
 pub mod public_struct {
     pub struct PublicStruct;
-    //~^ missing_fused_iterator
 
     impl Iterator for PublicStruct {
+        //~^ missing_fused_iterator
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -22,11 +22,11 @@ pub mod public_struct {
 
 pub mod public_enum {
     pub enum PublicEnum {
-        //~^ missing_fused_iterator
         Empty,
     }
 
     impl Iterator for PublicEnum {
+        //~^ missing_fused_iterator
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -37,11 +37,11 @@ pub mod public_enum {
 
 pub mod public_union {
     pub union PublicUnion {
-        //~^ missing_fused_iterator
         value: u8,
     }
 
     impl Iterator for PublicUnion {
+        //~^ missing_fused_iterator
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -52,9 +52,9 @@ pub mod public_union {
 
 pub mod public_generic {
     pub struct PublicGeneric<T>(T);
-    //~^ missing_fused_iterator
 
     impl<T> Iterator for PublicGeneric<T> {
+        //~^ missing_fused_iterator
         type Item = T;
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -89,9 +89,9 @@ pub mod crate_visible_type {
 
 mod visibility {
     pub struct Reexported;
-    //~^ missing_fused_iterator
 
     impl Iterator for Reexported {
+        //~^ missing_fused_iterator
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -100,9 +100,9 @@ mod visibility {
     }
 
     pub struct Returned;
-    //~^ missing_fused_iterator
 
     impl Iterator for Returned {
+        //~^ missing_fused_iterator
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -186,9 +186,9 @@ pub mod explicitly_not_an_iterator {
 pub mod doc_hidden {
     #[doc(hidden)]
     pub struct DocHidden;
-    //~^ missing_fused_iterator
 
     impl Iterator for DocHidden {
+        //~^ missing_fused_iterator
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -257,9 +257,9 @@ mod shadow_fused_iterator {
     pub trait FusedIterator {}
 
     pub struct RealIterator;
-    //~^ missing_fused_iterator
 
     impl std::iter::Iterator for RealIterator {
+        //~^ missing_fused_iterator
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -276,9 +276,9 @@ pub mod local_macro {
     macro_rules! local_iterator {
         ($name:ident) => {
             pub struct $name;
-            //~^ missing_fused_iterator
 
             impl Iterator for $name {
+                //~^ missing_fused_iterator
                 type Item = ();
 
                 fn next(&mut self) -> Option<Self::Item> {
@@ -306,9 +306,9 @@ pub mod external_macro {
 }
 
 pub mod lint_levels {
-    #[allow(clippy::missing_fused_iterator)]
     pub struct Allowed;
 
+    #[allow(clippy::missing_fused_iterator)]
     impl Iterator for Allowed {
         type Item = ();
 
@@ -317,9 +317,9 @@ pub mod lint_levels {
         }
     }
 
-    #[expect(clippy::missing_fused_iterator)]
     pub struct Expected;
 
+    #[expect(clippy::missing_fused_iterator)]
     impl Iterator for Expected {
         type Item = ();
 
@@ -330,9 +330,9 @@ pub mod lint_levels {
 }
 
 pub mod msrv {
-    #[clippy::msrv = "1.25"]
     pub struct BeforeMsrv;
 
+    #[clippy::msrv = "1.25"]
     impl Iterator for BeforeMsrv {
         type Item = ();
 
@@ -341,11 +341,102 @@ pub mod msrv {
         }
     }
 
-    #[clippy::msrv = "1.26"]
     pub struct AtMsrv;
-    //~^ missing_fused_iterator
 
+    #[clippy::msrv = "1.26"]
     impl Iterator for AtMsrv {
+        //~^ missing_fused_iterator
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    pub struct AtLintReasons;
+
+    // `#[expect]` and `reason` need 1.81, below that the suppression suggestion uses `#[allow]`.
+    #[clippy::msrv = "1.81"]
+    impl Iterator for AtLintReasons {
+        //~^ missing_fused_iterator
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+}
+
+pub mod multiple_impls {
+    pub struct Multiple<T>(T);
+
+    impl Iterator for Multiple<u8> {
+        //~^ missing_fused_iterator
+        type Item = u8;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl Iterator for Multiple<u16> {
+        //~^ missing_fused_iterator
+        type Item = u16;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+}
+
+pub mod bounded_generic {
+    pub struct Bounded<T>(T);
+
+    //~v missing_fused_iterator
+    impl<T: Clone> Iterator for Bounded<T>
+    where
+        T: Default,
+        T: Copy,
+    {
+        type Item = T;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+}
+
+pub mod conditional {
+    pub struct Conditional;
+
+    #[cfg(not(test))]
+    impl Iterator for Conditional {
+        //~^ missing_fused_iterator
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    pub struct ConditionalAttr;
+
+    #[cfg_attr(not(test), cfg(not(test)))]
+    impl Iterator for ConditionalAttr {
+        //~^ missing_fused_iterator
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    pub struct InactiveConditionalAttr;
+
+    #[cfg(not(test))]
+    #[cfg_attr(test, cfg(any()))]
+    impl Iterator for InactiveConditionalAttr {
+        //~^ missing_fused_iterator
         type Item = ();
 
         fn next(&mut self) -> Option<Self::Item> {

--- a/tests/ui/missing_fused_iterator.rs
+++ b/tests/ui/missing_fused_iterator.rs
@@ -1,0 +1,321 @@
+//@no-rustfix
+//@aux-build:proc_macros.rs
+
+#![allow(dead_code)]
+#![feature(negative_impls)]
+#![warn(clippy::missing_fused_iterator)]
+
+extern crate proc_macros;
+
+use std::iter::{FusedIterator as RenamedFusedIterator, Iterator as RenamedIterator};
+
+pub struct PublicStruct;
+//~^ missing_fused_iterator
+
+impl Iterator for PublicStruct {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+pub enum PublicEnum {
+    //~^ missing_fused_iterator
+    Empty,
+}
+
+impl Iterator for PublicEnum {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+pub union PublicUnion {
+    //~^ missing_fused_iterator
+    value: u8,
+}
+
+impl Iterator for PublicUnion {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+pub struct PublicGeneric<T>(T);
+//~^ missing_fused_iterator
+
+impl<T> Iterator for PublicGeneric<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+struct Private;
+
+impl Iterator for Private {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+pub(crate) struct CrateVisible;
+
+impl Iterator for CrateVisible {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+mod visibility {
+    pub struct Reexported;
+    //~^ missing_fused_iterator
+
+    impl Iterator for Reexported {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    pub struct Returned;
+    //~^ missing_fused_iterator
+
+    impl Iterator for Returned {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    pub fn returned() -> Returned {
+        Returned
+    }
+
+    pub struct UnreachableInPrivateModule;
+
+    impl Iterator for UnreachableInPrivateModule {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+}
+
+pub use visibility::Reexported;
+
+pub fn returned() -> visibility::Returned {
+    visibility::returned()
+}
+
+pub struct AlreadyFused;
+
+impl Iterator for AlreadyFused {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+impl std::iter::FusedIterator for AlreadyFused {}
+
+pub struct ConditionallyFused<T>(T);
+
+impl<T> Iterator for ConditionallyFused<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+// Deliberately does not cover every `T` for which the `Iterator` implementation applies. Any
+// implementation for the nominal type is enough to suppress the lint.
+impl<T: Clone> std::iter::FusedIterator for ConditionallyFused<T> {}
+
+pub struct ExplicitlyNotFused;
+
+impl Iterator for ExplicitlyNotFused {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+// An explicit negative implementation documents that this type is intentionally not fused.
+impl !std::iter::FusedIterator for ExplicitlyNotFused {}
+
+pub struct ExplicitlyNotAnIterator;
+
+// Negative `Iterator` implementations must not satisfy the positive-implementation check.
+impl !Iterator for ExplicitlyNotAnIterator {}
+
+#[doc(hidden)]
+pub struct DocHidden;
+//~^ missing_fused_iterator
+
+impl Iterator for DocHidden {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+pub struct IteratorByReference;
+
+// The declared nominal type does not itself implement `Iterator`.
+impl Iterator for &IteratorByReference {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+struct OpaqueIterator;
+
+impl Iterator for OpaqueIterator {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+// `FusedIterator` would need to be part of this opaque return bound to be exposed publicly.
+pub fn opaque_iterator() -> impl Iterator<Item = ()> {
+    OpaqueIterator
+}
+
+pub struct RenamedTraits;
+
+impl RenamedIterator for RenamedTraits {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+impl RenamedFusedIterator for RenamedTraits {}
+
+mod shadow_iterator {
+    pub trait Iterator {}
+
+    pub struct OnlyLocalIterator;
+
+    impl Iterator for OnlyLocalIterator {}
+}
+
+pub use shadow_iterator::OnlyLocalIterator;
+
+mod shadow_fused_iterator {
+    pub trait FusedIterator {}
+
+    pub struct RealIterator;
+    //~^ missing_fused_iterator
+
+    impl std::iter::Iterator for RealIterator {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl FusedIterator for RealIterator {}
+}
+
+pub use shadow_fused_iterator::RealIterator;
+
+macro_rules! local_iterator {
+    ($name:ident) => {
+        pub struct $name;
+        //~^ missing_fused_iterator
+
+        impl Iterator for $name {
+            type Item = ();
+
+            fn next(&mut self) -> Option<Self::Item> {
+                None
+            }
+        }
+    };
+}
+
+local_iterator!(LocalMacroIterator);
+
+proc_macros::external! {
+    pub struct ExternalMacroIterator;
+
+    impl Iterator for ExternalMacroIterator {
+        type Item = ();
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+}
+
+#[allow(clippy::missing_fused_iterator)]
+pub struct Allowed;
+
+impl Iterator for Allowed {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+#[expect(clippy::missing_fused_iterator)]
+pub struct Expected;
+
+impl Iterator for Expected {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+#[clippy::msrv = "1.25"]
+pub struct BeforeMsrv;
+
+impl Iterator for BeforeMsrv {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+#[clippy::msrv = "1.26"]
+pub struct AtMsrv;
+//~^ missing_fused_iterator
+
+impl Iterator for AtMsrv {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+fn main() {}

--- a/tests/ui/missing_fused_iterator.stderr
+++ b/tests/ui/missing_fused_iterator.stderr
@@ -1,147 +1,333 @@
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:11:5
-   |
-LL |     pub struct PublicStruct;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:14:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:13:5
    |
 LL |     impl Iterator for PublicStruct {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
    = note: `-D clippy::missing-fused-iterator` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::missing_fused_iterator)]`
+help: implement `FusedIterator` for `PublicStruct`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for PublicStruct {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for PublicStruct {
+   |
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:24:5
-   |
-LL | /     pub enum PublicEnum {
-LL | |
-LL | |         Empty,
-LL | |     }
-   | |_____^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:29:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:28:5
    |
 LL |     impl Iterator for PublicEnum {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `PublicEnum`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for PublicEnum {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for PublicEnum {
+   |
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:39:5
-   |
-LL | /     pub union PublicUnion {
-LL | |
-LL | |         value: u8,
-LL | |     }
-   | |_____^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:44:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:43:5
    |
 LL |     impl Iterator for PublicUnion {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `PublicUnion`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for PublicUnion {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for PublicUnion {
+   |
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:54:5
-   |
-LL |     pub struct PublicGeneric<T>(T);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:57:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:56:5
    |
 LL |     impl<T> Iterator for PublicGeneric<T> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `PublicGeneric<T>`
+   |
+LL ~     }
+LL + 
+LL +     impl<T> std::iter::FusedIterator for PublicGeneric<T> {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl<T> Iterator for PublicGeneric<T> {
+   |
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:91:5
-   |
-LL |     pub struct Reexported;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:94:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:93:5
    |
 LL |     impl Iterator for Reexported {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `Reexported`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for Reexported {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for Reexported {
+   |
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:102:5
-   |
-LL |     pub struct Returned;
-   |     ^^^^^^^^^^^^^^^^^^^^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:105:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:104:5
    |
 LL |     impl Iterator for Returned {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `Returned`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for Returned {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for Returned {
+   |
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:188:5
-   |
-LL |     pub struct DocHidden;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:191:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:190:5
    |
 LL |     impl Iterator for DocHidden {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `DocHidden`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for DocHidden {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for DocHidden {
+   |
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:259:5
-   |
-LL |     pub struct RealIterator;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:262:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:261:5
    |
 LL |     impl std::iter::Iterator for RealIterator {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `RealIterator`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for RealIterator {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl std::iter::Iterator for RealIterator {
+   |
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:278:13
-   |
-LL |             pub struct $name;
-   |             ^^^^^^^^^^^^^^^^^
-...
-LL |     local_iterator!(LocalMacroIterator);
-   |     ----------------------------------- in this macro invocation
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:281:13
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:280:13
    |
 LL |             impl Iterator for $name {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
 ...
 LL |     local_iterator!(LocalMacroIterator);
    |     ----------------------------------- in this macro invocation
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+   = help: implement `FusedIterator` for `local_macro::LocalMacroIterator`
+   = help: if this iterator is intentionally not fused, suppress the lint with `#[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]`
    = note: this error originates in the macro `local_iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:345:5
-   |
-LL |     pub struct AtMsrv;
-   |     ^^^^^^^^^^^^^^^^^^
-   |
-help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:348:5
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:347:5
    |
 LL |     impl Iterator for AtMsrv {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `AtMsrv`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for AtMsrv {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[allow(clippy::missing_fused_iterator)] // <why this iterator can yield again after returning `None`>
+LL ~     impl Iterator for AtMsrv {
+   |
 
-error: aborting due to 10 previous errors
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:360:5
+   |
+LL |     impl Iterator for AtLintReasons {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `AtLintReasons`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for AtLintReasons {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for AtLintReasons {
+   |
+
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:374:5
+   |
+LL |     impl Iterator for Multiple<u8> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `Multiple<u8>`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for Multiple<u8> {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for Multiple<u8> {
+   |
+
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:383:5
+   |
+LL |     impl Iterator for Multiple<u16> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `Multiple<u16>`
+   |
+LL ~     }
+LL + 
+LL +     impl std::iter::FusedIterator for Multiple<u16> {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for Multiple<u16> {
+   |
+
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:397:5
+   |
+LL | /     impl<T: Clone> Iterator for Bounded<T>
+LL | |     where
+LL | |         T: Default, // needed for the default value
+LL | |         T: Copy,
+   | |________________^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `Bounded<T>`
+   |
+LL ~     }
+LL + 
+LL +     impl<T: Clone> std::iter::FusedIterator for Bounded<T>
+LL +     where
+LL +         T: Default, // needed for the default value
+LL +         T: Copy,
+LL +     {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl<T: Clone> Iterator for Bounded<T>
+   |
+
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:416:5
+   |
+LL |     impl Iterator for Conditional {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `Conditional`
+   |
+LL ~     }
+LL + 
+LL +     #[cfg(not(test))]
+LL +     impl std::iter::FusedIterator for Conditional {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for Conditional {
+   |
+
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:429:5
+   |
+LL |     impl Iterator for ConditionalAttr {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `ConditionalAttr`
+   |
+LL ~     }
+LL + 
+LL +     #[cfg_attr(not(test), cfg(not(test)))]
+LL +     impl std::iter::FusedIterator for ConditionalAttr {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for ConditionalAttr {
+   |
+
+error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:443:5
+   |
+LL |     impl Iterator for InactiveConditionalAttr {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
+   |
+   = note: public iterators that keep returning `None` once exhausted should implement `FusedIterator` so that `Iterator::fuse` can become a no-op
+help: implement `FusedIterator` for `InactiveConditionalAttr`
+   |
+LL ~     }
+LL + 
+LL +     #[cfg(not(test))]
+LL +     #[cfg_attr(test, cfg(any()))]
+LL +     impl std::iter::FusedIterator for InactiveConditionalAttr {}
+   |
+help: if this iterator is intentionally not fused, suppress the lint
+   |
+LL ~     #[expect(clippy::missing_fused_iterator, reason = "<why this iterator can yield again after returning `None`>")]
+LL ~     impl Iterator for InactiveConditionalAttr {
+   |
+
+error: aborting due to 17 previous errors
 

--- a/tests/ui/missing_fused_iterator.stderr
+++ b/tests/ui/missing_fused_iterator.stderr
@@ -205,7 +205,7 @@ LL ~     impl Iterator for AtLintReasons {
    |
 
 error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:374:5
+  --> tests/ui/missing_fused_iterator.rs:373:5
    |
 LL |     impl Iterator for Multiple<u8> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
@@ -224,7 +224,7 @@ LL ~     impl Iterator for Multiple<u8> {
    |
 
 error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:383:5
+  --> tests/ui/missing_fused_iterator.rs:382:5
    |
 LL |     impl Iterator for Multiple<u16> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
@@ -243,7 +243,7 @@ LL ~     impl Iterator for Multiple<u16> {
    |
 
 error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:397:5
+  --> tests/ui/missing_fused_iterator.rs:396:5
    |
 LL | /     impl<T: Clone> Iterator for Bounded<T>
 LL | |     where
@@ -269,7 +269,7 @@ LL ~     impl<T: Clone> Iterator for Bounded<T>
    |
 
 error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:416:5
+  --> tests/ui/missing_fused_iterator.rs:413:5
    |
 LL |     impl Iterator for Conditional {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
@@ -289,7 +289,7 @@ LL ~     impl Iterator for Conditional {
    |
 
 error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:429:5
+  --> tests/ui/missing_fused_iterator.rs:425:5
    |
 LL |     impl Iterator for ConditionalAttr {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation
@@ -309,7 +309,7 @@ LL ~     impl Iterator for ConditionalAttr {
    |
 
 error: publicly reachable type with `Iterator` implementation does not implement `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:443:5
+  --> tests/ui/missing_fused_iterator.rs:438:5
    |
 LL |     impl Iterator for InactiveConditionalAttr {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `FusedIterator` implementation

--- a/tests/ui/missing_fused_iterator.stderr
+++ b/tests/ui/missing_fused_iterator.stderr
@@ -1,94 +1,147 @@
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:12:1
+  --> tests/ui/missing_fused_iterator.rs:11:5
    |
-LL | pub struct PublicStruct;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     pub struct PublicStruct;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:14:5
+   |
+LL |     impl Iterator for PublicStruct {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
    = note: `-D clippy::missing-fused-iterator` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::missing_fused_iterator)]`
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:23:1
+  --> tests/ui/missing_fused_iterator.rs:24:5
    |
-LL | / pub enum PublicEnum {
+LL | /     pub enum PublicEnum {
 LL | |
-LL | |     Empty,
-LL | | }
-   | |_^
+LL | |         Empty,
+LL | |     }
+   | |_____^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:29:5
+   |
+LL |     impl Iterator for PublicEnum {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:36:1
+  --> tests/ui/missing_fused_iterator.rs:39:5
    |
-LL | / pub union PublicUnion {
+LL | /     pub union PublicUnion {
 LL | |
-LL | |     value: u8,
-LL | | }
-   | |_^
+LL | |         value: u8,
+LL | |     }
+   | |_____^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:44:5
+   |
+LL |     impl Iterator for PublicUnion {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:49:1
+  --> tests/ui/missing_fused_iterator.rs:54:5
    |
-LL | pub struct PublicGeneric<T>(T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     pub struct PublicGeneric<T>(T);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:57:5
+   |
+LL |     impl<T> Iterator for PublicGeneric<T> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:81:5
+  --> tests/ui/missing_fused_iterator.rs:91:5
    |
 LL |     pub struct Reexported;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:94:5
+   |
+LL |     impl Iterator for Reexported {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:92:5
+  --> tests/ui/missing_fused_iterator.rs:102:5
    |
 LL |     pub struct Returned;
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:105:5
+   |
+LL |     impl Iterator for Returned {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:169:1
+  --> tests/ui/missing_fused_iterator.rs:188:5
    |
-LL | pub struct DocHidden;
-   | ^^^^^^^^^^^^^^^^^^^^^
+LL |     pub struct DocHidden;
+   |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:191:5
+   |
+LL |     impl Iterator for DocHidden {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:231:5
+  --> tests/ui/missing_fused_iterator.rs:259:5
    |
 LL |     pub struct RealIterator;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:262:5
+   |
+LL |     impl std::iter::Iterator for RealIterator {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:249:9
+  --> tests/ui/missing_fused_iterator.rs:278:13
    |
-LL |         pub struct $name;
-   |         ^^^^^^^^^^^^^^^^^
+LL |             pub struct $name;
+   |             ^^^^^^^^^^^^^^^^^
 ...
-LL | local_iterator!(LocalMacroIterator);
-   | ----------------------------------- in this macro invocation
+LL |     local_iterator!(LocalMacroIterator);
+   |     ----------------------------------- in this macro invocation
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:281:13
+   |
+LL |             impl Iterator for $name {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     local_iterator!(LocalMacroIterator);
+   |     ----------------------------------- in this macro invocation
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
    = note: this error originates in the macro `local_iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this publicly reachable type implements `Iterator` but not `FusedIterator`
-  --> tests/ui/missing_fused_iterator.rs:310:1
+  --> tests/ui/missing_fused_iterator.rs:345:5
    |
-LL | pub struct AtMsrv;
-   | ^^^^^^^^^^^^^^^^^^
+LL |     pub struct AtMsrv;
+   |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:348:5
+   |
+LL |     impl Iterator for AtMsrv {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: otherwise, add `#[allow(clippy::missing_fused_iterator)]` with a comment saying why this iterator is not fused
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/missing_fused_iterator.stderr
+++ b/tests/ui/missing_fused_iterator.stderr
@@ -1,0 +1,94 @@
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:12:1
+   |
+LL | pub struct PublicStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+   = note: `-D clippy::missing-fused-iterator` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_fused_iterator)]`
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:23:1
+   |
+LL | / pub enum PublicEnum {
+LL | |
+LL | |     Empty,
+LL | | }
+   | |_^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:36:1
+   |
+LL | / pub union PublicUnion {
+LL | |
+LL | |     value: u8,
+LL | | }
+   | |_^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:49:1
+   |
+LL | pub struct PublicGeneric<T>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:81:5
+   |
+LL |     pub struct Reexported;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:92:5
+   |
+LL |     pub struct Returned;
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:169:1
+   |
+LL | pub struct DocHidden;
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:231:5
+   |
+LL |     pub struct RealIterator;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:249:9
+   |
+LL |         pub struct $name;
+   |         ^^^^^^^^^^^^^^^^^
+...
+LL | local_iterator!(LocalMacroIterator);
+   | ----------------------------------- in this macro invocation
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+   = note: this error originates in the macro `local_iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: this publicly reachable type implements `Iterator` but not `FusedIterator`
+  --> tests/ui/missing_fused_iterator.rs:310:1
+   |
+LL | pub struct AtMsrv;
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this iterator remains exhausted after returning `None`, consider implementing `FusedIterator`
+
+error: aborting due to 10 previous errors
+


### PR DESCRIPTION
Adds `clippy::missing_fused_iterator`, an MSRV-aware `pedantic` lint for publicly reachable structs, enums, and unions that have a positive `Iterator` impl but no `FusedIterator` impl.

Fixes rust-lang/rust-clippy#17608

The lint uses `is_reachable` rather than the more common `is_exported`, so it also covers types leaked through public signatures. Any `FusedIterator` impl suppresses it, including a conditional or negative one. I deliberately left two cases out: impls on a reference to the type, and types reachable only through RPIT.

I filed it as `pedantic` because Clippy cannot prove an iterator stays exhausted. If your iterator resumes on purpose, allow the lint and say so in the docs.

- [x] Followed [lint naming conventions](https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints)
- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo dev fmt`

changelog: new lint: [`missing_fused_iterator`]

Used an LLM to help me understand the issue and as an extra reviewer for my work.