### PR TITLE
manual_intra_doc_links: lint hardcoded `.html` links in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7232,6 +7232,7 @@ Released 2018-09-13
 [`manual_ilog2`]: https://rust-lang.github.io/rust-clippy/main/index.html#manual_ilog2
 [`manual_inspect`]: https://rust-lang.github.io/rust-clippy/main/index.html#manual_inspect
 [`manual_instant_elapsed`]: https://rust-lang.github.io/rust-clippy/main/index.html#manual_instant_elapsed
+[`manual_intra_doc_links`]: https://rust-lang.github.io/rust-clippy/main/index.html#manual_intra_doc_links
 [`manual_is_ascii_check`]: https://rust-lang.github.io/rust-clippy/main/index.html#manual_is_ascii_check
 [`manual_is_finite`]: https://rust-lang.github.io/rust-clippy/main/index.html#manual_is_finite
 [`manual_is_infinite`]: https://rust-lang.github.io/rust-clippy/main/index.html#manual_is_infinite

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -128,6 +128,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::doc::DOC_PARAGRAPHS_MISSING_PUNCTUATION_INFO,
     crate::doc::DOC_SUSPICIOUS_FOOTNOTES_INFO,
     crate::doc::EMPTY_DOCS_INFO,
+    crate::doc::MANUAL_INTRA_DOC_LINKS_INFO,
     crate::doc::MISSING_ERRORS_DOC_INFO,
     crate::doc::MISSING_PANICS_DOC_INFO,
     crate::doc::MISSING_SAFETY_DOC_INFO,

