### PR TITLE
chore: add the `llm-assisted` label to the unauthorised list

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,7 +1,7 @@
 [relabel]
 allow-unauthenticated = [
     "A-*", "C-*", "D-*", "E-*", "I-*", "L-*", "P-*", "S-*", "T-*",
-    "good first issue", "beta-nominated"
+    "good first issue", "beta-nominated", "llm-assisted"
 ]
 
 # Allows shortcuts like `@rustbot ready`


### PR DESCRIPTION
changelog: none

Label is mentioned in our llm policy.

<img width="1118" height="451" alt="image" src="https://github.com/user-attachments/assets/ecbfbb2b-bb08-4cb2-97b5-91cac89cd9a4" />

> [!IMPORTANT]
> label does not exist yet, so needs to be created before merging the PR