### PR TITLE
fix(large_futures): lint when the future is user code but the await is macro-generated

### DIFF
--- a/clippy_lints/src/large_futures.rs
+++ b/clippy_lints/src/large_futures.rs
@@ -1,5 +1,6 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::macros::span_is_local;
 use clippy_utils::source::snippet;
 use clippy_utils::ty::implements_trait;
 use rustc_abi::Size;
@@ -61,7 +62,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeFuture {
             && let ExprKind::Call(func, [arg]) = scrutinee.kind
             && let ExprKind::Path(qpath) = func.kind
             && cx.tcx.qpath_is_lang_item(qpath, LangItem::IntoFutureIntoFuture)
-            && !expr.span.from_expansion()
+            && span_is_local(arg.span)
             && let ty = cx.typeck_results().expr_ty(arg)
             && let Some(future_trait_def_id) = cx.tcx.lang_items().future_trait()
             && implements_trait(cx, ty, future_trait_def_id, &[])

--- a/tests/ui/large_futures.fixed
+++ b/tests/ui/large_futures.fixed
@@ -1,5 +1,10 @@
+//@aux-build:proc_macros.rs
 #![expect(clippy::manual_async_fn)]
 #![warn(clippy::large_futures)]
+
+extern crate proc_macros;
+
+use proc_macros::{external, with_span};
 
 async fn big_fut(_arg: [u8; 1024 * 16]) {}
 
@@ -65,6 +70,55 @@ pub async fn macro_expn() {
         };
     }
     macro_!().await
+}
+
+pub async fn macro_await() {
+    async fn big() -> u8 {
+        let x = [0u8; 1024 * 16];
+        async {}.await;
+        x[0]
+    }
+    macro_rules! call_it {
+        ($f:expr) => {
+            $f.await
+        };
+    }
+    let _v = call_it!(Box::pin(big()));
+    //~^ large_futures
+}
+
+pub async fn macro_external() {
+    async fn big() -> u8 {
+        let x = [0u8; 1024 * 16];
+        async {}.await;
+        x[0]
+    }
+    external!(big().await);
+}
+
+pub async fn macro_with_span() {
+    async fn big() -> u8 {
+        let x = [0u8; 1024 * 16];
+        async {}.await;
+        x[0]
+    }
+    with_span!(span $(Box::pin(big())).await);
+    //~^ large_futures
+}
+
+pub async fn macro_all_internal() {
+    macro_rules! run {
+        () => {{
+            async fn inner() -> u8 {
+                let x = [0u8; 1024 * 16];
+                async {}.await;
+                x[0]
+            }
+            Box::pin(inner()).await
+            //~^ large_futures
+        }};
+    }
+    let _v = run!();
 }
 
 fn main() {}

--- a/tests/ui/large_futures.rs
+++ b/tests/ui/large_futures.rs
@@ -1,5 +1,10 @@
+//@aux-build:proc_macros.rs
 #![expect(clippy::manual_async_fn)]
 #![warn(clippy::large_futures)]
+
+extern crate proc_macros;
+
+use proc_macros::{external, with_span};
 
 async fn big_fut(_arg: [u8; 1024 * 16]) {}
 
@@ -65,6 +70,55 @@ pub async fn macro_expn() {
         };
     }
     macro_!().await
+}
+
+pub async fn macro_await() {
+    async fn big() -> u8 {
+        let x = [0u8; 1024 * 16];
+        async {}.await;
+        x[0]
+    }
+    macro_rules! call_it {
+        ($f:expr) => {
+            $f.await
+        };
+    }
+    let _v = call_it!(big());
+    //~^ large_futures
+}
+
+pub async fn macro_external() {
+    async fn big() -> u8 {
+        let x = [0u8; 1024 * 16];
+        async {}.await;
+        x[0]
+    }
+    external!(big().await);
+}
+
+pub async fn macro_with_span() {
+    async fn big() -> u8 {
+        let x = [0u8; 1024 * 16];
+        async {}.await;
+        x[0]
+    }
+    with_span!(span $(big()).await);
+    //~^ large_futures
+}
+
+pub async fn macro_all_internal() {
+    macro_rules! run {
+        () => {{
+            async fn inner() -> u8 {
+                let x = [0u8; 1024 * 16];
+                async {}.await;
+                x[0]
+            }
+            inner().await
+            //~^ large_futures
+        }};
+    }
+    let _v = run!();
 }
 
 fn main() {}

--- a/tests/ui/large_futures.stderr
+++ b/tests/ui/large_futures.stderr
@@ -1,5 +1,5 @@
 error: large future with a size of 16385 bytes
-  --> tests/ui/large_futures.rs:8:9
+  --> tests/ui/large_futures.rs:13:9
    |
 LL |         big_fut([0u8; 1024 * 16]).await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(big_fut([0u8; 1024 * 16]))`
@@ -8,37 +8,37 @@ LL |         big_fut([0u8; 1024 * 16]).await;
    = help: to override `-D warnings` add `#[allow(clippy::large_futures)]`
 
 error: large future with a size of 16386 bytes