--- a/clippy_lints/src/doc/manual_intra_doc_links.rs
+++ b/clippy_lints/src/doc/manual_intra_doc_links.rs
@@ -1,0 +1,320 @@
+use crate::doc::{Fragments, MANUAL_INTRA_DOC_LINKS};
+use clippy_utils::diagnostics::span_lint_and_then;
+use rustc_crate_store::ExternCrateSource;
+use rustc_data_structures::fx::FxHashMap;
+use rustc_errors::Applicability;
+use rustc_hir::def::DefKind;
+use rustc_hir::definitions::DefPathData;
+use rustc_lint::LateContext;
+use rustc_resolve::rustdoc::pulldown_cmark::LinkType;
+use rustc_span::def_id::LocalDefId;
+use rustc_span::{Symbol, kw};
+use std::ops::Range;
+
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn check(
+    current_item: LocalDefId,
+    dest_url: &str,
+    doc: &str,
+    doc_span: Range<usize>,
+    fragments: &Fragments<'_>,
+    reference_definitions: &FxHashMap<Box<str>, Range<usize>>,
+    link_type: LinkType,
+    link_id: &str,
+    cx: &LateContext<'_>,
+) {
+    let Some(intra_doc_link) = check_docsrs(dest_url, cx).or_else(|| check_relative(current_item, dest_url, cx)) else {
+        return;
+    };
+    let Some(span) = fragments.span(cx, doc_span.clone()) else {
+        return;
+    };
+    span_lint_and_then(cx, MANUAL_INTRA_DOC_LINKS, span, "manual intra-doc link", |diag| {
+        if matches!(
+            link_type,
+            LinkType::Reference
+                | LinkType::ReferenceUnknown
+                | LinkType::Collapsed
+                | LinkType::CollapsedUnknown
+                | LinkType::Shortcut
+                | LinkType::ShortcutUnknown
+        ) && let Some(refdef) = reference_definitions.get(link_id)
+        {
+            let Some(span) = fragments.span(cx, refdef.clone()) else {
+                return;
+            };
+            let text = &doc[refdef.clone()];
+            let text = &text[text.find('[').expect("markdown links use square brackets") + 1
+                ..text.rfind(']').expect("markdown links use square brackets")];
+            diag.span_suggestion_verbose(
+                span,
+                "consider linking by path instead",
+                format!("[{text}]: {intra_doc_link}"),
+                Applicability::MachineApplicable,
+            );
+        } else if matches!(link_type, LinkType::Inline) {
+            let text = &doc[doc_span];
+            let text = &text[text.find('[').expect("markdown links use square brackets") + 1
+                ..text.rfind(']').expect("markdown links use square brackets")];
+            diag.span_suggestion_verbose(
+                span,
+                "consider linking by path instead",
+                format!("[{text}]({intra_doc_link})"),
+                Applicability::MachineApplicable,
+            );
+        } else {
+            // used by <./AutoLink.html> and other rarely-used link syntaxes
+            diag.span_suggestion_verbose(
+                span,
+                "consider linking by path instead",
+                format!("[{intra_doc_link}][]"),
+                Applicability::MachineApplicable,
+            );
+        }
+    });
+}
+
+/// Parse relative links,
+/// such as `../other_module/struct.Foo.html`
+fn check_relative(mut current_item: LocalDefId, mut dest_url: &str, cx: &LateContext<'_>) -> Option<String> {
+    // The directory always corresponds to a module.
+    while !matches!(cx.tcx.def_kind(current_item.to_def_id()), DefKind::Mod) {
+        current_item = cx.tcx.local_parent(current_item);
+    }
+    let module_path = cx.tcx.def_path(current_item.to_def_id());
+    let mut module_path_data = module_path
+        .data
+        .iter()
+        .map(|data| data.data)
+        .collect::<Vec<DefPathData>>();
+    assert_ne!(module_path_data.first(), Some(&DefPathData::CrateRoot));
+    module_path_data.insert(0, DefPathData::CrateRoot);
+
+    // count how many times `../` was written at the start of the relative path
+    let mut path_component_parent_count = 0;
+    while dest_url.starts_with('.') {
+        if dest_url.starts_with("../") {
+            dest_url = &dest_url[3..];
+            if path_component_parent_count > module_path_data.len() {
+                // if the `../` reaches module_path_data.len, then that means
+                // we've gone above the crate root, and are looking at
+                // another crate
+                //
+                // if it's module_path_data.len + 1, then we're above the doc
+                // bundle entirely
+                return None;
+            }
+            path_component_parent_count += 1;
+        } else if dest_url.starts_with("./") {
+            dest_url = &dest_url[2..];
+        } else {
+            // path component starts with `.`, but not with `../` or `./`
+            // module names can't contain `.` in Rust, so this can't be
+            // a link to an item in a module
+            return None;
+        }
+    }
+    let mut parent_path_components =
+        symbols_for_def_path_data(&module_path_data[..module_path_data.len() - path_component_parent_count]);
+
+    if (dest_url == "index.html" || dest_url.is_empty()) && !parent_path_components.is_empty() {
+        let parent_path = parent_path_components
+            .iter()
+            .map(Symbol::as_str)
+            .collect::<Vec<&str>>()
+            .join("::");
+        return Some(format!("mod@{parent_path}"));
+    }
+
+    // parse the URL after the `../`s
+    let (mut path_components, disambiguator, item_name) = check_url_inner(dest_url)?;
+
+    // find the path to the crate, if any
+    let crate_path_components = if parent_path_components.is_empty()
+        && let crate_name = path_components.first().copied().unwrap_or(item_name)
+        && let Some(crate_path_components) = cx.tcx.crates(()).iter().find_map(|&cnum| {
+            let extern_crate = cx.tcx.extern_crate(cnum)?;
+            // manual intra-doc links are only redundant if the crate is already a dependency
+            if !extern_crate.is_direct() || cx.tcx.crate_name(cnum).as_str() != crate_name {
+                return None;
+            }
+            match extern_crate.src {
+                ExternCrateSource::Path => Some(vec![cx.tcx.crate_name(cnum)]),
+                ExternCrateSource::Extern(did) => Some(symbols_for_def_path_data(
+                    &std::iter::once(DefPathData::CrateRoot)
+                        .chain(cx.tcx.def_path(did).data.iter().map(|data| data.data))
+                        .collect::<Vec<_>>(),
+                )),
+            }
+        }) {
+        if path_components.is_empty() {
+            // This is a link directly to the crate.
+            return Some(format!(
+                "mod@{}",
+                crate_path_components
+                    .iter()
+                    .map(Symbol::as_str)
+                    .collect::<Vec<&str>>()
+                    .join("::")
+            ));
+        }
+        path_components.remove(0);
+        crate_path_components
+    } else if !parent_path_components.is_empty() {
+        vec![parent_path_components.remove(0)]
+    } else {
+        // path always contains at least a crate
+        return None;
+    };
+    let crate_path = crate_path_components
+        .iter()
+        .map(Symbol::as_str)
+        .collect::<Vec<&str>>()
+        .join("::");
+
+    let parent_path = parent_path_components
+        .iter()
+        .map(Symbol::as_str)
+        .collect::<Vec<&str>>()
+        .join("::");
+    let path = path_components.join("::");
+    Some(format!(
+        "{disambiguator}@{crate_path}{sep1}{parent_path}{sep2}{path}::{item_name}",
+        sep1 = if crate_path.is_empty() || parent_path.is_empty() {
+            ""
+        } else {
+            "::"
+        },
+        sep2 = if path.is_empty() || (parent_path.is_empty() && crate_path.is_empty()) {
+            ""
+        } else {
+            "::"
+        },
+    ))
+}
+
+/// Parse docs.rs links,
+/// if the link points at a crate that is also a dependency.
+fn check_docsrs(mut dest_url: &str, cx: &LateContext<'_>) -> Option<String> {
+    if dest_url.starts_with("https://docs.rs/") {
+        dest_url = &dest_url[16..];
+    } else {
+        // not a docs.rs link
+        return None;
+    }
+    let (_package_name, version_and_path) = dest_url.split_once('/')?;
+    let Some(("latest", path)) = version_and_path.split_once('/') else {
+        // if a version is specified, it might be different from the
+        // actual dependency version
+        return None;
+    };
+    let (crate_name, path) = path.split_once('/')?;
+    let crate_path = cx.tcx.crates(()).iter().find_map(|&cnum| {
+        let extern_crate = cx.tcx.extern_crate(cnum)?;
+        // docs.rs links are only redundant if the crate is already a dependency
+        if !extern_crate.is_direct() || cx.tcx.crate_name(cnum).as_str() != crate_name {
+            return None;
+        }
+        match extern_crate.src {
+            ExternCrateSource::Path => Some(vec![cx.tcx.crate_name(cnum)]),
+            ExternCrateSource::Extern(did) => Some(symbols_for_def_path_data(
+                &std::iter::once(DefPathData::CrateRoot)
+                    .chain(cx.tcx.def_path(did).data.iter().map(|data| data.data))
+                    .collect::<Vec<_>>(),
+            )),
+        }
+    })?;
+
+    let crate_path = crate_path.iter().map(Symbol::as_str).collect::<Vec<&str>>().join("::");
+
+    if path == "index.html" || path.is_empty() {
+        return Some(format!("mod@{crate_path}"));
+    }
+
+    let (path_components, disambiguator, item_name) = check_url_inner(path)?;
+
+    let path = path_components.join("::");
+    Some(format!(
+        "{disambiguator}@{crate_path}{sep}{path}::{item_name}",
+        sep = if crate_path.is_empty() || path.is_empty() {
+            ""
+        } else {
+            "::"
+        }
+    ))
+}
+
+fn check_url_inner(mut path: &str) -> Option<(Vec<&str>, &str, &str)> {
+    let mut path_components = Vec::with_capacity(path.bytes().filter(|c| *c == b'/').count() + 1);
+    while let Some((dirname, child_path)) = path.split_once('/') {
+        if dirname.contains('.') || dirname.is_empty() {
+            // module names can't contain `.` in Rust, so this can't be
+            // a link to an item in a module
+            return None;
+        }
+        path_components.push(dirname);
+        path = child_path;
+    }
+
+    if path == "index.html" || path.is_empty() {
+        let item_name = path_components.pop()?;
+        return Some((path_components, "mod", item_name));
+    }
+
+    let filename_parts = path.split('.').collect::<Vec<_>>();
+    let &[disambiguator, item_name, html] = &filename_parts[..] else {
+        // filename doesn't file pattern `DISAMBIGUATOR.MyName.html`
+        return None;
+    };
+    if html != "html"
+        || !matches!(
+            disambiguator,
+            // copied from librustdoc/formats/item_type.rs
+            |"mod"| "externcrate"
+                | "import"
+                | "struct"
+                | "union"
+                | "enum"
+                | "fn"
+                | "type"
+                | "static"
+                | "trait"
+                | "impl"
+                | "tymethod"
+                | "method"
+                | "structfield"
+                | "variant"
+                | "macro"
+                | "primitive"
+                | "associatedtype"
+                | "constant"
+                | "associatedconstant"
+                | "foreigntype"
+                | "keyword"
+                | "attr"
+                | "derive"
+                | "traitalias"
+                | "attribute"
+        )
+    {
+        // filename doesn't file pattern `DISAMBIGUATOR.MyName.html`
+        return None;
+    }
+
+    Some((path_components, disambiguator, item_name))
+}
+
+/// Generate an intra-doc link for a defpath
+/// that should never contain non-module parents.
+fn symbols_for_def_path_data(data: &[DefPathData]) -> Vec<Symbol> {
+    data.iter()
+        .map(|part| {
+            if *part == DefPathData::CrateRoot {
+                kw::Crate
+            } else {
+                part.get_opt_name()
+                    .expect("a module's parents are the crate, plus other modules")
+            }
+        })
+        .collect()
+}

