### PR TITLE
Extend from_str_radix_10 to NonZero types

### DIFF
--- a/clippy_lints/src/from_str_radix_10.rs
+++ b/clippy_lints/src/from_str_radix_10.rs
@@ -1,21 +1,26 @@
+use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef as _;
+use clippy_utils::source::snippet;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{is_in_const_context, is_integer_literal, sym};
 use rustc_attr_ir::lang_items::LangItem;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, PrimTy, QPath, TyKind, def};
-use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
+use rustc_hir::{self as hir, Expr, ExprKind, PrimTy, QPath, TyKind, def};
+use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
 use rustc_middle::ty::Ty;
 
 declare_clippy_lint! {
     /// ### What it does
     ///
-    /// Checks for function invocations of the form `primitive::from_str_radix(s, 10)`
+    /// Checks for function invocations of the form `integer::from_str_radix(s, 10)`
+    ///
+    /// This also applies to `NonZero` integer types on Rust 1.98 and later.
     ///
     /// ### Why is this bad?
     ///
-    /// This specific common use case can be rewritten as `s.parse::<primitive>()`
+    /// This specific common use case can be rewritten as `s.parse::<integer>()`
     /// (and in most cases, the turbofish can be removed), which reduces code length
     /// and complexity.
     ///
@@ -40,10 +45,24 @@ declare_clippy_lint! {
     "from_str_radix with radix 10"
 }
 
-declare_lint_pass!(FromStrRadix10 => [FROM_STR_RADIX_10]);
+impl_lint_pass!(FromStrRadix10 => [FROM_STR_RADIX_10]);
+
+pub struct FromStrRadix10 {
+    msrv: Msrv,
+}
+
+impl FromStrRadix10 {
+    pub fn new(conf: &'static Conf) -> Self {
+        Self { msrv: conf.msrv.into() }
+    }
+}
 
 impl<'tcx> LateLintPass<'tcx> for FromStrRadix10 {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, exp: &Expr<'tcx>) {
+        if exp.span.from_expansion() {
+            return;
+        }
+
         if let ExprKind::Call(maybe_path, [src, radix]) = &exp.kind
             && let ExprKind::Path(QPath::TypeRelative(ty, pathseg)) = &maybe_path.kind
 
@@ -54,11 +73,10 @@ impl<'tcx> LateLintPass<'tcx> for FromStrRadix10 {
             // function `from_str_radix`
             && pathseg.ident.name == sym::from_str_radix
 
-            // check if the first part of the path is some integer primitive
+            // check if the first part of the path is some integer primitive or NonZero integer
             && let TyKind::Path(ty_qpath) = &ty.kind
-            && let ty_res = cx.qpath_res(ty_qpath, ty.hir_id)
-            && let def::Res::PrimTy(prim_ty) = ty_res
-            && matches!(prim_ty, PrimTy::Int(_) | PrimTy::Uint(_))
+            && let Some(integer_ty) = get_integer_ty(cx, ty, ty_qpath)
+            && (matches!(integer_ty, IntegerTy::Primitive(_)) || self.msrv.meets(cx, msrvs::NONZERO_FROM_STR_RADIX))
 
             // do not lint in constant context, because the suggestion won't work.
             // NB: keep this check until a new `const_trait_impl` is available and stabilized.
@@ -71,8 +89,15 @@ impl<'tcx> LateLintPass<'tcx> for FromStrRadix10 {
                 &src
             };
 
-            let sugg =
-                Sugg::hir_with_applicability(cx, expr, "<string>", &mut Applicability::MachineApplicable).maybe_paren();
+            let type_name = match integer_ty {
+                IntegerTy::Primitive(prim_ty) => prim_ty.name_str().to_owned(),
+                IntegerTy::NonZero(ty) => {
+                    // Keep the source spelling, including aliases like `MyNonZero` and
+                    // qualified paths like `std::num::NonZeroU8`.
+                    snippet(cx, ty.span, "<integer>").into_owned()
+                },
+            };
+            let sugg = Sugg::hir(cx, expr, "<string>").maybe_paren();
 
             span_lint_and_sugg(
                 cx,
@@ -80,10 +105,29 @@ impl<'tcx> LateLintPass<'tcx> for FromStrRadix10 {
                 exp.span,
                 "this call to `from_str_radix` can be replaced with a call to `str::parse`",
                 "try",
-                format!("{sugg}.parse::<{}>()", prim_ty.name_str()),
+                format!("{sugg}.parse::<{type_name}>()"),
                 Applicability::MaybeIncorrect,
             );
         }
+    }
+}
+
+enum IntegerTy<'tcx> {
+    Primitive(PrimTy),
+    NonZero(&'tcx hir::Ty<'tcx>),
+}
+
+fn get_integer_ty<'tcx>(
+    cx: &LateContext<'tcx>,
+    ty: &'tcx hir::Ty<'tcx>,
+    ty_qpath: &QPath<'tcx>,
+) -> Option<IntegerTy<'tcx>> {
+    match cx.qpath_res(ty_qpath, ty.hir_id) {
+        def::Res::PrimTy(prim_ty) if matches!(prim_ty, PrimTy::Int(_) | PrimTy::Uint(_)) => {
+            Some(IntegerTy::Primitive(prim_ty))
+        },
+        _ if cx.typeck_results().node_type(ty.hir_id).is_diag_item(cx, sym::NonZero) => Some(IntegerTy::NonZero(ty)),
+        _ => None,
     }
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -720,7 +720,7 @@ rustc_lint::late_lint_methods!(
         ZeroSizedMapValues: zero_sized_map_values::ZeroSizedMapValues = zero_sized_map_values::ZeroSizedMapValues,
         VecInitThenPush: vec_init_then_push::VecInitThenPush = <vec_init_then_push::VecInitThenPush>::default(),
         RedundantSlicing: redundant_slicing::RedundantSlicing = redundant_slicing::RedundantSlicing,
-        FromStrRadix10: from_str_radix_10::FromStrRadix10 = from_str_radix_10::FromStrRadix10,
+        FromStrRadix10: from_str_radix_10::FromStrRadix10 = from_str_radix_10::FromStrRadix10::new(conf),
         IfThenSomeElseNone: if_then_some_else_none::IfThenSomeElseNone = if_then_some_else_none::IfThenSomeElseNone::new(conf),
         BoolAssertComparison: bool_assert_comparison::BoolAssertComparison = bool_assert_comparison::BoolAssertComparison,
         UnusedAsync: unused_async::UnusedAsync = <unused_async::UnusedAsync>::default(),

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -25,7 +25,7 @@ macro_rules! msrv_aliases {
 
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
-    1,98,0 { MAP_OR_DEFAULT }
+    1,98,0 { MAP_OR_DEFAULT, NONZERO_FROM_STR_RADIX }
     1,97,0 { ISOLATE_LOWEST_ONE, BIT_WIDTH }
     1,94,0 { EULER_GAMMA, GOLDEN_RATIO }
     1,93,0 { VEC_DEQUE_POP_BACK_IF, VEC_DEQUE_POP_FRONT_IF }

--- a/tests/ui/from_str_radix_10.fixed
+++ b/tests/ui/from_str_radix_10.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::from_str_radix_10)]
 
