### PR TITLE
Track clippy.toml existence, even if it doesn't exist.

### DIFF
--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -860,7 +860,7 @@ pub fn sanitize_explanation(raw_docs: &str) -> String {
 /// # Errors
 ///
 /// Returns any unexpected filesystem error encountered when searching for the config file
-fn load_conf_file(sess: &Session) -> Option<Arc<SourceFile>> {
+pub fn load_conf_file(sess: &Session) -> Option<Arc<SourceFile>> {
     /// Possible filename to search for.
     const CONFIG_FILE_NAMES: [&str; 2] = [".clippy.toml", "clippy.toml"];
 

--- a/clippy_config/src/lib.rs
+++ b/clippy_config/src/lib.rs
@@ -22,5 +22,5 @@ mod conf;
 mod metadata;
 pub mod types;
 
-pub use conf::{Conf, sanitize_explanation};
+pub use conf::{Conf, load_conf_file, sanitize_explanation};
 pub use metadata::ConfMetadata;

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -180,6 +180,7 @@ generate! {
     chunks_exact,
     chunks_exact_mut,
     clamp,
+    clippy_toml_does_not_exist,
     clippy_utils,
     clone_into,
     cloned,

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -15,6 +15,7 @@ extern crate rustc_span;
 // Override the C allocator in the same way that the `rustc` binary would do.
 rustc_driver::override_c_allocator_in_binary!();
 
+use clippy_config::load_conf_file;
 use clippy_utils::sym;
 use declare_clippy_lint::LintListBuilder;
 use rustc_interface::interface;
@@ -100,7 +101,12 @@ fn track_files(sess: &Session) {
         file_depinfo.insert(sym::Cargo_toml);
     }
 
-    // `clippy.toml` will be automatically tracked as it's loaded with `sess.source_map().load_file()`
+    // Try loading clippy.toml, if it does not exist, track it's non-existence
+    if load_conf_file(sess).is_none() {
+        file_depinfo.insert(sym::clippy_toml_does_not_exist);
+    } else {
+        file_depinfo.swap_remove(&sym::clippy_toml_does_not_exist);
+    }
 
     // During development track the `clippy-driver` executable so that cargo will re-run clippy whenever
     // it is rebuilt

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -94,6 +94,7 @@ fn track_clippy_args(sess: &Session, args_env_var: Option<&str>) {
 /// when any of them are modified
 fn track_files(sess: &Session) {
     let mut file_depinfo = sess.file_depinfo.borrow_mut();
+    let mut env_depinfo = sess.env_depinfo.borrow_mut();
 
     // Used by `clippy::cargo` lints and to determine the MSRV. `cargo clippy` executes `clippy-driver`
     // with the current directory set to `CARGO_MANIFEST_DIR` so a relative path is fine
@@ -103,9 +104,9 @@ fn track_files(sess: &Session) {
 
     // Try loading clippy.toml, if it does not exist, track it's non-existence
     if load_conf_file(sess).is_none() {
-        file_depinfo.insert(sym::clippy_toml_does_not_exist);
+        env_depinfo.insert((sym::clippy_toml_does_not_exist, None));
     } else {
-        file_depinfo.swap_remove(&sym::clippy_toml_does_not_exist);
+        env_depinfo.swap_remove(&(sym::clippy_toml_does_not_exist, None));
     }
 
     // During development track the `clippy-driver` executable so that cargo will re-run clippy whenever

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,3 +1,5 @@
+use std::fs::OpenOptions;
+use std::io::Write as _;
 use std::path::PathBuf;
 use std::process::Command;
 use test_utils::{CARGO_CLIPPY_PATH, IS_RUSTC_TEST_SUITE};
@@ -63,6 +65,10 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
         .args(["-p", "path_dep"])
         .output()
         .unwrap();
+
+    // Cleanup the temporary clippy.toml, just in case.
+    let clippy_toml_path = cwd.join("subcrate").join("clippy.toml");
+    let _ = std::fs::remove_file(&clippy_toml_path);
 
     // `path_dep` is a path dependency of `subcrate` that would trigger a denied lint.
     // Make sure that with the `--no-deps` argument Clippy does not run on `path_dep`.
@@ -130,20 +136,40 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
         println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
         println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
 
-        assert!(output.status.success());
-
         output
     };
 
     // Trigger a successful build, so Cargo would like to cache the build result.
-    successful_build();
+    assert!(successful_build().status.success());
 
+    let output = successful_build();
+    assert!(output.status.success());
     // Make sure there's no spurious rebuild when nothing changes.
-    let stderr = String::from_utf8(successful_build().stderr).unwrap();
+    let stderr: String = String::from_utf8(output.stderr).unwrap();
+
     assert!(!stderr.contains("Compiling"));
     assert!(!stderr.contains("Checking"));
     assert!(stderr.contains("Finished"));
 
     // Make sure Cargo is aware of the new `--cfg` flag.
     lint_path_dep();
+
+    // Create an invalid clippy.toml, and make sure that we track that a new file exists and parse
+    // it. See #9928
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&clippy_toml_path)
+        .unwrap();
+    writeln!(&mut file, "msrv = \"invalid\"").expect("Could not write to shim clippy.toml");
+
+    let output = successful_build();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("failed to parse rust version"));
+
+    // Cleanup
+    std::fs::remove_file(clippy_toml_path).unwrap();
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/9928

Turns out that `SourceMap::load_file` only tracks a file if it exists,  thus if you run `cargo clippy` on a workspace without `clippy.toml`, it won't add clippy.toml to the track-files list.

We should track clippy.toml somehow, so if it doesn't exist, we manually add it to `file_depinfo`.

changelog: Correctly track clippy.toml, even when it doesn't exist.