--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -3,9 +3,9 @@ use clippy_utils::attrs::is_doc_hidden;
 use clippy_utils::diagnostics::{span_lint, span_lint_and_help, span_lint_and_then};
 use clippy_utils::{is_entrypoint_fn, is_trait_impl_item};
 use rustc_attr_ir::Attribute;
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::Applicability;
-use rustc_hir::{FieldDef, ImplItemKind, ItemKind, Node, Safety, TraitItemKind};
+use rustc_hir::{FieldDef, ImplItemKind, ItemKind, Node, OwnerId, Safety, TraitItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintContext as _, impl_lint_pass};
 use rustc_resolve::rustdoc::pulldown_cmark::Event::{
     Code, DisplayMath, End, FootnoteReference, HardBreak, Html, InlineHtml, InlineMath, Rule, SoftBreak, Start,
@@ -30,6 +30,7 @@ mod doc_suspicious_footnotes;
 mod include_in_doc_without_cfg;
 mod lazy_continuation;
 mod link_with_quotes;
+mod manual_intra_doc_links;
 mod markdown;
 mod missing_headers;
 mod needless_doctest_main;
@@ -422,6 +423,31 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Detects links that are written as URLs, but could have been written as Rust paths.
+    ///
+    /// ### Why is this bad?
+    /// Path-based intra-doc links are:
+    /// - warned about if they don't resolve
+    /// - rewritten if `#[doc(inline)]` changes the item's URL
+    ///
+    /// ### Example
+    /// ```no_run
+    /// /// [module link](index.html)
+    /// # pub struct Foo;
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// /// [module link](crate)
+    /// # pub struct Foo;
+    /// ```
+    #[clippy::version = "1.100.0"]
+    pub MANUAL_INTRA_DOC_LINKS,
+    pedantic,
+    "lint hardcoded `.html` links to docs"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks the doc comments of publicly visible functions that
     /// return a `Result` type and warns if there is no `# Errors` section.
     ///
@@ -717,6 +743,7 @@ impl_lint_pass!(Documentation => [
     DOC_PARAGRAPHS_MISSING_PUNCTUATION,
     DOC_SUSPICIOUS_FOOTNOTES,
     EMPTY_DOCS,
+    MANUAL_INTRA_DOC_LINKS,
     MISSING_ERRORS_DOC,
     MISSING_PANICS_DOC,
     MISSING_SAFETY_DOC,
@@ -749,7 +776,12 @@ impl EarlyLintPass for Documentation {
 
 impl<'tcx> LateLintPass<'tcx> for Documentation {
     fn check_attributes(&mut self, cx: &LateContext<'tcx>, attrs: &'tcx [Attribute]) {
-        let Some(headers) = check_attrs(cx, self.valid_idents, attrs) else {
+        let current_item = cx
+            .last_node_with_lint_attrs
+            .as_owner()
+            .unwrap_or_else(|| cx.tcx.hir_get_parent_item(cx.last_node_with_lint_attrs));
+
+        let Some(headers) = check_attrs(cx, self.valid_idents, attrs, current_item) else {
             return;
         };
 
@@ -863,7 +895,12 @@ struct DocHeaders {
 /// Others are checked elsewhere, e.g. in `check_doc` if they need access to markdown, or
 /// back in the various late lint pass methods if they need the final doc headers, like "Safety" or
 /// "Panics" sections.
-fn check_attrs(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, attrs: &[Attribute]) -> Option<DocHeaders> {
+fn check_attrs(
+    cx: &LateContext<'_>,
+    valid_idents: &FxHashSet<String>,
+    attrs: &[Attribute],
+    current_item: OwnerId,
+) -> Option<DocHeaders> {
     // We don't want the parser to choke on intra doc links. Since we don't
     // actually care about rendering them, just pretend that all broken links
     // point to a fake address.
@@ -960,6 +997,7 @@ fn check_attrs(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, attrs: &[
             fragments: &fragments,
         },
         attrs,
+        current_item,
     ))
 }
 
@@ -1102,13 +1140,14 @@ impl CodeTags {
 /// so lints here will generally access that information.
 /// Returns documentation headers -- whether a "Safety", "Errors", "Panic" section was found
 #[expect(clippy::too_many_lines, reason = "big match statement")]
-fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize>)>>(
+fn check_doc<'p, C: pulldown_cmark::BrokenLinkCallback<'p>>(
     cx: &LateContext<'_>,
     valid_idents: &FxHashSet<String>,
-    events: Events,
+    events: pulldown_cmark::OffsetIter<'p, C>,
     doc: &str,
     fragments: Fragments<'_>,
     attrs: &[Attribute],
+    current_item: OwnerId,
 ) -> DocHeaders {
     // true if a safety header was found
     let mut headers = DocHeaders::default();
@@ -1128,6 +1167,13 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
 
     // Skip collecting text and the per-word scan when `DOC_MARKDOWN` (pedantic) is allowed.
     let check_doc_markdown = !clippy_utils::is_lint_allowed(cx, DOC_MARKDOWN, cx.last_node_with_lint_attrs);
+
+    // Once the iterator is wrapped in Peekable, there's no way to call this method.
+    let reference_definitions: FxHashMap<Box<str>, Range<usize>> = events
+        .reference_definitions()
+        .iter()
+        .map(|(name, def)| (name.into(), def.span.clone()))
+        .collect();
 
     let mut events = events.peekable();
 
@@ -1184,7 +1230,19 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                 });
             },
             End(TagEnd::CodeBlock) => code = None,
-            Start(Link { dest_url, .. }) => in_link = Some(dest_url),
+            Start(Link { dest_url, link_type, id, .. }) => {
+                manual_intra_doc_links::check(current_item.def_id,
+                    &dest_url,
+                    doc,
+                    range.clone(),
+                    &fragments,
+                    &reference_definitions,
+                    link_type,
+                    &id,
+                    cx,
+                );
+                in_link = Some(dest_url);
+            },
             End(TagEnd::Link) => in_link = None,
             Start(Heading { .. } | Paragraph | Item) => {
                 if let Start(Heading { .. }) = event {

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -27,6 +27,7 @@ extern crate rustc_arena;
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
 extern crate rustc_attr_ir;
+extern crate rustc_crate_store;
 extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hir;

--- a/tests/ui/manual_intra_doc_links.fixed
+++ b/tests/ui/manual_intra_doc_links.fixed
@@ -1,0 +1,116 @@
+//@aux-build:external_item.rs
+//@aux-build:external_consts.rs
+
+//! Link with [refdef] and [mod@crate::extern_crate::external_item][]
+//! and [inner link][refdef].
+//!
+//! [refdef]: mod@crate
+//~^^^ manual_intra_doc_links
+//~^^^^^ manual_intra_doc_links
+//~| manual_intra_doc_links
+
+#![warn(clippy::manual_intra_doc_links)]
+
+pub mod extern_crate {
+    pub(crate) extern crate external_item;
+}
+
+/// Link to [external item](struct@crate::extern_crate::external_item::_ExternalStruct)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkExtern;
+
+/// Link to [external item](mod@crate::extern_crate::external_item)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkExternIndexHtmlCrate;
+
+/// Link to [external item](mod@crate::extern_crate::external_item::module)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkExternIndexHtmlModule;
+
+/// Link to [a crate that isn't a dependency](https://docs.rs/regex/latest/regex/index.html)
+pub struct DocsrsLinkNonDependency;
+
+use external_consts::MAGIC_NUMBER;
+/// Link to [external const](constant@external_consts::MAGIC_NUMBER)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkUse;
+/// Link to [external const](mod@external_consts)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkUseIndexHtmlCrate;
+/// Link to [external const](mod@external_consts::module)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkUseIndexHtmlModule;
+
+/// Link to [external item](struct@crate::extern_crate::external_item::_ExternalStruct)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkExtern;
+/// Link to [external item](mod@crate::extern_crate::external_item)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkExternIndexHtmlCrate;
+/// Link to [external item](mod@crate::extern_crate::external_item::module)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkExternIndexHtmlModule;
+
+/// Link to [external item](constant@external_consts::MAGIC_NUMBER)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkUse;
+/// Link to [external item](mod@external_consts)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkUseIndexHtmlCrate;
+/// Link to [external item](mod@external_consts::module)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkUseIndexHtmlModule;
+
+/// Link to [local item](struct@crate::FooBar)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkLocalItem;
+
+/// Link to [myself](mod@crate::my_mod)
+//~^ manual_intra_doc_links
+pub mod my_mod {
+    /// Link to [local item](struct@crate::my_mod::FooBar)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalSubmoduleItem;
+    /// Link to [local item](struct@crate::FooBar)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalParentItem;
+    /// Link to [local item](struct@crate::my_mod::mod_2::FooBar)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalChildModItem;
+    /// Link to [local item](mod@crate::my_mod)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalModule;
+    /// Link to [local item](mod@crate)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalParentCrate;
+    /// Link to [outside the docs](../../index.html)
+    pub struct RelativeLinkLocalRoot;
+
+    pub struct FooBar;
+    pub mod mod_2 {
+        pub struct FooBar;
+    }
+
+    /// Link to [external item](struct@crate::extern_crate::external_item::_ExternalStruct)
+    //~^ manual_intra_doc_links
+    pub struct DocsrsLinkExtern;
+    /// Link to [external const](constant@external_consts::MAGIC_NUMBER)
+    //~^ manual_intra_doc_links
+    pub struct DocsrsLinkUse;
+    /// Link to [external item](struct@crate::extern_crate::external_item::_ExternalStruct)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkExtern;
+    /// Link to [external item](constant@external_consts::MAGIC_NUMBER)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkUse;
+}
+
+pub struct FooBar;
+
+/// Link to [a crate that isn't a dependency](../nonexistant/index.html)
+pub struct RelativeLinkNonDependency;
+
+/// Link to [external item](../constant.MAGIC_NUMBER.html)
+pub struct RelativeLinkOutsideCrate;
+/// Link to [external item](../index.html)
+pub struct RelativeLinkOutsideCrateIndexHtml;

--- a/tests/ui/manual_intra_doc_links.rs
+++ b/tests/ui/manual_intra_doc_links.rs
@@ -1,0 +1,116 @@
+//@aux-build:external_item.rs
+//@aux-build:external_consts.rs
+
+//! Link with [refdef] and <https://docs.rs/external_item/latest/external_item/index.html>
+//! and [inner link][refdef].
+//!
+//! [refdef]: index.html
+//~^^^ manual_intra_doc_links
+//~^^^^^ manual_intra_doc_links
+//~| manual_intra_doc_links
+
+#![warn(clippy::manual_intra_doc_links)]
+
+pub mod extern_crate {
+    pub(crate) extern crate external_item;
+}
+
+/// Link to [external item](https://docs.rs/external_item/latest/external_item/struct._ExternalStruct.html)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkExtern;
+
+/// Link to [external item](https://docs.rs/external_item/latest/external_item/index.html)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkExternIndexHtmlCrate;
+
+/// Link to [external item](https://docs.rs/external_item/latest/external_item/module/index.html)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkExternIndexHtmlModule;
+
+/// Link to [a crate that isn't a dependency](https://docs.rs/regex/latest/regex/index.html)
+pub struct DocsrsLinkNonDependency;
+
+use external_consts::MAGIC_NUMBER;
+/// Link to [external const](https://docs.rs/external_consts/latest/external_consts/constant.MAGIC_NUMBER.html)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkUse;
+/// Link to [external const](https://docs.rs/external_consts/latest/external_consts/index.html)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkUseIndexHtmlCrate;
+/// Link to [external const](https://docs.rs/external_consts/latest/external_consts/module/index.html)
+//~^ manual_intra_doc_links
+pub struct DocsrsLinkUseIndexHtmlModule;
+
+/// Link to [external item](../external_item/struct._ExternalStruct.html)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkExtern;
+/// Link to [external item](../external_item/index.html)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkExternIndexHtmlCrate;
+/// Link to [external item](../external_item/module/index.html)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkExternIndexHtmlModule;
+
+/// Link to [external item](../external_consts/constant.MAGIC_NUMBER.html)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkUse;
+/// Link to [external item](../external_consts/index.html)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkUseIndexHtmlCrate;
+/// Link to [external item](../external_consts/module/index.html)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkUseIndexHtmlModule;
+
+/// Link to [local item](struct.FooBar.html)
+//~^ manual_intra_doc_links
+pub struct RelativeLinkLocalItem;
+
+/// Link to [myself](index.html)
+//~^ manual_intra_doc_links
+pub mod my_mod {
+    /// Link to [local item](struct.FooBar.html)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalSubmoduleItem;
+    /// Link to [local item](../struct.FooBar.html)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalParentItem;
+    /// Link to [local item](mod_2/struct.FooBar.html)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalChildModItem;
+    /// Link to [local item](index.html)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalModule;
+    /// Link to [local item](../index.html)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkLocalParentCrate;
+    /// Link to [outside the docs](../../index.html)
+    pub struct RelativeLinkLocalRoot;
+
+    pub struct FooBar;
+    pub mod mod_2 {
+        pub struct FooBar;
+    }
+
+    /// Link to [external item](https://docs.rs/external_item/latest/external_item/struct._ExternalStruct.html)
+    //~^ manual_intra_doc_links
+    pub struct DocsrsLinkExtern;
+    /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/constant.MAGIC_NUMBER.html)
+    //~^ manual_intra_doc_links
+    pub struct DocsrsLinkUse;
+    /// Link to [external item](../../external_item/struct._ExternalStruct.html)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkExtern;
+    /// Link to [external item](../../external_consts/constant.MAGIC_NUMBER.html)
+    //~^ manual_intra_doc_links
+    pub struct RelativeLinkUse;
+}
+
+pub struct FooBar;
+
+/// Link to [a crate that isn't a dependency](../nonexistant/index.html)
+pub struct RelativeLinkNonDependency;
+
+/// Link to [external item](../constant.MAGIC_NUMBER.html)
+pub struct RelativeLinkOutsideCrate;
+/// Link to [external item](../index.html)
+pub struct RelativeLinkOutsideCrateIndexHtml;

--- a/tests/ui/manual_intra_doc_links.stderr
+++ b/tests/ui/manual_intra_doc_links.stderr
@@ -1,0 +1,316 @@
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:4:15
+   |
+LL | //! Link with [refdef] and <https://docs.rs/external_item/latest/external_item/index.html>
+   |               ^^^^^^^^
+   |
+   = note: `-D clippy::manual-intra-doc-links` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_intra_doc_links)]`
+help: consider linking by path instead
+   |
+LL - //! [refdef]: index.html
+LL + //! [refdef]: mod@crate
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:4:28
+   |
+LL | //! Link with [refdef] and <https://docs.rs/external_item/latest/external_item/index.html>
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - //! Link with [refdef] and <https://docs.rs/external_item/latest/external_item/index.html>
+LL + //! Link with [refdef] and [mod@crate::extern_crate::external_item][]
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:5:9
+   |
+LL | //! and [inner link][refdef].
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - //! [refdef]: index.html
+LL + //! [refdef]: mod@crate
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:18:13
+   |
+LL | /// Link to [external item](https://docs.rs/external_item/latest/external_item/struct._ExternalStruct.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](https://docs.rs/external_item/latest/external_item/struct._ExternalStruct.html)
+LL + /// Link to [external item](struct@crate::extern_crate::external_item::_ExternalStruct)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:22:13
+   |
+LL | /// Link to [external item](https://docs.rs/external_item/latest/external_item/index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](https://docs.rs/external_item/latest/external_item/index.html)
+LL + /// Link to [external item](mod@crate::extern_crate::external_item)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:26:13
+   |
+LL | /// Link to [external item](https://docs.rs/external_item/latest/external_item/module/index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](https://docs.rs/external_item/latest/external_item/module/index.html)
+LL + /// Link to [external item](mod@crate::extern_crate::external_item::module)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:34:13
+   |
+LL | /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/constant.MAGIC_NUMBER.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/constant.MAGIC_NUMBER.html)
+LL + /// Link to [external const](constant@external_consts::MAGIC_NUMBER)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:37:13
+   |
+LL | /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/index.html)
+LL + /// Link to [external const](mod@external_consts)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:40:13
+   |
+LL | /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/module/index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/module/index.html)
+LL + /// Link to [external const](mod@external_consts::module)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:44:13
+   |
+LL | /// Link to [external item](../external_item/struct._ExternalStruct.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](../external_item/struct._ExternalStruct.html)
+LL + /// Link to [external item](struct@crate::extern_crate::external_item::_ExternalStruct)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:47:13
+   |
+LL | /// Link to [external item](../external_item/index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](../external_item/index.html)
+LL + /// Link to [external item](mod@crate::extern_crate::external_item)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:50:13
+   |
+LL | /// Link to [external item](../external_item/module/index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](../external_item/module/index.html)
+LL + /// Link to [external item](mod@crate::extern_crate::external_item::module)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:54:13
+   |
+LL | /// Link to [external item](../external_consts/constant.MAGIC_NUMBER.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](../external_consts/constant.MAGIC_NUMBER.html)
+LL + /// Link to [external item](constant@external_consts::MAGIC_NUMBER)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:57:13
+   |
+LL | /// Link to [external item](../external_consts/index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](../external_consts/index.html)
+LL + /// Link to [external item](mod@external_consts)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:60:13
+   |
+LL | /// Link to [external item](../external_consts/module/index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [external item](../external_consts/module/index.html)
+LL + /// Link to [external item](mod@external_consts::module)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:64:13
+   |
+LL | /// Link to [local item](struct.FooBar.html)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [local item](struct.FooBar.html)
+LL + /// Link to [local item](struct@crate::FooBar)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:68:13
+   |
+LL | /// Link to [myself](index.html)
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL - /// Link to [myself](index.html)
+LL + /// Link to [myself](mod@crate::my_mod)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:71:17
+   |
+LL |     /// Link to [local item](struct.FooBar.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [local item](struct.FooBar.html)
+LL +     /// Link to [local item](struct@crate::my_mod::FooBar)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:74:17
+   |
+LL |     /// Link to [local item](../struct.FooBar.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [local item](../struct.FooBar.html)
+LL +     /// Link to [local item](struct@crate::FooBar)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:77:17
+   |
+LL |     /// Link to [local item](mod_2/struct.FooBar.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [local item](mod_2/struct.FooBar.html)
+LL +     /// Link to [local item](struct@crate::my_mod::mod_2::FooBar)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:80:17
+   |
+LL |     /// Link to [local item](index.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [local item](index.html)
+LL +     /// Link to [local item](mod@crate::my_mod)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:83:17
+   |
+LL |     /// Link to [local item](../index.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [local item](../index.html)
+LL +     /// Link to [local item](mod@crate)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:94:17
+   |
+LL |     /// Link to [external item](https://docs.rs/external_item/latest/external_item/struct._ExternalStruct.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [external item](https://docs.rs/external_item/latest/external_item/struct._ExternalStruct.html)
+LL +     /// Link to [external item](struct@crate::extern_crate::external_item::_ExternalStruct)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:97:17
+   |
+LL |     /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/constant.MAGIC_NUMBER.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [external const](https://docs.rs/external_consts/latest/external_consts/constant.MAGIC_NUMBER.html)
+LL +     /// Link to [external const](constant@external_consts::MAGIC_NUMBER)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:100:17
+   |
+LL |     /// Link to [external item](../../external_item/struct._ExternalStruct.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [external item](../../external_item/struct._ExternalStruct.html)
+LL +     /// Link to [external item](struct@crate::extern_crate::external_item::_ExternalStruct)
+   |
+
+error: manual intra-doc link
+  --> tests/ui/manual_intra_doc_links.rs:103:17
+   |
+LL |     /// Link to [external item](../../external_consts/constant.MAGIC_NUMBER.html)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider linking by path instead
+   |
+LL -     /// Link to [external item](../../external_consts/constant.MAGIC_NUMBER.html)
+LL +     /// Link to [external item](constant@external_consts::MAGIC_NUMBER)
+   |
+
+error: aborting due to 26 previous errors
+


### PR DESCRIPTION
Encourages documentation authors to write links using paths, instead of writing rustdoc URLs by hand.

This lint detects the two common cases: local URLs and docs.rs. It avoids warning on paths that point at crates that aren't dependencies, because those can't be written as paths. It doesn't detect broken links, because rustdoc itself should detect them.

I tested all the generated intra-doc links using rustdoc in https://gist.github.com/notriddle/1db64b4aa206fce9284871ec1b4116ee

changelog: [`manual_intra_doc_links`]: lint hardcoded `.html` links in docs

Fixes https://github.com/rust-lang/rust-clippy/issues/1912
Fixes https://github.com/rust-lang/rust/issues/75805