+use std::num::{NonZeroI32, NonZeroU16, NonZeroU32};
+
+type MyNonZero = NonZeroU32;
+
 mod some_mod {
     // fake function that shouldn't trigger the lint
     pub fn from_str_radix(_: &str, _: u32) -> Result<(), std::num::ParseIntError> {
@@ -83,4 +87,32 @@ fn fix_str_ref_check() {
     let s_ref = &s;
     let _ = s_ref.parse::<u32>().unwrap();
     //~^ from_str_radix_10
+}
+
+// https://github.com/rust-lang/rust-clippy/issues/17712
+fn issue_17712() -> Result<(), Box<dyn std::error::Error>> {
+    macro_rules! parse_radix_10 {
+        ($t:ty, $s:expr) => {
+            <$t>::from_str_radix($s, 10)
+        };
+    }
+
+    "8".parse::<NonZeroU16>()?;
+    //~^ from_str_radix_10
+
+    "42".parse::<std::num::NonZeroI32>()?;
+    //~^ from_str_radix_10
+
+    "11".parse::<MyNonZero>()?;
+    //~^ from_str_radix_10
+
+    let _ = parse_radix_10!(std::num::NonZeroU32, "9");
+
+    Ok(())
+}
+
+#[allow(clippy::incompatible_msrv)]
+#[clippy::msrv = "1.97"]
+fn issue_17712_msrv() {
+    let _ = NonZeroU16::from_str_radix("8", 10);
 }

--- a/tests/ui/from_str_radix_10.rs
+++ b/tests/ui/from_str_radix_10.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::from_str_radix_10)]
 
