### PR TITLE
chore: add the internal `repeated_is_diagnostic_item` to `LINTS`

### DIFF
--- a/clippy_lints_internal/src/lib.rs
+++ b/clippy_lints_internal/src/lib.rs
@@ -51,6 +51,7 @@ static LINTS: &[&Lint] = &[
     unnecessary_def_path::UNNECESSARY_DEF_PATH,
     unsorted_clippy_utils_paths::UNSORTED_CLIPPY_UTILS_PATHS,
     unusual_names::UNUSUAL_NAMES,
+    repeated_is_diagnostic_item::REPEATED_IS_DIAGNOSTIC_ITEM,
 ];
 
 pub fn register_lints(store: &mut LintStore) {


### PR DESCRIPTION
noticed during implementing
- https://github.com/rust-lang/rust-clippy/pull/17631#issuecomment-5573594711

I don't fully know why this first registration is not done, but off all internal lints, this is the only one which is not in `LINTS` and I don't quite get why.
Seems like an oversight.

Likely another internal lint worth having 😆 

Added in
- https://github.com/rust-lang/rust-clippy/pull/15937

r? @ada4a if this was intentional

changelog: none