### PR TITLE
Add `std_wildcard_imports` lint for wildcard imports from standard library crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7583,6 +7583,7 @@ Released 2018-09-13
 [`stable_sort_primitive`]: https://rust-lang.github.io/rust-clippy/main/index.html#stable_sort_primitive
 [`std_instead_of_alloc`]: https://rust-lang.github.io/rust-clippy/main/index.html#std_instead_of_alloc
 [`std_instead_of_core`]: https://rust-lang.github.io/rust-clippy/main/index.html#std_instead_of_core
+[`std_wildcard_imports`]: https://rust-lang.github.io/rust-clippy/main/index.html#std_wildcard_imports
 [`str_split_at_newline`]: https://rust-lang.github.io/rust-clippy/main/index.html#str_split_at_newline
 [`str_to_string`]: https://rust-lang.github.io/rust-clippy/main/index.html#str_to_string
 [`string_add`]: https://rust-lang.github.io/rust-clippy/main/index.html#string_add

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -323,6 +323,7 @@ allowed-wildcard-imports = [ "utils", "common" ]
 1. This configuration has no effects if used with `warn_on_all_wildcard_imports = true`.
 2. Paths with any segment that containing the word 'prelude'
 are already allowed by default.
+3. This configuration does not affect `std_wildcard_imports`.
 
 **Default Value:** `[]`
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -347,6 +347,7 @@ define_Conf! {
     /// 1. This configuration has no effects if used with `warn_on_all_wildcard_imports = true`.
     /// 2. Paths with any segment that containing the word 'prelude'
     /// are already allowed by default.
+    /// 3. This configuration does not affect `std_wildcard_imports`.
     #[lints(wildcard_imports)]
     allowed_wildcard_imports("allowed-wildcard-imports"): FxHashSet<String>,
     /// Suppress checking of the passed type names in all types of operations.

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -446,6 +446,7 @@ declare_clippy_lint! {
     /// * clippy::module_name_repetitions
     /// * clippy::redundant_pub_crate
     /// * clippy::single_component_path_imports
+    /// * clippy::std_wildcard_imports
     /// * clippy::unsafe_removed_from_name
     /// * clippy::wildcard_imports
     ///

--- a/clippy_lints/src/attrs/useless_attribute.rs
+++ b/clippy_lints/src/attrs/useless_attribute.rs
@@ -45,6 +45,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, item: &Item, attrs: &[Attribute]) {
                             && matches!(
                                 name,
                                 sym::wildcard_imports
+                                    | sym::std_wildcard_imports
                                     | sym::enum_glob_use
                                     | sym::redundant_pub_crate
                                     | sym::macro_use_imports

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -820,6 +820,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::visibility::PUB_WITHOUT_SHORTHAND_INFO,
     crate::volatile_composites::VOLATILE_COMPOSITES_INFO,
     crate::wildcard_imports::ENUM_GLOB_USE_INFO,
+    crate::wildcard_imports::STD_WILDCARD_IMPORTS_INFO,
     crate::wildcard_imports::WILDCARD_IMPORTS_INFO,
     crate::with_capacity_zero::WITH_CAPACITY_ZERO_INFO,
     crate::write::PRINT_LITERAL_INFO,

--- a/clippy_lints/src/wildcard_imports.rs
+++ b/clippy_lints/src/wildcard_imports.rs
@@ -1,15 +1,15 @@
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::is_in_test;
 use clippy_utils::source::{snippet, snippet_with_applicability};
-use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::Applicability;
-use rustc_hir::def::{DefKind, Res};
-use rustc_hir::{Item, ItemKind, PathSegment, UseKind};
-use rustc_lint::{LateContext, LateLintPass, LintContext as _, impl_lint_pass};
+use clippy_utils::{is_in_test, is_lint_allowed};
+use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
+use rustc_errors::{Applicability, DiagMessage};
+use rustc_hir::def::{DefKind, PerNS, Res};
+use rustc_hir::{Item, ItemKind, Path, PathSegment, UseKind};
+use rustc_lint::{LateContext, LateLintPass, Lint, LintContext as _, impl_lint_pass};
 use rustc_middle::ty;
-use rustc_span::BytePos;
-use rustc_span::symbol::kw;
+use rustc_span::symbol::{STDLIB_STABLE_CRATES, Symbol, kw, sym};
+use rustc_span::{BytePos, Span};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -42,6 +42,57 @@ declare_clippy_lint! {
     pub ENUM_GLOB_USE,
     pedantic,
     "use items that import all variants of an enum"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for private wildcard imports `use _::*` from the `std`, `core`, `alloc`,
+    /// `proc_macro`, and `test` crates, including reexports of their modules.
+    ///
+    /// ### Why is this bad?
+    /// Wildcard imports from the standard library can break name resolution when a new item is
+    /// added with the same name as a locally defined or imported item. This can happen even when
+    /// the new standard library item is unstable.
+    ///
+    /// ### Exceptions
+    /// Wildcard imports are allowed from modules whose names contain `prelude`. Many crates
+    /// (including the standard library) provide modules named "prelude" specifically designed
+    /// for wildcard imports.
+    ///
+    /// Wildcard imports reexported through `pub use` are also allowed.
+    ///
+    /// This lint does not check enum variant imports; enable `enum_glob_use` to check those. The
+    /// `allowed-wildcard-imports` and `warn-on-all-wildcard-imports` configuration options only
+    /// affect `wildcard_imports`. When both lints are enabled, this lint takes precedence over
+    /// `wildcard_imports` for eligible standard-library imports.
+    ///
+    /// ### Known problems
+    /// Applying the suggestion when explicit imports of items imported through the glob already
+    /// exist may result in `unused_imports` warnings.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// use foo::bar;
+    /// use std::rc::*;
+    ///
+    /// # mod foo { pub fn bar() {} }
+    /// bar();
+    /// let _ = Rc::new(5);
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// use foo::bar;
+    /// use std::rc::Rc;
+    ///
+    /// # mod foo { pub fn bar() {} }
+    /// bar();
+    /// let _ = Rc::new(5);
+    /// ```
+    #[clippy::version = "1.99.0"]
+    pub STD_WILDCARD_IMPORTS,
+    pedantic,
+    "lint `use _::*` from standard library crates"
 }
 
 declare_clippy_lint! {
@@ -99,7 +150,11 @@ declare_clippy_lint! {
     "lint `use _::*` statements"
 }
 
-impl_lint_pass!(WildcardImports => [ENUM_GLOB_USE, WILDCARD_IMPORTS]);
+impl_lint_pass!(WildcardImports => [
+    ENUM_GLOB_USE,
+    STD_WILDCARD_IMPORTS,
+    WILDCARD_IMPORTS,
+]);
 
 pub struct WildcardImports {
     warn_on_all: bool,
@@ -122,56 +177,52 @@ impl LateLintPass<'_> for WildcardImports {
         }
 
         let module = cx.tcx.parent_module_from_def_id(item.owner_id.def_id);
-        if cx.tcx.local_visibility(item.owner_id.def_id) != ty::Visibility::Restricted(module) && !self.warn_on_all {
-            return;
-        }
         if let ItemKind::Use(use_path, UseKind::Glob) = &item.kind
-            && (self.warn_on_all || !self.check_exceptions(cx, item, use_path.segments))
             && let Some(used_imports) = cx.tcx.resolutions(()).glob_map.get(&item.owner_id.def_id)
             && !used_imports.is_empty() // Already handled by `unused_imports`
             && !used_imports.contains(&kw::Underscore)
         {
+            let is_private = cx.tcx.local_visibility(item.owner_id.def_id) == ty::Visibility::Restricted(module);
+            let is_enum_import = matches!(use_path.res.value_ns, Some(Res::Def(DefKind::Enum, _)));
+            let wildcard_imports_applies =
+                || self.warn_on_all || (is_private && !self.check_exceptions(cx, item, use_path.segments));
+
+            let (lint, message): (&'static Lint, DiagMessage) = if is_enum_import {
+                if !wildcard_imports_applies() {
+                    return;
+                }
+                (ENUM_GLOB_USE, "usage of wildcard import for enum variants".into())
+            } else if is_private
+                && !item.span.from_expansion()
+                && !is_prelude_import(use_path.segments)
+                && is_std_wildcard_import(cx, use_path)
+                && !is_lint_allowed(cx, STD_WILDCARD_IMPORTS, item.hir_id())
+            {
+                let wildcard_imports_level = cx.tcx.lint_level_spec_at_node(WILDCARD_IMPORTS, item.hir_id());
+                if wildcard_imports_level.is_expect()
+                    && wildcard_imports_applies()
+                    && let Some(expectation) = wildcard_imports_level.lint_id()
+                {
+                    // The more focused lint replaces `WILDCARD_IMPORTS`, but expectations of the
+                    // latter still need to be fulfilled as it would otherwise have been emitted.
+                    cx.fulfill_expectation(expectation);
+                }
+                (
+                    STD_WILDCARD_IMPORTS,
+                    "usage of wildcard import from the standard library".into(),
+                )
+            } else {
+                if !wildcard_imports_applies() {
+                    return;
+                }
+                (WILDCARD_IMPORTS, "usage of wildcard import".into())
+            };
+
             let mut applicability = Applicability::MachineApplicable;
             let import_source_snippet = snippet_with_applicability(cx, use_path.span, "..", &mut applicability);
-            let (span, braced_glob) = if import_source_snippet.is_empty() {
-                // This is a `_::{_, *}` import
-                // In this case `use_path.span` is empty and ends directly in front of the `*`,
-                // so we need to extend it by one byte.
-                (use_path.span.with_hi(use_path.span.hi() + BytePos(1)), true)
-            } else {
-                // In this case, the `use_path.span` ends right before the `::*`, so we need to
-                // extend it up to the `*`. Since it is hard to find the `*` in weird
-                // formatting like `use _ ::  *;`, we extend it up to, but not including the
-                // `;`. In nested imports, like `use _::{inner::*, _}` there is no `;` and we
-                // can just use the end of the item span
-                let mut span = use_path.span.with_hi(item.span.hi());
-                if snippet(cx, span, "").ends_with(';') {
-                    span = use_path.span.with_hi(item.span.hi() - BytePos(1));
-                }
-                (span, false)
-            };
-
-            let mut imports: Vec<_> = used_imports.iter().map(ToString::to_string).collect();
-            let imports_string = if imports.len() == 1 {
-                imports.pop().unwrap()
-            } else if braced_glob {
-                imports.join(", ")
-            } else {
-                format!("{{{}}}", imports.join(", "))
-            };
-
-            let sugg = if braced_glob {
-                imports_string
-            } else {
-                format!("{import_source_snippet}::{imports_string}")
-            };
-
-            // Glob imports always have a single resolution. Enums are in the value namespace.
-            let (lint, message) = if let Some(Res::Def(DefKind::Enum, _)) = use_path.res.value_ns {
-                (ENUM_GLOB_USE, "usage of wildcard import for enum variants")
-            } else {
-                (WILDCARD_IMPORTS, "usage of wildcard import")
-            };
+            let braced_glob = import_source_snippet.is_empty();
+            let span = whole_glob_import_span(cx, use_path, item.span.hi(), braced_glob);
+            let sugg = sugg_glob_import(&import_source_snippet, used_imports, braced_glob);
 
             span_lint_and_sugg(cx, lint, span, message, "try", sugg, applicability);
         }
@@ -198,10 +249,70 @@ fn is_super_only_import(segments: &[PathSegment<'_>]) -> bool {
     segments.len() == 1 && segments[0].ident.name == kw::Super
 }
 
+fn is_std_wildcard_import(cx: &LateContext<'_>, use_path: &Path<'_, PerNS<Option<Res>>>) -> bool {
+    let Some(Res::Def(DefKind::Mod, def_id)) = use_path.res.type_ns else {
+        return false;
+    };
+    if def_id.is_local() {
+        return false;
+    }
+
+    // Crate names are not reserved, so require the resolved crate to come from the sysroot too.
+    let crate_name = cx.tcx.crate_name(def_id.krate);
+    (STDLIB_STABLE_CRATES.contains(&crate_name) || crate_name == sym::test)
+        && cx
+            .tcx
+            .used_crate_source(def_id.krate)
+            .paths()
+            .any(|path| path.starts_with(cx.sess().opts.sysroot.path()))
+}
+
 // Allow skipping imports containing user configured segments,
 // i.e. "...::utils::...::*" if user put `allowed-wildcard-imports = ["utils"]` in `Clippy.toml`
 fn is_allowed_via_config(segments: &[PathSegment<'_>], allowed_segments: &FxHashSet<String>) -> bool {
     // segment matching need to be exact instead of using 'contains', in case user unintentionally put
     // a single character in the config thus skipping most of the warnings.
     segments.iter().any(|seg| allowed_segments.contains(seg.ident.as_str()))
+}
+
+/// Returns the entire span for a glob import statement, including the `*` symbol.
+fn whole_glob_import_span(
+    cx: &LateContext<'_>,
+    use_path: &Path<'_, PerNS<Option<Res>>>,
+    item_hi: BytePos,
+    braced_glob: bool,
+) -> Span {
+    if braced_glob {
+        // This is a `_::{_, *}` import. In this case `use_path.span` is empty and ends directly
+        // in front of the `*`, so we need to extend it by one byte.
+        use_path.span.with_hi(use_path.span.hi() + BytePos(1))
+    } else {
+        // In this case, the `use_path.span` ends right before the `::*`, so we need to extend it
+        // up to the `*`. Since it is hard to find the `*` in weird formatting like
+        // `use _ ::  *;`, we extend it up to, but not including the `;`. In nested imports, like
+        // `use _::{inner::*, _}` there is no `;` and we can just use the end of the item span.
+        let mut span = use_path.span.with_hi(item_hi);
+        if snippet(cx, span, "").ends_with(';') {
+            span = use_path.span.with_hi(item_hi - BytePos(1));
+        }
+        span
+    }
+}
+
+/// Generates a replacement for a glob import using only the names that are actually used.
+fn sugg_glob_import(import_source_snippet: &str, used_imports: &FxIndexSet<Symbol>, braced_glob: bool) -> String {
+    let mut imports: Vec<_> = used_imports.iter().map(ToString::to_string).collect();
+    let imports_string = if imports.len() == 1 {
+        imports.pop().unwrap()
+    } else if braced_glob {
+        imports.join(", ")
+    } else {
+        format!("{{{}}}", imports.join(", "))
+    };
+
+    if braced_glob {
+        imports_string
+    } else {
+        format!("{import_source_snippet}::{imports_string}")
+    }
 }

--- a/clippy_utils/src/sym.rs
+++ b/clippy_utils/src/sym.rs
@@ -573,6 +573,7 @@ generate! {
     sqrt,
     starts_with,
     std_detect,
+    std_wildcard_imports,
     step_by,
     str_chars,
     str_ends_with,

--- a/tests/ui-cargo/std_wildcard_imports_dependency_named_test/Cargo.toml
+++ b/tests/ui-cargo/std_wildcard_imports_dependency_named_test/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "std_wildcard_imports_dependency_named_test"
+edition = "2024"
+publish = false
+version = "0.1.0"
+
+[workspace]
+
+[dependencies]
+fake_test = { package = "test", path = "test" }

--- a/tests/ui-cargo/std_wildcard_imports_dependency_named_test/src/main.rs
+++ b/tests/ui-cargo/std_wildcard_imports_dependency_named_test/src/main.rs
@@ -1,0 +1,7 @@
+#![warn(clippy::std_wildcard_imports)]
+
+use fake_test::items::*;
+
+fn main() {
+    fake_item();
+}

--- a/tests/ui-cargo/std_wildcard_imports_dependency_named_test/test/Cargo.toml
+++ b/tests/ui-cargo/std_wildcard_imports_dependency_named_test/test/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "test"
+edition = "2024"
+publish = false
+version = "0.1.0"

--- a/tests/ui-cargo/std_wildcard_imports_dependency_named_test/test/src/lib.rs
+++ b/tests/ui-cargo/std_wildcard_imports_dependency_named_test/test/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod items {
+    pub fn fake_item() {}
+}

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.fixed
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.fixed
@@ -1,5 +1,5 @@
 //@aux-build:../../ui/auxiliary/proc_macros.rs
-#![warn(clippy::wildcard_imports)]
+#![warn(clippy::std_wildcard_imports, clippy::wildcard_imports)]
 
 mod prelude {
     pub const FOO: u8 = 1;
@@ -26,6 +26,8 @@ use my_crate::utils::my_util_fn;
 //~^ ERROR: usage of wildcard import
 use prelude::FOO;
 //~^ ERROR: usage of wildcard import
+use std::io::prelude::Read;
+//~^ ERROR: usage of wildcard import
 
 proc_macros::external! {
     use my_crate::utils2::*;
@@ -38,4 +40,16 @@ fn main() {
     let _ = BAR;
     print();
     my_util_fn();
+    let mut reader = Reader;
+    needs_read(&mut reader);
 }
+
+struct Reader;
+
+impl Read for Reader {
+    fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+        Ok(0)
+    }
+}
+
+fn needs_read(_: &mut dyn Read) {}

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.rs
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.rs
@@ -1,5 +1,5 @@
 //@aux-build:../../ui/auxiliary/proc_macros.rs
-#![warn(clippy::wildcard_imports)]
+#![warn(clippy::std_wildcard_imports, clippy::wildcard_imports)]
 
 mod prelude {
     pub const FOO: u8 = 1;
@@ -26,6 +26,8 @@ use my_crate::utils::*;
 //~^ ERROR: usage of wildcard import
 use prelude::*;
 //~^ ERROR: usage of wildcard import
+use std::io::prelude::*;
+//~^ ERROR: usage of wildcard import
 
 proc_macros::external! {
     use my_crate::utils2::*;
@@ -38,4 +40,16 @@ fn main() {
     let _ = BAR;
     print();
     my_util_fn();
+    let mut reader = Reader;
+    needs_read(&mut reader);
 }
+
+struct Reader;
+
+impl Read for Reader {
+    fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+        Ok(0)
+    }
+}
+
+fn needs_read(_: &mut dyn Read) {}

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.stderr
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.stderr
@@ -19,5 +19,11 @@ error: usage of wildcard import
 LL | use prelude::*;
    |     ^^^^^^^^^^ help: try: `prelude::FOO`
 
-error: aborting due to 3 previous errors
+error: usage of wildcard import
+  --> tests/ui-toml/wildcard_imports/wildcard_imports.rs:29:5
+   |
+LL | use std::io::prelude::*;
+   |     ^^^^^^^^^^^^^^^^^^^ help: try: `std::io::prelude::Read`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/auxiliary/wildcard_imports_helper.rs
+++ b/tests/ui/auxiliary/wildcard_imports_helper.rs
@@ -1,4 +1,5 @@
 pub use crate::extern_exports::*;
+pub use std::fmt;
 
 pub fn extern_foo() {}
 pub fn extern_bar() {}

--- a/tests/ui/std_wildcard_imports.fixed
+++ b/tests/ui/std_wildcard_imports.fixed
@@ -1,0 +1,107 @@
+//@aux-build:wildcard_imports_helper.rs
+
+#![feature(test)]
+#![warn(clippy::std_wildcard_imports)]
+
+extern crate alloc;
+extern crate proc_macro;
+extern crate std as standard;
+extern crate test as test_crate;
+extern crate wildcard_imports_helper;
+
+use alloc::boxed::Box;
+//~^ std_wildcard_imports
+use core::cell::Cell;
+//~^ std_wildcard_imports
+use proc_macro::is_available;
+//~^ std_wildcard_imports
+use std::any::type_name;
+//~^ std_wildcard_imports
+use standard::mem::{swap, align_of};
+//~^ std_wildcard_imports
+use test_crate::bench::black_box;
+//~^ std_wildcard_imports
+use ::std::fs::File;
+//~^ std_wildcard_imports
+use wildcard_imports_helper::fmt::Debug;
+//~^ std_wildcard_imports
+
+use std::io::prelude::*;
+
+pub mod reexports {
+    pub use std::fmt::*;
+
+    pub fn use_debug(_: &dyn Debug) {}
+}
+
+use wildcard_imports_helper::*;
+
+macro_rules! import_fmt {
+    () => {
+        use std::fmt::*;
+    };
+}
+
+mod macro_expansion {
+    import_fmt!();
+
+    pub fn use_display(_: &dyn Display) {}
+}
+
+mod local_std {
+    mod std {
+        pub mod things {
+            pub fn item() {}
+        }
+    }
+
+    use std::things::*;
+
+    pub fn use_item() {
+        item();
+    }
+}
+
+// This is intentionally checked by `enum_glob_use`, not this lint.
+use std::cmp::Ordering::*;
+
+mod both_lints {
+    #![warn(clippy::wildcard_imports)]
+
+    use std::rc::Rc;
+    //~^ std_wildcard_imports
+
+    pub fn new_rc() -> Rc<()> {
+        Rc::new(())
+    }
+}
+
+struct Reader;
+
+impl Read for Reader {
+    fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+        Ok(0)
+    }
+}
+
+fn main() {
+    let _ = Box::new(());
+    let _ = Cell::new(());
+    let _ = is_available();
+    let _ = type_name::<i32>();
+
+    let mut a = 1;
+    let mut b = 2;
+    swap(&mut a, &mut b);
+    let _ = align_of::<i32>();
+
+    black_box(());
+    let _ = File::open("does-not-exist");
+    let _: &dyn Debug = &0;
+    let _ = Reader;
+    extern_foo();
+    macro_expansion::use_display(&0);
+    local_std::use_item();
+    let _ = Less;
+    let _ = both_lints::new_rc();
+}

--- a/tests/ui/std_wildcard_imports.rs
+++ b/tests/ui/std_wildcard_imports.rs
@@ -1,0 +1,107 @@
+//@aux-build:wildcard_imports_helper.rs
+
+#![feature(test)]
+#![warn(clippy::std_wildcard_imports)]
+
+extern crate alloc;
+extern crate proc_macro;
+extern crate std as standard;
+extern crate test as test_crate;
+extern crate wildcard_imports_helper;
+
+use alloc::boxed::*;
+//~^ std_wildcard_imports
+use core::cell::*;
+//~^ std_wildcard_imports
+use proc_macro::*;
+//~^ std_wildcard_imports
+use std::any::*;
+//~^ std_wildcard_imports
+use standard::mem::{swap, *};
+//~^ std_wildcard_imports
+use test_crate::bench::*;
+//~^ std_wildcard_imports
+use ::std::fs::*;
+//~^ std_wildcard_imports
+use wildcard_imports_helper::fmt::*;
+//~^ std_wildcard_imports
+
+use std::io::prelude::*;
+
+pub mod reexports {
+    pub use std::fmt::*;
+
+    pub fn use_debug(_: &dyn Debug) {}
+}
+
+use wildcard_imports_helper::*;
+
+macro_rules! import_fmt {
+    () => {
+        use std::fmt::*;
+    };
+}
+
+mod macro_expansion {
+    import_fmt!();
+
+    pub fn use_display(_: &dyn Display) {}
+}
+
+mod local_std {
+    mod std {
+        pub mod things {
+            pub fn item() {}
+        }
+    }
+
+    use std::things::*;
+
+    pub fn use_item() {
+        item();
+    }
+}
+
+// This is intentionally checked by `enum_glob_use`, not this lint.
+use std::cmp::Ordering::*;
+
+mod both_lints {
+    #![warn(clippy::wildcard_imports)]
+
+    use std::rc::*;
+    //~^ std_wildcard_imports
+
+    pub fn new_rc() -> Rc<()> {
+        Rc::new(())
+    }
+}
+
+struct Reader;
+
+impl Read for Reader {
+    fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+        Ok(0)
+    }
+}
+
+fn main() {
+    let _ = Box::new(());
+    let _ = Cell::new(());
+    let _ = is_available();
+    let _ = type_name::<i32>();
+
+    let mut a = 1;
+    let mut b = 2;
+    swap(&mut a, &mut b);
+    let _ = align_of::<i32>();
+
+    black_box(());
+    let _ = File::open("does-not-exist");
+    let _: &dyn Debug = &0;
+    let _ = Reader;
+    extern_foo();
+    macro_expansion::use_display(&0);
+    local_std::use_item();
+    let _ = Less;
+    let _ = both_lints::new_rc();
+}

--- a/tests/ui/std_wildcard_imports.stderr
+++ b/tests/ui/std_wildcard_imports.stderr
@@ -1,0 +1,59 @@
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:12:5
+   |
+LL | use alloc::boxed::*;
+   |     ^^^^^^^^^^^^^^^ help: try: `alloc::boxed::Box`
+   |
+   = note: `-D clippy::std-wildcard-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::std_wildcard_imports)]`
+
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:14:5
+   |
+LL | use core::cell::*;
+   |     ^^^^^^^^^^^^^ help: try: `core::cell::Cell`
+
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:16:5
+   |
+LL | use proc_macro::*;
+   |     ^^^^^^^^^^^^^ help: try: `proc_macro::is_available`
+
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:18:5
+   |
+LL | use std::any::*;
+   |     ^^^^^^^^^^^ help: try: `std::any::type_name`
+
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:20:27
+   |
+LL | use standard::mem::{swap, *};
+   |                           ^ help: try: `align_of`
+
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:22:5
+   |
+LL | use test_crate::bench::*;
+   |     ^^^^^^^^^^^^^^^^^^^^ help: try: `test_crate::bench::black_box`
+
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:24:5
+   |
+LL | use ::std::fs::*;
+   |     ^^^^^^^^^^^^ help: try: `::std::fs::File`
+
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:26:5
+   |
+LL | use wildcard_imports_helper::fmt::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::fmt::Debug`
+
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports.rs:71:9
+   |
+LL |     use std::rc::*;
+   |         ^^^^^^^^^^ help: try: `std::rc::Rc`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/std_wildcard_imports_expect.rs
+++ b/tests/ui/std_wildcard_imports_expect.rs
@@ -1,0 +1,11 @@
+//@no-rustfix
+
+#![warn(clippy::std_wildcard_imports, clippy::wildcard_imports)]
+
+#[expect(clippy::wildcard_imports)]
+use std::rc::*;
+//~^ std_wildcard_imports
+
+fn main() {
+    let _ = Rc::new(());
+}

--- a/tests/ui/std_wildcard_imports_expect.stderr
+++ b/tests/ui/std_wildcard_imports_expect.stderr
@@ -1,0 +1,11 @@
+error: usage of wildcard import from the standard library
+  --> tests/ui/std_wildcard_imports_expect.rs:6:5
+   |
+LL | use std::rc::*;
+   |     ^^^^^^^^^^ help: try: `std::rc::Rc`
+   |
+   = note: `-D clippy::std-wildcard-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::std_wildcard_imports)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/std_wildcard_imports_local_crate.rs
+++ b/tests/ui/std_wildcard_imports_local_crate.rs
@@ -1,0 +1,21 @@
+//@compile-flags: --crate-name test
+//@check-pass
+//@no-rustfix
+
+#![warn(clippy::std_wildcard_imports)]
+
+mod crate_items {
+    pub fn from_crate() {}
+}
+
+mod self_items {
+    pub fn from_self() {}
+}
+
+use self::self_items::*;
+use crate::crate_items::*;
+
+fn main() {
+    from_crate();
+    from_self();
+}

--- a/tests/ui/useless_attribute.fixed
+++ b/tests/ui/useless_attribute.fixed
@@ -70,6 +70,14 @@ pub use std::io::prelude::*;
 #[allow(clippy::enum_glob_use)]
 pub use std::cmp::Ordering::*;
 
+// don't lint on clippy::std_wildcard_imports for `use` items
+#[allow(clippy::std_wildcard_imports)]
+use std::any::*;
+
+// don't lint on `expect(clippy::std_wildcard_imports)` for `use` items
+#[expect(clippy::std_wildcard_imports)]
+use std::mem::*;
+
 // don't lint on clippy::redundant_pub_crate
 mod c {
     #[allow(clippy::redundant_pub_crate)]
@@ -95,7 +103,10 @@ mod module {
 #[allow(unused_braces)]
 use module::{Struct};
 
-fn main() {}
+fn main() {
+    let _ = type_name::<i32>();
+    let _ = size_of::<i32>();
+}
 
 // Regression test for https://github.com/rust-lang/rust-clippy/issues/4467
 #[allow(dead_code)]

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -70,6 +70,14 @@ pub use std::io::prelude::*;
 #[allow(clippy::enum_glob_use)]
 pub use std::cmp::Ordering::*;
 
+// don't lint on clippy::std_wildcard_imports for `use` items
+#[allow(clippy::std_wildcard_imports)]
+use std::any::*;
+
+// don't lint on `expect(clippy::std_wildcard_imports)` for `use` items
+#[expect(clippy::std_wildcard_imports)]
+use std::mem::*;
+
 // don't lint on clippy::redundant_pub_crate
 mod c {
     #[allow(clippy::redundant_pub_crate)]
@@ -95,7 +103,10 @@ mod module {
 #[allow(unused_braces)]
 use module::{Struct};
 
-fn main() {}
+fn main() {
+    let _ = type_name::<i32>();
+    let _ = size_of::<i32>();
+}
 
 // Regression test for https://github.com/rust-lang/rust-clippy/issues/4467
 #[allow(dead_code)]

--- a/tests/ui/wildcard_imports.fixed
+++ b/tests/ui/wildcard_imports.fixed
@@ -28,6 +28,8 @@ use wildcard_imports_helper::inner::inner_for_self_import::inner_extern_bar;
 //~^ wildcard_imports
 use wildcard_imports_helper::{extern_foo, ExternA};
 //~^ wildcard_imports
+use std::any::type_name;
+//~^ wildcard_imports
 
 use std::io::prelude::*;
 use wildcard_imports_helper::extern_prelude::v1::*;
@@ -112,6 +114,7 @@ fn main() {
     inner_mod::foo();
     extern_foo();
     inner_extern_bar();
+    let _ = type_name::<i32>();
 
     let _ = A;
     let _ = inner_struct_mod::C;

--- a/tests/ui/wildcard_imports.rs
+++ b/tests/ui/wildcard_imports.rs
@@ -28,6 +28,8 @@ use wildcard_imports_helper::inner::inner_for_self_import::*;
 //~^ wildcard_imports
 use wildcard_imports_helper::*;
 //~^ wildcard_imports
+use std::any::*;
+//~^ wildcard_imports
 
 use std::io::prelude::*;
 use wildcard_imports_helper::extern_prelude::v1::*;
@@ -112,6 +114,7 @@ fn main() {
     inner_mod::foo();
     extern_foo();
     inner_extern_bar();
+    let _ = type_name::<i32>();
 
     let _ = A;
     let _ = inner_struct_mod::C;

--- a/tests/ui/wildcard_imports.stderr
+++ b/tests/ui/wildcard_imports.stderr
@@ -38,61 +38,67 @@ LL | use wildcard_imports_helper::*;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_foo, ExternA}`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:100:13
+  --> tests/ui/wildcard_imports.rs:31:5
+   |
+LL | use std::any::*;
+   |     ^^^^^^^^^^^ help: try: `std::any::type_name`
+
+error: usage of wildcard import
+  --> tests/ui/wildcard_imports.rs:102:13
    |
 LL |         use self::exports_underscore_ish::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `self::exports_underscore_ish::{_Deref, dummy}`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:132:13
+  --> tests/ui/wildcard_imports.rs:135:13
    |
 LL |         use crate::fn_mod::*;
    |             ^^^^^^^^^^^^^^^^ help: try: `crate::fn_mod::foo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:139:75
+  --> tests/ui/wildcard_imports.rs:142:75
    |
 LL |         use wildcard_imports_helper::inner::inner_for_self_import::{self, *};
    |                                                                           ^ help: try: `inner_extern_foo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:141:13
+  --> tests/ui/wildcard_imports.rs:144:13
    |
 LL |         use wildcard_imports_helper::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_foo, ExternA}`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:154:20
+  --> tests/ui/wildcard_imports.rs:157:20
    |
 LL |         use self::{inner::*, inner2::*};
    |                    ^^^^^^^^ help: try: `inner::inner_foo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:154:30
+  --> tests/ui/wildcard_imports.rs:157:30
    |
 LL |         use self::{inner::*, inner2::*};
    |                              ^^^^^^^^^ help: try: `inner2::inner_bar`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:163:13
+  --> tests/ui/wildcard_imports.rs:166:13
    |
 LL |         use wildcard_imports_helper::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_exported, ExternExportedStruct, ExternExportedEnum}`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:193:9
+  --> tests/ui/wildcard_imports.rs:196:9
    |
 LL |     use crate::in_fn_test::*;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `crate::in_fn_test::{exported, ExportedStruct, ExportedEnum}`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:203:9
+  --> tests/ui/wildcard_imports.rs:206:9
    |
 LL |     use crate:: in_fn_test::  * ;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `crate:: in_fn_test::exported`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:205:9
+  --> tests/ui/wildcard_imports.rs:208:9
    |
 LL |       use crate:: fn_mod::
    |  _________^
@@ -101,40 +107,40 @@ LL | |         *;
    | |_________^ help: try: `crate:: fn_mod::foo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:217:13
+  --> tests/ui/wildcard_imports.rs:220:13
    |
 LL |         use super::*;
    |             ^^^^^^^^ help: try: `super::foofoo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:256:17
+  --> tests/ui/wildcard_imports.rs:259:17
    |
 LL |             use super::*;
    |                 ^^^^^^^^ help: try: `super::insidefoo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:265:13
+  --> tests/ui/wildcard_imports.rs:268:13
    |
 LL |         use crate::super_imports::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `crate::super_imports::foofoo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:275:17
+  --> tests/ui/wildcard_imports.rs:278:17
    |
 LL |             use super::super::*;
    |                 ^^^^^^^^^^^^^^^ help: try: `super::super::foofoo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:285:13
+  --> tests/ui/wildcard_imports.rs:288:13
    |
 LL |         use super::super::super_imports::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `super::super::super_imports::foofoo`
 
 error: usage of wildcard import
-  --> tests/ui/wildcard_imports.rs:294:13
+  --> tests/ui/wildcard_imports.rs:297:13
    |
 LL |         use super::*;
    |             ^^^^^^^^ help: try: `super::foofoo`
 
-error: aborting due to 22 previous errors
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
Adds `std_wildcard_imports`, a pedantic lint for private wildcard imports from `std`, `core`, `alloc`, `proc_macro`, and `test`.

Wildcard imports from the standard library can unexpectedly break name resolution when new items are added, even when those items are unstable.

The lint resolves imports semantically, so it recognizes renamed standard library crates and modules re-exported by other crates without flagging local modules or dependencies that merely use a standard-library crate name.

Prelude paths, public glob re-exports, macro-expanded imports, and enum variant globs are excluded. Enum variant globs remain handled by `enum_glob_use`. The `allowed-wildcard-imports` and `warn-on-all-wildcard-imports` configuration options continue to affect only `wildcard_imports`.

When both lints are enabled, `std_wildcard_imports` takes precedence for eligible standard-library imports, preventing duplicate diagnostics.

Fixes rust-lang/rust-clippy#13961

- [x] Followed [lint naming conventions](https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints)
- [x] Added passing UI tests, including committed `.stderr` files
- [x] `cargo test` passes locally
- [x] Ran `cargo dev update_lints`
- [x] Added lint documentation
- [x] Ran `cargo dev fmt`

---

changelog: [`std_wildcard_imports`]: new lint for wildcard imports from standard library crates