### PR TITLE
fix(cast_ptr_alignment): recognize diverging is_aligned guards

### DIFF
--- a/clippy_lints/src/casts/cast_ptr_alignment.rs
+++ b/clippy_lints/src/casts/cast_ptr_alignment.rs
@@ -1,10 +1,13 @@
 use clippy_utils::diagnostics::span_lint;
 use clippy_utils::ty::is_c_void;
-use clippy_utils::{get_parent_expr, is_hir_ty_cfg_dependant, sym};
-use rustc_hir::{Expr, ExprKind, GenericArg};
+use clippy_utils::usage::local_used_in;
+use clippy_utils::visitors::for_each_local_use_after_expr;
+use clippy_utils::{get_parent_expr, is_hir_ty_cfg_dependant, is_never_expr, sym};
+use rustc_hir::{BinOpKind, BindingMode, Expr, ExprKind, GenericArg, HirId, Node, PatKind, UnOp};
 use rustc_lint::LateContext;
 use rustc_middle::ty::layout::LayoutOf as _;
 use rustc_middle::ty::{self, Ty};
+use std::ops::ControlFlow;
 
 use super::CAST_PTR_ALIGNMENT;
 
@@ -35,7 +38,8 @@ fn lint_cast_ptr_alignment<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, cast_f
         && !is_c_void(cx, from_ptr_ty)
         // when casting from a ZST, we don't know enough to properly lint
         && !from_layout.is_zst()
-        && !is_used_as_unaligned(cx, expr)
+        && !is_used_safely(cx, expr)
+        && !is_guarded_by_alignment_check(cx, expr)
         && !expr.span.in_external_macro(cx.tcx.sess.source_map())
     {
         span_lint(
@@ -51,44 +55,105 @@ fn lint_cast_ptr_alignment<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, cast_f
     }
 }
 