-  --> tests/ui/large_futures.rs:11:5
+  --> tests/ui/large_futures.rs:16:5
    |
 LL |     f.await
    |     ^ help: consider `Box::pin` on it: `Box::pin(f)`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:16:9
+  --> tests/ui/large_futures.rs:21:9
    |
 LL |         wait().await;
    |         ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:22:13
+  --> tests/ui/large_futures.rs:27:13
    |
 LL |             wait().await;
    |             ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:30:5
+  --> tests/ui/large_futures.rs:35:5
    |
 LL |     foo().await;
    |     ^^^^^ help: consider `Box::pin` on it: `Box::pin(foo())`
 
 error: large future with a size of 49159 bytes
-  --> tests/ui/large_futures.rs:33:5
+  --> tests/ui/large_futures.rs:38:5
    |
 LL |     calls_fut(fut).await;
    |     ^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(calls_fut(fut))`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:46:5
+  --> tests/ui/large_futures.rs:51:5
    |
 LL | /     async {
 LL | |
@@ -61,7 +61,7 @@ LL +     })
    |
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:59:13
+  --> tests/ui/large_futures.rs:64:13
    |
 LL | /             async {
 LL | |
@@ -85,5 +85,28 @@ LL +                 println!("macro: {:?}", x);
 LL +             })
    |
 
-error: aborting due to 8 previous errors
+error: large future with a size of 16386 bytes
+  --> tests/ui/large_futures.rs:86:23
+   |
+LL |     let _v = call_it!(big());
+   |                       ^^^^^ help: consider `Box::pin` on it: `Box::pin(big())`
+
+error: large future with a size of 16386 bytes
+  --> tests/ui/large_futures.rs:105:23
+   |
+LL |     with_span!(span $(big()).await);
+   |                       ^^^^^ help: consider `Box::pin` on it: `Box::pin(big())`
+
+error: large future with a size of 16386 bytes
+  --> tests/ui/large_futures.rs:117:13
+   |
+LL |             inner().await
+   |             ^^^^^^^ help: consider `Box::pin` on it: `Box::pin(inner())`
+...
+LL |     let _v = run!();
+   |              ------ in this macro invocation
+   |
+   = note: this error originates in the macro `run` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
my apologies. in attemtps to solve the related issue, i might have introduced a behavior change to the lint (not just a bug fix), which is why i'm opening it as a draft. the original lint deliberately went silent on macro expansion, that was a choice made on review back in pr rust-lang/rust-clippy#10414, and this pr changes it. (genuinely i was initially scared to open this pr, but i'm viewing as an opportunity to learn) so i want a maintainer read before it i call it a quit.

fixes rust-lang/rust-clippy#17586 

the problem: `large_futures` didn't fire when the `.await` came from a macro, even when the future being awaited was normal user code and just as big as the direct case. (please see rust-lang/rust-clippy#17586)

the reason is the guard checked `expr.span.from_expansion()` on the whole desugared await, so it was really keying on where the `.await` syntax lived, not exactly where the future came from. hence, if you hand-write `.await` outside a macro it fires no matter where the future is from. but if the `.await` is macro-generated it stays silent no matter where the future is from. the original reporter's case is a framework macro polling a future the user wrote, which lands in the silent faction, and here is exactly where big futures can hide and blow the stack.

now to what i changed. i check the awaited expression's own span with `span_is_local` instead, so the call is about the future's origin, not the await syntax. this is the part i believe i introduced the behavior change, as the old rule suppressed all expansion, but the new rule only suppresses futures coming from an external crate's macro and lints through local ones.

what actually happens now (i'm still new to the codebase, so there might be more cases beyond my current purview), tested against the `proc_macros` aux helpers:

- local `macro_rules!` generating the `.await` over a clean call: now fires, this is the reported issue.
- hand-written `.await` on a macro-produced future (the existing `macro_expn` test): still fires, unchanged.
- direct `.await`: still fires, unchanged.
- `external!` wrapped await (foreign crate macro): stays silent.
- `with_span!`, a proc macro that keeps the caller's span: fires.

the one i'm not sure about, and i would love your call on: a local macro that generates both the future and the `.await` fully inside itself, where the user only writes `run!()`. 

```rs
pub async fn all_in_macro() {
    macro_rules! run {
        () => {{
            async fn inner() -> u8 {
                let x = [0u8; 1024 * 16];
                async {}.await;
                x[0]
            }
            inner().await
        }};
    }
    let _v = run!();
}
```

that now fires, with the suggestion pointing into the macro body, and if one calls that macro N times you get N warnings. based on my judgement, i lean towards that being right for a lint that's about stack overflows, since it's the user's own macro and they can fix it once, but it does reverse the original blanket silence on purpose, so i can't just decide that myself.

also, one last thing, the reporter's actual case was `#[tauri::command]`, which is a proc macro. whether this catches that comes down to whether tauri keeps the original span when it re-emits the command body, and that is outside clippy's. The `with_span!` case shows a span-preserving proc macro is caught, so it depends entirely on how tauri is written.

I used Claude (web) to only understand the issue by sharing it code excerpts.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`large_futures`]: lint when the `.await` is macro-generated but the awaited future is user code
