### PR TITLE
Fix `explicit_auto_deref` triggering on refs to never type

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -304,6 +304,7 @@ impl<'tcx> LateLintPass<'tcx> for Dereferencing<'tcx> {
                             && !use_node.is_recv()
                             && let Some(ty) = use_node.defined_ty(cx)
                             && TyCoercionStability::for_defined_ty(cx, ty, use_node.is_return()).is_deref_stable()
+                            && !use_site.adjustments.iter().any(|adj| matches!(adj.kind, Adjust::NeverToAny))
                         {
                             self.state = Some((
                                 State::ExplicitDeref { mutability: None },

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -428,3 +428,13 @@ mod issue_9841 {
         todo!()
     }
 }
+
+mod issue_17713 {
+    fn ref_never(input: &!) -> &u32 {
+        *input
+    }
+
+    fn mut_ref_never(input: &mut !) -> &mut u32 {
+        *input
+    }
+}

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -428,3 +428,13 @@ mod issue_9841 {
         todo!()
     }
 }
+
+mod issue_17713 {
+    fn ref_never(input: &!) -> &u32 {
+        *input
+    }
+
+    fn mut_ref_never(input: &mut !) -> &mut u32 {
+        *input
+    }
+}


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17713

changelog: [`explicit_auto_deref`]: Stop linting on explicit dereferences of the never type