-fn is_used_as_unaligned(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
+fn is_used_safely(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
     let Some(parent) = get_parent_expr(cx, e) else {
         return false;
     };
     match parent.kind {
         ExprKind::MethodCall(name, self_arg, ..) if self_arg.hir_id == e.hir_id => {
-            if matches!(name.ident.name, sym::read_unaligned | sym::write_unaligned)
-                && let Some(def_id) = cx.typeck_results().type_dependent_def_id(parent.hir_id)
-                && let Some(def_id) = cx.tcx.impl_of_assoc(def_id)
-                && cx
-                    .tcx
-                    .type_of(def_id)
-                    .instantiate_identity()
-                    .skip_norm_wip()
-                    .is_raw_ptr()
-            {
-                true
-            } else {
-                false
-            }
+            matches!(
+                name.ident.name,
+                sym::read_unaligned | sym::write_unaligned | sym::is_aligned
+            ) && is_raw_ptr_method(cx, parent)
         },
         ExprKind::Call(func, [arg, ..]) if arg.hir_id == e.hir_id => {
             if let ExprKind::Path(path) = &func.kind
                 && let Some(def_id) = cx.qpath_res(path, func.hir_id).opt_def_id()
                 && let Some(name) = cx.tcx.get_diagnostic_name(def_id)
-                && matches!(
+            {
+                matches!(
                     name,
                     sym::ptr_write_unaligned
                         | sym::ptr_read_unaligned
                         | sym::intrinsics_unaligned_volatile_load
                         | sym::intrinsics_unaligned_volatile_store
                 )
-            {
-                true
             } else {
                 false
             }
         },
         _ => false,
     }
+}
+
+fn is_raw_ptr_method(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) else {
+        return false;
+    };
+    let Some(def_id) = cx.tcx.impl_of_assoc(def_id) else {
+        return false;
+    };
+
+    cx.tcx
+        .type_of(def_id)
+        .instantiate_identity()
+        .skip_norm_wip()
+        .is_raw_ptr()
+}
+
+// TODO: this is a purely syntactic check and is not exhaustive. It only recognizes an
+// `is_aligned()` call as the pointer's very first use, inside a diverging `if` sitting directly in
+// the block the pointer is bound in. Guards hidden behind a helper function, a `match`, a stored
+// `bool`, or a conditionally executed block are missed. This should be replaced once `clippy_utils`
+// grows a proper "is this pointer known to be aligned here" query.
+fn is_guarded_by_alignment_check(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    if let Node::LetStmt(local) = cx.tcx.parent_hir_node(expr.hir_id)
+        && let PatKind::Binding(BindingMode::NONE, local_id, _, None) = local.pat.kind
+        && local.init.is_some_and(|init| init.hir_id == expr.hir_id)
+        && let Some(block_id) = enclosing_block_id(cx, local.hir_id)
+        && let ControlFlow::Break(first_use) =
+            for_each_local_use_after_expr(cx, local_id, expr.hir_id, ControlFlow::Break)
+        && let Some(check) = get_parent_expr(cx, first_use)
+        && is_alignment_check(cx, check)
+        && let Some(negation) = get_parent_expr(cx, check)
+        && matches!(negation.kind, ExprKind::Unary(UnOp::Not, _))
+        && let Some(guard) = peel_or_chain(cx, negation)
+        && let ExprKind::If(_, then, None) = guard.kind
+        && enclosing_block_id(cx, guard.hir_id) == Some(block_id)
+        && is_never_expr(cx, then).is_some()
+        && !local_used_in(cx, local_id, then)
+    {
+        true
+    } else {
+        false
+    }
+}
+
+fn enclosing_block_id(cx: &LateContext<'_>, hir_id: HirId) -> Option<HirId> {
+    let Node::Stmt(stmt) = cx.tcx.parent_hir_node(hir_id) else {
+        return None;
+    };
+    match cx.tcx.parent_hir_node(stmt.hir_id) {
+        Node::Block(block) => Some(block.hir_id),
+        _ => None,
+    }
+}
+
+fn peel_or_chain<'tcx>(cx: &LateContext<'tcx>, mut expr: &'tcx Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    loop {
+        let parent = get_parent_expr(cx, expr)?;
+        if matches!(parent.kind, ExprKind::Binary(op, ..) if op.node == BinOpKind::Or) {
+            expr = parent;
+        } else {
+            return Some(parent);
+        }
+    }
+}
+
+fn is_alignment_check(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    matches!(
+        expr.kind,
+        ExprKind::MethodCall(name, _, [], _)
+            if name.ident.name == sym::is_aligned && is_raw_ptr_method(cx, expr)
+    )
 }

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -372,10 +372,19 @@ declare_clippy_lint! {
     /// Dereferencing the resulting pointer may be undefined behavior.
     ///
     /// ### Known problems
-    /// Using [`std::ptr::read_unaligned`](https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html) and [`std::ptr::write_unaligned`](https://doc.rust-lang.org/std/ptr/fn.write_unaligned.html) or
-    /// similar on the resulting pointer is fine. Is over-zealous: casts with
-    /// manual alignment checks or casts like `u64` -> `u8` -> `u16` can be
-    /// fine. Miri is able to do a more in-depth analysis.
+    /// A cast to a more-strictly-aligned pointer can still be fine:
+    ///
+    /// - Reading or writing through it with [`read_unaligned`](https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html)
+    ///   or [`write_unaligned`](https://doc.rust-lang.org/std/ptr/fn.write_unaligned.html) or similar.
+    /// - A diverging [`is_aligned`](https://doc.rust-lang.org/std/primitive.pointer.html#method.is_aligned)
+    ///   guard in the same block as the cast, as long as the pointer is not used before the check
+    ///   or inside the guard's branch.
+    ///   Other alignment checks, such as checks in an `else` branch, a stored result, address arithmetic, or
+    ///   [`is_aligned_to`](https://doc.rust-lang.org/std/primitive.pointer.html#method.is_aligned_to),
+    ///   are not recognized.
+    /// - Cast chains like `u64` -> `u8` -> `u16`.
+    ///
+    /// Use Miri for a more in-depth analysis if in doubt.
     ///
     /// ### Example
     /// ```no_run

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -372,6 +372,7 @@ generate! {
     io_errorkind,
     io_stderr,
     io_stdout,
+    is_aligned,
     is_ascii,
     is_char_boundary,
     is_diag_item,

--- a/tests/ui/cast_alignment.rs
+++ b/tests/ui/cast_alignment.rs
@@ -1,6 +1,7 @@
 //! Test casts for alignment issues
 
 #![feature(core_intrinsics)]
+#![feature(pointer_is_aligned_to)]
 #![warn(clippy::cast_ptr_alignment)]
 #![expect(clippy::no_effect)]
 
@@ -45,5 +46,325 @@ fn main() {
         (ptr as *mut u16).write_unaligned(0);
         core::ptr::write_unaligned(ptr as *mut u16, 0);
         core::intrinsics::unaligned_volatile_store(ptr as *mut u16, 0);
+    }
+}
+
+// alignment check that follows after creating the pointer, but before use
+mod issue17636 {
+    /* Checking the alignment of the cast itself */
+
+    fn checked_immediately() {
+        let _ = ((&1u8 as *const u8) as *const u16).is_aligned();
+        let _ = (&1u8 as *const u8).cast::<u16>().is_aligned();
+        let _ = ((&mut 1u8 as *mut u8) as *mut u16).is_aligned();
+        let _ = (&mut 1u8 as *mut u8).cast::<u16>().is_aligned();
+    }
+
+    /* The guard's branch must diverge */
+
+    fn guard_diverges() {
+        let ptr = (&1u8 as *const u8).cast::<u16>();
+        if !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn guard_does_not_diverge() {
+        let ptr = (&1u8 as *const u8).cast::<u16>();
+        //~^ cast_ptr_alignment
+        if !ptr.is_aligned() {
+            let _ = ();
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn diverges_on_aligned() {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    // This guard establishes alignment, but `else` branches are not recognized.
+    fn guard_with_else_branch() {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if !ptr.is_aligned() {
+            return;
+        } else {
+            unsafe {
+                let _ = ptr.read();
+            }
+        }
+
+        std::hint::black_box(ptr);
+    }
+
+    /* The check must come before every other use */
+
+    fn guard_after_unrelated_statement() {
+        let data = [0_u8; 2];
+        let ptr = data.as_ptr().cast::<u16>();
+        let len = data.len();
+        if !ptr.is_aligned() || len < size_of::<u16>() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn used_before_guard() {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        let _ = ptr;
+        if !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn used_in_rejecting_branch() {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if !ptr.is_aligned() {
+            unsafe { ptr.read() };
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    /* The guard must sit in the pointer's own block */
+
+    #[expect(clippy::collapsible_if)]
+    fn guard_inside_conditional_block(flag: bool) {
+        let data = [0_u8; 4];
+        let ptr = data.as_ptr().cast::<u16>();
+        //~^ cast_ptr_alignment
+        if flag {
+            if !ptr.is_aligned() {
+                return;
+            }
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn guard_inside_closure() {
+        let data = [0_u8; 4];
+        let ptr = data.as_ptr().cast::<u16>();
+        //~^ cast_ptr_alignment
+        let check = || {
+            if !ptr.is_aligned() {
+                return;
+            }
+            std::hint::black_box(());
+        };
+        check();
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn guard_inside_loop(n: usize) {
+        let data = [0_u8; 4];
+        let ptr = data.as_ptr().cast::<u16>();
+        //~^ cast_ptr_alignment
+        for _ in 0..n {
+            if !ptr.is_aligned() {
+                break;
+            }
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    /* `!ptr.is_aligned()` as one operand of a `||` chain */
+
+    fn guard_is_first_operand() {
+        let data = [0_u8; 2];
+        let ptr = data.as_ptr() as *const u16;
+        if !ptr.is_aligned() || data.len() < size_of::<u16>() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn guard_is_last_operand() {
+        let data = [0_u8; 2];
+        let ptr = data.as_ptr() as *const u16;
+        if data.len() < size_of::<u16>() || !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn unrelated_operand_is_negated(flag: bool) {
+        let data = [0_u8; 2];
+        let ptr = data.as_ptr() as *const u16;
+        if !flag || !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn used_after_guard_operand() {
+        let data = [0_u8; 2];
+        let ptr = data.as_ptr() as *const u16;
+        if !ptr.is_aligned() || unsafe { ptr.read() } == 0 {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn read_before_guard_operand() {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if unsafe { ptr.read() } == 0 || !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn guard_in_and_chain(flag: bool) {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if flag && !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    /* The guard must be about this pointer's alignment */
+
+    fn guard_on_a_different_pointer() {
+        let data = [0_u8; 4];
+        let checked = data.as_ptr().cast::<u16>();
+        let unchecked = data[2..].as_ptr().cast::<u16>();
+        //~^ cast_ptr_alignment
+        if !checked.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = unchecked.read();
+        }
+    }
+
+    fn unrelated_diverging_guard() {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if std::hint::black_box(false) {
+            let _ = ptr;
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn address_arithmetic_check() {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if !ptr.addr().is_multiple_of(align_of::<u16>()) {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn is_aligned_to_check() {
+        let ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if !ptr.is_aligned_to(align_of::<u16>()) {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    /* Only a plain, immutable binding of the cast is tracked */
+
+    fn mutable_binding() {
+        let mut ptr = (&1u8 as *const u8) as *const u16;
+        //~^ cast_ptr_alignment
+        if !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn destructured_binding() {
+        let (ptr,) = (((&1u8 as *const u8) as *const u16),);
+        //~^ cast_ptr_alignment
+        if !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            let _ = ptr.read();
+        }
+    }
+
+    fn mutable_pointer() {
+        let mut data = [0_u8; 2];
+        let ptr = data.as_mut_ptr().cast::<u16>();
+        if !ptr.is_aligned() {
+            return;
+        }
+
+        unsafe {
+            ptr.write(0);
+        }
     }
 }

--- a/tests/ui/cast_alignment.stderr
+++ b/tests/ui/cast_alignment.stderr
@@ -1,5 +1,5 @@
 error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
-  --> tests/ui/cast_alignment.rs:11:5
+  --> tests/ui/cast_alignment.rs:12:5
    |
 LL |     (&1u8 as *const u8) as *const u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,22 +8,118 @@ LL |     (&1u8 as *const u8) as *const u16;
    = help: to override `-D warnings` add `#[allow(clippy::cast_ptr_alignment)]`
 
 error: casting from `*mut u8` to a more-strictly-aligned pointer (`*mut u16`) (1 < 2 bytes)
-  --> tests/ui/cast_alignment.rs:14:5
+  --> tests/ui/cast_alignment.rs:15:5
    |
 LL |     (&mut 1u8 as *mut u8) as *mut u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
-  --> tests/ui/cast_alignment.rs:18:5
+  --> tests/ui/cast_alignment.rs:19:5
    |
 LL |     (&1u8 as *const u8).cast::<u16>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting from `*mut u8` to a more-strictly-aligned pointer (`*mut u16`) (1 < 2 bytes)
-  --> tests/ui/cast_alignment.rs:21:5
+  --> tests/ui/cast_alignment.rs:22:5
    |
 LL |     (&mut 1u8 as *mut u8).cast::<u16>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:77:19
+   |
+LL |         let ptr = (&1u8 as *const u8).cast::<u16>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:89:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:102:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:131:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:144:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:161:19
+   |
+LL |         let ptr = data.as_ptr().cast::<u16>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:176:19
+   |
+LL |         let ptr = data.as_ptr().cast::<u16>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:193:19
+   |
+LL |         let ptr = data.as_ptr().cast::<u16>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:257:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:269:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:285:25
+   |
+LL |         let unchecked = data[2..].as_ptr().cast::<u16>();
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:297:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:310:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:322:19
+   |
+LL |         let ptr = (&1u8 as *const u8) as *const u16;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:336:23
+   |
+LL |         let mut ptr = (&1u8 as *const u8) as *const u16;
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
+  --> tests/ui/cast_alignment.rs:348:23
+   |
+LL |         let (ptr,) = (((&1u8 as *const u8) as *const u16),);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust-clippy#17636.

`cast_ptr_alignment` now recognizes `is_aligned()` calls on casts and diverging alignment guards before the pointer’s first use, including within `||` chains. It remains conservative when alignment is not established before use.

Tests and documentation were updated, and `is_aligned` was added to `clippy_utils::sym`.

changelog: [`cast_ptr_alignment`]: avoid linting casts followed by a diverging `is_aligned()` guard