### PR TITLE
Preserve caller locations in closure rewrites

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -104,6 +104,7 @@ use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 use rustc_lint::{LateContext, Level, Lint, LintContext as _};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::hir::place::PlaceBase;
+use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::mir::{AggregateKind, Operand, RETURN_PLACE, Rvalue, StatementKind, TerminatorKind};
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, DerefAdjustKind, PointerCoercion};
 use rustc_middle::ty::layout::IntegerExt as _;
@@ -719,12 +720,28 @@ fn is_default_equivalent_from(cx: &LateContext<'_>, from_func: &Expr<'_>, arg: &
     false
 }
 
+fn is_track_caller(cx: &LateContext<'_>, def_id: DefId) -> bool {
+    cx.tcx
+        .codegen_fn_attrs(def_id)
+        .flags
+        .contains(CodegenFnAttrFlags::TRACK_CALLER)
+}
+
+fn would_change_caller_location(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    let Some(callee) = fn_def_id(cx, expr) else {
+        return false;
+    };
+    let enclosing_body = cx.tcx.hir_enclosing_body_owner(expr.hir_id);
+    is_track_caller(cx, enclosing_body.to_def_id()) && is_track_caller(cx, callee)
+}
+
 /// Checks if the top level expression can be moved into a closure as is.
 /// Currently checks for:
 /// * Break/Continue outside the given loop HIR ids.
 /// * Yield/Return statements.
 /// * Inline assembly.
 /// * Usages of a field of a local where the type of the local can be partially moved.
+/// * Calls which would stop propagation from an enclosing `#[track_caller]` function.
 ///
 /// For example, given the following function:
 ///
@@ -756,6 +773,10 @@ pub fn can_move_expr_to_closure_no_visit<'tcx>(
     loop_ids: &[HirId],
     ignore_locals: &HirIdSet,
 ) -> bool {
+    if would_change_caller_location(cx, expr) {
+        return false;
+    }
+
     match expr.kind {
         ExprKind::Break(Destination { target_id: Ok(id), .. }, _)
         | ExprKind::Continue(Destination { target_id: Ok(id), .. })

--- a/tests/ui/manual_map/track_caller.fixed
+++ b/tests/ui/manual_map/track_caller.fixed
@@ -1,0 +1,60 @@
+// run-rustfix
+#![warn(clippy::manual_map)]
+
+use std::panic::Location;
+
+#[track_caller]
+fn caller_line() -> u32 {
+    Location::caller().line()
+}
+
+fn make_value(value: u32, caller: u32) -> (u32, u32) {
+    (value, caller)
+}
+
+#[track_caller]
+fn track_caller_false_positive(value: Option<u32>) -> Option<(u32, u32)> {
+    match value {
+        Some(value) => Some(make_value(value, caller_line())),
+        None => None,
+    }
+}
+
+#[track_caller]
+fn tracked_function(value: u32) -> u32 {
+    let _ = Location::caller();
+    value
+}
+
+#[track_caller]
+fn track_caller_function_item(value: Option<u32>) -> Option<u32> {
+    match value {
+        Some(value) => Some(tracked_function(value)),
+        None => None,
+    }
+}
+
+#[track_caller]
+fn track_caller_without_tracked_call(value: Option<u32>) -> Option<u32> {
+    value.map(|value| value + 1)
+}
+
+fn untracked_with_tracked_call(value: Option<u32>) -> Option<(u32, u32)> {
+    value.map(|value| make_value(value, caller_line()))
+}
+
+trait TrackCallerMap {
+    #[track_caller]
+    fn map(value: Option<u32>) -> Option<(u32, u32)>;
+}
+
+impl TrackCallerMap for () {
+    fn map(value: Option<u32>) -> Option<(u32, u32)> {
+        match value {
+            Some(value) => Some(make_value(value, caller_line())),
+            None => None,
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/manual_map/track_caller.rs
+++ b/tests/ui/manual_map/track_caller.rs
@@ -1,0 +1,68 @@
+// run-rustfix
+#![warn(clippy::manual_map)]
+
+use std::panic::Location;
+
+#[track_caller]
+fn caller_line() -> u32 {
+    Location::caller().line()
+}
+
+fn make_value(value: u32, caller: u32) -> (u32, u32) {
+    (value, caller)
+}
+
+#[track_caller]
+fn track_caller_false_positive(value: Option<u32>) -> Option<(u32, u32)> {
+    match value {
+        Some(value) => Some(make_value(value, caller_line())),
+        None => None,
+    }
+}
+
+#[track_caller]
+fn tracked_function(value: u32) -> u32 {
+    let _ = Location::caller();
+    value
+}
+
+#[track_caller]
+fn track_caller_function_item(value: Option<u32>) -> Option<u32> {
+    match value {
+        Some(value) => Some(tracked_function(value)),
+        None => None,
+    }
+}
+
+#[track_caller]
+fn track_caller_without_tracked_call(value: Option<u32>) -> Option<u32> {
+    match value {
+        //~^ manual_map
+        Some(value) => Some(value + 1),
+        None => None,
+    }
+}
+
+fn untracked_with_tracked_call(value: Option<u32>) -> Option<(u32, u32)> {
+    match value {
+        //~^ manual_map
+        Some(value) => Some(make_value(value, caller_line())),
+        None => None,
+    }
+}
+
+trait TrackCallerMap {
+    #[track_caller]
+    fn map(value: Option<u32>) -> Option<(u32, u32)>;
+}
+
+impl TrackCallerMap for () {
+    fn map(value: Option<u32>) -> Option<(u32, u32)> {
+        match value {
+            Some(value) => Some(make_value(value, caller_line())),
+            None => None,
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/manual_map/track_caller.stderr
+++ b/tests/ui/manual_map/track_caller.stderr
@@ -1,0 +1,25 @@
+error: manual implementation of `Option::map`
+  --> tests/ui/manual_map/track_caller.rs:39:5
+   |
+LL | /     match value {
+LL | |
+LL | |         Some(value) => Some(value + 1),
+LL | |         None => None,
+LL | |     }
+   | |_____^ help: try: `value.map(|value| value + 1)`
+   |
+   = note: `-D clippy::manual-map` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_map)]`
+
+error: manual implementation of `Option::map`
+  --> tests/ui/manual_map/track_caller.rs:47:5
+   |
+LL | /     match value {
+LL | |
+LL | |         Some(value) => Some(make_value(value, caller_line())),
+LL | |         None => None,
+LL | |     }
+   | |_____^ help: try: `value.map(|value| make_value(value, caller_line()))`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Moving a call into a generated closure can change the location observed by a `#[track_caller]` function. Reject these transformations so Clippy does not suggest behavior-changing rewrites.

changelog: fix `manual_map` false positive when the suggestion would change `#[track_caller]` location propagation. rust-lang/rust-clippy#17706 

**Note:** I could’ve added this in `manual_map`, but it seemed a bit messy, so I tried putting the check in `can_move_expr_to_closure_no_visit` instead. Please let me know what would be a better approach..
