### PR TITLE
`let_unit_value` bail out if initializer is cfg-dependent

### DIFF
--- a/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/clippy_lints/src/unit_types/let_unit_value.rs
@@ -1,7 +1,9 @@
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::is_under_cfg;
 use clippy_utils::macros::{FormatArgsStorage, find_format_arg_expr, is_format_macro, root_macro_call_first_node};
+use clippy_utils::res::MaybeResPath as _;
 use clippy_utils::source::{snippet_indent, walk_span_to_context};
-use clippy_utils::visitors::{for_each_local_assignment, for_each_value_source};
+use clippy_utils::visitors::{for_each_expr, for_each_local_assignment, for_each_value_source};
 use core::ops::ControlFlow;
 use rustc_ast::{FormatArgs, FormatArgumentKind};
 use rustc_errors::Applicability;
@@ -27,6 +29,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, format_args: &FormatArgsStorag
         && !local.span.in_external_macro(cx.sess().source_map())
         && !local.span.is_from_async_await()
         && cx.typeck_results().pat_ty(local.pat).is_unit()
+        && !binding_used_under_cfg(cx, local)
     {
         // skip `let awa = ()`
         if let ExprKind::Tup([]) = init.kind {
@@ -330,4 +333,21 @@ fn needs_inferred_result_ty(
     } else {
         false
     }
+}
+
+fn binding_used_under_cfg<'tcx>(cx: &LateContext<'tcx>, local: &'tcx LetStmt<'_>) -> bool {
+    let PatKind::Binding(_, binding_id, ..) = local.pat.kind else {
+        return false;
+    };
+    let Some(body_id) = cx.enclosing_body else {
+        return false;
+    };
+    for_each_expr(cx.tcx, cx.tcx.hir_body(body_id).value, |e| {
+        if e.res_local_id() == Some(binding_id) && is_under_cfg(cx.tcx, e.hir_id) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .is_some()
 }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2443,6 +2443,12 @@ pub fn is_in_cfg_test(tcx: TyCtxt<'_>, id: HirId) -> bool {
     tcx.hir_parent_id_iter(id).any(|parent_id| is_cfg_test(tcx, parent_id))
 }
 
+/// Checks if any parent node of `HirId` has a `#[cfg(...)]` or `#[cfg_attr(...)]` attribute applied.
+pub fn is_under_cfg(tcx: TyCtxt<'_>, id: HirId) -> bool {
+    tcx.hir_parent_id_iter(id)
+        .any(|id| find_attr!(tcx, id, CfgTrace(..) | CfgAttrTrace(..)))
+}
+
 /// Checks if the node is in a `#[test]` function or has any parent node marked `#[cfg(test)]`
 pub fn is_in_test(tcx: TyCtxt<'_>, hir_id: HirId) -> bool {
     is_in_test_function(tcx, hir_id) || is_in_cfg_test(tcx, hir_id)

--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -234,3 +234,22 @@ fn issue15789() {
 
     Foo { value: () };
 }
+
+mod issue15790 {
+    fn takes_str(_: &str) {}
+    fn takes_unit(_: ()) {}
+
+    fn foo() {
+        let value = {
+            #[cfg(test)]
+            {
+                "not a unit"
+            }
+        };
+
+        #[cfg(test)]
+        takes_str(value);
+        #[cfg(not(test))]
+        takes_unit(value);
+    }
+}

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -232,3 +232,22 @@ fn issue15789() {
 
     Foo { value };
 }
+
+mod issue15790 {
+    fn takes_str(_: &str) {}
+    fn takes_unit(_: ()) {}
+
+    fn foo() {
+        let value = {
+            #[cfg(test)]
+            {
+                "not a unit"
+            }
+        };
+
+        #[cfg(test)]
+        takes_str(value);
+        #[cfg(not(test))]
+        takes_unit(value);
+    }
+}


### PR DESCRIPTION
fixes rust-lang/rust-clippy#15790 

changelog: [`let_unit_value`]: do not lint if initializer is cfg-dependent