+use std::num::{NonZeroI32, NonZeroU16, NonZeroU32};
+
+type MyNonZero = NonZeroU32;
+
 mod some_mod {
     // fake function that shouldn't trigger the lint
     pub fn from_str_radix(_: &str, _: u32) -> Result<(), std::num::ParseIntError> {
@@ -83,4 +87,32 @@ fn fix_str_ref_check() {
     let s_ref = &s;
     let _ = u32::from_str_radix(&s_ref, 10).unwrap();
     //~^ from_str_radix_10
+}
+
+// https://github.com/rust-lang/rust-clippy/issues/17712
+fn issue_17712() -> Result<(), Box<dyn std::error::Error>> {
+    macro_rules! parse_radix_10 {
+        ($t:ty, $s:expr) => {
+            <$t>::from_str_radix($s, 10)
+        };
+    }
+
+    NonZeroU16::from_str_radix("8", 10)?;
+    //~^ from_str_radix_10
+
+    std::num::NonZeroI32::from_str_radix("42", 10)?;
+    //~^ from_str_radix_10
+
+    MyNonZero::from_str_radix("11", 10)?;
+    //~^ from_str_radix_10
+
+    let _ = parse_radix_10!(std::num::NonZeroU32, "9");
+
+    Ok(())
+}
+
+#[allow(clippy::incompatible_msrv)]
+#[clippy::msrv = "1.97"]
+fn issue_17712_msrv() {
+    let _ = NonZeroU16::from_str_radix("8", 10);
 }

--- a/tests/ui/from_str_radix_10.stderr
+++ b/tests/ui/from_str_radix_10.stderr
@@ -1,5 +1,5 @@
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:28:5
+  --> tests/ui/from_str_radix_10.rs:32:5
    |
 LL |     u32::from_str_radix("30", 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"30".parse::<u32>()`
@@ -8,58 +8,76 @@ LL |     u32::from_str_radix("30", 10)?;
    = help: to override `-D warnings` add `#[allow(clippy::from_str_radix_10)]`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:31:5
+  --> tests/ui/from_str_radix_10.rs:35:5
    |
 LL |     i64::from_str_radix("24", 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"24".parse::<i64>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:34:5
+  --> tests/ui/from_str_radix_10.rs:38:5
    |
 LL |     isize::from_str_radix("100", 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"100".parse::<isize>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:37:5
+  --> tests/ui/from_str_radix_10.rs:41:5
    |
 LL |     u8::from_str_radix("7", 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"7".parse::<u8>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:40:5
+  --> tests/ui/from_str_radix_10.rs:44:5
    |
 LL |     u16::from_str_radix(&("10".to_owned() + "5"), 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `("10".to_owned() + "5").parse::<u16>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:43:5
+  --> tests/ui/from_str_radix_10.rs:47:5
    |
 LL |     i128::from_str_radix(Test + Test, 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(Test + Test).parse::<i128>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:47:5
+  --> tests/ui/from_str_radix_10.rs:51:5
    |
 LL |     i32::from_str_radix(string, 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.parse::<i32>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:51:5
+  --> tests/ui/from_str_radix_10.rs:55:5
    |
 LL |     i32::from_str_radix(&stringier, 10)?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `stringier.parse::<i32>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:81:13
+  --> tests/ui/from_str_radix_10.rs:85:13
    |
 LL |     let _ = u32::from_str_radix(&s, 10).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.parse::<u32>()`
 
 error: this call to `from_str_radix` can be replaced with a call to `str::parse`
-  --> tests/ui/from_str_radix_10.rs:84:13
+  --> tests/ui/from_str_radix_10.rs:88:13
    |
 LL |     let _ = u32::from_str_radix(&s_ref, 10).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s_ref.parse::<u32>()`
 
-error: aborting due to 10 previous errors
+error: this call to `from_str_radix` can be replaced with a call to `str::parse`
+  --> tests/ui/from_str_radix_10.rs:100:5
+   |
+LL |     NonZeroU16::from_str_radix("8", 10)?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"8".parse::<NonZeroU16>()`
+
+error: this call to `from_str_radix` can be replaced with a call to `str::parse`
+  --> tests/ui/from_str_radix_10.rs:103:5
+   |
+LL |     std::num::NonZeroI32::from_str_radix("42", 10)?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"42".parse::<std::num::NonZeroI32>()`
+
+error: this call to `from_str_radix` can be replaced with a call to `str::parse`
+  --> tests/ui/from_str_radix_10.rs:106:5
+   |
+LL |     MyNonZero::from_str_radix("11", 10)?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"11".parse::<MyNonZero>()`
+
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
closes rust-lang/rust-clippy#17712

The `from_str_radix_10` lint now covers `NonZero*` types, which gained `from_str_radix` in Rust 1.98.

Uses `is_diag_item(sym::NonZero)` for detection and guards the suggestion with MSRV 1.98.

changelog: [`from_str_radix_10`]: now lints on `NonZero*` types